### PR TITLE
fix: move katex CSS import from component to globals.css

### DIFF
--- a/docs/content/docs/(root)/troubleshooting/dev-console.mdx
+++ b/docs/content/docs/(root)/troubleshooting/dev-console.mdx
@@ -1,0 +1,88 @@
+---
+title: Using the Dev Console
+description: Learn how to use CopilotKit's Dev Console to debug and troubleshoot your copilot application.
+icon: "lucide/Terminal"
+---
+
+# Using the Dev Console to Troubleshoot
+
+CopilotKit includes a built-in **Dev Console** that helps you inspect and debug the runtime behavior of your copilot. It is one of the most useful tools for troubleshooting issues with actions, readable state, messages, and more.
+
+## Enabling the Dev Console
+
+The Dev Console is available through the `<CopilotKit>` provider. To enable it, set the `showDevConsole` prop to `true` (or `"auto"` for development-only):
+
+```tsx title="YourApp.tsx"
+import { CopilotKit } from "@copilotkit/react-core";
+
+export function App() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      showDevConsole={true} // or "auto" to show only in development
+    >
+      {/* Your app components */}
+    </CopilotKit>
+  );
+}
+```
+
+<Callout type="info">
+  When set to `"auto"`, the Dev Console is only shown in development mode (`process.env.NODE_ENV === "development"`).
+</Callout>
+
+## What You Can Debug
+
+The Dev Console provides visibility into the following:
+
+### 1. Registered Actions
+See all the actions that have been registered via `useCopilotAction`. This helps you verify:
+- Whether your actions are being registered correctly
+- The parameters and descriptions of each action
+- If any actions are missing or misconfigured
+
+### 2. Readable State
+Inspect all readable state provided via `useCopilotReadable`. This allows you to:
+- Confirm that the correct data is being sent to the LLM
+- Debug missing or stale context
+- Verify the structure of your readable state
+
+### 3. Messages
+View the full message history exchanged between your app and the LLM, including:
+- User messages
+- Assistant responses
+- Action calls and results
+- System messages
+
+### 4. Debug Information
+Access debug logs and runtime information to understand:
+- Request/response cycles
+- Error details
+- Configuration issues
+
+## Troubleshooting Tips
+
+### Actions Not Appearing
+If your actions are not showing up in the Dev Console:
+1. Ensure the component calling `useCopilotAction` is rendered inside the `<CopilotKit>` provider
+2. Check that the action hook is not conditionally rendered in a way that unmounts it
+3. Verify the action name is unique
+
+### Readable State Missing
+If your readable state is not visible:
+1. Confirm that `useCopilotReadable` is called inside the `<CopilotKit>` provider
+2. Check that the `description` is provided
+3. Ensure the `value` is serializable
+
+### Messages Not Sending
+If messages are not being sent:
+1. Verify the `runtimeUrl` is correct and accessible
+2. Check the browser's Network tab for failed requests
+3. Ensure your runtime endpoint is properly configured
+
+## Best Practices
+
+- **Always enable the Dev Console during development** by setting `showDevConsole="auto"`
+- **Check the Dev Console first** when debugging any CopilotKit-related issue
+- **Use the Network tab alongside the Dev Console** for a complete picture of what's happening
+- **Verify your actions and readable state** in the Dev Console before testing the chat interface

