### PR TITLE
fix(runtime): preserve realtime gateway handoff continuity

### DIFF
--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -341,6 +341,7 @@ describe("DeliveryAdapter Slack cadence", () => {
           kind: "slack.stream.append",
           providerReference: "pref_v1_slack_stream_01",
           delta: "B",
+          fullText: "AB",
         },
       ]);
 

--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -3,6 +3,7 @@ import { DeliveryAdapter } from "./delivery-adapter.js";
 import type { PlatformAdapter } from "@copilotkit/channels-core";
 import { emoji } from "@copilotkit/channels-ui";
 import type { ChannelProviderPayload } from "./delivery-contracts.js";
+import { SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY } from "./delivery-contracts.js";
 import type {
   ClaimedChannelDelivery,
   PreparedChannelDelivery,
@@ -308,7 +309,11 @@ describe("DeliveryAdapter Slack cadence", () => {
       const session = { effect } as unknown as ClaimedChannelDelivery;
       const renderer = adapter().createRunRenderer({
         claimedDelivery: session,
-        delivery: { ...delivery(), adapter: "slack" },
+        delivery: {
+          ...delivery(),
+          adapter: "slack",
+          capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
+        },
       });
       const subscriber = renderer.subscriber;
 

--- a/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
@@ -8,12 +8,17 @@ import {
 import type { PreparedChannelDelivery } from "./delivery-transport.js";
 import { assertDeliveryPacket } from "./delivery-contracts.js";
 import type { ChannelProviderPayload } from "./delivery-contracts.js";
+import { SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY } from "./delivery-contracts.js";
 import type {
   RealtimeGatewayDeliveryChannel,
   RealtimeGatewaySession,
 } from "./realtime-gateway.js";
 
-function preparedDelivery(): PreparedChannelDelivery {
+function preparedDelivery(
+  capabilities: PreparedChannelDelivery["capabilities"] = [
+    SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY,
+  ],
+): PreparedChannelDelivery {
   return {
     protocol: "channel_delivery_v1",
     deliveryId: "dlv_slack_stream_01",
@@ -23,6 +28,7 @@ function preparedDelivery(): PreparedChannelDelivery {
     canonicalThreadId: "thread_slack_stream",
     appUserId: "slack:T1:U1",
     adapter: "slack",
+    capabilities,
     turn: {
       eventId: "evt_slack_stream",
       receivedAt: "2026-07-29T17:00:00.000Z",
@@ -42,8 +48,8 @@ function preparedDelivery(): PreparedChannelDelivery {
   };
 }
 
-function setup() {
-  const delivery = preparedDelivery();
+function setup(capabilities?: PreparedChannelDelivery["capabilities"]) {
+  const delivery = preparedDelivery(capabilities);
   const payloads: ChannelProviderPayload[] = [];
   const deliveryChannel: RealtimeGatewayDeliveryChannel = {
     joinReply: delivery,
@@ -166,6 +172,25 @@ test("starts an explicit managed Slack stream with its first text chunk", async 
         providerReference: "pref_v1_slack_stream_01",
       },
     ]);
+  } finally {
+    fixture.teardown();
+  }
+});
+
+test("uses the legacy append shape when the gateway does not negotiate snapshots", async () => {
+  const fixture = setup([]);
+
+  try {
+    await fixture.adapter.stream(
+      fixture.target,
+      streamChunks("Hello", " world"),
+    );
+
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.append",
+      providerReference: "pref_v1_slack_stream_01",
+      delta: " world",
+    });
   } finally {
     fixture.teardown();
   }

--- a/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
@@ -159,6 +159,7 @@ test("starts an explicit managed Slack stream with its first text chunk", async 
         kind: "slack.stream.append",
         providerReference: "pref_v1_slack_stream_01",
         delta: " world",
+        fullText: "Hello world",
       },
       {
         kind: "slack.stream.stop",

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -576,9 +576,11 @@ export class DeliveryAdapter implements PlatformAdapter {
       let bodyError: unknown;
       let bodyFailed = false;
       let streamStarted = false;
+      let fullText = "";
       try {
         for await (const delta of chunks) {
           if (delta.length === 0) continue;
+          fullText += delta;
           if (!streamStarted) {
             const startResult = await target.claimedDelivery.effect(
               responseId,
@@ -597,6 +599,7 @@ export class DeliveryAdapter implements PlatformAdapter {
             kind: "slack.stream.append",
             providerReference,
             delta,
+            fullText,
           });
         }
         if (!streamStarted) {
@@ -891,6 +894,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     responseId: string,
   ): RunRenderer {
     let providerReference: string | undefined;
+    let fullText = "";
     return createSlackRunRenderer({
       target: { channel: "managed", threadTs: "managed" },
       showToolStatus: this.options.showToolStatus ?? false,
@@ -933,6 +937,7 @@ export class DeliveryAdapter implements PlatformAdapter {
           : {}),
         transport: {
           startStream: async () => {
+            fullText = "";
             providerReference = providerReferenceFromResult(
               await claimedDelivery.effect(responseId, {
                 kind: "slack.stream.start",
@@ -941,6 +946,7 @@ export class DeliveryAdapter implements PlatformAdapter {
             return responseId;
           },
           startStreamWithText: async (initialText) => {
+            fullText = initialText;
             providerReference = providerReferenceFromResult(
               await claimedDelivery.effect(responseId, {
                 kind: "slack.stream.start",
@@ -951,11 +957,13 @@ export class DeliveryAdapter implements PlatformAdapter {
           },
           appendText: async (_id, delta) => {
             if (delta.length === 0) return;
+            fullText += delta;
             assertProviderReference(providerReference);
             await claimedDelivery.effect(responseId, {
               kind: "slack.stream.append",
               providerReference,
               delta,
+              fullText,
             });
           },
           appendChunks: async (_id, chunks) => {

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -49,6 +49,7 @@ import {
   renderTeamsMarkdown,
 } from "@copilotkit/channels-teams/render";
 import type { ChannelProviderPayload } from "./delivery-contracts.js";
+import { SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY } from "./delivery-contracts.js";
 import type {
   ClaimedChannelDelivery,
   ChannelDeliveryTransport,
@@ -595,12 +596,15 @@ export class DeliveryAdapter implements PlatformAdapter {
             continue;
           }
           assertProviderReference(providerReference);
-          await target.claimedDelivery.effect(responseId, {
-            kind: "slack.stream.append",
-            providerReference,
-            delta,
-            fullText,
-          });
+          await target.claimedDelivery.effect(
+            responseId,
+            slackStreamAppendPayload(
+              target.delivery,
+              providerReference,
+              delta,
+              fullText,
+            ),
+          );
         }
         if (!streamStarted) {
           const startResult = await target.claimedDelivery.effect(responseId, {
@@ -883,7 +887,11 @@ export class DeliveryAdapter implements PlatformAdapter {
     const responseId = mintId("response_");
     const renderer =
       target.delivery.adapter === "slack"
-        ? this.createSlackRenderer(target.claimedDelivery, responseId)
+        ? this.createSlackRenderer(
+            target.claimedDelivery,
+            responseId,
+            target.delivery,
+          )
         : this.createTeamsRenderer(target.claimedDelivery, responseId);
     this.rendererResponses.set(renderer, responseId);
     return renderer;
@@ -892,6 +900,7 @@ export class DeliveryAdapter implements PlatformAdapter {
   private createSlackRenderer(
     claimedDelivery: ClaimedChannelDelivery,
     responseId: string,
+    delivery: PreparedChannelDelivery,
   ): RunRenderer {
     let providerReference: string | undefined;
     let fullText = "";
@@ -959,12 +968,15 @@ export class DeliveryAdapter implements PlatformAdapter {
             if (delta.length === 0) return;
             fullText += delta;
             assertProviderReference(providerReference);
-            await claimedDelivery.effect(responseId, {
-              kind: "slack.stream.append",
-              providerReference,
-              delta,
-              fullText,
-            });
+            await claimedDelivery.effect(
+              responseId,
+              slackStreamAppendPayload(
+                delivery,
+                providerReference,
+                delta,
+                fullText,
+              ),
+            );
           },
           appendChunks: async (_id, chunks) => {
             assertProviderReference(providerReference);
@@ -1385,6 +1397,24 @@ function historyText(content: unknown): string {
         : [],
     )
     .join("");
+}
+
+function slackStreamAppendPayload(
+  delivery: PreparedChannelDelivery,
+  providerReference: string,
+  delta: string,
+  fullText: string,
+): ChannelProviderPayload {
+  const append = {
+    kind: "slack.stream.append" as const,
+    providerReference,
+    delta,
+  };
+  return delivery.capabilities?.includes(
+    SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY,
+  )
+    ? { ...append, fullText }
+    : append;
 }
 
 function teamsMessageEffect(

--- a/packages/channels-intelligence/src/delivery-contracts.test.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.test.ts
@@ -35,7 +35,7 @@ test("accepts one destination-free packet", () => {
   expect(() => assertDeliveryPacket(packet())).not.toThrow();
 });
 
-test("requires an authoritative Slack snapshot on every stream append", () => {
+test("accepts a legacy Slack stream append without an authoritative snapshot", () => {
   const missingSnapshot = {
     ...packet(),
     payload: {
@@ -45,9 +45,7 @@ test("requires an authoritative Slack snapshot on every stream append", () => {
     },
   };
 
-  expect(() => assertDeliveryPacket(missingSnapshot)).toThrow(
-    "delivery payload is invalid",
-  );
+  expect(() => assertDeliveryPacket(missingSnapshot)).not.toThrow();
 });
 
 test("rejects trusted addressing and credentials", () => {

--- a/packages/channels-intelligence/src/delivery-contracts.test.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.test.ts
@@ -12,6 +12,7 @@ const appendPayload = (): ChannelProviderPayload => ({
   kind: "slack.stream.append",
   providerReference: "pref_v1_reference_01",
   delta: "Hello",
+  fullText: "Hello",
 });
 
 const packet = (): ChannelDeliveryPacket => {
@@ -32,6 +33,21 @@ test("uses the hard-cut realtime delivery protocol", () => {
 
 test("accepts one destination-free packet", () => {
   expect(() => assertDeliveryPacket(packet())).not.toThrow();
+});
+
+test("requires an authoritative Slack snapshot on every stream append", () => {
+  const missingSnapshot = {
+    ...packet(),
+    payload: {
+      kind: "slack.stream.append",
+      providerReference: "pref_v1_reference_01",
+      delta: " world",
+    },
+  };
+
+  expect(() => assertDeliveryPacket(missingSnapshot)).toThrow(
+    "delivery payload is invalid",
+  );
 });
 
 test("rejects trusted addressing and credentials", () => {

--- a/packages/channels-intelligence/src/delivery-contracts.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.ts
@@ -25,6 +25,7 @@ export type ChannelProviderPayload =
       kind: "slack.stream.append";
       providerReference: string;
       delta: string;
+      fullText: string;
     }
   | {
       kind: "slack.stream.task";
@@ -248,9 +249,15 @@ function isDeliveryPayload(value: unknown): value is ChannelDeliveryPayload {
       );
     case "slack.stream.append":
       return (
-        hasExactFields(value, ["kind", "providerReference", "delta"]) &&
+        hasExactFields(value, [
+          "kind",
+          "providerReference",
+          "delta",
+          "fullText",
+        ]) &&
         validReference(value.providerReference) &&
-        boundedString(value.delta, 1, 40_000)
+        boundedString(value.delta, 1, 40_000) &&
+        boundedString(value.fullText, 1, 40_000)
       );
     case "slack.stream.task":
       return (

--- a/packages/channels-intelligence/src/delivery-contracts.ts
+++ b/packages/channels-intelligence/src/delivery-contracts.ts
@@ -1,6 +1,10 @@
 /** Hard-cut protocol for the dedicated `/channels` socket. */
 export const CHANNEL_DELIVERY_PROTOCOL = "channel_delivery_v1" as const;
 
+/** Negotiates authoritative snapshots for retry-safe Slack stream appends. */
+export const SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY =
+  "slack_stream_append_full_text_v1" as const;
+
 /** Fixed one-use delivery join-token lifetime. */
 export const CHANNEL_DELIVERY_JOIN_TOKEN_TTL_SECONDS = 60;
 
@@ -25,7 +29,7 @@ export type ChannelProviderPayload =
       kind: "slack.stream.append";
       providerReference: string;
       delta: string;
-      fullText: string;
+      fullText?: string;
     }
   | {
       kind: "slack.stream.task";
@@ -249,15 +253,15 @@ function isDeliveryPayload(value: unknown): value is ChannelDeliveryPayload {
       );
     case "slack.stream.append":
       return (
-        hasExactFields(value, [
-          "kind",
-          "providerReference",
-          "delta",
-          "fullText",
-        ]) &&
+        hasExactFields(
+          value,
+          ["kind", "providerReference", "delta", "fullText"],
+          ["fullText"],
+        ) &&
         validReference(value.providerReference) &&
         boundedString(value.delta, 1, 40_000) &&
-        boundedString(value.fullText, 1, 40_000)
+        (value.fullText === undefined ||
+          boundedString(value.fullText, 1, 40_000))
       );
     case "slack.stream.task":
       return (

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -11,6 +11,7 @@ import type {
   RealtimeGatewayDeliveryChannel,
   RealtimeGatewaySession,
 } from "./realtime-gateway.js";
+import { SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY } from "./delivery-contracts.js";
 
 function preparedDelivery() {
   return {
@@ -521,7 +522,10 @@ test("wrong-provider handler output uses only the trusted active-provider fallba
 });
 
 test("claims an invitation and consumes the one-use token on delivery join", async () => {
-  const deliveryChannel = channel();
+  const deliveryChannel = channel({
+    ...preparedDelivery(),
+    capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
+  });
   const control: RealtimeGatewaySession = {
     push: vi.fn().mockResolvedValue(claimResult("dlv_delivery_01")),
     on: vi.fn(),
@@ -549,11 +553,15 @@ test("claims an invitation and consumes the one-use token on delivery join", asy
     runtimeInstanceId: "rti_runtime_01",
     ownerGeneration: 7,
     joinToken: "chj_token_delivery_01",
+    capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
   });
 });
 
 test("reconnect accepts the distinct join-token response without a claim result", async () => {
-  const first = channel();
+  const first = channel({
+    ...preparedDelivery(),
+    capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
+  });
   const second = channel();
   vi.mocked(first.push).mockRejectedValueOnce(new Error("socket dropped"));
   const control: RealtimeGatewaySession = {
@@ -578,11 +586,15 @@ test("reconnect accepts the distinct join-token response without a claim result"
     session: control,
     runtimeInstanceId: "rti_runtime_01",
   });
-  transport.start(async (claimed) => {
+  let capabilitiesAfterReconnect:
+    | PreparedChannelDelivery["capabilities"]
+    | undefined;
+  transport.start(async (claimed, delivery) => {
     await claimed.effect("response_01", {
       kind: "slack.message.create",
       text: "Hello after reconnect",
     });
+    capabilitiesAfterReconnect = delivery.capabilities;
   });
 
   const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
@@ -600,9 +612,11 @@ test("reconnect accepts the distinct join-token response without a claim result"
     runtimeInstanceId: "rti_runtime_01",
     ownerGeneration: 8,
     joinToken: "chj_reconnect_delivery_01",
+    capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
   });
   expect(first.leave).toHaveBeenCalledOnce();
   expect(second.push).toHaveBeenCalledTimes(2);
+  expect(capabilitiesAfterReconnect).toBeUndefined();
   await transport.stop();
 });
 
@@ -1445,6 +1459,13 @@ test("rejects malformed capabilities on every prepared input that carries one", 
     kind: "interaction",
     actionId: "ck:approve",
     messageRef: { id: "raw-provider-message-id" },
+  });
+});
+
+test("rejects an unrecognized prepared delivery capability", async () => {
+  await expectPreparedDeliveryRejected({
+    ...preparedDelivery(),
+    capabilities: ["slack_stream_append_future_v2"],
   });
 });
 

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -1305,6 +1305,7 @@ test("still allows stream.stop after a permanent non-terminal failure", async ()
       kind: "slack.stream.append",
       providerReference: "pref_v1_message_01",
       delta: "x",
+      fullText: "x",
     }),
   ).rejects.toBeInstanceOf(RealtimeGatewayPushError);
 

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -620,6 +620,92 @@ test("reconnect accepts the distinct join-token response without a claim result"
   await transport.stop();
 });
 
+test("adapts an in-flight Slack append across new-old-new gateway rejoins", async () => {
+  const first = channel({
+    ...preparedDelivery(),
+    capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
+  });
+  const second = channel();
+  const third = channel({
+    ...preparedDelivery(),
+    capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
+  });
+  vi.mocked(first.push).mockRejectedValueOnce(new Error("socket dropped"));
+  vi.mocked(second.push).mockRejectedValueOnce(new Error("socket dropped"));
+  let ownerGeneration = 7;
+  const control: RealtimeGatewaySession = {
+    push: vi.fn().mockImplementation((event, payload) => {
+      const deliveryId = (payload as { deliveryId: string }).deliveryId;
+      if (event === "claim") return Promise.resolve(claimResult(deliveryId));
+      if (event === "join_token") {
+        ownerGeneration += 1;
+        return Promise.resolve({
+          deliveryId,
+          ownerGeneration,
+          joinToken: `chj_reconnect_delivery_${ownerGeneration}`,
+          joinTokenExpiresAt: "2099-07-29T16:02:00.000Z",
+          deliveryExpiresAt: "2099-07-29T18:00:00.000Z",
+        });
+      }
+      return Promise.resolve({});
+    }),
+    on: vi.fn(),
+    join: vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second)
+      .mockResolvedValueOnce(third),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_runtime_01",
+  });
+  transport.start(async (claimed) => {
+    await claimed.effect("response_01", {
+      kind: "slack.stream.append",
+      providerReference: "pref_v1_safe_reference",
+      delta: " world",
+      fullText: "Hello world",
+    });
+  });
+
+  const invitationHandler = vi.mocked(control.on).mock.calls[0]![1];
+  invitationHandler(invitation("dlv_delivery_01", "thread_01"));
+
+  await vi.waitFor(() => expect(third.leave).toHaveBeenCalledOnce());
+  const initialPacket = vi.mocked(first.push).mock.calls[0]![1] as {
+    packetId: string;
+    seq: number;
+    payload: Record<string, unknown>;
+  };
+  const retriedPacket = vi.mocked(second.push).mock.calls[0]![1] as {
+    packetId: string;
+    seq: number;
+    payload: Record<string, unknown>;
+  };
+  const restoredPacket = vi.mocked(third.push).mock.calls[0]![1] as {
+    packetId: string;
+    seq: number;
+    payload: Record<string, unknown>;
+  };
+  expect(initialPacket.payload).toMatchObject({
+    kind: "slack.stream.append",
+    delta: " world",
+    fullText: "Hello world",
+  });
+  expect(retriedPacket.payload).toEqual({
+    kind: "slack.stream.append",
+    providerReference: "pref_v1_safe_reference",
+    delta: " world",
+  });
+  expect(retriedPacket.packetId).toBe(initialPacket.packetId);
+  expect(retriedPacket.seq).toBe(initialPacket.seq);
+  expect(restoredPacket.payload).toEqual(initialPacket.payload);
+  expect(restoredPacket.packetId).toBe(initialPacket.packetId);
+  expect(restoredPacket.seq).toBe(initialPacket.seq);
+  await transport.stop();
+});
+
 test("claims bounded pending work but does not execute above the local limit", async () => {
   let releaseFirst: (() => void) | undefined;
   const firstDelivery = new Promise<void>((resolve) => {

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -12,6 +12,7 @@ import type {
 import { RealtimeGatewayPushError } from "./realtime-gateway.js";
 import {
   CHANNEL_DELIVERY_PROTOCOL,
+  SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY,
   assertDeliveryPacket,
   assertProviderMessageId,
   assertProviderReference,
@@ -85,6 +86,7 @@ export interface PreparedChannelDelivery {
   channelId: string;
   channelName: string;
   adapter: ChannelDeliveryAdapter;
+  capabilities?: readonly (typeof SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY)[];
   tenant?: { id: string; name?: string };
   installation?: { id: string };
   conversation?: { id: string; kind?: string };
@@ -260,6 +262,7 @@ export class ClaimedChannelDelivery {
       channel: RealtimeGatewayDeliveryChannel;
       owner: DeliveryOwner;
       deliveryExpiresAt?: string;
+      capabilities?: PreparedChannelDelivery["capabilities"];
     }>,
     private readonly files?: ChannelDeliveryFileClient,
     private readonly transcripts?: ChannelDeliveryTranscriptClient,
@@ -280,8 +283,21 @@ export class ClaimedChannelDelivery {
   }
 
   /** Refresh ownership metadata after a successful join_token reconnect. */
-  updateOwner(owner: DeliveryOwner, deliveryExpiresAt?: string): void {
+  updateOwner(
+    owner: DeliveryOwner,
+    deliveryExpiresAt?: string,
+    capabilities?: PreparedChannelDelivery["capabilities"],
+  ): void {
     this.owner = owner;
+    if (capabilities === undefined) {
+      delete (this.delivery as { capabilities?: unknown }).capabilities;
+    } else {
+      (
+        this.delivery as {
+          capabilities?: PreparedChannelDelivery["capabilities"];
+        }
+      ).capabilities = capabilities;
+    }
     if (
       deliveryExpiresAt !== undefined &&
       Number.isFinite(Date.parse(deliveryExpiresAt))
@@ -633,7 +649,11 @@ export class ClaimedChannelDelivery {
         if (Date.now() >= Date.parse(this.delivery.deliveryExpiresAt)) break;
         const refreshed = await this.reconnect();
         this.channel = refreshed.channel;
-        this.updateOwner(refreshed.owner, refreshed.deliveryExpiresAt);
+        this.updateOwner(
+          refreshed.owner,
+          refreshed.deliveryExpiresAt,
+          refreshed.capabilities,
+        );
       }
     }
     throw new Error("Channel delivery ownership expired");
@@ -967,6 +987,7 @@ export class ChannelDeliveryTransport {
         channel: RealtimeGatewayDeliveryChannel;
         owner: DeliveryOwner;
         deliveryExpiresAt?: string;
+        capabilities?: PreparedChannelDelivery["capabilities"];
       }> => {
         const previous = joined;
         const refreshed = assertJoinTokenResult(
@@ -1001,6 +1022,7 @@ export class ChannelDeliveryTransport {
             runtimeInstanceId: refreshed.runtimeInstanceId,
           },
           deliveryExpiresAt: rejoinDelivery.deliveryExpiresAt,
+          capabilities: rejoinDelivery.capabilities,
         };
       };
       claimedDelivery = new ClaimedChannelDelivery(
@@ -1129,6 +1151,7 @@ export class ChannelDeliveryTransport {
       runtimeInstanceId: owner.runtimeInstanceId,
       ownerGeneration: owner.ownerGeneration,
       joinToken,
+      capabilities: [SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY],
     });
   }
 }
@@ -1324,7 +1347,7 @@ function assertPreparedDelivery(
         "adapter",
         "turn",
       ],
-      ["tenant", "installation", "conversation", "surfaceKind"],
+      ["tenant", "installation", "conversation", "surfaceKind", "capabilities"],
     )
   ) {
     throw new TypeError("Gateway returned an invalid prepared delivery");
@@ -1340,6 +1363,13 @@ function assertPreparedDelivery(
     !isSafeExternalId(prepared.canonicalThreadId) ||
     !isSafeAppUserId(prepared.appUserId) ||
     (prepared.adapter !== "slack" && prepared.adapter !== "teams") ||
+    (prepared.capabilities !== undefined &&
+      (!Array.isArray(prepared.capabilities) ||
+        prepared.capabilities.length > 1 ||
+        prepared.capabilities.some(
+          (capability) =>
+            capability !== SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY,
+        ))) ||
     (prepared.tenant !== undefined && !isPreparedTenant(prepared.tenant)) ||
     (prepared.installation !== undefined &&
       !isPreparedInstallation(prepared.installation)) ||

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -613,14 +613,15 @@ export class ClaimedChannelDelivery {
     packet: ChannelDeliveryPacket,
   ): Promise<ChannelDeliveryPacketAck> {
     let attempt = 0;
+    let pendingPacket = packet;
     while (Date.now() < Date.parse(this.delivery.deliveryExpiresAt)) {
       throwIfStopped(this.signal);
       try {
         const acknowledgement = (await this.channel.push(
           PACKET_EVENT,
-          packet,
+          pendingPacket,
         )) as ChannelDeliveryPacketAck;
-        this.assertExactAcknowledgement(packet, acknowledgement);
+        this.assertExactAcknowledgement(pendingPacket, acknowledgement);
         if (acknowledgement.phase !== "retry_wait") {
           return acknowledgement;
         }
@@ -654,6 +655,17 @@ export class ClaimedChannelDelivery {
           refreshed.deliveryExpiresAt,
           refreshed.capabilities,
         );
+        pendingPacket = packet;
+        if (
+          packet.payload.kind === "slack.stream.append" &&
+          packet.payload.fullText !== undefined &&
+          !refreshed.capabilities?.includes(
+            SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY,
+          )
+        ) {
+          const { fullText: _fullText, ...legacyPayload } = packet.payload;
+          pendingPacket = { ...packet, payload: legacyPayload };
+        }
       }
     }
     throw new Error("Channel delivery ownership expired");

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -412,6 +412,7 @@ export class MockSocket {
 
   private errorHandlers: Array<(error?: any) => void> = [];
   private openHandlers: Array<() => void> = [];
+  private closeHandlers: Array<(event?: { code?: number }) => void> = [];
 
   constructor(url: string = "", opts: Record<string, any> = {}) {
     this.url = url;
@@ -434,6 +435,10 @@ export class MockSocket {
     this.openHandlers.push(callback);
   }
 
+  onClose(callback: (event?: { code?: number }) => void): void {
+    this.closeHandlers.push(callback);
+  }
+
   channel(topic: string, params: Record<string, any> = {}): MockChannel {
     const ch = new MockChannel(topic, params);
     this.channels.push(ch);
@@ -448,5 +453,10 @@ export class MockSocket {
   /** Test helper — simulate a successful (re)connection. */
   triggerOpen(): void {
     for (const handler of this.openHandlers) handler();
+  }
+
+  /** Test helper — simulate the WebSocket transport closing. */
+  triggerClose(event?: { code?: number }): void {
+    for (const handler of this.closeHandlers) handler(event);
   }
 }

--- a/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
@@ -1,0 +1,144 @@
+import { writeFile } from "node:fs/promises";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput, RunAgentResult } from "@ag-ui/client";
+import { EMPTY, firstValueFrom } from "rxjs";
+import { toArray } from "rxjs/operators";
+
+const chunks = Number(process.env.CPKI_KIND_EVENT_CHUNKS ?? "400");
+const resultPath = process.env.CPKI_KIND_RESULT_PATH;
+const closeMode = process.env.CPKI_KIND_CLOSE_MODE ?? "planned";
+const closeCodes: number[] = [];
+const NativeWebSocket = globalThis.WebSocket;
+
+class ObservedWebSocket extends NativeWebSocket {
+  constructor(address: string | URL, protocols?: string | string[]) {
+    super(address, protocols);
+    this.addEventListener("close", (event) => closeCodes.push(event.code));
+  }
+}
+
+Object.assign(globalThis, { WebSocket: ObservedWebSocket });
+
+class SlowLifecycleAgent extends AbstractAgent {
+  runCount = 0;
+  emittedEvents = 0;
+
+  async runAgent(
+    input: RunAgentInput,
+    subscriber?: { onEvent?: (arg: { event: BaseEvent }) => void },
+  ): Promise<RunAgentResult> {
+    this.runCount += 1;
+    const emit = (event: BaseEvent) => {
+      this.emittedEvents += 1;
+      subscriber?.onEvent?.({ event });
+    };
+    emit({
+      type: EventType.RUN_STARTED,
+      threadId: input.threadId,
+      runId: input.runId,
+    } as BaseEvent);
+    emit({
+      type: EventType.TEXT_MESSAGE_START,
+      messageId: "message-kind-handoff",
+      role: "assistant",
+    } as BaseEvent);
+
+    for (let index = 0; index < chunks; index += 1) {
+      emit({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-kind-handoff",
+        delta: `${index},`,
+      } as BaseEvent);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    }
+
+    emit({
+      type: EventType.TEXT_MESSAGE_END,
+      messageId: "message-kind-handoff",
+    } as BaseEvent);
+    emit({
+      type: EventType.RUN_FINISHED,
+      threadId: input.threadId,
+      runId: input.runId,
+    } as BaseEvent);
+    return { result: undefined, newMessages: [] };
+  }
+
+  abortRun(): void {}
+  clone(): AbstractAgent {
+    return new SlowLifecycleAgent();
+  }
+  run(): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+  protected connect(): ReturnType<AbstractAgent["connect"]> {
+    return EMPTY;
+  }
+}
+
+async function main(): Promise<void> {
+  const { IntelligenceAgentRunner } = await import("../../intelligence");
+  const runner = new IntelligenceAgentRunner({
+    url: process.env.CPKI_KIND_GATEWAY_URL ?? "ws://127.0.0.1:4401/runner",
+    authToken: "ck_test_longsecret",
+    maxReconnectMs: 500,
+    maxRejoinMs: 500,
+  });
+  const agent = new SlowLifecycleAgent();
+  const threadId = process.env.CPKI_KIND_THREAD_ID ?? "thread-kind-handoff";
+  const runId = process.env.CPKI_KIND_RUN_ID ?? "run-kind-handoff";
+  const input = {
+    threadId,
+    runId,
+    messages: [],
+    tools: [],
+    context: [],
+    state: {},
+  } as RunAgentInput;
+
+  const progressTimer = setInterval(() => {
+    process.stdout.write(
+      `CPKI_KIND_PROGRESS ${JSON.stringify({ closeCodes, emittedEvents: agent.emittedEvents, runCount: agent.runCount })}\n`,
+    );
+  }, 5_000);
+  const runnerEvents = await firstValueFrom(
+    runner.run({ threadId, agent, input }).pipe(toArray()),
+  ).finally(() => clearInterval(progressTimer));
+
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const result = {
+    closeCodes,
+    runCount: agent.runCount,
+    runnerErrors: runnerEvents.filter(
+      (event) => event.type === EventType.RUN_ERROR,
+    ).length,
+    expectedEvents: chunks + 4,
+  };
+
+  if (resultPath) await writeFile(resultPath, JSON.stringify(result));
+  process.stdout.write(`CPKI_KIND_RESULT ${JSON.stringify(result)}\n`);
+
+  if (closeMode === "planned" && !closeCodes.includes(1012)) {
+    throw new Error(
+      `expected Phoenix service-restart close 1012, observed ${closeCodes.join(",")}`,
+    );
+  }
+  if (closeMode === "abrupt" && !closeCodes.includes(1006)) {
+    throw new Error(
+      `expected abnormal close 1006, observed ${closeCodes.join(",")}`,
+    );
+  }
+  if (agent.runCount !== 1) {
+    throw new Error(`agent executed ${agent.runCount} times`);
+  }
+  if (result.runnerErrors !== 0) {
+    throw new Error(`runner emitted ${result.runnerErrors} terminal errors`);
+  }
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.stack : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
@@ -22,6 +22,7 @@ Object.assign(globalThis, { WebSocket: ObservedWebSocket });
 class SlowLifecycleAgent extends AbstractAgent {
   runCount = 0;
   emittedEvents = 0;
+  aborted = false;
 
   async runAgent(
     input: RunAgentInput,
@@ -64,7 +65,9 @@ class SlowLifecycleAgent extends AbstractAgent {
     return { result: undefined, newMessages: [] };
   }
 
-  abortRun(): void {}
+  abortRun(): void {
+    this.aborted = true;
+  }
   clone(): AbstractAgent {
     return new SlowLifecycleAgent();
   }
@@ -112,6 +115,7 @@ async function main(): Promise<void> {
     runnerErrors: runnerEvents.filter(
       (event) => event.type === EventType.RUN_ERROR,
     ).length,
+    agentAborted: agent.aborted,
     expectedEvents: chunks + 4,
   };
 
@@ -133,6 +137,11 @@ async function main(): Promise<void> {
   }
   if (result.runnerErrors !== 0) {
     throw new Error(`runner emitted ${result.runnerErrors} terminal errors`);
+  }
+  if (result.agentAborted) {
+    throw new Error(
+      "runner aborted the accepted agent during gateway recovery",
+    );
   }
 }
 

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -25,12 +25,42 @@ let mockChannels: MockRunnerChannel[] = [];
 let mockSockets: MockSocket[] = [];
 
 class MockRunnerChannel extends MockChannel {
+  state = "closed";
+
+  join(payload?: Record<string, any>): MockPush {
+    this.state = "joining";
+    return super.join(payload);
+  }
+
   push(event: string, payload: any): MockPush {
     const push = super.push(event, payload);
     if (autoAcknowledgePushes) {
       queueMicrotask(() => push.trigger("ok"));
     }
     return push;
+  }
+
+  beginRejoin(): void {
+    this.state = "joining";
+  }
+
+  triggerJoin(
+    status: "ok" | "error" | "timeout",
+    response?: unknown,
+  ): void {
+    this.state =
+      status === "ok" ? "joined" : status === "error" ? "errored" : "closed";
+    super.triggerJoin(status, response);
+  }
+
+  triggerError(reason?: string): void {
+    this.state = "errored";
+    super.triggerError(reason);
+  }
+
+  leave(): void {
+    this.state = "closed";
+    super.leave();
   }
 }
 
@@ -948,6 +978,75 @@ describe("IntelligenceAgentRunner", () => {
       ch.pushLog[2].push.trigger("ok");
       await waitForCondition(() => ch.pushLog.length === 4);
       ch.pushLog[3].push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("waits for rejoin before replaying with the latest event protocol", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-rejoin-latest-protocol";
+      const input = createRunInput({
+        threadId,
+        runId: "r-rejoin-latest-protocol",
+      });
+      const agent = new PausingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "hello",
+        } as TextMessageContentEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(ch.pushLog).toHaveLength(1);
+      expect(ch.pushLog[0].event).toBe("events");
+      const originalEvents = ch.pushLog[0].payload.events;
+      const originalMetadata = originalEvents.map((event: any) =>
+        event.metadata,
+      );
+
+      ch.pushLog[0].push.trigger("error", { reason: "channel_closed" });
+      ch.triggerError("channel_closed");
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(ch.state).toBe("errored");
+      expect(ch.pushLog).toHaveLength(1);
+
+      ch.beginRejoin();
+      expect(ch.state).toBe("joining");
+      ch.triggerJoin("ok", { capabilities: [] });
+
+      for (const [index, metadata] of originalMetadata.entries()) {
+        const replay = ch.pushLog[index + 1];
+        expect(replay.event).toBe("event");
+        expect(replay.payload.metadata).toEqual(metadata);
+        replay.push.trigger("ok");
+      }
+      expect(ch.pushLog).toHaveLength(originalEvents.length + 1);
+
+      agent.emit({
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "msg-1",
+      } as TextMessageEndEvent);
+      agent.emit({
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId: input.runId,
+      } as RunFinishedEvent);
+      agent.finish();
+      ch.pushLog.at(-1)!.push.trigger("ok");
+      ch.pushLog.at(-1)!.push.trigger("ok");
       await eventsPromise;
     });
 

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import type {
   BaseEvent,
   RunAgentInput,
@@ -82,6 +82,53 @@ class MockAgent extends AbstractAgent {
 
   clone(): AbstractAgent {
     return new MockAgent(this.events);
+  }
+
+  run(): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+
+  protected connect(): ReturnType<AbstractAgent["connect"]> {
+    return EMPTY;
+  }
+}
+
+class PausingMockAgent extends AbstractAgent {
+  private subscriber:
+    | { onEvent?: (arg: { event: BaseEvent }) => void }
+    | undefined;
+  private resolveRun: (() => void) | undefined;
+
+  constructor(private initialEvents: BaseEvent[]) {
+    super();
+  }
+
+  async runAgent(
+    _input: RunAgentInput,
+    subscriber?: { onEvent?: (arg: { event: BaseEvent }) => void },
+  ): Promise<RunAgentResult> {
+    this.subscriber = subscriber;
+    for (const event of this.initialEvents) {
+      subscriber?.onEvent?.({ event });
+    }
+    await new Promise<void>((resolve) => {
+      this.resolveRun = resolve;
+    });
+    return { result: undefined, newMessages: [] };
+  }
+
+  emit(event: BaseEvent): void {
+    this.subscriber?.onEvent?.({ event });
+  }
+
+  finish(): void {
+    this.resolveRun?.();
+  }
+
+  abortRun(): void {}
+
+  clone(): AbstractAgent {
+    return new PausingMockAgent(this.initialEvents);
   }
 
   run(): ReturnType<AbstractAgent["run"]> {
@@ -188,6 +235,10 @@ describe("IntelligenceAgentRunner", () => {
     mockSockets = [];
     autoAcknowledgePushes = true;
     runner = new IntelligenceAgentRunner({ url: "ws://localhost:4000/runner" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("passes Phoenix authToken to the runner socket when configured", () => {
@@ -328,6 +379,215 @@ describe("IntelligenceAgentRunner", () => {
       expect(ch.pushLog[0].payload.metadata.cpki_event_seq).toBe(1);
       expect(ch.pushLog[1].payload.metadata.cpki_event_seq).toBe(2);
       expect(ch.pushLog[2].payload.metadata.cpki_event_seq).toBe(3);
+    });
+
+    it("batches separate durable events after negotiating runner_event_batch_v1", async () => {
+      const threadId = "t-batch-negotiated";
+      const input = createRunInput({ threadId, runId: "r-batch-negotiated" });
+      const agent = new MockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "first",
+        } as TextMessageContentEvent,
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "second",
+        } as TextMessageContentEvent,
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: "msg-1",
+        } as TextMessageEndEvent,
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+
+      await eventsPromise;
+
+      expect(ch.pushLog).toHaveLength(1);
+      expect(ch.pushLog[0].event).toBe("events");
+      const events = ch.pushLog[0].payload.events;
+      expect(events.map((event: any) => event.type)).toEqual([
+        EventType.RUN_STARTED,
+        EventType.TEXT_MESSAGE_START,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_CONTENT,
+        EventType.TEXT_MESSAGE_END,
+        EventType.RUN_FINISHED,
+      ]);
+      expect(events.map((event: any) => event.metadata.cpki_event_id)).toEqual(
+        expect.arrayContaining([
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+          expect.any(String),
+        ]),
+      );
+      expect(
+        new Set(events.map((event: any) => event.metadata.cpki_event_id)).size,
+      ).toBe(events.length);
+      expect(events.map((event: any) => event.metadata.cpki_event_seq)).toEqual([
+        1, 2, 3, 4, 5, 6,
+      ]);
+    });
+
+    it("waits five milliseconds for a partial negotiated batch and flushes a full batch immediately", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-batch-flush";
+      const input = createRunInput({ threadId, runId: "r-batch-flush" });
+      const agent = new MockAgent(
+        [
+          {
+            type: EventType.TEXT_MESSAGE_START,
+            messageId: "msg-1",
+            role: "assistant",
+          } as TextMessageStartEvent,
+          ...Array.from(
+            { length: 30 },
+            (_, index) =>
+              ({
+                type: EventType.TEXT_MESSAGE_CONTENT,
+                messageId: "msg-1",
+                delta: String(index),
+              }) as TextMessageContentEvent,
+          ),
+          {
+            type: EventType.TEXT_MESSAGE_END,
+            messageId: "msg-1",
+          } as TextMessageEndEvent,
+          {
+            type: EventType.RUN_FINISHED,
+            threadId,
+            runId: input.runId,
+          } as RunFinishedEvent,
+        ],
+      );
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await Promise.resolve();
+
+      expect(ch.pushLog).toHaveLength(1);
+      expect(ch.pushLog[0]).toMatchObject({
+        event: "events",
+        payload: { events: expect.any(Array) },
+      });
+      expect(ch.pushLog[0].payload.events).toHaveLength(32);
+
+      ch.pushLog[0].push.trigger("ok");
+      await vi.advanceTimersByTimeAsync(4);
+      expect(ch.pushLog).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(ch.pushLog).toHaveLength(2);
+      expect(ch.pushLog[1].payload.events).toHaveLength(2);
+
+      ch.pushLog[1].push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("retries a negotiated batch with the same payload objects and keeps all members until acknowledgement", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-batch-retry";
+      const input = createRunInput({ threadId, runId: "r-batch-retry" });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(ch.pushLog).toHaveLength(1);
+      const originalEvents = ch.pushLog[0].payload.events;
+      ch.pushLog[0].push.trigger("error", { reason: "redis_unavailable" });
+      await vi.advanceTimersByTimeAsync(105);
+
+      expect(ch.pushLog).toHaveLength(2);
+      expect(ch.pushLog[1]).toMatchObject({ event: "events" });
+      expect(ch.pushLog[1].payload.events).toEqual(originalEvents);
+      expect(ch.pushLog[1].payload.events[0]).toBe(originalEvents[0]);
+      expect(ch.pushLog[1].payload.events[1]).toBe(originalEvents[1]);
+      expect(await runner.isRunning({ threadId })).toBe(true);
+
+      ch.pushLog[1].push.trigger("ok");
+      await eventsPromise;
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
+    it("retries the original negotiated batch before events queued during its failed push", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-batch-retry-members";
+      const input = createRunInput({ threadId, runId: "r-batch-retry-members" });
+      const agent = new PausingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "first",
+        } as TextMessageContentEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      const originalEvents = ch.pushLog[0].payload.events;
+      agent.emit({
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "msg-1",
+      } as TextMessageEndEvent);
+      agent.emit({
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId: input.runId,
+      } as RunFinishedEvent);
+      agent.finish();
+      ch.pushLog[0].push.trigger("error", { reason: "redis_unavailable" });
+      await vi.advanceTimersByTimeAsync(105);
+
+      expect(ch.pushLog[1].payload.events).toEqual(originalEvents);
+      ch.pushLog[1].push.trigger("ok");
+      await vi.advanceTimersByTimeAsync(5);
+      expect(ch.pushLog[2].payload.events).toHaveLength(2);
+      ch.pushLog[2].push.trigger("ok");
+      await eventsPromise;
     });
 
     it("overrides conflicting event thread and run ownership before pushing to the channel", async () => {

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -221,7 +221,17 @@ class BlockingMockAgent extends AbstractAgent {
   aborted = false;
   private rejectFn: ((reason: Error) => void) | null = null;
 
-  async runAgent(): Promise<RunAgentResult> {
+  constructor(private initialEvents: BaseEvent[] = []) {
+    super();
+  }
+
+  async runAgent(
+    _input: RunAgentInput,
+    subscriber?: { onEvent?: (arg: { event: BaseEvent }) => void },
+  ): Promise<RunAgentResult> {
+    for (const event of this.initialEvents) {
+      subscriber?.onEvent?.({ event });
+    }
     return new Promise<RunAgentResult>((_resolve, reject) => {
       this.rejectFn = reject;
     });
@@ -233,7 +243,7 @@ class BlockingMockAgent extends AbstractAgent {
   }
 
   clone(): AbstractAgent {
-    return new BlockingMockAgent();
+    return new BlockingMockAgent(this.initialEvents);
   }
 
   run(): ReturnType<AbstractAgent["run"]> {
@@ -699,16 +709,24 @@ describe("IntelligenceAgentRunner", () => {
         threadId,
         runId: "r-event-failure-replacement-next",
       });
+      const failedAgent = new BlockingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-failed",
+          role: "assistant",
+        } as TextMessageStartEvent,
+      ]);
+      const replacementAgent = new BlockingMockAgent();
       let replacementSubscription:
         | ReturnType<ReturnType<typeof runner.run>["subscribe"]>
         | undefined;
 
-      runner.run({ threadId, agent: new MockAgent(), input }).subscribe({
+      runner.run({ threadId, agent: failedAgent, input }).subscribe({
         error: () => {
           replacementSubscription = runner
             .run({
               threadId,
-              agent: new BlockingMockAgent(),
+              agent: replacementAgent,
               input: replacementInput,
             })
             .subscribe();
@@ -718,9 +736,13 @@ describe("IntelligenceAgentRunner", () => {
       failedChannel.triggerJoin("ok");
       await waitForCondition(() => failedChannel.pushLog.length === 1);
       failedChannel.pushLog[0].push.trigger("error", { retryable: false });
+      await Promise.resolve();
 
+      expect(failedAgent.aborted).toBe(true);
+      expect(failedChannel.pushLog).toHaveLength(1);
       expect(replacementSubscription).toBeDefined();
       expect(await runner.isRunning({ threadId })).toBe(true);
+      expect(replacementAgent.aborted).toBe(false);
       expect(mockChannels[1].left).toBe(false);
       expect(mockSockets[1].disconnected).toBe(false);
 
@@ -857,6 +879,40 @@ describe("IntelligenceAgentRunner", () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
+    it("aborts a blocked producer when its queued event reaches the durability deadline", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-deadline-abort-producer";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-deadline-abort-producer",
+      });
+      const agent = new BlockingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-blocked",
+          role: "assistant",
+        } as TextMessageStartEvent,
+      ]);
+      let errors = 0;
+
+      runner
+        .run({ threadId, agent, input })
+        .subscribe({ error: () => errors++ });
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+      expect(ch.pushLog).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(60_000 - 5);
+
+      expect(errors).toBe(1);
+      expect(agent.aborted).toBe(true);
+      expect(ch.pushLog).toHaveLength(1);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
     it("does not reset a queued event's durability deadline after rejoin", async () => {
       vi.useFakeTimers();
       autoAcknowledgePushes = false;
@@ -896,6 +952,37 @@ describe("IntelligenceAgentRunner", () => {
       await vi.advanceTimersByTimeAsync(1_000);
 
       expect(errors).toBe(1);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
+    it("fails and aborts an accepted blocked run on an explicit permanent rejoin error", async () => {
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-permanent-rejoin";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-permanent-rejoin",
+      });
+      const agent = new BlockingMockAgent();
+      let receivedError: Error | undefined;
+
+      runner.run({ threadId, agent, input }).subscribe({
+        error: (error) => (receivedError = error),
+      });
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok");
+      expect(ch.pushLog).toHaveLength(0);
+
+      ch.triggerJoin("error", {
+        reason: "runner_evicted",
+        retryable: false,
+      });
+      await Promise.resolve();
+
+      expect(receivedError?.message).toContain("runner_evicted");
+      expect(agent.aborted).toBe(true);
+      expect(ch.pushLog).toHaveLength(0);
+      expect(ch.left).toBe(true);
+      expect(mockSockets[0].disconnected).toBe(true);
       expect(await runner.isRunning({ threadId })).toBe(false);
     });
 

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -76,6 +76,21 @@ class MockSocketImpl extends MockSocket {
     mockChannels.push(ch);
     return ch;
   }
+
+  isConnected(): boolean {
+    return this.connected && !this.disconnected;
+  }
+
+  triggerClose(event?: { code?: number }): void {
+    this.connected = false;
+    super.triggerClose(event);
+  }
+
+  triggerOpen(): void {
+    this.connected = true;
+    this.disconnected = false;
+    super.triggerOpen();
+  }
 }
 
 vi.mock("phoenix", () => ({
@@ -533,6 +548,63 @@ describe("IntelligenceAgentRunner", () => {
       expect(ch.pushLog[1].payload.events).toHaveLength(2);
 
       ch.pushLog[1].push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("flushes an aged partial batch immediately after the active batch is acknowledged", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-batch-aged-behind-active";
+      const input = createRunInput({
+        threadId,
+        runId: "r-batch-aged-behind-active",
+      });
+      const agent = new PausingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+        ...Array.from(
+          { length: 30 },
+          (_, index) =>
+            ({
+              type: EventType.TEXT_MESSAGE_CONTENT,
+              messageId: "msg-1",
+              delta: String(index),
+            }) as TextMessageContentEvent,
+        ),
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+
+      expect(ch.pushLog[0].payload.events).toHaveLength(32);
+      agent.emit({
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "msg-1",
+      } as TextMessageEndEvent);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(ch.pushLog).toHaveLength(1);
+
+      ch.pushLog[0].push.trigger("ok");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(ch.pushLog).toHaveLength(2);
+      expect(ch.pushLog[1].payload.events).toHaveLength(1);
+
+      agent.emit({
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId: input.runId,
+      } as RunFinishedEvent);
+      agent.finish();
+      ch.pushLog[1].push.trigger("ok");
+      await vi.advanceTimersByTimeAsync(5);
+      ch.pushLog[2].push.trigger("ok");
       await eventsPromise;
     });
 
@@ -1047,6 +1119,115 @@ describe("IntelligenceAgentRunner", () => {
       agent.finish();
       ch.pushLog.at(-1)!.push.trigger("ok");
       ch.pushLog.at(-1)!.push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("preserves failed batch membership across a same-capability rejoin", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-rejoin-same-protocol";
+      const input = createRunInput({
+        threadId,
+        runId: "r-rejoin-same-protocol",
+      });
+      const agent = new PausingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "hello",
+        } as TextMessageContentEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      const originalEvents = ch.pushLog[0].payload.events;
+      expect(originalEvents).toHaveLength(3);
+      agent.emit({
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "msg-1",
+      } as TextMessageEndEvent);
+      agent.emit({
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId: input.runId,
+      } as RunFinishedEvent);
+      agent.finish();
+
+      ch.pushLog[0].push.trigger("error", { reason: "channel_closed" });
+      ch.triggerError("channel_closed");
+      ch.beginRejoin();
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(ch.pushLog).toHaveLength(2);
+      expect(ch.pushLog[1].event).toBe("events");
+      expect(ch.pushLog[1].payload.events).toEqual(originalEvents);
+      ch.pushLog[1].push.trigger("ok");
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(ch.pushLog[2].payload.events).toHaveLength(2);
+      expect(
+        ch.pushLog[2].payload.events.map(
+          (event: any) => event.metadata.cpki_event_seq,
+        ),
+      ).toEqual([4, 5]);
+      ch.pushLog[2].push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("waits for socket reconnect and rejoin before pushing pending events", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-rejoin-disconnected-socket";
+      const input = createRunInput({
+        threadId,
+        runId: "r-rejoin-disconnected-socket",
+      });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      const socket = mockSockets[0] as MockSocketImpl;
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      socket.triggerClose({ code: 1006 });
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(ch.state).toBe("joined");
+      expect(socket.isConnected()).toBe(false);
+      expect(ch.pushLog).toHaveLength(0);
+
+      socket.triggerOpen();
+      expect(ch.pushLog).toHaveLength(0);
+      ch.beginRejoin();
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(ch.pushLog).toHaveLength(1);
+      expect(ch.pushLog[0].event).toBe("events");
+      expect(
+        ch.pushLog[0].payload.events.map(
+          (event: any) => event.metadata.cpki_event_seq,
+        ),
+      ).toEqual([1, 2]);
+      ch.pushLog[0].push.trigger("ok");
       await eventsPromise;
     });
 

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -44,10 +44,7 @@ class MockRunnerChannel extends MockChannel {
     this.state = "joining";
   }
 
-  triggerJoin(
-    status: "ok" | "error" | "timeout",
-    response?: unknown,
-  ): void {
+  triggerJoin(status: "ok" | "error" | "timeout", response?: unknown): void {
     this.state =
       status === "ok" ? "joined" : status === "error" ? "errored" : "closed";
     super.triggerJoin(status, response);
@@ -488,9 +485,9 @@ describe("IntelligenceAgentRunner", () => {
       expect(
         new Set(events.map((event: any) => event.metadata.cpki_event_id)).size,
       ).toBe(events.length);
-      expect(events.map((event: any) => event.metadata.cpki_event_seq)).toEqual([
-        1, 2, 3, 4, 5, 6,
-      ]);
+      expect(events.map((event: any) => event.metadata.cpki_event_seq)).toEqual(
+        [1, 2, 3, 4, 5, 6],
+      );
     });
 
     it("waits five milliseconds for a partial negotiated batch and flushes a full batch immediately", async () => {
@@ -498,33 +495,31 @@ describe("IntelligenceAgentRunner", () => {
       autoAcknowledgePushes = false;
       const threadId = "t-batch-flush";
       const input = createRunInput({ threadId, runId: "r-batch-flush" });
-      const agent = new MockAgent(
-        [
-          {
-            type: EventType.TEXT_MESSAGE_START,
-            messageId: "msg-1",
-            role: "assistant",
-          } as TextMessageStartEvent,
-          ...Array.from(
-            { length: 30 },
-            (_, index) =>
-              ({
-                type: EventType.TEXT_MESSAGE_CONTENT,
-                messageId: "msg-1",
-                delta: String(index),
-              }) as TextMessageContentEvent,
-          ),
-          {
-            type: EventType.TEXT_MESSAGE_END,
-            messageId: "msg-1",
-          } as TextMessageEndEvent,
-          {
-            type: EventType.RUN_FINISHED,
-            threadId,
-            runId: input.runId,
-          } as RunFinishedEvent,
-        ],
-      );
+      const agent = new MockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+        ...Array.from(
+          { length: 30 },
+          (_, index) =>
+            ({
+              type: EventType.TEXT_MESSAGE_CONTENT,
+              messageId: "msg-1",
+              delta: String(index),
+            }) as TextMessageContentEvent,
+        ),
+        {
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: "msg-1",
+        } as TextMessageEndEvent,
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
 
       const eventsPromise = collectEvents(
         runner.run({ threadId, agent, input }),
@@ -645,11 +640,201 @@ describe("IntelligenceAgentRunner", () => {
       expect(await runner.isRunning({ threadId })).toBe(false);
     });
 
+    it("errors once and cleans up when the gateway permanently rejects queued events", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-permanent-rejection";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-permanent-rejection",
+      });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+      let errors = 0;
+      let completions = 0;
+
+      runner.run({ threadId, agent, input }).subscribe({
+        error: () => errors++,
+        complete: () => completions++,
+      });
+      const ch = mockChannels[0];
+      const socket = mockSockets[0] as MockSocketImpl;
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      socket.triggerClose({ code: 1006 });
+      ch.pushLog[0].push.trigger("error", {
+        reason: "invalid_event_batch",
+        retryable: false,
+      });
+      await Promise.resolve();
+
+      expect(errors).toBe(1);
+      expect(completions).toBe(0);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+      expect(ch.left).toBe(true);
+      expect(socket.disconnected).toBe(true);
+      expect(ch.pushLog).toHaveLength(1);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(
+        ch.pushLog[0].payload.events.some(
+          (event: BaseEvent) => event.type === EventType.RUN_ERROR,
+        ),
+      ).toBe(false);
+    });
+
+    it("keeps retrying the original payload until its original durability deadline", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-durability-deadline";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-durability-deadline",
+      });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+      let receivedError: Error | undefined;
+
+      runner.run({ threadId, agent, input }).subscribe({
+        error: (error) => (receivedError = error),
+      });
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      const originalEvents = ch.pushLog[0].payload.events;
+      ch.pushLog[0].push.trigger("error", { retryable: true });
+      await vi.advanceTimersByTimeAsync(100);
+      ch.pushLog[1].push.trigger("error", {});
+      await vi.advanceTimersByTimeAsync(200);
+      ch.pushLog[2].push.trigger("timeout");
+      await vi.advanceTimersByTimeAsync(400);
+
+      for (const replay of ch.pushLog.slice(1)) {
+        expect(replay.payload.events).toHaveLength(originalEvents.length);
+        replay.payload.events.forEach((event: BaseEvent, index: number) => {
+          expect(event).toBe(originalEvents[index]);
+        });
+        expect(
+          replay.payload.events.map(
+            (event: any) => event.metadata.cpki_event_id,
+          ),
+        ).toEqual(
+          originalEvents.map((event: any) => event.metadata.cpki_event_id),
+        );
+      }
+      await vi.advanceTimersByTimeAsync(60_000 - 5 - 100 - 200 - 400);
+
+      expect(receivedError).toBeInstanceOf(Error);
+      expect(receivedError?.message).toMatch(/durably deliver/i);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("does not reset a queued event's durability deadline after rejoin", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-deadline-rejoin";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-deadline-rejoin",
+      });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+      let errors = 0;
+
+      runner
+        .run({ threadId, agent, input })
+        .subscribe({ error: () => errors++ });
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+      const originalEvents = ch.pushLog[0].payload.events;
+
+      ch.triggerError("channel_closed");
+      ch.beginRejoin();
+      await vi.advanceTimersByTimeAsync(59_000 - 5);
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+
+      expect(ch.pushLog).toHaveLength(2);
+      ch.pushLog[1].payload.events.forEach(
+        (event: BaseEvent, index: number) => {
+          expect(event).toBe(originalEvents[index]);
+        },
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(errors).toBe(1);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
+    it("ignores late callbacks, agent emissions, and joins after terminal event cleanup", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-terminal-stale-callbacks";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-terminal-stale-callbacks",
+      });
+      const agent = new PausingMockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_START,
+          messageId: "msg-1",
+          role: "assistant",
+        } as TextMessageStartEvent,
+      ]);
+      let errors = 0;
+
+      runner
+        .run({ threadId, agent, input })
+        .subscribe({ error: () => errors++ });
+      const ch = mockChannels[0];
+      const socket = mockSockets[0] as MockSocketImpl;
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+      const stalePush = ch.pushLog[0].push;
+      stalePush.trigger("error", { retryable: false });
+      socket.triggerOpen();
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      agent.emit({
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "msg-1",
+        delta: "late",
+      } as TextMessageContentEvent);
+      agent.finish();
+      stalePush.trigger("ok");
+      stalePush.trigger("error", { retryable: false });
+      await vi.runAllTimersAsync();
+
+      expect(errors).toBe(1);
+      expect(ch.pushLog).toHaveLength(1);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
     it("retries the original negotiated batch before events queued during its failed push", async () => {
       vi.useFakeTimers();
       autoAcknowledgePushes = false;
       const threadId = "t-batch-retry-members";
-      const input = createRunInput({ threadId, runId: "r-batch-retry-members" });
+      const input = createRunInput({
+        threadId,
+        runId: "r-batch-retry-members",
+      });
       const agent = new PausingMockAgent([
         {
           type: EventType.TEXT_MESSAGE_START,
@@ -1084,8 +1269,8 @@ describe("IntelligenceAgentRunner", () => {
       expect(ch.pushLog).toHaveLength(1);
       expect(ch.pushLog[0].event).toBe("events");
       const originalEvents = ch.pushLog[0].payload.events;
-      const originalMetadata = originalEvents.map((event: any) =>
-        event.metadata,
+      const originalMetadata = originalEvents.map(
+        (event: any) => event.metadata,
       );
 
       ch.pushLog[0].push.trigger("error", { reason: "channel_closed" });

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -728,6 +728,52 @@ describe("IntelligenceAgentRunner", () => {
       expect(await runner.isRunning({ threadId })).toBe(false);
     });
 
+    it("ignores a late stop control event from a failed run after replacement startup", async () => {
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-failure-stale-stop";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-failure-stale-stop",
+      });
+      const replacementInput = createRunInput({
+        threadId,
+        runId: "r-event-failure-stale-stop-next",
+      });
+      const replacementAgent = new BlockingMockAgent();
+      let replacementSubscription:
+        | ReturnType<ReturnType<typeof runner.run>["subscribe"]>
+        | undefined;
+
+      runner.run({ threadId, agent: new MockAgent(), input }).subscribe({
+        error: () => {
+          replacementSubscription = runner
+            .run({
+              threadId,
+              agent: replacementAgent,
+              input: replacementInput,
+            })
+            .subscribe();
+          mockChannels[1].triggerJoin("ok");
+        },
+      });
+      const failedChannel = mockChannels[0];
+      failedChannel.triggerJoin("ok");
+      await waitForCondition(() => failedChannel.pushLog.length === 1);
+      failedChannel.pushLog[0].push.trigger("error", { retryable: false });
+
+      expect(mockChannels[1].state).toBe("joined");
+      expect(await runner.isRunning({ threadId })).toBe(true);
+      failedChannel.serverPush("ag-ui", {
+        type: EventType.CUSTOM,
+        name: "stop",
+      });
+
+      expect(replacementAgent.aborted).toBe(false);
+      expect(await runner.isRunning({ threadId })).toBe(true);
+
+      replacementSubscription?.unsubscribe();
+    });
+
     it("rejects a second subscription to the same run observable without replacing its owner", async () => {
       const threadId = "t-duplicate-run-subscription";
       const input = createRunInput({

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -1162,7 +1162,7 @@ describe("IntelligenceAgentRunner", () => {
       sub.unsubscribe();
     });
 
-    it("aborts after repeated unrelated transport failures", () => {
+    it("keeps an accepted run alive through prolonged abnormal reconnect failures", () => {
       const threadId = "t-exhaust";
       const input = createRunInput({ threadId, runId: "r-exhaust" });
       const agent = new BlockingMockAgent();
@@ -1171,8 +1171,30 @@ describe("IntelligenceAgentRunner", () => {
       const socket = mockSockets[0];
       mockChannels[0].triggerJoin("ok");
 
-      for (let i = 0; i < 5; i++) {
+      socket.triggerClose({ code: 1006 });
+      for (let i = 0; i < 20; i++) {
         socket.triggerError(new Error("connection lost"));
+        socket.triggerClose({ code: 1006 });
+      }
+
+      expect(agent.aborted).toBe(false);
+      socket.triggerOpen();
+      sub.unsubscribe();
+    });
+
+    it("retains the pre-join error budget before a run has been accepted", () => {
+      const threadId = "t-prejoin-exhaust";
+      const input = createRunInput({
+        threadId,
+        runId: "r-prejoin-exhaust",
+      });
+      const agent = new BlockingMockAgent();
+
+      const sub = runner.run({ threadId, agent, input }).subscribe();
+      const socket = mockSockets[0];
+
+      for (let i = 0; i < 5; i++) {
+        socket.triggerError(new Error("connection refused"));
       }
 
       expect(agent.aborted).toBe(true);

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -650,6 +650,52 @@ describe("IntelligenceAgentRunner", () => {
       expect(await runner.isRunning({ threadId })).toBe(false);
     });
 
+    it("snapshots nested event data before a durable retry", async () => {
+      vi.useFakeTimers();
+      autoAcknowledgePushes = false;
+      const threadId = "t-batch-retry-snapshot";
+      const input = createRunInput({
+        threadId,
+        runId: "r-batch-retry-snapshot",
+      });
+      const snapshot = { nested: { value: "original" } };
+      const agent = new PausingMockAgent([
+        {
+          type: EventType.STATE_SNAPSHOT,
+          snapshot,
+        } as BaseEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+
+      snapshot.nested.value = "mutated";
+      ch.pushLog[0].push.trigger("error", { reason: "redis_unavailable" });
+      await vi.advanceTimersByTimeAsync(105);
+
+      const retriedSnapshot = ch.pushLog[1].payload.events.find(
+        (event: BaseEvent) => event.type === EventType.STATE_SNAPSHOT,
+      );
+      expect(retriedSnapshot.snapshot).toEqual({
+        nested: { value: "original" },
+      });
+
+      ch.pushLog[1].push.trigger("ok");
+      agent.emit({
+        type: EventType.RUN_FINISHED,
+        threadId,
+        runId: input.runId,
+      } as RunFinishedEvent);
+      agent.finish();
+      await vi.advanceTimersByTimeAsync(5);
+      ch.pushLog[2].push.trigger("ok");
+      await eventsPromise;
+    });
+
     it("errors once and cleans up when the gateway permanently rejects queued events", async () => {
       vi.useFakeTimers();
       autoAcknowledgePushes = false;

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -667,9 +667,13 @@ describe("IntelligenceAgentRunner", () => {
       ]);
       let errors = 0;
       let completions = 0;
+      let receivedError: Error | undefined;
 
       runner.run({ threadId, agent, input }).subscribe({
-        error: () => errors++,
+        error: (error) => {
+          errors++;
+          receivedError = error;
+        },
         complete: () => completions++,
       });
       const ch = mockChannels[0];
@@ -685,6 +689,9 @@ describe("IntelligenceAgentRunner", () => {
       await Promise.resolve();
 
       expect(errors).toBe(1);
+      expect(receivedError?.message).toBe(
+        "Runner event durability failed: invalid_event_batch",
+      );
       expect(completions).toBe(0);
       expect(await runner.isRunning({ threadId })).toBe(false);
       expect(ch.left).toBe(true);

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -13,13 +13,26 @@ import type {
 import { AbstractAgent, EventType } from "@ag-ui/client";
 import { EMPTY, firstValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
+import type { MockPush } from "../../../../../../core/src/__tests__/test-utils";
 import {
   MockChannel,
   MockSocket,
+  waitForCondition,
 } from "../../../../../../core/src/__tests__/test-utils";
 
-let mockChannels: MockChannel[] = [];
+let autoAcknowledgePushes = true;
+let mockChannels: MockRunnerChannel[] = [];
 let mockSockets: MockSocket[] = [];
+
+class MockRunnerChannel extends MockChannel {
+  push(event: string, payload: any): MockPush {
+    const push = super.push(event, payload);
+    if (autoAcknowledgePushes) {
+      queueMicrotask(() => push.trigger("ok"));
+    }
+    return push;
+  }
+}
 
 class MockSocketImpl extends MockSocket {
   constructor(url: string, opts?: any) {
@@ -27,8 +40,9 @@ class MockSocketImpl extends MockSocket {
     mockSockets.push(this);
   }
 
-  channel(topic: string, params: Record<string, any> = {}): MockChannel {
-    const ch = super.channel(topic, params);
+  channel(topic: string, params: Record<string, any> = {}): MockRunnerChannel {
+    const ch = new MockRunnerChannel(topic, params);
+    this.channels.push(ch);
     mockChannels.push(ch);
     return ch;
   }
@@ -43,6 +57,7 @@ vi.mock("ws", () => ({ default: class MockWebSocket {} }));
 
 class MockAgent extends AbstractAgent {
   aborted = false;
+  runCount = 0;
   private events: BaseEvent[];
 
   constructor(events: BaseEvent[] = []) {
@@ -54,6 +69,7 @@ class MockAgent extends AbstractAgent {
     _input: RunAgentInput,
     subscriber?: { onEvent?: (arg: { event: BaseEvent }) => void },
   ): Promise<RunAgentResult> {
+    this.runCount += 1;
     for (const event of this.events) {
       subscriber?.onEvent?.({ event });
     }
@@ -170,6 +186,7 @@ describe("IntelligenceAgentRunner", () => {
   beforeEach(() => {
     mockChannels = [];
     mockSockets = [];
+    autoAcknowledgePushes = true;
     runner = new IntelligenceAgentRunner({ url: "ws://localhost:4000/runner" });
   });
 
@@ -595,6 +612,142 @@ describe("IntelligenceAgentRunner", () => {
       ).toEqual([1, 2, 3, 4, 5]);
     });
 
+    it("keeps a completed run alive until every durable event is acknowledged", async () => {
+      autoAcknowledgePushes = false;
+      const threadId = "t-ack-boundary";
+      const input = createRunInput({ threadId, runId: "r-ack-boundary" });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok");
+      await waitForCondition(() => ch.pushLog.length === 1);
+
+      expect(await runner.isRunning({ threadId })).toBe(true);
+      expect(ch.left).toBe(false);
+      expect(mockSockets[0].disconnected).toBe(false);
+
+      ch.pushLog[0].push.trigger("ok");
+      await waitForCondition(() => ch.pushLog.length === 2);
+      expect(await runner.isRunning({ threadId })).toBe(true);
+
+      ch.pushLog[1].push.trigger("ok");
+      await eventsPromise;
+      expect(await runner.isRunning({ threadId })).toBe(false);
+      expect(ch.left).toBe(true);
+      expect(mockSockets[0].disconnected).toBe(true);
+    });
+
+    it("replays only unacknowledged payloads in sequence after channel rejoin", async () => {
+      autoAcknowledgePushes = false;
+      const threadId = "t-replay-unacked";
+      const input = createRunInput({ threadId, runId: "r-replay-unacked" });
+      const agent = new MockAgent([
+        {
+          type: EventType.TEXT_MESSAGE_CONTENT,
+          messageId: "msg-1",
+          delta: "hello",
+        } as TextMessageContentEvent,
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok");
+      await waitForCondition(() => ch.pushLog.length === 1);
+
+      ch.pushLog[0].push.trigger("ok");
+      await waitForCondition(() => ch.pushLog.length === 2);
+      const unacknowledged = ch.pushLog[1].payload;
+      ch.triggerJoin("ok");
+      await waitForCondition(() => ch.pushLog.length === 3);
+
+      const replayed = ch.pushLog[2].payload;
+      expect(agent.runCount).toBe(1);
+      expect(replayed.metadata.cpki_event_id).toBe(
+        unacknowledged.metadata.cpki_event_id,
+      );
+      expect(replayed.metadata.cpki_event_seq).toBe(
+        unacknowledged.metadata.cpki_event_seq,
+      );
+
+      ch.pushLog[2].push.trigger("ok");
+      await waitForCondition(() => ch.pushLog.length === 4);
+      ch.pushLog[3].push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("retries an unacknowledged push after Redis recovers without a channel rejoin", async () => {
+      autoAcknowledgePushes = false;
+      const threadId = "t-retry-push";
+      const input = createRunInput({ threadId, runId: "r-retry-push" });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok");
+      await waitForCondition(() => ch.pushLog.length === 1);
+
+      const original = ch.pushLog[0].payload;
+      ch.pushLog[0].push.trigger("error", { reason: "redis_unavailable" });
+      await waitForCondition(() => ch.pushLog.length === 2);
+
+      expect(ch.joinCount).toBe(1);
+      expect(ch.pushLog[1].payload).toEqual(original);
+      ch.pushLog[1].push.trigger("ok");
+      await waitForCondition(() => ch.pushLog.length === 3);
+      ch.pushLog[2].push.trigger("ok");
+      await eventsPromise;
+    });
+
+    it("keeps retryable gateway_draining joins pending instead of emitting RUN_ERROR", async () => {
+      const threadId = "t-draining-join";
+      const input = createRunInput({ threadId, runId: "r-draining-join" });
+      const agent = new MockAgent([
+        {
+          type: EventType.RUN_FINISHED,
+          threadId,
+          runId: input.runId,
+        } as RunFinishedEvent,
+      ]);
+
+      const eventsPromise = collectEvents(
+        runner.run({ threadId, agent, input }),
+      );
+      const ch = mockChannels[0];
+      ch.triggerJoin("error", {
+        reason: "gateway_draining",
+        retryable: true,
+      });
+
+      expect(await runner.isRunning({ threadId })).toBe(true);
+      expect(ch.left).toBe(false);
+      ch.triggerJoin("ok");
+      expect(await eventsPromise).toEqual([]);
+    });
+
     it("throws when the thread is already running", () => {
       const threadId = "t-dup";
       const input = createRunInput({ threadId, runId: "r-dup" });
@@ -993,7 +1146,7 @@ describe("IntelligenceAgentRunner", () => {
     });
   });
 
-  describe("socket error exhaustion", () => {
+  describe("socket recovery", () => {
     it("does not abort the agent on a single socket error", () => {
       const threadId = "t-single-err";
       const input = createRunInput({ threadId, runId: "r-single-err" });
@@ -1009,27 +1162,41 @@ describe("IntelligenceAgentRunner", () => {
       sub.unsubscribe();
     });
 
-    it("aborts the agent after 5 consecutive socket errors", async () => {
+    it("aborts after repeated unrelated transport failures", () => {
       const threadId = "t-exhaust";
       const input = createRunInput({ threadId, runId: "r-exhaust" });
       const agent = new BlockingMockAgent();
 
-      const eventsPromise = collectEvents(
-        runner.run({ threadId, agent, input }),
-      );
+      const sub = runner.run({ threadId, agent, input }).subscribe();
       const socket = mockSockets[0];
       mockChannels[0].triggerJoin("ok");
 
-      // Fire 5 consecutive errors — should trigger abortRun()
       for (let i = 0; i < 5; i++) {
         socket.triggerError(new Error("connection lost"));
       }
 
-      // The abort causes runAgent() to reject, which cascades through
-      // catchError → finalize → removeThread → Observable completes.
-      await eventsPromise;
-
       expect(agent.aborted).toBe(true);
+      sub.unsubscribe();
+    });
+
+    it("does not spend the ordinary error budget during a planned 1012 restart", () => {
+      const threadId = "t-planned-restart";
+      const input = createRunInput({ threadId, runId: "r-planned-restart" });
+      const agent = new BlockingMockAgent();
+
+      const sub = runner.run({ threadId, agent, input }).subscribe();
+      const socket = mockSockets[0];
+      mockChannels[0].triggerJoin("ok");
+
+      socket.triggerClose({ code: 1012 });
+      for (let i = 0; i < 10; i++) {
+        socket.triggerError(new Error("replacement not ready"));
+        socket.triggerClose({ code: 1006 });
+      }
+
+      expect(agent.aborted).toBe(false);
+      socket.triggerOpen();
+      sub.unsubscribe();
     });
 
     it("resets the error counter on successful reconnection", () => {
@@ -1057,29 +1224,6 @@ describe("IntelligenceAgentRunner", () => {
       expect(agent.aborted).toBe(false);
 
       sub.unsubscribe();
-    });
-
-    it("fully cleans up after socket error exhaustion", async () => {
-      const threadId = "t-exhaust-cleanup";
-      const input = createRunInput({ threadId, runId: "r-exhaust-cleanup" });
-      const agent = new BlockingMockAgent();
-
-      const eventsPromise = collectEvents(
-        runner.run({ threadId, agent, input }),
-      );
-      const socket = mockSockets[0];
-      const ch = mockChannels[0];
-      ch.triggerJoin("ok");
-
-      for (let i = 0; i < 5; i++) {
-        socket.triggerError();
-      }
-
-      await eventsPromise;
-
-      expect(ch.left).toBe(true);
-      expect(socket.disconnected).toBe(true);
-      expect(await runner.isRunning({ threadId })).toBe(false);
     });
   });
 });

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -688,6 +688,76 @@ describe("IntelligenceAgentRunner", () => {
       ).toBe(false);
     });
 
+    it("does not let failed-run teardown remove a synchronous replacement run", async () => {
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-failure-replacement";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-failure-replacement",
+      });
+      const replacementInput = createRunInput({
+        threadId,
+        runId: "r-event-failure-replacement-next",
+      });
+      let replacementSubscription:
+        | ReturnType<ReturnType<typeof runner.run>["subscribe"]>
+        | undefined;
+
+      runner.run({ threadId, agent: new MockAgent(), input }).subscribe({
+        error: () => {
+          replacementSubscription = runner
+            .run({
+              threadId,
+              agent: new BlockingMockAgent(),
+              input: replacementInput,
+            })
+            .subscribe();
+        },
+      });
+      const failedChannel = mockChannels[0];
+      failedChannel.triggerJoin("ok");
+      await waitForCondition(() => failedChannel.pushLog.length === 1);
+      failedChannel.pushLog[0].push.trigger("error", { retryable: false });
+
+      expect(replacementSubscription).toBeDefined();
+      expect(await runner.isRunning({ threadId })).toBe(true);
+      expect(mockChannels[1].left).toBe(false);
+      expect(mockSockets[1].disconnected).toBe(false);
+
+      replacementSubscription?.unsubscribe();
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
+    it("rejects a second subscription to the same run observable without replacing its owner", async () => {
+      const threadId = "t-duplicate-run-subscription";
+      const input = createRunInput({
+        threadId,
+        runId: "r-duplicate-run-subscription",
+      });
+      const events = runner.run({
+        threadId,
+        agent: new BlockingMockAgent(),
+        input,
+      });
+      let secondError: Error | undefined;
+
+      const firstSubscription = events.subscribe();
+      const firstSocket = mockSockets[0];
+      const secondSubscription = events.subscribe({
+        error: (error) => (secondError = error),
+      });
+
+      expect(secondError?.message).toBe("Thread already running");
+      expect(secondSubscription.closed).toBe(true);
+      expect(mockSockets).toHaveLength(1);
+      expect(await runner.isRunning({ threadId })).toBe(true);
+      expect(firstSocket.disconnected).toBe(false);
+
+      firstSubscription.unsubscribe();
+      expect(await runner.isRunning({ threadId })).toBe(false);
+      expect(firstSocket.disconnected).toBe(true);
+    });
+
     it("keeps retrying the original payload until its original durability deadline", async () => {
       vi.useFakeTimers();
       autoAcknowledgePushes = false;
@@ -780,6 +850,86 @@ describe("IntelligenceAgentRunner", () => {
       await vi.advanceTimersByTimeAsync(1_000);
 
       expect(errors).toBe(1);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
+    it("fails instead of replaying on rejoin at the exact durability deadline", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-deadline-exact-rejoin";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-deadline-exact-rejoin",
+      });
+      let errors = 0;
+
+      runner
+        .run({
+          threadId,
+          agent: new MockAgent([
+            {
+              type: EventType.RUN_FINISHED,
+              threadId,
+              runId: input.runId,
+            } as RunFinishedEvent,
+          ]),
+          input,
+        })
+        .subscribe({ error: () => errors++ });
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+      expect(ch.pushLog).toHaveLength(1);
+
+      ch.triggerError("channel_closed");
+      ch.beginRejoin();
+      vi.setSystemTime(60_000);
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+
+      expect(errors).toBe(1);
+      expect(ch.pushLog).toHaveLength(1);
+      expect(await runner.isRunning({ threadId })).toBe(false);
+    });
+
+    it("fails instead of accepting an acknowledgement at the exact durability deadline", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      autoAcknowledgePushes = false;
+      const threadId = "t-event-deadline-exact-ack";
+      const input = createRunInput({
+        threadId,
+        runId: "r-event-deadline-exact-ack",
+      });
+      let errors = 0;
+      let completions = 0;
+
+      runner
+        .run({
+          threadId,
+          agent: new MockAgent([
+            {
+              type: EventType.RUN_FINISHED,
+              threadId,
+              runId: input.runId,
+            } as RunFinishedEvent,
+          ]),
+          input,
+        })
+        .subscribe({
+          error: () => errors++,
+          complete: () => completions++,
+        });
+      const ch = mockChannels[0];
+      ch.triggerJoin("ok", { capabilities: ["runner_event_batch_v1"] });
+      await vi.advanceTimersByTimeAsync(5);
+      expect(ch.pushLog).toHaveLength(1);
+
+      vi.setSystemTime(60_000);
+      ch.pushLog[0].push.trigger("ok");
+
+      expect(errors).toBe(1);
+      expect(completions).toBe(0);
       expect(await runner.isRunning({ threadId })).toBe(false);
     });
 

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -5,8 +5,7 @@ import type {
 } from "./agent-runner";
 import { AgentRunner } from "./agent-runner";
 import type { AgentRunnerStopRequest } from "./agent-runner";
-import { EMPTY, Observable, from } from "rxjs";
-import { catchError, finalize } from "rxjs/operators";
+import { Observable } from "rxjs";
 import type { AbstractAgent, BaseEvent, RunStartedEvent } from "@ag-ui/client";
 import { EventType } from "@ag-ui/client";
 import {
@@ -44,7 +43,20 @@ interface ThreadState {
   currentEvents: BaseEvent[];
   nextEventSeq: number;
   hasRunStarted: boolean;
+  hasJoined: boolean;
+  producerFinished: boolean;
+  pendingEvents: Map<string, Record<string, unknown>>;
+  activeEventPush: { eventId: string; attempt: number } | null;
+  nextEventPushAttempt: number;
+  eventRetryTimer: ReturnType<typeof setTimeout> | null;
+  socketReconnectWatchdog: ReturnType<typeof setTimeout> | null;
+  eventRetryAttempt: number;
+  completeRun: () => void;
 }
+
+const MAX_CONSECUTIVE_SOCKET_ERRORS = 5;
+const EVENT_RETRY_BASE_MS = 100;
+const EVENT_RETRY_MAX_MS = 2_000;
 
 export class IntelligenceAgentRunner extends AgentRunner {
   private options: IntelligenceAgentRunnerOptions;
@@ -207,39 +219,54 @@ export class IntelligenceAgentRunner extends AgentRunner {
         currentEvents: [],
         nextEventSeq: 1,
         hasRunStarted: false,
+        hasJoined: false,
+        producerFinished: false,
+        pendingEvents: new Map(),
+        activeEventPush: null,
+        nextEventPushAttempt: 0,
+        eventRetryTimer: null,
+        socketReconnectWatchdog: null,
+        eventRetryAttempt: 0,
+        completeRun: () => observer.complete(),
       };
       this.threads.set(threadId, state);
 
-      // Track consecutive socket errors for this run. Phoenix retries
-      // automatically via reconnectAfterMs, but if the connection fails
-      // repeatedly we abort the agent — otherwise runAgent() completes
-      // normally, finalization events buffer silently on the dead
-      // channel, and the client never receives them.
-      //
-      // Aborting the agent is the single trigger that cascades through
-      // the existing error pipeline: runAgent() rejects → catchError
-      // pushes RUN_ERROR → finalize calls finalizeRunEvents +
-      // removeThread → channel.leave() + socket.disconnect().
-      const MAX_CONSECUTIVE_ERRORS = 5;
-      let consecutiveErrors = 0;
+      let consecutiveSocketErrors = 0;
+      let plannedRestart = false;
 
-      socket.onError(() => {
-        consecutiveErrors++;
-        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS && state.agent) {
-          try {
-            state.agent.abortRun();
-          } catch {
-            // Ignore abort errors.
-          }
+      socket.onClose((event) => {
+        plannedRestart = plannedRestart || event?.code === 1012;
+        if (event?.code !== 1000 && state.socketReconnectWatchdog === null) {
+          state.socketReconnectWatchdog = setTimeout(() => {
+            state.socketReconnectWatchdog = null;
+            if (!state.isRunning || socket.isConnected()) {
+              return;
+            }
+            socket.disconnect(() => {
+              if (state.isRunning && !socket.isConnected()) {
+                socket.connect();
+              }
+            });
+          }, 1_000);
         }
-        // Otherwise: Phoenix retries automatically using the exponential
-        // backoff schedule configured in createSocket().
       });
-
       socket.onOpen(() => {
-        // A successful (re)connection resets the counter so transient
-        // network blips don't accumulate across recoveries.
-        consecutiveErrors = 0;
+        if (state.socketReconnectWatchdog !== null) {
+          clearTimeout(state.socketReconnectWatchdog);
+          state.socketReconnectWatchdog = null;
+        }
+        consecutiveSocketErrors = 0;
+        plannedRestart = false;
+      });
+      socket.onError(() => {
+        if (plannedRestart) {
+          return;
+        }
+
+        consecutiveSocketErrors += 1;
+        if (consecutiveSocketErrors >= MAX_CONSECUTIVE_SOCKET_ERRORS) {
+          state.agent?.abortRun();
+        }
       });
 
       // Listen for custom "stop" events pushed by the client over the
@@ -259,14 +286,23 @@ export class IntelligenceAgentRunner extends AgentRunner {
       channel
         .join()
         .receive("ok", () => {
+          if (state.hasJoined) {
+            this.resetPendingEventRetry(state);
+            this.replayPendingEvents(state);
+            return;
+          }
+
+          state.hasJoined = true;
           startupBoundary?.resolveStartup();
-          this.executeAgentRun(request, state, threadId, (event) => {
+          void this.executeAgentRun(request, state, threadId, (event) => {
             observer.next(event);
-          }).subscribe({
-            complete: () => observer.complete(),
           });
         })
         .receive("error", (resp) => {
+          if (state.hasJoined || this.isRetryableJoinError(resp)) {
+            return;
+          }
+
           const error = new Error(
             `Failed to join channel: ${JSON.stringify(resp)}`,
           );
@@ -282,6 +318,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
           observer.complete();
         })
         .receive("timeout", () => {
+          if (state.hasJoined) {
+            return;
+          }
+
           const error = new Error("Timed out joining channel");
           const errorEvent = {
             type: EventType.RUN_ERROR,
@@ -373,15 +413,13 @@ export class IntelligenceAgentRunner extends AgentRunner {
     return Promise.resolve(true);
   }
 
-  // The emitted values are ignored by the caller (only `complete` matters);
-  // `runAgent()` resolves with a RunAgentResult that flows through `from()`.
-  private executeAgentRun(
+  private async executeAgentRun(
     request: AgentRunnerRunRequest,
     state: ThreadState,
     threadId: string,
     onRunError: (event: BaseEvent) => void,
-  ): Observable<unknown> {
-    const { currentEvents, channel } = state;
+  ): Promise<void> {
+    const { currentEvents } = state;
     const pushCanonicalEvent = (event: BaseEvent): void => {
       const canonicalEvent = this.stampRunnerMetadata(
         this.stampCanonicalRunOwnership(event, request),
@@ -393,9 +431,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
         state.hasRunStarted = true;
       }
 
-      channel.push(
-        "event",
+      this.queueRunnerEvent(
         this.createRunnerEventPayload(canonicalEvent, request, state),
+        state,
       );
     };
 
@@ -434,8 +472,8 @@ export class IntelligenceAgentRunner extends AgentRunner {
       }
     };
 
-    return from(
-      request.agent.runAgent(request.input, {
+    try {
+      await request.agent.runAgent(request.input, {
         onEvent: ({ event }: { event: BaseEvent }) => {
           if (event.type === EventType.RUN_STARTED) {
             pushCanonicalEvent(buildRunStartedEvent(event as RunStartedEvent));
@@ -445,39 +483,167 @@ export class IntelligenceAgentRunner extends AgentRunner {
           ensureRunStarted();
           pushCanonicalEvent(event);
         },
-      }),
-    ).pipe(
-      catchError((error) => {
-        ensureRunStarted();
-        const existingError = currentEvents.find(
-          (event) => event.type === EventType.RUN_ERROR,
-        );
-        if (existingError) {
-          onRunError(existingError);
-          return EMPTY;
-        }
+      });
+    } catch (error) {
+      ensureRunStarted();
+      const existingError = currentEvents.find(
+        (event) => event.type === EventType.RUN_ERROR,
+      );
+      if (existingError) {
+        onRunError(existingError);
+      } else {
         const errorEvent = {
           type: EventType.RUN_ERROR,
           message: error instanceof Error ? error.message : String(error),
         } as BaseEvent;
         pushCanonicalEvent(errorEvent);
         onRunError(errorEvent);
-        return EMPTY;
-      }),
-      finalize(() => {
-        ensureRunStarted();
-        const appended = finalizeRunEvents(currentEvents, {
-          stopRequested: state.stopRequested,
-        });
-        for (const event of appended) {
-          channel.push(
-            "event",
-            this.createRunnerEventPayload(event, request, state),
-          );
+      }
+    } finally {
+      ensureRunStarted();
+      const appended = finalizeRunEvents(currentEvents, {
+        stopRequested: state.stopRequested,
+      });
+      for (const event of appended) {
+        const canonicalEvent = this.stampRunnerMetadata(
+          this.stampCanonicalRunOwnership(event, request),
+          state,
+        );
+        this.queueRunnerEvent(
+          this.createRunnerEventPayload(canonicalEvent, request, state),
+          state,
+        );
+      }
+      state.producerFinished = true;
+      this.completeWhenDurable(threadId, state);
+    }
+  }
+
+  /** Queue one immutable event payload until Redis-backed gateway acknowledgement. */
+  private queueRunnerEvent(
+    payload: Record<string, unknown>,
+    state: ThreadState,
+  ): void {
+    const eventId = this.runnerEventId(payload);
+    if (!state.pendingEvents.has(eventId)) {
+      state.pendingEvents.set(eventId, payload);
+    }
+    this.replayPendingEvents(state);
+  }
+
+  private pushPendingEvent(
+    eventId: string,
+    payload: Record<string, unknown>,
+    state: ThreadState,
+  ): void {
+    const attempt = ++state.nextEventPushAttempt;
+    state.activeEventPush = { eventId, attempt };
+
+    state.channel
+      .push("event", payload)
+      .receive("ok", () => {
+        state.pendingEvents.delete(eventId);
+        if (state.activeEventPush?.eventId === eventId) {
+          state.activeEventPush = null;
         }
-        this.removeThread(threadId);
-      }),
+        state.eventRetryAttempt = 0;
+        if (state.pendingEvents.size === 0) {
+          this.clearPendingEventRetry(state);
+        }
+        this.completeWhenDurable((payload.thread_id as string) ?? "", state);
+        this.replayPendingEvents(state);
+      })
+      .receive("error", () => this.handlePendingEventFailure(state, attempt))
+      .receive("timeout", () => this.handlePendingEventFailure(state, attempt));
+  }
+
+  private handlePendingEventFailure(state: ThreadState, attempt: number): void {
+    if (state.activeEventPush?.attempt !== attempt) {
+      return;
+    }
+
+    state.activeEventPush = null;
+    this.schedulePendingEventRetry(state);
+  }
+
+  private schedulePendingEventRetry(state: ThreadState): void {
+    if (
+      !state.isRunning ||
+      state.pendingEvents.size === 0 ||
+      state.eventRetryTimer !== null
+    ) {
+      return;
+    }
+
+    const delay = Math.min(
+      EVENT_RETRY_BASE_MS * 2 ** state.eventRetryAttempt,
+      EVENT_RETRY_MAX_MS,
     );
+    state.eventRetryAttempt += 1;
+    state.eventRetryTimer = setTimeout(() => {
+      state.eventRetryTimer = null;
+      if (!state.isRunning || state.pendingEvents.size === 0) {
+        return;
+      }
+      this.replayPendingEvents(state);
+    }, delay);
+  }
+
+  private clearPendingEventRetry(state: ThreadState): void {
+    if (state.eventRetryTimer !== null) {
+      clearTimeout(state.eventRetryTimer);
+      state.eventRetryTimer = null;
+    }
+  }
+
+  private resetPendingEventRetry(state: ThreadState): void {
+    this.clearPendingEventRetry(state);
+    state.eventRetryAttempt = 0;
+    state.activeEventPush = null;
+  }
+
+  private replayPendingEvents(state: ThreadState): void {
+    if (state.activeEventPush !== null) {
+      return;
+    }
+
+    const [next] = [...state.pendingEvents.entries()].sort(
+      ([, left], [, right]) =>
+        this.runnerEventSeq(left) - this.runnerEventSeq(right),
+    );
+    if (next) {
+      this.pushPendingEvent(next[0], next[1], state);
+    }
+  }
+
+  private completeWhenDurable(threadId: string, state: ThreadState): void {
+    if (!state.producerFinished || state.pendingEvents.size !== 0) {
+      return;
+    }
+    if (this.threads.get(threadId) !== state) {
+      return;
+    }
+
+    this.removeThread(threadId);
+    state.completeRun();
+  }
+
+  private runnerEventId(payload: Record<string, unknown>): string {
+    const metadata = payload.metadata as Record<string, unknown>;
+    return metadata.cpki_event_id as string;
+  }
+
+  private runnerEventSeq(payload: Record<string, unknown>): number {
+    const metadata = payload.metadata as Record<string, unknown>;
+    return metadata.cpki_event_seq as number;
+  }
+
+  private isRetryableJoinError(response: unknown): boolean {
+    if (typeof response !== "object" || response === null) {
+      return false;
+    }
+    const value = response as { reason?: unknown; retryable?: unknown };
+    return value.retryable === true || value.reason === "gateway_draining";
   }
 
   /**
@@ -495,6 +661,12 @@ export class IntelligenceAgentRunner extends AgentRunner {
 
     // Delete first so concurrent calls see the entry as already removed.
     this.threads.delete(threadId);
+    state.isRunning = false;
+    this.clearPendingEventRetry(state);
+    if (state.socketReconnectWatchdog !== null) {
+      clearTimeout(state.socketReconnectWatchdog);
+      state.socketReconnectWatchdog = null;
+    }
 
     try {
       state.channel.leave();

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -300,12 +300,21 @@ export class IntelligenceAgentRunner extends AgentRunner {
       channel
         .join()
         .receive("ok", (response) => {
-          state.supportsRunnerEventBatch = this.supportsRunnerEventBatch(
-            response,
-          );
+          const supportsRunnerEventBatch =
+            this.supportsRunnerEventBatch(response);
+          const activeEventBatch =
+            state.supportsRunnerEventBatch === supportsRunnerEventBatch
+              ? state.activeEventBatch
+              : null;
+          state.supportsRunnerEventBatch = supportsRunnerEventBatch;
           if (state.hasJoined) {
             this.resetPendingEventRetry(state);
-            this.replayPendingEvents(state);
+            if (activeEventBatch !== null) {
+              state.activeEventBatch = activeEventBatch;
+              this.retryActiveEventBatch(state);
+            } else {
+              this.replayPendingEvents(state);
+            }
             return;
           }
 
@@ -553,7 +562,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
     events: Array<{ payload: Record<string, unknown>; queuedAt: number }>,
     state: ThreadState,
   ): void {
-    if (state.channel.state !== "joined") {
+    if (state.channel.state !== "joined" || !state.socket.isConnected()) {
       return;
     }
 
@@ -635,10 +644,17 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return;
     }
 
+    const oldestQueuedAt = Math.min(
+      ...[...state.pendingEvents.values()].map((event) => event.queuedAt),
+    );
+    const delay = Math.max(
+      0,
+      oldestQueuedAt + RUNNER_EVENT_BATCH_FLUSH_MS - Date.now(),
+    );
     state.eventFlushTimer = setTimeout(() => {
       state.eventFlushTimer = null;
       this.flushPendingEventBatch(state);
-    }, RUNNER_EVENT_BATCH_FLUSH_MS);
+    }, delay);
   }
 
   private clearPendingEventFlush(state: ThreadState): void {

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -44,11 +44,16 @@ interface ThreadState {
   nextEventSeq: number;
   hasRunStarted: boolean;
   hasJoined: boolean;
+  supportsRunnerEventBatch: boolean;
   producerFinished: boolean;
-  pendingEvents: Map<string, Record<string, unknown>>;
-  activeEventPush: { eventId: string; attempt: number } | null;
+  pendingEvents: Map<
+    string,
+    { payload: Record<string, unknown>; queuedAt: number }
+  >;
+  activeEventBatch: { eventIds: string[]; attempt: number } | null;
   nextEventPushAttempt: number;
   eventRetryTimer: ReturnType<typeof setTimeout> | null;
+  eventFlushTimer: ReturnType<typeof setTimeout> | null;
   socketReconnectWatchdog: ReturnType<typeof setTimeout> | null;
   eventRetryAttempt: number;
   completeRun: () => void;
@@ -57,6 +62,9 @@ interface ThreadState {
 const MAX_CONSECUTIVE_SOCKET_ERRORS = 5;
 const EVENT_RETRY_BASE_MS = 100;
 const EVENT_RETRY_MAX_MS = 2_000;
+const RUNNER_EVENT_BATCH_CAPABILITY = "runner_event_batch_v1";
+const MAX_RUNNER_EVENT_BATCH_SIZE = 32;
+const RUNNER_EVENT_BATCH_FLUSH_MS = 5;
 
 export class IntelligenceAgentRunner extends AgentRunner {
   private options: IntelligenceAgentRunnerOptions;
@@ -220,11 +228,13 @@ export class IntelligenceAgentRunner extends AgentRunner {
         nextEventSeq: 1,
         hasRunStarted: false,
         hasJoined: false,
+        supportsRunnerEventBatch: false,
         producerFinished: false,
         pendingEvents: new Map(),
-        activeEventPush: null,
+        activeEventBatch: null,
         nextEventPushAttempt: 0,
         eventRetryTimer: null,
+        eventFlushTimer: null,
         socketReconnectWatchdog: null,
         eventRetryAttempt: 0,
         completeRun: () => observer.complete(),
@@ -289,7 +299,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
 
       channel
         .join()
-        .receive("ok", () => {
+        .receive("ok", (response) => {
+          state.supportsRunnerEventBatch = this.supportsRunnerEventBatch(
+            response,
+          );
           if (state.hasJoined) {
             this.resetPendingEventRetry(state);
             this.replayPendingEvents(state);
@@ -530,31 +543,40 @@ export class IntelligenceAgentRunner extends AgentRunner {
   ): void {
     const eventId = this.runnerEventId(payload);
     if (!state.pendingEvents.has(eventId)) {
-      state.pendingEvents.set(eventId, payload);
+      state.pendingEvents.set(eventId, { payload, queuedAt: Date.now() });
     }
     this.replayPendingEvents(state);
   }
 
-  private pushPendingEvent(
-    eventId: string,
-    payload: Record<string, unknown>,
+  private pushPendingEventBatch(
+    eventIds: string[],
+    events: Array<{ payload: Record<string, unknown>; queuedAt: number }>,
     state: ThreadState,
   ): void {
     const attempt = ++state.nextEventPushAttempt;
-    state.activeEventPush = { eventId, attempt };
+    state.activeEventBatch = { eventIds, attempt };
+    const payloads = events.map((event) => event.payload);
+    const isBatch = state.supportsRunnerEventBatch;
 
     state.channel
-      .push("event", payload)
+      .push(isBatch ? "events" : "event", isBatch ? { events: payloads } : payloads[0])
       .receive("ok", () => {
-        state.pendingEvents.delete(eventId);
-        if (state.activeEventPush?.eventId === eventId) {
-          state.activeEventPush = null;
+        if (state.activeEventBatch?.attempt !== attempt) {
+          return;
         }
+        for (const eventId of eventIds) {
+          state.pendingEvents.delete(eventId);
+        }
+        state.activeEventBatch = null;
         state.eventRetryAttempt = 0;
         if (state.pendingEvents.size === 0) {
           this.clearPendingEventRetry(state);
+          this.clearPendingEventFlush(state);
         }
-        this.completeWhenDurable((payload.thread_id as string) ?? "", state);
+        this.completeWhenDurable(
+          (payloads[0]?.thread_id as string) ?? "",
+          state,
+        );
         this.replayPendingEvents(state);
       })
       .receive("error", () => this.handlePendingEventFailure(state, attempt))
@@ -562,11 +584,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
   }
 
   private handlePendingEventFailure(state: ThreadState, attempt: number): void {
-    if (state.activeEventPush?.attempt !== attempt) {
+    if (state.activeEventBatch?.attempt !== attempt) {
       return;
     }
 
-    state.activeEventPush = null;
     this.schedulePendingEventRetry(state);
   }
 
@@ -589,7 +610,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
       if (!state.isRunning || state.pendingEvents.size === 0) {
         return;
       }
-      this.replayPendingEvents(state);
+      this.retryActiveEventBatch(state);
     }, delay);
   }
 
@@ -600,24 +621,106 @@ export class IntelligenceAgentRunner extends AgentRunner {
     }
   }
 
-  private resetPendingEventRetry(state: ThreadState): void {
-    this.clearPendingEventRetry(state);
-    state.eventRetryAttempt = 0;
-    state.activeEventPush = null;
-  }
-
-  private replayPendingEvents(state: ThreadState): void {
-    if (state.activeEventPush !== null) {
+  private schedulePendingEventFlush(state: ThreadState): void {
+    if (
+      !state.isRunning ||
+      state.pendingEvents.size === 0 ||
+      state.activeEventBatch !== null ||
+      state.eventFlushTimer !== null
+    ) {
       return;
     }
 
-    const [next] = [...state.pendingEvents.entries()].sort(
-      ([, left], [, right]) =>
-        this.runnerEventSeq(left) - this.runnerEventSeq(right),
-    );
-    if (next) {
-      this.pushPendingEvent(next[0], next[1], state);
+    state.eventFlushTimer = setTimeout(() => {
+      state.eventFlushTimer = null;
+      this.flushPendingEventBatch(state);
+    }, RUNNER_EVENT_BATCH_FLUSH_MS);
+  }
+
+  private clearPendingEventFlush(state: ThreadState): void {
+    if (state.eventFlushTimer !== null) {
+      clearTimeout(state.eventFlushTimer);
+      state.eventFlushTimer = null;
     }
+  }
+
+  private resetPendingEventRetry(state: ThreadState): void {
+    this.clearPendingEventRetry(state);
+    this.clearPendingEventFlush(state);
+    state.eventRetryAttempt = 0;
+    state.activeEventBatch = null;
+  }
+
+  private replayPendingEvents(state: ThreadState): void {
+    if (state.activeEventBatch !== null) {
+      return;
+    }
+
+    const pendingEvents = [...state.pendingEvents.entries()].sort(
+      ([, left], [, right]) =>
+        this.runnerEventSeq(left.payload) - this.runnerEventSeq(right.payload),
+    );
+    if (pendingEvents.length === 0) {
+      return;
+    }
+
+    const batchSize = state.supportsRunnerEventBatch
+      ? MAX_RUNNER_EVENT_BATCH_SIZE
+      : 1;
+    if (!state.supportsRunnerEventBatch || pendingEvents.length >= batchSize) {
+      this.clearPendingEventFlush(state);
+      const batch = pendingEvents.slice(0, batchSize);
+      this.pushPendingEventBatch(
+        batch.map(([eventId]) => eventId),
+        batch.map(([, event]) => event),
+        state,
+      );
+      return;
+    }
+
+    this.schedulePendingEventFlush(state);
+  }
+
+  private flushPendingEventBatch(state: ThreadState): void {
+    if (state.activeEventBatch !== null || state.pendingEvents.size === 0) {
+      return;
+    }
+
+    const batch = [...state.pendingEvents.entries()]
+      .sort(
+        ([, left], [, right]) =>
+          this.runnerEventSeq(left.payload) - this.runnerEventSeq(right.payload),
+      )
+      .slice(0, MAX_RUNNER_EVENT_BATCH_SIZE);
+    this.pushPendingEventBatch(
+      batch.map(([eventId]) => eventId),
+      batch.map(([, event]) => event),
+      state,
+    );
+  }
+
+  private retryActiveEventBatch(state: ThreadState): void {
+    const activeBatch = state.activeEventBatch;
+    if (activeBatch === null) {
+      this.replayPendingEvents(state);
+      return;
+    }
+
+    const events = activeBatch.eventIds
+      .map((eventId) => state.pendingEvents.get(eventId))
+      .filter(
+        (
+          event,
+        ): event is { payload: Record<string, unknown>; queuedAt: number } =>
+          event !== undefined,
+      );
+    if (events.length !== activeBatch.eventIds.length) {
+      state.activeEventBatch = null;
+      this.replayPendingEvents(state);
+      return;
+    }
+
+    this.pushPendingEventBatch(activeBatch.eventIds, events, state);
   }
 
   private completeWhenDurable(threadId: string, state: ThreadState): void {
@@ -640,6 +743,17 @@ export class IntelligenceAgentRunner extends AgentRunner {
   private runnerEventSeq(payload: Record<string, unknown>): number {
     const metadata = payload.metadata as Record<string, unknown>;
     return metadata.cpki_event_seq as number;
+  }
+
+  private supportsRunnerEventBatch(response: unknown): boolean {
+    if (typeof response !== "object" || response === null) {
+      return false;
+    }
+    const capabilities = (response as { capabilities?: unknown }).capabilities;
+    return (
+      Array.isArray(capabilities) &&
+      capabilities.includes(RUNNER_EVENT_BATCH_CAPABILITY)
+    );
   }
 
   private isRetryableJoinError(response: unknown): boolean {
@@ -667,6 +781,8 @@ export class IntelligenceAgentRunner extends AgentRunner {
     this.threads.delete(threadId);
     state.isRunning = false;
     this.clearPendingEventRetry(state);
+    this.clearPendingEventFlush(state);
+    state.activeEventBatch = null;
     if (state.socketReconnectWatchdog !== null) {
       clearTimeout(state.socketReconnectWatchdog);
       state.socketReconnectWatchdog = null;

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -353,7 +353,23 @@ export class IntelligenceAgentRunner extends AgentRunner {
           if (!this.isCurrentThreadState(threadId, state)) {
             return;
           }
-          if (state.hasJoined || this.isRetryableJoinError(resp)) {
+          if (state.hasJoined) {
+            if (this.isPermanentEventFailure(resp)) {
+              const reason =
+                typeof (resp as { reason?: unknown }).reason === "string"
+                  ? `: ${(resp as { reason: string }).reason}`
+                  : "";
+              this.failThread(
+                threadId,
+                state,
+                new Error(
+                  `Gateway permanently rejected channel rejoin${reason}`,
+                ),
+              );
+            }
+            return;
+          }
+          if (this.isRetryableJoinError(resp)) {
             return;
           }
 
@@ -931,6 +947,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return;
     }
     this.removeThread(threadId, state);
+    try {
+      state.agent?.abortRun();
+    } catch {
+      // The terminal durability error must still reach the subscriber.
+    }
     state.failRun(error);
   }
 

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -34,6 +34,7 @@ export interface RunnerStartupBoundary {
 }
 
 interface ThreadState {
+  threadId: string;
   runId: string;
   socket: Socket;
   channel: Channel;
@@ -54,9 +55,11 @@ interface ThreadState {
   nextEventPushAttempt: number;
   eventRetryTimer: ReturnType<typeof setTimeout> | null;
   eventFlushTimer: ReturnType<typeof setTimeout> | null;
+  eventDeadlineTimer: ReturnType<typeof setTimeout> | null;
   socketReconnectWatchdog: ReturnType<typeof setTimeout> | null;
   eventRetryAttempt: number;
   completeRun: () => void;
+  failRun: (error: Error) => void;
 }
 
 const MAX_CONSECUTIVE_SOCKET_ERRORS = 5;
@@ -65,6 +68,7 @@ const EVENT_RETRY_MAX_MS = 2_000;
 const RUNNER_EVENT_BATCH_CAPABILITY = "runner_event_batch_v1";
 const MAX_RUNNER_EVENT_BATCH_SIZE = 32;
 const RUNNER_EVENT_BATCH_FLUSH_MS = 5;
+const EVENT_DURABILITY_DEADLINE_MS = 60_000;
 
 export class IntelligenceAgentRunner extends AgentRunner {
   private options: IntelligenceAgentRunnerOptions;
@@ -218,6 +222,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
       });
 
       const state: ThreadState = {
+        threadId,
         runId: input.runId,
         socket,
         channel,
@@ -235,9 +240,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
         nextEventPushAttempt: 0,
         eventRetryTimer: null,
         eventFlushTimer: null,
+        eventDeadlineTimer: null,
         socketReconnectWatchdog: null,
         eventRetryAttempt: 0,
         completeRun: () => observer.complete(),
+        failRun: (error) => observer.error(error),
       };
       this.threads.set(threadId, state);
 
@@ -245,6 +252,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
       let plannedRestart = false;
 
       socket.onClose((event) => {
+        if (!this.isCurrentThreadState(threadId, state)) {
+          return;
+        }
         plannedRestart = plannedRestart || event?.code === 1012;
         if (event?.code !== 1000 && state.socketReconnectWatchdog === null) {
           state.socketReconnectWatchdog = setTimeout(() => {
@@ -261,6 +271,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
         }
       });
       socket.onOpen(() => {
+        if (!this.isCurrentThreadState(threadId, state)) {
+          return;
+        }
         if (state.socketReconnectWatchdog !== null) {
           clearTimeout(state.socketReconnectWatchdog);
           state.socketReconnectWatchdog = null;
@@ -269,6 +282,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
         plannedRestart = false;
       });
       socket.onError(() => {
+        if (!this.isCurrentThreadState(threadId, state)) {
+          return;
+        }
         // Once the gateway has accepted the run, transport recovery is not a
         // terminal condition. The agent may still be producing the
         // authoritative answer while Phoenix reconnects and replays durable
@@ -300,6 +316,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
       channel
         .join()
         .receive("ok", (response) => {
+          if (!this.isCurrentThreadState(threadId, state)) {
+            return;
+          }
           const supportsRunnerEventBatch =
             this.supportsRunnerEventBatch(response);
           const activeEventBatch =
@@ -325,6 +344,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
           });
         })
         .receive("error", (resp) => {
+          if (!this.isCurrentThreadState(threadId, state)) {
+            return;
+          }
           if (state.hasJoined || this.isRetryableJoinError(resp)) {
             return;
           }
@@ -344,6 +366,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
           observer.complete();
         })
         .receive("timeout", () => {
+          if (!this.isCurrentThreadState(threadId, state)) {
+            return;
+          }
           if (state.hasJoined) {
             return;
           }
@@ -447,6 +472,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
   ): Promise<void> {
     const { currentEvents } = state;
     const pushCanonicalEvent = (event: BaseEvent): void => {
+      if (!this.isCurrentThreadState(threadId, state)) {
+        return;
+      }
       const canonicalEvent = this.stampRunnerMetadata(
         this.stampCanonicalRunOwnership(event, request),
         state,
@@ -511,6 +539,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
         },
       });
     } catch (error) {
+      if (!this.isCurrentThreadState(threadId, state)) {
+        return;
+      }
       ensureRunStarted();
       const existingError = currentEvents.find(
         (event) => event.type === EventType.RUN_ERROR,
@@ -526,6 +557,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
         onRunError(errorEvent);
       }
     } finally {
+      if (!this.isCurrentThreadState(threadId, state)) {
+        return;
+      }
       ensureRunStarted();
       const appended = finalizeRunEvents(currentEvents, {
         stopRequested: state.stopRequested,
@@ -550,10 +584,14 @@ export class IntelligenceAgentRunner extends AgentRunner {
     payload: Record<string, unknown>,
     state: ThreadState,
   ): void {
+    if (!this.isCurrentThreadState(state.threadId, state)) {
+      return;
+    }
     const eventId = this.runnerEventId(payload);
     if (!state.pendingEvents.has(eventId)) {
       state.pendingEvents.set(eventId, { payload, queuedAt: Date.now() });
     }
+    this.scheduleEventDeadline(state);
     this.replayPendingEvents(state);
   }
 
@@ -562,7 +600,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
     events: Array<{ payload: Record<string, unknown>; queuedAt: number }>,
     state: ThreadState,
   ): void {
-    if (state.channel.state !== "joined" || !state.socket.isConnected()) {
+    if (
+      !this.isCurrentThreadState(state.threadId, state) ||
+      state.channel.state !== "joined" ||
+      !state.socket.isConnected()
+    ) {
       return;
     }
 
@@ -572,9 +614,15 @@ export class IntelligenceAgentRunner extends AgentRunner {
     const isBatch = state.supportsRunnerEventBatch;
 
     state.channel
-      .push(isBatch ? "events" : "event", isBatch ? { events: payloads } : payloads[0])
+      .push(
+        isBatch ? "events" : "event",
+        isBatch ? { events: payloads } : payloads[0],
+      )
       .receive("ok", () => {
-        if (state.activeEventBatch?.attempt !== attempt) {
+        if (
+          !this.isCurrentThreadState(state.threadId, state) ||
+          state.activeEventBatch?.attempt !== attempt
+        ) {
           return;
         }
         for (const eventId of eventIds) {
@@ -586,27 +634,42 @@ export class IntelligenceAgentRunner extends AgentRunner {
           this.clearPendingEventRetry(state);
           this.clearPendingEventFlush(state);
         }
-        this.completeWhenDurable(
-          (payloads[0]?.thread_id as string) ?? "",
-          state,
-        );
+        this.scheduleEventDeadline(state);
+        this.completeWhenDurable(state.threadId, state);
         this.replayPendingEvents(state);
       })
-      .receive("error", () => this.handlePendingEventFailure(state, attempt))
+      .receive("error", (response) =>
+        this.handlePendingEventFailure(state, attempt, response),
+      )
       .receive("timeout", () => this.handlePendingEventFailure(state, attempt));
   }
 
-  private handlePendingEventFailure(state: ThreadState, attempt: number): void {
-    if (state.activeEventBatch?.attempt !== attempt) {
+  private handlePendingEventFailure(
+    state: ThreadState,
+    attempt: number,
+    response?: unknown,
+  ): void {
+    if (
+      !this.isCurrentThreadState(state.threadId, state) ||
+      state.activeEventBatch?.attempt !== attempt
+    ) {
       return;
     }
 
+    if (this.isPermanentEventFailure(response)) {
+      this.failThread(
+        state.threadId,
+        state,
+        new Error("Gateway permanently rejected queued runner events"),
+      );
+      return;
+    }
     this.schedulePendingEventRetry(state);
   }
 
   private schedulePendingEventRetry(state: ThreadState): void {
     if (
-      !state.isRunning ||
+      !this.isCurrentThreadState(state.threadId, state) ||
       state.pendingEvents.size === 0 ||
       state.eventRetryTimer !== null
     ) {
@@ -620,7 +683,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
     state.eventRetryAttempt += 1;
     state.eventRetryTimer = setTimeout(() => {
       state.eventRetryTimer = null;
-      if (!state.isRunning || state.pendingEvents.size === 0) {
+      if (
+        !this.isCurrentThreadState(state.threadId, state) ||
+        state.pendingEvents.size === 0
+      ) {
         return;
       }
       this.retryActiveEventBatch(state);
@@ -636,7 +702,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
 
   private schedulePendingEventFlush(state: ThreadState): void {
     if (
-      !state.isRunning ||
+      !this.isCurrentThreadState(state.threadId, state) ||
       state.pendingEvents.size === 0 ||
       state.activeEventBatch !== null ||
       state.eventFlushTimer !== null
@@ -653,6 +719,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
     );
     state.eventFlushTimer = setTimeout(() => {
       state.eventFlushTimer = null;
+      if (!this.isCurrentThreadState(state.threadId, state)) {
+        return;
+      }
       this.flushPendingEventBatch(state);
     }, delay);
   }
@@ -672,7 +741,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
   }
 
   private replayPendingEvents(state: ThreadState): void {
-    if (state.activeEventBatch !== null) {
+    if (
+      !this.isCurrentThreadState(state.threadId, state) ||
+      state.activeEventBatch !== null
+    ) {
       return;
     }
 
@@ -702,14 +774,19 @@ export class IntelligenceAgentRunner extends AgentRunner {
   }
 
   private flushPendingEventBatch(state: ThreadState): void {
-    if (state.activeEventBatch !== null || state.pendingEvents.size === 0) {
+    if (
+      !this.isCurrentThreadState(state.threadId, state) ||
+      state.activeEventBatch !== null ||
+      state.pendingEvents.size === 0
+    ) {
       return;
     }
 
     const batch = [...state.pendingEvents.entries()]
       .sort(
         ([, left], [, right]) =>
-          this.runnerEventSeq(left.payload) - this.runnerEventSeq(right.payload),
+          this.runnerEventSeq(left.payload) -
+          this.runnerEventSeq(right.payload),
       )
       .slice(0, MAX_RUNNER_EVENT_BATCH_SIZE);
     this.pushPendingEventBatch(
@@ -720,6 +797,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
   }
 
   private retryActiveEventBatch(state: ThreadState): void {
+    if (!this.isCurrentThreadState(state.threadId, state)) {
+      return;
+    }
     const activeBatch = state.activeEventBatch;
     if (activeBatch === null) {
       this.replayPendingEvents(state);
@@ -744,7 +824,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
   }
 
   private completeWhenDurable(threadId: string, state: ThreadState): void {
-    if (!state.producerFinished || state.pendingEvents.size !== 0) {
+    if (
+      !this.isCurrentThreadState(threadId, state) ||
+      !state.producerFinished ||
+      state.pendingEvents.size !== 0
+    ) {
       return;
     }
     if (this.threads.get(threadId) !== state) {
@@ -781,7 +865,70 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return false;
     }
     const value = response as { reason?: unknown; retryable?: unknown };
+    if (value.retryable === false) {
+      return false;
+    }
     return value.retryable === true || value.reason === "gateway_draining";
+  }
+
+  private isPermanentEventFailure(response: unknown): boolean {
+    return (
+      typeof response === "object" &&
+      response !== null &&
+      (response as { retryable?: unknown }).retryable === false
+    );
+  }
+
+  private scheduleEventDeadline(state: ThreadState): void {
+    if (state.eventDeadlineTimer !== null) {
+      clearTimeout(state.eventDeadlineTimer);
+      state.eventDeadlineTimer = null;
+    }
+    if (
+      !this.isCurrentThreadState(state.threadId, state) ||
+      state.pendingEvents.size === 0
+    ) {
+      return;
+    }
+
+    const oldestQueuedAt = Math.min(
+      ...[...state.pendingEvents.values()].map((event) => event.queuedAt),
+    );
+    const deadline = oldestQueuedAt + EVENT_DURABILITY_DEADLINE_MS;
+    state.eventDeadlineTimer = setTimeout(
+      () => {
+        state.eventDeadlineTimer = null;
+        if (!this.isCurrentThreadState(state.threadId, state)) {
+          return;
+        }
+
+        const oldestPending = Math.min(
+          ...[...state.pendingEvents.values()].map((event) => event.queuedAt),
+        );
+        if (Date.now() < oldestPending + EVENT_DURABILITY_DEADLINE_MS) {
+          this.scheduleEventDeadline(state);
+          return;
+        }
+        this.failThread(
+          state.threadId,
+          state,
+          new Error("Timed out trying to durably deliver runner events"),
+        );
+      },
+      Math.max(0, deadline - Date.now()),
+    );
+  }
+
+  private failThread(threadId: string, state: ThreadState, error: Error): void {
+    if (!this.isCurrentThreadState(threadId, state)) {
+      return;
+    }
+    this.removeThread(threadId);
+    state.failRun(error);
+  }
+
+  private isCurrentThreadState(threadId: string, state: ThreadState): boolean {
+    return state.isRunning && this.threads.get(threadId) === state;
   }
 
   /**
@@ -802,6 +949,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
     state.isRunning = false;
     this.clearPendingEventRetry(state);
     this.clearPendingEventFlush(state);
+    if (state.eventDeadlineTimer !== null) {
+      clearTimeout(state.eventDeadlineTimer);
+      state.eventDeadlineTimer = null;
+    }
     state.activeEventBatch = null;
     if (state.socketReconnectWatchdog !== null) {
       clearTimeout(state.socketReconnectWatchdog);

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -553,6 +553,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
     events: Array<{ payload: Record<string, unknown>; queuedAt: number }>,
     state: ThreadState,
   ): void {
+    if (state.channel.state !== "joined") {
+      return;
+    }
+
     const attempt = ++state.nextEventPushAttempt;
     state.activeEventBatch = { eventIds, attempt };
     const payloads = events.map((event) => event.payload);

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -611,7 +611,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
     }
     const eventId = this.runnerEventId(payload);
     if (!state.pendingEvents.has(eventId)) {
-      state.pendingEvents.set(eventId, { payload, queuedAt: Date.now() });
+      state.pendingEvents.set(eventId, {
+        payload: structuredClone(payload),
+        queuedAt: Date.now(),
+      });
     }
     this.scheduleEventDeadline(state);
     this.replayPendingEvents(state);

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -214,6 +214,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
     }
 
     return new Observable((observer) => {
+      if (this.threads.get(threadId)?.isRunning) {
+        observer.error(new Error("Thread already running"));
+        return;
+      }
+
       const socket = this.createSocket(request.authToken);
 
       const channel = socket.channel(`ingestion:${input.runId}`, {
@@ -361,7 +366,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
           } as BaseEvent;
           observer.next(errorEvent);
           state.currentEvents.push(errorEvent);
-          this.removeThread(threadId);
+          this.removeThread(threadId, state);
           startupBoundary?.rejectStartup(error);
           observer.complete();
         })
@@ -381,13 +386,13 @@ export class IntelligenceAgentRunner extends AgentRunner {
           } as BaseEvent;
           observer.next(errorEvent);
           state.currentEvents.push(errorEvent);
-          this.removeThread(threadId);
+          this.removeThread(threadId, state);
           startupBoundary?.rejectStartup(error);
           observer.complete();
         });
 
       return () => {
-        this.removeThread(threadId);
+        this.removeThread(threadId, state);
       };
     });
   }
@@ -602,6 +607,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
   ): void {
     if (
       !this.isCurrentThreadState(state.threadId, state) ||
+      this.failIfEventDeadlineExceeded(state) ||
       state.channel.state !== "joined" ||
       !state.socket.isConnected()
     ) {
@@ -623,6 +629,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
           !this.isCurrentThreadState(state.threadId, state) ||
           state.activeEventBatch?.attempt !== attempt
         ) {
+          return;
+        }
+        if (this.failIfEventDeadlineExceeded(state)) {
           return;
         }
         for (const eventId of eventIds) {
@@ -656,6 +665,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return;
     }
 
+    if (this.failIfEventDeadlineExceeded(state)) {
+      return;
+    }
     if (this.isPermanentEventFailure(response)) {
       this.failThread(
         state.threadId,
@@ -797,7 +809,10 @@ export class IntelligenceAgentRunner extends AgentRunner {
   }
 
   private retryActiveEventBatch(state: ThreadState): void {
-    if (!this.isCurrentThreadState(state.threadId, state)) {
+    if (
+      !this.isCurrentThreadState(state.threadId, state) ||
+      this.failIfEventDeadlineExceeded(state)
+    ) {
       return;
     }
     const activeBatch = state.activeEventBatch;
@@ -835,7 +850,7 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return;
     }
 
-    this.removeThread(threadId);
+    this.removeThread(threadId, state);
     state.completeRun();
   }
 
@@ -902,18 +917,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
           return;
         }
 
-        const oldestPending = Math.min(
-          ...[...state.pendingEvents.values()].map((event) => event.queuedAt),
-        );
-        if (Date.now() < oldestPending + EVENT_DURABILITY_DEADLINE_MS) {
+        if (!this.failIfEventDeadlineExceeded(state)) {
           this.scheduleEventDeadline(state);
-          return;
         }
-        this.failThread(
-          state.threadId,
-          state,
-          new Error("Timed out trying to durably deliver runner events"),
-        );
       },
       Math.max(0, deadline - Date.now()),
     );
@@ -923,8 +929,26 @@ export class IntelligenceAgentRunner extends AgentRunner {
     if (!this.isCurrentThreadState(threadId, state)) {
       return;
     }
-    this.removeThread(threadId);
+    this.removeThread(threadId, state);
     state.failRun(error);
+  }
+
+  private failIfEventDeadlineExceeded(state: ThreadState): boolean {
+    if (state.pendingEvents.size === 0) {
+      return false;
+    }
+    const oldestQueuedAt = Math.min(
+      ...[...state.pendingEvents.values()].map((event) => event.queuedAt),
+    );
+    if (Date.now() < oldestQueuedAt + EVENT_DURABILITY_DEADLINE_MS) {
+      return false;
+    }
+    this.failThread(
+      state.threadId,
+      state,
+      new Error("Timed out trying to durably deliver runner events"),
+    );
+    return true;
   }
 
   private isCurrentThreadState(threadId: string, state: ThreadState): boolean {
@@ -938,9 +962,8 @@ export class IntelligenceAgentRunner extends AgentRunner {
    * Idempotent — safe to call multiple times for the same threadId
    * (e.g. from join error handlers, finalize, and Observable teardown).
    */
-  private removeThread(threadId: string): void {
-    const state = this.threads.get(threadId);
-    if (!state) {
+  private removeThread(threadId: string, state: ThreadState): void {
+    if (this.threads.get(threadId) !== state) {
       return;
     }
 

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -311,10 +311,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
       // runner is guaranteed to receive it while still joined.
       channel.on(AG_UI_CHANNEL_EVENT, (payload: BaseEvent) => {
         if (
+          this.isCurrentThreadState(threadId, state) &&
           payload.type === EventType.CUSTOM &&
           (payload as BaseEvent & { name?: string }).name === "stop"
         ) {
-          this.stop({ threadId });
+          this.stop({ threadId, runId: state.runId });
         }
       });
 

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -259,7 +259,11 @@ export class IntelligenceAgentRunner extends AgentRunner {
         plannedRestart = false;
       });
       socket.onError(() => {
-        if (plannedRestart) {
+        // Once the gateway has accepted the run, transport recovery is not a
+        // terminal condition. The agent may still be producing the
+        // authoritative answer while Phoenix reconnects and replays durable
+        // events, so an arbitrary socket-error count must not abort it.
+        if (plannedRestart || state.hasJoined) {
           return;
         }
 

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -686,10 +686,16 @@ export class IntelligenceAgentRunner extends AgentRunner {
       return;
     }
     if (this.isPermanentEventFailure(response)) {
+      const reason =
+        typeof response === "object" &&
+        response !== null &&
+        typeof (response as { reason?: unknown }).reason === "string"
+          ? (response as { reason: string }).reason
+          : "permanent_gateway_rejection";
       this.failThread(
         state.threadId,
         state,
-        new Error("Gateway permanently rejected queued runner events"),
+        new Error(`Runner event durability failed: ${reason}`),
       );
       return;
     }


### PR DESCRIPTION
## Summary
- replay runner events sequentially with immutable IDs, terminal acknowledgements, and bounded retries
- preserve accepted runs across planned and prolonged abnormal reconnects without manufacturing terminal errors
- watchdog stalled abnormal socket reconnects while keeping pre-join failure behavior bounded
- make Slack and Teams delivery settlement safe across deployment handoffs
- add the compiled cross-service Kind runner used by the Intelligence integration suite

## Test plan
- [x] `NX_DAEMON=false NX_SKIP_NX_CACHE=true pnpm nx test runtime` (1,840 tests)
- [x] focused Intelligence runner suite (42 tests)
- [x] `pnpm --filter @copilotkit/runtime check-types`
- [x] `pnpm --filter @copilotkit/channels-intelligence check-types`
- [x] channels-intelligence suite (174 tests)
- [x] real cross-service Kind planned and hard-stop lifecycle suite; accepted agent remains un-aborted