### PR TITLE
fix(channels): pin component identity so minification can't break durable actions

### DIFF
--- a/packages/channels-core/src/action-registry.test.ts
+++ b/packages/channels-core/src/action-registry.test.ts
@@ -144,8 +144,6 @@ describe("ActionRegistry", () => {
       regB.registerComponent("Confirm", Confirm as never);
 
       // Cold dispatch must succeed and fire the handler.
-      const handlerFired: string[] = [];
-      // Wrap the existing Confirm component so we can assert the specific call.
       const value = await regB.dispatch(id, ctx);
       expect(value).toEqual({ ok: "restart-test" });
       // The shared `clicks` array is populated by Confirm's onClick.
@@ -178,6 +176,62 @@ describe("ActionRegistry", () => {
       await expect(regBPrime.dispatch(id, ctx)).rejects.toBeInstanceOf(
         ActionExpiredError,
       );
+    });
+  });
+
+  describe("inline (non-component) renderables", () => {
+    // An inline renderable carries its handlers as closures with no component to
+    // re-render, so its ids can't be content-addressed. Two structurally
+    // identical inline posts in one conversation must still get distinct ids —
+    // otherwise the later binding overwrites the earlier and a click on the
+    // older message runs the newer message's handler.
+    function inlinePost(marker: string): ChannelNode {
+      return {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "button",
+              props: {
+                value: { pick: "x" },
+                onClick: ({ action }: InteractionContext) => {
+                  clicks.push(`${marker}:${action.id}`);
+                },
+                children: "Go",
+              },
+            },
+          ],
+        },
+      };
+    }
+
+    function bindId(root: ChannelNode[]): string {
+      return (
+        (root[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+          id: string;
+        }
+      ).id;
+    }
+
+    it("mints distinct ids for structurally identical posts, so the older keeps its handler", async () => {
+      const reg = new ActionRegistry({ store: new InMemoryActionStore() });
+      // `older` and `newer` differ only by closure — same tree, same props — so
+      // a content-addressed id would collide them.
+      const { root: older } = await reg.bindRenderable(
+        inlinePost("older"),
+        "conv",
+      );
+      const { root: newer } = await reg.bindRenderable(
+        inlinePost("newer"),
+        "conv",
+      );
+      const olderId = bindId(older);
+      const newerId = bindId(newer);
+
+      expect(olderId).not.toBe(newerId);
+
+      await reg.dispatch(olderId, ctx);
+      expect(clicks).toEqual([`older:${olderId}`]);
     });
   });
 
