### PR TITLE
fix(runtime-client-gql): guard abort errors without message

### DIFF
--- a/.changeset/guard-abort-error-message.md
+++ b/.changeset/guard-abort-error-message.md
@@ -1,0 +1,7 @@
+---
+"@copilotkit/runtime-client-gql": patch
+---
+
+fix(runtime-client-gql): guard abort errors without message
+
+Prevent early-stop abort handling from throwing when the abort cause does not expose a string message.

--- a/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
+++ b/packages/runtime-client-gql/src/client/CopilotRuntimeClient.ts
@@ -1,6 +1,6 @@
 import { Client, cacheExchange, fetchExchange } from "@urql/core";
 import * as packageJson from "../../package.json";
-import {
+import type {
   AvailableAgentsQuery,
   GenerateCopilotResponseMutation,
   GenerateCopilotResponseMutationVariables,
@@ -11,7 +11,7 @@ import {
   getAvailableAgentsQuery,
   loadAgentStateQuery,
 } from "../graphql/definitions/queries";
-import { OperationResultSource, OperationResult } from "urql";
+import type { OperationResultSource, OperationResult } from "urql";
 import {
   ResolvedCopilotKitError,
   CopilotKitLowLevelError,
@@ -19,6 +19,23 @@ import {
   CopilotKitVersionMismatchError,
   getPossibleVersionMismatch,
 } from "@copilotkit/shared";
+
+const KNOWN_ABORT_MESSAGES = [
+  "BodyStreamBuffer was aborted",
+  "signal is aborted without reason",
+];
+
+const isAbortError = (error: unknown) => {
+  if (error === null || typeof error !== "object") {
+    return false;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  return (
+    typeof message === "string" &&
+    KNOWN_ABORT_MESSAGES.some((phrase) => message.includes(phrase))
+  );
+};
 
 const createFetchFn =
   (signal?: AbortSignal, handleGQLWarning?: (warning: string) => void) =>
@@ -52,10 +69,7 @@ const createFetchFn =
       return result;
     } catch (error) {
       // Let abort error pass through. It will be suppressed later
-      if (
-        (error as Error).message.includes("BodyStreamBuffer was aborted") ||
-        (error as Error).message.includes("signal is aborted without reason")
-      ) {
+      if (isAbortError(error)) {
         throw error;
       }
       if (error instanceof CopilotKitError) {
@@ -139,10 +153,7 @@ export class CopilotRuntimeClient {
       start(controller) {
         source.subscribe(({ data, hasNext, error }) => {
           if (error) {
-            if (
-              error.message.includes("BodyStreamBuffer was aborted") ||
-              error.message.includes("signal is aborted without reason")
-            ) {
+            if (isAbortError(error)) {
               // close the stream if there is no next item
               if (!hasNext) controller.close();
 

--- a/packages/runtime-client-gql/src/client/__tests__/CopilotRuntimeClient.test.ts
+++ b/packages/runtime-client-gql/src/client/__tests__/CopilotRuntimeClient.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { CopilotRuntimeClient } from "../CopilotRuntimeClient";
+import { CopilotKitLowLevelError } from "@copilotkit/shared";
+
+type Settled<T> =
+  | { status: "fulfilled"; value: T }
+  | { status: "rejected"; reason: unknown };
+
+const readStream = async (stream: ReadableStream<unknown>) => {
+  const reader = stream.getReader();
+  const chunks: unknown[] = [];
+
+  try {
+    while (true) {
+      const result = await reader.read();
+      if (result.done) {
+        return { status: "done", chunks } as const;
+      }
+      chunks.push(result.value);
+    }
+  } catch (error) {
+    return { status: "error", error } as const;
+  }
+};
+
+const settle = async <T>(promise: Promise<T>): Promise<Settled<T>> => {
+  try {
+    return { status: "fulfilled", value: await promise };
+  } catch (reason) {
+    return { status: "rejected", reason };
+  }
+};
+
+describe("CopilotRuntimeClient abort suppression", () => {
+  const makeClient = () =>
+    new CopilotRuntimeClient({ url: "https://example.com/runtime" });
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not throw when fetch rejects with a string abort cause", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
+      "signal is aborted without reason",
+    );
+
+    const result = await settle(
+      makeClient()
+        .generateCopilotResponse({
+          data: {} as any,
+          properties: {} as any,
+        })
+        .toPromise(),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.value).toMatchObject({
+      error: {
+        name: "CombinedError",
+        networkError: expect.any(CopilotKitLowLevelError),
+      },
+    });
+  });
+
+  it("wraps non-message abort causes in low-level error in fetch wrapper", async () => {
+    const fetchError = { reason: "timeout" } as any;
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(fetchError);
+
+    const result = await settle(
+      makeClient()
+        .generateCopilotResponse({
+          data: {} as any,
+          properties: {} as any,
+        })
+        .toPromise(),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.value).toMatchObject({
+      error: {
+        networkError: expect.any(CopilotKitLowLevelError),
+      },
+    });
+  });
+
+  it("suppresses abort errors in stream errors without message access", async () => {
+    const stream = makeClient().asStream({
+      subscribe: (next) => {
+        next({
+          data: undefined,
+          hasNext: false,
+          error: new Error("signal is aborted without reason"),
+        });
+      },
+    } as any);
+
+    expect(await readStream(stream)).toEqual({
+      status: "done",
+      chunks: [],
+    });
+  });
+
+  it("surfaces non-string error objects in stream errors without throwing", async () => {
+    const streamError = { code: "network" } as any;
+    const stream = makeClient().asStream({
+      subscribe: (next) => {
+        next({
+          data: undefined,
+          hasNext: false,
+          error: streamError,
+        });
+      },
+    } as any);
+
+    expect(await readStream(stream)).toEqual({
+      status: "error",
+      error: streamError,
+    });
+  });
+});


### PR DESCRIPTION
Port of #5437.