--- a/docs/content/docs/integrations/direct-to-llm/guides/docker-model-runner.mdx
+++ b/docs/content/docs/integrations/direct-to-llm/guides/docker-model-runner.mdx
@@ -1,0 +1,151 @@
+---
+title: "Docker Model Runner"
+description: "Connect CopilotKit to a self-hosted LLM using Docker Model Runner."
+icon: "lucide/Container"
+---
+
+# Using Docker Model Runner with CopilotKit
+
+[Docker Model Runner](https://docs.docker.com/ai/model-runner/get-started/) allows you to run local LLMs directly inside Docker Desktop. Since Docker Model Runner exposes an **OpenAI-compatible API**, you can easily connect it to CopilotKit using the `OpenAIAdapter`.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) with Model Runner enabled
+- A CopilotKit project with self-hosted runtime
+
+## Step 1: Enable Docker Model Runner
+
+Enable the Model Runner feature in Docker Desktop:
+
+```bash
+docker desktop enable model-runner --tcp 12434
+```
+
+Pull a model to use:
+
+```bash
+docker model pull ai/llama3.2:1B-Q8_0
+```
+
+Verify the model is available:
+
+```bash
+curl http://localhost:12434/engines/llama.cpp/v1/models
+```
+
+## Step 2: Configure CopilotKit Runtime
+
+Since Docker Model Runner exposes an OpenAI-compatible endpoint, you can use the `OpenAIAdapter` with a custom `baseURL` pointing to your local Docker Model Runner instance.
+
+```ts title="app/api/copilotkit/route.ts"
+import {
+  CopilotRuntime,
+  OpenAIAdapter,
+  copilotRuntimeNextJSAppRouterEndpoint,
+} from "@copilotkit/runtime";
+import OpenAI from "openai";
+import { NextRequest } from "next/server";
+
+// Point to Docker Model Runner's OpenAI-compatible endpoint
+const openai = new OpenAI({
+  baseURL: "http://localhost:12434/engines/llama.cpp/v1",
+  apiKey: "docker-model-runner", // any non-empty string works
+});
+
+const serviceAdapter = new OpenAIAdapter({ openai });
+const runtime = new CopilotRuntime();
+
+export const POST = async (req: NextRequest) => {
+  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+    runtime,
+    serviceAdapter,
+    endpoint: "/api/copilotkit",
+  });
+
+  return handleRequest(req);
+};
+```
+
+## Step 3: Using with Docker Compose
+
+You can also configure Docker Model Runner as a service in your `docker-compose.yml`:
+
+```yaml title="docker-compose.yml"
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - OPENAI_BASE_URL=http://model-runner.docker.internal/engines/llama.cpp/v1
+      - OPENAI_API_KEY=docker-model-runner
+    depends_on:
+      - model-runner
+
+  model-runner:
+    provider:
+      type: model
+      options:
+        model: ai/llama3.2:1B-Q8_0
+```
+
+<Callout type="info">
+  When using Docker Compose, the model runner is available at `http://model-runner.docker.internal/engines/llama.cpp/v1` from within your application container.
+</Callout>
+
+## Step 4: Configure the Frontend
+
+No special frontend configuration is needed. Set up your `<CopilotKit>` provider as usual:
+
+```tsx title="layout.tsx"
+import { CopilotKit } from "@copilotkit/react-core";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <CopilotKit runtimeUrl="/api/copilotkit">
+          {children}
+        </CopilotKit>
+      </body>
+    </html>
+  );
+}
+```
+
+## Supported Models
+
+Docker Model Runner supports various models from the [Docker Hub AI catalog](https://hub.docker.com/catalogs/ai). Some popular options:
+
+| Model | Pull Command |
+|-------|-------------|
+| Llama 3.2 1B | `docker model pull ai/llama3.2:1B-Q8_0` |
+| Llama 3.2 3B | `docker model pull ai/llama3.2:3B-Q8_0` |
+| Mistral 7B | `docker model pull ai/mistral:7B-Q4_K_M` |
+| Phi-3 Mini | `docker model pull ai/phi-3:3.8B-Q4_K_M` |
+| Gemma 2B | `docker model pull ai/gemma:2B-Q8_0` |
+
+## Troubleshooting
+
+### Connection Refused
+Ensure Docker Model Runner is running with TCP enabled:
+```bash
+docker desktop enable model-runner --tcp 12434
+```
+
+### Model Not Found
+Verify the model is pulled and available:
+```bash
+docker model list
+```
+
+### Slow Responses
+Local LLM performance depends on your hardware. Consider using smaller quantized models (Q4) for faster inference on consumer hardware.
+
+## References
+
+- [Docker Model Runner Documentation](https://docs.docker.com/ai/model-runner/get-started/)
+- [Docker Compose with Models](https://docs.docker.com/ai/compose/models-and-compose/)
+- [Example Repository](https://github.com/docker/hello-genai)
+- [CopilotKit Self-Hosting Guide](/guides/self-hosting)
+- [OpenAI Adapter Reference](/reference/v1/classes/llm-adapters/OpenAIAdapter)

--- a/packages/v2/react/src/components/chat/CopilotChatAssistantMessage.tsx
+++ b/packages/v2/react/src/components/chat/CopilotChatAssistantMessage.tsx
@@ -19,7 +19,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import "katex/dist/katex.min.css";
 import { WithSlots, renderSlot } from "@/lib/slots";
 import { Streamdown } from "streamdown";
 import CopilotChatToolCallsView from "./CopilotChatToolCallsView";

--- a/packages/v2/react/src/styles/globals.css
+++ b/packages/v2/react/src/styles/globals.css
@@ -3,6 +3,7 @@
 @source "../**/*.{ts,tsx}";
 @source "../../node_modules/streamdown/dist/index.js";
 
+@import "katex/dist/katex.min.css";
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
@@ -120,12 +121,15 @@
 
 @theme {
   --animate-pulse-cursor: pulse-cursor 0.9s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+
   @keyframes pulse-cursor {
+
     0%,
     100% {
       transform: scale(1);
       opacity: 1;
     }
+
     50% {
       transform: scale(1.5);
       opacity: 0.8;
@@ -137,6 +141,7 @@
   * {
     @apply cpk:border-border cpk:outline-ring/50;
   }
+
   /* Apply foreground/background on CopilotKit roots (replaces body rule) */
   [data-copilotkit] {
     color: var(--foreground);
@@ -175,7 +180,7 @@
   }
 }
 
-[data-copilotkit] div[data-streamdown="code-block"] > pre {
+[data-copilotkit] div[data-streamdown="code-block"]>pre {
   @apply cpk:mt-0 cpk:mb-0;
 }
 


### PR DESCRIPTION
Fixes Next.js 'Global CSS cannot be imported from within node_modules' build failures. Fixes #2851.