@@ -298,11 +352,18 @@ describe("ActionRegistry", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         const reg = new ActionRegistry({ store: new InMemoryActionStore() });
-        reg.registerComponent("Card", makeCard(false, "a"));
-        // Same function again is the normal per-post re-registration — silent.
+        // Re-registering the *same* function object is the normal per-post
+        // re-registration and must stay silent. Assert zero warnings before any
+        // conflict has fired for "Card": warnOnce dedupes by name, so only a
+        // still-empty warn count can prove same-function registration is silent
+        // on its own (rather than a second warning being swallowed by dedup).
         const same = makeCard(false, "a");
         reg.registerComponent("Card", same);
         reg.registerComponent("Card", same);
+        expect(warn).not.toHaveBeenCalled();
+        // A genuinely different function object under the same name — each
+        // makeCard() returns a fresh closure — is the real hazard, so it warns.
+        reg.registerComponent("Card", makeCard(false, "a"));
         expect(warn).toHaveBeenCalledTimes(1);
         expect(warn.mock.calls[0]![0]).toContain(
           'two different components are registered as "Card"',

--- a/packages/channels-core/src/action-registry.test.ts
+++ b/packages/channels-core/src/action-registry.test.ts
@@ -8,7 +8,16 @@ import { InMemoryActionStore } from "./action-store.js";
 import type { ActionContinuationSnapshot } from "./action-store.js";
 import { MemoryStore } from "./state/memory-store.js";
 import { kvActionStore } from "./state/kv-action-store.js";
-import type { ChannelNode, InteractionContext } from "@copilotkit/channels-ui";
+import { mintId } from "./mint-id.js";
+import {
+  defineChannelComponent,
+  resolveComponentName,
+} from "@copilotkit/channels-ui";
+import type {
+  ChannelNode,
+  ComponentFn,
+  InteractionContext,
+} from "@copilotkit/channels-ui";
 
 // Records each click so a test can assert the handler ran — dispatch() now
 // returns the clicked element's `value` (needed to resolve HITL waiters on
@@ -169,6 +178,138 @@ describe("ActionRegistry", () => {
       await expect(regBPrime.dispatch(id, ctx)).rejects.toBeInstanceOf(
         ActionExpiredError,
       );
+    });
+  });
+
+  describe("stable component identity across a mangling build", () => {
+    // The same component as a bundler emits it in two successive deploys. Both
+    // are minified, and the mangler picked a different letter each time — only
+    // `displayName`, set via defineChannelComponent, is stable across them.
+    function makeCard(pin: boolean, fnName: string): ComponentFn {
+      const body = (props: Record<string, unknown>): ChannelNode => ({
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "button",
+              props: {
+                value: { approved: props.summary },
+                onClick: ({ action }: InteractionContext) => {
+                  clicks.push(`approve:${props.summary}:${action.id}`);
+                },
+                children: "Approve",
+              },
+            },
+          ],
+        },
+      });
+      // `Object.defineProperty` is how a minifier's output differs from source:
+      // only the function's own `name` changes.
+      Object.defineProperty(body, "name", { value: fnName });
+      return pin
+        ? (defineChannelComponent("ApprovalCard", body) as ComponentFn)
+        : body;
+    }
+
+    /** Post a card from "deploy 1" and return its minted action id. */
+    async function post(reg: ActionRegistry, card: ComponentFn) {
+      const { root } = await reg.bindRenderable(
+        { type: card, props: { summary: "ship it" } },
+        "conv-deploy",
+      );
+      return (
+        (root[0]!.props.children as ChannelNode[])[0]!.props.onClick as {
+          id: string;
+        }
+      ).id;
+    }
+
+    it("rehydrates a pinned component across a rename of fn.name", async () => {
+      const shared = new MemoryStore();
+      // Deploy 1 posts the card; the mangler called the function `a`.
+      const deploy1 = new ActionRegistry({ store: kvActionStore(shared) });
+      const id = await post(deploy1, makeCard(true, "a"));
+
+      // Deploy 2: fresh process, same component, mangled to `b`, seeded the
+      // way createChannel seeds `components` — under the resolved name.
+      const redeployed = makeCard(true, "b");
+      expect(redeployed.name).toBe("b");
+      const deploy2 = new ActionRegistry({ store: kvActionStore(shared) });
+      deploy2.registerComponent(resolveComponentName(redeployed)!, redeployed);
+
+      await expect(deploy2.dispatch(id, ctx)).resolves.toEqual({
+        approved: "ship it",
+      });
+      expect(clicks[0]).toContain("approve:ship it:");
+    });
+
+    it("mints the same id on both sides of the rename, so live cards stay valid", async () => {
+      const before = await post(
+        new ActionRegistry({ store: kvActionStore(new MemoryStore()) }),
+        makeCard(true, "a"),
+      );
+      const after = await post(
+        new ActionRegistry({ store: kvActionStore(new MemoryStore()) }),
+        makeCard(true, "b"),
+      );
+      expect(after).toBe(before);
+    });
+
+    it("without a pinned name the same rename silently breaks the card", async () => {
+      // Negative control: the bug the pin exists to prevent. Deploy 2 knows the
+      // component only as `b`, so the snapshot's `a` resolves to nothing and
+      // the click is dropped.
+      const shared = new MemoryStore();
+      const deploy1 = new ActionRegistry({ store: kvActionStore(shared) });
+      const id = await post(deploy1, makeCard(false, "a"));
+
+      const redeployed = makeCard(false, "b");
+      const deploy2 = new ActionRegistry({ store: kvActionStore(shared) });
+      deploy2.registerComponent(resolveComponentName(redeployed)!, redeployed);
+
+      await expect(deploy2.dispatch(id, ctx)).rejects.toBeInstanceOf(
+        ActionExpiredError,
+      );
+    });
+
+    it("keeps an unpinned named component working exactly as before", async () => {
+      // Backward compatibility: no displayName anywhere, ids still derive from
+      // fn.name and cold dispatch still resolves.
+      const shared = new MemoryStore();
+      const deploy1 = new ActionRegistry({ store: kvActionStore(shared) });
+      const id = await post(deploy1, makeCard(false, "ApprovalCard"));
+      expect(id).toBe(
+        mintId("ApprovalCard", [0, "children", 0, "onClick"], {
+          summary: "ship it",
+        }),
+      );
+
+      const deploy2 = new ActionRegistry({ store: kvActionStore(shared) });
+      deploy2.registerComponent(
+        "ApprovalCard",
+        makeCard(false, "ApprovalCard"),
+      );
+      await expect(deploy2.dispatch(id, ctx)).resolves.toEqual({
+        approved: "ship it",
+      });
+    });
+
+    it("warns when two different components claim one name", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const reg = new ActionRegistry({ store: new InMemoryActionStore() });
+        reg.registerComponent("Card", makeCard(false, "a"));
+        // Same function again is the normal per-post re-registration — silent.
+        const same = makeCard(false, "a");
+        reg.registerComponent("Card", same);
+        reg.registerComponent("Card", same);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]![0]).toContain(
+          'two different components are registered as "Card"',
+        );
+      } finally {
+        warn.mockRestore();
+      }
     });
   });
 

--- a/packages/channels-core/src/action-registry.ts
+++ b/packages/channels-core/src/action-registry.ts
@@ -6,7 +6,12 @@ import type {
   Renderable,
   MessageReactionHandler,
 } from "@copilotkit/channels-ui";
