### PR TITLE
Reskinnable demo: a supply-chain control tower skin with a server-enforced authority gate

### DIFF
--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/decisions/route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/decisions/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "./route";
+import * as store from "@/skins/logistics/data/store";
+
+beforeEach(() => store.reset());
+
+const call = (body: unknown) =>
+  POST(
+    new Request("http://localhost/x", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  );
+
+describe("POST /decisions", () => {
+  it("records a decision with decidedBy/role from the PLANNER, not the body", async () => {
+    const res = await call({
+      shipmentId: "shp-4821",
+      kind: "escalation",
+      rationale: "Ops accepted the recommendation verbally.",
+      plannerId: "pl-rosa",
+      // Decoys the server must ignore — never trust decidedBy/role from a client.
+      decidedBy: "Mallory",
+      role: "Director",
+    });
+    expect(res.status).toBe(201);
+    const decision = store.decisions()[0];
+    expect(decision).toMatchObject({
+      shipmentId: "shp-4821",
+      kind: "escalation",
+      decidedBy: "Rosa Delgado",
+      role: "Planner",
+      status: "committed",
+    });
+    expect(decision.decidedBy).not.toBe("Mallory");
+    expect(decision.role).not.toBe("Director");
+  });
+
+  it("404s an unknown shipmentId", async () => {
+    const res = await call({
+      shipmentId: "nope",
+      kind: "reroute",
+      rationale: "x",
+      plannerId: "pl-rosa",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("400s a missing plannerId", async () => {
+    const res = await call({
+      shipmentId: "shp-4821",
+      kind: "reroute",
+      rationale: "x",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/decisions/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/decisions/route.ts
@@ -1,0 +1,28 @@
+import * as store from "@/skins/logistics/data/store";
+
+export const GET = async () => Response.json(store.decisions());
+
+export const POST = async (req: Request) => {
+  const body = await req.json();
+  const { shipmentId, kind, costUsd, rationale, decidedBy, role, status } =
+    body;
+  if (!shipmentId || !kind || !rationale) {
+    return Response.json(
+      {
+        error: "BAD_REQUEST",
+        message: "shipmentId, kind and rationale are required.",
+      },
+      { status: 400 },
+    );
+  }
+  const filed = store.addDecision({
+    shipmentId,
+    kind,
+    costUsd: Number(costUsd) || 0,
+    rationale,
+    decidedBy: decidedBy ?? "Unknown",
+    role: role ?? "Planner",
+    status: status === "escalated" ? "escalated" : "committed",
+  });
+  return Response.json(filed, { status: 201 });
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/decisions/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/decisions/route.ts
@@ -4,8 +4,10 @@ export const GET = async () => Response.json(store.decisions());
 
 export const POST = async (req: Request) => {
   const body = await req.json();
-  const { shipmentId, kind, costUsd, rationale, decidedBy, role, status } =
-    body;
+  // decidedBy/role are NEVER read from the body — they are derived from the
+  // resolved planner server-side. A client that could set them (or an arbitrary
+  // costUsd that walked through a gate) would be forging the audit trail.
+  const { shipmentId, kind, costUsd, rationale, plannerId, status } = body;
   if (!shipmentId || !kind || !rationale) {
     return Response.json(
       {
@@ -15,13 +17,32 @@ export const POST = async (req: Request) => {
       { status: 400 },
     );
   }
+  if (!plannerId) {
+    return Response.json(
+      { error: "BAD_REQUEST", message: "plannerId is required." },
+      { status: 400 },
+    );
+  }
+  const planner = store.findPlanner(plannerId);
+  if (!planner) {
+    return Response.json(
+      { error: "BAD_REQUEST", message: "Unknown planner." },
+      { status: 400 },
+    );
+  }
+  if (!store.findShipment(shipmentId)) {
+    return Response.json(
+      { error: "NOT_FOUND", message: "Shipment not found." },
+      { status: 404 },
+    );
+  }
   const filed = store.addDecision({
     shipmentId,
     kind,
     costUsd: Number(costUsd) || 0,
     rationale,
-    decidedBy: decidedBy ?? "Unknown",
-    role: role ?? "Planner",
+    decidedBy: planner.name,
+    role: planner.role,
     status: status === "escalated" ? "escalated" : "committed",
   });
   return Response.json(filed, { status: 201 });

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/dev/reset/route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/dev/reset/route.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { POST } from "./route";
+import * as store from "@/skins/logistics/data/store";
+
+describe("POST /dev/reset", () => {
+  it("restores mutated state back to seed", async () => {
+    store.updateShipment("shp-4821", { status: "resolved" });
+    store.addDecision({
+      shipmentId: "shp-4821",
+      kind: "absorb",
+      costUsd: 0,
+      rationale: "x",
+      decidedBy: "y",
+      role: "Planner",
+      status: "committed",
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(store.findShipment("shp-4821")?.status).toBe("delayed");
+    expect(store.decisions()).toHaveLength(0);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/dev/reset/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/dev/reset/route.ts
@@ -1,9 +1,13 @@
 import * as store from "@/skins/logistics/data/store";
+import { presenterResetEnabled } from "@/lib/presenter";
 
 /** Dev-only: re-seed the store so the over-authority scenario can be re-run
  *  without restarting the server. */
 export const POST = async () => {
-  if (process.env.NODE_ENV === "production") {
+  // Allowed when a presenter/booth deployment has explicitly enabled reset, OR
+  // in any non-production environment (local dev + the unit tests). A production
+  // deployment without the flag still refuses.
+  if (!presenterResetEnabled() && process.env.NODE_ENV === "production") {
     return Response.json(
       { error: "FORBIDDEN", message: "Not available in production." },
       { status: 403 },

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/dev/reset/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/dev/reset/route.ts
@@ -1,0 +1,14 @@
+import * as store from "@/skins/logistics/data/store";
+
+/** Dev-only: re-seed the store so the over-authority scenario can be re-run
+ *  without restarting the server. */
+export const POST = async () => {
+  if (process.env.NODE_ENV === "production") {
+    return Response.json(
+      { error: "FORBIDDEN", message: "Not available in production." },
+      { status: 403 },
+    );
+  }
+  store.reset();
+  return Response.json({ ok: true });
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/escalations/[id]/approve/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/escalations/[id]/approve/route.ts
@@ -1,0 +1,21 @@
+import * as store from "@/skins/logistics/data/store";
+
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  try {
+    return Response.json(store.approveEscalation(id));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "UNKNOWN";
+    const status = reason === "NOT_FOUND" ? 404 : 409;
+    return Response.json(
+      {
+        error: reason,
+        message: `Could not approve the escalation (${reason}).`,
+      },
+      { status },
+    );
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/escalations/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/escalations/route.ts
@@ -1,0 +1,28 @@
+import * as store from "@/skins/logistics/data/store";
+
+export const GET = async () => Response.json(store.escalations());
+
+export const POST = async (req: Request) => {
+  const { shipmentId, code, rationale } = await req.json();
+  try {
+    return Response.json(
+      store.openEscalation(shipmentId, code, rationale ?? ""),
+      { status: 201 },
+    );
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "UNKNOWN";
+    if (reason === "NOT_FOUND") {
+      return Response.json(
+        { error: reason, message: "Shipment not found." },
+        { status: 404 },
+      );
+    }
+    return Response.json(
+      {
+        error: "INVALID_ESCALATION_CODE",
+        message: `"${code}" is not a recognized escalation code.`,
+      },
+      { status: 422 },
+    );
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/inventory/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/inventory/route.ts
@@ -1,0 +1,4 @@
+import * as store from "@/skins/logistics/data/store";
+
+// daysOfCover / atRisk are DERIVED here, never stored.
+export const GET = async () => Response.json(store.inventoryRisk());

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/lanes/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/lanes/route.ts
@@ -1,0 +1,3 @@
+import * as store from "@/skins/logistics/data/store";
+
+export const GET = async () => Response.json(store.lanes());

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/planners/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/planners/route.ts
@@ -1,0 +1,3 @@
+import * as store from "@/skins/logistics/data/store";
+
+export const GET = async () => Response.json(store.planners());

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/mitigate/route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/mitigate/route.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "./route";
+import * as store from "@/skins/logistics/data/store";
+
+beforeEach(() => store.reset());
+
+const call = (id: string, body: unknown) =>
+  POST(
+    new Request("http://localhost/x", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+    {
+      params: Promise.resolve({ id }),
+    },
+  );
+
+describe("POST /shipments/:id/mitigate", () => {
+  it("commits a mitigation within the planner's authority", async () => {
+    const res = await call("shp-4821", {
+      kind: "reroute",
+      rationale: "Priority berthing at LAX.",
+      plannerId: "pl-rosa",
+    });
+    expect(res.status).toBe(200);
+    expect(store.findShipment("shp-4821")?.appliedMitigation?.kind).toBe(
+      "reroute",
+    );
+  });
+
+  it("blocks an over-authority expedite with 403 and does not mutate", async () => {
+    const res = await call("shp-4821", {
+      kind: "expedite",
+      rationale: "Need it now.",
+      plannerId: "pl-rosa",
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("OVER_AUTHORITY");
+    expect(body.message).toContain("$8,400");
+    expect(store.findShipment("shp-4821")?.appliedMitigation).toBeUndefined();
+  });
+
+  it("IGNORES a client-supplied cost and recomputes server-side", async () => {
+    const res = await call("shp-4821", {
+      kind: "expedite",
+      rationale: "x",
+      plannerId: "pl-rosa",
+      costUsd: 1,
+    });
+    expect(res.status).toBe(403); // the $1 the client sent must not be trusted
+  });
+
+  it("lets a Director commit the same expedite", async () => {
+    const res = await call("shp-4821", {
+      kind: "expedite",
+      rationale: "Customer commit.",
+      plannerId: "pl-ibrahim",
+    });
+    expect(res.status).toBe(200);
+    expect(store.findShipment("shp-4821")?.appliedMitigation?.costUsd).toBe(
+      8400,
+    );
+  });
+
+  it("allows the expedite once a justifying escalation is approved", async () => {
+    const draft = store.openEscalation(
+      "shp-4821",
+      "LINE_DOWN_RISK",
+      "LA DC stops Thursday.",
+    );
+    store.approveEscalation(draft.id);
+    const res = await call("shp-4821", {
+      kind: "expedite",
+      rationale: "Escalation approved.",
+      plannerId: "pl-rosa",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("still blocks after a NON-justifying escalation is approved", async () => {
+    const draft = store.openEscalation(
+      "shp-4821",
+      "INTERNAL_CONVENIENCE",
+      "Easier for the team.",
+    );
+    store.approveEscalation(draft.id);
+    const res = await call("shp-4821", {
+      kind: "expedite",
+      rationale: "x",
+      plannerId: "pl-rosa",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("404s an unknown shipment and 422s an unavailable option kind", async () => {
+    expect(
+      (
+        await call("nope", {
+          kind: "absorb",
+          rationale: "x",
+          plannerId: "pl-rosa",
+        })
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await call("shp-4821", {
+          kind: "banana",
+          rationale: "x",
+          plannerId: "pl-rosa",
+        })
+      ).status,
+    ).toBe(422);
+  });
+
+  it("400s a missing plannerId", async () => {
+    expect(
+      (await call("shp-4821", { kind: "absorb", rationale: "x" })).status,
+    ).toBe(400);
+  });
+
+  it("files a decision record on every successful commit", async () => {
+    await call("shp-4821", {
+      kind: "absorb",
+      rationale: "Cover holds.",
+      plannerId: "pl-rosa",
+    });
+    expect(store.decisions()[0]).toMatchObject({
+      shipmentId: "shp-4821",
+      kind: "absorb",
+      status: "committed",
+    });
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/mitigate/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/mitigate/route.ts
@@ -1,0 +1,82 @@
+import * as store from "@/skins/logistics/data/store";
+import { findOption } from "@/skins/logistics/data/mitigation-options";
+import { checkAuthority } from "@/skins/logistics/data/authority";
+
+/**
+ * The gated write. Cost is ALWAYS recomputed here from lane + shipment; any
+ * `costUsd` in the request body is ignored. Trusting a client figure would let
+ * a caller send `{ costUsd: 1 }` and walk straight through the authority gate.
+ */
+export const POST = async (
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const shipment = store.findShipment(id);
+  if (!shipment) {
+    return Response.json(
+      { error: "NOT_FOUND", message: "Shipment not found." },
+      { status: 404 },
+    );
+  }
+
+  const body = await req.json();
+  const { kind, rationale, plannerId } = body;
+  if (!plannerId) {
+    return Response.json(
+      { error: "BAD_REQUEST", message: "plannerId is required." },
+      { status: 400 },
+    );
+  }
+  const planner = store.findPlanner(plannerId);
+  if (!planner) {
+    return Response.json(
+      { error: "BAD_REQUEST", message: "Unknown planner." },
+      { status: 400 },
+    );
+  }
+
+  const option = findOption(shipment, store.lanes(), kind);
+  if (!option) {
+    return Response.json(
+      {
+        error: "UNAVAILABLE_OPTION",
+        message: `"${kind}" is not an available mitigation for this shipment.`,
+      },
+      { status: 422 },
+    );
+  }
+
+  const verdict = checkAuthority({
+    costUsd: option.costUsd,
+    planner,
+    shipment,
+    escalations: store.escalations(),
+  });
+  if (!verdict.allowed) {
+    return Response.json(
+      { error: verdict.code, message: verdict.message },
+      { status: 403 },
+    );
+  }
+
+  const updated = store.updateShipment(id, {
+    appliedMitigation: {
+      kind: option.kind,
+      costUsd: option.costUsd,
+      decidedAt: new Date().toISOString(),
+    },
+    status: option.slaMet ? "resolved" : "at_risk",
+    etaCurrent: option.etaDate,
+  });
+  store.addDecision({
+    shipmentId: id,
+    kind: option.kind,
+    costUsd: option.costUsd,
+    rationale: rationale ?? option.rationale,
+    decidedBy: planner.name,
+    role: planner.role,
+    status: "committed",
+  });
+  return Response.json({ shipment: updated, option });
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/options/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/options/route.ts
@@ -1,0 +1,17 @@
+import * as store from "@/skins/logistics/data/store";
+import { computeMitigationOptions } from "@/skins/logistics/data/mitigation-options";
+
+export const GET = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const shipment = store.findShipment(id);
+  if (!shipment) {
+    return Response.json(
+      { error: "NOT_FOUND", message: "Shipment not found." },
+      { status: 404 },
+    );
+  }
+  return Response.json(computeMitigationOptions(shipment, store.lanes()));
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { PATCH } from "./route";
+import { POST as MITIGATE } from "./mitigate/route";
+import * as store from "@/skins/logistics/data/store";
+
+beforeEach(() => store.reset());
+
+const patch = (id: string, body: unknown) =>
+  PATCH(
+    new Request("http://localhost/x", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+    {
+      params: Promise.resolve({ id }),
+    },
+  );
+
+const mitigate = (id: string, body: unknown) =>
+  MITIGATE(
+    new Request("http://localhost/x", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+    {
+      params: Promise.resolve({ id }),
+    },
+  );
+
+describe("PATCH /shipments/:id", () => {
+  it("patches status", async () => {
+    const res = await patch("shp-4821", { status: "resolved" });
+    expect(res.status).toBe(200);
+    expect(store.findShipment("shp-4821")?.status).toBe("resolved");
+  });
+
+  it("patches etaCurrent", async () => {
+    const res = await patch("shp-4821", { etaCurrent: "2026-08-09" });
+    expect(res.status).toBe(200);
+    expect(store.findShipment("shp-4821")?.etaCurrent).toBe("2026-08-09");
+  });
+
+  it("rejects weightKg with 422 and does not write", async () => {
+    const res = await patch("shp-4821", { weightKg: 1 });
+    expect(res.status).toBe(422);
+    expect(store.findShipment("shp-4821")?.weightKg).toBe(1400);
+  });
+
+  it("rejects laneId with 422 and does not write", async () => {
+    const res = await patch("shp-4821", { laneId: "ln-sha-lax-air" });
+    expect(res.status).toBe(422);
+    expect(store.findShipment("shp-4821")?.laneId).toBe("ln-sha-lax-ocean");
+  });
+
+  it("rejects a present-but-null gated field (presence-based)", async () => {
+    const res = await patch("shp-4821", { appliedMitigation: null });
+    expect(res.status).toBe(422);
+  });
+
+  it("cannot lower expedite cost under the authority limit by patching weightKg", async () => {
+    const patched = await patch("shp-4821", { weightKg: 1 });
+    expect(patched.status).toBe(422);
+
+    const res = await mitigate("shp-4821", {
+      kind: "expedite",
+      plannerId: "pl-rosa",
+    });
+    expect(res.status).toBe(403);
+    expect(store.findShipment("shp-4821")?.appliedMitigation).toBeUndefined();
+  });
+
+  it("404s an unknown shipment", async () => {
+    const res = await patch("nope", { status: "resolved" });
+    expect(res.status).toBe(404);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/route.ts
@@ -1,0 +1,52 @@
+import * as store from "@/skins/logistics/data/store";
+import type { Shipment } from "@/skins/logistics/data/types";
+
+export const GET = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const shipment = store.findShipment(id);
+  if (!shipment) {
+    return Response.json(
+      { error: "NOT_FOUND", message: "Shipment not found." },
+      { status: 404 },
+    );
+  }
+  return Response.json(shipment);
+};
+
+/**
+ * Status / ETA patch only.
+ *
+ * `appliedMitigation` and `activeEscalationId` are writable ONLY through the
+ * gated endpoints (mitigate / escalations-approve). Without this guard a
+ * caller could PATCH them directly and route straight around the authority
+ * check, making the whole gate theater.
+ */
+const GATED_FIELDS = ["appliedMitigation", "activeEscalationId"] as const;
+
+export const PATCH = async (
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  if (!store.findShipment(id)) {
+    return Response.json(
+      { error: "NOT_FOUND", message: "Shipment not found." },
+      { status: 404 },
+    );
+  }
+  const body = (await req.json()) as Partial<Shipment>;
+  const attempted = GATED_FIELDS.filter((f) => f in body);
+  if (attempted.length) {
+    return Response.json(
+      {
+        error: "FORBIDDEN_FIELD",
+        message: `${attempted.join(", ")} can only be set through the mitigate or escalation endpoints.`,
+      },
+      { status: 422 },
+    );
+  }
+  return Response.json(store.updateShipment(id, body));
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/[id]/route.ts
@@ -19,12 +19,15 @@ export const GET = async (
 /**
  * Status / ETA patch only.
  *
- * `appliedMitigation` and `activeEscalationId` are writable ONLY through the
- * gated endpoints (mitigate / escalations-approve). Without this guard a
- * caller could PATCH them directly and route straight around the authority
- * check, making the whole gate theater.
+ * This is an ALLOW-list, not a deny-list, and that is deliberate. The mitigate
+ * endpoint recomputes cost from the shipment's own fields, so ANY writable
+ * field that feeds pricing (`weightKg`, `laneId`, …) is a side channel around
+ * the authority gate: patch the input, and the server honestly computes a
+ * small cost that clears the limit. Only fields listed here may be written;
+ * `appliedMitigation` and `activeEscalationId` remain writable solely through
+ * the gated mitigate / escalation-approve endpoints.
  */
-const GATED_FIELDS = ["appliedMitigation", "activeEscalationId"] as const;
+const PATCHABLE_FIELDS = ["status", "etaCurrent"] as const;
 
 export const PATCH = async (
   req: Request,
@@ -37,16 +40,18 @@ export const PATCH = async (
       { status: 404 },
     );
   }
-  const body = (await req.json()) as Partial<Shipment>;
-  const attempted = GATED_FIELDS.filter((f) => f in body);
-  if (attempted.length) {
+  const body = (await req.json()) as Record<string, unknown>;
+  const illegal = Object.keys(body).filter(
+    (k) => !(PATCHABLE_FIELDS as readonly string[]).includes(k),
+  );
+  if (illegal.length) {
     return Response.json(
       {
         error: "FORBIDDEN_FIELD",
-        message: `${attempted.join(", ")} can only be set through the mitigate or escalation endpoints.`,
+        message: `${illegal.join(", ")} cannot be patched. Only ${PATCHABLE_FIELDS.join(", ")} are writable here; mitigations and escalations go through their own endpoints.`,
       },
       { status: 422 },
     );
   }
-  return Response.json(store.updateShipment(id, body));
+  return Response.json(store.updateShipment(id, body as Partial<Shipment>));
 };

--- a/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/logistics/v1/shipments/route.ts
@@ -1,0 +1,3 @@
+import * as store from "@/skins/logistics/data/store";
+
+export const GET = async () => Response.json(store.shipments());

--- a/examples/showcases/reskinnable-demo/src/shell/agent-registry.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/agent-registry.ts
@@ -2,6 +2,8 @@ import type { BuiltInAgent } from "@copilotkit/runtime/v2";
 import { bankingAgent } from "@/skins/banking/agent";
 import { airlineAgent } from "@/skins/airline/agent";
 import { bankingIdentifyUser } from "@/skins/banking/intelligence/user-id";
+import { logisticsAgent } from "@/skins/logistics/agent";
+import { logisticsIdentifyUser } from "@/skins/logistics/intelligence/user-id";
 
 /**
  * Server-safe map of skin id → its server-side registration (agent factory +
@@ -39,6 +41,9 @@ export const agentRegistry: Record<string, AgentRegistration> = {
   banking: { createAgent: bankingAgent, identifyUser: bankingIdentifyUser },
   // Airline has no auth and no memory, so it contributes no identity resolver.
   airline: { createAgent: airlineAgent },
+  // Logistics scopes Intelligence per planner (authority + durable memory), so
+  // it contributes its own resolver.
+  logistics: { createAgent: logisticsAgent, identifyUser: logisticsIdentifyUser },
 };
 
 export const agentIds = Object.keys(agentRegistry);

--- a/examples/showcases/reskinnable-demo/src/shell/registry.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/registry.ts
@@ -1,6 +1,7 @@
 import type { Skin } from "./skin-contract";
 import banking from "@/skins/banking/skin";
 import airline from "@/skins/airline/skin";
+import logistics from "@/skins/logistics/skin";
 
 export { defaultSkinId } from "./skins-config";
 
@@ -9,6 +10,7 @@ export { defaultSkinId } from "./skins-config";
 export const SkinRegistry: Record<string, Skin> = {
   [banking.id]: banking,
   [airline.id]: airline,
+  [logistics.id]: logistics,
 };
 
 export function getSkin(id: string | undefined): Skin | null {

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/actions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/actions.ts
@@ -167,8 +167,9 @@ export function useLogistics() {
           body: JSON.stringify({
             ...input,
             status: input.status ?? "committed",
-            decidedBy: currentPlanner.name,
-            role: currentPlanner.role,
+            // decidedBy/role are derived server-side from the planner; the
+            // client only forwards which planner is acting.
+            plannerId: currentPlanner.id,
           }),
         });
         notifyDataChanged();
@@ -180,7 +181,7 @@ export function useLogistics() {
         return { ok: false as const, error: "Network error." };
       }
     },
-    [currentPlanner.name, currentPlanner.role],
+    [currentPlanner.id],
   );
 
   return {

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/actions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/actions.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { usePlannerAuth } from "./components/planner-auth-context";
+import type {
+  Decision,
+  Escalation,
+  InventoryRisk,
+  Lane,
+  MitigationKind,
+  MitigationOption,
+  Shipment,
+} from "./data/types";
+
+/**
+ * Cross-instance revalidation bus. Every live `useLogistics()` registers a
+ * refetch callback; any mutation calls `notifyDataChanged()` so all instances
+ * re-pull. Without this, the agent committing a mitigation in chat would leave
+ * the control-tower board showing the shipment as still delayed.
+ */
+const listeners = new Set<() => void>();
+function notifyDataChanged() {
+  for (const listener of listeners) listener();
+}
+
+const BASE = "/api/logistics/v1";
+
+async function getJson<T>(path: string, fallback: T): Promise<T> {
+  try {
+    const res = await fetch(`${BASE}${path}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as T;
+  } catch (error) {
+    console.error(`[logistics] GET ${path} failed:`, error);
+    return fallback;
+  }
+}
+
+export function useLogistics() {
+  const { currentPlanner } = usePlannerAuth();
+  const [shipments, setShipments] = useState<Shipment[]>([]);
+  const [lanes, setLanes] = useState<Lane[]>([]);
+  const [inventory, setInventory] = useState<InventoryRisk[]>([]);
+  const [decisions, setDecisions] = useState<Decision[]>([]);
+
+  const refresh = useCallback(() => {
+    void getJson<Shipment[]>("/shipments", []).then(setShipments);
+    void getJson<Lane[]>("/lanes", []).then(setLanes);
+    void getJson<InventoryRisk[]>("/inventory", []).then(setInventory);
+    void getJson<Decision[]>("/decisions", []).then(setDecisions);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    listeners.add(refresh);
+    return () => {
+      listeners.delete(refresh);
+    };
+  }, [refresh]);
+
+  const fetchOptions = useCallback(
+    (shipmentId: string) =>
+      getJson<MitigationOption[]>(`/shipments/${shipmentId}/options`, []),
+    [],
+  );
+
+  /**
+   * Commit a mitigation. Sends NO cost — the server recomputes it. Always
+   * refreshes, success or failure, so the UI shows real state rather than an
+   * optimistic guess, and surfaces the server's message on a 403 so the agent
+   * can learn the block instead of reporting a false success.
+   */
+  const commitMitigation = useCallback(
+    async ({
+      shipmentId,
+      kind,
+      rationale,
+    }: {
+      shipmentId: string;
+      kind: MitigationKind;
+      rationale: string;
+    }) => {
+      try {
+        const res = await fetch(`${BASE}/shipments/${shipmentId}/mitigate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            kind,
+            rationale,
+            plannerId: currentPlanner.id,
+          }),
+        });
+        const body = await res.json().catch(() => null);
+        notifyDataChanged();
+        if (!res.ok)
+          return {
+            ok: false as const,
+            error: body?.message ?? "Could not commit the mitigation.",
+          };
+        return { ok: true as const, option: body?.option as MitigationOption };
+      } catch (error) {
+        console.error("[logistics] commitMitigation failed:", error);
+        return { ok: false as const, error: "Network error." };
+      }
+    },
+    [currentPlanner.id],
+  );
+
+  /** Open a draft escalation and approve it (the demo has no review step). */
+  const fileEscalation = useCallback(
+    async ({
+      shipmentId,
+      code,
+      rationale,
+    }: {
+      shipmentId: string;
+      code: string;
+      rationale: string;
+    }) => {
+      try {
+        const openRes = await fetch(`${BASE}/escalations`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ shipmentId, code, rationale }),
+        });
+        const draft = await openRes.json().catch(() => null);
+        if (!openRes.ok) {
+          notifyDataChanged();
+          return {
+            ok: false as const,
+            error: draft?.message ?? "Could not open the escalation.",
+          };
+        }
+        const approveRes = await fetch(
+          `${BASE}/escalations/${draft.id}/approve`,
+          { method: "POST" },
+        );
+        const approved = await approveRes.json().catch(() => null);
+        notifyDataChanged();
+        if (!approveRes.ok) {
+          return {
+            ok: false as const,
+            error: approved?.message ?? "Could not approve the escalation.",
+          };
+        }
+        return { ok: true as const, escalation: approved as Escalation };
+      } catch (error) {
+        console.error("[logistics] fileEscalation failed:", error);
+        return { ok: false as const, error: "Network error." };
+      }
+    },
+    [],
+  );
+
+  const fileDecision = useCallback(
+    async (input: {
+      shipmentId: string;
+      kind: MitigationKind | "escalation";
+      costUsd: number;
+      rationale: string;
+      status?: "committed" | "escalated";
+    }) => {
+      try {
+        const res = await fetch(`${BASE}/decisions`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...input,
+            status: input.status ?? "committed",
+            decidedBy: currentPlanner.name,
+            role: currentPlanner.role,
+          }),
+        });
+        notifyDataChanged();
+        if (!res.ok)
+          return { ok: false as const, error: "Could not file the decision." };
+        return { ok: true as const };
+      } catch (error) {
+        console.error("[logistics] fileDecision failed:", error);
+        return { ok: false as const, error: "Network error." };
+      }
+    },
+    [currentPlanner.name, currentPlanner.role],
+  );
+
+  return {
+    shipments,
+    lanes,
+    inventory,
+    decisions,
+    refresh,
+    fetchOptions,
+    commitMitigation,
+    fileEscalation,
+    fileDecision,
+  };
+}
+
+export default useLogistics;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/agent.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/agent.ts
@@ -1,8 +1,36 @@
-import { BuiltInAgent } from "@copilotkit/runtime/v2";
+import { BuiltInAgent, defineTool } from "@copilotkit/runtime/v2";
+import {
+  renderBriefParams,
+  buildBriefOps,
+  A2UI_OPERATIONS_KEY,
+} from "./build-brief-ops";
 
 // SERVER-SAFE. No "use client", no JSX, no React. Imported only by the server
 // agent registry (src/shell/agent-registry.ts), never by the client skin
 // module. Keyed by the same id as the skin: "logistics".
+//
+// `build-brief-ops` (and the `catalog/definitions` it re-exports CATALOG_ID
+// from) are plain Zod + string constants — no React, no .tsx — so importing
+// them here keeps this module server-safe.
+
+/**
+ * Backend tool: render the decision brief on the CANVAS. Mirrors banking's
+ * render_report — the agent supplies only selections + label-only text, and
+ * this handler deterministically expands them into A2UI operations wrapped in
+ * `a2ui_operations`. The A2UI middleware only converts that payload into an
+ * `a2ui-surface` activity when it observes it in an in-stream TOOL_CALL_RESULT
+ * event, so the emission MUST run server-side (a client frontend-tool result
+ * never produces one). Named exactly "renderBrief" — the prompt below and the
+ * skin's toolLabels both reference that name.
+ */
+const renderBriefTool = defineTool({
+  name: "renderBrief",
+  description:
+    "Build a decision brief on the canvas. Pick which KPIs, charts, and tables to show; the figures bind to " +
+    "live data on the client, so supply selections and LABEL-ONLY text — never numbers.",
+  parameters: renderBriefParams,
+  execute: async (spec) => ({ [A2UI_OPERATIONS_KEY]: buildBriefOps(spec) }),
+});
 
 const LOGISTICS_PROMPT = `
 You are **Meridian Control**, the decision-support agent in a freight control
@@ -40,6 +68,10 @@ You cover three behaviors — treat them as gated:
      because every number on the brief binds to live data.
    - After it renders, tell the planner it is on the canvas and give ONE line of
      takeaway. Do not restate the brief in chat.
+   - Call "createDecisionRecord" to log a decision you did NOT execute through
+     "commitMitigation" — a recommendation the planner accepted verbally, or an
+     escalation outcome — so it lands in the Decision Log. Keep the rationale to
+     one sentence.
 
 RULES
 - Read the live context rather than guessing. The planner, their authority, the
@@ -57,4 +89,5 @@ export const logisticsAgent = () =>
   new BuiltInAgent({
     model: "openai/gpt-5.4",
     prompt: LOGISTICS_PROMPT,
+    tools: [renderBriefTool],
   });

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/agent.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/agent.ts
@@ -1,0 +1,60 @@
+import { BuiltInAgent } from "@copilotkit/runtime/v2";
+
+// SERVER-SAFE. No "use client", no JSX, no React. Imported only by the server
+// agent registry (src/shell/agent-registry.ts), never by the client skin
+// module. Keyed by the same id as the skin: "logistics".
+
+const LOGISTICS_PROMPT = `
+You are **Meridian Control**, the decision-support agent in a freight control
+tower. You work with ONE supply-chain planner at a time. Speak like a senior
+planner: terse, numerate, decisive. Never breezy, never salesy.
+
+You cover three behaviors — treat them as gated:
+
+1. TRIAGE
+   - Lead with the "showExceptions" component when asked what needs attention.
+   - Use "showShipment" for one shipment, "showLane" for network health, and
+     "showInventoryRisk" for cover shortfalls.
+   - Every figure you state must come from the live context you are given. If
+     the context is empty, say you are pulling it up — never invent a number.
+
+2. DECIDE
+   - ALWAYS call "compareMitigations" before you recommend anything. Present the
+     trade-off, then make ONE recommendation with a one-line reason.
+   - To act, call the "commitMitigation" human-in-the-loop tool. The planner
+     confirms in the UI. Do NOT assume a mitigation is applied until the tool
+     returns confirmation.
+   - The server recomputes cost and may REJECT a commit as over the planner's
+     approval authority. When a tool result starts with "REJECTED:", relay the
+     block plainly — do not retry the same commit and do not claim success.
+     Offer to file an escalation instead.
+   - To escalate, call "fileEscalation" with a code from the escalation-code
+     catalogue in your context. Not every code authorizes the spend; if an
+     escalation is approved and the mitigation still fails, say so and suggest
+     asking a Director rather than guessing another code.
+
+3. BRIEF
+   - Call "renderBrief" for a written decision brief; it renders on the canvas.
+     Choose which KPIs, charts, and tables to include. Supply LABEL-ONLY text —
+     no figures, amounts, percentages, or trend claims in the title or summary,
+     because every number on the brief binds to live data.
+   - After it renders, tell the planner it is on the canvas and give ONE line of
+     takeaway. Do not restate the brief in chat.
+
+RULES
+- Read the live context rather than guessing. The planner, their authority, the
+  shipments, lanes, inventory, KPIs, and valid escalation codes are all provided.
+- Confirm before anything that writes. Those go through the human-in-the-loop
+  tools above.
+- Keep replies short. Render the relevant component instead of describing it,
+  then add one sentence of guidance.
+- Never emit a markdown table — render the relevant component instead.
+- Stay in the supply-chain domain. If asked something unrelated, redirect to the
+  tower, a shipment, or the brief.
+`.trim();
+
+export const logisticsAgent = () =>
+  new BuiltInAgent({
+    model: "openai/gpt-5.4",
+    prompt: LOGISTICS_PROMPT,
+  });

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/brief-data.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/brief-data.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type { Lane, Shipment } from "./data/types";
+
+/**
+ * Binds live ledger data into the a2ui catalog renderers. Data never travels
+ * inside the A2UI operations — the agent selects WHAT to show and the
+ * renderers read the real figures from here, so no number on the canvas is
+ * ever model-authored.
+ */
+type BriefData = { shipments: Shipment[]; lanes: Lane[] };
+
+const BriefDataContext = createContext<BriefData>({ shipments: [], lanes: [] });
+
+export const useBriefData = (): BriefData => useContext(BriefDataContext);
+
+export function BriefDataProvider({
+  value,
+  children,
+}: {
+  value: BriefData;
+  children: ReactNode;
+}) {
+  return (
+    <BriefDataContext.Provider value={value}>
+      {children}
+    </BriefDataContext.Provider>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/build-brief-ops.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/build-brief-ops.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildBriefOps,
+  extractSurfaceId,
+  SURFACE_ID,
+  renderBriefParams,
+} from "./build-brief-ops";
+import type { A2UIOp } from "./build-brief-ops";
+
+type Comp = Record<string, unknown>;
+
+function componentsOf(ops: A2UIOp[]): Comp[] {
+  const uc = ops.find((op) => "updateComponents" in op) as
+    | { updateComponents: { components: Comp[] } }
+    | undefined;
+  return uc?.updateComponents.components ?? [];
+}
+
+function byId(comps: Comp[], id: string): Comp | undefined {
+  return comps.find((c) => c.id === id);
+}
+
+describe("buildBriefOps", () => {
+  it("emits createSurface then updateComponents with a root Stack", () => {
+    const ops = buildBriefOps({
+      title: "Weekly Exceptions",
+      kpis: [],
+      charts: [],
+    });
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: SURFACE_ID },
+    });
+    const components = componentsOf(ops);
+    expect(components[0]).toMatchObject({ id: "root", component: "Stack" });
+    expect(byId(components, "heading")).toMatchObject({
+      component: "Heading",
+      text: "Weekly Exceptions",
+    });
+  });
+
+  it("expands each selected KPI into a StatCard inside a grid", () => {
+    const ops = buildBriefOps({
+      title: "T",
+      kpis: ["onTimeRate", "exposureUsd"],
+      charts: [],
+    });
+    const components = componentsOf(ops);
+    expect(byId(components, "kpi-onTimeRate")).toMatchObject({
+      component: "StatCard",
+      metric: "onTimeRate",
+      label: "On-time rate",
+    });
+    expect(byId(components, "kpi-grid")).toMatchObject({
+      component: "Grid",
+      columns: 2,
+      children: ["kpi-onTimeRate", "kpi-exposureUsd"],
+    });
+  });
+
+  it("carries NO data in the ops — only selections and labels", () => {
+    const ops = buildBriefOps({
+      title: "T",
+      kpis: ["exposureUsd"],
+      charts: ["delayTrend"],
+      exceptions: "delayed",
+    });
+    const json = JSON.stringify(ops);
+    expect(json).not.toMatch(/\d{3,}/); // no raw figures leaked into the ops
+  });
+
+  it("includes the exception table and the tradeoff table only when requested", () => {
+    const bare = componentsOf(
+      buildBriefOps({ title: "T", kpis: [], charts: [] }),
+    );
+    expect(bare.find((c) => c.component === "ExceptionTable")).toBeUndefined();
+
+    const full = componentsOf(
+      buildBriefOps({
+        title: "T",
+        kpis: [],
+        charts: [],
+        exceptions: "at_risk",
+        tradeoffShipmentId: "shp-4821",
+      }),
+    );
+    expect(full.find((c) => c.component === "ExceptionTable")).toMatchObject({
+      status: "at_risk",
+    });
+    expect(full.find((c) => c.component === "TradeoffTable")).toMatchObject({
+      shipmentId: "shp-4821",
+    });
+  });
+
+  it("adds an optional muted summary caption", () => {
+    const components = componentsOf(
+      buildBriefOps({
+        title: "T",
+        kpis: [],
+        charts: [],
+        summary: "Trans-Pacific focus",
+      }),
+    );
+    expect(byId(components, "summary")).toMatchObject({
+      component: "Text",
+      tone: "muted",
+    });
+  });
+
+  it("extracts the surface id from any op kind", () => {
+    expect(
+      extractSurfaceId(buildBriefOps({ title: "T", kpis: [], charts: [] })),
+    ).toBe(SURFACE_ID);
+    expect(extractSurfaceId([])).toBeNull();
+  });
+
+  it("rejects an uncatalogued metric at the schema boundary", () => {
+    expect(
+      renderBriefParams.safeParse({ title: "T", kpis: ["madeUp"], charts: [] })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/build-brief-ops.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/build-brief-ops.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+import { CATALOG_ID } from "./catalog/definitions";
+
+/** Must match the A2UI middleware's key so tryParseA2UIOperations detects it. */
+export const A2UI_OPERATIONS_KEY = "a2ui_operations";
+
+export const SURFACE_ID = "decision-brief";
+
+export const BRIEF_METRICS = [
+  "onTimeRate",
+  "atRiskCount",
+  "exposureUsd",
+  "avgDelayDays",
+] as const;
+export type BriefMetric = (typeof BRIEF_METRICS)[number];
+
+export const BRIEF_CHARTS = [
+  "lanePerformance",
+  "exposureByLane",
+  "delayTrend",
+  "modeSplit",
+] as const;
+export type BriefChart = (typeof BRIEF_CHARTS)[number];
+
+export const BRIEF_TABLE_STATUSES = [
+  "all",
+  "at_risk",
+  "delayed",
+  "on_track",
+] as const;
+export type BriefTableStatus = (typeof BRIEF_TABLE_STATUSES)[number];
+
+/** Human captions per KPI — assigned here so the agent needn't supply them. */
+const METRIC_LABELS: Record<BriefMetric, string> = {
+  onTimeRate: "On-time rate",
+  atRiskCount: "Shipments at risk",
+  exposureUsd: "Value exposed",
+  avgDelayDays: "Average delay",
+};
+
+export const renderBriefParams = z.object({
+  title: z
+    .string()
+    .describe(
+      "Short brief title, e.g. 'Trans-Pacific Exceptions'. LABEL ONLY — no figures, amounts, counts, or trend claims.",
+    ),
+  kpis: z
+    .array(z.enum(BRIEF_METRICS))
+    .describe("Which KPI stat cards to show, in order."),
+  charts: z
+    .array(z.enum(BRIEF_CHARTS))
+    .describe("Which charts to show, in order."),
+  exceptions: z
+    .enum(BRIEF_TABLE_STATUSES)
+    .optional()
+    .describe(
+      "Include a live shipment table filtered by status. Omit to leave it out.",
+    ),
+  tradeoffShipmentId: z
+    .string()
+    .optional()
+    .describe(
+      "Include the live mitigation trade-off table for this shipment id (e.g. 'shp-4821'). Omit to leave it out.",
+    ),
+  summary: z
+    .string()
+    .optional()
+    .describe(
+      "Optional one-line NEUTRAL caption under the title. Label-only — no figures, amounts, or trends.",
+    ),
+});
+export type RenderBriefSpec = z.infer<typeof renderBriefParams>;
+
+export type A2UIOp = Record<string, unknown> & { version?: string };
+type Component = { id: string; component: string } & Record<string, unknown>;
+
+/**
+ * Expand a brief selection into A2UI v0.9 operations (createSurface +
+ * updateComponents, flat components under root id "root").
+ *
+ * Data is NOT carried in the ops: StatCard/Chart/ExceptionTable/TradeoffTable
+ * bind live client data through useBriefData(). The agent supplies only
+ * selections and label-only text.
+ */
+export function buildBriefOps(
+  spec: RenderBriefSpec,
+  surfaceId: string = SURFACE_ID,
+): A2UIOp[] {
+  const components: Component[] = [];
+  const rootChildren: string[] = [];
+
+  components.push({ id: "heading", component: "Heading", text: spec.title });
+  rootChildren.push("heading");
+
+  if (spec.summary) {
+    components.push({
+      id: "summary",
+      component: "Text",
+      text: spec.summary,
+      tone: "muted",
+    });
+    rootChildren.push("summary");
+  }
+
+  if (spec.kpis.length) {
+    const kpiIds = spec.kpis.map((metric) => {
+      const id = `kpi-${metric}`;
+      components.push({
+        id,
+        component: "StatCard",
+        metric,
+        label: METRIC_LABELS[metric],
+      });
+      return id;
+    });
+    components.push({
+      id: "kpi-grid",
+      component: "Grid",
+      columns: Math.min(spec.kpis.length, 4),
+      children: kpiIds,
+    });
+    rootChildren.push("kpi-grid");
+  }
+
+  if (spec.charts.length) {
+    const chartIds = spec.charts.map((kind) => {
+      const id = `chart-${kind}`;
+      components.push({ id, component: "Chart", kind });
+      return id;
+    });
+    components.push({
+      id: "chart-grid",
+      component: "Grid",
+      columns: spec.charts.length >= 2 ? 2 : 1,
+      children: chartIds,
+    });
+    rootChildren.push("chart-grid");
+  }
+
+  if (spec.tradeoffShipmentId) {
+    components.push({
+      id: "tradeoffs",
+      component: "TradeoffTable",
+      shipmentId: spec.tradeoffShipmentId,
+    });
+    rootChildren.push("tradeoffs");
+  }
+
+  if (spec.exceptions) {
+    components.push({
+      id: "exceptions",
+      component: "ExceptionTable",
+      status: spec.exceptions,
+    });
+    rootChildren.push("exceptions");
+  }
+
+  components.unshift({
+    id: "root",
+    component: "Stack",
+    gap: "lg",
+    children: rootChildren,
+  });
+
+  return [
+    { version: "v0.9", createSurface: { surfaceId, catalogId: CATALOG_ID } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
+  ];
+}
+
+/** Read the surfaceId out of an A2UI operation list (any op kind). */
+export function extractSurfaceId(ops: A2UIOp[]): string | null {
+  for (const op of ops) {
+    const target = (op.createSurface ??
+      op.updateComponents ??
+      op.updateDataModel) as { surfaceId?: string } | undefined;
+    if (target?.surfaceId) return target.surfaceId;
+  }
+  return null;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/canvas-surface.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/canvas-surface.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  A2UIProvider,
+  A2UIRenderer,
+  useA2UIActions,
+} from "@copilotkit/a2ui-renderer";
+import { useAgent } from "@copilotkit/react-core/v2";
+import { useLogistics } from "./actions";
+import { catalog } from "./catalog";
+import { BriefDataProvider } from "./brief-data";
+import {
+  A2UI_OPERATIONS_KEY,
+  extractSurfaceId,
+  type A2UIOp,
+} from "./build-brief-ops";
+
+/**
+ * The Meridian decision-brief canvas — `skin.CanvasSurface`. The shell owns the
+ * canvas region, OGUI rendering and surface-kind detection; this renders only
+ * this skin's OWN a2ui surface, binding live ledger data into the catalog
+ * renderers.
+ */
+type MaybeActivityMessage = {
+  role?: string;
+  activityType?: string;
+  content?: Record<string, unknown>;
+};
+
+function useBriefSurface(): { operations: A2UIOp[]; surfaceId: string | null } {
+  const { agent } = useAgent();
+  const messages = agent?.messages as MaybeActivityMessage[] | undefined;
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (
+        message?.role === "activity" &&
+        message?.activityType === "a2ui-surface"
+      ) {
+        const operations =
+          (message.content?.[A2UI_OPERATIONS_KEY] as A2UIOp[]) ?? [];
+        return {
+          operations,
+          surfaceId: operations.length ? extractSurfaceId(operations) : null,
+        };
+      }
+    }
+  }
+  return { operations: [], surfaceId: null };
+}
+
+export function LogisticsCanvasSurface() {
+  const { shipments, lanes } = useLogistics();
+  return (
+    <BriefDataProvider value={{ shipments, lanes }}>
+      <A2UIProvider catalog={catalog}>
+        <CanvasInner />
+      </A2UIProvider>
+    </BriefDataProvider>
+  );
+}
+
+function CanvasInner() {
+  const { operations, surfaceId } = useBriefSurface();
+  const hasContent = operations.length > 0 && !!surfaceId;
+  return (
+    <>
+      {surfaceId ? (
+        <SurfaceMessageProcessor
+          operations={operations}
+          surfaceId={surfaceId}
+        />
+      ) : null}
+      {hasContent ? (
+        <div className="h-full overflow-y-auto">
+          <div className="a2ui-surface p-6 md:p-8" data-testid="a2ui-surface">
+            <A2UIRenderer surfaceId={surfaceId} />
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Feeds operations into the A2UI provider. The activity content carries the
+ * FULL operation list on each snapshot, so strip a duplicate createSurface once
+ * the surface exists (the MessageProcessor throws on it) and skip re-processing
+ * identical op lists.
+ */
+function SurfaceMessageProcessor({
+  operations,
+  surfaceId,
+}: {
+  operations: A2UIOp[];
+  surfaceId: string;
+}) {
+  const { processMessages, getSurface } = useA2UIActions();
+  const lastHashRef = useRef("");
+
+  useEffect(() => {
+    if (!operations.length) return;
+    const hash = JSON.stringify(operations);
+    if (hash === lastHashRef.current) return;
+    lastHashRef.current = hash;
+
+    const isExisting = !!getSurface(surfaceId);
+    const ops = isExisting
+      ? operations.filter((op) => !("createSurface" in op))
+      : operations;
+    if (!ops.length) return;
+    try {
+      processMessages(ops as Array<Record<string, unknown>>);
+    } catch (err) {
+      console.warn("[logistics-canvas] processMessages threw:", err);
+    }
+  }, [operations, processMessages, getSurface, surfaceId]);
+
+  return null;
+}
+
+export default LogisticsCanvasSurface;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/catalog/definitions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/catalog/definitions.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+export const CATALOG_ID = "https://cpk-a2ui.local/catalogs/logistics/v1";
+
+const childRef = z.string();
+const childrenRef = z.array(z.string());
+const stringOrPath = z.union([z.string(), z.object({ path: z.string() })]);
+
+export const definitions = {
+  Stack: {
+    description:
+      "Vertical layout. Children stack top→bottom. The default section container.",
+    props: z.object({
+      children: childrenRef,
+      gap: z.enum(["sm", "md", "lg", "xl"]).optional(),
+    }),
+  },
+  Row: {
+    description:
+      "Horizontal layout; wraps on small screens. Use for metric rows or chip groups.",
+    props: z.object({
+      children: childrenRef,
+      gap: z.enum(["sm", "md", "lg"]).optional(),
+    }),
+  },
+  Grid: {
+    description:
+      "Responsive grid. Use for a row of StatCards or a pair of charts.",
+    props: z.object({
+      children: childrenRef,
+      columns: z.number().int().min(1).max(4).optional(),
+    }),
+  },
+  Section: {
+    description:
+      "Titled section grouping a region of the brief (e.g. 'Network health').",
+    props: z.object({ title: z.string(), child: childRef }),
+  },
+  Heading: {
+    description:
+      "The brief title — a LABEL ONLY. Use once at the top. Do NOT embed figures, " +
+      "amounts, percentages, counts, or trend claims (e.g. NOT 'Exposure up 12%') — " +
+      "all quantitative content comes from StatCard/Chart/ExceptionTable.",
+    props: z.object({ text: stringOrPath }),
+  },
+  Text: {
+    description:
+      "A short NEUTRAL caption or section label (e.g. 'Network health', 'This week'). " +
+      "Label-only: do NOT state figures, amounts, percentages, counts, deltas, or trend " +
+      "claims — every quantitative claim must come from StatCard/Chart/ExceptionTable/" +
+      "TradeoffTable, which bind live client data. Use tone='muted' for secondary captions.",
+    props: z.object({
+      text: stringOrPath,
+      tone: z.enum(["default", "muted"]).optional(),
+    }),
+  },
+  StatCard: {
+    description:
+      "A single KPI computed live on the client. `metric` selects which: 'onTimeRate' " +
+      "(share of shipments arriving by their promised date), 'atRiskCount' (active " +
+      "shipments at risk or delayed), 'exposureUsd' (value of active shipments that miss " +
+      "their promised date), 'avgDelayDays' (mean slip against plan). Provide `label`.",
+    props: z.object({
+      metric: z.enum([
+        "onTimeRate",
+        "atRiskCount",
+        "exposureUsd",
+        "avgDelayDays",
+      ]),
+      label: stringOrPath,
+    }),
+  },
+  Chart: {
+    description:
+      "A live network chart. `kind` selects which: 'lanePerformance' (on-time rate per " +
+      "lane), 'exposureByLane' (at-risk value per lane), 'delayTrend' (slip over time), " +
+      "'modeSplit' (shipment count by transport mode). Data is bound on the client — " +
+      "do NOT pass numbers.",
+    props: z.object({
+      kind: z.enum([
+        "lanePerformance",
+        "exposureByLane",
+        "delayTrend",
+        "modeSplit",
+      ]),
+    }),
+  },
+  ExceptionTable: {
+    description:
+      "A live table of shipments. `status` filters which rows show: 'all', 'at_risk', " +
+      "'delayed', or 'on_track' (defaults to 'all'). Data is bound on the client — " +
+      "do NOT pass rows or figures.",
+    props: z.object({
+      status: z.enum(["all", "at_risk", "delayed", "on_track"]).optional(),
+    }),
+  },
+  TradeoffTable: {
+    description:
+      "The live mitigation trade-off table for ONE shipment: cost, resulting ETA, whether " +
+      "the promised date is met, and risk for each available option. Pass the shipment id " +
+      "(e.g. 'shp-4821'); all figures are computed on the client.",
+    props: z.object({ shipmentId: z.string() }),
+  },
+};
+
+export type Definitions = typeof definitions;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/catalog/index.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/catalog/index.ts
@@ -1,0 +1,12 @@
+import { createCatalog, extractSchema } from "@copilotkit/a2ui-renderer";
+import { CATALOG_ID, definitions } from "./definitions";
+import { renderers } from "./renderers";
+
+export const catalog = createCatalog(definitions, renderers, {
+  catalogId: CATALOG_ID,
+  includeBasicCatalog: false,
+});
+
+export const catalogSchema = extractSchema(definitions);
+
+export { CATALOG_ID, definitions };

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/catalog/renderers.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/catalog/renderers.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import type { RendererProps } from "@copilotkit/a2ui-renderer";
+import { cn } from "@/lib/utils";
+import { useBriefData } from "../brief-data";
+import {
+  deriveKpis,
+  ExceptionBoard,
+  TradeoffTable,
+  LanePerformanceChart,
+  ExposureByLaneChart,
+  DelayTrendChart,
+  ModeSplitChart,
+} from "../components";
+import { computeMitigationOptions } from "../data/mitigation-options";
+
+const GAP = { sm: "gap-2", md: "gap-4", lg: "gap-6", xl: "gap-10" } as const;
+
+// Text props in the catalog are `string | { path }` (a data-bound ref). The
+// A2UI runtime resolves refs before render, but the Zod-inferred type still
+// carries the union, so coerce to a display string here.
+type TextRef = string | { path: string };
+const asText = (value: TextRef): string =>
+  typeof value === "string" ? value : "";
+
+function Slot({ render }: { render: React.ReactNode }) {
+  return <>{render}</>;
+}
+
+const Stack = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; gap?: keyof typeof GAP }>) => (
+  <div className={cn("flex flex-col", GAP[props.gap ?? "md"])}>
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Row = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; gap?: "sm" | "md" | "lg" }>) => (
+  <div className={cn("flex flex-wrap", GAP[props.gap ?? "md"])}>
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Grid = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; columns?: number }>) => (
+  <div
+    className="grid gap-4"
+    style={{
+      gridTemplateColumns: `repeat(${props.columns ?? 3}, minmax(0, 1fr))`,
+    }}
+  >
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Section = ({
+  props,
+  children,
+}: RendererProps<{ title: string; child: string }>) => (
+  <section className="space-y-3">
+    <h2 className="text-lg font-semibold text-ink">{props.title}</h2>
+    <Slot render={children(props.child)} />
+  </section>
+);
+
+const Heading = ({ props }: RendererProps<{ text: TextRef }>) => (
+  <h1 className="text-2xl font-semibold tracking-tight text-ink">
+    {asText(props.text)}
+  </h1>
+);
+
+const Text = ({
+  props,
+}: RendererProps<{ text: TextRef; tone?: "default" | "muted" }>) => (
+  <p
+    className={cn(
+      "text-sm",
+      props.tone === "muted" ? "text-ink-muted" : "text-ink",
+    )}
+  >
+    {asText(props.text)}
+  </p>
+);
+
+const METRIC_FORMAT = {
+  onTimeRate: (k: ReturnType<typeof deriveKpis>) =>
+    `${Math.round(k.onTimeRate * 100)}%`,
+  atRiskCount: (k: ReturnType<typeof deriveKpis>) => String(k.atRiskCount),
+  exposureUsd: (k: ReturnType<typeof deriveKpis>) =>
+    `$${Math.round(k.exposureUsd).toLocaleString("en-US")}`,
+  avgDelayDays: (k: ReturnType<typeof deriveKpis>) => `${k.avgDelayDays}d`,
+} as const;
+
+const StatCard = ({
+  props,
+}: RendererProps<{ metric: keyof typeof METRIC_FORMAT; label: TextRef }>) => {
+  const { shipments } = useBriefData();
+  const kpis = deriveKpis(shipments);
+  return (
+    <div className="rounded-lg border border-hairline bg-surface p-4 shadow-soft">
+      <div className="text-xs font-medium uppercase tracking-wide text-ink-muted">
+        {asText(props.label)}
+      </div>
+      <div className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+        {METRIC_FORMAT[props.metric](kpis)}
+      </div>
+    </div>
+  );
+};
+
+const CHARTS = {
+  lanePerformance: LanePerformanceChart,
+  exposureByLane: ExposureByLaneChart,
+  delayTrend: DelayTrendChart,
+  modeSplit: ModeSplitChart,
+} as const;
+
+const Chart = ({ props }: RendererProps<{ kind: keyof typeof CHARTS }>) => {
+  const { shipments, lanes } = useBriefData();
+  const Component = CHARTS[props.kind];
+  return <Component shipments={shipments} lanes={lanes} />;
+};
+
+const ExceptionTable = ({
+  props,
+}: RendererProps<{ status?: "all" | "at_risk" | "delayed" | "on_track" }>) => {
+  const { shipments, lanes } = useBriefData();
+  const status = props.status ?? "all";
+  const rows =
+    status === "all" ? shipments : shipments.filter((s) => s.status === status);
+  return <ExceptionBoard shipments={rows} lanes={lanes} />;
+};
+
+const TradeoffTableRenderer = ({
+  props,
+}: RendererProps<{ shipmentId: string }>) => {
+  const { shipments, lanes } = useBriefData();
+  const shipment = shipments.find(
+    (s) => s.id === props.shipmentId || s.reference === props.shipmentId,
+  );
+  if (!shipment) {
+    return (
+      <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
+        Shipment not found.
+      </div>
+    );
+  }
+  // authorityUsd is null here: the brief is a read-only artifact, so it shows
+  // every option without gating. The gate applies at commit time, in chat.
+  return (
+    <TradeoffTable
+      options={computeMitigationOptions(shipment, lanes)}
+      authorityUsd={null}
+    />
+  );
+};
+
+export const renderers = {
+  Stack,
+  Row,
+  Grid,
+  Section,
+  Heading,
+  Text,
+  StatCard,
+  Chart,
+  ExceptionTable,
+  TradeoffTable: TradeoffTableRenderer,
+};

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/charts.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/charts.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import type { Lane, Shipment } from "../data/types";
+import { cn } from "@/lib/utils";
+
+const fmtUsd = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+const Empty = ({ children }: { children: string }) => (
+  <p className="text-sm text-ink-muted">{children}</p>
+);
+
+/** A single labelled horizontal bar: label · fill · trailing figure. */
+function Bar({
+  label,
+  figure,
+  pct,
+  soft,
+}: {
+  label: string;
+  figure: string;
+  pct: number;
+  soft?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2 text-sm">
+        <span className="min-w-0 truncate text-ink">{label}</span>
+        <span className="flex-none tabular-nums text-ink-muted">{figure}</span>
+      </div>
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-brand-soft">
+        <div
+          className={cn(
+            "h-full rounded-full",
+            soft ? "bg-brand-soft" : "bg-brand",
+          )}
+          style={{ width: `${Math.max(2, Math.min(100, pct))}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Horizontal bars of on-time reliability per lane, worst reliability last. */
+export function LanePerformanceChart({
+  lanes,
+}: {
+  shipments: Shipment[];
+  lanes: Lane[];
+}) {
+  if (!lanes.length) return <Empty>No lanes to chart.</Empty>;
+  const rows = [...lanes].sort((a, b) => b.reliability - a.reliability);
+  return (
+    <div className="space-y-2.5">
+      {rows.map((l) => (
+        <Bar
+          key={l.id}
+          label={`${l.origin} → ${l.destination}`}
+          figure={`${Math.round(l.reliability * 100)}%`}
+          pct={l.reliability * 100}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Horizontal bars of summed at-risk shipment value, grouped by lane. */
+export function ExposureByLaneChart({
+  shipments,
+  lanes,
+}: {
+  shipments: Shipment[];
+  lanes: Lane[];
+}) {
+  const laneById = new Map(lanes.map((l) => [l.id, l]));
+  const byLane = new Map<string, number>();
+  for (const s of shipments) {
+    if (s.status !== "at_risk" && s.status !== "delayed") continue;
+    byLane.set(s.laneId, (byLane.get(s.laneId) ?? 0) + s.valueUsd);
+  }
+  const rows = [...byLane.entries()]
+    .map(([laneId, value]) => {
+      const lane = laneById.get(laneId);
+      return {
+        laneId,
+        label: lane ? `${lane.origin} → ${lane.destination}` : laneId,
+        value,
+      };
+    })
+    .sort((a, b) => b.value - a.value);
+
+  if (!rows.length) return <Empty>No at-risk exposure to chart.</Empty>;
+  const max = rows[0].value || 1;
+  return (
+    <div className="space-y-2.5">
+      {rows.map((r) => (
+        <Bar
+          key={r.laneId}
+          label={r.label}
+          figure={fmtUsd(r.value)}
+          pct={(r.value / max) * 100}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** A polyline of per-shipment delay (days) ordered by planned ETA. */
+export function DelayTrendChart({
+  shipments,
+}: {
+  shipments: Shipment[];
+  lanes: Lane[];
+}) {
+  const points = [...shipments]
+    .sort((a, b) => a.etaPlanned.localeCompare(b.etaPlanned))
+    .map((s) => {
+      const ms =
+        Date.parse(`${s.etaCurrent}T00:00:00Z`) -
+        Date.parse(`${s.etaPlanned}T00:00:00Z`);
+      return Math.max(0, Math.round(ms / 86_400_000));
+    });
+
+  if (points.length < 2)
+    return <Empty>Not enough shipments to chart a trend.</Empty>;
+
+  const w = 100;
+  const h = 40;
+  const maxDelay = Math.max(1, ...points);
+  const coords = points.map((d, i) => {
+    const x = (i / (points.length - 1)) * w;
+    const y = h - (d / maxDelay) * h;
+    return `${x.toFixed(2)},${y.toFixed(2)}`;
+  });
+
+  return (
+    <div className="space-y-1">
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        preserveAspectRatio="none"
+        className="h-24 w-full text-brand"
+        role="img"
+        aria-label="Delay days per shipment, ordered by planned ETA"
+      >
+        <polyline
+          points={coords.join(" ")}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+      <div className="flex justify-between text-xs text-ink-muted tabular-nums">
+        <span>peak {maxDelay}d</span>
+        <span>{points.length} shipments</span>
+      </div>
+    </div>
+  );
+}
+
+/** A stacked proportional bar of shipment count by lane transport mode. */
+export function ModeSplitChart({
+  shipments,
+  lanes,
+}: {
+  shipments: Shipment[];
+  lanes: Lane[];
+}) {
+  const modeByLane = new Map(lanes.map((l) => [l.id, l.mode]));
+  const counts = new Map<string, number>();
+  for (const s of shipments) {
+    const mode = modeByLane.get(s.laneId);
+    if (!mode) continue;
+    counts.set(mode, (counts.get(mode) ?? 0) + 1);
+  }
+  const rows = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  const total = rows.reduce((sum, [, n]) => sum + n, 0);
+
+  if (!total) return <Empty>No shipments to split by mode.</Empty>;
+
+  return (
+    <div className="space-y-2">
+      <div
+        className="flex h-3 w-full overflow-hidden rounded-full bg-brand-soft"
+        role="img"
+        aria-label="Shipment share by mode"
+      >
+        {rows.map(([mode, n], i) => (
+          <div
+            key={mode}
+            className={cn("h-full", i % 2 === 0 ? "bg-brand" : "bg-brand-soft")}
+            style={{ width: `${(n / total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {rows.map(([mode, n], i) => (
+          <li key={mode} className="flex items-center gap-1.5 text-ink-muted">
+            <span
+              aria-hidden
+              className={cn(
+                "h-2 w-2 flex-none rounded-full",
+                i % 2 === 0 ? "bg-brand" : "bg-brand-soft",
+              )}
+            />
+            <span className="capitalize text-ink">{mode}</span>
+            <span className="tabular-nums">
+              {Math.round((n / total) * 100)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/decision-log.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/decision-log.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { Decision } from "../data/types";
+import { cn } from "@/lib/utils";
+
+const fmtUsd = (n: number) =>
+  n === 0 ? "—" : `$${Math.round(n).toLocaleString("en-US")}`;
+
+const STATUS_TONE: Record<Decision["status"], string> = {
+  committed: "bg-positive-soft text-positive",
+  escalated: "bg-negative-soft text-negative",
+};
+
+export function DecisionLog({ decisions }: { decisions: Decision[] }) {
+  if (!decisions.length) {
+    return <p className="text-sm text-ink-muted">No decisions filed yet.</p>;
+  }
+
+  // Newest first.
+  const rows = [...decisions].sort((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
+
+  return (
+    <ul className="space-y-2">
+      {rows.map((d) => (
+        <li
+          key={d.id}
+          className="rounded-lg border border-hairline bg-surface p-3 shadow-soft"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <span className="rounded-md bg-surface-muted px-1.5 py-0.5 text-xs font-medium capitalize text-ink-muted">
+                {d.kind}
+              </span>
+              <span className="font-medium text-ink">{d.shipmentId}</span>
+              <span className="text-sm tabular-nums text-ink-muted">
+                {fmtUsd(d.costUsd)}
+              </span>
+            </div>
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-xs font-medium capitalize",
+                STATUS_TONE[d.status],
+              )}
+            >
+              {d.status}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-ink">{d.rationale}</p>
+          <div className="mt-1 text-xs text-ink-muted">
+            {d.decidedBy} · {d.role}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/exception-board.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/exception-board.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { Lane, Shipment } from "../data/types";
+import { cn } from "@/lib/utils";
+
+const fmtUsd = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+// Worst-first: delayed outranks at_risk, which outranks everything else.
+const STATUS_RANK: Record<Shipment["status"], number> = {
+  delayed: 0,
+  at_risk: 1,
+  on_track: 2,
+  resolved: 3,
+};
+
+export function ExceptionBoard({
+  shipments,
+  lanes,
+  onSelect,
+}: {
+  shipments: Shipment[];
+  lanes: Lane[];
+  onSelect?: (id: string) => void;
+}) {
+  if (!shipments.length) {
+    return (
+      <p className="text-sm text-ink-muted">No exceptions on the board.</p>
+    );
+  }
+
+  const laneById = new Map(lanes.map((l) => [l.id, l]));
+  const rows = [...shipments].sort(
+    (a, b) =>
+      STATUS_RANK[a.status] - STATUS_RANK[b.status] || b.valueUsd - a.valueUsd,
+  );
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-hairline bg-surface shadow-soft">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-hairline text-left text-xs uppercase tracking-wide text-ink-muted">
+            <th className="px-3 py-2 font-medium">Reference</th>
+            <th className="px-3 py-2 font-medium">Lane</th>
+            <th className="px-3 py-2 font-medium">Carrier</th>
+            <th className="px-3 py-2 font-medium">Exception</th>
+            <th className="px-3 py-2 font-medium">ETA / SLA</th>
+            <th className="px-3 py-2 font-medium">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((s) => {
+            const lane = laneById.get(s.laneId);
+            const missed = s.etaCurrent > s.slaDate;
+            return (
+              <tr
+                key={s.id}
+                onClick={onSelect ? () => onSelect(s.id) : undefined}
+                className={cn(
+                  "border-b border-hairline last:border-0 align-top",
+                  onSelect && "cursor-pointer hover:bg-surface-muted",
+                )}
+              >
+                <td className="px-3 py-2.5 font-medium text-ink">
+                  {s.reference}
+                </td>
+                <td className="px-3 py-2.5 text-ink-muted">
+                  {lane ? `${lane.origin} → ${lane.destination}` : s.laneId}
+                </td>
+                <td className="px-3 py-2.5 text-ink-muted">{s.carrier}</td>
+                <td className="px-3 py-2.5">
+                  {s.exception ? (
+                    <span className="rounded-md bg-surface-muted px-1.5 py-0.5 text-xs font-medium text-ink-muted">
+                      {s.exception.code}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-ink-muted">—</span>
+                  )}
+                </td>
+                <td
+                  className={cn(
+                    "px-3 py-2.5 tabular-nums",
+                    missed ? "text-negative" : "text-ink",
+                  )}
+                >
+                  {s.etaCurrent}
+                  <span className="text-ink-muted"> / {s.slaDate}</span>
+                </td>
+                <td className="px-3 py-2.5 tabular-nums text-ink">
+                  {fmtUsd(s.valueUsd)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/index.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/index.ts
@@ -1,0 +1,13 @@
+export { deriveKpis, KpiStrip } from "./kpi-strip";
+export { ExceptionBoard } from "./exception-board";
+export { ShipmentCard } from "./shipment-card";
+export { LaneTable } from "./lane-table";
+export { TradeoffTable } from "./tradeoff-table";
+export { InventoryRiskList } from "./inventory-risk";
+export { DecisionLog } from "./decision-log";
+export {
+  LanePerformanceChart,
+  ExposureByLaneChart,
+  DelayTrendChart,
+  ModeSplitChart,
+} from "./charts";

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/inventory-risk.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/inventory-risk.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { InventoryRisk } from "../data/types";
+import { cn } from "@/lib/utils";
+
+export function InventoryRiskList({ items }: { items: InventoryRisk[] }) {
+  if (!items.length) {
+    return <p className="text-sm text-ink-muted">No inventory risk to show.</p>;
+  }
+
+  // At-risk SKUs first, then the tightest cover next.
+  const rows = [...items].sort(
+    (a, b) =>
+      Number(b.atRisk) - Number(a.atRisk) || a.daysOfCover - b.daysOfCover,
+  );
+
+  return (
+    <ul className="space-y-2">
+      {rows.map((item) => {
+        const belowFloor = item.daysOfCover < item.safetyStockDays;
+        return (
+          <li
+            key={item.skuId}
+            className="rounded-lg border border-hairline bg-surface p-3 shadow-soft"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="font-medium text-ink">{item.name}</div>
+                <div className="text-xs text-ink-muted">{item.skuId}</div>
+              </div>
+              <div className="text-right text-sm">
+                <div
+                  className={cn(
+                    "font-semibold tabular-nums",
+                    belowFloor ? "text-negative" : "text-ink",
+                  )}
+                >
+                  {item.daysOfCover}d cover
+                </div>
+                <div className="text-xs text-ink-muted tabular-nums">
+                  floor {item.safetyStockDays}d
+                </div>
+              </div>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-ink-muted tabular-nums">
+              <span>On hand {item.onHandUnits.toLocaleString("en-US")}</span>
+              <span>Demand {item.dailyDemand.toLocaleString("en-US")}/day</span>
+            </div>
+            {item.inboundShipmentIds.length ? (
+              <div className="mt-2 text-xs text-ink-muted">
+                Inbound:{" "}
+                <span className="text-ink">
+                  {item.inboundShipmentIds.join(", ")}
+                </span>
+              </div>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/kpi-strip.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/kpi-strip.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { Shipment } from "../data/types";
+
+/**
+ * The four headline KPIs, derived from the live shipment list. Exported so the
+ * a2ui StatCard renderer (Task 10) and the OGUI snapshot (Task 13) compute the
+ * SAME figures — one definition, three surfaces.
+ */
+export function deriveKpis(shipments: Shipment[]) {
+  const active = shipments.filter((s) => s.status !== "resolved");
+  const onTime = shipments.filter((s) => s.etaCurrent <= s.slaDate).length;
+  const delays = shipments
+    .map((s) => daysBetween(s.etaPlanned, s.etaCurrent))
+    .filter((d) => d > 0);
+  return {
+    onTimeRate: shipments.length ? onTime / shipments.length : 1,
+    atRiskCount: active.filter(
+      (s) => s.status === "at_risk" || s.status === "delayed",
+    ).length,
+    exposureUsd: active
+      .filter((s) => s.etaCurrent > s.slaDate)
+      .reduce((sum, s) => sum + s.valueUsd, 0),
+    avgDelayDays: delays.length
+      ? Math.round(delays.reduce((a, b) => a + b, 0) / delays.length)
+      : 0,
+  };
+}
+
+function daysBetween(fromIso: string, toIso: string): number {
+  const ms =
+    Date.parse(`${toIso}T00:00:00Z`) - Date.parse(`${fromIso}T00:00:00Z`);
+  return Math.round(ms / 86_400_000);
+}
+
+const fmtUsd = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+export function KpiStrip({ shipments }: { shipments: Shipment[] }) {
+  const k = deriveKpis(shipments);
+  const tiles = [
+    { label: "On-time rate", value: `${Math.round(k.onTimeRate * 100)}%` },
+    { label: "At risk", value: String(k.atRiskCount) },
+    { label: "Exposure", value: fmtUsd(k.exposureUsd) },
+    { label: "Avg delay", value: `${k.avgDelayDays}d` },
+  ];
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {tiles.map((t) => (
+        <div
+          key={t.label}
+          className="rounded-lg border border-hairline bg-surface p-4 shadow-soft"
+        >
+          <div className="text-xs font-medium uppercase tracking-wide text-ink-muted">
+            {t.label}
+          </div>
+          <div className="mt-1 text-2xl font-semibold tracking-tight text-ink">
+            {t.value}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/lane-table.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/lane-table.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { Lane } from "../data/types";
+import { cn } from "@/lib/utils";
+
+const STATUS_TONE: Record<Lane["status"], string> = {
+  healthy: "text-positive",
+  degraded: "text-ink-muted",
+  blocked: "text-negative",
+};
+
+export function LaneTable({ lanes }: { lanes: Lane[] }) {
+  if (!lanes.length) {
+    return <p className="text-sm text-ink-muted">No lanes to show.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-hairline bg-surface shadow-soft">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-hairline text-left text-xs uppercase tracking-wide text-ink-muted">
+            <th className="px-3 py-2 font-medium">Lane</th>
+            <th className="px-3 py-2 font-medium">Mode</th>
+            <th className="px-3 py-2 font-medium">Transit</th>
+            <th className="px-3 py-2 font-medium">Reliability</th>
+            <th className="px-3 py-2 font-medium">Cost/kg</th>
+            <th className="px-3 py-2 font-medium">Status</th>
+            <th className="px-3 py-2 font-medium">Note</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lanes.map((l) => (
+            <tr
+              key={l.id}
+              className="border-b border-hairline last:border-0 align-top"
+            >
+              <td className="px-3 py-2.5 font-medium text-ink">
+                {l.origin} → {l.destination}
+              </td>
+              <td className="px-3 py-2.5 capitalize text-ink-muted">
+                {l.mode}
+              </td>
+              <td className="px-3 py-2.5 tabular-nums text-ink">
+                {l.transitDays}d
+              </td>
+              <td className="px-3 py-2.5 tabular-nums text-ink">
+                {Math.round(l.reliability * 100)}%
+              </td>
+              <td className="px-3 py-2.5 tabular-nums text-ink">
+                ${l.costPerKg.toFixed(2)}
+              </td>
+              <td
+                className={cn(
+                  "px-3 py-2.5 font-medium capitalize",
+                  STATUS_TONE[l.status],
+                )}
+              >
+                {l.status}
+              </td>
+              <td className="px-3 py-2.5 text-ink-muted">{l.note ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/planner-auth-context.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/planner-auth-context.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import type { Planner } from "@/skins/logistics/data/types";
+
+interface PlannerAuthValue {
+  currentPlanner: Planner;
+  plannerId: string;
+  setPlannerId: (id: string) => void;
+  planners: Planner[];
+  ready: boolean;
+}
+
+const PlannerAuthContext = createContext<PlannerAuthValue | null>(null);
+
+export function usePlannerAuth(): PlannerAuthValue {
+  const ctx = useContext(PlannerAuthContext);
+  if (!ctx)
+    throw new Error("usePlannerAuth must be used inside <PlannerAuthProvider>");
+  return ctx;
+}
+
+/**
+ * Establishes the acting planner. Mounted by the skin's RuntimeProviders ABOVE
+ * CopilotKitProvider, so `useLogisticsRuntimeProperties` can read it and the
+ * provider owns the identity from its first commit. Renders null until the
+ * roster resolves so no run is ever scoped to an unknown planner.
+ */
+export function PlannerAuthProvider({ children }: { children: ReactNode }) {
+  const [planners, setPlanners] = useState<Planner[]>([]);
+  const [plannerId, setPlannerId] = useState<string>("");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/logistics/v1/planners")
+      .then((r) => r.json())
+      .then((rows: Planner[]) => {
+        if (cancelled || !rows.length) return;
+        setPlanners(rows);
+        setPlannerId((current) => current || rows[0].id);
+      })
+      .catch((err) =>
+        console.error("[logistics-auth] roster fetch failed:", err),
+      );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo<PlannerAuthValue | null>(() => {
+    const currentPlanner = planners.find((p) => p.id === plannerId);
+    if (!currentPlanner) return null;
+    return { currentPlanner, plannerId, setPlannerId, planners, ready: true };
+  }, [planners, plannerId]);
+
+  if (!value) return null;
+  return (
+    <PlannerAuthContext.Provider value={value}>
+      {children}
+    </PlannerAuthContext.Provider>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/shipment-card.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/shipment-card.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { Lane, Shipment } from "../data/types";
+import { cn } from "@/lib/utils";
+
+const fmtUsd = (n: number) => `$${Math.round(n).toLocaleString("en-US")}`;
+
+function daysBetween(fromIso: string, toIso: string): number {
+  const ms =
+    Date.parse(`${toIso}T00:00:00Z`) - Date.parse(`${fromIso}T00:00:00Z`);
+  return Math.round(ms / 86_400_000);
+}
+
+const STATUS_LABEL: Record<Shipment["status"], string> = {
+  on_track: "On track",
+  at_risk: "At risk",
+  delayed: "Delayed",
+  resolved: "Resolved",
+};
+
+const STATUS_TONE: Record<Shipment["status"], string> = {
+  on_track: "bg-positive-soft text-positive",
+  at_risk: "bg-negative-soft text-negative",
+  delayed: "bg-negative-soft text-negative",
+  resolved: "bg-surface-muted text-ink-muted",
+};
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-ink-muted">
+        {label}
+      </div>
+      <div className="mt-0.5 tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}
+
+export function ShipmentCard({
+  shipment,
+  lane,
+}: {
+  shipment: Shipment;
+  lane?: Lane;
+}) {
+  const delta = daysBetween(shipment.slaDate, shipment.etaCurrent);
+  const late = delta > 0;
+
+  return (
+    <div className="rounded-lg border border-hairline bg-surface p-4 shadow-soft">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-base font-semibold text-ink">
+            {shipment.reference}
+          </div>
+          <div className="text-sm text-ink-muted">
+            {lane ? `${lane.origin} → ${lane.destination}` : shipment.laneId} ·{" "}
+            {shipment.carrier}
+          </div>
+        </div>
+        <span
+          className={cn(
+            "rounded-md px-2 py-0.5 text-xs font-medium",
+            STATUS_TONE[shipment.status],
+          )}
+        >
+          {STATUS_LABEL[shipment.status]}
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-3 text-sm">
+        <Field label="Units" value={shipment.units.toLocaleString("en-US")} />
+        <Field
+          label="Weight"
+          value={`${shipment.weightKg.toLocaleString("en-US")} kg`}
+        />
+        <Field label="Value" value={fmtUsd(shipment.valueUsd)} />
+      </div>
+
+      <div className="mt-4 flex items-baseline justify-between border-t border-hairline pt-3 text-sm">
+        <span className="text-ink-muted">
+          ETA {shipment.etaCurrent} · SLA {shipment.slaDate}
+        </span>
+        <span
+          className={cn(
+            "font-medium tabular-nums",
+            late ? "text-negative" : "text-positive",
+          )}
+        >
+          {delta === 0
+            ? "On SLA"
+            : late
+              ? `${delta}d late`
+              : `${-delta}d early`}
+        </span>
+      </div>
+
+      {shipment.exception ? (
+        <div className="mt-3 rounded-md bg-surface-muted p-3 text-sm">
+          <span className="font-medium text-ink">
+            {shipment.exception.code}
+          </span>
+          <span className="text-ink-muted"> — {shipment.exception.detail}</span>
+        </div>
+      ) : null}
+
+      {shipment.appliedMitigation ? (
+        <div className="mt-3 text-sm text-ink-muted">
+          Applied mitigation:{" "}
+          <span className="font-medium capitalize text-ink">
+            {shipment.appliedMitigation.kind}
+          </span>{" "}
+          ({fmtUsd(shipment.appliedMitigation.costUsd)})
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/tradeoff-table.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/tradeoff-table.tsx
@@ -20,6 +20,14 @@ export function TradeoffTable({
   authorityUsd: number | null;
   onChoose?: (kind: MitigationKind) => void;
 }) {
+  if (!options.length) {
+    return (
+      <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
+        No mitigation options are available for this shipment.
+      </div>
+    );
+  }
+
   const overAuthority = (cost: number) =>
     authorityUsd !== null && cost > authorityUsd;
 

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/tradeoff-table.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/tradeoff-table.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import type { MitigationKind, MitigationOption } from "../data/types";
+import { cn } from "@/lib/utils";
+
+const RISK_TONE: Record<MitigationOption["riskLevel"], string> = {
+  low: "text-positive",
+  medium: "text-ink-muted",
+  high: "text-negative",
+};
+
+const fmtUsd = (n: number) => (n === 0 ? "—" : `$${n.toLocaleString("en-US")}`);
+
+export function TradeoffTable({
+  options,
+  authorityUsd,
+  onChoose,
+}: {
+  options: MitigationOption[];
+  authorityUsd: number | null;
+  onChoose?: (kind: MitigationKind) => void;
+}) {
+  const overAuthority = (cost: number) =>
+    authorityUsd !== null && cost > authorityUsd;
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-hairline bg-surface shadow-soft">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-hairline text-left text-xs uppercase tracking-wide text-ink-muted">
+            <th className="px-3 py-2 font-medium">Option</th>
+            <th className="px-3 py-2 font-medium">Cost</th>
+            <th className="px-3 py-2 font-medium">ETA</th>
+            <th className="px-3 py-2 font-medium">SLA</th>
+            <th className="px-3 py-2 font-medium">Risk</th>
+            {onChoose ? <th className="px-3 py-2" /> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {options.map((o) => {
+            const blocked = overAuthority(o.costUsd);
+            return (
+              <tr
+                key={o.kind}
+                className="border-b border-hairline last:border-0 align-top"
+              >
+                <td className="px-3 py-2.5">
+                  <div className="font-medium text-ink">{o.label}</div>
+                  <div className="text-xs text-ink-muted">{o.rationale}</div>
+                  {blocked ? (
+                    <div className="mt-1 text-xs font-medium text-negative">
+                      Above your approval authority — needs an escalation.
+                    </div>
+                  ) : null}
+                </td>
+                <td className="px-3 py-2.5 tabular-nums text-ink">
+                  {fmtUsd(o.costUsd)}
+                </td>
+                <td className="px-3 py-2.5 tabular-nums text-ink">
+                  {o.etaDate}
+                </td>
+                <td
+                  className={cn(
+                    "px-3 py-2.5 font-medium",
+                    o.slaMet ? "text-positive" : "text-negative",
+                  )}
+                >
+                  {o.slaMet ? "Met" : "Missed"}
+                </td>
+                <td
+                  className={cn(
+                    "px-3 py-2.5 capitalize",
+                    RISK_TONE[o.riskLevel],
+                  )}
+                >
+                  {o.riskLevel}
+                </td>
+                {onChoose ? (
+                  <td className="px-3 py-2.5">
+                    <button
+                      type="button"
+                      onClick={() => onChoose(o.kind)}
+                      className="rounded-md bg-brand px-2.5 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
+                    >
+                      Choose
+                    </button>
+                  </td>
+                ) : null}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/components/use-ask-copilot.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/components/use-ask-copilot.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  useAgent,
+  useCopilotChatConfiguration,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+
+/**
+ * Send a message to the copilot on the user's behalf: opens the docked panel,
+ * appends the message, and starts a run — the same addMessage + runAgent path
+ * a suggestion-pill click takes inside CopilotChat, so the conversation reads
+ * exactly as if the planner had typed it. Used by Meridian's in-app "ask the
+ * copilot" surfaces (e.g. the sidebar Help control).
+ *
+ * Ported (not imported) from banking's equivalent: a skin's only inbound
+ * dependency is the shell's `Skin` contract, so `src/skins/logistics/**` must
+ * never reach into `src/skins/banking/**`.
+ */
+export function useAskCopilot() {
+  // No explicit agentId: inherit the surrounding CopilotChatConfiguration's
+  // agentId (the active skin's id, "logistics"), so this drives the SAME
+  // agent/thread the docked chat panel uses.
+  const { agent } = useAgent();
+  const { copilotkit } = useCopilotKit();
+  const configuration = useCopilotChatConfiguration();
+  const setModalOpen = configuration?.setModalOpen;
+
+  return useCallback(
+    async (message: string) => {
+      setModalOpen?.(true);
+      agent.addMessage({
+        id: crypto.randomUUID(),
+        role: "user",
+        content: message,
+      });
+      try {
+        await copilotkit.runAgent({ agent });
+      } catch (error) {
+        console.error("askCopilot: runAgent failed", error);
+      }
+    },
+    [agent, copilotkit, setModalOpen],
+  );
+}
+
+export default useAskCopilot;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/authority.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/authority.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { checkAuthority } from "./authority";
+import type { Escalation, Planner, Shipment } from "./types";
+
+const rosa: Planner = {
+  id: "pl-rosa",
+  name: "Rosa Delgado",
+  role: "Planner",
+  region: "Trans-Pacific",
+  authorityUsd: 5000,
+};
+const ibrahim: Planner = {
+  id: "pl-ibrahim",
+  name: "Ibrahim Okonjo",
+  role: "Director",
+  region: "Global",
+  authorityUsd: null,
+};
+
+const shipment: Shipment = {
+  id: "shp-4821",
+  reference: "PO-88213",
+  laneId: "ocean",
+  carrier: "Pacific Star Line",
+  skuId: "sku-a14",
+  units: 4800,
+  weightKg: 1400,
+  valueUsd: 240000,
+  etaPlanned: "2026-08-06",
+  etaCurrent: "2026-08-12",
+  slaDate: "2026-08-08",
+  status: "delayed",
+};
+
+const esc = (over: Partial<Escalation>): Escalation => ({
+  id: "esc-1",
+  shipmentId: "shp-4821",
+  code: "CUSTOMER_COMMITMENT",
+  status: "approved",
+  rationale: "x",
+  createdAt: "2026-08-01T00:00:00Z",
+  ...over,
+});
+
+describe("checkAuthority", () => {
+  it("allows spend at or under the planner's authority", () => {
+    expect(
+      checkAuthority({
+        costUsd: 5000,
+        planner: rosa,
+        shipment,
+        escalations: [],
+      }).allowed,
+    ).toBe(true);
+    expect(
+      checkAuthority({ costUsd: 600, planner: rosa, shipment, escalations: [] })
+        .allowed,
+    ).toBe(true);
+  });
+
+  it("blocks spend above the planner's authority with a symptom-only message", () => {
+    const result = checkAuthority({
+      costUsd: 8400,
+      planner: rosa,
+      shipment,
+      escalations: [],
+    });
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("unreachable");
+    expect(result.code).toBe("OVER_AUTHORITY");
+    expect(result.message).toContain("$8,400");
+    expect(result.message).toContain("$5,000");
+    // Must NOT leak which codes lift the gate — the agent learns that elsewhere.
+    expect(result.message).not.toContain("CUSTOMER_COMMITMENT");
+    expect(result.message).not.toContain("justifying");
+  });
+
+  it("lets a Director (unlimited authority) through at any cost", () => {
+    expect(
+      checkAuthority({
+        costUsd: 999999,
+        planner: ibrahim,
+        shipment,
+        escalations: [],
+      }).allowed,
+    ).toBe(true);
+  });
+
+  it("lifts the gate for an APPROVED escalation under a JUSTIFYING code", () => {
+    const withEsc = { ...shipment, activeEscalationId: "esc-1" };
+    const result = checkAuthority({
+      costUsd: 8400,
+      planner: rosa,
+      shipment: withEsc,
+      escalations: [esc({})],
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("does NOT lift the gate for a DRAFT escalation", () => {
+    const withEsc = { ...shipment, activeEscalationId: "esc-1" };
+    const result = checkAuthority({
+      costUsd: 8400,
+      planner: rosa,
+      shipment: withEsc,
+      escalations: [esc({ status: "draft" })],
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("does NOT lift the gate for an approved NON-justifying code", () => {
+    const withEsc = { ...shipment, activeEscalationId: "esc-1" };
+    const result = checkAuthority({
+      costUsd: 8400,
+      planner: rosa,
+      shipment: withEsc,
+      escalations: [esc({ code: "INTERNAL_CONVENIENCE" })],
+    });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("does NOT lift the gate when the linked escalation is missing", () => {
+    const withEsc = { ...shipment, activeEscalationId: "esc-gone" };
+    expect(
+      checkAuthority({
+        costUsd: 8400,
+        planner: rosa,
+        shipment: withEsc,
+        escalations: [],
+      }).allowed,
+    ).toBe(false);
+  });
+
+  it("allows zero-cost mitigations regardless of authority", () => {
+    expect(
+      checkAuthority({ costUsd: 0, planner: rosa, shipment, escalations: [] })
+        .allowed,
+    ).toBe(true);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/authority.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/authority.ts
@@ -1,0 +1,51 @@
+import { isJustifying } from "./escalation-codes";
+import type { Escalation, Planner, Shipment } from "./types";
+
+export type AuthorityCheck =
+  | { allowed: true }
+  | { allowed: false; code: "OVER_AUTHORITY"; message: string };
+
+export const formatUsd = (n: number): string =>
+  `$${Math.round(n).toLocaleString("en-US")}`;
+
+/**
+ * The authority gate — this skin's analogue of banking's policy-limit gate.
+ *
+ * A mitigation is allowed when ANY of these holds:
+ *   1. the planner has unlimited authority (a Director), OR
+ *   2. the cost is at or under their authority, OR
+ *   3. the shipment carries an APPROVED escalation filed under a JUSTIFYING
+ *      code (a non-justifying code is recorded for history but lifts nothing).
+ *
+ * The rejection names only the SYMPTOM (cost vs authority) and the generic
+ * recovery path. It deliberately does NOT reveal which codes are justifying —
+ * the agent has to learn that from the code catalogue, exactly as banking
+ * makes it learn the policy-exception recipe.
+ */
+export function checkAuthority(input: {
+  costUsd: number;
+  planner: Planner;
+  shipment: Shipment;
+  escalations: Escalation[];
+}): AuthorityCheck {
+  const { costUsd, planner, shipment, escalations } = input;
+
+  if (planner.authorityUsd === null) return { allowed: true };
+  if (costUsd <= planner.authorityUsd) return { allowed: true };
+
+  const linked = shipment.activeEscalationId
+    ? escalations.find((e) => e.id === shipment.activeEscalationId)
+    : undefined;
+  if (linked && linked.status === "approved" && isJustifying(linked.code)) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    code: "OVER_AUTHORITY",
+    message:
+      `This mitigation costs ${formatUsd(costUsd)}, above your ` +
+      `${formatUsd(planner.authorityUsd)} approval authority. ` +
+      `File an escalation or ask a Director to approve it.`,
+  };
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/escalation-codes.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/escalation-codes.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import {
+  ESCALATION_CODES,
+  ESCALATION_CODE_LABELS,
+  isJustifying,
+  isValidEscalationCode,
+} from "./escalation-codes";
+
+describe("escalation codes", () => {
+  it("accepts catalogued codes and rejects invented ones", () => {
+    expect(isValidEscalationCode("CUSTOMER_COMMITMENT")).toBe(true);
+    expect(isValidEscalationCode("URGENT")).toBe(false);
+    expect(isValidEscalationCode("customer_commitment")).toBe(false); // case-sensitive
+  });
+
+  it("splits justifying from recorded-only codes", () => {
+    expect(isJustifying("CUSTOMER_COMMITMENT")).toBe(true);
+    expect(isJustifying("LINE_DOWN_RISK")).toBe(true);
+    expect(isJustifying("REGULATORY_DEADLINE")).toBe(true);
+    expect(isJustifying("COST_AVOIDANCE")).toBe(true);
+    // Recorded for history, but they do NOT lift the authority gate.
+    expect(isJustifying("PEAK_SEASON")).toBe(false);
+    expect(isJustifying("INTERNAL_CONVENIENCE")).toBe(false);
+  });
+
+  it("is not justifying for an invalid code", () => {
+    expect(isJustifying("NOT_A_CODE")).toBe(false);
+  });
+
+  it("labels every catalogued code", () => {
+    for (const code of ESCALATION_CODES) {
+      expect(ESCALATION_CODE_LABELS[code]).toBeTruthy();
+    }
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/escalation-codes.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/escalation-codes.ts
@@ -1,0 +1,42 @@
+/**
+ * The closed catalogue of escalation codes. Mirrors banking's
+ * policy-exception-codes: a fixed vocabulary with a justifying/non-justifying
+ * split, so the agent must LEARN the valid codes rather than invent plausible
+ * strings. An uncatalogued code is a 422 at the route.
+ */
+export const ESCALATION_CODES = [
+  "CUSTOMER_COMMITMENT",
+  "LINE_DOWN_RISK",
+  "REGULATORY_DEADLINE",
+  "COST_AVOIDANCE",
+  "PEAK_SEASON",
+  "INTERNAL_CONVENIENCE",
+] as const;
+
+export type EscalationCode = (typeof ESCALATION_CODES)[number];
+
+export const ESCALATION_CODE_LABELS: Record<EscalationCode, string> = {
+  CUSTOMER_COMMITMENT: "Contractual customer commitment at risk",
+  LINE_DOWN_RISK: "Production line stops without this stock",
+  REGULATORY_DEADLINE: "Regulatory or customs deadline",
+  COST_AVOIDANCE: "Spend now avoids a larger downstream cost",
+  PEAK_SEASON: "Peak-season pressure (recorded only)",
+  INTERNAL_CONVENIENCE: "Internal convenience (recorded only)",
+};
+
+/**
+ * Codes that actually LIFT the authority gate once approved. The other two are
+ * recorded for history so the decision log stays honest, but an approved
+ * escalation filed under them does not authorize over-authority spend.
+ */
+const JUSTIFYING = new Set<string>([
+  "CUSTOMER_COMMITMENT",
+  "LINE_DOWN_RISK",
+  "REGULATORY_DEADLINE",
+  "COST_AVOIDANCE",
+]);
+
+export const isValidEscalationCode = (code: string): code is EscalationCode =>
+  (ESCALATION_CODES as readonly string[]).includes(code);
+
+export const isJustifying = (code: string): boolean => JUSTIFYING.has(code);

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/mitigation-options.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/mitigation-options.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { computeMitigationOptions, findOption } from "./mitigation-options";
+import type { Lane, Shipment } from "./types";
+
+const lanes: Lane[] = [
+  {
+    id: "ocean",
+    origin: "Shanghai (SHA)",
+    destination: "Los Angeles (LAX)",
+    mode: "ocean",
+    transitDays: 24,
+    reliability: 0.71,
+    costPerKg: 0.45,
+    status: "degraded",
+  },
+  {
+    id: "air",
+    origin: "Shanghai (SHA)",
+    destination: "Los Angeles (LAX)",
+    mode: "air",
+    transitDays: 2,
+    reliability: 0.94,
+    costPerKg: 6.0,
+    status: "healthy",
+  },
+  {
+    id: "alt",
+    origin: "Shanghai (SHA)",
+    destination: "Los Angeles (LAX)",
+    mode: "rail",
+    transitDays: 18,
+    reliability: 0.86,
+    costPerKg: 0.7,
+    status: "healthy",
+  },
+  {
+    id: "blocked-air",
+    origin: "X",
+    destination: "Nowhere",
+    mode: "air",
+    transitDays: 1,
+    reliability: 0.5,
+    costPerKg: 9,
+    status: "blocked",
+  },
+];
+
+const shipment: Shipment = {
+  id: "shp-4821",
+  reference: "PO-88213",
+  laneId: "ocean",
+  carrier: "Pacific Star Line",
+  skuId: "sku-a14",
+  units: 4800,
+  weightKg: 1400,
+  valueUsd: 240000,
+  etaPlanned: "2026-08-06",
+  etaCurrent: "2026-08-12",
+  slaDate: "2026-08-08",
+  status: "delayed",
+};
+
+describe("computeMitigationOptions", () => {
+  it("prices expedite at weight x air cost/kg — the $8,400 headline beat", () => {
+    const expedite = findOption(shipment, lanes, "expedite");
+    expect(expedite?.costUsd).toBe(8400); // 1400kg x $6.00
+  });
+
+  it("pulls the expedited ETA in by the transit days saved and meets the SLA", () => {
+    const expedite = findOption(shipment, lanes, "expedite");
+    // 24 - 2 = 22 days saved, but ETA cannot precede today's data: 2026-08-12 - 22d
+    expect(expedite?.etaDate).toBe("2026-07-21");
+    expect(expedite?.slaMet).toBe(true);
+  });
+
+  it("absorb is free, keeps the current ETA, and misses the SLA here", () => {
+    const absorb = findOption(shipment, lanes, "absorb");
+    expect(absorb?.costUsd).toBe(0);
+    expect(absorb?.etaDate).toBe("2026-08-12");
+    expect(absorb?.slaMet).toBe(false); // 08-12 is after the 08-08 SLA
+    expect(absorb?.riskLevel).toBe("high");
+  });
+
+  it("reroute charges only the cost DELTA plus the flat re-documentation fee", () => {
+    const reroute = findOption(shipment, lanes, "reroute");
+    // 1400 x (0.70 - 0.45) = 350, + 250 fee
+    expect(reroute?.costUsd).toBe(600);
+    expect(reroute?.etaDate).toBe("2026-08-06"); // 24 - 18 = 6 days saved
+  });
+
+  it("split prices half the weight by air plus handling", () => {
+    const split = findOption(shipment, lanes, "split");
+    expect(split?.costUsd).toBe(4350); // 700 x 6.00 + 150
+    expect(split?.riskLevel).toBe("medium");
+  });
+
+  it("never lets a cheaper alternate lane produce a negative reroute cost", () => {
+    const cheapAlt: Lane[] = [
+      lanes[0],
+      { ...lanes[2], costPerKg: 0.1 }, // cheaper than the current ocean lane
+    ];
+    expect(findOption(shipment, cheapAlt, "reroute")?.costUsd).toBe(250); // fee only, never negative
+  });
+
+  it("omits options whose replacement lane does not exist", () => {
+    const oceanOnly = [lanes[0]];
+    const kinds = computeMitigationOptions(shipment, oceanOnly).map(
+      (o) => o.kind,
+    );
+    expect(kinds).toEqual(["absorb"]); // no air lane, no alternate lane
+  });
+
+  it("ignores blocked lanes when picking a replacement", () => {
+    const withBlockedAir: Lane[] = [
+      lanes[0],
+      { ...lanes[1], status: "blocked" },
+    ];
+    expect(findOption(shipment, withBlockedAir, "expedite")).toBeUndefined();
+  });
+
+  it("returns options cheapest-first after absorb", () => {
+    const kinds = computeMitigationOptions(shipment, lanes).map((o) => o.kind);
+    expect(kinds).toEqual(["absorb", "reroute", "split", "expedite"]);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/mitigation-options.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/mitigation-options.ts
@@ -1,0 +1,141 @@
+import type { Lane, MitigationKind, MitigationOption, Shipment } from "./types";
+
+/** Flat re-documentation fee for switching a shipment onto another lane. */
+const REROUTE_FEE_USD = 250;
+/** Flat handling fee for splitting a shipment across two lanes. */
+const SPLIT_HANDLING_USD = 150;
+
+/** Shift an ISO date (YYYY-MM-DD) by whole days. UTC-based so it is stable
+ *  regardless of the machine's timezone — no wall-clock reads. */
+function shiftDate(iso: string, days: number): string {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+const usable = (lane: Lane) => lane.status !== "blocked";
+
+/** The fastest usable air lane serving this shipment's destination. */
+function airLaneFor(
+  shipment: Shipment,
+  lanes: Lane[],
+  current: Lane,
+): Lane | undefined {
+  return lanes
+    .filter(
+      (l) =>
+        l.mode === "air" && l.destination === current.destination && usable(l),
+    )
+    .sort((a, b) => a.transitDays - b.transitDays)[0];
+}
+
+/** The fastest usable NON-air alternate lane to the same destination. */
+function altLaneFor(
+  shipment: Shipment,
+  lanes: Lane[],
+  current: Lane,
+): Lane | undefined {
+  return lanes
+    .filter(
+      (l) =>
+        l.id !== current.id &&
+        l.mode !== "air" &&
+        l.destination === current.destination &&
+        usable(l),
+    )
+    .sort((a, b) => a.transitDays - b.transitDays)[0];
+}
+
+const daysSaved = (current: Lane, replacement: Lane) =>
+  Math.max(0, current.transitDays - replacement.transitDays);
+
+/**
+ * Compute the mitigation options available for a shipment. Pure and
+ * deterministic: every ETA derives from the shipment's own `etaCurrent` and
+ * lane transit deltas, never from the wall clock, so tests are stable.
+ *
+ * The SERVER calls this to recompute cost on every mitigate request — a
+ * client-supplied cost is never trusted, or the authority gate would be
+ * theater.
+ */
+export function computeMitigationOptions(
+  shipment: Shipment,
+  lanes: Lane[],
+): MitigationOption[] {
+  const current = lanes.find((l) => l.id === shipment.laneId);
+  if (!current) return [];
+
+  const options: MitigationOption[] = [];
+  const meets = (etaDate: string) => etaDate <= shipment.slaDate;
+
+  // absorb — always available.
+  const absorbMet = meets(shipment.etaCurrent);
+  options.push({
+    kind: "absorb",
+    label: "Absorb the delay",
+    costUsd: 0,
+    etaDate: shipment.etaCurrent,
+    slaMet: absorbMet,
+    riskLevel: absorbMet ? "low" : "high",
+    rationale: absorbMet
+      ? "The current ETA still clears the promised date."
+      : "No spend, but the promised date is missed.",
+  });
+
+  const air = airLaneFor(shipment, lanes, current);
+  const alt = altLaneFor(shipment, lanes, current);
+
+  if (alt) {
+    const etaDate = shiftDate(shipment.etaCurrent, -daysSaved(current, alt));
+    const delta = Math.max(
+      0,
+      shipment.weightKg * (alt.costPerKg - current.costPerKg),
+    );
+    options.push({
+      kind: "reroute",
+      label: `Reroute via ${alt.origin} → ${alt.destination} (${alt.mode})`,
+      costUsd: Math.round(delta + REROUTE_FEE_USD),
+      etaDate,
+      slaMet: meets(etaDate),
+      riskLevel: "medium",
+      rationale: `Moves to a ${Math.round(alt.reliability * 100)}%-on-time lane at ${alt.transitDays} days transit.`,
+    });
+  }
+
+  if (air) {
+    const etaDate = shiftDate(shipment.etaCurrent, -daysSaved(current, air));
+    options.push({
+      kind: "split",
+      label: "Split — half by air, half stays",
+      costUsd: Math.round(
+        (shipment.weightKg / 2) * air.costPerKg + SPLIT_HANDLING_USD,
+      ),
+      etaDate,
+      slaMet: meets(etaDate),
+      riskLevel: "medium",
+      rationale: "Covers immediate demand by air while the balance sails.",
+    });
+    options.push({
+      kind: "expedite",
+      label: "Expedite the full shipment by air",
+      costUsd: Math.round(shipment.weightKg * air.costPerKg),
+      etaDate,
+      slaMet: meets(etaDate),
+      riskLevel: "low",
+      rationale: `Full volume on a ${air.transitDays}-day air lane.`,
+    });
+  }
+
+  // absorb first (the do-nothing baseline), then cheapest-first.
+  const [absorb, ...rest] = options;
+  rest.sort((a, b) => a.costUsd - b.costUsd);
+  return [absorb, ...rest];
+}
+
+export function findOption(
+  shipment: Shipment,
+  lanes: Lane[],
+  kind: MitigationKind,
+): MitigationOption | undefined {
+  return computeMitigationOptions(shipment, lanes).find((o) => o.kind === kind);
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/seed.json
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/seed.json
@@ -30,7 +30,7 @@
       "reliability": 0.88,
       "costPerKg": 0.52,
       "status": "healthy",
-      "note": "Longer drayage to the LA DC, but berths are clear."
+      "note": "Direct Pacific Northwest service; berths are clear."
     },
     {
       "id": "ln-rtm-nyc-ocean",
@@ -62,6 +62,50 @@
       "costPerKg": 0.9,
       "status": "degraded",
       "note": "Customs staffing shortage at Laredo."
+    },
+    {
+      "id": "ln-sha-lax-ocean-exp",
+      "origin": "Shanghai (SHA)",
+      "destination": "Los Angeles (LAX)",
+      "mode": "ocean",
+      "transitDays": 18,
+      "reliability": 0.89,
+      "costPerKg": 0.68,
+      "status": "healthy",
+      "note": "Premium service with a priority berthing window at LAX."
+    },
+    {
+      "id": "ln-sha-lax-searail",
+      "origin": "Shanghai (SHA)",
+      "destination": "Los Angeles (LAX)",
+      "mode": "rail",
+      "transitDays": 20,
+      "reliability": 0.84,
+      "costPerKg": 0.62,
+      "status": "healthy",
+      "note": "Transload at Seattle, rail south to LAX — bypasses the LA berth queue."
+    },
+    {
+      "id": "ln-rtm-nyc-ocean-alt",
+      "origin": "Rotterdam (RTM)",
+      "destination": "New York (NYC)",
+      "mode": "ocean",
+      "transitDays": 12,
+      "reliability": 0.87,
+      "costPerKg": 0.72,
+      "status": "healthy",
+      "note": "Second carrier on a faster string at a higher rate."
+    },
+    {
+      "id": "ln-mty-dfw-rail",
+      "origin": "Monterrey (MTY)",
+      "destination": "Dallas (DFW)",
+      "mode": "rail",
+      "transitDays": 4,
+      "reliability": 0.92,
+      "costPerKg": 0.55,
+      "status": "healthy",
+      "note": "Crosses at Eagle Pass, avoiding the Laredo backlog."
     }
   ],
   "shipments": [

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/seed.json
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/seed.json
@@ -1,0 +1,225 @@
+{
+  "lanes": [
+    {
+      "id": "ln-sha-lax-ocean",
+      "origin": "Shanghai (SHA)",
+      "destination": "Los Angeles (LAX)",
+      "mode": "ocean",
+      "transitDays": 24,
+      "reliability": 0.71,
+      "costPerKg": 0.45,
+      "status": "degraded",
+      "note": "Berth congestion at LAX; 4-6 day dwell."
+    },
+    {
+      "id": "ln-sha-lax-air",
+      "origin": "Shanghai (SHA)",
+      "destination": "Los Angeles (LAX)",
+      "mode": "air",
+      "transitDays": 2,
+      "reliability": 0.94,
+      "costPerKg": 6.0,
+      "status": "healthy"
+    },
+    {
+      "id": "ln-sha-sea-ocean",
+      "origin": "Shanghai (SHA)",
+      "destination": "Seattle (SEA)",
+      "mode": "ocean",
+      "transitDays": 19,
+      "reliability": 0.88,
+      "costPerKg": 0.52,
+      "status": "healthy",
+      "note": "Longer drayage to the LA DC, but berths are clear."
+    },
+    {
+      "id": "ln-rtm-nyc-ocean",
+      "origin": "Rotterdam (RTM)",
+      "destination": "New York (NYC)",
+      "mode": "ocean",
+      "transitDays": 14,
+      "reliability": 0.91,
+      "costPerKg": 0.61,
+      "status": "healthy"
+    },
+    {
+      "id": "ln-rtm-nyc-air",
+      "origin": "Rotterdam (RTM)",
+      "destination": "New York (NYC)",
+      "mode": "air",
+      "transitDays": 1,
+      "reliability": 0.96,
+      "costPerKg": 5.2,
+      "status": "healthy"
+    },
+    {
+      "id": "ln-mty-dfw-truck",
+      "origin": "Monterrey (MTY)",
+      "destination": "Dallas (DFW)",
+      "mode": "truck",
+      "transitDays": 3,
+      "reliability": 0.83,
+      "costPerKg": 0.9,
+      "status": "degraded",
+      "note": "Customs staffing shortage at Laredo."
+    }
+  ],
+  "shipments": [
+    {
+      "id": "shp-4821",
+      "reference": "PO-88213",
+      "laneId": "ln-sha-lax-ocean",
+      "carrier": "Pacific Star Line",
+      "skuId": "sku-a14",
+      "units": 4800,
+      "weightKg": 1400,
+      "valueUsd": 240000,
+      "etaPlanned": "2026-08-06",
+      "etaCurrent": "2026-08-12",
+      "slaDate": "2026-08-08",
+      "status": "delayed",
+      "exception": {
+        "code": "PORT_CONGESTION",
+        "detail": "Vessel waiting for berth at LAX; six days lost.",
+        "since": "2026-07-28"
+      }
+    },
+    {
+      "id": "shp-4822",
+      "reference": "PO-88240",
+      "laneId": "ln-rtm-nyc-ocean",
+      "carrier": "Northline",
+      "skuId": "sku-b02",
+      "units": 1200,
+      "weightKg": 610,
+      "valueUsd": 74000,
+      "etaPlanned": "2026-08-09",
+      "etaCurrent": "2026-08-11",
+      "slaDate": "2026-08-14",
+      "status": "at_risk",
+      "exception": {
+        "code": "CUSTOMS_HOLD",
+        "detail": "Commercial invoice mismatch on two pallets.",
+        "since": "2026-07-30"
+      }
+    },
+    {
+      "id": "shp-4823",
+      "reference": "PO-88251",
+      "laneId": "ln-mty-dfw-truck",
+      "carrier": "Norte Freight",
+      "skuId": "sku-c31",
+      "units": 900,
+      "weightKg": 320,
+      "valueUsd": 28000,
+      "etaPlanned": "2026-08-03",
+      "etaCurrent": "2026-08-05",
+      "slaDate": "2026-08-04",
+      "status": "delayed",
+      "exception": {
+        "code": "DOC_MISMATCH",
+        "detail": "Certificate of origin rejected at Laredo.",
+        "since": "2026-07-31"
+      }
+    },
+    {
+      "id": "shp-4824",
+      "reference": "PO-88266",
+      "laneId": "ln-sha-sea-ocean",
+      "carrier": "Pacific Star Line",
+      "skuId": "sku-a14",
+      "units": 2600,
+      "weightKg": 780,
+      "valueUsd": 131000,
+      "etaPlanned": "2026-08-15",
+      "etaCurrent": "2026-08-15",
+      "slaDate": "2026-08-20",
+      "status": "on_track"
+    },
+    {
+      "id": "shp-4825",
+      "reference": "PO-88274",
+      "laneId": "ln-rtm-nyc-ocean",
+      "carrier": "Northline",
+      "skuId": "sku-d07",
+      "units": 400,
+      "weightKg": 210,
+      "valueUsd": 19500,
+      "etaPlanned": "2026-08-18",
+      "etaCurrent": "2026-08-18",
+      "slaDate": "2026-08-24",
+      "status": "on_track"
+    },
+    {
+      "id": "shp-4826",
+      "reference": "PO-88281",
+      "laneId": "ln-sha-lax-ocean",
+      "carrier": "Blue Meridian",
+      "skuId": "sku-b02",
+      "units": 3100,
+      "weightKg": 940,
+      "valueUsd": 96000,
+      "etaPlanned": "2026-08-20",
+      "etaCurrent": "2026-08-23",
+      "slaDate": "2026-08-26",
+      "status": "at_risk",
+      "exception": {
+        "code": "CAPACITY_SHORTFALL",
+        "detail": "Rolled to the next sailing.",
+        "since": "2026-07-29"
+      }
+    }
+  ],
+  "inventory": [
+    {
+      "skuId": "sku-a14",
+      "name": "A14 Drive Assembly",
+      "onHandUnits": 3200,
+      "dailyDemand": 800,
+      "safetyStockDays": 5,
+      "inboundShipmentIds": ["shp-4821", "shp-4824"]
+    },
+    {
+      "skuId": "sku-b02",
+      "name": "B02 Control Board",
+      "onHandUnits": 5400,
+      "dailyDemand": 300,
+      "safetyStockDays": 7,
+      "inboundShipmentIds": ["shp-4822", "shp-4826"]
+    },
+    {
+      "skuId": "sku-c31",
+      "name": "C31 Harness Kit",
+      "onHandUnits": 260,
+      "dailyDemand": 130,
+      "safetyStockDays": 4,
+      "inboundShipmentIds": ["shp-4823"]
+    },
+    {
+      "skuId": "sku-d07",
+      "name": "D07 Sensor Pack",
+      "onHandUnits": 4100,
+      "dailyDemand": 90,
+      "safetyStockDays": 6,
+      "inboundShipmentIds": ["shp-4825"]
+    }
+  ],
+  "planners": [
+    {
+      "id": "pl-rosa",
+      "name": "Rosa Delgado",
+      "role": "Planner",
+      "region": "Trans-Pacific",
+      "authorityUsd": 5000
+    },
+    {
+      "id": "pl-ibrahim",
+      "name": "Ibrahim Okonjo",
+      "role": "Director",
+      "region": "Global",
+      "authorityUsd": null
+    }
+  ],
+  "escalations": [],
+  "decisions": []
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/store.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/store.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as store from "./store";
+
+beforeEach(() => store.reset());
+
+describe("store", () => {
+  it("seeds the headline shipment and both planners", () => {
+    expect(store.findShipment("shp-4821")?.reference).toBe("PO-88213");
+    expect(store.planners()).toHaveLength(2);
+    expect(store.findPlanner("pl-ibrahim")?.authorityUsd).toBeNull();
+  });
+
+  it("derives daysOfCover and flags at-risk SKUs without storing it", () => {
+    const risks = store.inventoryRisk();
+    const c31 = risks.find((r) => r.skuId === "sku-c31");
+    expect(c31?.daysOfCover).toBe(2); // 260 / 130
+    expect(c31?.atRisk).toBe(true); // 2 < safetyStockDays 4
+    const d07 = risks.find((r) => r.skuId === "sku-d07");
+    expect(d07?.atRisk).toBe(false);
+  });
+
+  it("openEscalation creates a draft; approveEscalation links it to the shipment", () => {
+    const draft = store.openEscalation(
+      "shp-4821",
+      "CUSTOMER_COMMITMENT",
+      "Line down risk at the LA DC.",
+    );
+    expect(draft.status).toBe("draft");
+    expect(store.findShipment("shp-4821")?.activeEscalationId).toBeUndefined();
+
+    const approved = store.approveEscalation(draft.id);
+    expect(approved.status).toBe("approved");
+    expect(store.findShipment("shp-4821")?.activeEscalationId).toBe(draft.id);
+  });
+
+  it("rejects an unknown escalation code and a double approval", () => {
+    expect(() => store.openEscalation("shp-4821", "NOT_A_CODE", "x")).toThrow(
+      "INVALID_ESCALATION_CODE",
+    );
+    expect(() =>
+      store.openEscalation("nope", "CUSTOMER_COMMITMENT", "x"),
+    ).toThrow("NOT_FOUND");
+    const d = store.openEscalation("shp-4822", "LINE_DOWN_RISK", "x");
+    store.approveEscalation(d.id);
+    expect(() => store.approveEscalation(d.id)).toThrow("ALREADY_APPROVED");
+  });
+
+  it("reset restores mutations back to seed", () => {
+    store.updateShipment("shp-4821", { status: "resolved" });
+    store.addDecision({
+      shipmentId: "shp-4821",
+      kind: "absorb",
+      costUsd: 0,
+      rationale: "x",
+      decidedBy: "Rosa Delgado",
+      role: "Planner",
+      status: "committed",
+    });
+    expect(store.decisions()).toHaveLength(1);
+    store.reset();
+    expect(store.findShipment("shp-4821")?.status).toBe("delayed");
+    expect(store.decisions()).toHaveLength(0);
+  });
+
+  it("files decisions newest-first", () => {
+    store.addDecision({
+      shipmentId: "a",
+      kind: "absorb",
+      costUsd: 0,
+      rationale: "first",
+      decidedBy: "x",
+      role: "Planner",
+      status: "committed",
+    });
+    store.addDecision({
+      shipmentId: "b",
+      kind: "expedite",
+      costUsd: 10,
+      rationale: "second",
+      decidedBy: "x",
+      role: "Planner",
+      status: "committed",
+    });
+    expect(store.decisions()[0].rationale).toBe("second");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/store.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/store.ts
@@ -1,0 +1,136 @@
+import seed from "./seed.json";
+import type {
+  Decision,
+  Escalation,
+  InventoryItem,
+  InventoryRisk,
+  Lane,
+  Planner,
+  Shipment,
+} from "./types";
+import { isValidEscalationCode } from "./escalation-codes";
+
+/**
+ * In-memory, file-seeded store for the Meridian control tower.
+ * Seeded once at module init and deep-cloned so mutations never bleed back
+ * into the imported JSON. All mutations live for the server process only;
+ * restarting the dev server resets to seed. Intentional demo behavior.
+ */
+type DB = {
+  lanes: Lane[];
+  shipments: Shipment[];
+  inventory: InventoryItem[];
+  planners: Planner[];
+  escalations: Escalation[];
+  decisions: Decision[];
+};
+
+const db: DB = structuredClone(seed) as DB;
+
+let idCounter = 0;
+const nextId = (prefix: string) =>
+  `${prefix}-${Date.now().toString(36)}-${idCounter++}`;
+
+export const reset = (): void => {
+  const fresh = structuredClone(seed) as DB;
+  db.lanes = fresh.lanes;
+  db.shipments = fresh.shipments;
+  db.inventory = fresh.inventory;
+  db.planners = fresh.planners;
+  db.escalations = [];
+  db.decisions = [];
+  idCounter = 0;
+};
+
+// ---- Reads --------------------------------------------------------------
+export const lanes = (): Lane[] => db.lanes;
+export const shipments = (): Shipment[] => db.shipments;
+export const inventory = (): InventoryItem[] => db.inventory;
+export const planners = (): Planner[] => db.planners;
+export const escalations = (): Escalation[] => db.escalations;
+export const decisions = (): Decision[] => db.decisions;
+
+export const findLane = (id: string): Lane | undefined =>
+  db.lanes.find((l) => l.id === id);
+export const findShipment = (id: string): Shipment | undefined =>
+  db.shipments.find((s) => s.id === id);
+export const findPlanner = (id: string): Planner | undefined =>
+  db.planners.find((p) => p.id === id);
+export const findEscalation = (id: string): Escalation | undefined =>
+  db.escalations.find((e) => e.id === id);
+
+/**
+ * Days of cover is DERIVED, never stored: on-hand divided by daily demand.
+ * A SKU is at risk when its cover is below its safety-stock floor.
+ */
+export const inventoryRisk = (): InventoryRisk[] =>
+  db.inventory.map((item) => {
+    const daysOfCover =
+      item.dailyDemand > 0
+        ? Math.floor(item.onHandUnits / item.dailyDemand)
+        : Infinity;
+    return { ...item, daysOfCover, atRisk: daysOfCover < item.safetyStockDays };
+  });
+
+// ---- Mutations ----------------------------------------------------------
+export const updateShipment = (
+  id: string,
+  patch: Partial<Shipment>,
+): Shipment | undefined => {
+  const idx = db.shipments.findIndex((s) => s.id === id);
+  if (idx === -1) return undefined;
+  db.shipments[idx] = { ...db.shipments[idx], ...patch };
+  return db.shipments[idx];
+};
+
+/** File a decision; newest first so the Decision Log leads with it. */
+export const addDecision = (
+  decision: Omit<Decision, "id" | "createdAt">,
+): Decision => {
+  const filed: Decision = {
+    ...decision,
+    id: nextId("dec"),
+    createdAt: new Date().toISOString(),
+  };
+  db.decisions.unshift(filed);
+  return filed;
+};
+
+/**
+ * Open a DRAFT escalation. Throws code-like Errors (`NOT_FOUND`,
+ * `INVALID_ESCALATION_CODE`) that the calling route maps to HTTP status.
+ * The closed code catalogue forces the agent to learn valid codes rather
+ * than invent plausible-looking strings.
+ */
+export const openEscalation = (
+  shipmentId: string,
+  code: string,
+  rationale: string,
+): Escalation => {
+  if (!findShipment(shipmentId)) throw new Error("NOT_FOUND");
+  if (!isValidEscalationCode(code)) throw new Error("INVALID_ESCALATION_CODE");
+  const escalation: Escalation = {
+    id: nextId("esc"),
+    shipmentId,
+    code,
+    status: "draft",
+    rationale,
+    createdAt: new Date().toISOString(),
+  };
+  db.escalations.push(escalation);
+  return escalation;
+};
+
+/**
+ * Approve a draft escalation (auto-approve; no review step in the demo) and
+ * link it to its shipment's `activeEscalationId` — which is what lifts the
+ * authority gate, PROVIDED the code is justifying (see authority.ts).
+ */
+export const approveEscalation = (escalationId: string): Escalation => {
+  const esc = findEscalation(escalationId);
+  if (!esc) throw new Error("NOT_FOUND");
+  if (esc.status !== "draft") throw new Error("ALREADY_APPROVED");
+  esc.status = "approved";
+  updateShipment(esc.shipmentId, { activeEscalationId: esc.id });
+  return esc;
+};

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/data/types.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/data/types.ts
@@ -1,0 +1,105 @@
+export type Mode = "ocean" | "air" | "rail" | "truck";
+
+export type ExceptionCode =
+  | "PORT_CONGESTION"
+  | "CUSTOMS_HOLD"
+  | "CARRIER_DELAY"
+  | "WEATHER"
+  | "CAPACITY_SHORTFALL"
+  | "DOC_MISMATCH";
+
+export type MitigationKind = "expedite" | "reroute" | "split" | "absorb";
+
+export interface Lane {
+  id: string;
+  origin: string;
+  destination: string;
+  mode: Mode;
+  transitDays: number;
+  /** On-time rate, 0..1. */
+  reliability: number;
+  costPerKg: number;
+  status: "healthy" | "degraded" | "blocked";
+  note?: string;
+}
+
+export interface Shipment {
+  id: string;
+  reference: string;
+  laneId: string;
+  carrier: string;
+  skuId: string;
+  units: number;
+  weightKg: number;
+  valueUsd: number;
+  /** ISO date (YYYY-MM-DD). */
+  etaPlanned: string;
+  etaCurrent: string;
+  /** Promised-to-customer date. */
+  slaDate: string;
+  status: "on_track" | "at_risk" | "delayed" | "resolved";
+  exception?: { code: ExceptionCode; detail: string; since: string };
+  appliedMitigation?: {
+    kind: MitigationKind;
+    costUsd: number;
+    decidedAt: string;
+  };
+  /** Set by approveEscalation. This is what lifts the authority gate. */
+  activeEscalationId?: string;
+}
+
+export interface InventoryItem {
+  skuId: string;
+  name: string;
+  onHandUnits: number;
+  dailyDemand: number;
+  safetyStockDays: number;
+  inboundShipmentIds: string[];
+}
+
+export interface Planner {
+  id: string;
+  name: string;
+  role: "Planner" | "Director";
+  region: string;
+  /** null = unlimited (Director). */
+  authorityUsd: number | null;
+}
+
+export interface Escalation {
+  id: string;
+  shipmentId: string;
+  code: string;
+  status: "draft" | "approved";
+  rationale: string;
+  createdAt: string;
+}
+
+export interface Decision {
+  id: string;
+  shipmentId: string;
+  kind: MitigationKind | "escalation";
+  costUsd: number;
+  rationale: string;
+  decidedBy: string;
+  role: string;
+  status: "committed" | "escalated";
+  createdAt: string;
+}
+
+/** Computed on demand from lane + shipment; never persisted. */
+export interface MitigationOption {
+  kind: MitigationKind;
+  label: string;
+  costUsd: number;
+  etaDate: string;
+  slaMet: boolean;
+  riskLevel: "low" | "medium" | "high";
+  rationale: string;
+}
+
+/** Derived view of an inventory item (daysOfCover is never stored). */
+export interface InventoryRisk extends InventoryItem {
+  daysOfCover: number;
+  atRisk: boolean;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/design-skill.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/design-skill.ts
@@ -1,0 +1,17 @@
+/** OGUI design brief — injected as agent context to style generated UIs so a
+ *  sandboxed surface reads as part of Meridian rather than a generic page. */
+export const MERIDIAN_DESIGN_SKILL = [
+  "Meridian is a freight control tower: a dense, high-signal operations console.",
+  "Visual language: warm signal amber (#f59e0b family) as the single accent on a",
+  "warm graphite-and-paper neutral ground. Tight 8px corner radii, hairline 1px",
+  "borders, generous tabular padding, no gradients, no glassmorphism, no drop",
+  "shadows beyond a faint lift on cards.",
+  "Typography: one sans family. Numbers are tabular and right-aligned; labels are",
+  "small uppercase with wide tracking; headings are semibold and tight.",
+  "Semantics: green for on-time/healthy, amber for the accent and at-risk,",
+  "red only for a missed promised date or a blocked lane. Never color by",
+  "decoration — color always encodes state.",
+  "Layout: lead with a KPI row, then the table or chart that answers the question.",
+  "Prefer a dense table over cards for more than four rows. Every number must be",
+  "fetched through the provided data functions — never invent or hardcode figures.",
+].join(" ");

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/identity.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/identity.ts
@@ -46,6 +46,6 @@ export const logisticsIdentity = {
   favicon: "🧭",
   assistantName: "Meridian Control",
   greeting:
-    "Rosa — Meridian Control here. Six lanes are live and three shipments need a call today. " +
+    "Rosa — Meridian Control here. The tower's up and a few shipments need a call today. " +
     "I can triage the tower, weigh your options on a late shipment, or build a decision brief. Where do you want to start?",
 } as const;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/identity.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/identity.ts
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+
+/**
+ * Meridian — a fictional freight control tower. The agent triages shipment
+ * exceptions and helps a planner decide: expedite, reroute, split, or absorb.
+ * Palette is a warm signal-amber on graphite, deliberately distinct from
+ * banking's violet and airline's teal.
+ */
+function MeridianLogo({ className }: { className?: string }) {
+  // A compass rose / crosshair mark. `currentColor` so it inherits the brand
+  // color wherever it mounts (nav, selector, chat header).
+  return createElement(
+    "svg",
+    {
+      className,
+      viewBox: "0 0 24 24",
+      fill: "none",
+      xmlns: "http://www.w3.org/2000/svg",
+      "aria-hidden": true,
+    },
+    createElement("circle", {
+      cx: 12,
+      cy: 12,
+      r: 9,
+      stroke: "currentColor",
+      strokeWidth: 1.8,
+      opacity: 0.55,
+    }),
+    createElement("path", {
+      d: "M12 4.5 14.6 12 12 19.5 9.4 12z",
+      fill: "currentColor",
+    }),
+    createElement("path", {
+      d: "M4.5 12h15",
+      stroke: "currentColor",
+      strokeWidth: 1.6,
+      opacity: 0.45,
+    }),
+  );
+}
+
+export const logisticsIdentity = {
+  brand: "Meridian",
+  tagline: "Every exception, decided.",
+  logo: MeridianLogo,
+  favicon: "🧭",
+  assistantName: "Meridian Control",
+  greeting:
+    "Rosa — Meridian Control here. Six lanes are live and three shipments need a call today. " +
+    "I can triage the tower, weigh your options on a late shipment, or build a decision brief. Where do you want to start?",
+} as const;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/intelligence/user-id.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/intelligence/user-id.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  logisticsIdentifyUser,
+  resolveUserId,
+  resolveUserName,
+  DEMO_DEFAULT_USER_ID,
+} from "./user-id";
+
+const ORIGINAL = { ...process.env };
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+});
+
+describe("logistics identity", () => {
+  it("maps a known planner id onto a stable scope", () => {
+    expect(resolveUserId({ plannerId: "pl-rosa" })).toBe("rosa-delgado");
+    expect(resolveUserName({ plannerId: "pl-rosa" })).toBe("Rosa Delgado");
+  });
+
+  it("keeps the two planners in separate memory scopes", () => {
+    expect(resolveUserId({ plannerId: "pl-rosa" })).not.toBe(
+      resolveUserId({ plannerId: "pl-ibrahim" }),
+    );
+  });
+
+  it("falls back to a role-derived scope for an unmapped planner", () => {
+    expect(resolveUserId({ plannerId: "pl-unknown", role: "Director" })).toBe(
+      "meridian-director",
+    );
+  });
+
+  it("falls back to the demo default with no planner and no role", () => {
+    expect(resolveUserId({})).toBe(DEMO_DEFAULT_USER_ID);
+  });
+
+  it("lets a pinned env id win so CI stays deterministic", () => {
+    process.env.INTELLIGENCE_USER_ID = "ci-pinned";
+    process.env.INTELLIGENCE_USER_NAME = "CI User";
+    expect(resolveUserId({ plannerId: "pl-rosa" })).toBe("ci-pinned");
+    expect(resolveUserName({ plannerId: "pl-rosa" })).toBe("CI User");
+  });
+
+  it("reads the client-forwarded properties bag", () => {
+    expect(
+      logisticsIdentifyUser({ userId: "pl-ibrahim", userRole: "Director" }),
+    ).toEqual({ id: "ibrahim-okonjo", name: "Ibrahim Okonjo" });
+    expect(logisticsIdentifyUser(undefined).id).toBe(DEMO_DEFAULT_USER_ID);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/intelligence/user-id.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/intelligence/user-id.ts
@@ -1,0 +1,70 @@
+/**
+ * Resolve a stable end-user identity for Intelligence requests (thread +
+ * durable-memory scoping). SERVER-SAFE: plain .ts, no "use client", no JSX.
+ *
+ * Precedence: pinned env > mapped planner id > role-derived > demo default.
+ * The pinned env wins so CI (Playwright/aimock) stays deterministic on one
+ * seeded identity.
+ */
+
+/** Planner id (seed.json) -> memory scope. Kept 1:1 so two on-screen people
+ *  never share one memory scope. */
+const PLANNER_IDENTITY: Record<string, { userId: string; userName: string }> = {
+  "pl-rosa": { userId: "rosa-delgado", userName: "Rosa Delgado" },
+  "pl-ibrahim": { userId: "ibrahim-okonjo", userName: "Ibrahim Okonjo" },
+};
+
+export const SEEDED_USER_IDS: readonly string[] = Object.values(
+  PLANNER_IDENTITY,
+).map((p) => p.userId);
+
+export const DEMO_DEFAULT_USER_ID = "meridian-demo-user";
+
+export type IdentityInput = { plannerId?: string; role?: string };
+
+function roleSlug(role?: string): string {
+  if (!role) return DEMO_DEFAULT_USER_ID;
+  const slug = role
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  return slug ? `meridian-${slug}` : DEMO_DEFAULT_USER_ID;
+}
+
+export function resolveUserId({ plannerId, role }: IdentityInput = {}): string {
+  const pinned = process.env.INTELLIGENCE_USER_ID;
+  if (pinned) return pinned;
+  if (plannerId && PLANNER_IDENTITY[plannerId])
+    return PLANNER_IDENTITY[plannerId].userId;
+  return roleSlug(role);
+}
+
+export function resolveUserName({
+  plannerId,
+  role,
+}: IdentityInput = {}): string {
+  if (process.env.INTELLIGENCE_USER_ID) {
+    return (
+      process.env.INTELLIGENCE_USER_NAME ?? process.env.INTELLIGENCE_USER_ID
+    );
+  }
+  if (plannerId && PLANNER_IDENTITY[plannerId])
+    return PLANNER_IDENTITY[plannerId].userName;
+  return role ? `Meridian ${role}` : "Meridian Demo User";
+}
+
+/**
+ * The logistics skin's `IdentifyRunUser`, registered in agent-registry.ts. The
+ * client forwards the active planner through CopilotKit `properties`
+ * ({ userRole, userId }); this maps them onto a stable per-planner scope
+ * WITHOUT the shared API route importing anything skin-specific.
+ */
+export function logisticsIdentifyUser(
+  properties: { userRole?: string; userId?: string } | undefined,
+): { id: string; name: string } {
+  const input: IdentityInput = {
+    plannerId: properties?.userId,
+    role: properties?.userRole,
+  };
+  return { id: resolveUserId(input), name: resolveUserName(input) };
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/layout.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/layout.tsx
@@ -65,9 +65,15 @@ export function LogisticsLayout({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <div className="flex min-h-screen bg-canvas text-ink">
+    // h-screen + overflow-hidden (not min-h-screen): the shell must be exactly
+    // one viewport tall so the nav stays pinned and <main> scrolls INSIDE it.
+    // With min-h-screen the container grows past the viewport on a long page,
+    // which scrolls the whole document — taking the nav with it — and leaves
+    // <main>'s own overflow-y-auto inert because its parent is unbounded.
+    // Mirrors banking's layout.
+    <div className="flex h-screen overflow-hidden bg-canvas text-ink">
       <aside
-        className="hidden shrink-0 flex-col border-r border-hairline bg-surface px-3 py-5 md:flex"
+        className="hidden h-full shrink-0 flex-col border-r border-hairline bg-surface px-3 py-5 md:flex"
         style={{ width: SIDEBAR_WIDTH_PX }}
       >
         <div className="mb-7 flex items-center gap-2.5 px-2 text-brand">

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/layout.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/layout.tsx
@@ -5,8 +5,18 @@ import { useEffect } from "react";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { HelpCircle, RotateCcw } from "lucide-react";
 import { useSkin } from "@/shell/skin-provider";
+import { usePresenterReset } from "@/shell/presenter-reset-context";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { usePlannerAuth } from "./components/planner-auth-context";
+import { useAskCopilot } from "./components/use-ask-copilot";
 import { cn } from "@/lib/utils";
 
 const SIDEBAR_WIDTH_PX = 240;
@@ -15,7 +25,32 @@ export function LogisticsLayout({ children }: { children: ReactNode }) {
   const skin = useSkin();
   const pathname = usePathname();
   const { currentPlanner, planners, setPlannerId } = usePlannerAuth();
+  const resetEnabled = usePresenterReset();
+  const askCopilot = useAskCopilot();
   const Logo = skin.identity.logo;
+
+  const handleReset = async () => {
+    if (
+      !window.confirm("Reset demo state? This restores the seeded scenario.")
+    ) {
+      return;
+    }
+    try {
+      const res = await fetch("/api/logistics/v1/dev/reset", {
+        method: "POST",
+      });
+      if (res.ok) {
+        // Hard navigate to the skin root for a pristine client slate (fresh
+        // store, cleared canvas, new thread on next message) AND the clean
+        // starting URL the demo should always open on.
+        window.location.assign(`/${skin.id}`);
+      } else {
+        window.alert(`Reset failed (HTTP ${res.status}). See the server logs.`);
+      }
+    } catch (err) {
+      window.alert(`Reset failed: ${err instanceof Error ? err.message : err}`);
+    }
+  };
 
   // Tell the shell how much width our nav reserves so the floating skin
   // selector docks in the content band and never lands on the sidebar.
@@ -67,28 +102,86 @@ export function LogisticsLayout({ children }: { children: ReactNode }) {
           })}
         </nav>
 
-        {/* Role switcher — swapping to the Director is what visibly lifts the
-            authority gate, so it belongs in the always-visible chrome. */}
-        <div className="mt-auto rounded-md border border-hairline bg-surface-muted p-3">
-          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-ink-muted">
-            On duty
-          </div>
-          <select
-            aria-label="Acting planner"
-            className="w-full rounded-md border border-hairline bg-surface px-2 py-1.5 text-sm text-ink"
-            value={currentPlanner.id}
-            onChange={(e) => setPlannerId(e.target.value)}
-          >
-            {planners.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name} — {p.role}
-              </option>
-            ))}
-          </select>
-          <div className="mt-1.5 text-[11px] text-ink-muted">
-            {currentPlanner.authorityUsd === null
-              ? "Unlimited approval authority"
-              : `Approves up to $${currentPlanner.authorityUsd.toLocaleString("en-US")}`}
+        {/* Bottom group: meta-utility strip stacked directly above the
+            always-visible "On duty" planner switcher. */}
+        <div className="mt-auto flex flex-col gap-3">
+          {/* Meta-utility strip — Reset (presenter-gated), theme toggle, and a
+              copilot Help shortcut. Semantic utilities only, so a reskin swaps
+              the palette without touching this chrome. */}
+          <TooltipProvider>
+            <div className="flex items-center gap-1 border-t border-hairline px-1 pt-3">
+              {resetEnabled && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={handleReset}
+                      aria-label="Reset demo state"
+                      className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p>Reset demo state</p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <ThemeToggle />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>Toggle theme</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Ask the copilot for help"
+                    onClick={() =>
+                      void askCopilot(
+                        "What can you help me with in this control tower? Give me a short list.",
+                      )
+                    }
+                    className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>Ask the copilot for help</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+
+          {/* Role switcher — swapping to the Director is what visibly lifts the
+              authority gate, so it belongs in the always-visible chrome. */}
+          <div className="rounded-md border border-hairline bg-surface-muted p-3">
+            <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-ink-muted">
+              On duty
+            </div>
+            <select
+              aria-label="Acting planner"
+              className="w-full rounded-md border border-hairline bg-surface px-2 py-1.5 text-sm text-ink"
+              value={currentPlanner.id}
+              onChange={(e) => setPlannerId(e.target.value)}
+            >
+              {planners.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name} — {p.role}
+                </option>
+              ))}
+            </select>
+            <div className="mt-1.5 text-[11px] text-ink-muted">
+              {currentPlanner.authorityUsd === null
+                ? "Unlimited approval authority"
+                : `Approves up to $${currentPlanner.authorityUsd.toLocaleString("en-US")}`}
+            </div>
           </div>
         </div>
       </aside>

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/layout.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/layout.tsx
@@ -1,0 +1,99 @@
+"use client";
+import "./theme.css"; // side-effect import registers the .theme-logistics block
+
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useSkin } from "@/shell/skin-provider";
+import { usePlannerAuth } from "./components/planner-auth-context";
+import { cn } from "@/lib/utils";
+
+const SIDEBAR_WIDTH_PX = 240;
+
+export function LogisticsLayout({ children }: { children: ReactNode }) {
+  const skin = useSkin();
+  const pathname = usePathname();
+  const { currentPlanner, planners, setPlannerId } = usePlannerAuth();
+  const Logo = skin.identity.logo;
+
+  // Tell the shell how much width our nav reserves so the floating skin
+  // selector docks in the content band and never lands on the sidebar.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--nw-nav-inset-left", `${SIDEBAR_WIDTH_PX}px`);
+    root.style.setProperty("--nw-nav-inset-right", "0px");
+    return () => {
+      root.style.removeProperty("--nw-nav-inset-left");
+      root.style.removeProperty("--nw-nav-inset-right");
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-screen bg-canvas text-ink">
+      <aside
+        className="hidden shrink-0 flex-col border-r border-hairline bg-surface px-3 py-5 md:flex"
+        style={{ width: SIDEBAR_WIDTH_PX }}
+      >
+        <div className="mb-7 flex items-center gap-2.5 px-2 text-brand">
+          <Logo className="h-7 w-7" />
+          <span className="text-base font-bold tracking-tight text-ink">
+            {skin.identity.brand}
+          </span>
+        </div>
+        <nav className="flex flex-col gap-0.5">
+          {skin.nav.map((route) => {
+            const href = route.segment
+              ? `/${skin.id}/${route.segment}`
+              : `/${skin.id}`;
+            const active = pathname === href;
+            const Icon = route.icon;
+            return (
+              <Link
+                key={route.segment || "index"}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-brand-soft text-brand"
+                    : "text-ink-muted hover:bg-surface-muted hover:text-ink",
+                )}
+              >
+                {Icon ? <Icon className="h-4 w-4" /> : null}
+                {route.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Role switcher — swapping to the Director is what visibly lifts the
+            authority gate, so it belongs in the always-visible chrome. */}
+        <div className="mt-auto rounded-md border border-hairline bg-surface-muted p-3">
+          <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-ink-muted">
+            On duty
+          </div>
+          <select
+            aria-label="Acting planner"
+            className="w-full rounded-md border border-hairline bg-surface px-2 py-1.5 text-sm text-ink"
+            value={currentPlanner.id}
+            onChange={(e) => setPlannerId(e.target.value)}
+          >
+            {planners.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name} — {p.role}
+              </option>
+            ))}
+          </select>
+          <div className="mt-1.5 text-[11px] text-ink-muted">
+            {currentPlanner.authorityUsd === null
+              ? "Unlimited approval authority"
+              : `Approves up to $${currentPlanner.authorityUsd.toLocaleString("en-US")}`}
+          </div>
+        </div>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto px-5 py-6">{children}</main>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/nav.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/nav.ts
@@ -1,0 +1,9 @@
+import { Radar, Route, Boxes, ClipboardList } from "lucide-react";
+import type { NavRoute } from "@/shell/skin-contract";
+
+export const logisticsNav: NavRoute[] = [
+  { segment: "", label: "Control Tower", icon: Radar },
+  { segment: "lanes", label: "Lanes", icon: Route },
+  { segment: "inventory", label: "Inventory", icon: Boxes },
+  { segment: "decisions", label: "Decision Log", icon: ClipboardList },
+];

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/pages/control-tower.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/pages/control-tower.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useLogistics } from "../actions";
+import { KpiStrip, ExceptionBoard } from "../components";
+
+export function ControlTowerPage() {
+  const { shipments, lanes } = useLogistics();
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          Control Tower
+        </h1>
+        <p className="mt-1 text-sm text-ink-muted">
+          Live exceptions across the network, worst first.
+        </p>
+      </header>
+      <KpiStrip shipments={shipments} />
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-ink-muted">
+          Exceptions
+        </h2>
+        <ExceptionBoard shipments={shipments} lanes={lanes} />
+      </section>
+    </div>
+  );
+}
+
+export default ControlTowerPage;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/pages/decisions.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/pages/decisions.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useLogistics } from "../actions";
+import { DecisionLog } from "../components";
+
+export function DecisionsPage() {
+  const { decisions } = useLogistics();
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          Decision Log
+        </h1>
+        <p className="mt-1 text-sm text-ink-muted">
+          Every committed and escalated call, newest first.
+        </p>
+      </header>
+      <DecisionLog decisions={decisions} />
+    </div>
+  );
+}
+
+export default DecisionsPage;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/pages/inventory.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/pages/inventory.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useLogistics } from "../actions";
+import { InventoryRiskList } from "../components";
+
+export function InventoryPage() {
+  const { inventory } = useLogistics();
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          Inventory at Risk
+        </h1>
+        <p className="mt-1 text-sm text-ink-muted">
+          Days of cover against inbound arrivals.
+        </p>
+      </header>
+      <InventoryRiskList items={inventory} />
+    </div>
+  );
+}
+
+export default InventoryPage;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/pages/lanes.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/pages/lanes.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useLogistics } from "../actions";
+import { LaneTable } from "../components";
+
+export function LanesPage() {
+  const { lanes } = useLogistics();
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          Lanes
+        </h1>
+        <p className="mt-1 text-sm text-ink-muted">Network health by lane.</p>
+      </header>
+      <LaneTable lanes={lanes} />
+    </div>
+  );
+}
+
+export default LanesPage;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/providers.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/providers.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+import {
+  PlannerAuthProvider,
+  usePlannerAuth,
+} from "./components/planner-auth-context";
+import { SandboxDataSync } from "./sandbox-data-sync";
+
+/**
+ * Mounted by the shell ABOVE CopilotKitProvider. Establishes the planner auth
+ * context so `useLogisticsRuntimeProperties` can read it and the provider owns
+ * the identity from its first commit — rather than a child racing an imperative
+ * setProperties after mount. PlannerAuthProvider renders null until the roster
+ * resolves, so no run is ever scoped to an unknown planner.
+ */
+export function LogisticsRuntimeProviders({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <PlannerAuthProvider>{children}</PlannerAuthProvider>;
+}
+
+/**
+ * Threaded into CopilotKitProvider's `properties` prop by the shell. Memoized
+ * on the planner's id/role so only a planner switch re-scopes the run. Does NOT
+ * set `a2uiCatalogAvailable` — the shell adds that itself when a catalog exists.
+ */
+export function useLogisticsRuntimeProperties(): Record<string, unknown> {
+  const { currentPlanner } = usePlannerAuth();
+  return useMemo(
+    () => ({ userRole: currentPlanner.role, userId: currentPlanner.id }),
+    [currentPlanner.role, currentPlanner.id],
+  );
+}
+
+/**
+ * The below-provider stack — `skin.Providers`. Everything here may consume the
+ * CopilotKit context, which is exactly why it cannot be hoisted above the
+ * provider. SandboxDataSync mirrors the live ledger into the OGUI snapshot.
+ */
+export function LogisticsProviders({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <SandboxDataSync />
+      {children}
+    </>
+  );
+}
+
+export default LogisticsProviders;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/sandbox-data-sync.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/sandbox-data-sync.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLogistics } from "./actions";
+import { setSandboxSnapshot } from "./sandbox-functions";
+
+/**
+ * Mirrors the live ledger into the OGUI sandbox snapshot. Renders null.
+ * Mounted in the skin's `Providers` (below CopilotKitProvider) so a generated
+ * UI always reads the same data the app is showing.
+ */
+export function SandboxDataSync() {
+  const { shipments, lanes, inventory } = useLogistics();
+  useEffect(() => {
+    setSandboxSnapshot({ shipments, lanes, inventory });
+  }, [shipments, lanes, inventory]);
+  return null;
+}
+
+export default SandboxDataSync;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/sandbox-functions.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/sandbox-functions.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  sandboxFunctions,
+  setSandboxSnapshot,
+  type Snapshot,
+} from "./sandbox-functions";
+import type { Lane, Shipment } from "./data/types";
+
+const lanes: Lane[] = [
+  {
+    id: "ocean",
+    origin: "Shanghai (SHA)",
+    destination: "Los Angeles (LAX)",
+    mode: "ocean",
+    transitDays: 24,
+    reliability: 0.71,
+    costPerKg: 0.45,
+    status: "degraded",
+    note: "congestion",
+  },
+  {
+    id: "air",
+    origin: "Shanghai (SHA)",
+    destination: "Los Angeles (LAX)",
+    mode: "air",
+    transitDays: 2,
+    reliability: 0.94,
+    costPerKg: 6.0,
+    status: "healthy",
+  },
+];
+
+const shipments: Shipment[] = [
+  {
+    id: "shp-4821",
+    reference: "PO-88213",
+    laneId: "ocean",
+    carrier: "Pacific Star Line",
+    skuId: "sku-a14",
+    units: 4800,
+    weightKg: 1400,
+    valueUsd: 240000,
+    etaPlanned: "2026-08-06",
+    etaCurrent: "2026-08-12",
+    slaDate: "2026-08-08",
+    status: "delayed",
+    exception: {
+      code: "PORT_CONGESTION",
+      detail: "Berth wait.",
+      since: "2026-07-28",
+    },
+    activeEscalationId: "esc-secret",
+  },
+  {
+    id: "shp-4824",
+    reference: "PO-88266",
+    laneId: "ocean",
+    carrier: "Pacific Star Line",
+    skuId: "sku-a14",
+    units: 2600,
+    weightKg: 780,
+    valueUsd: 131000,
+    etaPlanned: "2026-08-15",
+    etaCurrent: "2026-08-15",
+    slaDate: "2026-08-20",
+    status: "on_track",
+  },
+];
+
+const snapshot: Snapshot = {
+  shipments,
+  lanes,
+  inventory: [
+    {
+      skuId: "sku-a14",
+      name: "A14 Drive Assembly",
+      onHandUnits: 3200,
+      dailyDemand: 800,
+      safetyStockDays: 5,
+      inboundShipmentIds: ["shp-4821"],
+      daysOfCover: 4,
+      atRisk: true,
+    },
+  ],
+};
+
+const call = (name: string, args: unknown = {}) => {
+  const fn = sandboxFunctions.find((f) => f.name === name);
+  if (!fn) throw new Error(`no sandbox function named ${name}`);
+  return fn.handler(args as never);
+};
+
+beforeEach(() => setSandboxSnapshot(snapshot));
+
+describe("sandbox functions", () => {
+  it("projects shipments to an allowlisted DTO and drops internal fields", async () => {
+    const rows = (await call("getShipments")) as Record<string, unknown>[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveProperty("reference", "PO-88213");
+    // Internal plumbing must never cross the iframe boundary.
+    expect(rows[0]).not.toHaveProperty("activeEscalationId");
+    expect(rows[0]).not.toHaveProperty("appliedMitigation");
+  });
+
+  it("filters shipments by status", async () => {
+    const rows = (await call("getShipments", {
+      status: "delayed",
+    })) as unknown[];
+    expect(rows).toHaveLength(1);
+  });
+
+  it("returns lanes, inventory risk, and KPIs", async () => {
+    expect((await call("getLanes")) as unknown[]).toHaveLength(2);
+    expect((await call("getInventoryRisk")) as unknown[]).toHaveLength(1);
+    const kpis = (await call("getKpis")) as Record<string, number>;
+    expect(kpis).toHaveProperty("atRiskCount");
+    expect(kpis).toHaveProperty("exposureUsd");
+  });
+
+  it("returns mitigation options for a shipment and an empty list for an unknown id", async () => {
+    const options = (await call("getMitigationOptions", {
+      shipmentId: "shp-4821",
+    })) as unknown[];
+    expect(options.length).toBeGreaterThan(1);
+    expect(
+      (await call("getMitigationOptions", { shipmentId: "nope" })) as unknown[],
+    ).toEqual([]);
+  });
+
+  it("exposes a stable array identity so the provider never re-registers", () => {
+    expect(sandboxFunctions).toBe(sandboxFunctions);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/sandbox-functions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/sandbox-functions.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+import type { SandboxFunction } from "@copilotkit/react-core/v2";
+import type { InventoryRisk, Lane, Shipment } from "./data/types";
+import { computeMitigationOptions } from "./data/mitigation-options";
+import { deriveKpis } from "./components/kpi-strip";
+
+/**
+ * The single source the OGUI sandbox reads. Holds FULL domain objects; every
+ * handler projects to a DTO at the boundary so no internal field
+ * (activeEscalationId, appliedMitigation) ever crosses into the iframe's
+ * LLM-authored JS. <SandboxDataSync/> keeps this in sync with the live view.
+ */
+export type Snapshot = {
+  shipments: Shipment[];
+  lanes: Lane[];
+  inventory: InventoryRisk[];
+};
+
+let snapshot: Snapshot = { shipments: [], lanes: [], inventory: [] };
+
+/**
+ * Replace the snapshot the handlers read. Takes ownership of `next` by
+ * reference — it does not clone. The sole caller is <SandboxDataSync/>, which
+ * passes React state treated as immutable.
+ */
+export function setSandboxSnapshot(next: Snapshot): void {
+  snapshot = next;
+}
+
+// ── Projection DTOs (allowlist — no raw domain object crosses the boundary) ──
+type SafeShipment = {
+  id: string;
+  reference: string;
+  laneId: string;
+  carrier: string;
+  skuId: string;
+  units: number;
+  weightKg: number;
+  valueUsd: number;
+  etaPlanned: string;
+  etaCurrent: string;
+  slaDate: string;
+  status: Shipment["status"];
+  exceptionCode: string | null;
+  slaMet: boolean;
+};
+type SafeLane = {
+  id: string;
+  origin: string;
+  destination: string;
+  mode: Lane["mode"];
+  transitDays: number;
+  reliability: number;
+  costPerKg: number;
+  status: Lane["status"];
+};
+type SafeInventory = {
+  skuId: string;
+  name: string;
+  onHandUnits: number;
+  dailyDemand: number;
+  daysOfCover: number;
+  safetyStockDays: number;
+  atRisk: boolean;
+};
+
+const toSafeShipment = (s: Shipment): SafeShipment => ({
+  id: s.id,
+  reference: s.reference,
+  laneId: s.laneId,
+  carrier: s.carrier,
+  skuId: s.skuId,
+  units: s.units,
+  weightKg: s.weightKg,
+  valueUsd: s.valueUsd,
+  etaPlanned: s.etaPlanned,
+  etaCurrent: s.etaCurrent,
+  slaDate: s.slaDate,
+  status: s.status,
+  exceptionCode: s.exception?.code ?? null,
+  slaMet: s.etaCurrent <= s.slaDate,
+});
+
+const toSafeLane = (l: Lane): SafeLane => ({
+  id: l.id,
+  origin: l.origin,
+  destination: l.destination,
+  mode: l.mode,
+  transitDays: l.transitDays,
+  reliability: l.reliability,
+  costPerKg: l.costPerKg,
+  status: l.status,
+});
+
+const toSafeInventory = (i: InventoryRisk): SafeInventory => ({
+  skuId: i.skuId,
+  name: i.name,
+  onHandUnits: i.onHandUnits,
+  dailyDemand: i.dailyDemand,
+  daysOfCover: i.daysOfCover,
+  safetyStockDays: i.safetyStockDays,
+  atRisk: i.atRisk,
+});
+
+/**
+ * Stable module-scope array — safe to hand straight to the provider. Handlers
+ * close over the mutable module snapshot, so the array identity never changes
+ * (no per-render re-registration) while the DATA stays live.
+ */
+export const sandboxFunctions: SandboxFunction[] = [
+  {
+    name: "getShipments",
+    description:
+      "Return the current shipments (real app data): reference, lane, carrier, units, weight, " +
+      "value, planned/current ETA, promised date, status, exception code, and whether the " +
+      "promised date is met. Optional `status` filters to on_track/at_risk/delayed/resolved.",
+    parameters: z.object({
+      status: z.enum(["on_track", "at_risk", "delayed", "resolved"]).optional(),
+    }),
+    handler: async ({ status }: { status?: Shipment["status"] }) =>
+      (status
+        ? snapshot.shipments.filter((s) => s.status === status)
+        : snapshot.shipments
+      ).map(toSafeShipment),
+  },
+  {
+    name: "getLanes",
+    description:
+      "Return the network lanes (origin, destination, mode, transit days, on-time reliability, " +
+      "cost per kg, status) — real app data.",
+    parameters: z.object({}),
+    handler: async () => snapshot.lanes.map(toSafeLane),
+  },
+  {
+    name: "getInventoryRisk",
+    description:
+      "Return inventory positions with derived days of cover and an at-risk flag (cover below " +
+      "the safety-stock floor) — real app data.",
+    parameters: z.object({}),
+    handler: async () => snapshot.inventory.map(toSafeInventory),
+  },
+  {
+    name: "getKpis",
+    description:
+      "Return headline KPIs: onTimeRate (0..1), atRiskCount, exposureUsd, avgDelayDays — real app data.",
+    parameters: z.object({}),
+    handler: async () => deriveKpis(snapshot.shipments),
+  },
+  {
+    name: "getMitigationOptions",
+    description:
+      "Return the available mitigation options for one shipment (kind, cost, resulting ETA, " +
+      "whether the promised date is met, risk). Pass the shipment id, e.g. 'shp-4821'. " +
+      "Returns an empty list for an unknown id.",
+    parameters: z.object({ shipmentId: z.string() }),
+    handler: async ({ shipmentId }: { shipmentId: string }) => {
+      const shipment = snapshot.shipments.find(
+        (s) => s.id === shipmentId || s.reference === shipmentId,
+      );
+      return shipment ? computeMitigationOptions(shipment, snapshot.lanes) : [];
+    },
+  },
+];

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/skin.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/skin.tsx
@@ -6,7 +6,11 @@ import { logisticsIdentity } from "./identity";
 import { logisticsNav } from "./nav";
 import { LogisticsLayout } from "./layout";
 import { LogisticsTools } from "./tools";
-import { LogisticsProviders, LogisticsRuntimeProviders, useLogisticsRuntimeProperties } from "./providers";
+import {
+  LogisticsProviders,
+  LogisticsRuntimeProviders,
+  useLogisticsRuntimeProperties,
+} from "./providers";
 import { LogisticsCanvasSurface } from "./canvas-surface";
 import { catalog } from "./catalog";
 import { logisticsSuggestions } from "./suggestions";
@@ -36,6 +40,7 @@ const TOOL_LABELS: Record<string, string> = {
   compareMitigations: "Weighing the options",
   commitMitigation: "Committing the decision",
   fileEscalation: "Filing an escalation",
+  createDecisionRecord: "Filing to the decision log",
   renderBrief: "Building the decision brief",
   generateSandboxedUi: "Generating an interactive view",
   recall_memory: "Recalling from long-term memory",
@@ -51,7 +56,8 @@ const logistics: Skin = {
   themeClass: "theme-logistics",
   Layout: LogisticsLayout,
   nav: logisticsNav,
-  resolvePage: (segments) => PAGES[segments.length === 0 ? "" : segments.join("/")] ?? null,
+  resolvePage: (segments) =>
+    PAGES[segments.length === 0 ? "" : segments.join("/")] ?? null,
   Tools: LogisticsTools,
   catalog,
   suggestions: logisticsSuggestions,

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/skin.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/skin.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { ComponentType } from "react";
+import type { Skin } from "@/shell/skin-contract";
+import { logisticsIdentity } from "./identity";
+import { logisticsNav } from "./nav";
+import { LogisticsLayout } from "./layout";
+import { LogisticsTools } from "./tools";
+import { LogisticsProviders, LogisticsRuntimeProviders, useLogisticsRuntimeProperties } from "./providers";
+import { LogisticsCanvasSurface } from "./canvas-surface";
+import { catalog } from "./catalog";
+import { logisticsSuggestions } from "./suggestions";
+import { MERIDIAN_DESIGN_SKILL } from "./design-skill";
+import { sandboxFunctions } from "./sandbox-functions";
+import { ControlTowerPage } from "./pages/control-tower";
+import { LanesPage } from "./pages/lanes";
+import { InventoryPage } from "./pages/inventory";
+import { DecisionsPage } from "./pages/decisions";
+
+// Route segments after /logistics → page component. Empty → the control tower.
+const PAGES: Record<string, ComponentType> = {
+  "": ControlTowerPage,
+  lanes: LanesPage,
+  inventory: InventoryPage,
+  decisions: DecisionsPage,
+};
+
+// Human-readable activity-chip labels for this skin's own tools, in the
+// present-participle voice both shipped skins use. Unlisted tools fall back to
+// a prettified raw name.
+const TOOL_LABELS: Record<string, string> = {
+  showExceptions: "Scanning the exception queue",
+  showShipment: "Pulling up the shipment",
+  showLane: "Checking lane health",
+  showInventoryRisk: "Checking inventory cover",
+  compareMitigations: "Weighing the options",
+  commitMitigation: "Committing the decision",
+  fileEscalation: "Filing an escalation",
+  renderBrief: "Building the decision brief",
+  generateSandboxedUi: "Generating an interactive view",
+  recall_memory: "Recalling from long-term memory",
+  save_memory: "Saving to long-term memory",
+};
+
+// NOTE: no `agent` field — agents are server-only, registered in
+// src/shell/agent-registry.ts under this same id ("logistics"). This module
+// must NEVER import agent.ts.
+const logistics: Skin = {
+  id: "logistics",
+  identity: logisticsIdentity,
+  themeClass: "theme-logistics",
+  Layout: LogisticsLayout,
+  nav: logisticsNav,
+  resolvePage: (segments) => PAGES[segments.length === 0 ? "" : segments.join("/")] ?? null,
+  Tools: LogisticsTools,
+  catalog,
+  suggestions: logisticsSuggestions,
+  designSkill: MERIDIAN_DESIGN_SKILL,
+
+  // Planner auth lives ABOVE CopilotKitProvider so identity flows through the
+  // provider's `properties` prop rather than a child racing setProperties.
+  RuntimeProviders: LogisticsRuntimeProviders,
+  useRuntimeProperties: useLogisticsRuntimeProperties,
+  Providers: LogisticsProviders,
+  CanvasSurface: LogisticsCanvasSurface,
+  sandboxFunctions,
+  toolLabels: TOOL_LABELS,
+
+  // `useData` is omitted: like banking, components read the REST ledger through
+  // useLogistics() and the planner through usePlannerAuth() directly, so
+  // useSkinData<T>() correctly returns undefined.
+  // `chatHeaderActions` and `onSuggestionSelect` are omitted deliberately —
+  // both exist in banking only to serve its PDF-attachment beat.
+};
+
+export default logistics;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/suggestions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/suggestions.ts
@@ -1,0 +1,8 @@
+import type { Suggestion } from "@/shell/skin-contract";
+
+export const logisticsSuggestions: Suggestion[] = [
+  { title: "Triage the tower", message: "What needs my attention right now?" },
+  { title: "Weigh the options", message: "PO-88213 is running late — what are my options?" },
+  { title: "Inventory at risk", message: "Which SKUs run out before their inbound arrives?" },
+  { title: "Decision brief", message: "Build me a decision brief for this week's exceptions." },
+];

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/theme.css
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/theme.css
@@ -6,11 +6,20 @@
    tight where both others are generous — a dense operations console rather
    than a friendly consumer app.
 
-   Light-only by design: this block does NOT set `--nw-dark-capable`, so the
-   shell's theme reconciler pins the skin to light mode. Do not add it. */
+   Ships both palettes: the light block below plus a `.dark .theme-logistics`
+   block at the end, so the theme toggle is a real control. */
 
 .theme-logistics {
   --radius: 0.5rem;
+
+  /* Dark capability, declared on the theme root. The shared `.dark` signal on
+     <html> is global, but only a skin that ships a dark palette (the
+     `.dark .theme-logistics` block below) should react to it — otherwise a
+     light-only skin inherits a dark chat chrome and renders half-dark. The
+     shell's theme reconciler (useSkinThemeReconcile in hooks/use-theme.ts)
+     reads this inherited property and forces light for any skin that does NOT
+     set it. Opt-IN for the special case (dark support). */
+  --nw-dark-capable: 1;
 
   /* Brand: signal amber, deepening toward copper. */
   --brand: 32 94% 48%;
@@ -35,4 +44,27 @@
   --positive-soft: 152 60% 94%;
   --negative: 8 78% 50%;
   --negative-soft: 8 86% 96%;
+}
+
+/* DARK — warm graphite. `.dark` lands on <html> (an ancestor of the
+   `.theme-logistics` root), so this descendant selector re-values only the
+   tokens that differ; the amber brand ramp and --radius inherit from above. */
+.dark .theme-logistics {
+  --background: 30 12% 8%;
+  --foreground: 40 20% 95%;
+  color-scheme: dark;
+
+  --canvas: 30 12% 8%;
+  --surface: 30 10% 12%;
+  --surface-muted: 32 9% 15%;
+  --ink: 40 20% 95%;
+  --ink-muted: 36 8% 62%;
+  --hairline: 32 10% 22%;
+
+  --brand-soft: 32 60% 18%;
+
+  --positive: 152 52% 48%;
+  --positive-soft: 152 35% 15%;
+  --negative: 8 76% 62%;
+  --negative-soft: 8 40% 18%;
 }

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/theme.css
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/theme.css
@@ -1,0 +1,38 @@
+/* Meridian (logistics) theme — a warm signal-amber on graphite control-tower
+   palette. Re-values only the shared design tokens the shell defines in
+   globals.css; adds no new token names. Imported (side-effect) from layout.tsx
+   so it loads whenever the logistics skin mounts. Deliberately distinct from
+   banking's violet and airline's jet teal: this one is WARM, and its radius is
+   tight where both others are generous — a dense operations console rather
+   than a friendly consumer app.
+
+   Light-only by design: this block does NOT set `--nw-dark-capable`, so the
+   shell's theme reconciler pins the skin to light mode. Do not add it. */
+
+.theme-logistics {
+  --radius: 0.5rem;
+
+  /* Brand: signal amber, deepening toward copper. */
+  --brand: 32 94% 48%;
+  --brand-violet: 32 94% 48%;
+  --brand-indigo: 20 88% 40%;
+  /* Dark ink ON amber — white text on a 48%-lightness amber fails contrast. */
+  --brand-foreground: 30 50% 10%;
+  --brand-soft: 36 90% 94%;
+
+  /* Surfaces: warm graphite-tinted paper. */
+  --background: 40 20% 98%;
+  --foreground: 30 12% 12%;
+
+  --canvas: 40 14% 95%;
+  --surface: 0 0% 100%;
+  --surface-muted: 40 16% 96%;
+  --ink: 30 12% 13%;
+  --ink-muted: 32 8% 42%;
+  --hairline: 38 14% 86%;
+
+  --positive: 152 58% 36%;
+  --positive-soft: 152 60% 94%;
+  --negative: 8 78% 50%;
+  --negative-soft: 8 86% 96%;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/tools.tsx
@@ -87,270 +87,302 @@ export function LogisticsTools() {
   });
 
   // ── Gen-UI (rendered inline in chat) ─────────────────────────────────────
-  useComponent({
-    name: "showExceptions",
-    description:
-      "Display the exception queue — shipments needing a decision, worst first.",
-    render: () => <ExceptionBoard shipments={shipments} lanes={lanes} />,
-  });
-
-  useComponent({
-    name: "showShipment",
-    description:
-      "Display one shipment as a card. Pass its reference (e.g. 'PO-88213') or id (e.g. 'shp-4821').",
-    parameters: z.object({
-      shipment: z.string().describe("Shipment reference or id."),
-    }),
-    render: ({ shipment: ref }) => {
-      const shipment = findShipment(ref ?? "");
-      if (!shipment) {
-        return (
-          <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
-            No shipment matches that reference.
-          </div>
-        );
-      }
-      return (
-        <ShipmentCard
-          shipment={shipment}
-          lane={lanes.find((l) => l.id === shipment.laneId)}
-        />
-      );
+  useComponent(
+    {
+      name: "showExceptions",
+      description:
+        "Display the exception queue — shipments needing a decision, worst first.",
+      render: () => <ExceptionBoard shipments={shipments} lanes={lanes} />,
     },
-  });
+    [shipments, lanes],
+  );
 
-  useComponent({
-    name: "showLane",
-    description: "Display lane health across the network.",
-    render: () => <LaneTable lanes={lanes} />,
-  });
-
-  useComponent({
-    name: "showInventoryRisk",
-    description:
-      "Display SKUs whose days of cover fall below their safety-stock floor.",
-    render: () => <InventoryRiskList items={inventory} />,
-  });
-
-  useComponent({
-    name: "compareMitigations",
-    description:
-      "Display the mitigation trade-off table for one shipment — cost, resulting ETA, whether the promised " +
-      "date is met, and risk for each option. ALWAYS call this before recommending an option.",
-    parameters: z.object({
-      shipment: z.string().describe("Shipment reference or id."),
-    }),
-    render: ({ shipment: ref }) => {
-      const shipment = findShipment(ref ?? "");
-      if (!shipment) {
+  useComponent(
+    {
+      name: "showShipment",
+      description:
+        "Display one shipment as a card. Pass its reference (e.g. 'PO-88213') or id (e.g. 'shp-4821').",
+      parameters: z.object({
+        shipment: z.string().describe("Shipment reference or id."),
+      }),
+      render: ({ shipment: ref }) => {
+        const shipment = findShipment(ref ?? "");
+        if (!shipment) {
+          return (
+            <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
+              No shipment matches that reference.
+            </div>
+          );
+        }
         return (
-          <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
-            No shipment matches that reference.
-          </div>
+          <ShipmentCard
+            shipment={shipment}
+            lane={lanes.find((l) => l.id === shipment.laneId)}
+          />
         );
-      }
-      return (
-        <TradeoffTable
-          options={computeMitigationOptions(shipment, lanes)}
-          authorityUsd={currentPlanner.authorityUsd}
-        />
-      );
+      },
     },
-  });
+    [shipments, lanes],
+  );
+
+  useComponent(
+    {
+      name: "showLane",
+      description: "Display lane health across the network.",
+      render: () => <LaneTable lanes={lanes} />,
+    },
+    [lanes],
+  );
+
+  useComponent(
+    {
+      name: "showInventoryRisk",
+      description:
+        "Display SKUs whose days of cover fall below their safety-stock floor.",
+      render: () => <InventoryRiskList items={inventory} />,
+    },
+    [inventory],
+  );
+
+  useComponent(
+    {
+      name: "compareMitigations",
+      description:
+        "Display the mitigation trade-off table for one shipment — cost, resulting ETA, whether the promised " +
+        "date is met, and risk for each option. ALWAYS call this before recommending an option.",
+      parameters: z.object({
+        shipment: z.string().describe("Shipment reference or id."),
+      }),
+      render: ({ shipment: ref }) => {
+        const shipment = findShipment(ref ?? "");
+        if (!shipment) {
+          return (
+            <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
+              No shipment matches that reference.
+            </div>
+          );
+        }
+        return (
+          <TradeoffTable
+            options={computeMitigationOptions(shipment, lanes)}
+            authorityUsd={currentPlanner.authorityUsd}
+          />
+        );
+      },
+    },
+    [shipments, lanes, currentPlanner.authorityUsd],
+  );
 
   // ── HITL: commit a mitigation (confirm before writing) ───────────────────
-  useHumanInTheLoop({
-    name: "commitMitigation",
-    description:
-      "Ask the planner to confirm committing a mitigation for a shipment. Pass the shipment reference and the " +
-      "kind you recommend. The server recomputes the cost and may REJECT it as over the planner's approval " +
-      "authority — report that honestly and offer to file an escalation. Never claim success without confirmation.",
-    parameters: z.object({
-      shipment: z
-        .string()
-        .describe("Shipment reference or id, e.g. 'PO-88213'."),
-      kind: z
-        .enum(["expedite", "reroute", "split", "absorb"])
-        .describe("Which mitigation to commit."),
-      rationale: z.string().describe("One short sentence on why this option."),
-    }),
-    render: ({ args, status, respond }) => {
-      const kind = args?.kind ?? "absorb";
-      const ref = args?.shipment ?? "";
-      if (status === ToolCallStatus.Executing && respond) {
+  useHumanInTheLoop(
+    {
+      name: "commitMitigation",
+      description:
+        "Ask the planner to confirm committing a mitigation for a shipment. Pass the shipment reference and the " +
+        "kind you recommend. The server recomputes the cost and may REJECT it as over the planner's approval " +
+        "authority — report that honestly and offer to file an escalation. Never claim success without confirmation.",
+      parameters: z.object({
+        shipment: z
+          .string()
+          .describe("Shipment reference or id, e.g. 'PO-88213'."),
+        kind: z
+          .enum(["expedite", "reroute", "split", "absorb"])
+          .describe("Which mitigation to commit."),
+        rationale: z
+          .string()
+          .describe("One short sentence on why this option."),
+      }),
+      render: ({ args, status, respond }) => {
+        const kind = args?.kind ?? "absorb";
+        const ref = args?.shipment ?? "";
+        if (status === ToolCallStatus.Executing && respond) {
+          return (
+            <div className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
+              <div className="text-sm text-ink">
+                Commit <span className="font-semibold text-brand">{kind}</span>{" "}
+                on <span className="font-mono font-semibold">{ref}</span>?
+              </div>
+              <div className="text-xs text-ink-muted">{args?.rationale}</div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
+                  onClick={async () => {
+                    const shipment = findShipment(ref);
+                    if (!shipment)
+                      return void respond(
+                        "No shipment matches that reference.",
+                      );
+                    const result = await commitMitigation({
+                      shipmentId: shipment.id,
+                      kind,
+                      rationale: args?.rationale ?? "",
+                    });
+                    void respond(
+                      result.ok
+                        ? `Committed ${kind} on ${ref} at $${result.option?.costUsd.toLocaleString("en-US")}.`
+                        : // Surface the server's block verbatim so the agent learns it
+                          // instead of reporting a false success.
+                          `REJECTED: ${result.error}`,
+                    );
+                  }}
+                >
+                  Commit {kind}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md border border-hairline px-3 py-1.5 text-xs font-medium text-ink-muted hover:bg-surface-muted"
+                  onClick={() =>
+                    void respond("Planner declined this mitigation.")
+                  }
+                >
+                  Not this one
+                </button>
+              </div>
+            </div>
+          );
+        }
         return (
-          <div className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
-            <div className="text-sm text-ink">
-              Commit <span className="font-semibold text-brand">{kind}</span> on{" "}
-              <span className="font-mono font-semibold">{ref}</span>?
-            </div>
-            <div className="text-xs text-ink-muted">{args?.rationale}</div>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
-                onClick={async () => {
-                  const shipment = findShipment(ref);
-                  if (!shipment)
-                    return void respond("No shipment matches that reference.");
-                  const result = await commitMitigation({
-                    shipmentId: shipment.id,
-                    kind,
-                    rationale: args?.rationale ?? "",
-                  });
-                  void respond(
-                    result.ok
-                      ? `Committed ${kind} on ${ref} at $${result.option?.costUsd.toLocaleString("en-US")}.`
-                      : // Surface the server's block verbatim so the agent learns it
-                        // instead of reporting a false success.
-                        `REJECTED: ${result.error}`,
-                  );
-                }}
-              >
-                Commit {kind}
-              </button>
-              <button
-                type="button"
-                className="rounded-md border border-hairline px-3 py-1.5 text-xs font-medium text-ink-muted hover:bg-surface-muted"
-                onClick={() =>
-                  void respond("Planner declined this mitigation.")
-                }
-              >
-                Not this one
-              </button>
-            </div>
+          <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
+            {status === ToolCallStatus.Complete
+              ? `Mitigation on ${ref} handled.`
+              : "Preparing the decision…"}
           </div>
         );
-      }
-      return (
-        <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
-          {status === ToolCallStatus.Complete
-            ? `Mitigation on ${ref} handled.`
-            : "Preparing the decision…"}
-        </div>
-      );
+      },
     },
-  });
+    [shipments, commitMitigation],
+  );
 
   // ── HITL: file an escalation (the recovery path from an authority block) ──
-  useHumanInTheLoop({
-    name: "fileEscalation",
-    description:
-      "File an escalation so an over-authority mitigation can proceed. Pass the shipment and a code from the " +
-      "valid escalation-code catalogue in your context. Only some codes actually authorize the spend; an " +
-      "invalid code is rejected.",
-    parameters: z.object({
-      shipment: z.string().describe("Shipment reference or id."),
-      code: z
-        .enum(ESCALATION_CODES)
-        .describe("An escalation code from the catalogue."),
-      rationale: z
-        .string()
-        .describe("One short sentence justifying the escalation."),
-    }),
-    render: ({ args, status, respond }) => {
-      const ref = args?.shipment ?? "";
-      const code = args?.code ?? "";
-      if (status === ToolCallStatus.Executing && respond) {
+  useHumanInTheLoop(
+    {
+      name: "fileEscalation",
+      description:
+        "File an escalation so an over-authority mitigation can proceed. Pass the shipment and a code from the " +
+        "valid escalation-code catalogue in your context. Only some codes actually authorize the spend; an " +
+        "invalid code is rejected.",
+      parameters: z.object({
+        shipment: z.string().describe("Shipment reference or id."),
+        code: z
+          .enum(ESCALATION_CODES)
+          .describe("An escalation code from the catalogue."),
+        rationale: z
+          .string()
+          .describe("One short sentence justifying the escalation."),
+      }),
+      render: ({ args, status, respond }) => {
+        const ref = args?.shipment ?? "";
+        const code = args?.code ?? "";
+        if (status === ToolCallStatus.Executing && respond) {
+          return (
+            <div className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
+              <div className="text-sm text-ink">
+                File escalation{" "}
+                <span className="font-mono font-semibold text-brand">
+                  {code}
+                </span>{" "}
+                on <span className="font-mono font-semibold">{ref}</span>?
+              </div>
+              <div className="text-xs text-ink-muted">{args?.rationale}</div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
+                  onClick={async () => {
+                    const shipment = findShipment(ref);
+                    if (!shipment)
+                      return void respond(
+                        "No shipment matches that reference.",
+                      );
+                    const result = await fileEscalation({
+                      shipmentId: shipment.id,
+                      code,
+                      rationale: args?.rationale ?? "",
+                    });
+                    void respond(
+                      result.ok
+                        ? `Escalation ${code} approved on ${ref}. Re-attempt the mitigation to see whether it now clears.`
+                        : `REJECTED: ${result.error}`,
+                    );
+                  }}
+                >
+                  File it
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md border border-hairline px-3 py-1.5 text-xs font-medium text-ink-muted hover:bg-surface-muted"
+                  onClick={() => void respond("Planner declined to escalate.")}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          );
+        }
         return (
-          <div className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
-            <div className="text-sm text-ink">
-              File escalation{" "}
-              <span className="font-mono font-semibold text-brand">{code}</span>{" "}
-              on <span className="font-mono font-semibold">{ref}</span>?
-            </div>
-            <div className="text-xs text-ink-muted">{args?.rationale}</div>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
-                onClick={async () => {
-                  const shipment = findShipment(ref);
-                  if (!shipment)
-                    return void respond("No shipment matches that reference.");
-                  const result = await fileEscalation({
-                    shipmentId: shipment.id,
-                    code,
-                    rationale: args?.rationale ?? "",
-                  });
-                  void respond(
-                    result.ok
-                      ? `Escalation ${code} approved on ${ref}. Re-attempt the mitigation to see whether it now clears.`
-                      : `REJECTED: ${result.error}`,
-                  );
-                }}
-              >
-                File it
-              </button>
-              <button
-                type="button"
-                className="rounded-md border border-hairline px-3 py-1.5 text-xs font-medium text-ink-muted hover:bg-surface-muted"
-                onClick={() => void respond("Planner declined to escalate.")}
-              >
-                Cancel
-              </button>
-            </div>
+          <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
+            {status === ToolCallStatus.Complete
+              ? "Escalation handled."
+              : "Preparing the escalation…"}
           </div>
         );
-      }
-      return (
-        <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
-          {status === ToolCallStatus.Complete
-            ? "Escalation handled."
-            : "Preparing the escalation…"}
-        </div>
-      );
+      },
     },
-  });
+    [shipments, fileEscalation],
+  );
 
   // ── Frontend tool: file a durable decision record ────────────────────────
   // Logs a decision the agent did NOT execute through commitMitigation (a
   // verbally-accepted recommendation, an escalation outcome). Registered here so
   // it works from any page. The server derives decidedBy/role from the planner
   // and ignores any client cost — so we file at 0 and let the server own trust.
-  useFrontendTool({
-    name: "createDecisionRecord",
-    description:
-      "File a durable decision record in the Decision Log for a decision NOT already committed through " +
-      "commitMitigation — e.g. a recommendation the planner accepted verbally, or an escalation outcome. Pass " +
-      "the shipment reference and a one-sentence rationale.",
-    parameters: z.object({
-      shipment: z
-        .string()
-        .describe("Shipment reference or id, e.g. 'PO-88213'."),
-      kind: z
-        .enum(["expedite", "reroute", "split", "absorb", "escalation"])
-        .describe("What was decided."),
-      rationale: z.string().describe("One short sentence on why."),
-      costUsd: z
-        .number()
-        .optional()
-        .describe(
-          "The cost if known. The server does not trust this and files the record at 0.",
-        ),
-    }),
-    handler: async ({ shipment: ref, kind, rationale }) => {
-      const shipment = findShipment(ref ?? "");
-      if (!shipment)
-        return "No shipment matches that reference; nothing was filed.";
-      const result = await fileDecision({
-        shipmentId: shipment.id,
-        kind: kind ?? "absorb",
-        costUsd: 0,
-        rationale: rationale ?? "",
-      });
-      return result.ok
-        ? `Filed ${kind} on ${ref} to the Decision Log.`
-        : `REJECTED: ${result.error}`;
+  useFrontendTool(
+    {
+      name: "createDecisionRecord",
+      description:
+        "File a durable decision record in the Decision Log for a decision NOT already committed through " +
+        "commitMitigation — e.g. a recommendation the planner accepted verbally, or an escalation outcome. Pass " +
+        "the shipment reference and a one-sentence rationale.",
+      parameters: z.object({
+        shipment: z
+          .string()
+          .describe("Shipment reference or id, e.g. 'PO-88213'."),
+        kind: z
+          .enum(["expedite", "reroute", "split", "absorb", "escalation"])
+          .describe("What was decided."),
+        rationale: z.string().describe("One short sentence on why."),
+        costUsd: z
+          .number()
+          .optional()
+          .describe(
+            "The cost if known. The server does not trust this and files the record at 0.",
+          ),
+      }),
+      handler: async ({ shipment: ref, kind, rationale }) => {
+        const shipment = findShipment(ref ?? "");
+        if (!shipment)
+          return "No shipment matches that reference; nothing was filed.";
+        const result = await fileDecision({
+          shipmentId: shipment.id,
+          kind: kind ?? "absorb",
+          costUsd: 0,
+          rationale: rationale ?? "",
+        });
+        return result.ok
+          ? `Filed ${kind} on ${ref} to the Decision Log.`
+          : `REJECTED: ${result.error}`;
+      },
+      render: ({ status }) => (
+        <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
+          {status === ToolCallStatus.Complete
+            ? "Filed to the Decision Log."
+            : "Filing to the decision log…"}
+        </div>
+      ),
     },
-    render: ({ status }) => (
-      <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
-        {status === ToolCallStatus.Complete
-          ? "Filed to the Decision Log."
-          : "Filing to the decision log…"}
-      </div>
-    ),
-  });
+    [shipments, fileDecision],
+  );
 
   return null;
 }

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/tools.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { z } from "zod";
+import {
+  useAgentContext,
+  useComponent,
+  useFrontendTool,
+  useHumanInTheLoop,
+  ToolCallStatus,
+} from "@copilotkit/react-core/v2";
+import { useLogistics } from "./actions";
+import { usePlannerAuth } from "./components/planner-auth-context";
+import {
+  ExceptionBoard,
+  ShipmentCard,
+  LaneTable,
+  TradeoffTable,
+  InventoryRiskList,
+  deriveKpis,
+} from "./components";
+import { computeMitigationOptions } from "./data/mitigation-options";
+import {
+  ESCALATION_CODES,
+  ESCALATION_CODE_LABELS,
+} from "./data/escalation-codes";
+import {
+  renderBriefParams,
+  buildBriefOps,
+  A2UI_OPERATIONS_KEY,
+} from "./build-brief-ops";
+
+/**
+ * Registers everything Meridian Control can do on the client: gen-UI rendered
+ * inline in chat, human-in-the-loop confirmations for anything that writes, and
+ * agent-context readables so the model always knows the live network state.
+ * Renders null — it is a registration host.
+ */
+export function LogisticsTools() {
+  const {
+    shipments,
+    lanes,
+    inventory,
+    decisions,
+    commitMitigation,
+    fileEscalation,
+  } = useLogistics();
+  const { currentPlanner } = usePlannerAuth();
+
+  const findShipment = (ref: string) =>
+    shipments.find((s) => s.id === ref || s.reference === ref);
+
+  // ── Agent-context readables ──────────────────────────────────────────────
+  useAgentContext({
+    description:
+      "The acting planner and their approval authority in USD (null means unlimited).",
+    value: JSON.stringify({
+      name: currentPlanner.name,
+      role: currentPlanner.role,
+      region: currentPlanner.region,
+      authorityUsd: currentPlanner.authorityUsd,
+    }),
+  });
+  useAgentContext({
+    description:
+      "Every live shipment: reference, lane, carrier, value, planned vs current ETA, promised date, status, and exception.",
+    value: JSON.stringify(shipments),
+  });
+  useAgentContext({
+    description:
+      "The network lanes: origin, destination, mode, transit days, on-time reliability, cost per kg, status.",
+    value: JSON.stringify(lanes),
+  });
+  useAgentContext({
+    description:
+      "Inventory positions with derived days of cover and an at-risk flag.",
+    value: JSON.stringify(inventory),
+  });
+  useAgentContext({
+    description:
+      "Recent decisions already committed or escalated on the network — the audit trail of what has been done.",
+    value: JSON.stringify(decisions),
+  });
+  useAgentContext({
+    description: "Headline KPIs for the network right now.",
+    value: JSON.stringify(deriveKpis(shipments)),
+  });
+  useAgentContext({
+    description:
+      "Valid escalation codes. Only these are accepted when filing an escalation.",
+    value: JSON.stringify(ESCALATION_CODE_LABELS),
+  });
+
+  // ── Gen-UI (rendered inline in chat) ─────────────────────────────────────
+  useComponent({
+    name: "showExceptions",
+    description:
+      "Display the exception queue — shipments needing a decision, worst first.",
+    render: () => <ExceptionBoard shipments={shipments} lanes={lanes} />,
+  });
+
+  useComponent({
+    name: "showShipment",
+    description:
+      "Display one shipment as a card. Pass its reference (e.g. 'PO-88213') or id (e.g. 'shp-4821').",
+    parameters: z.object({
+      shipment: z.string().describe("Shipment reference or id."),
+    }),
+    render: ({ shipment: ref }) => {
+      const shipment = findShipment(ref ?? "");
+      if (!shipment) {
+        return (
+          <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
+            No shipment matches that reference.
+          </div>
+        );
+      }
+      return (
+        <ShipmentCard
+          shipment={shipment}
+          lane={lanes.find((l) => l.id === shipment.laneId)}
+        />
+      );
+    },
+  });
+
+  useComponent({
+    name: "showLane",
+    description: "Display lane health across the network.",
+    render: () => <LaneTable lanes={lanes} />,
+  });
+
+  useComponent({
+    name: "showInventoryRisk",
+    description:
+      "Display SKUs whose days of cover fall below their safety-stock floor.",
+    render: () => <InventoryRiskList items={inventory} />,
+  });
+
+  useComponent({
+    name: "compareMitigations",
+    description:
+      "Display the mitigation trade-off table for one shipment — cost, resulting ETA, whether the promised " +
+      "date is met, and risk for each option. ALWAYS call this before recommending an option.",
+    parameters: z.object({
+      shipment: z.string().describe("Shipment reference or id."),
+    }),
+    render: ({ shipment: ref }) => {
+      const shipment = findShipment(ref ?? "");
+      if (!shipment) {
+        return (
+          <div className="rounded-lg border border-dashed border-hairline p-4 text-sm text-ink-muted">
+            No shipment matches that reference.
+          </div>
+        );
+      }
+      return (
+        <TradeoffTable
+          options={computeMitigationOptions(shipment, lanes)}
+          authorityUsd={currentPlanner.authorityUsd}
+        />
+      );
+    },
+  });
+
+  // ── HITL: commit a mitigation (confirm before writing) ───────────────────
+  useHumanInTheLoop({
+    name: "commitMitigation",
+    description:
+      "Ask the planner to confirm committing a mitigation for a shipment. Pass the shipment reference and the " +
+      "kind you recommend. The server recomputes the cost and may REJECT it as over the planner's approval " +
+      "authority — report that honestly and offer to file an escalation. Never claim success without confirmation.",
+    parameters: z.object({
+      shipment: z
+        .string()
+        .describe("Shipment reference or id, e.g. 'PO-88213'."),
+      kind: z
+        .enum(["expedite", "reroute", "split", "absorb"])
+        .describe("Which mitigation to commit."),
+      rationale: z.string().describe("One short sentence on why this option."),
+    }),
+    render: ({ args, status, respond }) => {
+      const kind = args?.kind ?? "absorb";
+      const ref = args?.shipment ?? "";
+      if (status === ToolCallStatus.Executing && respond) {
+        return (
+          <div className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
+            <div className="text-sm text-ink">
+              Commit <span className="font-semibold text-brand">{kind}</span> on{" "}
+              <span className="font-mono font-semibold">{ref}</span>?
+            </div>
+            <div className="text-xs text-ink-muted">{args?.rationale}</div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
+                onClick={async () => {
+                  const shipment = findShipment(ref);
+                  if (!shipment)
+                    return void respond("No shipment matches that reference.");
+                  const result = await commitMitigation({
+                    shipmentId: shipment.id,
+                    kind,
+                    rationale: args?.rationale ?? "",
+                  });
+                  void respond(
+                    result.ok
+                      ? `Committed ${kind} on ${ref} at $${result.option?.costUsd.toLocaleString("en-US")}.`
+                      : // Surface the server's block verbatim so the agent learns it
+                        // instead of reporting a false success.
+                        `REJECTED: ${result.error}`,
+                  );
+                }}
+              >
+                Commit {kind}
+              </button>
+              <button
+                type="button"
+                className="rounded-md border border-hairline px-3 py-1.5 text-xs font-medium text-ink-muted hover:bg-surface-muted"
+                onClick={() =>
+                  void respond("Planner declined this mitigation.")
+                }
+              >
+                Not this one
+              </button>
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
+          {status === ToolCallStatus.Complete
+            ? `Mitigation on ${ref} handled.`
+            : "Preparing the decision…"}
+        </div>
+      );
+    },
+  });
+
+  // ── HITL: file an escalation (the recovery path from an authority block) ──
+  useHumanInTheLoop({
+    name: "fileEscalation",
+    description:
+      "File an escalation so an over-authority mitigation can proceed. Pass the shipment and a code from the " +
+      "valid escalation-code catalogue in your context. Only some codes actually authorize the spend; an " +
+      "invalid code is rejected.",
+    parameters: z.object({
+      shipment: z.string().describe("Shipment reference or id."),
+      code: z
+        .enum(ESCALATION_CODES)
+        .describe("An escalation code from the catalogue."),
+      rationale: z
+        .string()
+        .describe("One short sentence justifying the escalation."),
+    }),
+    render: ({ args, status, respond }) => {
+      const ref = args?.shipment ?? "";
+      const code = args?.code ?? "";
+      if (status === ToolCallStatus.Executing && respond) {
+        return (
+          <div className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4">
+            <div className="text-sm text-ink">
+              File escalation{" "}
+              <span className="font-mono font-semibold text-brand">{code}</span>{" "}
+              on <span className="font-mono font-semibold">{ref}</span>?
+            </div>
+            <div className="text-xs text-ink-muted">{args?.rationale}</div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-md bg-brand px-3 py-1.5 text-xs font-medium text-brand-foreground hover:opacity-90"
+                onClick={async () => {
+                  const shipment = findShipment(ref);
+                  if (!shipment)
+                    return void respond("No shipment matches that reference.");
+                  const result = await fileEscalation({
+                    shipmentId: shipment.id,
+                    code,
+                    rationale: args?.rationale ?? "",
+                  });
+                  void respond(
+                    result.ok
+                      ? `Escalation ${code} approved on ${ref}. Re-attempt the mitigation to see whether it now clears.`
+                      : `REJECTED: ${result.error}`,
+                  );
+                }}
+              >
+                File it
+              </button>
+              <button
+                type="button"
+                className="rounded-md border border-hairline px-3 py-1.5 text-xs font-medium text-ink-muted hover:bg-surface-muted"
+                onClick={() => void respond("Planner declined to escalate.")}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
+          {status === ToolCallStatus.Complete
+            ? "Escalation handled."
+            : "Preparing the escalation…"}
+        </div>
+      );
+    },
+  });
+
+  // ── Frontend tool: render the decision brief on the canvas ───────────────
+  useFrontendTool({
+    name: "renderBrief",
+    description:
+      "Build a decision brief on the canvas. Pick which KPIs, charts, and tables to show; the figures bind to " +
+      "live data on the client, so supply selections and LABEL-ONLY text — never numbers.",
+    parameters: renderBriefParams,
+    handler: async (spec) => ({ [A2UI_OPERATIONS_KEY]: buildBriefOps(spec) }),
+    render: ({ status }) => (
+      <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
+        {status === ToolCallStatus.Complete
+          ? "Decision brief is on the canvas."
+          : "Building the decision brief…"}
+      </div>
+    ),
+  });
+
+  return null;
+}
+
+export default LogisticsTools;

--- a/examples/showcases/reskinnable-demo/src/skins/logistics/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/logistics/tools.tsx
@@ -23,11 +23,6 @@ import {
   ESCALATION_CODES,
   ESCALATION_CODE_LABELS,
 } from "./data/escalation-codes";
-import {
-  renderBriefParams,
-  buildBriefOps,
-  A2UI_OPERATIONS_KEY,
-} from "./build-brief-ops";
 
 /**
  * Registers everything Meridian Control can do on the client: gen-UI rendered
@@ -43,6 +38,7 @@ export function LogisticsTools() {
     decisions,
     commitMitigation,
     fileEscalation,
+    fileDecision,
   } = useLogistics();
   const { currentPlanner } = usePlannerAuth();
 
@@ -307,19 +303,51 @@ export function LogisticsTools() {
     },
   });
 
-  // ── Frontend tool: render the decision brief on the canvas ───────────────
+  // ── Frontend tool: file a durable decision record ────────────────────────
+  // Logs a decision the agent did NOT execute through commitMitigation (a
+  // verbally-accepted recommendation, an escalation outcome). Registered here so
+  // it works from any page. The server derives decidedBy/role from the planner
+  // and ignores any client cost — so we file at 0 and let the server own trust.
   useFrontendTool({
-    name: "renderBrief",
+    name: "createDecisionRecord",
     description:
-      "Build a decision brief on the canvas. Pick which KPIs, charts, and tables to show; the figures bind to " +
-      "live data on the client, so supply selections and LABEL-ONLY text — never numbers.",
-    parameters: renderBriefParams,
-    handler: async (spec) => ({ [A2UI_OPERATIONS_KEY]: buildBriefOps(spec) }),
+      "File a durable decision record in the Decision Log for a decision NOT already committed through " +
+      "commitMitigation — e.g. a recommendation the planner accepted verbally, or an escalation outcome. Pass " +
+      "the shipment reference and a one-sentence rationale.",
+    parameters: z.object({
+      shipment: z
+        .string()
+        .describe("Shipment reference or id, e.g. 'PO-88213'."),
+      kind: z
+        .enum(["expedite", "reroute", "split", "absorb", "escalation"])
+        .describe("What was decided."),
+      rationale: z.string().describe("One short sentence on why."),
+      costUsd: z
+        .number()
+        .optional()
+        .describe(
+          "The cost if known. The server does not trust this and files the record at 0.",
+        ),
+    }),
+    handler: async ({ shipment: ref, kind, rationale }) => {
+      const shipment = findShipment(ref ?? "");
+      if (!shipment)
+        return "No shipment matches that reference; nothing was filed.";
+      const result = await fileDecision({
+        shipmentId: shipment.id,
+        kind: kind ?? "absorb",
+        costUsd: 0,
+        rationale: rationale ?? "",
+      });
+      return result.ok
+        ? `Filed ${kind} on ${ref} to the Decision Log.`
+        : `REJECTED: ${result.error}`;
+    },
     render: ({ status }) => (
       <div className="rounded-lg border border-hairline bg-surface px-4 py-3 text-sm text-ink-muted">
         {status === ToolCallStatus.Complete
-          ? "Decision brief is on the canvas."
-          : "Building the decision brief…"}
+          ? "Filed to the Decision Log."
+          : "Filing to the decision log…"}
       </div>
     ),
   });


### PR DESCRIPTION
Adds a third skin to `examples/showcases/reskinnable-demo`: **Meridian** (`/logistics`), a supply-chain control tower built at the **maximal** end of the frozen `Skin` contract.

## Why a third skin

The two shipped skins bracket the contract — `airline` is in-memory with four optional slots, `banking` is REST-backed with nearly all of them. A third earns its place only if it demonstrates something, so this one runs a **different domain rule** through the same machinery.

Banking's most valuable property isn't the HTTP (its store is a module-scope object seeded from JSON). It's that a **server-side rule the client cannot bypass** rejects a write, returns a symptom, and forces the agent to learn the failure and route around it. Meridian reproduces that shape with **role-scoped approval authority** instead of a policy budget.

## The headline beat, verified end-to-end over HTTP

| Attempt | Result |
| --- | --- |
| Rosa (authority $5,000) expedites `PO-88213` at $8,400 | `403 OVER_AUTHORITY` |
| Same request, body claims `costUsd: 1` | `403` — server recomputes; client cost is never trusted |
| `PATCH {weightKg: 1}` then expedite | `422 FORBIDDEN_FIELD` — pricing inputs are not writable |
| Approve a **non-justifying** escalation, then expedite | `403` — still blocked |
| Approve `LINE_DOWN_RISK`, then expedite | `200`, logged at $8,400 |
| Director expedites with no escalation | `200` |

`PATCH` is an **allow-list** (`status`, `etaCurrent`) rather than a deny-list, precisely so no pricing input becomes a side channel around the gate. There is a named regression test for that bypass.

## What it exercises

- **REST substrate** — `/api/logistics/v1/*` over a seeded store, with the authority gate and a two-step escalation recovery under a closed code catalogue.
- **Identity triad** — `RuntimeProviders` (auth above the provider) + `useRuntimeProperties` + a server-safe `identifyUser`, scoping runs per planner.
- **a2ui canvas** — a Decision Brief from a deterministic op-builder; no figures travel in the ops, every number binds client-side.
- **OGUI sandbox** — five functions, each projecting to an allowlisted DTO so no internal field reaches iframe-authored JS.
- **Theme** — warm signal-amber on graphite at a tight radius, against banking's violet and airline's teal. Pure token re-valuing; no component edits, no `globals.css` change.

Deliberately omits `chatHeaderActions` and `onSuggestionSelect` (they exist in banking only to serve its PDF-attachment beat) and `useData` (components read REST directly, like banking).

## Verification

`pnpm test:unit` 22 files / 110 tests · `pnpm lint` 0 issues · `pnpm build` compiles.

Driven in a real browser: all four routes render; theme applies; the exception board sorts worst-first on real data; switching skins restores banking with no theme or nav-inset leak.

**Not verified:** the chat agent itself — no API key was available, so gen-UI, the HITL cards, `renderBrief` on the canvas, and OGUI are unexercised at runtime. A live smoke test of those paths is the main thing a reviewer should add.

## Known follow-ups (non-blocking)

Unused parameter in two private lane helpers · duplicate enum selections in `buildBriefOps` could emit two components sharing an id · `getMitigationOptions` returns its type raw while the other four sandbox handlers project · `req.json()` unguarded (malformed body → 500 not 400) · `ModeSplitChart` uses two tones across four modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