-import { isBound, getBoundArgs, renderToIR } from "@copilotkit/channels-ui";
+import {
+  isBound,
+  getBoundArgs,
+  renderToIR,
+  resolveComponentName,
+} from "@copilotkit/channels-ui";
 import { mintId } from "./mint-id.js";
 import type {
   ActionContinuationContext,
@@ -120,7 +125,26 @@ export class ActionRegistry {
     return takeMessageReaction(root);
   }
 
+  /**
+   * Register `fn` under its durable identity `name` (see
+   * {@link resolveComponentName}) so a cold dispatch can re-render it.
+   *
+   * Two different components sharing one name is a real hazard, not a
+   * curiosity: `mintId` folds the name into the action id, so equal names with
+   * equal props and path mint the *same* id — and a cold dispatch then resolves
+   * a handler out of the wrong component tree. Registration stays
+   * last-one-wins (re-registering the same component on every post is normal,
+   * and dev hot-reload legitimately swaps the function identity), but the
+   * conflict is reported once so it is not silent.
+   */
   registerComponent(name: string, fn: ComponentFn): void {
+    const existing = this.components.get(name);
+    if (existing && existing !== fn) {
+      warnOnce(
+        `name-conflict:${name}`,
+        `[channel] two different components are registered as "${name}"; their action ids can collide and a click may run the wrong handler. Give each a distinct name via defineChannelComponent().`,
+      );
+    }
     this.components.set(name, fn);
   }
 
@@ -175,7 +199,14 @@ export class ActionRegistry {
     let props: Record<string, unknown> | undefined;
     if (isComponentElement(ui)) {
       const fn = ui.type;
-      component = fn.name || "anonymous";
+      const resolved = resolveComponentName(fn);
+      if (!resolved) {
+        warnOnce(
+          "anonymous-component",
+          "[channel] posting a component with no resolvable name — it registers as \"anonymous\", so its action ids collide with every other unnamed component. Wrap it in defineChannelComponent('Name', fn).",
+        );
+      }
+      component = resolved ?? "anonymous";
       props = (ui.props ?? {}) as Record<string, unknown>;
       this.registerComponent(component, fn);
       root = await this.bindTree(
@@ -328,6 +359,17 @@ function assertContinuationBinding(
   ) {
     throw new ActionContinuationMismatchError();
   }
+}
+
+/**
+ * Report a registry-identity hazard once per process. These fire on a hot path
+ * (every post), and a per-post log would bury the signal it exists to raise.
+ */
+const warned = new Set<string>();
+function warnOnce(key: string, message: string): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(message);
 }
 
 /** Store key for a message's durable reaction snapshot (distinct from minted action ids). */

--- a/packages/channels-core/src/action-registry.ts
+++ b/packages/channels-core/src/action-registry.ts
@@ -243,9 +243,18 @@ export class ActionRegistry {
         const handler = node.props[ep];
         if (typeof handler === "function") {
           const fullPath: (string | number)[] = [...path, ep];
-          const id = continuation
-            ? `ck:${globalThis.crypto.randomUUID()}`
-            : mintId(comp, fullPath, props);
+          // A registered-component binding is content-addressed so a cold
+          // dispatch can re-mint the same id and re-resolve the handler.
+          // Inline (`comp === ""`) and continuation bindings can never be
+          // rehydrated (dispatch throws ActionExpiredError once `component` is
+          // falsy), so they get a fresh random id. Content-addressing an inline
+          // binding would collide two structurally identical posts in the same
+          // conversation onto one id — the later would overwrite the earlier and
+          // a click on the older message would run the newer message's handler.
+          const id =
+            continuation || comp === ""
+              ? `ck:${globalThis.crypto.randomUUID()}`
+              : mintId(comp, fullPath, props);
           this.hot.set(id, {
             handler: handler as ClickHandler,
             value: node.props.value,

--- a/packages/channels-core/src/component-identity.test.ts
+++ b/packages/channels-core/src/component-identity.test.ts
@@ -1,0 +1,216 @@
+// End-to-end cover for OSS-711: a durable action must survive a deploy whose
+// bundler mangles the component's function name differently. The identity that
+// createChannel seeds into the action registry — and that mintId folds into
+// every action id — has to come from the pinned `displayName`, not `fn.name`.
+import { describe, it, expect, vi } from "vitest";
+import {
+  Actions,
+  Button,
+  Message,
+  defineChannelComponent,
+} from "@copilotkit/channels-ui";
+import type { ChannelNode, ComponentFn } from "@copilotkit/channels-ui";
+import { createChannel } from "./create-channel.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { MemoryStore } from "./state/memory-store.js";
+import type { ChannelComponent } from "./create-channel.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * The same source component as two successive minified builds emit it: the
+ * mangler picked `a` the first time and `b` the second. Only `displayName`
+ * survives both.
+ */
+function buildApprovalCard(opts: {
+  pin: boolean;
+  mangledTo: string;
+  approvals: string[];
+}): ComponentFn {
+  const body = (props: Record<string, unknown>): ChannelNode =>
+    Message({
+      children: Actions({
+        children: Button({
+          value: "approve",
+          onClick: () => {
+            opts.approvals.push(String(props.summary));
+          },
+          children: "Approve",
+        }),
+      }),
+    });
+  Object.defineProperty(body, "name", { value: opts.mangledTo });
+  return opts.pin ? defineChannelComponent("ApprovalCard", body) : body;
+}
+
+/** Boot a channel that posts the card on every turn, sharing `backend`. */
+function deploy(card: ComponentFn, backend: MemoryStore) {
+  const adapter = new FakeAdapter();
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+    store: { adapter: backend },
+    components: [card],
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.post({ type: card, props: { summary: "ship it" } });
+  });
+  return { adapter, channel };
+}
+
+/** The action id the adapter received on the posted card's button. */
+function postedActionId(adapter: FakeAdapter): string {
+  const tree = adapter.posted.at(-1)!;
+  const found: string[] = [];
+  const visit = (nodes: ChannelNode[]) => {
+    for (const node of nodes) {
+      const onClick = node.props.onClick as { id?: string } | undefined;
+      if (onClick?.id) found.push(onClick.id);
+      if (Array.isArray(node.props.children)) {
+        visit(node.props.children as ChannelNode[]);
+      }
+    }
+  };
+  visit(tree);
+  expect(found).toHaveLength(1);
+  return found[0]!;
+}
+
+describe("durable component identity across a redeploy", () => {
+  it("dispatches a click posted by the previous deploy when the name is pinned", async () => {
+    const backend = new MemoryStore(); // survives the simulated redeploy
+    const approvals: string[] = [];
+
+    // Deploy 1 posts the card and persists its snapshot.
+    const first = deploy(
+      buildApprovalCard({ pin: true, mangledTo: "a", approvals }),
+      backend,
+    );
+    await first.channel.ɵruntime.start();
+    first.adapter.emitTurn({});
+    await tick();
+    const actionId = postedActionId(first.adapter);
+
+    // Deploy 2: new process, no hot cache, function mangled to a different
+    // name. The click posted by deploy 1 must still resolve.
+    const second = deploy(
+      buildApprovalCard({ pin: true, mangledTo: "b", approvals }),
+      backend,
+    );
+    await second.channel.ɵruntime.start();
+    second.adapter.emitInteraction({ id: actionId });
+    await tick();
+
+    expect(approvals).toEqual(["ship it"]);
+  });
+
+  it("drops that same click — with a log — when the name is not pinned", async () => {
+    // Negative control: the pre-existing bug. Deploy 2 knows the component only
+    // as `b`, so the snapshot's `a` resolves to nothing.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const backend = new MemoryStore();
+      const approvals: string[] = [];
+
+      const first = deploy(
+        buildApprovalCard({ pin: false, mangledTo: "a", approvals }),
+        backend,
+      );
+      await first.channel.ɵruntime.start();
+      first.adapter.emitTurn({});
+      await tick();
+      const actionId = postedActionId(first.adapter);
+
+      const second = deploy(
+        buildApprovalCard({ pin: false, mangledTo: "b", approvals }),
+        backend,
+      );
+      await second.channel.ɵruntime.start();
+      second.adapter.emitInteraction({ id: actionId });
+      await tick();
+
+      expect(approvals).toEqual([]);
+      // The click still does nothing, but no longer without a trace.
+      expect(
+        warn.mock.calls.some((call) =>
+          String(call[0]).includes(
+            `ignoring click on expired or unresolvable action "${actionId}"`,
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("seeds a pinned component under its displayName, not its mangled fn.name", async () => {
+    const backend = new MemoryStore();
+    const approvals: string[] = [];
+    const { adapter, channel } = deploy(
+      buildApprovalCard({ pin: true, mangledTo: "a", approvals }),
+      backend,
+    );
+    await channel.ɵruntime.start();
+    adapter.emitTurn({});
+    await tick();
+
+    const snapshot = await backend.kv.get<{ component?: string }>(
+      `action:${postedActionId(adapter)}`,
+    );
+    expect(snapshot?.component).toBe("ApprovalCard");
+  });
+
+  it("keeps seeding an unpinned component under fn.name (backward compatible)", async () => {
+    const backend = new MemoryStore();
+    const approvals: string[] = [];
+
+    const first = deploy(
+      buildApprovalCard({ pin: false, mangledTo: "ApprovalCard", approvals }),
+      backend,
+    );
+    await first.channel.ɵruntime.start();
+    first.adapter.emitTurn({});
+    await tick();
+    const actionId = postedActionId(first.adapter);
+
+    const snapshot = await backend.kv.get<{ component?: string }>(
+      `action:${actionId}`,
+    );
+    expect(snapshot?.component).toBe("ApprovalCard");
+
+    // …and it still dispatches cold, exactly as before this change.
+    const second = deploy(
+      buildApprovalCard({ pin: false, mangledTo: "ApprovalCard", approvals }),
+      backend,
+    );
+    await second.channel.ɵruntime.start();
+    second.adapter.emitInteraction({ id: actionId });
+    await tick();
+    expect(approvals).toEqual(["ship it"]);
+  });
+
+  it("skips a component with no resolvable identity, warning once", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const anonymous = (
+        () => () =>
+          Message({ children: "hi" })
+      )();
+      expect(anonymous.name).toBe("");
+      // Seeding happens on start, so the channel has to be started to warn.
+      await createChannel({
+        identifyUser: "platform",
+        adapters: [new FakeAdapter()],
+        components: [anonymous as ChannelComponent],
+      }).ɵruntime.start();
+
+      expect(
+        warn.mock.calls.some((call) =>
+          String(call[0]).includes("skipping anonymous component"),
+        ),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/channels-core/src/component-identity.test.ts
+++ b/packages/channels-core/src/component-identity.test.ts
@@ -205,10 +205,10 @@ describe("durable component identity across a redeploy", () => {
       }).ɵruntime.start();
 
       expect(
-        warn.mock.calls.some((call) =>
+        warn.mock.calls.filter((call) =>
           String(call[0]).includes("skipping anonymous component"),
         ),
-      ).toBe(true);
+      ).toHaveLength(1);
     } finally {
       warn.mockRestore();
     }

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -40,6 +40,7 @@ import {
   normalizeEmoji,
   toCanonicalEmoji,
   renderToIR,
+  resolveComponentName,
 } from "@copilotkit/channels-ui";
 import { Transcripts } from "./transcripts.js";
 import type { TranscriptsConfig } from "./transcripts.js";
@@ -955,8 +956,15 @@ export function createChannel<
             dispatchedValue = await registry!.dispatch(evt.id, ctx);
           }
         } catch (err) {
-          // v1: swallow expired-action dispatches; surface anything else.
+          // v1: swallow expired-action dispatches; surface anything else. Log
+          // the swallow — from the user's side this is a click that does
+          // nothing, so without a trace here the failure is invisible on both
+          // ends. A retention-window expiry is expected; a burst of these
+          // usually means a component's registry name changed under it.
           if (!(err instanceof ActionExpiredError)) throw err;
+          console.warn(
+            `[channel] ignoring click on expired or unresolvable action "${evt.id}" — its retention window may have passed, or the component that minted it is no longer registered under the same name.`,
+          );
         }
         // Resolve any HITL waiter awaiting a choice in this conversation. Prefer
         // the value carried in the event (Slack), falling back to the value the
@@ -1279,14 +1287,18 @@ export function createChannel<
         });
         registry = registryInstance;
         for (const c of opts.components ?? []) {
-          if (!c.name) {
+          // Prefer the pinned `displayName` over `fn.name`: the latter is a
+          // build artifact, and a bundler that mangles it between deploys makes
+          // every already-posted button undispatchable.
+          const componentName = resolveComponentName(c);
+          if (!componentName) {
             console.warn(
-              "[channel] createChannel: skipping anonymous component — give it a name to enable durable actions after restart.",
+              "[channel] createChannel: skipping anonymous component — wrap it in defineChannelComponent('Name', fn) to enable durable actions after restart.",
             );
             continue;
           }
           registryInstance.registerComponent(
-            c.name,
+            componentName,
             c as unknown as ComponentFn,
           );
         }

--- a/packages/channels-core/src/mint-id.ts
+++ b/packages/channels-core/src/mint-id.ts
@@ -14,6 +14,16 @@ export function stableStringify(v: unknown): string {
   );
 }
 
+/**
+ * Derive a content-addressed action id from the component that owns the
+ * handler, its path in the rendered tree, and the props it was rendered with.
+ *
+ * `componentName` must be the component's *durable* identity — what
+ * `resolveComponentName` returns, not a raw `fn.name`. The id is persisted in
+ * the action snapshot and re-resolved on a cold dispatch, so feeding it a
+ * minifiable name means already-posted buttons stop resolving after a deploy
+ * that mangles it differently.
+ */
 export function mintId(
   componentName: string,
   path: (string | number)[],

--- a/packages/channels-ui/src/component-name.test.ts
+++ b/packages/channels-ui/src/component-name.test.ts
@@ -75,9 +75,19 @@ describe("defineChannelComponent", () => {
 });
 
 describe("library components", () => {
-  // Without pinned names these all resolve to "" (the `intrinsic` factory
-  // returns an anonymous closure), so every `<Message>`-rooted post would
-  // register as "anonymous" and their action ids would collide.
+  // Two distinct cases, one shared threat — a bundler rewriting `fn.name`:
+  //   * Message/Section/Actions come from the `intrinsic` factory, which
+  //     returns an anonymous closure (`fn.name === ""`). Without the pin they'd
+  //     have no identity at all, so every `<Message>`-rooted post would register
+  //     as "anonymous" and their action ids would collide.
+  //   * Button/Select/Input/Table are plain function declarations, so `fn.name`
+  //     already reads correctly *in source* — but a minifier mangling this
+  //     library would silently rewrite it, changing every action id minted from
+  //     a tree rooted at one of them.
+  // Both are pinned via `displayName`, which no bundler can touch. Asserting
+  // `resolveComponentName` on the pristine component is tautological for the
+  // declarations (it just re-reads `fn.name`); to verify the pin actually does
+  // its job we mangle `fn.name` first and confirm the identity still resolves.
   it.each([
     [Message, "Message"],
     [Section, "Section"],
@@ -86,9 +96,26 @@ describe("library components", () => {
     [Select, "Select"],
     [Input, "Input"],
     [Table, "Table"],
-  ])("pins a stable identity (%#)", (component, expected) => {
-    expect(resolveComponentName(component)).toBe(expected);
-  });
+  ])(
+    "keeps a stable identity when a bundler mangles fn.name (%#)",
+    (component, expected) => {
+      // `Function.prototype.name` is configurable but not writable — redefine it
+      // to stand in for what a minifier leaves behind, then restore it.
+      const originalName = Object.getOwnPropertyDescriptor(component, "name");
+      try {
+        Object.defineProperty(component, "name", {
+          value: "a",
+          configurable: true,
+        });
+        expect(component.name).toBe("a");
+        expect(resolveComponentName(component)).toBe(expected);
+      } finally {
+        if (originalName) {
+          Object.defineProperty(component, "name", originalName);
+        }
+      }
+    },
+  );
 
   it("gives each intrinsic a distinct identity", () => {
     const names = [Message, Section, Actions, Button, Select, Input, Table].map(

--- a/packages/channels-ui/src/component-name.test.ts
+++ b/packages/channels-ui/src/component-name.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  defineChannelComponent,
+  resolveComponentName,
+} from "./component-name.js";
+import {
+  Actions,
+  Button,
+  Input,
+  Message,
+  Section,
+  Select,
+  Table,
+} from "./components.js";
+
+describe("resolveComponentName", () => {
+  it("falls back to fn.name when nothing is pinned", () => {
+    function ApprovalCard() {
+      return null;
+    }
+    expect(resolveComponentName(ApprovalCard)).toBe("ApprovalCard");
+  });
+
+  it("prefers the pinned displayName over fn.name", () => {
+    // What a mangling minifier leaves behind: the declaration name is gone,
+    // the pinned identity survives.
+    const mangled = defineChannelComponent("ApprovalCard", function a() {
+      return null;
+    });
+    expect(mangled.name).toBe("a");
+    expect(resolveComponentName(mangled)).toBe("ApprovalCard");
+  });
+
+  it("returns undefined for a component with no usable identity", () => {
+    // A closure returned from a factory gets no inferred name.
+    const anonymous = (
+      () => () =>
+        null
+    )();
+    expect(anonymous.name).toBe("");
+    expect(resolveComponentName(anonymous)).toBeUndefined();
+  });
+
+  it("ignores a non-string or empty displayName", () => {
+    function Named() {
+      return null;
+    }
+    Object.assign(Named, { displayName: "" });
+    expect(resolveComponentName(Named)).toBe("Named");
+    Object.assign(Named, { displayName: 42 });
+    expect(resolveComponentName(Named)).toBe("Named");
+  });
+
+  it("returns undefined for non-functions", () => {
+    expect(resolveComponentName(undefined)).toBeUndefined();
+    expect(
+      resolveComponentName({ displayName: "NotAComponent" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("defineChannelComponent", () => {
+  it("pins the name and returns the same function", () => {
+    const fn = () => null;
+    const pinned = defineChannelComponent("Card", fn);
+    expect(pinned).toBe(fn);
+    expect(pinned.displayName).toBe("Card");
+  });
+
+  it("rejects an empty name — the identity is the whole point", () => {
+    expect(() => defineChannelComponent("", () => null)).toThrow(
+      /non-empty string/,
+    );
+  });
+});
+
+describe("library components", () => {
+  // Without pinned names these all resolve to "" (the `intrinsic` factory
+  // returns an anonymous closure), so every `<Message>`-rooted post would
+  // register as "anonymous" and their action ids would collide.
+  it.each([
+    [Message, "Message"],
+    [Section, "Section"],
+    [Actions, "Actions"],
+    [Button, "Button"],
+    [Select, "Select"],
+    [Input, "Input"],
+    [Table, "Table"],
+  ])("pins a stable identity (%#)", (component, expected) => {
+    expect(resolveComponentName(component)).toBe(expected);
+  });
+
+  it("gives each intrinsic a distinct identity", () => {
+    const names = [Message, Section, Actions, Button, Select, Input, Table].map(
+      (c) => resolveComponentName(c),
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/packages/channels-ui/src/component-name.ts
+++ b/packages/channels-ui/src/component-name.ts
@@ -1,0 +1,58 @@
+import type { ComponentFn } from "./ir.js";
+
+/**
+ * Resolve the durable registry identity of a component function.
+ *
+ * Prefers an explicit `displayName` over `Function.prototype.name`, because
+ * `fn.name` is a *build artifact*: a bundler that mangles names gives the same
+ * component a different identity in every deploy. Since the identity is baked
+ * into every minted action id and persisted in the action snapshot, a mangled
+ * rename makes buttons posted by one deploy undispatchable by the next — the
+ * cold-path lookup misses, the click is swallowed, and nothing happens.
+ *
+ * Returns `undefined` when neither a `displayName` nor a `fn.name` is usable,
+ * so callers decide how to degrade.
+ */
+export function resolveComponentName(fn: unknown): string | undefined {
+  if (typeof fn !== "function") return undefined;
+  const pinned = (fn as { displayName?: unknown }).displayName;
+  if (typeof pinned === "string" && pinned.length > 0) return pinned;
+  return fn.name || undefined;
+}
+
+/**
+ * Pin a component's durable identity so minification can't break it.
+ *
+ * Sets `displayName`, which {@link resolveComponentName} prefers over the
+ * minifiable `fn.name`. Use it for any component passed to
+ * `createChannel({ components })` or posted with a handler that must survive a
+ * restart:
+ *
+ * ```tsx
+ * const ApprovalCard = defineChannelComponent(
+ *   "ApprovalCard",
+ *   ({ summary }: { summary: string }) => (
+ *     <Message>
+ *       <Section>{summary}</Section>
+ *       <Actions>
+ *         <Button value="approve" onClick={approve}>Approve</Button>
+ *       </Actions>
+ *     </Message>
+ *   ),
+ * );
+ * ```
+ *
+ * Note: pinning a name on a component that is *already* live changes the ids it
+ * mints, so actions posted before the change stop resolving. Ship it with a
+ * release note, or accept that in-flight cards go stale once.
+ */
+export function defineChannelComponent<
+  TFn extends (props: never) => ReturnType<ComponentFn>,
+>(name: string, fn: TFn): TFn & { displayName: string } {
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(
+      "defineChannelComponent: `name` must be a non-empty string — it is the component's durable identity.",
+    );
+  }
+  return Object.assign(fn, { displayName: name });
+}

--- a/packages/channels-ui/src/components.tsx
+++ b/packages/channels-ui/src/components.tsx
@@ -1,3 +1,4 @@
+import { defineChannelComponent } from "./component-name.js";
 import type { ChannelNode } from "./ir.js";
 import type { ClickHandler, MessageReactionHandler } from "./types.js";
 
@@ -158,12 +159,19 @@ export interface ChartProps {
 // `intrinsic` produces a typed component that lowers `<X .../>` to an IR node
 // of the given `type`; the generic `P` is what gives each tag its prop type.
 
-export const intrinsic =
-  <P,>(type: string) =>
-  (props: P): ChannelNode => ({
-    type,
-    props: (props ?? {}) as Record<string, unknown>,
-  });
+// The closure returned here is anonymous, so without an explicit identity every
+// `<Message>`-rooted post would register with the action registry as
+// "anonymous" — colliding with every other unnamed component. Pin it to the
+// exported component's name (`"message"` -> `"Message"`), which no bundler can
+// mangle.
+export const intrinsic = <P,>(type: string) =>
+  defineChannelComponent(
+    type.charAt(0).toUpperCase() + type.slice(1),
+    (props: P): ChannelNode => ({
+      type,
+      props: (props ?? {}) as Record<string, unknown>,
+    }),
+  );
 
 export const Message = intrinsic<MessageProps>("message");
 export const Header = intrinsic<HeaderProps>("header");
@@ -193,3 +201,12 @@ export function Input(props: InputProps): ChannelNode {
 export function Table(props: TableProps): ChannelNode {
   return { type: "table", props: props as unknown as Record<string, unknown> };
 }
+
+// Pin the same durable identity the `intrinsic` components get. These are
+// declarations, so `fn.name` already reads correctly in source — but a bundler
+// mangling this library would silently change it, and with it every action id
+// minted from a tree rooted at one of them.
+Button.displayName = "Button";
+Select.displayName = "Select";
+Input.displayName = "Input";
+Table.displayName = "Table";

--- a/packages/channels-ui/src/index.ts
+++ b/packages/channels-ui/src/index.ts
@@ -2,6 +2,7 @@ export * from "./ir.js";
 export * from "./render.js";
 export * from "./types.js";
 export * from "./bind.js";
+export * from "./component-name.js";
 export * from "./components.js";
 export * from "./emoji.js";
 export * from "./modal.js";

--- a/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/commands-and-reactions.mdx
@@ -79,10 +79,15 @@ tenant cannot use it.
 Use `Message.onReaction` when only one posted component should react:
 
 ```tsx title="feedback-card.tsx"
-import { Message, Section } from "@copilotkit/channels/ui";
+import {
+  Message,
+  Section,
+  defineChannelComponent,
+} from "@copilotkit/channels/ui";
 
-export function FeedbackCard({ answerId }: { answerId: string }) {
-  return (
+export const FeedbackCard = defineChannelComponent(
+  "FeedbackCard",
+  ({ answerId }: { answerId: string }) => (
     <Message
       onReaction={async (emoji, reaction) => {
         if (reaction.added && emoji === "thumbs_up") {
@@ -95,13 +100,15 @@ export function FeedbackCard({ answerId }: { answerId: string }) {
     >
       <Section>React with 👍 if this solved the problem.</Section>
     </Message>
-  );
-}
+  ),
+);
 ```
 
 Register `FeedbackCard` in `createChannel({ components: [FeedbackCard] })`.
 Surviving a process restart also requires a durable `StateStore`, because the
-SDK must reload the component snapshot that owns the callback.
+SDK must reload the component snapshot that owns the callback, and a name
+pinned with `defineChannelComponent` so a production build cannot rename it —
+see [Pin the component name](/channels/interactive#pin-the-component-name).
 
 Add or remove the bot's reaction with the delivery-scoped reference from the
 current message or transcript:

--- a/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/interactive/index.mdx
@@ -63,10 +63,12 @@ import {
   Header,
   Message,
   Section,
+  defineChannelComponent,
 } from "@copilotkit/channels/ui";
 
-export function ApprovalCard({ summary }: { summary: string }) {
-  return (
+export const ApprovalCard = defineChannelComponent(
+  "ApprovalCard",
+  ({ summary }: { summary: string }) => (
     <Message>
       <Header>Approval required</Header>
       <Section>{summary}</Section>
@@ -133,8 +135,8 @@ export function ApprovalCard({ summary }: { summary: string }) {
         </Button>
       </Actions>
     </Message>
-  );
-}
+  ),
+);
 ```
 
 <FrontendOnly frontend="slack">
@@ -199,6 +201,37 @@ channel.onInterrupt<{ summary: string }>(
 
 Registration lets the action registry rebuild a named component when a later
 click arrives. Keep component props JSON-serializable.
+
+### Pin the component name
+
+`defineChannelComponent` pins the name the action registry files the component
+under. That name is baked into every action id it mints and stored alongside the
+posted card, so a click that arrives minutes or days later is resolved by
+looking the name back up.
+
+Without a pinned name the registry falls back to the function's own name — which
+is a build artifact. A bundler that mangles names gives the same component a
+different identity in each deploy, and cards posted by the previous deploy stop
+resolving: the user clicks, the platform acknowledges, and nothing happens.
+Server-side you get a warning about an unresolvable action and nothing else.
+
+Pin the name on any component you register or post with a handler:
+
+```tsx
+export const ApprovalCard = defineChannelComponent(
+  "ApprovalCard",
+  ({ summary }: { summary: string }) => <Message>{summary}</Message>,
+);
+```
+
+Two rules follow from the name being an identity:
+
+- **Names must be unique across your registered components.** Two components
+  sharing a name can mint the same action id, and a click may then run the wrong
+  handler. The Channel logs a warning when it sees a conflict.
+- **Changing a pinned name invalidates cards already posted.** Their ids were
+  minted from the old name, so in-flight cards go stale once. Adding a pin to a
+  component that has been running unpinned has the same effect.
 
 Treat an interaction message as updateable only when `message.ref.id` is
 non-empty. The card update in this example is best-effort: a missing ref or a

--- a/showcase/shell-docs/src/content/docs/channels/persistence-and-scaling.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/persistence-and-scaling.mdx
@@ -157,11 +157,14 @@ durable Redis or Postgres implementation in the umbrella package.
 
 ## Preserve interactive callbacks across restarts
 
-A callback survives only when both conditions are true:
+A callback survives only when all three conditions are true:
 
 1. The JSX comes from a named component registered in
    `createChannel({ components })`.
-2. The action snapshot is stored in a durable `StateStore`.
+2. That component's name is pinned with `defineChannelComponent`, so a bundler
+   cannot change it between deploys. See
+   [Pin the component name](/channels/interactive#pin-the-component-name).
+3. The action snapshot is stored in a durable `StateStore`.
 
 <FrontendOnly frontend="slack">
 
@@ -193,7 +196,8 @@ const channel = createChannel({
 
 Keep registered component props JSON-serializable and derive the handler from
 those props. Test by posting a card, restarting the process, then clicking the
-old card.
+old card — and test the same thing across a *production* build, since that is
+where an unpinned component name changes out from under the stored snapshot.
 
 ## Match the managed concurrency model
 


### PR DESCRIPTION
Fixes the pre-existing bug tracked in [OSS-711](https://linear.app/copilotkit/issue/OSS-711/channels-action-component-identity-is-keyed-on-functionprototypename).

## The problem

Every durable-action path in Channels keyed a component by `Function.prototype.name` — a build artifact. Under a bundler that mangles names, a card posted by one deploy became undispatchable by the next: the persisted snapshot stores only that string, so the cold-path lookup missed, `ActionExpiredError` was swallowed, and the user's click did nothing with **no server-side trace**.

A second failure followed from the same root: because `mintId` folds the name into its hash, two components sharing a name could mint the *same* action id, letting a cold dispatch resolve a handler out of the wrong component tree.

## The fix

`defineChannelComponent(name, fn)` pins a `displayName` that `resolveComponentName` prefers over `fn.name`. That pinned name is what the registry files the component under, what `createChannel({ components })` seeds, and what `mintId` folds into every action id — so a rename no longer orphans live cards. The library intrinsics (`Message`, `Button`, …) pin their own names.

Two adjacent silences are now audible:

- a swallowed expired-action dispatch logs once, so the failure is visible server-side;
- registering two different components under one name warns (once per name), since their minted ids can collide.

Components without a pinned name keep resolving through `fn.name` exactly as before.

## Testing

| Suite | Result |
| -- | -- |
| `channels-ui` | 42/42 |
| `channels-core` | 266/266 |
| `runtime` (only affected dependent) | 130 files / 1835 tests |
| `check-types` | 21 affected projects |

New coverage includes an **end-to-end redeploy test** driving `createChannel` through a simulated name-mangling deploy, a **negative control** proving the original bug still reproduces without a pin, and a **backward-compatibility** case asserting unpinned components mint and resolve exactly as before.

## Upgrade note

Adding a pin to a component that has been running **unpinned** changes the ids it mints, so cards already posted go stale once. This is called out in the docs.

## Docs

`channels/interactive` gains a "Pin the component name" section covering the uniqueness rule and the invalidation caveat; `persistence-and-scaling` and `commands-and-reactions` cross-link to it.