### PR TITLE
fix(channels): make <Input onSubmit> round-trip on Teams and Slack

### DIFF
--- a/packages/channels-core/package.json
+++ b/packages/channels-core/package.json
@@ -32,8 +32,8 @@
       "import": "./dist/index.js"
     },
     "./testing": {
-      "types": "./dist/testing/state-store-conformance.d.ts",
-      "import": "./dist/testing/state-store-conformance.js"
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js"
     },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.ts",

--- a/packages/channels-core/src/testing/index.ts
+++ b/packages/channels-core/src/testing/index.ts
@@ -3,6 +3,10 @@
  * (`channels-slack`, `channels-teams`, …) import these to drive a real
  * `createChannel` runtime end-to-end — render → interaction → dispatch —
  * without standing up a platform.
+ *
+ * This entrypoint requires `vitest` to be installed: the conformance suite
+ * below imports it eagerly. That matches the package's optional `vitest` peer
+ * dependency — the subpath is only ever consumed from a test environment.
  */
 export { FakeAdapter, makeFakeRunRenderer } from "./fake-adapter.js";
 export { FakeAgent } from "./fake-agent.js";

--- a/packages/channels-core/src/testing/index.ts
+++ b/packages/channels-core/src/testing/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Test doubles shared across the channels packages. Adapter packages
+ * (`channels-slack`, `channels-teams`, …) import these to drive a real
+ * `createChannel` runtime end-to-end — render → interaction → dispatch —
+ * without standing up a platform.
+ */
+export { FakeAdapter, makeFakeRunRenderer } from "./fake-adapter.js";
+export { FakeAgent } from "./fake-agent.js";
+export type { FakeAgentScriptStep } from "./fake-agent.js";
+export { runStateStoreConformance } from "./state-store-conformance.js";

--- a/packages/channels-slack/src/input-submit.e2e.test.ts
+++ b/packages/channels-slack/src/input-submit.e2e.test.ts
@@ -56,18 +56,26 @@ const REPORTED_STATE: Record<
  * groups them: block → element. The renderer puts them in exactly two places —
  * an `input` block's `element` and an `actions` block's `elements`.
  *
- * The renderer leaves `block_id` to Slack, so these stand in for the ids Slack
- * would generate; only the grouping they express is load-bearing.
+ * Slack echoes each block's own `block_id` back as the outer `state.values`
+ * key, so the id is read off the RENDERED block rather than invented here: a
+ * block holding a single field carries the renderer's `ckf:<fieldId>`, which is
+ * what `decodeInteraction` strips to key `values` by field id. Only a block the
+ * renderer left unnamed — the shared `actions` block of `<Button>`s — needs a
+ * stand-in for the id Slack would auto-generate.
  */
 function statefulBlocks(
   blocks: KnownBlock[],
 ): { id: string; elements: StateElement[] }[] {
   return blocks
     .map((block, i) => {
-      const b = block as { element?: StateElement; elements?: StateElement[] };
+      const b = block as {
+        block_id?: string;
+        element?: StateElement;
+        elements?: StateElement[];
+      };
       const candidates = b.element ? [b.element] : (b.elements ?? []);
       return {
-        id: `block-${i}`,
+        id: b.block_id ?? `block-${i}`,
         elements: candidates.filter((el) => el && el.type in REPORTED_STATE),
       };
     })
@@ -177,6 +185,9 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     expect(submitted).toBe("ship it");
     // The submitting input reports its own text in `state.values` as well, so
     // both accessors must hand the handler the same string for one control.
+    // The key is the field id off the block's `ckf:` id, which for a field with
+    // no `name` is the same minted handler id as the element's `action_id` —
+    // so this pins the value, not `name`-based keying.
     expect(seenValues).toEqual({ [input.action_id]: "ship it" });
     await expect(choice!).resolves.toBe("ship it");
   });

--- a/packages/channels-slack/src/input-submit.e2e.test.ts
+++ b/packages/channels-slack/src/input-submit.e2e.test.ts
@@ -24,6 +24,9 @@ const THREAD_TS = "100.0";
 
 type StateElement = { type: string; action_id: string };
 
+/** What the user put into one control, or `undefined` if they never touched it. */
+type Entered = string | string[] | undefined;
+
 /**
  * How Slack reports one element's current reading, per element type. `entered`
  * is what the user put in; absent means untouched, which Slack reports as an
@@ -31,25 +34,35 @@ type StateElement = { type: string; action_id: string };
  * choice, `[]` for a multi-select) — never as a missing key. Keying off this
  * table is also what decides which elements appear in `state.values` at all: a
  * `<Button>` holds no state, so Slack lists none for it.
+ *
+ * Null-prototype, for the same reason `flattenBlockState` in `interaction.ts`
+ * builds its output that way: this table is probed with `in` and then INDEXED
+ * by a type read off an element, so on a plain `{}` a type of `toString` or
+ * `constructor` resolves to an `Object.prototype` member — it passes the
+ * membership check and is then CALLED as a state factory, reporting
+ * `"[object Object]"` as that element's state instead of the element being
+ * filtered out as the stateless thing it is. With no prototype, `in` is exactly
+ * own-key and only the three real Slack element types below can match.
  */
-const REPORTED_STATE: Record<
-  string,
-  (entered: string | string[] | undefined) => object
-> = {
-  plain_text_input: (entered) => ({
-    type: "plain_text_input",
-    value: entered ?? null,
-  }),
-  static_select: (entered) => ({
-    type: "static_select",
-    selected_option: entered === undefined ? null : { value: String(entered) },
-  }),
-  multi_static_select: (entered) => ({
-    type: "multi_static_select",
-    selected_options:
-      entered === undefined ? [] : [entered].flat().map((value) => ({ value })),
-  }),
-};
+const REPORTED_STATE: Record<string, (entered: Entered) => object> =
+  Object.assign(Object.create(null), {
+    plain_text_input: (entered: Entered) => ({
+      type: "plain_text_input",
+      value: entered ?? null,
+    }),
+    static_select: (entered: Entered) => ({
+      type: "static_select",
+      selected_option:
+        entered === undefined ? null : { value: String(entered) },
+    }),
+    multi_static_select: (entered: Entered) => ({
+      type: "multi_static_select",
+      selected_options:
+        entered === undefined
+          ? []
+          : [entered].flat().map((value) => ({ value })),
+    }),
+  });
 
 /**
  * The stateful elements of the rendered message, grouped the way `state.values`
@@ -116,8 +129,15 @@ function blockActions(
   entered: Record<string, string | string[]> = {},
   nonce = 0,
 ) {
+  // Own-key lookup: `entered` is a plain object literal, so a bare
+  // `entered[actionId]` resolves an action id of `constructor`/`toString` to an
+  // `Object.prototype` member and reports that function as the user's reading
+  // for a control nobody touched — where an id absent from `entered` must read
+  // as untouched.
+  const enteredBy = (actionId: string) =>
+    Object.hasOwn(entered, actionId) ? entered[actionId] : undefined;
   const readingOf = (el: StateElement) =>
-    el.action_id === action.action_id ? action.value : entered[el.action_id];
+    el.action_id === action.action_id ? action.value : enteredBy(el.action_id);
   const state = {
     values: Object.fromEntries(
       statefulBlocks(blocks).map((block) => [
@@ -165,6 +185,12 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
           },
         }),
       );
+      // The waiter settles only once the submit below is dispatched — long
+      // after `onMention` returns — so it cannot be awaited here. Observe it
+      // now anyway: if an earlier expectation aborts the test before the
+      // assertion at the end, a rejection would otherwise escape as an
+      // unhandled rejection attributed to some later test.
+      void choice.catch(() => {});
     });
 
     await channel.ɵruntime.start();

--- a/packages/channels-slack/src/input-submit.e2e.test.ts
+++ b/packages/channels-slack/src/input-submit.e2e.test.ts
@@ -1,0 +1,226 @@
+/**
+ * End-to-end coverage for `<Input onSubmit>` on Slack: render → submit →
+ * dispatch → resume, driving a real `createChannel` runtime through the real
+ * {@link renderBlockKit} and {@link decodeInteraction}.
+ *
+ * The defects this locks down lived between those two functions — `parseValue`
+ * JSON-coerced user-typed text, and an `<Input>` nested in `<Actions>` was
+ * dropped — so unit tests on either side alone kept passing while the
+ * round-trip corrupted or lost the value.
+ */
+import { describe, it, expect } from "vitest";
+import { createChannel } from "@copilotkit/channels-core";
+import { FakeAdapter, FakeAgent } from "@copilotkit/channels-core/testing";
+import { Actions, Button, Input } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
+import type { KnownBlock } from "@slack/types";
+import { renderBlockKit } from "./render/block-kit.js";
+import { decodeInteraction } from "./interaction.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+const CHANNEL = "C1";
+const THREAD_TS = "100.0";
+
+type InputBlock = {
+  type: string;
+  element: { type: string; action_id: string };
+};
+
+/** The `plain_text_input` elements Slack will report state for, in block order. */
+function textInputs(blocks: KnownBlock[]): InputBlock[] {
+  return blocks.filter(
+    (b): b is KnownBlock & InputBlock =>
+      (b as InputBlock).type === "input" &&
+      (b as InputBlock).element?.type === "plain_text_input",
+  );
+}
+
+/**
+ * Everything a real Slack client does between rendered blocks and the
+ * `block_actions` payload it posts back: the dispatching element fires with the
+ * user's raw keystrokes, and every input still on the message rides along in
+ * `state.values`.
+ *
+ * `nonce` distinguishes one submit from the next. The engine dedups inbound
+ * interactions on `channel:messageTs:actionTs`, so reusing a nonce is how a
+ * genuine duplicate delivery looks — every distinct click needs its own.
+ */
+function blockActions(
+  blocks: KnownBlock[],
+  action: { action_id: string; type: string; value?: string },
+  typed: Record<string, string> = {},
+  nonce = 0,
+) {
+  const state = {
+    values: Object.fromEntries(
+      textInputs(blocks).map((b, i) => [
+        `block-${i}`,
+        {
+          [b.element.action_id]: {
+            type: "plain_text_input",
+            value: typed[b.element.action_id],
+          },
+        },
+      ]),
+    ),
+  };
+  return decodeInteraction({
+    type: "block_actions",
+    user: { id: "U1", name: "Ana" },
+    channel: { id: CHANNEL },
+    message: { ts: `111.${nonce}`, thread_ts: THREAD_TS },
+    actions: [{ ...action, action_ts: `112.${nonce}` }],
+    state,
+  });
+}
+
+const conversationKey = `${CHANNEL}::${THREAD_TS}`;
+
+describe("<Input onSubmit> round-trip (Slack)", () => {
+  it("delivers the typed text to the handler and resumes the waiter", async () => {
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    let submitted: unknown;
+    let choice: Promise<unknown> | undefined;
+    channel.onMention(async ({ thread }) => {
+      choice = thread.awaitChoice(
+        Input({
+          placeholder: "Why?",
+          onSubmit: (ctx) => {
+            submitted = ctx.action.value;
+          },
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+    fake.emitTurn({ userText: "ask me", conversationKey });
+    await tick();
+
+    const blocks = renderBlockKit(fake.posted[0] as ChannelNode[]);
+    const input = textInputs(blocks)[0]!;
+
+    const evt = blockActions(blocks, {
+      action_id: input.element.action_id,
+      type: "plain_text_input",
+      value: "ship it",
+    })!;
+    fake.emitInteraction({ ...evt, conversationKey });
+    await tick();
+
+    expect(submitted).toBe("ship it");
+    await expect(choice!).resolves.toBe("ship it");
+  });
+
+  it("delivers JSON-shaped text verbatim, never coerced", async () => {
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    const received: unknown[] = [];
+    channel.onMention(async ({ thread }) => {
+      await thread.post(
+        Input({
+          onSubmit: (ctx) => {
+            received.push(ctx.action.value);
+          },
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+
+    const typedInputs = ["42", "true", "null", '{"a":1}'];
+    for (const [i, typed] of typedInputs.entries()) {
+      fake.emitTurn({ userText: "ask", conversationKey });
+      await tick();
+
+      const blocks = renderBlockKit(fake.posted[i] as ChannelNode[]);
+      const evt = blockActions(
+        blocks,
+        {
+          action_id: textInputs(blocks)[0]!.element.action_id,
+          type: "plain_text_input",
+          value: typed,
+        },
+        {},
+        i,
+      )!;
+      fake.emitInteraction({ ...evt, conversationKey });
+      await tick();
+    }
+
+    expect(received).toEqual(typedInputs);
+  });
+
+  it("renders an <Input> nested in <Actions> and delivers its text to a clicked <Button>", async () => {
+    // <Button> must be inside <Actions>, so this is the only JSX shape that can
+    // put the two side by side — and it is the shape Slack used to silently
+    // drop while Teams rendered it.
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    let clickedValue: unknown;
+    let seenValues: Record<string, unknown> | undefined;
+    channel.onMention(async ({ thread }) => {
+      await thread.post(
+        Actions({
+          children: [
+            Input({ onSubmit: () => {} }),
+            Button({
+              value: { decision: "yes" },
+              onClick: (ctx) => {
+                clickedValue = ctx.action.value;
+                seenValues = ctx.values;
+              },
+              children: "Approve",
+            }),
+          ],
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+    fake.emitTurn({ userText: "decide", conversationKey });
+    await tick();
+
+    const blocks = renderBlockKit(fake.posted[0] as ChannelNode[]);
+    const input = textInputs(blocks)[0];
+    expect(input).toBeDefined();
+
+    const button = fake.posted[0]!.flatMap((n) =>
+      ((n.props?.children ?? []) as ChannelNode[]).filter(
+        (c) => c.type === "button",
+      ),
+    )[0]!;
+    const buttonId = (button.props.onClick as { id: string }).id;
+
+    const evt = blockActions(
+      blocks,
+      {
+        action_id: buttonId,
+        type: "button",
+        value: JSON.stringify({ decision: "yes" }),
+      },
+      { [input!.element.action_id]: "looks good" },
+    )!;
+    fake.emitInteraction({ ...evt, conversationKey });
+    await tick();
+
+    expect(clickedValue).toEqual({ decision: "yes" });
+    expect(seenValues).toEqual({ [input!.element.action_id]: "looks good" });
+  });
+});

--- a/packages/channels-slack/src/input-submit.e2e.test.ts
+++ b/packages/channels-slack/src/input-submit.e2e.test.ts
@@ -111,7 +111,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
       type: "plain_text_input",
       value: "ship it",
     })!;
-    fake.emitInteraction({ ...evt, conversationKey });
+    fake.emitInteraction(evt);
     await tick();
 
     expect(submitted).toBe("ship it");
@@ -155,7 +155,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
         {},
         i,
       )!;
-      fake.emitInteraction({ ...evt, conversationKey });
+      fake.emitInteraction(evt);
       await tick();
     }
 
@@ -217,7 +217,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
       },
       { [input!.element.action_id]: "looks good" },
     )!;
-    fake.emitInteraction({ ...evt, conversationKey });
+    fake.emitInteraction(evt);
     await tick();
 
     expect(clickedValue).toEqual({ decision: "yes" });

--- a/packages/channels-slack/src/input-submit.e2e.test.ts
+++ b/packages/channels-slack/src/input-submit.e2e.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from "vitest";
 import { createChannel } from "@copilotkit/channels-core";
 import { FakeAdapter, FakeAgent } from "@copilotkit/channels-core/testing";
-import { Actions, Button, Input } from "@copilotkit/channels-ui";
+import { Actions, Button, Input, Select } from "@copilotkit/channels-ui";
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { KnownBlock } from "@slack/types";
 import { renderBlockKit } from "./render/block-kit.js";
@@ -22,25 +22,81 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 const CHANNEL = "C1";
 const THREAD_TS = "100.0";
 
-type InputBlock = {
-  type: string;
-  element: { type: string; action_id: string };
+type StateElement = { type: string; action_id: string };
+
+/**
+ * How Slack reports one element's current reading, per element type. `entered`
+ * is what the user put in; absent means untouched, which Slack reports as an
+ * explicit empty reading (`null` for a text input, `null` for an unmade single
+ * choice, `[]` for a multi-select) — never as a missing key. Keying off this
+ * table is also what decides which elements appear in `state.values` at all: a
+ * `<Button>` holds no state, so Slack lists none for it.
+ */
+const REPORTED_STATE: Record<
+  string,
+  (entered: string | string[] | undefined) => object
+> = {
+  plain_text_input: (entered) => ({
+    type: "plain_text_input",
+    value: entered ?? null,
+  }),
+  static_select: (entered) => ({
+    type: "static_select",
+    selected_option: entered === undefined ? null : { value: String(entered) },
+  }),
+  multi_static_select: (entered) => ({
+    type: "multi_static_select",
+    selected_options:
+      entered === undefined ? [] : [entered].flat().map((value) => ({ value })),
+  }),
 };
 
+/**
+ * The stateful elements of the rendered message, grouped the way `state.values`
+ * groups them: block → element. The renderer puts them in exactly two places —
+ * an `input` block's `element` and an `actions` block's `elements`.
+ *
+ * The renderer leaves `block_id` to Slack, so these stand in for the ids Slack
+ * would generate; only the grouping they express is load-bearing.
+ */
+function statefulBlocks(
+  blocks: KnownBlock[],
+): { id: string; elements: StateElement[] }[] {
+  return blocks
+    .map((block, i) => {
+      const b = block as { element?: StateElement; elements?: StateElement[] };
+      const candidates = b.element ? [b.element] : (b.elements ?? []);
+      return {
+        id: `block-${i}`,
+        elements: candidates.filter((el) => el && el.type in REPORTED_STATE),
+      };
+    })
+    .filter((b) => b.elements.length > 0);
+}
+
+/** Every element Slack will report state for, flattened, in block order. */
+function statefulElements(blocks: KnownBlock[]): StateElement[] {
+  return statefulBlocks(blocks).flatMap((b) => b.elements);
+}
+
 /** The `plain_text_input` elements Slack will report state for, in block order. */
-function textInputs(blocks: KnownBlock[]): InputBlock[] {
-  return blocks.filter(
-    (b): b is KnownBlock & InputBlock =>
-      (b as InputBlock).type === "input" &&
-      (b as InputBlock).element?.type === "plain_text_input",
+function textInputs(blocks: KnownBlock[]): StateElement[] {
+  return statefulElements(blocks).filter(
+    (el) => el.type === "plain_text_input",
   );
 }
 
 /**
  * Everything a real Slack client does between rendered blocks and the
  * `block_actions` payload it posts back: the dispatching element fires with the
- * user's raw keystrokes, and every input still on the message rides along in
- * `state.values`.
+ * user's raw keystrokes, and every stateful element still on the message — the
+ * dispatching one included — reports its current reading in `state.values`.
+ *
+ * `entered` is what the user put into the OTHER controls, keyed by action id;
+ * anything left out is reported the way Slack reports an untouched control. The
+ * dispatching control's reading is taken from `action` rather than from
+ * `entered`, because Slack cannot post a payload in which the two disagree
+ * about the control the user just used.
  *
  * `nonce` distinguishes one submit from the next. The engine dedups inbound
  * interactions on `channel:messageTs:actionTs`, so reusing a nonce is how a
@@ -49,19 +105,21 @@ function textInputs(blocks: KnownBlock[]): InputBlock[] {
 function blockActions(
   blocks: KnownBlock[],
   action: { action_id: string; type: string; value?: string },
-  typed: Record<string, string> = {},
+  entered: Record<string, string | string[]> = {},
   nonce = 0,
 ) {
+  const readingOf = (el: StateElement) =>
+    el.action_id === action.action_id ? action.value : entered[el.action_id];
   const state = {
     values: Object.fromEntries(
-      textInputs(blocks).map((b, i) => [
-        `block-${i}`,
-        {
-          [b.element.action_id]: {
-            type: "plain_text_input",
-            value: typed[b.element.action_id],
-          },
-        },
+      statefulBlocks(blocks).map((block) => [
+        block.id,
+        Object.fromEntries(
+          block.elements.map((el) => [
+            el.action_id,
+            REPORTED_STATE[el.type]!(readingOf(el)),
+          ]),
+        ),
       ]),
     ),
   };
@@ -87,6 +145,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     });
 
     let submitted: unknown;
+    let seenValues: Record<string, unknown> | undefined;
     let choice: Promise<unknown> | undefined;
     channel.onMention(async ({ thread }) => {
       choice = thread.awaitChoice(
@@ -94,6 +153,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
           placeholder: "Why?",
           onSubmit: (ctx) => {
             submitted = ctx.action.value;
+            seenValues = ctx.values;
           },
         }),
       );
@@ -107,7 +167,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     const input = textInputs(blocks)[0]!;
 
     const evt = blockActions(blocks, {
-      action_id: input.element.action_id,
+      action_id: input.action_id,
       type: "plain_text_input",
       value: "ship it",
     })!;
@@ -115,6 +175,9 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     await tick();
 
     expect(submitted).toBe("ship it");
+    // The submitting input reports its own text in `state.values` as well, so
+    // both accessors must hand the handler the same string for one control.
+    expect(seenValues).toEqual({ [input.action_id]: "ship it" });
     await expect(choice!).resolves.toBe("ship it");
   });
 
@@ -127,11 +190,13 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     });
 
     const received: unknown[] = [];
+    const echoedInValues: unknown[] = [];
     channel.onMention(async ({ thread }) => {
       await thread.post(
         Input({
           onSubmit: (ctx) => {
             received.push(ctx.action.value);
+            echoedInValues.push(ctx.values[ctx.action.id]);
           },
         }),
       );
@@ -148,7 +213,7 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
       const evt = blockActions(
         blocks,
         {
-          action_id: textInputs(blocks)[0]!.element.action_id,
+          action_id: textInputs(blocks)[0]!.action_id,
           type: "plain_text_input",
           value: typed,
         },
@@ -160,12 +225,16 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     }
 
     expect(received).toEqual(typedInputs);
+    // The same text arrives a second way — via the submitting input's own
+    // `state.values` entry — and must not be coerced on that path either.
+    expect(echoedInValues).toEqual(typedInputs);
   });
 
-  it("renders an <Input> nested in <Actions> and delivers its text to a clicked <Button>", async () => {
+  it("renders an <Input> nested in <Actions> and delivers its text — and a <Select>'s choice — to a clicked <Button>", async () => {
     // <Button> must be inside <Actions>, so this is the only JSX shape that can
     // put the two side by side — and it is the shape Slack used to silently
-    // drop while Teams rendered it.
+    // drop while Teams rendered it. The <Select> rides along because a click
+    // must carry every control's reading, not just the text ones.
     const fake = new FakeAdapter();
     const channel = createChannel({
       identifyUser: "platform",
@@ -180,6 +249,14 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
         Actions({
           children: [
             Input({ onSubmit: () => {} }),
+            Select({
+              placeholder: "Team",
+              options: [
+                { label: "Core", value: "core" },
+                { label: "Infra", value: "infra" },
+              ],
+              onSelect: () => {},
+            }),
             Button({
               value: { decision: "yes" },
               onClick: (ctx) => {
@@ -200,6 +277,10 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
     const blocks = renderBlockKit(fake.posted[0] as ChannelNode[]);
     const input = textInputs(blocks)[0];
     expect(input).toBeDefined();
+    const select = statefulElements(blocks).find(
+      (el) => el.type === "static_select",
+    );
+    expect(select).toBeDefined();
 
     const button = fake.posted[0]!.flatMap((n) =>
       ((n.props?.children ?? []) as ChannelNode[]).filter(
@@ -215,12 +296,15 @@ describe("<Input onSubmit> round-trip (Slack)", () => {
         type: "button",
         value: JSON.stringify({ decision: "yes" }),
       },
-      { [input!.element.action_id]: "looks good" },
+      { [input!.action_id]: "looks good", [select!.action_id]: "infra" },
     )!;
     fake.emitInteraction(evt);
     await tick();
 
     expect(clickedValue).toEqual({ decision: "yes" });
-    expect(seenValues).toEqual({ [input!.element.action_id]: "looks good" });
+    expect(seenValues).toEqual({
+      [input!.action_id]: "looks good",
+      [select!.action_id]: "infra",
+    });
   });
 });

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { decodeInteraction, conversationKeyOf } from "./interaction.js";
+import {
+  decodeInteraction,
+  conversationKeyOf,
+  decodeViewSubmission,
+} from "./interaction.js";
 import { DM_SCOPE } from "./types.js";
 
 describe("conversationKeyOf", () => {
@@ -182,6 +186,50 @@ describe("decodeInteraction", () => {
     expect(evt!.values).toEqual({});
   });
 
+  it("lands a `__proto__` element id as plain data, never on the prototype", () => {
+    // `__proto__` survives JSON.parse as an OWN key, so a crafted payload can
+    // carry one. On a plain `{}` the assignment runs the inherited setter: the
+    // handler then sees `values.injected` without `injected` ever appearing in
+    // `Object.keys(values)`.
+    const evt = decodeInteraction(
+      JSON.parse(`{
+        "type": "block_actions",
+        "container": { "channel_id": "C1", "thread_ts": "200.0" },
+        "actions": [{ "action_id": "ck:approve", "type": "button" }],
+        "state": {
+          "values": {
+            "block1": {
+              "__proto__": {
+                "type": "static_select",
+                "selected_option": { "value": "{\\"injected\\":true}" }
+              },
+              "ck:note": { "type": "plain_text_input", "value": "hi" }
+            }
+          }
+        }
+      }`),
+    );
+    const values = evt!.values!;
+    expect(values.injected).toBeUndefined();
+    expect(Object.keys(values).sort()).toEqual(["__proto__", "ck:note"]);
+    expect(values["__proto__"]).toEqual({ injected: true });
+    expect(values["ck:note"]).toBe("hi");
+  });
+
+  it("does not surface Object.prototype members through `values`", () => {
+    // A handler reading `ctx.values[someActionId]` must get submitted data or
+    // nothing — never an inherited builtin.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:b", type: "button" }],
+    });
+    const values = evt!.values!;
+    for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
+      expect(values[builtin]).toBeUndefined();
+    }
+  });
+
   it("returns undefined for non-block_actions or missing action_id", () => {
     expect(decodeInteraction({ type: "view_submission" })).toBeUndefined();
     expect(
@@ -250,5 +298,49 @@ describe("decodeInteraction", () => {
       actions: [{ action_id: "ck:x", value: "v" }],
     });
     expect(evt!.triggerId).toBe("T123.456");
+  });
+});
+
+describe("decodeViewSubmission field ids vs Object.prototype", () => {
+  it("lands a `__proto__` field id as plain data", () => {
+    // Same inbound-key hazard as `block_actions`: here the flattened value is a
+    // string, so the inherited setter drops it outright and the handler never
+    // sees the field at all.
+    const evt = decodeViewSubmission(
+      JSON.parse(`{
+        "callback_id": "triage",
+        "state": {
+          "values": {
+            "__proto__": {
+              "__proto__": { "type": "plain_text_input", "value": "pwned" }
+            },
+            "summary": {
+              "summary": { "type": "plain_text_input", "value": "boom" }
+            }
+          }
+        }
+      }`),
+    );
+    expect(Object.keys(evt.values).sort()).toEqual(["__proto__", "summary"]);
+    expect(evt.values["__proto__"]).toBe("pwned");
+    expect(evt.values.summary).toBe("boom");
+    for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
+      expect(evt.values[builtin]).toBeUndefined();
+    }
+  });
+
+  it("falls back to the first element for a block id that names a builtin", () => {
+    // The inner lookup is by block id too: an unguarded `inner[blockId]` finds
+    // `Object.prototype.toString`, which is truthy and so shadows the
+    // first-element fallback, yielding `undefined` for a real field.
+    const evt = decodeViewSubmission({
+      callback_id: "triage",
+      state: {
+        values: {
+          toString: { field: { type: "plain_text_input", value: "typed" } },
+        },
+      },
+    });
+    expect(evt.values["toString"]).toBe("typed");
   });
 });

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -292,9 +292,9 @@ describe("decodeInteraction", () => {
 
   it("lands a `__proto__` element id as plain data, never on the prototype", () => {
     // `__proto__` survives JSON.parse as an OWN key, so a crafted payload can
-    // carry one. On a plain `{}` the assignment runs the inherited setter: the
-    // handler then sees `values.injected` without `injected` ever appearing in
-    // `Object.keys(values)`.
+    // carry one. Assigned with `values[key] = v` it runs the inherited setter:
+    // the handler then sees `values.injected` without `injected` ever appearing
+    // in `Object.keys(values)`.
     const evt = decodeInteraction(
       JSON.parse(`{
         "type": "block_actions",
@@ -320,20 +320,61 @@ describe("decodeInteraction", () => {
     // lands as plain data on a plain key rather than as an object.
     expect(values["__proto__"]).toBe('{"injected":true}');
     expect(values["ck:note"]).toBe("hi");
+    // The crafted key is a field like any other, not the bag's prototype.
+    expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(values, "__proto__")).toBe(
+      true,
+    );
   });
 
-  it("does not surface Object.prototype members through `values`", () => {
-    // A handler reading `ctx.values[someActionId]` must get submitted data or
-    // nothing — never an inherited builtin.
+  it("hands handlers an ORDINARY object, prototype intact", () => {
+    // `values` is public API (`ctx.values`, typed `Record<string, unknown>`)
+    // and reaches third-party handlers. Hardening the inbound keys must not
+    // cost it `Object.prototype`: `ctx.values.hasOwnProperty(...)` is ordinary
+    // consumer code and must keep working.
     const evt = decodeInteraction({
       type: "block_actions",
       container: { channel_id: "C1", thread_ts: "200.0" },
       actions: [{ action_id: "ck:b", type: "button" }],
+      state: {
+        values: {
+          "ckf:reason": {
+            "ck:reason": { type: "plain_text_input", value: "ok" },
+          },
+        },
+      },
     });
     const values = evt!.values!;
-    for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
-      expect(values[builtin]).toBeUndefined();
-    }
+    expect(values.hasOwnProperty("reason")).toBe(true);
+    expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+    expect(values.hasOwnProperty("nope")).toBe(false);
+    expect(() => String(values)).not.toThrow();
+    expect({ ...values }).toEqual({ reason: "ok" });
+  });
+
+  it("delivers a submitted field whose id collides with a builtin", () => {
+    // The half of prototype hygiene that IS a correctness guarantee: a field
+    // the sender actually submitted must reach the handler as its own value,
+    // shadowing whatever `Object.prototype` happens to name.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:b", type: "button" }],
+      state: {
+        values: {
+          "ckf:toString": {
+            "ck:a": { type: "plain_text_input", value: "typed" },
+          },
+          "ckf:constructor": {
+            "ck:b": { type: "plain_text_input", value: "ctor" },
+          },
+        },
+      },
+    });
+    const values = evt!.values!;
+    expect(values.toString).toBe("typed");
+    expect(values.constructor).toBe("ctor");
+    expect(Object.keys(values).sort()).toEqual(["constructor", "toString"]);
   });
 
   it("keys `values` by the renderer's field ids, round-tripped through real blocks", () => {
@@ -483,9 +524,30 @@ describe("decodeViewSubmission field ids vs Object.prototype", () => {
     expect(Object.keys(evt.values).sort()).toEqual(["__proto__", "summary"]);
     expect(evt.values["__proto__"]).toBe("pwned");
     expect(evt.values.summary).toBe("boom");
-    for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
-      expect(evt.values[builtin]).toBeUndefined();
-    }
+    // The crafted key is a field like any other, not the bag's prototype.
+    expect(Object.getPrototypeOf(evt.values)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(evt.values, "__proto__")).toBe(
+      true,
+    );
+  });
+
+  it("hands handlers an ORDINARY object, prototype intact", () => {
+    // `IncomingModalSubmit.values` reaches an `onModalSubmit` handler verbatim
+    // (see channels-core `create-channel.ts`), so it owes the same ordinary-
+    // object contract as `ctx.values`.
+    const evt = decodeViewSubmission({
+      callback_id: "triage",
+      state: {
+        values: {
+          summary: { summary: { type: "plain_text_input", value: "boom" } },
+        },
+      },
+    });
+    expect(evt.values.hasOwnProperty("summary")).toBe(true);
+    expect(Object.getPrototypeOf(evt.values)).toBe(Object.prototype);
+    expect(evt.values.hasOwnProperty("nope")).toBe(false);
+    expect(() => String(evt.values)).not.toThrow();
+    expect({ ...evt.values }).toEqual({ summary: "boom" });
   });
 
   it("falls back to the first element for a block id that names a builtin", () => {

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -130,6 +130,51 @@ describe("decodeInteraction", () => {
     }
   });
 
+  it('delivers an EMPTY plain_text_input as "", in `value` and in `values` alike', () => {
+    // Slack reports a genuinely empty text input as `value: null`. Passing that
+    // through breaks the `ClickHandler<string>` contract, and it disagrees with
+    // Teams, where the same JSX arrives as `""` (Teams merges an untouched
+    // `Input.Text` into the submit that way — see its `render/adaptive-card.ts`
+    // and `input-submit.e2e.test.ts`). Empty is `""` on both surfaces.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [
+        { action_id: "ck:note", type: "plain_text_input", value: null },
+      ],
+      state: {
+        values: {
+          "ckf:note": { "ck:note": { type: "plain_text_input", value: null } },
+        },
+      },
+    });
+    expect(evt!.value).toBe("");
+    expect(evt!.values!.note).toBe("");
+  });
+
+  it('reports an untouched <Input> beside a clicked <Button> as "" in `values`', () => {
+    // The non-dispatching half of the same contract, and the exact shape Teams
+    // asserts: one field filled in, one left blank, submitted together. Slack
+    // still lists the blank one — as `null` — so `values` must report `""` for
+    // it, not `null` and not a missing key.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:approve", type: "button", value: '"yes"' }],
+      state: {
+        values: {
+          "ckf:why": {
+            "ck:why": { type: "plain_text_input", value: "ship it" },
+          },
+          "ckf:details": {
+            "ck:details": { type: "plain_text_input", value: null },
+          },
+        },
+      },
+    });
+    expect(evt!.values).toEqual({ why: "ship it", details: "" });
+  });
+
   it("still JSON-parses a button value (a payload we serialized ourselves)", () => {
     const evt = decodeInteraction({
       type: "block_actions",

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -281,6 +281,65 @@ describe("decodeInteraction", () => {
     expect(evt!.values!["ck:multi"]).toEqual(chosen);
   });
 
+  it('reports an untouched single <Select> beside a clicked <Button> as ""', () => {
+    // The select half of the same "empty is a reading, not absence" contract
+    // the blank `<Input>` case above pins. Slack lists an untouched single
+    // select as `selected_option: null` — a control that IS on the message and
+    // holds no choice — so `values` owes `""`, the string `onSelect`'s
+    // `ClickHandler<string | string[]>` declares, not `null` and not
+    // `undefined`. It is also what identical JSX delivers on Teams, which
+    // merges an untouched `Input.ChoiceSet` into the submit as `""` like every
+    // other `Input.*` (see `input-submit.e2e.test.ts` in channels-teams).
+    // The untouched MULTI select next to it already reads `[]` for the same
+    // reason; `undefined` would make the two disagree about the same emptiness.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:approve", type: "button", value: '"yes"' }],
+      state: {
+        values: {
+          "ckf:team": {
+            "ck:team": { type: "static_select", selected_option: null },
+          },
+          "ckf:owners": {
+            "ck:owners": {
+              type: "multi_static_select",
+              selected_options: [],
+            },
+          },
+        },
+      },
+    });
+    expect(evt!.values).toEqual({ team: "", owners: [] });
+  });
+
+  it('resolves an untouched single <Select> as "" in `value` too, never `undefined`', () => {
+    // The two readers must not disagree: whatever `ctx.values` reports for a
+    // choice-less single select, `ctx.action.value` reports the same.
+    const el = { type: "static_select", selected_option: null };
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:team", ...el }],
+      state: { values: { block1: { "ck:team": el } } },
+    });
+    expect(evt!.value).toBe("");
+    expect(evt!.values!["ck:team"]).toBe("");
+  });
+
+  it("still reports a valueless <Button> as `undefined`, not as an empty select", () => {
+    // The guard on the reading above: a button carries no `selected_option`
+    // slot at all, so `<Button onClick>` with no `value` prop stays absence.
+    // Keying the empty reading on the SLOT, not on a missing value, is what
+    // keeps these two apart.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:b", type: "button" }],
+    });
+    expect(evt!.value).toBeUndefined();
+  });
+
   it("reports empty `values` when the payload carries no block state", () => {
     const evt = decodeInteraction({
       type: "block_actions",

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -137,11 +137,40 @@ describe("decodeInteraction", () => {
     });
     expect(evt!.value).toBe("yes");
     expect(evt!.values).toEqual({
-      // Still a string: `values` is a form-value carrier, so nothing coerces.
+      // Still a string: typed text is never coerced, here or in `value`.
       "ck:note": "42",
       "ck:team": "core",
       "ck:owners": ["ada", "bo"],
     });
+  });
+
+  it("resolves the same <Select> identically in `value` and in `values`", () => {
+    // A non-string option value is serialized with String(...) on the way out,
+    // so both accessors must JSON-parse it back. Disagreeing would hand the
+    // handler `1` via ctx.action.value and "1" via ctx.values for one control.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [
+        {
+          action_id: "ck:sel",
+          type: "static_select",
+          selected_option: { value: "1" },
+        },
+      ],
+      state: {
+        values: {
+          block1: {
+            "ck:sel": {
+              type: "static_select",
+              selected_option: { value: "1" },
+            },
+          },
+        },
+      },
+    });
+    expect(evt!.value).toBe(1);
+    expect(evt!.values!["ck:sel"]).toBe(1);
   });
 
   it("reports empty `values` when the payload carries no block state", () => {

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -101,6 +101,23 @@ describe("decodeInteraction", () => {
     expect(evt!.actor).toEqual({ id: "unknown", kind: "unknown" });
   });
 
+  it("takes the picker message's ts from the container when `message` is absent", () => {
+    // The half of the container fallback the case above leaves untouched: with
+    // no `message` and no explicit thread_ts, the container's own message_ts is
+    // both the thread root the scope keys on and the ref an onClick
+    // `thread.update(message.ref, …)` targets. It is asserted here because the
+    // fixture above carries an explicit thread_ts and no message_ts, so neither
+    // fallback runs there.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C3", message_ts: "199.0" },
+      actions: [{ action_id: "ck:c", value: "x" }],
+    });
+    expect(evt!.conversationKey).toBe("C3::199.0");
+    expect(evt!.replyTarget).toEqual({ channel: "C3", threadTs: "199.0" });
+    expect(evt!.messageRef).toEqual({ id: "199.0", channel: "C3" });
+  });
+
   it("decodes a multi_static_select's selected_options into a string[] value", () => {
     const evt = decodeInteraction({
       type: "block_actions",
@@ -351,9 +368,12 @@ describe("decodeInteraction", () => {
 
   it("lands a `__proto__` element id as plain data, never on the prototype", () => {
     // `__proto__` survives JSON.parse as an OWN key, so a crafted payload can
-    // carry one. Assigned with `values[key] = v` it runs the inherited setter:
-    // the handler then sees `values.injected` without `injected` ever appearing
-    // in `Object.keys(values)`.
+    // carry one. Assigned with `values[key] = v` it runs the inherited setter,
+    // which for the STRING reading below drops the write outright: the field
+    // disappears from the bag and the handler never sees it. (The setter can
+    // only redirect the prototype when the reading is an object — the multi
+    // select in the next case. Asserting `values.injected` here would be
+    // unfalsifiable: a string can never become anyone's prototype.)
     const evt = decodeInteraction(
       JSON.parse(`{
         "type": "block_actions",
@@ -373,7 +393,6 @@ describe("decodeInteraction", () => {
       }`),
     );
     const values = evt!.values!;
-    expect(values.injected).toBeUndefined();
     expect(Object.keys(values).sort()).toEqual(["__proto__", "ck:note"]);
     // Verbatim: an option value is never JSON-decoded, so a JSON-shaped one
     // lands as plain data on a plain key rather than as an object.
@@ -384,6 +403,39 @@ describe("decodeInteraction", () => {
     expect(Object.prototype.hasOwnProperty.call(values, "__proto__")).toBe(
       true,
     );
+  });
+
+  it("keeps an OBJECT-valued `__proto__` reading off the bag's prototype", () => {
+    // The injection the string case above cannot reach. A multi select's
+    // reading is an array — an object — so `values["__proto__"] = reading`
+    // makes it the bag's PROTOTYPE: the field vanishes from `Object.keys` and
+    // every property the crafted reading carries reads back off `values` as
+    // though the workspace had submitted it.
+    const evt = decodeInteraction(
+      JSON.parse(`{
+        "type": "block_actions",
+        "container": { "channel_id": "C1", "thread_ts": "200.0" },
+        "actions": [{ "action_id": "ck:approve", "type": "button" }],
+        "state": {
+          "values": {
+            "block1": {
+              "__proto__": {
+                "type": "multi_static_select",
+                "selected_options": [{ "value": "pwned" }]
+              }
+            }
+          }
+        }
+      }`),
+    );
+    const values = evt!.values!;
+    expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+    // Nothing the crafted reading carries reads back as a submitted field.
+    expect(values["0"]).toBeUndefined();
+    expect(values["length"]).toBeUndefined();
+    // And the reading itself is an ordinary field, still enumerable.
+    expect(Object.keys(values)).toEqual(["__proto__"]);
+    expect(values["__proto__"]).toEqual(["pwned"]);
   });
 
   it("hands handlers an ORDINARY object, prototype intact", () => {
@@ -489,17 +541,53 @@ describe("decodeInteraction", () => {
     expect(evt!.values).toEqual({ input_1: "one", input_2: "two" });
   });
 
-  it("returns undefined for non-block_actions or missing action_id", () => {
-    expect(decodeInteraction({ type: "view_submission" })).toBeUndefined();
+  it("returns undefined for a payload that is not `block_actions`", () => {
+    // Each rejection below is pinned on ONE guard, and the fixture is
+    // otherwise fully decodable — the control at the end proves it. A fixture
+    // that is ALSO missing its channel or its action_id still returns
+    // undefined with this type check deleted, which is how the assertion goes
+    // dead: a later guard, not the one named, is what rejects it.
+    const decodable = {
+      channel: { id: "C1" },
+      message: { ts: "111.1" },
+      actions: [{ action_id: "ck:abc", value: "yes" }],
+    };
     expect(
-      decodeInteraction({ type: "block_actions", actions: [] }),
+      decodeInteraction({ ...decodable, type: "view_submission" }),
     ).toBeUndefined();
+    // No `type` at all (e.g. a slash command or an unparsed body).
+    expect(decodeInteraction({ ...decodable })).toBeUndefined();
+    // Control: the same payload decodes once the type matches, so the two
+    // undefineds above can only be the type guard.
+    expect(decodeInteraction({ ...decodable, type: "block_actions" })?.id).toBe(
+      "ck:abc",
+    );
+  });
+
+  it("returns undefined when the clicked action carries no action_id", () => {
+    // Same isolation: the channel resolves and the type matches, so the only
+    // thing left to reject these is the missing dispatch id. Without the
+    // channel these assertions pass with the action_id guard deleted — the
+    // channel guard downstream returns undefined and the case never reaches
+    // the id check.
+    const rest = {
+      type: "block_actions",
+      channel: { id: "C1" },
+      message: { ts: "111.1" },
+    };
     expect(
-      decodeInteraction({ type: "block_actions", actions: [{ value: "x" }] }),
+      decodeInteraction({ ...rest, actions: [{ value: "x" }] }),
     ).toBeUndefined();
+    expect(decodeInteraction({ ...rest, actions: [] })).toBeUndefined();
+    expect(decodeInteraction({ ...rest })).toBeUndefined();
+    // Control: identical payload, plus the id.
+    expect(
+      decodeInteraction({ ...rest, actions: [{ action_id: "ck:abc" }] })?.id,
+    ).toBe("ck:abc");
   });
 
   it("returns undefined when no channel can be resolved", () => {
+    // Carries an action_id so the guard above cannot be what rejects it.
     expect(
       decodeInteraction({
         type: "block_actions",
@@ -532,6 +620,9 @@ describe("decodeInteraction", () => {
       actions: [{ action_id: "ck:c", value: "x" }],
     });
     expect(evt!.eventId).toBe("trig-xyz");
+    // And with no message ts anywhere there is no message to update in place:
+    // the ref stays absent rather than being fabricated as `{ id: undefined }`.
+    expect(evt!.messageRef).toBeUndefined();
   });
 
   it("does NOT require a resume field (opaque id only)", () => {

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -148,33 +148,65 @@ describe("decodeInteraction", () => {
     });
   });
 
-  it("resolves the same <Select> identically in `value` and in `values`", () => {
-    // A non-string option value is serialized with String(...) on the way out,
-    // so both accessors must JSON-parse it back. Disagreeing would hand the
-    // handler `1` via ctx.action.value and "1" via ctx.values for one control.
+  it("resolves the same <Select> identically in `value` and in `values`, as the string Slack carried", () => {
+    // A `SelectOption.value` is a `string` and block-kit writes it to the wire
+    // verbatim — no JSON — so neither accessor may JSON-parse it back: "42"
+    // must stay "42", not become the number 42. The two must also agree, or one
+    // control would reach a handler as `42` via ctx.action.value and "42" via
+    // ctx.values. ("007" is the only one that survived parsing, by luck: it
+    // isn't valid JSON.)
+    for (const chosen of ["42", "true", "null", "007", "core"]) {
+      const evt = decodeInteraction({
+        type: "block_actions",
+        container: { channel_id: "C1", thread_ts: "200.0" },
+        actions: [
+          {
+            action_id: "ck:sel",
+            type: "static_select",
+            selected_option: { value: chosen },
+          },
+        ],
+        state: {
+          values: {
+            block1: {
+              "ck:sel": {
+                type: "static_select",
+                selected_option: { value: chosen },
+              },
+            },
+          },
+        },
+      });
+      expect(evt!.value).toBe(chosen);
+      expect(evt!.values!["ck:sel"]).toBe(chosen);
+    }
+  });
+
+  it("resolves a multi <Select> identically in `value` and in `values`, as the strings Slack carried", () => {
+    // Same contract for `selected_options`: `<Select multi onSelect>` is a
+    // `ClickHandler<string[]>`, so every element stays the string on the wire.
+    const chosen = ["42", "true", "null", "007"];
+    const selected_options = chosen.map((value) => ({ value }));
     const evt = decodeInteraction({
       type: "block_actions",
       container: { channel_id: "C1", thread_ts: "200.0" },
       actions: [
         {
-          action_id: "ck:sel",
-          type: "static_select",
-          selected_option: { value: "1" },
+          action_id: "ck:multi",
+          type: "multi_static_select",
+          selected_options,
         },
       ],
       state: {
         values: {
           block1: {
-            "ck:sel": {
-              type: "static_select",
-              selected_option: { value: "1" },
-            },
+            "ck:multi": { type: "multi_static_select", selected_options },
           },
         },
       },
     });
-    expect(evt!.value).toBe(1);
-    expect(evt!.values!["ck:sel"]).toBe(1);
+    expect(evt!.value).toEqual(chosen);
+    expect(evt!.values!["ck:multi"]).toEqual(chosen);
   });
 
   it("reports empty `values` when the payload carries no block state", () => {
@@ -212,7 +244,9 @@ describe("decodeInteraction", () => {
     const values = evt!.values!;
     expect(values.injected).toBeUndefined();
     expect(Object.keys(values).sort()).toEqual(["__proto__", "ck:note"]);
-    expect(values["__proto__"]).toEqual({ injected: true });
+    // Verbatim: an option value is never JSON-decoded, so a JSON-shaped one
+    // lands as plain data on a plain key rather than as an object.
+    expect(values["__proto__"]).toBe('{"injected":true}');
     expect(values["ck:note"]).toBe("hi");
   });
 

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -4,7 +4,31 @@ import {
   conversationKeyOf,
   decodeViewSubmission,
 } from "./interaction.js";
+import { renderBlockKit } from "./render/block-kit.js";
 import { DM_SCOPE } from "./types.js";
+
+/**
+ * The `state.values` Slack posts back for a rendered message's text inputs:
+ * block id → element `action_id` → the element's reading. Built from the real
+ * blocks so the renderer's own keying is what the decoder is handed.
+ */
+function textInputState(
+  blocks: unknown[],
+  typed: string[],
+): Record<string, Record<string, unknown>> {
+  const inputs = blocks.filter(
+    (b) =>
+      (b as { element?: { type?: string } }).element?.type ===
+      "plain_text_input",
+  ) as { block_id: string; element: { action_id: string } }[];
+  expect(inputs).toHaveLength(typed.length);
+  return Object.fromEntries(
+    inputs.map((b, i) => [
+      b.block_id,
+      { [b.element.action_id]: { type: "plain_text_input", value: typed[i] } },
+    ]),
+  );
+}
 
 describe("conversationKeyOf", () => {
   it("joins channelId + scope with the canonical separator", () => {
@@ -115,8 +139,11 @@ describe("decodeInteraction", () => {
     expect(evt!.value).toBe(42);
   });
 
-  it("carries every input on the message as `values`, keyed by action_id", () => {
+  it("falls back to the element's action_id for a block the renderer didn't name", () => {
     // So a <Button onClick> handler beside an <Input> can read what was typed.
+    // These block ids carry no `ckf:` field id (a <Raw> block, or a message
+    // rendered before that vocabulary existed), so the element's own action_id
+    // is the only stable key left.
     const evt = decodeInteraction({
       type: "block_actions",
       container: { channel_id: "C1", thread_ts: "200.0" },
@@ -262,6 +289,59 @@ describe("decodeInteraction", () => {
     for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
       expect(values[builtin]).toBeUndefined();
     }
+  });
+
+  it("keys `values` by the renderer's field ids, round-tripped through real blocks", () => {
+    // The half the unit tests above cannot see: the renderer picks the key and
+    // the decoder must read back the same one. `name` is the key on Teams (see
+    // `fieldId()` in channels-teams' `render/adaptive-card.ts`), so it has to be
+    // the key here too, even though `action_id` stays the minted dispatch id.
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "input",
+              props: { name: "reason", onSubmit: { id: "ck:in1" } },
+            },
+            { type: "input", props: { name: "detail" } },
+            {
+              type: "button",
+              props: {
+                onClick: { id: "ck:approve" },
+                children: [{ type: "text", props: { value: "Approve" } }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:approve", type: "button" }],
+      state: { values: textInputState(blocks, ["ship it", "looks good"]) },
+    });
+    expect(evt!.values).toEqual({ reason: "ship it", detail: "looks good" });
+  });
+
+  it("keeps two handler-less <Input>s from overwriting each other", () => {
+    // Both used to render `action_id: "input"`, so the flattening dropped one
+    // field's text on the floor.
+    const blocks = renderBlockKit([
+      { type: "input", props: { placeholder: "First" } },
+      { type: "input", props: { placeholder: "Second" } },
+    ]);
+
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:approve", type: "button" }],
+      state: { values: textInputState(blocks, ["one", "two"]) },
+    });
+    expect(evt!.values).toEqual({ input_1: "one", input_2: "two" });
   });
 
   it("returns undefined for non-block_actions or missing action_id", () => {

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -87,6 +87,72 @@ describe("decodeInteraction", () => {
     expect(evt!.value).toEqual(["core", "infra"]);
   });
 
+  it("keeps a plain_text_input's typed text as a string, never JSON-parsed", () => {
+    // `<Input onSubmit>` is a `ClickHandler<string>`. Parsing free text would
+    // silently hand the handler a number/boolean/null/object instead.
+    for (const typed of ["42", "true", "null", '{"a":1}', "ship it"]) {
+      const evt = decodeInteraction({
+        type: "block_actions",
+        container: { channel_id: "C1", thread_ts: "200.0" },
+        actions: [
+          { action_id: "ck:note", type: "plain_text_input", value: typed },
+        ],
+      });
+      expect(evt!.value).toBe(typed);
+    }
+  });
+
+  it("still JSON-parses a button value (a payload we serialized ourselves)", () => {
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:b", type: "button", value: "42" }],
+    });
+    expect(evt!.value).toBe(42);
+  });
+
+  it("carries every input on the message as `values`, keyed by action_id", () => {
+    // So a <Button onClick> handler beside an <Input> can read what was typed.
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:approve", type: "button", value: '"yes"' }],
+      state: {
+        values: {
+          block1: {
+            "ck:note": { type: "plain_text_input", value: "42" },
+          },
+          block2: {
+            "ck:team": {
+              type: "static_select",
+              selected_option: { value: "core" },
+            },
+            "ck:owners": {
+              type: "multi_static_select",
+              selected_options: [{ value: "ada" }, { value: "bo" }],
+            },
+          },
+        },
+      },
+    });
+    expect(evt!.value).toBe("yes");
+    expect(evt!.values).toEqual({
+      // Still a string: `values` is a form-value carrier, so nothing coerces.
+      "ck:note": "42",
+      "ck:team": "core",
+      "ck:owners": ["ada", "bo"],
+    });
+  });
+
+  it("reports empty `values` when the payload carries no block state", () => {
+    const evt = decodeInteraction({
+      type: "block_actions",
+      container: { channel_id: "C1", thread_ts: "200.0" },
+      actions: [{ action_id: "ck:b", type: "button", value: '"yes"' }],
+    });
+    expect(evt!.values).toEqual({});
+  });
+
   it("returns undefined for non-block_actions or missing action_id", () => {
     expect(decodeInteraction({ type: "view_submission" })).toBeUndefined();
     expect(

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -195,7 +195,14 @@ function stateElementValue(el: SlackStateElement): unknown {
 function flattenBlockState(state: SlackBlockState | undefined): {
   [actionId: string]: unknown;
 } {
-  const out: Record<string, unknown> = {};
+  // Null-prototype, because the element ids come from an inbound payload and
+  // `__proto__` survives `JSON.parse` as an OWN key: assigning it onto a plain
+  // `{}` runs `Object.prototype`'s setter instead of creating a field, so the
+  // handler would receive an INVISIBLE inherited property (absent from
+  // `Object.keys`) in place of the element's value. With no prototype every key
+  // lands as plain data and nothing is inherited, so `values` is exactly what
+  // the message carried — `constructor` and friends included.
+  const out: Record<string, unknown> = Object.create(null);
   for (const block of Object.values(state?.values ?? {})) {
     for (const [actionId, el] of Object.entries(block)) {
       out[actionId] = stateElementValue(el);
@@ -281,11 +288,21 @@ interface SlackViewState {
  * `block_actions` reader would silently change what `view_submission` delivers.
  */
 function flattenViewValues(view: SlackViewState): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
+  // Null-prototype for the same reason as {@link flattenBlockState}: block ids
+  // come from an inbound payload, and a `__proto__` key assigned onto a plain
+  // `{}` would run `Object.prototype`'s setter and reach the handler as an
+  // invisible inherited property instead of a submitted field.
+  const out: Record<string, unknown> = Object.create(null);
   const values = view.state?.values ?? {};
   for (const blockId of Object.keys(values)) {
     const inner = values[blockId]!;
-    const el = inner[blockId] ?? Object.values(inner)[0];
+    // Own-key lookup only: an unguarded `inner[blockId]` resolves ids like
+    // `constructor`/`toString` to an `Object.prototype` member, which is truthy
+    // and so would shadow the documented first-element fallback below.
+    const own = Object.prototype.hasOwnProperty.call(inner, blockId)
+      ? inner[blockId]
+      : undefined;
+    const el = own ?? Object.values(inner)[0];
     if (!el) continue;
     out[blockId] = el.value ?? el.selected_option?.value;
   }

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -78,21 +78,26 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     threadTs: isDm && !explicitThreadTs ? undefined : threadTs,
   };
 
-  // Tiny, non-sensitive value: the clicked button's value (or selected option
-  // value), JSON-parsed if it round-trips, otherwise the raw string. A
-  // multi_static_select reports `selected_options` (an array) → a `string[]`.
+  // Tiny, non-sensitive value: the clicked control's reading, decoded with the
+  // codec that encoded it (see block-kit.ts). Only a `<Button>`'s value is
+  // JSON-encoded there, so only `action.value` is JSON-parsed — falling back to
+  // the raw string when it isn't JSON.
   //
-  // Free text typed by a user is the exception: it is a string by contract
-  // (`<Input onSubmit>` is a `ClickHandler<string>`), and JSON-parsing it would
-  // silently hand the handler `42` as a number, `true` as a boolean, `null`, or
-  // `{"a":1}` as an object. Parsing is correct only for values WE serialized.
+  // Everything else is a string on the wire and stays one. Free text is a
+  // string by contract (`<Input onSubmit>` is a `ClickHandler<string>`), and so
+  // is a select's option value (`SelectOption.value` is a `string`, written out
+  // verbatim). JSON-parsing either would silently hand the handler `42` as a
+  // number, `true` as a boolean, `null`, or `{"a":1}` as an object. A
+  // multi_static_select reports `selected_options` (an array) → a `string[]`.
   let value: unknown;
   if (action.type === PLAIN_TEXT_INPUT) {
     value = action.value;
   } else if (action.selected_options) {
-    value = action.selected_options.map((o) => parseValue(o.value));
+    value = action.selected_options.map((o) => o.value);
+  } else if (action.value !== undefined) {
+    value = parseValue(action.value);
   } else {
-    value = parseValue(action.value ?? action.selected_option?.value);
+    value = action.selected_option?.value;
   }
 
   const actor = body.user?.id
@@ -145,7 +150,12 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   };
 }
 
-/** JSON-parse a control value so non-string option values round-trip; else keep the raw string. */
+/**
+ * JSON-parse a `<Button>` value — the one control whose value block-kit
+ * serializes with `JSON.stringify`, so `{decision:"yes"}` round-trips as an
+ * object. Falls back to the raw string when it isn't JSON (e.g. Slack's own
+ * `feedback_buttons`, whose "positive"/"negative" we never encoded).
+ */
 function parseValue(raw: string | undefined): unknown {
   if (typeof raw !== "string") return raw;
   try {
@@ -173,16 +183,18 @@ interface SlackBlockState {
 
 /**
  * The current value of one `state.values` element, resolved by exactly the rule
- * the clicked action uses above: user-typed text passes through verbatim, and
- * only option values — which we serialized ourselves — are JSON-parsed. The two
- * must agree, or the same `<Select>` would reach a handler as `1` via
- * `ctx.action.value` and `"1"` via `ctx.values`.
+ * the clicked action uses above. Nothing here is JSON-decoded: a `<Button>` is
+ * the only control whose value we JSON-encode and it holds no state, so every
+ * reading Slack reports — typed text, option values — is a string on the wire
+ * and stays one. The two readers must agree, or the same `<Select>` would reach
+ * a handler as `42` via `ctx.action.value` and `"42"` via `ctx.values`.
  */
 function stateElementValue(el: SlackStateElement): unknown {
+  // Explicit ahead of the shared fallback: Slack reports an EMPTY text input as
+  // `value: null`, which the `??` below would turn into `undefined`.
   if (el.type === PLAIN_TEXT_INPUT) return el.value;
-  if (el.selected_options)
-    return el.selected_options.map((o) => parseValue(o.value));
-  return parseValue(el.value ?? el.selected_option?.value);
+  if (el.selected_options) return el.selected_options.map((o) => o.value);
+  return el.value ?? el.selected_option?.value;
 }
 
 /**

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -172,13 +172,17 @@ interface SlackBlockState {
 }
 
 /**
- * The current value of one `state.values` element. Never JSON-parses: these are
- * form-field values, either user-typed text or an option value we rendered with
- * `String(...)`, so both are strings by contract.
+ * The current value of one `state.values` element, resolved by exactly the rule
+ * the clicked action uses above: user-typed text passes through verbatim, and
+ * only option values — which we serialized ourselves — are JSON-parsed. The two
+ * must agree, or the same `<Select>` would reach a handler as `1` via
+ * `ctx.action.value` and `"1"` via `ctx.values`.
  */
 function stateElementValue(el: SlackStateElement): unknown {
-  if (el.selected_options) return el.selected_options.map((o) => o.value);
-  return el.value ?? el.selected_option?.value;
+  if (el.type === PLAIN_TEXT_INPUT) return el.value;
+  if (el.selected_options)
+    return el.selected_options.map((o) => parseValue(o.value));
+  return parseValue(el.value ?? el.selected_option?.value);
 }
 
 /**
@@ -269,7 +273,12 @@ interface SlackViewState {
  * Flatten a Slack view's `state.values` to a flat `fieldId → value` map. The
  * modal vocabulary names every block id == action id (the field id), so for
  * each block we take the inner element keyed by that same block id, falling
- * back to the first element.
+ * back to the first element. Text inputs expose `value`; selects/radios expose
+ * `selected_option.value`.
+ *
+ * Deliberately NOT {@link stateElementValue}: modal submissions are a separate
+ * surface with its own settled semantics, and routing them through the
+ * `block_actions` reader would silently change what `view_submission` delivers.
  */
 function flattenViewValues(view: SlackViewState): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -278,7 +287,7 @@ function flattenViewValues(view: SlackViewState): Record<string, unknown> {
     const inner = values[blockId]!;
     const el = inner[blockId] ?? Object.values(inner)[0];
     if (!el) continue;
-    out[blockId] = stateElementValue(el);
+    out[blockId] = el.value ?? el.selected_option?.value;
   }
   return out;
 }

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -8,6 +8,20 @@ import { DM_SCOPE } from "./types.js";
 import type { ConversationKey, ReplyTarget } from "./types.js";
 
 /**
+ * Prefix marking a `block_id` the renderer minted to name the one field its
+ * block holds (see `fieldBlockId` in `render/block-kit.ts`).
+ *
+ * A field's `values` key must follow the author's `<Input name>`/`<Select name>`,
+ * as it does on Teams — but `action_id` cannot carry it, because that is the
+ * string the engine dispatches on and it has to stay the registry-minted `ck:`
+ * id. Slack keys `state.values` by block then by element, so the block id is the
+ * only other stable slot on the wire: the renderer writes the field id there and
+ * {@link flattenBlockState} reads it back. The prefix is what distinguishes a
+ * block we named from one Slack auto-numbered or a `<Raw>` author set.
+ */
+export const FIELD_BLOCK_PREFIX = "ckf:";
+
+/**
  * Stable string key shared by ingress (onTurn) and interaction decoding so the
  * bot's awaitChoice waiters resolve. Both paths MUST derive the conversation key
  * from this single helper — a mismatch silently strands the waiter.
@@ -131,9 +145,9 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     replyTarget,
     value,
     // Every input still on the message, so a `<Button onClick>` handler beside
-    // an `<Input>` can read what was typed. Slack keys `state.values` by block
-    // then by element; we flatten to the element's `action_id` — the minted
-    // `ck:` id — matching how Teams keys its merged card inputs.
+    // an `<Input>` can read what was typed. Keyed by field id — the author's
+    // `name` when set, else the minted `ck:` id — matching how Teams keys its
+    // merged card inputs. See {@link FIELD_BLOCK_PREFIX}.
     values: flattenBlockState(body.state),
     actor,
     messageRef,
@@ -198,14 +212,18 @@ function stateElementValue(el: SlackStateElement): unknown {
 }
 
 /**
- * Flatten a `block_actions` payload's `state.values` to a flat `action_id →
- * value` map. Unlike a modal view (whose vocabulary names block id == action
- * id, see {@link flattenViewValues}), a rendered message leaves `block_id` to
- * Slack, so the element's own `action_id` — the registry-minted `ck:` id — is
- * the only stable key.
+ * Flatten a `block_actions` payload's `state.values` to a flat `fieldId → value`
+ * map, keyed the way Teams keys the same JSX's merged card inputs: the author's
+ * `name` first, else the registry-minted `ck:` id, else a positional fallback.
+ *
+ * The renderer stamps that field id into the block id (see
+ * {@link FIELD_BLOCK_PREFIX}), so — as in a modal view, whose vocabulary also
+ * names block id == field id (see {@link flattenViewValues}) — the block is what
+ * names the field. A block without the prefix was not ours to name, and there
+ * the element's own `action_id` is the only stable key left.
  */
 function flattenBlockState(state: SlackBlockState | undefined): {
-  [actionId: string]: unknown;
+  [fieldId: string]: unknown;
 } {
   // Null-prototype, because the element ids come from an inbound payload and
   // `__proto__` survives `JSON.parse` as an OWN key: assigning it onto a plain
@@ -215,9 +233,14 @@ function flattenBlockState(state: SlackBlockState | undefined): {
   // lands as plain data and nothing is inherited, so `values` is exactly what
   // the message carried — `constructor` and friends included.
   const out: Record<string, unknown> = Object.create(null);
-  for (const block of Object.values(state?.values ?? {})) {
+  for (const [blockId, block] of Object.entries(state?.values ?? {})) {
+    // A `ckf:` block names its single field (the renderer never puts two in
+    // one), so every element under it resolves to that same field id.
+    const named = blockId.startsWith(FIELD_BLOCK_PREFIX)
+      ? blockId.slice(FIELD_BLOCK_PREFIX.length)
+      : undefined;
     for (const [actionId, el] of Object.entries(block)) {
-      out[actionId] = stateElementValue(el);
+      out[named ?? actionId] = stateElementValue(el);
     }
   }
   return out;

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -196,6 +196,45 @@ function textInputValue(raw: string | null | undefined): string {
   return raw ?? "";
 }
 
+/**
+ * Write one decoded field onto a `values` bag as an OWN data property.
+ *
+ * `key` is a block/element id from an inbound Slack payload, and `__proto__`
+ * survives `JSON.parse` as an own key. A plain `bag[key] = value` for that key
+ * runs `Object.prototype`'s `__proto__` SETTER instead of creating a field: the
+ * element's reading disappears from `Object.keys(bag)` and — when it is an
+ * object — becomes the bag's prototype, so every property it carries reads back
+ * off `bag` as though the workspace had submitted it. (In the modal reader,
+ * where the flattened reading is a string, the setter drops it outright and the
+ * handler never sees the field at all.) `defineProperty` writes the property
+ * itself and never consults a setter, so `__proto__` lands as ordinary
+ * enumerable data like any other field id.
+ *
+ * Deliberately a plain `{}` and NOT `Object.create(null)`. These bags are
+ * public API — `flattenBlockState`'s reaches handlers as `ctx.values` and
+ * `flattenViewValues`' as an `onModalSubmit` handler's `values`, both typed
+ * `Record<string, unknown>` (see channels-core's `InteractionContext` and
+ * `IncomingModalSubmit`) — and `values.hasOwnProperty(...)`/`toString()` is
+ * ordinary consumer code that a prototype-less bag would break. Dropping the
+ * prototype buys only that an ABSENT field id spelled like a builtin reads back
+ * `undefined` rather than the builtin, which is true of every other
+ * `Record<string, unknown>` in this API and is not what the injection was
+ * about. A field that WAS submitted still wins: an own property shadows its
+ * `Object.prototype` namesake.
+ */
+function setField(
+  bag: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(bag, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
 /** One entry of a Slack view/message `state.values` block. */
 interface SlackStateElement {
   type?: string;
@@ -241,14 +280,7 @@ function stateElementValue(el: SlackStateElement): unknown {
 function flattenBlockState(state: SlackBlockState | undefined): {
   [fieldId: string]: unknown;
 } {
-  // Null-prototype, because the element ids come from an inbound payload and
-  // `__proto__` survives `JSON.parse` as an OWN key: assigning it onto a plain
-  // `{}` runs `Object.prototype`'s setter instead of creating a field, so the
-  // handler would receive an INVISIBLE inherited property (absent from
-  // `Object.keys`) in place of the element's value. With no prototype every key
-  // lands as plain data and nothing is inherited, so `values` is exactly what
-  // the message carried — `constructor` and friends included.
-  const out: Record<string, unknown> = Object.create(null);
+  const out: Record<string, unknown> = {};
   for (const [blockId, block] of Object.entries(state?.values ?? {})) {
     // A `ckf:` block names its single field (the renderer never puts two in
     // one), so every element under it resolves to that same field id.
@@ -256,7 +288,7 @@ function flattenBlockState(state: SlackBlockState | undefined): {
       ? blockId.slice(FIELD_BLOCK_PREFIX.length)
       : undefined;
     for (const [actionId, el] of Object.entries(block)) {
-      out[named ?? actionId] = stateElementValue(el);
+      setField(out, named ?? actionId, stateElementValue(el));
     }
   }
   return out;
@@ -339,11 +371,7 @@ interface SlackViewState {
  * `block_actions` reader would silently change what `view_submission` delivers.
  */
 function flattenViewValues(view: SlackViewState): Record<string, unknown> {
-  // Null-prototype for the same reason as {@link flattenBlockState}: block ids
-  // come from an inbound payload, and a `__proto__` key assigned onto a plain
-  // `{}` would run `Object.prototype`'s setter and reach the handler as an
-  // invisible inherited property instead of a submitted field.
-  const out: Record<string, unknown> = Object.create(null);
+  const out: Record<string, unknown> = {};
   const values = view.state?.values ?? {};
   for (const blockId of Object.keys(values)) {
     const inner = values[blockId]!;
@@ -355,7 +383,7 @@ function flattenViewValues(view: SlackViewState): Record<string, unknown> {
       : undefined;
     const el = own ?? Object.values(inner)[0];
     if (!el) continue;
-    out[blockId] = el.value ?? el.selected_option?.value;
+    setField(out, blockId, el.value ?? el.selected_option?.value);
   }
   return out;
 }

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -55,7 +55,8 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     actions?: Array<{
       action_id?: string;
       type?: string;
-      value?: string;
+      /** `null`, not absent, when the control is a text input the user left empty. */
+      value?: string | null;
       selected_option?: { value?: string };
       selected_options?: Array<{ value?: string }>;
       action_ts?: string;
@@ -105,7 +106,7 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   // multi_static_select reports `selected_options` (an array) → a `string[]`.
   let value: unknown;
   if (action.type === PLAIN_TEXT_INPUT) {
-    value = action.value;
+    value = textInputValue(action.value);
   } else if (action.selected_options) {
     value = action.selected_options.map((o) => o.value);
   } else if (action.value !== undefined) {
@@ -170,7 +171,7 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
  * object. Falls back to the raw string when it isn't JSON (e.g. Slack's own
  * `feedback_buttons`, whose "positive"/"negative" we never encoded).
  */
-function parseValue(raw: string | undefined): unknown {
+function parseValue(raw: string | null | undefined): unknown {
   if (typeof raw !== "string") return raw;
   try {
     return JSON.parse(raw);
@@ -182,10 +183,24 @@ function parseValue(raw: string | undefined): unknown {
 /** Slack's element type for a free-text input — the one control whose value is user-typed. */
 const PLAIN_TEXT_INPUT = "plain_text_input";
 
+/**
+ * A `plain_text_input`'s reading, as the string its contract promises. Slack
+ * reports a field the user left EMPTY as `value: null`, but `<Input onSubmit>`
+ * is a `ClickHandler<string>` and an empty field is emptiness, not absence — so
+ * the reading is `""`. That is also what identical JSX delivers on Teams, which
+ * merges an untouched `Input.Text` into the submit as `""` (see
+ * `render/adaptive-card.ts` in channels-teams); handing a handler `null` here
+ * would make the two surfaces disagree about the same blank box.
+ */
+function textInputValue(raw: string | null | undefined): string {
+  return raw ?? "";
+}
+
 /** One entry of a Slack view/message `state.values` block. */
 interface SlackStateElement {
   type?: string;
-  value?: string;
+  /** `null`, not absent, when the element is a text input the user left empty. */
+  value?: string | null;
   selected_option?: { value?: string };
   selected_options?: Array<{ value?: string }>;
 }
@@ -205,8 +220,9 @@ interface SlackBlockState {
  */
 function stateElementValue(el: SlackStateElement): unknown {
   // Explicit ahead of the shared fallback: Slack reports an EMPTY text input as
-  // `value: null`, which the `??` below would turn into `undefined`.
-  if (el.type === PLAIN_TEXT_INPUT) return el.value;
+  // `value: null`, and the `??` below would resolve that to the (absent)
+  // `selected_option` rather than to the empty string a text field owes.
+  if (el.type === PLAIN_TEXT_INPUT) return textInputValue(el.value);
   if (el.selected_options) return el.selected_options.map((o) => o.value);
   return el.value ?? el.selected_option?.value;
 }

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -40,11 +40,13 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     };
     actions?: Array<{
       action_id?: string;
+      type?: string;
       value?: string;
       selected_option?: { value?: string };
       selected_options?: Array<{ value?: string }>;
       action_ts?: string;
     }>;
+    state?: SlackBlockState;
   };
   if (body.type !== "block_actions") return undefined;
   const action = body.actions?.[0];
@@ -79,8 +81,15 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   // Tiny, non-sensitive value: the clicked button's value (or selected option
   // value), JSON-parsed if it round-trips, otherwise the raw string. A
   // multi_static_select reports `selected_options` (an array) → a `string[]`.
+  //
+  // Free text typed by a user is the exception: it is a string by contract
+  // (`<Input onSubmit>` is a `ClickHandler<string>`), and JSON-parsing it would
+  // silently hand the handler `42` as a number, `true` as a boolean, `null`, or
+  // `{"a":1}` as an object. Parsing is correct only for values WE serialized.
   let value: unknown;
-  if (action.selected_options) {
+  if (action.type === PLAIN_TEXT_INPUT) {
+    value = action.value;
+  } else if (action.selected_options) {
     value = action.selected_options.map((o) => parseValue(o.value));
   } else {
     value = parseValue(action.value ?? action.selected_option?.value);
@@ -116,6 +125,11 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     conversationKey,
     replyTarget,
     value,
+    // Every input still on the message, so a `<Button onClick>` handler beside
+    // an `<Input>` can read what was typed. Slack keys `state.values` by block
+    // then by element; we flatten to the element's `action_id` — the minted
+    // `ck:` id — matching how Teams keys its merged card inputs.
+    values: flattenBlockState(body.state),
     actor,
     messageRef,
     triggerId: body.trigger_id,
@@ -139,6 +153,51 @@ function parseValue(raw: string | undefined): unknown {
   } catch {
     return raw;
   }
+}
+
+/** Slack's element type for a free-text input — the one control whose value is user-typed. */
+const PLAIN_TEXT_INPUT = "plain_text_input";
+
+/** One entry of a Slack view/message `state.values` block. */
+interface SlackStateElement {
+  type?: string;
+  value?: string;
+  selected_option?: { value?: string };
+  selected_options?: Array<{ value?: string }>;
+}
+
+/** Slack's `state` envelope: block id → element id → the element's current value. */
+interface SlackBlockState {
+  values?: Record<string, Record<string, SlackStateElement>>;
+}
+
+/**
+ * The current value of one `state.values` element. Never JSON-parses: these are
+ * form-field values, either user-typed text or an option value we rendered with
+ * `String(...)`, so both are strings by contract.
+ */
+function stateElementValue(el: SlackStateElement): unknown {
+  if (el.selected_options) return el.selected_options.map((o) => o.value);
+  return el.value ?? el.selected_option?.value;
+}
+
+/**
+ * Flatten a `block_actions` payload's `state.values` to a flat `action_id →
+ * value` map. Unlike a modal view (whose vocabulary names block id == action
+ * id, see {@link flattenViewValues}), a rendered message leaves `block_id` to
+ * Slack, so the element's own `action_id` — the registry-minted `ck:` id — is
+ * the only stable key.
+ */
+function flattenBlockState(state: SlackBlockState | undefined): {
+  [actionId: string]: unknown;
+} {
+  const out: Record<string, unknown> = {};
+  for (const block of Object.values(state?.values ?? {})) {
+    for (const [actionId, el] of Object.entries(block)) {
+      out[actionId] = stateElementValue(el);
+    }
+  }
+  return out;
 }
 
 interface SlackReactionEvent {
@@ -203,27 +262,14 @@ export function decodeReaction(
 interface SlackViewState {
   callback_id?: string;
   private_metadata?: string;
-  state?: {
-    values?: Record<
-      string,
-      Record<
-        string,
-        {
-          type?: string;
-          value?: string;
-          selected_option?: { value?: string };
-        }
-      >
-    >;
-  };
+  state?: SlackBlockState;
 }
 
 /**
  * Flatten a Slack view's `state.values` to a flat `fieldId → value` map. The
  * modal vocabulary names every block id == action id (the field id), so for
  * each block we take the inner element keyed by that same block id, falling
- * back to the first element. Text inputs expose `value`; selects/radios expose
- * `selected_option.value`.
+ * back to the first element.
  */
 function flattenViewValues(view: SlackViewState): Record<string, unknown> {
   const out: Record<string, unknown> = {};
@@ -232,7 +278,7 @@ function flattenViewValues(view: SlackViewState): Record<string, unknown> {
     const inner = values[blockId]!;
     const el = inner[blockId] ?? Object.values(inner)[0];
     if (!el) continue;
-    out[blockId] = el.value ?? el.selected_option?.value;
+    out[blockId] = stateElementValue(el);
   }
   return out;
 }

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -57,7 +57,7 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
       type?: string;
       /** `null`, not absent, when the control is a text input the user left empty. */
       value?: string | null;
-      selected_option?: { value?: string };
+      selected_option?: SelectedOption;
       selected_options?: Array<{ value?: string }>;
       action_ts?: string;
     }>;
@@ -103,7 +103,9 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   // is a select's option value (`SelectOption.value` is a `string`, written out
   // verbatim). JSON-parsing either would silently hand the handler `42` as a
   // number, `true` as a boolean, `null`, or `{"a":1}` as an object. A
-  // multi_static_select reports `selected_options` (an array) → a `string[]`.
+  // multi_static_select reports `selected_options` (an array) → a `string[]`;
+  // a single select reports `selected_option` → a `string` (see
+  // {@link selectedOptionValue} for the choice-less case).
   let value: unknown;
   if (action.type === PLAIN_TEXT_INPUT) {
     value = textInputValue(action.value);
@@ -112,7 +114,7 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   } else if (action.value !== undefined) {
     value = parseValue(action.value);
   } else {
-    value = action.selected_option?.value;
+    value = selectedOptionValue(action);
   }
 
   const actor = body.user?.id
@@ -197,6 +199,42 @@ function textInputValue(raw: string | null | undefined): string {
 }
 
 /**
+ * The `selected_option` slot a single-choice control carries: the chosen
+ * option, or `null` when it is a select nobody has picked from yet. Slack
+ * sends the key either way — `null` is how it says "this control is on the
+ * message and holds no choice", which is exactly the distinction
+ * {@link selectedOptionValue} keys the empty reading on.
+ */
+type SelectedOption = { value?: string } | null;
+
+/**
+ * A single `<Select>`'s reading, as the string its contract promises — or
+ * `undefined` for a control that has no `selected_option` slot at all.
+ *
+ * Slack reports an untouched single select as `selected_option: null`, and the
+ * reading is `""` — by the same rule that makes a blank text input `""` (see
+ * {@link textInputValue}) and an untouched multi select `[]`: empty is a
+ * reading, not absence. `onSelect` is a `ClickHandler<string | string[]>` (see
+ * `SelectProps` in channels-ui), which `undefined` does not satisfy, and it is
+ * what identical JSX delivers on Teams, where an untouched `Input.ChoiceSet`
+ * is merged into the submit as `""` like every other `Input.*` (see
+ * `render/adaptive-card.ts` and `input-submit.e2e.test.ts` in channels-teams).
+ *
+ * Keyed on the SLOT, not on a missing value: a `<Button>` with no `value` prop
+ * carries no `selected_option` at all and must stay `undefined`, since
+ * `ButtonProps.value` is genuinely optional and absence is its reading.
+ */
+function selectedOptionValue(el: {
+  selected_option?: SelectedOption;
+}): string | undefined {
+  const chosen = el.selected_option?.value;
+  if (chosen !== undefined) return chosen;
+  return Object.prototype.hasOwnProperty.call(el, "selected_option")
+    ? ""
+    : undefined;
+}
+
+/**
  * Write one decoded field onto a `values` bag as an OWN data property.
  *
  * `key` is a block/element id from an inbound Slack payload, and `__proto__`
@@ -240,7 +278,8 @@ interface SlackStateElement {
   type?: string;
   /** `null`, not absent, when the element is a text input the user left empty. */
   value?: string | null;
-  selected_option?: { value?: string };
+  /** `null`, not absent, when the element is a single select nobody has picked from. */
+  selected_option?: SelectedOption;
   selected_options?: Array<{ value?: string }>;
 }
 
@@ -256,6 +295,13 @@ interface SlackBlockState {
  * reading Slack reports — typed text, option values — is a string on the wire
  * and stays one. The two readers must agree, or the same `<Select>` would reach
  * a handler as `42` via `ctx.action.value` and `"42"` via `ctx.values`.
+ *
+ * One rule governs every control the user left alone, here and above: empty is
+ * a reading, not absence. A blank text input reads `""`, an untouched multi
+ * select reads `[]`, and an unpicked single select reads `""` (see
+ * {@link textInputValue} and {@link selectedOptionValue}) — never `null` and
+ * never `undefined`, which would make an on-screen control indistinguishable
+ * from one that is not on the message at all.
  */
 function stateElementValue(el: SlackStateElement): unknown {
   // Explicit ahead of the shared fallback: Slack reports an EMPTY text input as
@@ -263,7 +309,7 @@ function stateElementValue(el: SlackStateElement): unknown {
   // `selected_option` rather than to the empty string a text field owes.
   if (el.type === PLAIN_TEXT_INPUT) return textInputValue(el.value);
   if (el.selected_options) return el.selected_options.map((o) => o.value);
-  return el.value ?? el.selected_option?.value;
+  return el.value ?? selectedOptionValue(el);
 }
 
 /**

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -248,6 +248,60 @@ describe("renderBlockKit", () => {
     expect(block.element.action_id).toBe("ck:ms");
   });
 
+  it("renders an <Input> nested in <Actions> instead of dropping it", () => {
+    // Slack forbids plain_text_input inside an actions block while requiring
+    // <Button> to be in one; Teams' actions case just recurses. Peeling the
+    // input out keeps identical JSX from diverging between the two surfaces.
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "input",
+              props: { onSubmit: { id: "ck:note" }, placeholder: "Why?" },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "input",
+      dispatch_action: true,
+      element: { type: "plain_text_input", action_id: "ck:note" },
+    });
+  });
+
+  it("keeps source order when an <Input> is mixed with a button", () => {
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "input",
+              props: { onSubmit: { id: "ck:note" } },
+            },
+            {
+              type: "button",
+              props: {
+                onClick: { id: "ck:b" },
+                children: [{ type: "text", props: { value: "Go" } }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "input",
+      "actions",
+    ]);
+  });
+
   it("keeps source order when a multi-select is mixed with a button", () => {
     const blocks = renderBlockKit([
       {

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -1,6 +1,7 @@
 import { Header, Message, Section, renderToIR } from "@copilotkit/channels-ui";
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import { describe, expect, it } from "vitest";
+import { FIELD_BLOCK_PREFIX } from "../interaction.js";
 import { renderBlockKit, renderSlackMessage } from "./block-kit.js";
 
 describe("renderBlockKit", () => {
@@ -84,6 +85,8 @@ describe("renderBlockKit", () => {
     ).toEqual([
       {
         type: "input",
+        // Unnamed, so the field id `values` keys by is the minted id itself.
+        block_id: "ckf:ck:in1",
         dispatch_action: true,
         element: {
           type: "plain_text_input",
@@ -95,7 +98,7 @@ describe("renderBlockKit", () => {
     ]);
   });
 
-  it("gives a static_select a fallback action_id when onSelect is absent", () => {
+  it("gives a static_select a unique fallback action_id when onSelect is absent", () => {
     const blocks = renderBlockKit([
       {
         type: "actions",
@@ -111,8 +114,8 @@ describe("renderBlockKit", () => {
     ]);
     const select = (blocks[0] as { elements: { action_id: string }[] })
       .elements[0]!;
-    expect(select.action_id).toBe("select");
-    expect(select.action_id.length).toBeGreaterThan(0);
+    // The field id, not the bare `"select"` literal a second one would repeat.
+    expect(select.action_id).toBe("select_1");
   });
 
   it("writes select option values verbatim, never JSON-encoded", () => {
@@ -453,6 +456,121 @@ describe("renderBlockKit", () => {
     const rows = (blocks[0] as { rows: { text: string }[][] }).rows;
     expect(rows).toHaveLength(100);
     expect(rows[0]![0]!.text).toBe("Name");
+  });
+});
+
+/**
+ * The `values` key a field's reading arrives under, and how it gets onto the
+ * wire. Teams derives an Adaptive Card element's `id` — which becomes the
+ * `values` key there — as `name ?? mintedActionId ?? \`${kind}_${index}\``,
+ * deduped (see `fieldId()` in channels-teams' `render/adaptive-card.ts`). Slack
+ * must land on the same key for the same JSX, so it carries the field id in the
+ * block id and leaves `action_id` to dispatch.
+ */
+describe("field ids (Slack ↔ Teams `values` key parity)", () => {
+  /** The `ckf:`-stripped field id of each block that names one, in block order. */
+  function fieldIds(blocks: unknown[]): string[] {
+    return blocks
+      .map((b) => (b as { block_id?: string }).block_id)
+      .filter((id): id is string => id?.startsWith(FIELD_BLOCK_PREFIX) === true)
+      .map((id) => id.slice(FIELD_BLOCK_PREFIX.length));
+  }
+
+  it("keys a named <Input> by its `name`, while `action_id` stays the minted id", () => {
+    // Teams honours `name`; Slack ignored it, so `ctx.values.reason` resolved on
+    // one surface and was `undefined` on the other. `action_id` may not change
+    // with it: the engine dispatches on exactly that string.
+    const blocks = renderBlockKit([
+      {
+        type: "input",
+        props: {
+          name: "reason",
+          onSubmit: { id: "ck:in1" },
+          placeholder: "Why?",
+        },
+      },
+    ]);
+    expect(blocks[0]).toMatchObject({
+      type: "input",
+      block_id: "ckf:reason",
+      element: { type: "plain_text_input", action_id: "ck:in1" },
+    });
+  });
+
+  it("keys a named <Select> (single and multi) by its `name`", () => {
+    for (const multi of [false, true]) {
+      const blocks = renderBlockKit([
+        {
+          type: "actions",
+          props: {
+            children: [
+              {
+                type: "select",
+                props: {
+                  multi,
+                  name: "team",
+                  onSelect: { id: "ck:sel" },
+                  options: [{ label: "Core", value: "core" }],
+                },
+              },
+            ],
+          },
+        },
+      ]);
+      expect(fieldIds(blocks)).toEqual(["team"]);
+      // Dispatch is unmoved: the minted id still rides on the element.
+      const el = blocks[0] as {
+        element?: { action_id: string };
+        elements?: { action_id: string }[];
+      };
+      expect((el.element ?? el.elements![0]!).action_id).toBe("ck:sel");
+    }
+  });
+
+  it("gives two handler-less <Input>s distinct field ids", () => {
+    // Both used to be keyed `input`, so `flattenBlockState` overwrote one with
+    // the other and a field's submitted text was silently lost.
+    const blocks = renderBlockKit([
+      { type: "input", props: { placeholder: "First" } },
+      { type: "input", props: { placeholder: "Second" } },
+    ]);
+    expect(fieldIds(blocks)).toEqual(["input_1", "input_2"]);
+  });
+
+  it("numbers unnamed fields off one counter shared by inputs and selects", () => {
+    // The exact ids Teams' `fieldId()` mints for this JSX: an explicit `name`
+    // first, then the minted handler id, then `${kind}_${index}` off a counter
+    // that every field advances.
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            { type: "input", props: { name: "reason" } },
+            { type: "input", props: { onSubmit: { id: "ck:in2" } } },
+            { type: "input", props: {} },
+            {
+              type: "select",
+              props: { options: [{ label: "A", value: "a" }] },
+            },
+          ],
+        },
+      },
+    ]);
+    expect(fieldIds(blocks)).toEqual([
+      "reason",
+      "ck:in2",
+      "input_3",
+      "select_4",
+    ]);
+  });
+
+  it("dedupes two fields that claim the same `name`", () => {
+    const blocks = renderBlockKit([
+      { type: "input", props: { name: "reason" } },
+      { type: "input", props: { name: "reason" } },
+    ]);
+    expect(fieldIds(blocks)).toEqual(["reason", "reason_1"]);
   });
 });
 

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -647,6 +647,65 @@ describe("field ids (Slack ↔ Teams `values` key parity)", () => {
   });
 });
 
+/**
+ * Pins the Slack↔Teams gaps that peeling fields out of `<Actions>` did NOT
+ * close, so the follow-up that closes them has to flip an assertion rather than
+ * discover the divergence. Teams renders every node below outside an
+ * `<Actions>` (`Input.ChoiceSet`, an `Action.Submit`, and `Chart.Line`
+ * respectively); Slack's `renderNode` has no case for any of them.
+ */
+describe("Slack↔Teams render gaps (documented, not yet closed)", () => {
+  const select: ChannelNode = {
+    type: "select",
+    props: {
+      onSelect: { id: "ck:sel" },
+      options: [{ label: "A", value: "a" }],
+    },
+  };
+  const button: ChannelNode = {
+    type: "button",
+    props: {
+      onClick: { id: "ck:btn" },
+      children: [{ type: "text", props: { value: "Go" } }],
+    },
+  };
+  const chart: ChannelNode = {
+    type: "chart",
+    props: { type: "line", data: [{ label: "x", value: 1 }] },
+  };
+
+  it.each([
+    ["select", select],
+    ["button", button],
+    ["chart", chart],
+  ])("drops a top-level <%s> outside <Actions>", (_name, node) => {
+    expect(renderBlockKit([node])).toEqual([]);
+  });
+
+  it("drops all three together, emitting no blocks at all", () => {
+    expect(renderBlockKit([select, button, chart])).toEqual([]);
+  });
+
+  it("renders <Select> and <Button> inside <Actions>, but still drops <Chart>", () => {
+    const blocks = renderBlockKit([
+      { type: "actions", props: { children: [select, button, chart] } },
+    ]);
+    // The select is peeled into its own block; the button keeps an `actions`
+    // block. Nothing in between is the chart — it has no Slack rendering at
+    // any depth.
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toMatchObject({
+      type: "actions",
+      block_id: `${FIELD_BLOCK_PREFIX}ck:sel`,
+      elements: [{ type: "static_select" }],
+    });
+    expect(blocks[1]).toMatchObject({
+      type: "actions",
+      elements: [{ type: "button", action_id: "ck:btn" }],
+    });
+  });
+});
+
 /** `count` pre-bound `<Button>` IR nodes with distinct ids. */
 function buttons(count: number, prefix = "b"): ChannelNode[] {
   return Array.from({ length: count }, (_, i) => ({

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -137,7 +137,7 @@ describe("renderBlockKit", () => {
     ]);
   });
 
-  it("keeps the tall box for an <Input multiline> with no onSubmit, and claims no trigger for it", () => {
+  it("keeps the tall box for an <Input multiline> with no onSubmit, and dispatches nothing for it", () => {
     // Nothing to make unreachable: the text rides to a sibling `<Button>`'s
     // click in `state.values`, which needs no trigger on this element. Naming
     // one anyway would be the same unfireable configuration the bound case
@@ -153,7 +153,7 @@ describe("renderBlockKit", () => {
       {
         type: "input",
         block_id: "ckf:reason",
-        dispatch_action: true,
+        dispatch_action: false,
         element: {
           type: "plain_text_input",
           action_id: "reason",
@@ -162,6 +162,58 @@ describe("renderBlockKit", () => {
         label: { type: "plain_text", text: "Why?" },
       },
     ]);
+  });
+
+  it("does not let a decorative <Input> beside a <Button> claim a dispatch trigger", () => {
+    // The engine resolves a pending `thread.awaitChoice` on ANY interaction in
+    // the conversation, so an unbound notes box that dispatched would answer
+    // the Approve/Reject choice with whatever the user typed — the button
+    // handler never running. Only the button may dispatch here.
+    const blocks = renderBlockKit([
+      { type: "input", props: { name: "notes", placeholder: "Notes" } },
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "button",
+              props: {
+                onClick: { id: "ck:approve" },
+                children: [{ type: "text", props: { value: "Approve" } }],
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const input = blocks[0] as { type: string; dispatch_action: boolean };
+    expect(input.type).toBe("input");
+    expect(input.dispatch_action).toBe(false);
+    // …and the notes text still reaches the button's handler, because Slack
+    // reports every input in `state.values` regardless of `dispatch_action`.
+    expect(blocks[1]).toMatchObject({
+      type: "actions",
+      elements: [{ action_id: "ck:approve" }],
+    });
+  });
+
+  it("does not let an unbound <Select multi> claim a dispatch trigger", () => {
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            {
+              type: "select",
+              props: { multi: true, options: [{ label: "Core", value: "c" }] },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(blocks[0]).toMatchObject({ type: "input", dispatch_action: false });
   });
 
   it("gives a static_select a unique fallback action_id when onSelect is absent", () => {

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -92,8 +92,74 @@ describe("renderBlockKit", () => {
           type: "plain_text_input",
           action_id: "ck:in1",
           multiline: false,
+          // Enter-to-submit, named rather than left to Slack's default: a
+          // `plain_text_input`'s dispatch is "determined by the
+          // dispatch_action_config field" (Slack's block_actions reference).
+          dispatch_action_config: { trigger_actions_on: ["on_enter_pressed"] },
         },
         label: { type: "plain_text", text: "Name" },
+      },
+    ]);
+  });
+
+  it("renders a bound <Input multiline onSubmit> single-line, so Enter can submit it", () => {
+    // Slack cannot express both at once. In a multiline box Enter inserts a
+    // newline, so `on_enter_pressed` never fires; the only other trigger,
+    // `on_character_entered`, fires once per KEYSTROKE and would run
+    // `onSubmit` — a `ClickHandler<string>` promised "the submitted text" —
+    // on every prefix of it, resolving a `thread.awaitChoice` on the first
+    // character. A one-line box that submits the whole string beats a taller
+    // one that submits nothing or a fragment.
+    const blocks = renderBlockKit([
+      {
+        type: "input",
+        props: {
+          onSubmit: { id: "ck:note" },
+          placeholder: "Why?",
+          multiline: true,
+        },
+      },
+    ]);
+
+    expect(blocks).toEqual([
+      {
+        type: "input",
+        block_id: "ckf:ck:note",
+        dispatch_action: true,
+        element: {
+          type: "plain_text_input",
+          action_id: "ck:note",
+          multiline: false,
+          dispatch_action_config: { trigger_actions_on: ["on_enter_pressed"] },
+        },
+        label: { type: "plain_text", text: "Why?" },
+      },
+    ]);
+  });
+
+  it("keeps the tall box for an <Input multiline> with no onSubmit, and claims no trigger for it", () => {
+    // Nothing to make unreachable: the text rides to a sibling `<Button>`'s
+    // click in `state.values`, which needs no trigger on this element. Naming
+    // one anyway would be the same unfireable configuration the bound case
+    // avoids — `on_enter_pressed` cannot fire in a multiline box.
+    const blocks = renderBlockKit([
+      {
+        type: "input",
+        props: { name: "reason", placeholder: "Why?", multiline: true },
+      },
+    ]);
+
+    expect(blocks).toEqual([
+      {
+        type: "input",
+        block_id: "ckf:reason",
+        dispatch_action: true,
+        element: {
+          type: "plain_text_input",
+          action_id: "reason",
+          multiline: true,
+        },
+        label: { type: "plain_text", text: "Why?" },
       },
     ]);
   });
@@ -275,6 +341,13 @@ describe("renderBlockKit", () => {
     expect(block.dispatch_action).toBe(true);
     expect(block.element.type).toBe("multi_static_select");
     expect(block.element.action_id).toBe("ck:ms");
+    // `dispatch_action` alone IS reachable here, unlike on a multiline
+    // `plain_text_input`: Slack dispatches a `multi_*_select` "each time an
+    // item is chosen from the multi-select menu" (block_actions reference),
+    // with no trigger to configure. `dispatch_action_config` is documented as
+    // usable only with a plain-text or rich-text input, so adding one here
+    // would be an unsupported field, not a fix.
+    expect(block.element).not.toHaveProperty("dispatch_action_config");
   });
 
   it("renders an <Input> nested in <Actions> instead of dropping it", () => {

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -333,7 +333,113 @@ describe("renderBlockKit", () => {
       "input",
     ]);
   });
+
+  it("does not charge peeled-off inputs against the actions element budget", () => {
+    // The peeled <Input> and <Select multi> land in their own input blocks, so
+    // they occupy no slot in the actions block and must not cost it any.
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            { type: "input", props: { onSubmit: { id: "ck:note" } } },
+            {
+              type: "select",
+              props: {
+                multi: true,
+                onSelect: { id: "ck:ms" },
+                options: [{ label: "Core", value: "core" }],
+              },
+            },
+            ...buttons(25),
+          ],
+        },
+      },
+    ]);
+
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "input",
+      "input",
+      "actions",
+    ]);
+    expect((blocks[2] as { elements: unknown[] }).elements).toHaveLength(25);
+  });
+
+  it("budgets actions elements per emitted block, not per child list", () => {
+    // A peeled input splits the children across two actions blocks; each block
+    // is under the 25-element ceiling on its own, so nothing may be dropped.
+    const blocks = renderBlockKit([
+      {
+        type: "actions",
+        props: {
+          children: [
+            ...buttons(20, "a"),
+            { type: "input", props: { onSubmit: { id: "ck:note" } } },
+            ...buttons(20, "b"),
+          ],
+        },
+      },
+    ]);
+
+    expect(blocks.map((b) => (b as { type: string }).type)).toEqual([
+      "actions",
+      "input",
+      "actions",
+    ]);
+    expect((blocks[0] as { elements: unknown[] }).elements).toHaveLength(20);
+    expect((blocks[2] as { elements: unknown[] }).elements).toHaveLength(20);
+  });
+
+  it("still clamps an actions block that really overflows the element limit", () => {
+    const blocks = renderBlockKit([
+      { type: "actions", props: { children: buttons(30) } },
+    ]);
+
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { elements: unknown[] }).elements).toHaveLength(25);
+  });
+
+  it("counts the table header against the table row budget", () => {
+    // The header is a row of the emitted block, so 100 data rows + a header
+    // would put the table one row over Slack's ceiling.
+    const blocks = renderBlockKit([
+      {
+        type: "table",
+        props: {
+          columns: [{ header: "Name" }],
+          children: Array.from({ length: 100 }, (_, i) => ({
+            type: "row",
+            props: {
+              children: [
+                {
+                  type: "cell",
+                  props: {
+                    children: [{ type: "text", props: { value: `r${i}` } }],
+                  },
+                },
+              ],
+            },
+          })),
+        },
+      },
+    ]);
+
+    const rows = (blocks[0] as { rows: { text: string }[][] }).rows;
+    expect(rows).toHaveLength(100);
+    expect(rows[0]![0]!.text).toBe("Name");
+  });
 });
+
+/** `count` pre-bound `<Button>` IR nodes with distinct ids. */
+function buttons(count: number, prefix = "b"): ChannelNode[] {
+  return Array.from({ length: count }, (_, i) => ({
+    type: "button",
+    props: {
+      onClick: { id: `ck:${prefix}${i}` },
+      children: [{ type: "text", props: { value: `B${i}` } }],
+    },
+  }));
+}
 
 describe("renderSlackMessage", () => {
   it("extracts a top-level <Message accent> as the attachment color", () => {

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -115,6 +115,32 @@ describe("renderBlockKit", () => {
     expect(select.action_id.length).toBeGreaterThan(0);
   });
 
+  it("writes select option values verbatim, never JSON-encoded", () => {
+    // The wire codec the decoder is paired with: a `SelectOption.value` is a
+    // `string` and goes out as-is, so `interaction.ts` must NOT JSON-parse it
+    // back. (A `<Button>`'s value is the opposite — see the JSON.stringify
+    // case above.) Values that happen to look like JSON make the difference
+    // visible.
+    const options = [
+      { label: "A", value: "42" },
+      { label: "B", value: "true" },
+      { label: "C", value: "null" },
+    ];
+    for (const multi of [false, true]) {
+      const blocks = renderBlockKit([
+        {
+          type: "actions",
+          props: { children: [{ type: "select", props: { options, multi } }] },
+        },
+      ]);
+      const el = multi
+        ? (blocks[0] as { element: { options: { value: string }[] } }).element
+        : (blocks[0] as { elements: { options: { value: string }[] }[] })
+            .elements[0]!;
+      expect(el.options.map((o) => o.value)).toEqual(["42", "true", "null"]);
+    }
+  });
+
   it("renders a Table IR into a native Slack table block", () => {
     const ir: ChannelNode[] = [
       {

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -355,6 +355,10 @@ function renderActionElement(node: ChannelNode): object | null {
           type: "plain_text",
           text: String(props.placeholder ?? " "),
         },
+        // A plain string on the wire, never JSON: `SelectOption.value` is a
+        // `string`, so `interaction.ts` reads it back verbatim. (A `<Button>`'s
+        // value is the opposite — `JSON.stringify`d above, JSON-parsed on the
+        // way in.) `String(...)` keeps that true for an untyped JS caller.
         options: items.map((o) => ({
           text: { type: "plain_text", text: truncateText(o.label, 75) },
           value: truncateText(String(o.value), 150),
@@ -417,6 +421,7 @@ function multiSelectInput(node: ChannelNode): KnownBlock {
         type: "plain_text",
         text: String(props.placeholder ?? " "),
       },
+      // Verbatim strings, as in renderActionElement's `select` case.
       options: items.map((o) => ({
         text: { type: "plain_text", text: truncateText(o.label, 75) },
         value: truncateText(String(o.value), 150),

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -180,10 +180,6 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       return;
     }
     case "actions": {
-      const { items } = clampArray(
-        childNodes(node),
-        SLACK_LIMITS.actionsElements,
-      );
       // Neither a text input nor a multi-select can live in an `actions` block
       // (Slack allows both only in section/input blocks), so peel each one off
       // into its own dispatching input block; the rest stay as action elements.
@@ -195,11 +191,16 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       let elements: object[] = [];
       const flush = () => {
         if (elements.length > 0) {
-          out.push({ type: "actions", elements } as KnownBlock);
+          // `actionsElements` bounds one emitted `actions` block, so clamp
+          // here rather than over the children: peeled-off inputs and
+          // unrenderable children never take a slot in any block, and a peel
+          // splits the rest across several blocks that are budgeted apart.
+          const { items } = clampArray(elements, SLACK_LIMITS.actionsElements);
+          out.push({ type: "actions", elements: items } as KnownBlock);
           elements = [];
         }
       };
-      for (const child of items) {
+      for (const child of childNodes(node)) {
         if (child.type === "input") {
           flush();
           out.push(textInput(child));
@@ -267,7 +268,12 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       }
 
       const rowNodes = childNodes(node).filter((c) => c.type === "row");
-      const { items: dataRows } = clampArray(rowNodes, SLACK_LIMITS.tableRows);
+      // The header is a row of the emitted block too, so budget data rows
+      // against what it leaves of the table's row ceiling.
+      const { items: dataRows } = clampArray(
+        rowNodes,
+        SLACK_LIMITS.tableRows - rows.length,
+      );
       for (const rowNode of dataRows) {
         const cells = childNodes(rowNode).filter((c) => c.type === "cell");
         rows.push(cells.map((cell) => cellOf(collectText(cell))));

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -365,10 +365,46 @@ function renderActionElement(node: ChannelNode): object | null {
  * `plain_text_input` (which Slack forbids inside an `actions` block). Typing
  * and submitting fires a `block_actions` payload carrying the typed text
  * verbatim on the element's `action_id` — the registry-minted `onSubmit` id.
+ *
+ * `dispatch_action` on the block only permits that payload; WHEN it fires is
+ * the element's `dispatch_action_config` — a `plain_text_input`'s dispatch is
+ * "determined by the dispatch_action_config field" (Slack's `block_actions`
+ * reference), whose only two triggers are `on_enter_pressed` and
+ * `on_character_entered`. We name `on_enter_pressed` rather than lean on
+ * Slack's unspecified default: Enter-to-submit is the affordance `onSubmit`
+ * means, and naming it is what makes the multiline case below decidable.
+ *
+ * `multiline` is a presentation hint and `onSubmit` is a data contract, and on
+ * Slack a `plain_text_input` cannot honour both: a BOUND multiline input is
+ * therefore rendered single-line, so Enter submits it. Neither trigger works in
+ * a tall box —
+ *   - `on_enter_pressed` never fires, because Enter inserts a newline there.
+ *     That is the shape this replaces: the handler never ran, and a
+ *     `thread.awaitChoice` waiting on it hung forever.
+ *   - `on_character_entered` fires once per KEYSTROKE, so it would run
+ *     `onSubmit` on every prefix of the text and resolve an `awaitChoice` on
+ *     the first character. `onSubmit` is a `ClickHandler<string>` whose value
+ *     is the submitted text, not a fragment of it — a wrong value delivered
+ *     N times is worse than the hang it replaces.
+ * Slack also has no per-input submit button, and a synthesized one could not
+ * carry the text: only a static `value` rides on a `block_actions` action, so
+ * such a click would reach `onSubmit` (and any `awaitChoice`) as `undefined`
+ * while the text arrived separately in `state.values`. A one-line box that
+ * submits the whole string beats a taller box that submits nothing, a
+ * fragment, or nothing but a hole where the string should be.
+ *
+ * An UNBOUND `<Input multiline>` keeps its tall box: with no `onSubmit` there
+ * is nothing to make unreachable — its text rides to a sibling `<Button>`'s
+ * click in `state.values`, keyed by {@link fieldBlockId} — and it claims no
+ * trigger, since the one it could claim could not fire.
  */
 function textInput(node: ChannelNode, context: RenderContext): KnownBlock {
   const props = node.props ?? {};
   const id = fieldId(node, "onSubmit", "input", context);
+  // Only a handler-bound input has a submit to keep reachable; `multiline`
+  // costs an unbound one nothing, so it is honoured there.
+  const bound = idFromHandler(props.onSubmit) !== undefined;
+  const multiline = !!props.multiline && !bound;
   return {
     type: "input",
     block_id: fieldBlockId(id),
@@ -376,7 +412,17 @@ function textInput(node: ChannelNode, context: RenderContext): KnownBlock {
     element: {
       type: "plain_text_input",
       action_id: elementActionId(props.onSubmit, id),
-      multiline: !!props.multiline,
+      multiline,
+      // Claimed only where it can fire — see the multiline discussion above.
+      // Slack renders its own "press enter to submit" hint under a box
+      // configured this way.
+      ...(multiline
+        ? {}
+        : {
+            dispatch_action_config: {
+              trigger_actions_on: ["on_enter_pressed"],
+            },
+          }),
     },
     label: {
       type: "plain_text",

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -184,11 +184,14 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
         childNodes(node),
         SLACK_LIMITS.actionsElements,
       );
-      // A multi-select can't live in an `actions` block (Slack allows
-      // multi_static_select only in section/input blocks), so peel each one off
+      // Neither a text input nor a multi-select can live in an `actions` block
+      // (Slack allows both only in section/input blocks), so peel each one off
       // into its own dispatching input block; the rest stay as action elements.
-      // Flush the pending actions block BEFORE each peeled-off input so blocks
-      // stay in source order (e.g. [Button, Select multi] → actions, then input).
+      // Teams' `actions` case simply recurses, so peeling — rather than
+      // dropping — is what keeps identical JSX rendering the same on both MVP
+      // surfaces. Flush the pending actions block BEFORE each peeled-off input
+      // so blocks stay in source order (e.g. [Button, Select multi] → actions,
+      // then input).
       let elements: object[] = [];
       const flush = () => {
         if (elements.length > 0) {
@@ -197,6 +200,11 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
         }
       };
       for (const child of items) {
+        if (child.type === "input") {
+          flush();
+          out.push(textInput(child));
+          continue;
+        }
         if (child.type === "select" && child.props.multi) {
           flush();
           out.push(multiSelectInput(child));
@@ -222,22 +230,7 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       return;
     }
     case "input": {
-      out.push({
-        type: "input",
-        dispatch_action: true,
-        element: {
-          type: "plain_text_input",
-          action_id: truncateText(
-            idFromHandler(props.onSubmit) ?? "input",
-            SLACK_LIMITS.actionId,
-          ),
-          multiline: !!props.multiline,
-        },
-        label: {
-          type: "plain_text",
-          text: truncateText(String(props.placeholder ?? " "), 150),
-        },
-      } as KnownBlock);
+      out.push(textInput(node));
       return;
     }
     case "text": {
@@ -366,6 +359,32 @@ function renderActionElement(node: ChannelNode): object | null {
     default:
       return null;
   }
+}
+
+/**
+ * Render an `<Input>` as a dispatching input block holding a
+ * `plain_text_input` (which Slack forbids inside an `actions` block). Typing
+ * and submitting fires a `block_actions` payload carrying the typed text
+ * verbatim on the element's `action_id` — the registry-minted `onSubmit` id.
+ */
+function textInput(node: ChannelNode): KnownBlock {
+  const props = node.props ?? {};
+  return {
+    type: "input",
+    dispatch_action: true,
+    element: {
+      type: "plain_text_input",
+      action_id: truncateText(
+        idFromHandler(props.onSubmit) ?? "input",
+        SLACK_LIMITS.actionId,
+      ),
+      multiline: !!props.multiline,
+    },
+    label: {
+      type: "plain_text",
+      text: truncateText(String(props.placeholder ?? " "), 150),
+    },
+  } as KnownBlock;
 }
 
 /**

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -1,5 +1,6 @@
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { ContextActionsBlock, KnownBlock } from "@slack/types";
+import { FIELD_BLOCK_PREFIX } from "../interaction.js";
 import { markdownToMrkdwn } from "../markdown-to-mrkdwn.js";
 import { SLACK_LIMITS, clampArray, truncateText } from "./budget.js";
 
@@ -64,8 +65,9 @@ export function buildFeedbackBlocks(opts?: {
  */
 export function renderBlockKit(ir: ChannelNode[]): KnownBlock[] {
   const blocks: KnownBlock[] = [];
+  const context: RenderContext = { nextFieldIndex: 0, usedFieldIds: new Set() };
   for (const node of ir) {
-    renderNode(node, blocks);
+    renderNode(node, blocks, context);
   }
 
   // Top-level budget: clamp to the per-message block ceiling, leaving room for
@@ -96,6 +98,12 @@ export function renderSlackMessage(ir: ChannelNode[]): {
   return { blocks };
 }
 
+/** Per-message state for minting field ids — see {@link fieldId}. */
+interface RenderContext {
+  nextFieldIndex: number;
+  usedFieldIds: Set<string>;
+}
+
 function overflowSignal(count: number): KnownBlock {
   return {
     type: "context",
@@ -104,13 +112,17 @@ function overflowSignal(count: number): KnownBlock {
 }
 
 /** Render a single IR node, pushing zero or more blocks onto `out`. */
-function renderNode(node: ChannelNode, out: KnownBlock[]): void {
+function renderNode(
+  node: ChannelNode,
+  out: KnownBlock[],
+  context: RenderContext,
+): void {
   if (typeof node.type !== "string") return; // non-intrinsic — already expanded away
   const props = node.props ?? {};
   switch (node.type) {
     case "message": {
       // The message container is not a block; flatten its children.
-      for (const child of childNodes(node)) renderNode(child, out);
+      for (const child of childNodes(node)) renderNode(child, out, context);
       return;
     }
     case "header": {
@@ -180,14 +192,16 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       return;
     }
     case "actions": {
-      // Neither a text input nor a multi-select can live in an `actions` block
-      // (Slack allows both only in section/input blocks), so peel each one off
-      // into its own dispatching input block; the rest stay as action elements.
-      // Teams' `actions` case simply recurses, so peeling — rather than
-      // dropping — is what keeps identical JSX rendering the same on both MVP
-      // surfaces. Flush the pending actions block BEFORE each peeled-off input
-      // so blocks stay in source order (e.g. [Button, Select multi] → actions,
-      // then input).
+      // Every field is peeled into a block of its own, leaving `actions` blocks
+      // to the buttons. Two reasons, and both apply to all three field shapes:
+      // Slack forbids a text input and a multi-select inside an `actions` block
+      // at all (they belong in input blocks), and a field's `values` key rides
+      // on its block id (see `fieldBlockId`), which one shared block could only
+      // spell for one of them. Teams' `actions` case simply recurses, so peeling
+      // — rather than dropping — is what keeps identical JSX rendering the same
+      // on both MVP surfaces. Flush the pending actions block BEFORE each peeled
+      // field so blocks stay in source order (e.g. [Button, Select multi] →
+      // actions, then input).
       let elements: object[] = [];
       const flush = () => {
         if (elements.length > 0) {
@@ -203,12 +217,12 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       for (const child of childNodes(node)) {
         if (child.type === "input") {
           flush();
-          out.push(textInput(child));
+          out.push(textInput(child, context));
           continue;
         }
-        if (child.type === "select" && child.props.multi) {
+        if (child.type === "select") {
           flush();
-          out.push(multiSelectInput(child));
+          out.push(selectBlock(child, context));
           continue;
         }
         const el = renderActionElement(child);
@@ -231,7 +245,7 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       return;
     }
     case "input": {
-      out.push(textInput(node));
+      out.push(textInput(node, context));
       return;
     }
     case "text": {
@@ -303,8 +317,10 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
 }
 
 /**
- * Render one interactive element inside an `actions` block. Returns `null` for
- * children that aren't renderable as action elements (so callers can filter).
+ * Render one interactive element inside a shared `actions` block. Only a
+ * `<Button>` qualifies — every field is peeled into a block of its own by the
+ * caller. Returns `null` for children that aren't renderable as action elements
+ * (so callers can filter).
  */
 function renderActionElement(node: ChannelNode): object | null {
   if (typeof node.type !== "string") return null;
@@ -339,33 +355,6 @@ function renderActionElement(node: ChannelNode): object | null {
       }
       return el;
     }
-    case "select": {
-      const action_id = truncateText(
-        idFromHandler(props.onSelect) ?? "select",
-        SLACK_LIMITS.actionId,
-      );
-      const options =
-        (props.options as { label: string; value: unknown }[] | undefined) ??
-        [];
-      const { items } = clampArray(options, SLACK_LIMITS.selectOptions);
-      const el: Record<string, unknown> = {
-        type: "static_select",
-        action_id,
-        placeholder: {
-          type: "plain_text",
-          text: String(props.placeholder ?? " "),
-        },
-        // A plain string on the wire, never JSON: `SelectOption.value` is a
-        // `string`, so `interaction.ts` reads it back verbatim. (A `<Button>`'s
-        // value is the opposite — `JSON.stringify`d above, JSON-parsed on the
-        // way in.) `String(...)` keeps that true for an untyped JS caller.
-        options: items.map((o) => ({
-          text: { type: "plain_text", text: truncateText(o.label, 75) },
-          value: truncateText(String(o.value), 150),
-        })),
-      };
-      return el;
-    }
     default:
       return null;
   }
@@ -377,17 +366,16 @@ function renderActionElement(node: ChannelNode): object | null {
  * and submitting fires a `block_actions` payload carrying the typed text
  * verbatim on the element's `action_id` — the registry-minted `onSubmit` id.
  */
-function textInput(node: ChannelNode): KnownBlock {
+function textInput(node: ChannelNode, context: RenderContext): KnownBlock {
   const props = node.props ?? {};
+  const id = fieldId(node, "onSubmit", "input", context);
   return {
     type: "input",
+    block_id: fieldBlockId(id),
     dispatch_action: true,
     element: {
       type: "plain_text_input",
-      action_id: truncateText(
-        idFromHandler(props.onSubmit) ?? "input",
-        SLACK_LIMITS.actionId,
-      ),
+      action_id: elementActionId(props.onSubmit, id),
       multiline: !!props.multiline,
     },
     label: {
@@ -398,40 +386,100 @@ function textInput(node: ChannelNode): KnownBlock {
 }
 
 /**
- * Render a `<Select multi>` as a dispatching input block holding a
- * `multi_static_select` (which Slack forbids inside an `actions` block). The
- * block_actions payload carries `selected_options`, decoded to a `string[]`.
+ * Render a `<Select>` as a block of its own naming the field: an `input` block
+ * when `multi` (Slack forbids a `multi_static_select` inside an `actions` block
+ * and an input block is what dispatches it), else a single-element `actions`
+ * block, which is how a `static_select` renders inline. Either way the payload
+ * carries the chosen option value(s) — `selected_options` decodes to a
+ * `string[]`.
  */
-function multiSelectInput(node: ChannelNode): KnownBlock {
+function selectBlock(node: ChannelNode, context: RenderContext): KnownBlock {
   const props = node.props ?? {};
-  const action_id = truncateText(
-    idFromHandler(props.onSelect) ?? "select",
-    SLACK_LIMITS.actionId,
-  );
+  const id = fieldId(node, "onSelect", "select", context);
   const options =
     (props.options as { label: string; value: unknown }[] | undefined) ?? [];
   const { items } = clampArray(options, SLACK_LIMITS.selectOptions);
+  const element = {
+    type: props.multi ? "multi_static_select" : "static_select",
+    action_id: elementActionId(props.onSelect, id),
+    placeholder: {
+      type: "plain_text",
+      text: String(props.placeholder ?? " "),
+    },
+    // A plain string on the wire, never JSON: `SelectOption.value` is a
+    // `string`, so `interaction.ts` reads it back verbatim. (A `<Button>`'s
+    // value is the opposite — `JSON.stringify`d above, JSON-parsed on the way
+    // in.) `String(...)` keeps that true for an untyped JS caller.
+    options: items.map((o) => ({
+      text: { type: "plain_text", text: truncateText(o.label, 75) },
+      value: truncateText(String(o.value), 150),
+    })),
+  };
+  if (!props.multi) {
+    return {
+      type: "actions",
+      block_id: fieldBlockId(id),
+      elements: [element],
+    } as KnownBlock;
+  }
   return {
     type: "input",
+    block_id: fieldBlockId(id),
     dispatch_action: true,
-    element: {
-      type: "multi_static_select",
-      action_id,
-      placeholder: {
-        type: "plain_text",
-        text: String(props.placeholder ?? " "),
-      },
-      // Verbatim strings, as in renderActionElement's `select` case.
-      options: items.map((o) => ({
-        text: { type: "plain_text", text: truncateText(o.label, 75) },
-        value: truncateText(String(o.value), 150),
-      })),
-    },
+    element,
     label: {
       type: "plain_text",
       text: truncateText(String(props.placeholder ?? " "), 150),
     },
   } as KnownBlock;
+}
+
+/**
+ * The key this field's reading appears under in an interaction's `values`,
+ * derived exactly as Teams derives the Adaptive Card element `id` that plays the
+ * same role (`fieldId()` in channels-teams' `render/adaptive-card.ts`): an
+ * explicit `name` wins, else the registry-minted handler id, else a positional
+ * fallback numbered off a counter every field advances. Deduped with a numbered
+ * suffix, because two fields keyed alike would overwrite one another's reading.
+ */
+function fieldId(
+  node: ChannelNode,
+  handlerProp: "onSubmit" | "onSelect",
+  fallback: "input" | "select",
+  context: RenderContext,
+): string {
+  const props = node.props ?? {};
+  const index = ++context.nextFieldIndex;
+  const name = typeof props.name === "string" ? props.name.trim() : "";
+  const base =
+    name || idFromHandler(props[handlerProp]) || `${fallback}_${index}`;
+  let candidate = base;
+  let suffix = 1;
+  while (context.usedFieldIds.has(candidate)) {
+    candidate = `${base}_${suffix++}`;
+  }
+  context.usedFieldIds.add(candidate);
+  return candidate;
+}
+
+/**
+ * The `block_id` naming the single field a block holds, so `decodeInteraction`
+ * can key `values` by it. Slack caps a block id at the same 255 chars as an
+ * action id; the decode reads the key straight back off the block id, so a
+ * truncated one stays self-consistent.
+ */
+function fieldBlockId(id: string): string {
+  return truncateText(FIELD_BLOCK_PREFIX + id, SLACK_LIMITS.actionId);
+}
+
+/**
+ * A field element's `action_id`. The registry-minted handler id when there is
+ * one — the engine dispatches on exactly that string, so honouring `name` must
+ * not touch it — else the field id, which is unique where the old `"input"` /
+ * `"select"` literals collided.
+ */
+function elementActionId(handler: unknown, id: string): string {
+  return truncateText(idFromHandler(handler) ?? id, SLACK_LIMITS.actionId);
 }
 
 /** Derive a button's `action_id`: prefer the registry-stamped id, else a stable fallback. */

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -193,20 +193,30 @@ function renderNode(
     }
     case "actions": {
       // Every field is peeled into a block of its own, leaving `actions` blocks
-      // to the buttons. Two reasons, and both apply to all three field shapes:
-      // Slack forbids a text input and a multi-select inside an `actions` block
-      // at all (they belong in input blocks), and a field's `values` key rides
-      // on its block id (see `fieldBlockId`), which one shared block could only
-      // spell for one of them. Teams' `actions` case simply recurses, so peeling
-      // — rather than dropping — is what keeps identical JSX rendering the same
-      // on both MVP surfaces. Flush the pending actions block BEFORE each peeled
-      // field so blocks stay in source order (e.g. [Button, Select multi] →
-      // actions, then input).
+      // to the buttons. Slack forbids a text input and a multi-select inside an
+      // `actions` block at all (they belong in input blocks), which forces the
+      // peel for those two. A single `static_select` Slack *would* allow inline,
+      // and it is peeled anyway: a field's `values` key rides on its block id
+      // (see `fieldBlockId`), which one shared block could only spell for one
+      // field. Flush the pending actions block BEFORE each peeled field so
+      // blocks stay in source order (e.g. [Button, Select multi] → actions,
+      // then input).
+      //
+      // Peeling rather than dropping is what puts every field inside
+      // `<Actions>` onto Slack, which is what Teams does with the same JSX —
+      // its `actions` case just recurses into its full node switch. The match
+      // ends at that wrapper. Slack's `renderNode` has no top-level `select`,
+      // `button` or `chart` case, so all three render to nothing when they
+      // appear OUTSIDE an `<Actions>`, while Teams renders all three there;
+      // and `<Chart>` has no Slack rendering at any depth, since
+      // `renderActionElement` drops it inside `<Actions>` too. Identical JSX
+      // therefore still diverges across the two surfaces in those cases —
+      // closing that is separate follow-up work, not something this peel did.
       let elements: object[] = [];
       const flush = () => {
         if (elements.length > 0) {
           // `actionsElements` bounds one emitted `actions` block, so clamp
-          // here rather than over the children: peeled-off inputs and
+          // here rather than over the children: peeled-off fields and
           // unrenderable children never take a slot in any block, and a peel
           // splits the rest across several blocks that are budgeted apart.
           const { items } = clampArray(elements, SLACK_LIMITS.actionsElements);
@@ -319,8 +329,9 @@ function renderNode(
 /**
  * Render one interactive element inside a shared `actions` block. Only a
  * `<Button>` qualifies — every field is peeled into a block of its own by the
- * caller. Returns `null` for children that aren't renderable as action elements
- * (so callers can filter).
+ * caller. Returns `null` for every other child, which the caller then drops:
+ * a `<Chart>` inside `<Actions>` reaches Slack as nothing, where Teams renders
+ * it, because Teams' `actions` case recurses into its full node switch.
  */
 function renderActionElement(node: ChannelNode): object | null {
   if (typeof node.type !== "string") return null;
@@ -436,8 +447,9 @@ function textInput(node: ChannelNode, context: RenderContext): KnownBlock {
  * when `multi` (Slack forbids a `multi_static_select` inside an `actions` block
  * and an input block is what dispatches it), else a single-element `actions`
  * block, which is how a `static_select` renders inline. Either way the payload
- * carries the chosen option value(s) — `selected_options` decodes to a
- * `string[]`.
+ * carries the chosen option value(s), in the shape the element reports it:
+ * `selected_option` for the single case (decoded to a `string`),
+ * `selected_options` for the multi case (decoded to a `string[]`).
  */
 function selectBlock(node: ChannelNode, context: RenderContext): KnownBlock {
   const props = node.props ?? {};
@@ -482,11 +494,19 @@ function selectBlock(node: ChannelNode, context: RenderContext): KnownBlock {
 
 /**
  * The key this field's reading appears under in an interaction's `values`,
- * derived exactly as Teams derives the Adaptive Card element `id` that plays the
+ * derived the way Teams derives the Adaptive Card element `id` that plays the
  * same role (`fieldId()` in channels-teams' `render/adaptive-card.ts`): an
  * explicit `name` wins, else the registry-minted handler id, else a positional
  * fallback numbered off a counter every field advances. Deduped with a numbered
  * suffix, because two fields keyed alike would overwrite one another's reading.
+ *
+ * One Teams rule is deliberately absent here: Teams also refuses a `name` that
+ * collides with a `CARD_ENVELOPE_KEYS` entry, and seeds its used-id set with
+ * those keys, because every Teams reading shares one submit-data object with
+ * that envelope. A Slack field's key rides on its own block id instead, so
+ * there is nothing to collide with. The two surfaces therefore key a
+ * `<Select name="ckActionId">` differently — `ckActionId` here, the minted
+ * handler id on Teams.
  */
 function fieldId(
   node: ChannelNode,

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -419,7 +419,14 @@ function textInput(node: ChannelNode, context: RenderContext): KnownBlock {
   return {
     type: "input",
     block_id: fieldBlockId(id),
-    dispatch_action: true,
+    // Bound inputs only. An unbound box has no handler to reach, so a trigger
+    // here would post an interaction whose id dispatches nothing — and the
+    // engine resolves a pending `thread.awaitChoice` on ANY interaction in the
+    // conversation, so a decorative notes field would answer someone else's
+    // approval with whatever was typed in it. Its text still reaches handlers:
+    // Slack reports every input in `state.values` when a sibling `<Button>` is
+    // clicked, whether or not the input itself dispatches.
+    dispatch_action: bound,
     element: {
       type: "plain_text_input",
       action_id: elementActionId(props.onSubmit, id),
@@ -483,7 +490,10 @@ function selectBlock(node: ChannelNode, context: RenderContext): KnownBlock {
   return {
     type: "input",
     block_id: fieldBlockId(id),
-    dispatch_action: true,
+    // Bound selects only, for the same reason as `textInput`: an unbound
+    // multi-select that dispatches would resolve a pending `awaitChoice` with
+    // its own selection. Its reading still rides along in `state.values`.
+    dispatch_action: idFromHandler(props.onSelect) !== undefined,
     element,
     label: {
       type: "plain_text",

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -35,10 +35,10 @@ the action's `data`:
 ### The synthesized submit
 
 Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches us
-when some `Action.Submit` on the card fires. A card whose only controls are
-`<Input>`/`<Select>` would therefore have **zero** actions and could not be
-submitted at all, so `renderAdaptiveCard` appends one bound to the first
-handler-bound field:
+when some `Action.Submit` on the card fires, and `renderButton` is the only other
+producer of one. A card that has no submit able to route the click therefore
+cannot deliver its inputs anywhere, so `renderAdaptiveCard` appends one bound to
+the first handler-bound field:
 
 ```jsonc
 {
@@ -52,8 +52,22 @@ handler-bound field:
 ```
 
 The two differ whenever an explicit `<Input name>` (or a collision suffix) renames
-the field, so both are carried. This action is appended **only** when the card has
-no other action and at least one field is bound to a handler.
+the field, so both are carried.
+
+It is appended only when the card has **no dispatchable submit** — an
+`Action.Submit` carrying a `ckActionId`. Having _some_ action is not enough: an
+`Action.OpenUrl` (a link `<Button>`) opens a URL and submits nothing, and a
+`<Button>` with no `onClick` submits but routes nowhere, so an `<Input>` beside
+either still needs one.
+
+**One submit per card.** Adaptive Cards fires a single action, so only the first
+handler-bound field is bound; later `<Input onSubmit>` handlers never fire. Their
+text is _not_ lost — Teams merges every input into this one submit, so all of them
+arrive as submitted fields. Read them from `activity.value` (or
+`InteractionEvent.values`) rather than expecting a per-input handler.
+
+A field dropped by the body-element budget is skipped, since a submit with no
+visible input above it would dispatch `undefined` to a `ClickHandler<string>`.
 
 ## Inbound — what Teams delivers on click
 

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -13,18 +13,18 @@ Decoder: `parseCardAction` in [`src/interaction.ts`](../src/interaction.ts).
 
 ## Outbound — what the renderer emits
 
-A **non-link** `<Button>` — one with no `url` prop — renders as a **top-level
-Adaptive Card `Action.Submit`**, deliberately `Action.Submit` and **not
-`Action.Execute`** (no `verb`). Whether it carries an `onClick` handler decides
-what goes in `data`, not which action type is emitted. The opaque action id and
-optional value ride in the action's `data`:
+A **non-link** `<Button>` — one with no non-empty `url` prop — renders as a
+**top-level Adaptive Card `Action.Submit`**, deliberately `Action.Submit` and
+**not `Action.Execute`** (no `verb`) — but only when it carries an `onClick`
+handler, whose minted id is the one thing that can route the click back. The
+opaque action id and optional value ride in the action's `data`:
 
 ```jsonc
 {
   "type": "Action.Submit",
   "title": "Approve", // the button's text, truncated to TEAMS_LIMITS.buttonText
   "data": {
-    "ckActionId": "ck:approve", // opaque id; present only when the Button had an onClick handler
+    "ckActionId": "ck:approve", // opaque id; always present — see the drop rule below
     "value": { "decision": "yes" }, // present only when the Button had a `value` prop
   },
   "style": "positive", // optional: "positive" (style="primary") | "destructive" (style="danger" | "destructive")
@@ -33,9 +33,17 @@ optional value ride in the action's `data`:
 
 - A **link** `<Button>` (a non-empty `url` prop) renders as `Action.OpenUrl`
   instead and carries **no** `data` — it is not a submit and never round-trips.
-- `data` is omitted entirely if the button has neither an `onClick` id nor a
-  `value`. Such an `Action.Submit` still renders and still posts an activity, but
-  with no `ckActionId` the decoder rejects it as not-a-card-action.
+- **A `<Button>` with neither a non-empty `url` nor an `onClick` emits no action
+  at all** — not a dead `Action.Submit`. Adaptive Cards has no inert button: such
+  a submit would still post an activity, one the decoder rejects as
+  not-a-card-action (no `ckActionId`) and the adapter then drives as a blank user
+  turn; and because Teams merges every card input into whichever submit fires,
+  the click would also swallow whatever the user had typed. A `value` prop is not
+  a route — the decode keys on `ckActionId` — so a `<Button value>` with no
+  `onClick` is dropped just the same. A card left with no actions this way emits
+  no `actions` key at all, unless a submit is synthesized below.
+- So `data` is never emitted without a `ckActionId`: every `Action.Submit` on a
+  card this renderer produces can route its own click.
 - `renderButton` never emits `ckValueField`. That key belongs solely to the
   synthesized submit below.
 
@@ -45,7 +53,7 @@ Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches us
 when some `Action.Submit` on the card fires, and `renderButton` is the only other
 producer of one. A card with no submit able to route the click therefore cannot
 deliver its inputs anywhere, so `renderAdaptiveCard` adds one (`synthesizeSubmit`)
-bound to a handler-bound field:
+bound to a field that can both route a dispatch and produce a value:
 
 ```jsonc
 {
@@ -65,16 +73,24 @@ collision-dedupe suffix) renames the field, so both are carried.
 **When it is added.** Only when the card has **no dispatchable submit** — an
 `Action.Submit` whose `data.ckActionId` is a string. Having _some_ action is not
 enough: an `Action.OpenUrl` (a link `<Button>`) opens a URL and submits nothing,
-and a `<Button>` with no `onClick` submits but routes nowhere, so a field beside
-either still needs one.
+so a field beside one still needs a synthesized submit. A `<Button>` that routes
+nowhere does not enter into it either way — it is never emitted, so it can
+neither suppress synthesis nor compete for the click.
 
-**Which field it binds.** The _first_ field, in render order, that both (a) had a
-minted handler — `<Input onSubmit>` **or** `<Select onSelect>`; a field with
-neither is never a candidate — and (b) survived the `TEAMS_LIMITS.bodyElements`
-clamp. A field the body clamp dropped is skipped as a candidate, because a Submit
-with no visible input above it would dispatch `undefined` to a
-`ClickHandler<string>`. If no candidate survives, **nothing is synthesized** and
-the card can end up with no actions at all.
+**Which field it binds.** The _first_ field, in render order, meeting **all
+three** of: (a) it had a minted handler — `<Input onSubmit>` **or**
+`<Select onSelect>`; a field with neither is never a candidate; (b) it can
+produce a value — an `Input.Text` always can (it submits a string, empty when
+untouched), but an **option-less `<Select>`** cannot, since an empty
+`Input.ChoiceSet` offers nothing to pick; and (c) it survived the
+`TEAMS_LIMITS.bodyElements` clamp. (b) and (c) share a reason: a Submit bound to
+a field that is not there, or has nothing to give, would dispatch `undefined` to
+a `ClickHandler<string>`. A field failing any of the three is _skipped_, not
+consumed — an option-less `<Select>` above a usable `<Input>` leaves the
+`<Input>` to back the submit. Note the option-less `<Select>` is still rendered
+in the body, as an empty `Input.ChoiceSet`; only its candidacy is withheld. If no
+candidate survives, **nothing is synthesized** and the card can end up with no
+actions at all.
 
 **One submit per card.** Adaptive Cards fires a single action, so only that first
 field is bound; later `<Input onSubmit>` / `<Select onSelect>` handlers never

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -32,6 +32,29 @@ the action's `data`:
   carries **no** `data` — it is not an interactive submit and never round-trips.
 - `data` is omitted entirely if the button has neither an `onClick` id nor a `value`.
 
+### The synthesized submit
+
+Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches us
+when some `Action.Submit` on the card fires. A card whose only controls are
+`<Input>`/`<Select>` would therefore have **zero** actions and could not be
+submitted at all, so `renderAdaptiveCard` appends one bound to the first
+handler-bound field:
+
+```jsonc
+{
+  "type": "Action.Submit",
+  "title": "Submit",
+  "data": {
+    "ckActionId": "ck:note", // the field's minted handler id — what gets dispatched
+    "ckValueField": "reason", // the card `id` of the field whose text IS the action value
+  },
+}
+```
+
+The two differ whenever an explicit `<Input name>` (or a collision suffix) renames
+the field, so both are carried. This action is appended **only** when the card has
+no other action and at least one field is bound to a handler.
+
 ## Inbound — what Teams delivers on click
 
 Clicking an `Action.Submit` arrives as a **Message activity** (`activity.type ===
@@ -55,12 +78,19 @@ The action's `data` becomes `activity.value`, and the message `text` is empty:
 
 - **Is it a card action?** `typeof activity.value.ckActionId === "string"`. If not,
   it's an ordinary chat message.
-- **Fields:** `id = activity.value.ckActionId`, `value = activity.value.value`.
-  Carry only these two — no resume-data smuggling; durability rides on the
-  consumer's action store keyed by `id`.
+- **Fields:** `id = activity.value.ckActionId`. No resume-data smuggling —
+  durability rides on the consumer's action store keyed by `id`.
 - **Card inputs:** if the card also had `<Input>`/`<Select>` fields, Teams merges
-  their values into `activity.value` alongside `ckActionId`/`value`. Read the
-  named input keys directly from `activity.value` if needed.
+  their values into `activity.value` alongside the envelope keys. Every key that
+  is **not** `ckActionId` / `value` / `ckValueField` is a submitted field; those
+  three names are reserved and are never minted as field ids.
+- **Action value:** `activity.value[ckValueField]` when `ckValueField` is set and
+  names a present field (the synthesized input submit — the dispatched handler is
+  an `<Input onSubmit>`, whose contract is the typed text), else
+  `activity.value.value` (the clicked button's own value).
+- **Typed text is a string.** Teams delivers `Input.Text` values as strings and
+  nothing may coerce them: `42`, `true`, `null` and `{"a":1}` must reach the
+  handler as those four strings.
 - **Conversation key:** derive it from `activity.conversation.id` (see
   `conversationKeyOf`). Ingress and interaction decode MUST use the same key or the
   waiter is stranded.

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -203,12 +203,37 @@ the adapter never reads `activity.text` on this path:
 - **Typed text is a string.** Teams delivers `Input.Text` values as strings and
   nothing may coerce them: `42`, `true`, `null` and `{"a":1}` must reach the
   handler as those four strings.
-- **`values` carries only submitted data.** `parseCardAction` builds it with a
-  null prototype, because `__proto__` survives `JSON.parse` as an own key: an
-  out-of-band decoder that copies fields onto a plain `{}` runs
-  `Object.prototype`'s setter instead, and the handler then sees an invisible
-  inherited property in place of the submitted value. Build the field map with
-  `Object.create(null)`.
+- **Write each field with `defineProperty`; keep the bag an ordinary object.**
+  `__proto__` survives `JSON.parse` as an own key, so a crafted submit really
+  can carry one. A decoder that copies fields with `bag[key] = fieldValue` runs
+  `Object.prototype`'s `__proto__` **setter** instead of creating a field: the
+  submitted value vanishes from `Object.keys(bag)` and — being an object —
+  becomes the bag's prototype, so everything it carries reads back off the bag
+  as though it had been submitted. `parseCardAction` writes every field with
+  `Object.defineProperty` (see `setField` in `src/interaction.ts`), which
+  performs `[[DefineOwnProperty]]` and never consults a setter, so `__proto__`
+  lands as ordinary enumerable own data like any other field id. Reproduce with
+  `JSON.parse('{"ckActionId":"ck:x","__proto__":{"injected":true},"reason":"ok"}')`:
+  `values.injected` is `undefined`, `Object.keys(values)` is
+  `["__proto__", "reason"]`, and the global `Object.prototype` is untouched.
+  **Do _not_ reach for `Object.create(null)`.** It blocks the same injection,
+  but at a price you cannot pay here: `values` is public API — it reaches
+  application handlers as `ctx.values`, typed `Record<string, unknown>` — and a
+  prototype-less bag makes ordinary consumer code like
+  `ctx.values.hasOwnProperty(id)` throw and `String(ctx.values)` break.
+  `Object.getPrototypeOf(values)` is `Object.prototype`.
+- **What the ordinary prototype costs, and what it does not.** Because the bag
+  keeps its prototype, a field id that was **not** submitted but is spelled like
+  a builtin reads back the builtin rather than `undefined` — `values.toString`
+  is a function on a bag carrying no `toString` field. That is true of every
+  `Record<string, unknown>` on this API, and it is not the injection; test
+  presence with `Object.hasOwn(values, id)` or `Object.keys(values)`, never
+  truthiness. The half that _is_ guaranteed: a field that **was** submitted
+  always wins, because `defineProperty` creates an own property that shadows its
+  `Object.prototype` namesake — a submitted `toString` reads back as the
+  submitted string. The `ckValueField` lookup is `hasOwnProperty`-guarded for
+  the same reason, so a `ckValueField` naming an unsubmitted builtin misses and
+  takes the fallback above rather than dispatching `Object.prototype.toString`.
 - **Conversation key:** derive it from `activity.conversation.id` (see
   `conversationKeyOf`). Ingress and interaction decode MUST use the same key or
   the waiter is stranded.

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -16,8 +16,10 @@ Decoder: `parseCardAction` in [`src/interaction.ts`](../src/interaction.ts).
 A **non-link** `<Button>` — one with no non-empty `url` prop — renders as a
 **top-level Adaptive Card `Action.Submit`**, deliberately `Action.Submit` and
 **not `Action.Execute`** (no `verb`) — but only when it carries an `onClick`
-handler, whose minted id is the one thing that can route the click back. The
-opaque action id and optional value ride in the action's `data`:
+handler that the action registry has already stamped with an id (the renderer
+reads `onClick.id`, and that minted id is the one thing that can route the click
+back; an unstamped handler is indistinguishable from none here). The opaque
+action id and optional value ride in the action's `data`:
 
 ```jsonc
 {
@@ -27,9 +29,16 @@ opaque action id and optional value ride in the action's `data`:
     "ckActionId": "ck:approve", // opaque id; always present — see the drop rule below
     "value": { "decision": "yes" }, // present only when the Button had a `value` prop
   },
-  "style": "positive", // optional: "positive" (style="primary") | "destructive" (style="danger" | "destructive")
+  "style": "positive", // optional: "positive" (style="primary") | "destructive" (style="danger")
 }
 ```
+
+`ButtonProps.style` offers exactly `"primary" | "danger"` — those are the only
+two values a typed caller can send, and they map to Adaptive Cards' `"positive"`
+and `"destructive"`. `renderButton` additionally tolerates the raw
+`"destructive"` (same result as `"danger"`), for untyped callers reaching the
+renderer through a deep import; that is not a `<Button>` prop value and should
+not be relied on. Anything else leaves `style` off the action entirely.
 
 - A **link** `<Button>` (a non-empty `url` prop) renders as `Action.OpenUrl`
   instead and carries **no** `data` — it is not a submit and never round-trips.
@@ -95,15 +104,18 @@ actions at all.
 **One submit per card.** Adaptive Cards fires a single action, so only that first
 field is bound; later `<Input onSubmit>` / `<Select onSelect>` handlers never
 fire. Their values are _not_ lost — Teams merges every input into this one submit,
-so all of them arrive as submitted fields. Read them from `activity.value` (or
+so all of them arrive as submitted fields, including any the user left blank (as
+`""` — see the inbound rules below). Read them from `activity.value` (or
 `InteractionEvent.values`) rather than expecting a per-field handler.
 
-**Action budget.** Top-level actions are clamped to `TEAMS_LIMITS.actions` (6),
-and the synthesized submit's slot is reserved _inside_ that ceiling: the authored
-actions are clamped to `actions - 1` and the submit is then appended. So a card
-never emits more than the ceiling, the submit — the card's only route back into
-the engine — is never the entry the clamp drops, and it is always **last** in
-`actions`.
+**Action budget.** Top-level actions are clamped to `TEAMS_LIMITS.actions`, so a
+card never emits more than that many. _When a submit is synthesized_, its slot is
+reserved **inside** that ceiling — the authored actions are clamped to
+`TEAMS_LIMITS.actions - 1` and the submit is appended afterwards — so the submit,
+the card's only route back into the engine, is never the entry the clamp drops,
+and it is always **last** in `actions`. When nothing is synthesized the authored
+actions get the whole ceiling and keep the author's order, with no guarantee
+about which action is last.
 
 **Overflow does not create one.** Whether to synthesize is decided against the
 _unclamped_ action list. A dispatchable `<Button>` that the action clamp then
@@ -151,6 +163,20 @@ the adapter never reads `activity.text` on this path:
   three names are reserved (`CARD_ENVELOPE_KEYS`): the renderer seeds its used-id
   set with them and ignores an explicit `name` that matches one, so no field is
   ever minted under them.
+- **Which key a field arrives under.** Teams keys a submitted field by the card
+  `id` the renderer minted for it, so this rule is part of the wire contract for
+  anyone reading `values` (or `ckValueField`) out-of-band. `fieldId` picks, in
+  order: (1) the `name` prop, trimmed, when it is non-empty and not one of the
+  reserved keys; (2) otherwise the field's own minted handler id — the
+  `<Input onSubmit>` / `<Select onSelect>` id, the same string that would appear
+  in `ckActionId`; (3) otherwise a positional `input_N` / `select_N`, where `N`
+  counts every field on the card in render order, 1-based, with `<Input>`s and
+  `<Select>`s sharing one counter (so a `<Select>` then an `<Input>` yields
+  `select_1` then `input_2`). Whatever the source, a name already taken on the
+  card takes the first free `_1`, `_2`, … suffix: two `<Input>`s bound to the
+  same handler arrive as `ck:note` and `ck:note_1`. Field ids are card-local —
+  do not assume one is an action id, and do not assume it is stable across
+  renders of a card whose fields moved.
 - **Action value:** `activity.value[ckValueField]` when `ckValueField` is a string
   **and** that key is present among the submitted fields. That is the synthesized
   submit: the dispatched handler is an `<Input onSubmit>` or `<Select onSelect>`,
@@ -164,6 +190,16 @@ the adapter never reads `activity.text` on this path:
   `undefined`. A `ckValueField` naming a reserved key misses for the same reason
   (reserved keys are stripped before the lookup), though the renderer never emits
   one.
+- **An untouched input still arrives — as `""`.** Teams merges _every_ `Input.*`
+  on the card into the submit, not only the ones the user touched, so a field
+  left blank is present in `values` carrying an empty string: not absent, and not
+  `null`. `<Input onSubmit>` is a `ClickHandler<string>` and `""` is the reading
+  that contract promises for an empty box. `@copilotkit/channels-slack` matches
+  this — Slack reports an empty `plain_text_input` as `value: null` and its
+  decoder normalizes that to `""` — so identical JSX reads identically on both
+  surfaces. Modelled by the Teams-client simulation in
+  [`src/input-submit.e2e.test.ts`](../src/input-submit.e2e.test.ts), which
+  derives its payload from the rendered card rather than from what was typed.
 - **Typed text is a string.** Teams delivers `Input.Text` values as strings and
   nothing may coerce them: `42`, `true`, `null` and `{"a":1}` must reach the
   handler as those four strings.

--- a/packages/channels-teams/docs/button-action-envelope.md
+++ b/packages/channels-teams/docs/button-action-envelope.md
@@ -1,79 +1,113 @@
 # HITL button action envelope
 
-Authoritative wire shape for buttons rendered by `@copilotkit/channels-teams` and
-the click Teams delivers back. A consumer that decodes clicks out-of-band (e.g.
-the Intelligence managed-Teams ingress, which deep-imports this package's renderer
-but runs its own inbound decode) must match this exactly.
+Authoritative wire shape for the Adaptive Card actions `@copilotkit/channels-teams`
+emits and the click Teams delivers back. A consumer that decodes clicks out-of-band
+(e.g. the Intelligence managed-Teams ingress, which deep-imports this package's
+renderer but runs its own inbound decode) must match this exactly.
 
 Contract test: [`src/button-action-envelope.contract.test.ts`](../src/button-action-envelope.contract.test.ts).
-Emitter: `renderButton` in [`src/render/adaptive-card.ts`](../src/render/adaptive-card.ts).
+Emitters (both in [`src/render/adaptive-card.ts`](../src/render/adaptive-card.ts)):
+`renderButton` for a `<Button>`, `synthesizeSubmit` for the submit the renderer
+adds to a card that has none it can dispatch.
 Decoder: `parseCardAction` in [`src/interaction.ts`](../src/interaction.ts).
 
 ## Outbound — what the renderer emits
 
-A `<Button>` (with an `onClick` handler, i.e. not a link button) renders as a
-**top-level Adaptive Card `Action.Submit`** — deliberately `Action.Submit`, **not
-`Action.Execute`** (no `verb`). The opaque action id and optional value ride in
-the action's `data`:
+A **non-link** `<Button>` — one with no `url` prop — renders as a **top-level
+Adaptive Card `Action.Submit`**, deliberately `Action.Submit` and **not
+`Action.Execute`** (no `verb`). Whether it carries an `onClick` handler decides
+what goes in `data`, not which action type is emitted. The opaque action id and
+optional value ride in the action's `data`:
 
 ```jsonc
 {
   "type": "Action.Submit",
-  "title": "Approve",
+  "title": "Approve", // the button's text, truncated to TEAMS_LIMITS.buttonText
   "data": {
     "ckActionId": "ck:approve", // opaque id; present only when the Button had an onClick handler
     "value": { "decision": "yes" }, // present only when the Button had a `value` prop
   },
-  "style": "positive", // optional: "positive" (primary) | "destructive" (danger)
+  "style": "positive", // optional: "positive" (style="primary") | "destructive" (style="danger" | "destructive")
 }
 ```
 
-- A **link** `<Button>` (has a `url` prop) renders as `Action.OpenUrl` instead and
-  carries **no** `data` — it is not an interactive submit and never round-trips.
-- `data` is omitted entirely if the button has neither an `onClick` id nor a `value`.
+- A **link** `<Button>` (a non-empty `url` prop) renders as `Action.OpenUrl`
+  instead and carries **no** `data` — it is not a submit and never round-trips.
+- `data` is omitted entirely if the button has neither an `onClick` id nor a
+  `value`. Such an `Action.Submit` still renders and still posts an activity, but
+  with no `ckActionId` the decoder rejects it as not-a-card-action.
+- `renderButton` never emits `ckValueField`. That key belongs solely to the
+  synthesized submit below.
 
 ### The synthesized submit
 
 Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches us
 when some `Action.Submit` on the card fires, and `renderButton` is the only other
-producer of one. A card that has no submit able to route the click therefore
-cannot deliver its inputs anywhere, so `renderAdaptiveCard` appends one bound to
-the first handler-bound field:
+producer of one. A card with no submit able to route the click therefore cannot
+deliver its inputs anywhere, so `renderAdaptiveCard` adds one (`synthesizeSubmit`)
+bound to a handler-bound field:
 
 ```jsonc
 {
   "type": "Action.Submit",
-  "title": "Submit",
+  "title": "Submit", // always this literal
   "data": {
     "ckActionId": "ck:note", // the field's minted handler id — what gets dispatched
-    "ckValueField": "reason", // the card `id` of the field whose text IS the action value
+    "ckValueField": "reason", // the card `id` of the field whose submitted value IS the action value
   },
 }
 ```
 
-The two differ whenever an explicit `<Input name>` (or a collision suffix) renames
-the field, so both are carried.
+A synthesized submit never carries a `value` key: its action value comes from
+`ckValueField` instead. The two ids differ whenever an explicit `name` prop (or a
+collision-dedupe suffix) renames the field, so both are carried.
 
-It is appended only when the card has **no dispatchable submit** — an
-`Action.Submit` carrying a `ckActionId`. Having _some_ action is not enough: an
-`Action.OpenUrl` (a link `<Button>`) opens a URL and submits nothing, and a
-`<Button>` with no `onClick` submits but routes nowhere, so an `<Input>` beside
+**When it is added.** Only when the card has **no dispatchable submit** — an
+`Action.Submit` whose `data.ckActionId` is a string. Having _some_ action is not
+enough: an `Action.OpenUrl` (a link `<Button>`) opens a URL and submits nothing,
+and a `<Button>` with no `onClick` submits but routes nowhere, so a field beside
 either still needs one.
 
-**One submit per card.** Adaptive Cards fires a single action, so only the first
-handler-bound field is bound; later `<Input onSubmit>` handlers never fire. Their
-text is _not_ lost — Teams merges every input into this one submit, so all of them
-arrive as submitted fields. Read them from `activity.value` (or
-`InteractionEvent.values`) rather than expecting a per-input handler.
+**Which field it binds.** The _first_ field, in render order, that both (a) had a
+minted handler — `<Input onSubmit>` **or** `<Select onSelect>`; a field with
+neither is never a candidate — and (b) survived the `TEAMS_LIMITS.bodyElements`
+clamp. A field the body clamp dropped is skipped as a candidate, because a Submit
+with no visible input above it would dispatch `undefined` to a
+`ClickHandler<string>`. If no candidate survives, **nothing is synthesized** and
+the card can end up with no actions at all.
 
-A field dropped by the body-element budget is skipped, since a submit with no
-visible input above it would dispatch `undefined` to a `ClickHandler<string>`.
+**One submit per card.** Adaptive Cards fires a single action, so only that first
+field is bound; later `<Input onSubmit>` / `<Select onSelect>` handlers never
+fire. Their values are _not_ lost — Teams merges every input into this one submit,
+so all of them arrive as submitted fields. Read them from `activity.value` (or
+`InteractionEvent.values`) rather than expecting a per-field handler.
+
+**Action budget.** Top-level actions are clamped to `TEAMS_LIMITS.actions` (6),
+and the synthesized submit's slot is reserved _inside_ that ceiling: the authored
+actions are clamped to `actions - 1` and the submit is then appended. So a card
+never emits more than the ceiling, the submit — the card's only route back into
+the engine — is never the entry the clamp drops, and it is always **last** in
+`actions`.
+
+**Overflow does not create one.** Whether to synthesize is decided against the
+_unclamped_ action list. A dispatchable `<Button>` that the action clamp then
+drops still suppresses synthesis: the author bound that handler, and dispatching
+a field's handler in its place would be a wrong dispatch, which is worse than
+none. Such a card is emitted with no route back into the engine.
+
+**`<Select multi>` caveat.** `renderSelect` emits `isMultiSelect: true` and Teams
+submits the chosen values as a **comma-joined string**. Nothing on this path
+splits it, so a `<Select multi onSelect>` handler receives that single string, not
+the `string[]` that `SelectProps.onSelect` (`ClickHandler<string | string[]>`)
+advertises. This is a pre-existing Teams fidelity gap; the synthesized submit only
+makes it reachable.
 
 ## Inbound — what Teams delivers on click
 
 Clicking an `Action.Submit` arrives as a **Message activity** (`activity.type ===
 "message"`), NOT an `invoke` / `adaptiveCard/action` / `Action.Execute` activity.
-The action's `data` becomes `activity.value`, and the message `text` is empty:
+The action's `data` becomes `activity.value`; the click carries no user text and
+the adapter never reads `activity.text` on this path:
 
 ```jsonc
 {
@@ -90,21 +124,39 @@ The action's `data` becomes `activity.value`, and the message `text` is empty:
 
 ### Decode rules
 
-- **Is it a card action?** `typeof activity.value.ckActionId === "string"`. If not,
-  it's an ordinary chat message.
-- **Fields:** `id = activity.value.ckActionId`. No resume-data smuggling —
-  durability rides on the consumer's action store keyed by `id`.
+- **Is it a card action?** `activity.value` is a non-null object _and_
+  `typeof activity.value.ckActionId === "string"`. If not, it is an ordinary chat
+  message and `parseCardAction` returns `undefined`.
+- **Id:** `id = activity.value.ckActionId`. No resume-data smuggling — durability
+  rides on the consumer's action store keyed by `id`.
 - **Card inputs:** if the card also had `<Input>`/`<Select>` fields, Teams merges
   their values into `activity.value` alongside the envelope keys. Every key that
-  is **not** `ckActionId` / `value` / `ckValueField` is a submitted field; those
-  three names are reserved and are never minted as field ids.
-- **Action value:** `activity.value[ckValueField]` when `ckValueField` is set and
-  names a present field (the synthesized input submit — the dispatched handler is
-  an `<Input onSubmit>`, whose contract is the typed text), else
-  `activity.value.value` (the clicked button's own value).
+  is **not** `ckActionId` / `value` / `ckValueField` is a submitted field. Those
+  three names are reserved (`CARD_ENVELOPE_KEYS`): the renderer seeds its used-id
+  set with them and ignores an explicit `name` that matches one, so no field is
+  ever minted under them.
+- **Action value:** `activity.value[ckValueField]` when `ckValueField` is a string
+  **and** that key is present among the submitted fields. That is the synthesized
+  submit: the dispatched handler is an `<Input onSubmit>` or `<Select onSelect>`,
+  whose contract is the submitted value, not a (nonexistent) button value.
+  Otherwise the action value is `activity.value.value` — the clicked button's own
+  value.
+- **`ckValueField` miss.** The `else` above is also the miss fallback: if
+  `ckValueField` names a field absent from the payload, the decode neither throws
+  nor surfaces the raw envelope — it silently yields `activity.value.value`, which
+  on a synthesized submit is `undefined`, so a `ClickHandler<string>` receives
+  `undefined`. A `ckValueField` naming a reserved key misses for the same reason
+  (reserved keys are stripped before the lookup), though the renderer never emits
+  one.
 - **Typed text is a string.** Teams delivers `Input.Text` values as strings and
   nothing may coerce them: `42`, `true`, `null` and `{"a":1}` must reach the
   handler as those four strings.
+- **`values` carries only submitted data.** `parseCardAction` builds it with a
+  null prototype, because `__proto__` survives `JSON.parse` as an own key: an
+  out-of-band decoder that copies fields onto a plain `{}` runs
+  `Object.prototype`'s setter instead, and the handler then sees an invisible
+  inherited property in place of the submitted value. Build the field map with
+  `Object.create(null)`.
 - **Conversation key:** derive it from `activity.conversation.id` (see
-  `conversationKeyOf`). Ingress and interaction decode MUST use the same key or the
-  waiter is stranded.
+  `conversationKeyOf`). Ingress and interaction decode MUST use the same key or
+  the waiter is stranded.

--- a/packages/channels-teams/src/adapter.test.ts
+++ b/packages/channels-teams/src/adapter.test.ts
@@ -104,6 +104,56 @@ describe("TeamsAdapter card interactions", () => {
     expect(evt.replyTarget.context).toBe(inbound);
     expect(evt.messageRef.context).toBe(inbound);
   });
+
+  it("forwards the card's merged inputs onto the InteractionEvent", async () => {
+    // The adapter is what actually wires `values` onto the event; without it a
+    // <Button onClick> handler beside an <Input> never sees the typed text.
+    const adapter = new TeamsAdapter({});
+    const sink = mockSink();
+    const activity = {
+      type: ActivityTypes.Message,
+      value: {
+        ckActionId: "ck:approve",
+        value: { confirmed: true },
+        reason: "looks good",
+      },
+      conversation: { id: "conv-1" },
+      from: { id: "user-1", name: "Tester" },
+      replyToId: "card-activity-1",
+      getConversationReference: () => ({ conversation: { id: "conv-1" } }),
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (adapter as any).handleActivity(
+      { activity } as unknown as TurnContext,
+      sink,
+    );
+    await flush();
+
+    const evt = sink.onInteraction.mock.calls[0]![0];
+    expect(evt.value).toEqual({ confirmed: true });
+    expect(evt.values).toEqual({ reason: "looks good" });
+  });
+
+  it("decodeInteraction carries the merged inputs too", () => {
+    const adapter = new TeamsAdapter({});
+    const evt = adapter.decodeInteraction({
+      type: ActivityTypes.Message,
+      value: {
+        ckActionId: "ck:note",
+        ckValueField: "ck:note",
+        "ck:note": "42",
+      },
+      conversation: { id: "conv-1" },
+      from: { id: "user-1", role: "user" },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // The synthesized input submit: the typed text is the action value, as a
+    // string, and is also readable as a submitted field.
+    expect(evt!.value).toBe("42");
+    expect(evt!.values).toEqual({ "ck:note": "42" });
+  });
 });
 
 /** A plain inbound message activity carrying optional file attachments. */

--- a/packages/channels-teams/src/adapter.ts
+++ b/packages/channels-teams/src/adapter.ts
@@ -156,6 +156,7 @@ export class TeamsAdapter implements PlatformAdapter {
             id: action.id,
             conversationKey,
             value: action.value,
+            values: action.values,
             actor,
             identityContext: {
               ...identityContext,
@@ -547,6 +548,7 @@ export class TeamsAdapter implements PlatformAdapter {
       id: action.id,
       conversationKey,
       value: action.value,
+      values: action.values,
       actor,
       identityContext: this.identityContext(
         activity,

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -1,8 +1,10 @@
 /**
  * Contract test for the HITL button action envelope — the wire shape a consumer
  * (e.g. Intelligence managed-Teams ingress) must decode. Locks the shape in BOTH
- * directions: what {@link renderAdaptiveCard} emits for a `<Button>`, and how
- * {@link parseCardAction} decodes the click Teams delivers back. See
+ * directions for BOTH emitters: the `Action.Submit` {@link renderAdaptiveCard}
+ * emits for a `<Button>`, the one it synthesizes for a card with no dispatchable
+ * submit, the `Action.OpenUrl` a link `<Button>` becomes, and how
+ * {@link parseCardAction} decodes each click Teams delivers back. See
  * `docs/button-action-envelope.md`.
  */
 import { describe, it, expect } from "vitest";
@@ -74,5 +76,132 @@ describe("HITL button action envelope (contract)", () => {
     const ordinary: TeamsActivityLike = { value: undefined };
 
     expect(parseCardAction(ordinary)).toBeUndefined();
+  });
+});
+
+describe("synthesized submit envelope (contract)", () => {
+  it("emits { ckActionId, ckValueField } and NO `value` for a card with no dispatchable submit", () => {
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" }, placeholder: "Why?" }),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        // `ckValueField` names the field whose submitted value IS the action
+        // value; there is deliberately no `value` key to fall back to.
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
+  });
+
+  it("round-trips the synthesized submit: the named field's text becomes the action value", () => {
+    const action = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+    ]).actions![0]!;
+
+    // Teams merges every Input.* into the submit's data, keyed by element id.
+    const inbound: TeamsActivityLike = {
+      value: { ...(action.data as object), "ck:note": "ship it" },
+      conversation: { id: "conv-1" },
+    };
+
+    expect(parseCardAction(inbound)).toEqual({
+      id: "ck:note",
+      value: "ship it",
+      values: { "ck:note": "ship it" },
+    });
+  });
+
+  it("round-trips when an explicit <Input name> makes ckValueField diverge from ckActionId", () => {
+    const action = renderAdaptiveCard([
+      el("input", [], { name: "reason", onSubmit: { id: "ck:note" } }),
+    ]).actions![0]!;
+
+    expect(action.data).toEqual({
+      ckActionId: "ck:note",
+      ckValueField: "reason",
+    });
+    // Dispatch keys off `ckActionId`; the value is read from `ckValueField`.
+    expect(
+      parseCardAction({
+        value: { ...(action.data as object), reason: "ship it" },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "ship it",
+      values: { reason: "ship it" },
+    });
+  });
+
+  it("synthesizes for a <Select onSelect>-only card too — the trigger is not input-only", () => {
+    const action = renderAdaptiveCard([
+      el("select", [], {
+        onSelect: { id: "ck:pick" },
+        options: [{ label: "One", value: "1" }],
+      }),
+    ]).actions![0]!;
+
+    expect(action).toEqual({
+      type: "Action.Submit",
+      title: "Submit",
+      data: { ckActionId: "ck:pick", ckValueField: "ck:pick" },
+    });
+    expect(
+      parseCardAction({
+        value: { ...(action.data as object), "ck:pick": "1" },
+      }),
+    ).toEqual({ id: "ck:pick", value: "1", values: { "ck:pick": "1" } });
+  });
+
+  it("yields `undefined` (not the raw envelope) when ckValueField names an absent field", () => {
+    // The documented miss fallback: `data.value`, which a synthesized submit
+    // never carries. An out-of-band decoder must reproduce exactly this.
+    const action = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+    ]).actions![0]!;
+
+    expect(parseCardAction({ value: { ...(action.data as object) } })).toEqual({
+      id: "ck:note",
+      value: undefined,
+      values: {},
+    });
+  });
+});
+
+describe("link <Button> envelope (contract)", () => {
+  it("emits Action.OpenUrl with no `data`, so it never round-trips", () => {
+    const action = renderAdaptiveCard([
+      el("actions", [
+        el("button", [text("Docs")], { url: "https://example.com/docs" }),
+      ]),
+    ]).actions![0]!;
+
+    expect(action).toEqual({
+      type: "Action.OpenUrl",
+      title: "Docs",
+      url: "https://example.com/docs",
+    });
+    expect(action).not.toHaveProperty("data");
+    // Nothing to decode: an OpenUrl click never reaches the bot at all, and a
+    // payload carrying its (absent) data is not a card action.
+    expect(parseCardAction({ value: action.data })).toBeUndefined();
+  });
+
+  it("still gets a synthesized submit beside an <Input> — OpenUrl is not dispatchable", () => {
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("actions", [el("button", [text("Docs")], { url: "https://x.test" })]),
+    ]);
+
+    expect(card.actions).toEqual([
+      { type: "Action.OpenUrl", title: "Docs", url: "https://x.test" },
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
   });
 });

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -155,18 +155,59 @@ describe("synthesized submit envelope (contract)", () => {
     ).toEqual({ id: "ck:pick", value: "1", values: { "ck:pick": "1" } });
   });
 
-  it("yields `undefined` (not the raw envelope) when ckValueField names an absent field", () => {
-    // The documented miss fallback: `data.value`, which a synthesized submit
-    // never carries. An out-of-band decoder must reproduce exactly this.
-    const action = renderAdaptiveCard([
+  it('resolves ckValueField against an untouched field, which Teams submits as ""', () => {
+    // Teams merges EVERY `Input.*` on the card into the submit's `data`, keyed
+    // by the element's `id`: a field the user never touched still arrives, as
+    // an empty string. So on a card THIS renderer emits, `ckValueField` always
+    // names a key the payload carries, and blank text is the action value —
+    // never a miss. (`input-submit.e2e.test.ts` drives the same client model
+    // end-to-end; the two must not disagree about what Teams sends.)
+    const card = renderAdaptiveCard([
       el("input", [], { onSubmit: { id: "ck:note" } }),
-    ]).actions![0]!;
+    ]);
+    const action = card.actions![0]!;
+    const field = (action.data as { ckValueField: string }).ckValueField;
+    // `synthesizeSubmit` binds only a field that survived the body clamp, so
+    // the named field is one the card really rendered and Teams really sends.
+    expect(card.body.map((element) => element.id)).toContain(field);
 
-    expect(parseCardAction({ value: { ...(action.data as object) } })).toEqual({
-      id: "ck:note",
-      value: undefined,
-      values: {},
-    });
+    expect(
+      parseCardAction({ value: { ...(action.data as object), [field]: "" } }),
+    ).toEqual({ id: "ck:note", value: "", values: { [field]: "" } });
+  });
+
+  it("falls back to `data.value` when an out-of-band envelope names an absent field", () => {
+    // Not reachable through this renderer: `synthesizeSubmit` only ever names a
+    // field it rendered, and Teams submits every rendered field. But the
+    // envelope is a published wire contract (`docs/button-action-envelope.md`)
+    // that consumers mint and decode themselves, so a hand-authored card can
+    // carry a `ckValueField` naming nothing on the card. The decode must
+    // neither throw nor surface the raw envelope: it yields `data.value`.
+    expect(
+      parseCardAction({
+        value: { ckActionId: "ck:note", ckValueField: "gone" },
+      }),
+    ).toEqual({ id: "ck:note", value: undefined, values: {} });
+
+    // It is a real fallback, not a hardcoded `undefined` — an out-of-band
+    // envelope carrying both keys dispatches with its own `value`.
+    expect(
+      parseCardAction({
+        value: {
+          ckActionId: "ck:note",
+          ckValueField: "gone",
+          value: { decision: "yes" },
+        },
+      }),
+    ).toEqual({ id: "ck:note", value: { decision: "yes" }, values: {} });
+
+    // A `ckValueField` naming a reserved envelope key misses the same way:
+    // reserved keys are stripped before the lookup, so they are never fields.
+    expect(
+      parseCardAction({
+        value: { ckActionId: "ck:note", ckValueField: "value", value: "env" },
+      }),
+    ).toEqual({ id: "ck:note", value: "env", values: {} });
   });
 });
 
@@ -271,8 +312,13 @@ describe("routeless <Button> (contract)", () => {
     for (const action of card.actions!) {
       if (action.type !== "Action.Submit") continue;
       // Every Action.Submit we emit carries a routable `ckActionId`, so a
-      // consumer decoding the click never gets `undefined`.
-      expect(parseCardAction({ value: action.data })).toBeDefined();
+      // consumer decoding the click never gets `undefined` — including with
+      // the card's untouched input merged in, the way Teams sends it.
+      expect(
+        parseCardAction({
+          value: { ...(action.data as object), "ck:note": "" },
+        }),
+      ).toBeDefined();
     }
   });
 });

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -72,10 +72,33 @@ describe("HITL button action envelope (contract)", () => {
     expect(conversationKeyOf(inboundActivity)).toBe("conv-1");
   });
 
-  it("treats an ordinary chat message (no ckActionId) as not-a-card-action", () => {
+  it("treats an activity carrying no `value` object at all as not-a-card-action", () => {
+    // A typed chat message puts its text in `text` and carries no `value`, so
+    // the decode stops on the is-there-a-payload half of the guard, before
+    // `ckActionId` is ever consulted. `null` must take the same exit: `typeof
+    // null === "object"`, so reading through it would throw rather than
+    // return.
     const ordinary: TeamsActivityLike = { value: undefined };
 
     expect(parseCardAction(ordinary)).toBeUndefined();
+    expect(parseCardAction({})).toBeUndefined();
+    expect(parseCardAction({ value: null })).toBeUndefined();
+    // Nor is a non-object `value` an envelope, however it is spelled.
+    expect(parseCardAction({ value: "ck:approve" })).toBeUndefined();
+  });
+
+  it("treats a `value` object with no string ckActionId as not-a-card-action", () => {
+    // Past the payload guard, so this is the id test doing the deciding: an
+    // activity really can arrive with a `value` object that is not one of our
+    // submits, and only a *string* `ckActionId` routes. Anything else is an
+    // ordinary chat message the adapter drives as a user turn.
+    expect(parseCardAction({ value: {} })).toBeUndefined();
+    expect(parseCardAction({ value: { reason: "ship it" } })).toBeUndefined();
+    expect(parseCardAction({ value: { ckActionId: 42 } })).toBeUndefined();
+    expect(parseCardAction({ value: { ckActionId: null } })).toBeUndefined();
+    expect(
+      parseCardAction({ value: { ckActionId: ["ck:approve"] } }),
+    ).toBeUndefined();
   });
 });
 
@@ -225,9 +248,12 @@ describe("link <Button> envelope (contract)", () => {
       url: "https://example.com/docs",
     });
     expect(action).not.toHaveProperty("data");
-    // Nothing to decode: an OpenUrl click never reaches the bot at all, and a
-    // payload carrying its (absent) data is not a card action.
-    expect(parseCardAction({ value: action.data })).toBeUndefined();
+    // Nothing to decode: an OpenUrl click never reaches the bot at all. And
+    // there is no envelope hiding anywhere on it — posting the whole action
+    // back as an activity `value` still yields no card action, because no key
+    // on it is a `ckActionId`. (Asserting on `action.data` here would be
+    // vacuous: it is absent, so it only re-tests the no-payload case above.)
+    expect(parseCardAction({ value: action })).toBeUndefined();
   });
 
   it("still gets a synthesized submit beside an <Input> — OpenUrl is not dispatchable", () => {
@@ -320,5 +346,181 @@ describe("routeless <Button> (contract)", () => {
         }),
       ).toBeDefined();
     }
+  });
+});
+
+describe("submitted field ids (contract)", () => {
+  // Teams keys a submitted field by the card `id` the renderer minted for it,
+  // so what `fieldId` picks IS the wire name an out-of-band consumer reads
+  // `values` (and `ckValueField`) by.
+
+  it("keys a field by its `name`, else its minted handler id, else a positional slot on one shared counter", () => {
+    const card = renderAdaptiveCard([
+      // Neither a name nor a minted handler id: a positional slot.
+      el("select", [], { options: [{ label: "One", value: "1" }] }),
+      el("input", [], {}),
+      // A minted handler id but no name: the id itself.
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      // An explicit `name` outranks the minted id, and is trimmed.
+      el("input", [], { name: "  reason  ", onSubmit: { id: "ck:why" } }),
+    ]);
+
+    // `<Input>` and `<Select>` share ONE 1-based counter, so the input after a
+    // select is `input_2` — not `input_1`.
+    expect(card.body.map((element) => element.id)).toEqual([
+      "select_1",
+      "input_2",
+      "ck:note",
+      "reason",
+    ]);
+
+    // Those ids are exactly the keys the decode surfaces as `values`.
+    expect(
+      parseCardAction({
+        value: {
+          ...(card.actions![0]!.data as object),
+          select_1: "1",
+          input_2: "",
+          "ck:note": "why",
+          reason: "because",
+        },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "why",
+      values: {
+        select_1: "1",
+        input_2: "",
+        "ck:note": "why",
+        reason: "because",
+      },
+    });
+  });
+
+  it("suffixes a field id already taken on the card — two <Input>s on one handler", () => {
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+    ]);
+
+    expect(card.body.map((element) => element.id)).toEqual([
+      "ck:note",
+      "ck:note_1",
+    ]);
+    // Both fields answer to the same action id, so `ckValueField` has to be
+    // the FIELD id to name one of them; the two arrive as distinct keys.
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
+    expect(
+      parseCardAction({
+        value: {
+          ...(card.actions![0]!.data as object),
+          "ck:note": "first",
+          "ck:note_1": "second",
+        },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "first",
+      values: { "ck:note": "first", "ck:note_1": "second" },
+    });
+  });
+
+  it("never mints a field id over a reserved envelope key, whatever `name` asks for", () => {
+    const card = renderAdaptiveCard([
+      el("input", [], { name: "ckActionId", onSubmit: { id: "ck:note" } }),
+      el("input", [], { name: "value" }),
+      el("input", [], { name: "ckValueField" }),
+    ]);
+
+    // A `name` colliding with `CARD_ENVELOPE_KEYS` is ignored and the field
+    // falls back down the same ladder. Honouring it would key the user's text
+    // under an envelope name, which the decode strips as reserved — the text
+    // would vanish, and a `name: "ckActionId"` would forge the route.
+    expect(card.body.map((element) => element.id)).toEqual([
+      "ck:note",
+      "input_2",
+      "input_3",
+    ]);
+
+    expect(
+      parseCardAction({
+        value: {
+          ...(card.actions![0]!.data as object),
+          "ck:note": "why",
+          input_2: "b",
+          input_3: "c",
+        },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "why",
+      values: { "ck:note": "why", input_2: "b", input_3: "c" },
+    });
+  });
+});
+
+describe("decoded `values` bag (contract)", () => {
+  it("delivers typed text as a string — nothing on this path coerces it", () => {
+    // Teams submits an `Input.Text` as a string, so text that merely LOOKS
+    // like JSON stays text. `<Input onSubmit>` is a `ClickHandler<string>`:
+    // handing it a number, a boolean, `null` or an object breaks the contract
+    // that the value is what the user typed.
+    const action = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+    ]).actions![0]!;
+
+    for (const typed of ["42", "true", "null", '{"a":1}']) {
+      const decoded = parseCardAction({
+        value: { ...(action.data as object), "ck:note": typed },
+      });
+
+      expect(decoded).toEqual({
+        id: "ck:note",
+        value: typed,
+        values: { "ck:note": typed },
+      });
+      expect(typeof decoded!.value).toBe("string");
+      expect(typeof decoded!.values["ck:note"]).toBe("string");
+    }
+  });
+
+  it("lands a `__proto__` field as own data and leaves `values` an ordinary object", () => {
+    // `__proto__` survives `JSON.parse` as an OWN key, so a payload really can
+    // carry one. Copied onto a bag with `bag[key] = …` it would run
+    // `Object.prototype`'s SETTER instead of becoming a field: the submitted
+    // value would disappear from `Object.keys`, and — being an object — would
+    // become the bag's prototype, so everything it carries would read back off
+    // the bag as though it had been submitted. Build the payload the way the
+    // wire does, not with an object literal (which sets the prototype).
+    const inbound = JSON.parse(
+      '{"ckActionId":"ck:note","__proto__":{"polluted":"yes"},"reason":"ship it"}',
+    ) as Record<string, unknown>;
+
+    const decoded = parseCardAction({ value: inbound })!;
+
+    // It is a field like any other: own, enumerable, and carrying its value.
+    expect(Object.keys(decoded.values).sort()).toEqual(["__proto__", "reason"]);
+    expect(
+      Object.getOwnPropertyDescriptor(decoded.values, "__proto__"),
+    ).toMatchObject({ value: { polluted: "yes" }, enumerable: true });
+    // …and it reached no prototype: not the bag's, not every object's.
+    expect(Object.getPrototypeOf(decoded.values)).toBe(Object.prototype);
+    expect(decoded.values).not.toHaveProperty("polluted");
+    expect({}).not.toHaveProperty("polluted");
+
+    // The bag stays an ORDINARY object: `values` is public API (it reaches
+    // handlers as `ctx.values`, a `Record<string, unknown>`), and consumer
+    // code calls `Object.prototype` methods on it. A null-prototype bag would
+    // block the injection too, but at the cost of breaking that. (See
+    // `setField`; the doc bullet still describes the older `Object.create(null)`
+    // build and is stale on this point.)
+    expect(typeof decoded.values.hasOwnProperty).toBe("function");
+    expect(decoded.value).toBeUndefined();
   });
 });

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -205,3 +205,74 @@ describe("link <Button> envelope (contract)", () => {
     ]);
   });
 });
+
+describe("routeless <Button> (contract)", () => {
+  it("emits NO action for a <Button> with neither a url nor an onClick", () => {
+    const card = renderAdaptiveCard([
+      el("actions", [
+        el("button", [text("Dismiss")], {}),
+        // `value` is not a route: the decode keys on `ckActionId` alone.
+        el("button", [text("Later")], { value: "later" }),
+      ]),
+    ]);
+
+    expect(card.actions).toBeUndefined();
+  });
+
+  it("drops the routeless <Button> rather than emitting a submit the decode rejects", () => {
+    // The rule is a decode-side contract: a submit with no `ckActionId` posts a
+    // Message activity `parseCardAction` reads as an ordinary chat message, and
+    // since Teams merges every card input into whichever submit fires, that
+    // click would also swallow what the user typed. Only the synthesized submit
+    // is left, so the card's single click is always routable.
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("actions", [el("button", [text("Dismiss")], {})]),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
+    expect(
+      parseCardAction({
+        value: { ...(card.actions![0]!.data as object), "ck:note": "ship it" },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "ship it",
+      values: { "ck:note": "ship it" },
+    });
+  });
+
+  it("keeps only routable actions on a mixed card — every emitted submit decodes", () => {
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("actions", [
+        el("button", [text("Approve")], { onClick: { id: "ck:ok" } }),
+        el("button", [text("Dismiss")], {}), // routeless — not emitted
+        el("button", [text("Docs")], { url: "https://x.test" }),
+      ]),
+    ]);
+
+    // The dispatchable <Button> suppresses synthesis, so these are exactly the
+    // authored actions minus the routeless one, in author order.
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Approve",
+        data: { ckActionId: "ck:ok" },
+      },
+      { type: "Action.OpenUrl", title: "Docs", url: "https://x.test" },
+    ]);
+    for (const action of card.actions!) {
+      if (action.type !== "Action.Submit") continue;
+      // Every Action.Submit we emit carries a routable `ckActionId`, so a
+      // consumer decoding the click never gets `undefined`.
+      expect(parseCardAction({ value: action.data })).toBeDefined();
+    }
+  });
+});

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -64,6 +64,8 @@ describe("HITL button action envelope (contract)", () => {
     expect(parseCardAction(inboundActivity)).toEqual({
       id: "ck:approve",
       value: { decision: "yes" },
+      // No `<Input>` on this card, so nothing merged in alongside the envelope.
+      values: {},
     });
     expect(conversationKeyOf(inboundActivity)).toBe("conv-1");
   });

--- a/packages/channels-teams/src/button-action-envelope.contract.test.ts
+++ b/packages/channels-teams/src/button-action-envelope.contract.test.ts
@@ -517,9 +517,8 @@ describe("decoded `values` bag (contract)", () => {
     // The bag stays an ORDINARY object: `values` is public API (it reaches
     // handlers as `ctx.values`, a `Record<string, unknown>`), and consumer
     // code calls `Object.prototype` methods on it. A null-prototype bag would
-    // block the injection too, but at the cost of breaking that. (See
-    // `setField`; the doc bullet still describes the older `Object.create(null)`
-    // build and is stale on this point.)
+    // block the injection too, but at the cost of breaking that. See
+    // `setField`, and the prototype rule in `docs/button-action-envelope.md`.
     expect(typeof decoded.values.hasOwnProperty).toBe("function");
     expect(decoded.value).toBeUndefined();
   });

--- a/packages/channels-teams/src/index.ts
+++ b/packages/channels-teams/src/index.ts
@@ -15,7 +15,9 @@ export {
   conversationKeyOf,
   parseCardAction,
   CARD_ENVELOPE_KEYS,
+  isCardEnvelopeKey,
 } from "./interaction.js";
+export type { CardEnvelopeKey, TeamsActivityLike } from "./interaction.js";
 
 export { renderTeamsMarkdown } from "./render/markdown.js";
 export { autoCloseOpenMarkdown } from "./render/auto-close.js";

--- a/packages/channels-teams/src/index.ts
+++ b/packages/channels-teams/src/index.ts
@@ -11,7 +11,11 @@ export { TeamsConversationStore } from "./conversation-store.js";
 
 export { createRunRenderer } from "./event-renderer.js";
 
-export { conversationKeyOf, parseCardAction } from "./interaction.js";
+export {
+  conversationKeyOf,
+  parseCardAction,
+  CARD_ENVELOPE_KEYS,
+} from "./interaction.js";
 
 export { renderTeamsMarkdown } from "./render/markdown.js";
 export { autoCloseOpenMarkdown } from "./render/auto-close.js";

--- a/packages/channels-teams/src/input-submit.e2e.test.ts
+++ b/packages/channels-teams/src/input-submit.e2e.test.ts
@@ -8,6 +8,10 @@
  * every merged card input — so unit tests on either side alone kept passing
  * while the round-trip was broken.
  *
+ * `submitCard` below is this suite's model of the Teams client; the same model
+ * is asserted against the raw wire shape in `button-action-envelope.contract.test.ts`,
+ * and the two must not disagree about what Teams sends.
+ *
  * The cases below cover the synthesized submit on an input-only card, an
  * input's text arriving beside a clicked `<Button>`'s own value, JSON-shaped
  * text passing through uncoerced, and a multi-input card where only the first

--- a/packages/channels-teams/src/input-submit.e2e.test.ts
+++ b/packages/channels-teams/src/input-submit.e2e.test.ts
@@ -1,0 +1,188 @@
+/**
+ * End-to-end coverage for `<Input onSubmit>` on Teams: render → submit →
+ * dispatch → resume, driving a real `createChannel` runtime through the real
+ * {@link renderAdaptiveCard} and {@link parseCardAction}.
+ *
+ * The four defects this locks down all lived between those two functions —
+ * `renderInput` emitted no submit affordance, and `parseCardAction` discarded
+ * every merged card input — so unit tests on either side alone kept passing
+ * while the round-trip was broken.
+ */
+import { describe, it, expect } from "vitest";
+import { createChannel } from "@copilotkit/channels-core";
+import { FakeAdapter, FakeAgent } from "@copilotkit/channels-core/testing";
+import { Actions, Button, Input } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
+import { renderAdaptiveCard } from "./render/adaptive-card.js";
+import type { AdaptiveCard } from "./render/adaptive-card.js";
+import { parseCardAction } from "./interaction.js";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+const CONVERSATION = "19:abc@thread.tacv2";
+
+/**
+ * Everything a real Teams client does between a rendered card and the activity
+ * it posts back: the user fills in each `Input.*` and taps an action, and Teams
+ * merges the field values into that action's `data`.
+ */
+function submitCard(
+  card: AdaptiveCard,
+  typed: Record<string, string>,
+  actionIndex = 0,
+): ReturnType<typeof parseCardAction> {
+  const action = card.actions?.[actionIndex];
+  if (!action) throw new Error("card has no submittable action");
+  const data = (action.data ?? {}) as Record<string, unknown>;
+  return parseCardAction({
+    conversation: { id: CONVERSATION },
+    value: { ...data, ...typed },
+  });
+}
+
+/** The `id` Teams will key this card's single `Input.Text` under. */
+function inputFieldId(card: AdaptiveCard): string {
+  const el = card.body.find((e) => e.type === "Input.Text");
+  if (!el) throw new Error("card has no Input.Text");
+  return el.id as string;
+}
+
+describe("<Input onSubmit> round-trip (Teams)", () => {
+  it("delivers an Input-only card's typed text to the handler and resumes the waiter", async () => {
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    let submitted: unknown;
+    let seenValues: Record<string, unknown> | undefined;
+    let choice: Promise<unknown> | undefined;
+    channel.onMention(async ({ thread }) => {
+      choice = thread.awaitChoice(
+        Input({
+          placeholder: "Why?",
+          onSubmit: (ctx) => {
+            submitted = ctx.action.value;
+            seenValues = ctx.values;
+          },
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+    fake.emitTurn({ userText: "ask me", conversationKey: CONVERSATION });
+    await tick();
+
+    // Render: the card is submittable even though it holds no <Button>.
+    const card = renderAdaptiveCard(fake.posted[0] as ChannelNode[]);
+    expect(card.actions).toHaveLength(1);
+    expect(card.actions![0]).toMatchObject({ type: "Action.Submit" });
+
+    // Submit → dispatch.
+    const field = inputFieldId(card);
+    const action = submitCard(card, { [field]: "ship it" })!;
+    fake.emitInteraction({
+      id: action.id,
+      conversationKey: CONVERSATION,
+      value: action.value,
+      values: action.values,
+    });
+    await tick();
+
+    expect(submitted).toBe("ship it");
+    expect(seenValues).toEqual({ [field]: "ship it" });
+    // Resume: the HITL waiter resolves with the same text.
+    await expect(choice!).resolves.toBe("ship it");
+  });
+
+  it("delivers the input's text alongside a clicked <Button>'s own value", async () => {
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    let clickedValue: unknown;
+    let seenValues: Record<string, unknown> | undefined;
+    channel.onMention(async ({ thread }) => {
+      await thread.post(
+        Actions({
+          children: [
+            Input({ name: "reason", onSubmit: () => {} }),
+            Button({
+              value: { decision: "yes" },
+              onClick: (ctx) => {
+                clickedValue = ctx.action.value;
+                seenValues = ctx.values;
+              },
+              children: "Approve",
+            }),
+          ],
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+    fake.emitTurn({ userText: "decide", conversationKey: CONVERSATION });
+    await tick();
+
+    const card = renderAdaptiveCard(fake.posted[0] as ChannelNode[]);
+    // The button supplies the submit, so nothing is synthesized.
+    expect(card.actions).toHaveLength(1);
+
+    const action = submitCard(card, { reason: "looks good" })!;
+    fake.emitInteraction({
+      id: action.id,
+      conversationKey: CONVERSATION,
+      value: action.value,
+      values: action.values,
+    });
+    await tick();
+
+    expect(clickedValue).toEqual({ decision: "yes" });
+    expect(seenValues).toEqual({ reason: "looks good" });
+  });
+
+  it("delivers JSON-shaped text verbatim, never coerced", async () => {
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    const received: unknown[] = [];
+    channel.onMention(async ({ thread }) => {
+      await thread.post(
+        Input({
+          onSubmit: (ctx) => {
+            received.push(ctx.action.value);
+          },
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+
+    const typedInputs = ["42", "true", "null", '{"a":1}'];
+    for (const [i, typed] of typedInputs.entries()) {
+      fake.emitTurn({ userText: "ask", conversationKey: CONVERSATION });
+      await tick();
+
+      const card = renderAdaptiveCard(fake.posted[i] as ChannelNode[]);
+      const action = submitCard(card, { [inputFieldId(card)]: typed })!;
+      fake.emitInteraction({
+        id: action.id,
+        conversationKey: CONVERSATION,
+        value: action.value,
+        values: action.values,
+      });
+      await tick();
+    }
+
+    expect(received).toEqual(typedInputs);
+  });
+});

--- a/packages/channels-teams/src/input-submit.e2e.test.ts
+++ b/packages/channels-teams/src/input-submit.e2e.test.ts
@@ -3,10 +3,15 @@
  * dispatch → resume, driving a real `createChannel` runtime through the real
  * {@link renderAdaptiveCard} and {@link parseCardAction}.
  *
- * The four defects this locks down all lived between those two functions —
+ * Both defects this locks down lived between those two functions —
  * `renderInput` emitted no submit affordance, and `parseCardAction` discarded
  * every merged card input — so unit tests on either side alone kept passing
  * while the round-trip was broken.
+ *
+ * The cases below cover the synthesized submit on an input-only card, an
+ * input's text arriving beside a clicked `<Button>`'s own value, JSON-shaped
+ * text passing through uncoerced, and a multi-input card where only the first
+ * handler-bound field dispatches while every field's text still arrives.
  */
 import { describe, it, expect } from "vitest";
 import { createChannel } from "@copilotkit/channels-core";
@@ -21,10 +26,25 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 
 const CONVERSATION = "19:abc@thread.tacv2";
 
+/** Every `Input.*` id on the rendered card, in body order — exactly the set of
+ *  keys Teams will report for it. */
+function cardInputIds(card: AdaptiveCard): string[] {
+  return card.body
+    .filter((el) => String(el.type ?? "").startsWith("Input."))
+    .map((el) => el.id)
+    .filter((id): id is string => typeof id === "string");
+}
+
 /**
  * Everything a real Teams client does between a rendered card and the activity
- * it posts back: the user fills in each `Input.*` and taps an action, and Teams
- * merges the field values into that action's `data`.
+ * it posts back: the user fills in some of the card's inputs and taps an
+ * action, and Teams merges EVERY `Input.*` on the card into that action's
+ * `data`, keyed by the element's `id` — an input nobody touched still arrives,
+ * as an empty string.
+ *
+ * The payload is therefore derived from the RENDERED card, not from `typed`:
+ * a partial `typed` map is a user who left fields blank, not a card with fewer
+ * fields, and only the former is a submit Teams could actually send.
  */
 function submitCard(
   card: AdaptiveCard,
@@ -33,18 +53,30 @@ function submitCard(
 ): ReturnType<typeof parseCardAction> {
   const action = card.actions?.[actionIndex];
   if (!action) throw new Error("card has no submittable action");
+  const ids = cardInputIds(card);
+  // A `typed` key that names no rendered field is a test bug: Teams could
+  // never send it, and silently dropping it would assert against a submit no
+  // client produces.
+  for (const id of Object.keys(typed)) {
+    if (!ids.includes(id)) throw new Error(`card has no input "${id}"`);
+  }
   const data = (action.data ?? {}) as Record<string, unknown>;
   return parseCardAction({
     conversation: { id: CONVERSATION },
-    value: { ...data, ...typed },
+    value: {
+      ...data,
+      ...Object.fromEntries(ids.map((id) => [id, typed[id] ?? ""])),
+    },
   });
 }
 
-/** The `id` Teams will key this card's single `Input.Text` under. */
+/** The `id` Teams will key this card's single input under. */
 function inputFieldId(card: AdaptiveCard): string {
-  const el = card.body.find((e) => e.type === "Input.Text");
-  if (!el) throw new Error("card has no Input.Text");
-  return el.id as string;
+  const ids = cardInputIds(card);
+  if (ids.length !== 1) {
+    throw new Error(`expected exactly one card input, got ${ids.length}`);
+  }
+  return ids[0]!;
 }
 
 describe("<Input onSubmit> round-trip (Teams)", () => {
@@ -69,6 +101,12 @@ describe("<Input onSubmit> round-trip (Teams)", () => {
           },
         }),
       );
+      // The waiter settles only once the submit below is dispatched — long
+      // after `onMention` returns — so it cannot be awaited here. Observe it
+      // now anyway: if an earlier expectation aborts the test before the
+      // assertion at the end, a rejection would otherwise escape as an
+      // unhandled rejection attributed to some later test.
+      void choice.catch(() => {});
     });
 
     await channel.ɵruntime.start();
@@ -184,5 +222,69 @@ describe("<Input onSubmit> round-trip (Teams)", () => {
     }
 
     expect(received).toEqual(typedInputs);
+  });
+
+  it("delivers every field of a two-input card, including the one left blank", async () => {
+    // Adaptive Cards fires ONE action per card, so the synthesized submit binds
+    // to the first handler-bound field only. The second input's handler never
+    // runs — but its text must still reach the dispatched handler's `values`,
+    // and a field the user skipped must arrive blank rather than vanish.
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new FakeAgent(),
+    });
+
+    let submitted: unknown;
+    let seenValues: Record<string, unknown> | undefined;
+    let secondHandlerRuns = 0;
+    channel.onMention(async ({ thread }) => {
+      await thread.post(
+        Actions({
+          children: [
+            Input({
+              name: "why",
+              onSubmit: (ctx) => {
+                submitted = ctx.action.value;
+                seenValues = ctx.values;
+              },
+            }),
+            Input({
+              name: "details",
+              onSubmit: () => {
+                secondHandlerRuns++;
+              },
+            }),
+          ],
+        }),
+      );
+    });
+
+    await channel.ɵruntime.start();
+    fake.emitTurn({ userText: "ask me twice", conversationKey: CONVERSATION });
+    await tick();
+
+    const card = renderAdaptiveCard(fake.posted[0] as ChannelNode[]);
+    expect(cardInputIds(card)).toEqual(["why", "details"]);
+    // Two inputs, still one submit — synthesized, since neither input is a
+    // dispatchable action of its own.
+    expect(card.actions).toHaveLength(1);
+    expect(card.actions![0]).toMatchObject({ type: "Action.Submit" });
+
+    // The user fills the first field and taps Submit without touching the
+    // second; `submitCard` reports `details` the way Teams would.
+    const action = submitCard(card, { why: "ship it" })!;
+    fake.emitInteraction({
+      id: action.id,
+      conversationKey: CONVERSATION,
+      value: action.value,
+      values: action.values,
+    });
+    await tick();
+
+    expect(submitted).toBe("ship it");
+    expect(seenValues).toEqual({ why: "ship it", details: "" });
+    expect(secondHandlerRuns).toBe(0);
   });
 });

--- a/packages/channels-teams/src/interaction.test.ts
+++ b/packages/channels-teams/src/interaction.test.ts
@@ -1,5 +1,73 @@
 import { describe, it, expect } from "vitest";
-import { conversationKeyOf, parseCardAction } from "./interaction.js";
+import {
+  CARD_ENVELOPE_KEYS,
+  conversationKeyOf,
+  isCardEnvelopeKey,
+  parseCardAction,
+} from "./interaction.js";
+import type { CardEnvelopeKey } from "./interaction.js";
+
+describe("CARD_ENVELOPE_KEYS", () => {
+  it("is frozen, so a consumer cannot retarget the reserved set", () => {
+    // It is exported from the package, and BOTH safety behaviours read it
+    // live: the renderer seeds `usedFieldIds` from it and `parseCardAction`
+    // strips it out of `values`. Were it mutable, one `push` from anywhere
+    // in-process would silently disable them.
+    expect(Object.isFrozen(CARD_ENVELOPE_KEYS)).toBe(true);
+
+    // This module is ESM, hence always strict mode, so a rejected write is a
+    // thrown TypeError rather than a silent no-op. (`push` throws either way;
+    // the element assignment is the one that needs strict mode.)
+    const escaped = CARD_ENVELOPE_KEYS as unknown as string[];
+    expect(() => escaped.push("reason")).toThrow(TypeError);
+    expect(() => {
+      escaped[0] = "hijacked";
+    }).toThrow(TypeError);
+    expect(() => {
+      escaped.length = 0;
+    }).toThrow(TypeError);
+
+    expect([...CARD_ENVELOPE_KEYS]).toEqual([
+      "ckActionId",
+      "value",
+      "ckValueField",
+    ]);
+  });
+
+  it("keeps decoding intact after a mutation attempt", () => {
+    // The guarantee the freeze buys, end to end. Before it, `push("reason")`
+    // made the decoder strip a genuinely submitted `reason` field, and
+    // overwriting index 0 leaked `ckActionId` into `values`.
+    const escaped = CARD_ENVELOPE_KEYS as unknown as string[];
+    expect(() => escaped.push("reason")).toThrow(TypeError);
+    expect(() => {
+      escaped[0] = "hijacked";
+    }).toThrow(TypeError);
+
+    expect(
+      parseCardAction({ value: { ckActionId: "ck:x", reason: "ok" } }),
+    ).toEqual({ id: "ck:x", value: undefined, values: { reason: "ok" } });
+  });
+
+  it("exposes the member names in its type", () => {
+    // `readonly string[]` would erase them; `as const` keeps them, so a
+    // consumer can spell a reserved key in a type position.
+    const key: CardEnvelopeKey = "ckValueField";
+    expect(CARD_ENVELOPE_KEYS).toContain(key);
+    // @ts-expect-error — "reason" is not a reserved envelope key.
+    const notAKey: CardEnvelopeKey = "reason";
+    expect(notAKey).toBe("reason");
+  });
+
+  it("narrows an arbitrary string via isCardEnvelopeKey", () => {
+    for (const reserved of CARD_ENVELOPE_KEYS) {
+      expect(isCardEnvelopeKey(reserved)).toBe(true);
+    }
+    expect(isCardEnvelopeKey("reason")).toBe(false);
+    expect(isCardEnvelopeKey("ckactionid")).toBe(false);
+    expect(isCardEnvelopeKey("")).toBe(false);
+  });
+});
 
 describe("conversationKeyOf", () => {
   it("derives the key from activity.conversation.id", () => {

--- a/packages/channels-teams/src/interaction.test.ts
+++ b/packages/channels-teams/src/interaction.test.ts
@@ -124,9 +124,9 @@ describe("parseCardAction", () => {
 
   it("lands a `__proto__` field as plain data, never on the prototype", () => {
     // `__proto__` survives JSON.parse as an OWN key, so a crafted submit can
-    // carry one. On a plain `{}` the assignment runs the inherited setter: the
-    // handler then sees `values.injected` without `injected` ever appearing in
-    // `Object.keys(values)`.
+    // carry one. Assigned with `values[key] = v` it runs the inherited setter:
+    // the handler then sees `values.injected` without `injected` ever appearing
+    // in `Object.keys(values)`.
     const parsed = parseCardAction({
       value: JSON.parse(
         '{"ckActionId":"ck:x","__proto__":{"injected":true},"reason":"ok"}',
@@ -136,15 +136,38 @@ describe("parseCardAction", () => {
     expect(values.injected).toBeUndefined();
     expect(Object.keys(values).sort()).toEqual(["__proto__", "reason"]);
     expect(values.reason).toBe("ok");
+    // The crafted key is a field like any other, not the bag's prototype.
+    expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(values, "__proto__")).toBe(
+      true,
+    );
   });
 
-  it("does not surface Object.prototype members through `values`", () => {
-    // A handler reading `ctx.values[someFieldId]` must get submitted data or
-    // nothing — never an inherited builtin.
-    const values = parseCardAction({ value: { ckActionId: "ck:x" } })!.values;
-    for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
-      expect(values[builtin]).toBeUndefined();
-    }
+  it("hands handlers an ORDINARY object, prototype intact", () => {
+    // `values` is public API (`ctx.values`, typed `Record<string, unknown>`)
+    // and reaches third-party handlers. Hardening the inbound keys must not
+    // cost it `Object.prototype`: `ctx.values.hasOwnProperty(...)` is ordinary
+    // consumer code and must keep working.
+    const values = parseCardAction({
+      value: { ckActionId: "ck:x", reason: "ok" },
+    })!.values;
+    expect(values.hasOwnProperty("reason")).toBe(true);
+    expect(Object.getPrototypeOf(values)).toBe(Object.prototype);
+    expect(values.hasOwnProperty("nope")).toBe(false);
+    expect(() => String(values)).not.toThrow();
+    expect({ ...values }).toEqual({ reason: "ok" });
+  });
+
+  it("delivers a submitted field whose id collides with a builtin", () => {
+    // The half of prototype hygiene that IS a correctness guarantee: a field
+    // the sender actually submitted must reach the handler as its own value,
+    // shadowing whatever `Object.prototype` happens to name.
+    const values = parseCardAction({
+      value: { ckActionId: "ck:x", toString: "typed", constructor: "ctor" },
+    })!.values;
+    expect(values.toString).toBe("typed");
+    expect(values.constructor).toBe("ctor");
+    expect(Object.keys(values).sort()).toEqual(["constructor", "toString"]);
   });
 
   it("keeps typed text as a string even when it parses as JSON", () => {

--- a/packages/channels-teams/src/interaction.test.ts
+++ b/packages/channels-teams/src/interaction.test.ts
@@ -122,6 +122,31 @@ describe("parseCardAction", () => {
     ).toEqual({ id: "ck:note", value: "fallback", values: {} });
   });
 
+  it("lands a `__proto__` field as plain data, never on the prototype", () => {
+    // `__proto__` survives JSON.parse as an OWN key, so a crafted submit can
+    // carry one. On a plain `{}` the assignment runs the inherited setter: the
+    // handler then sees `values.injected` without `injected` ever appearing in
+    // `Object.keys(values)`.
+    const parsed = parseCardAction({
+      value: JSON.parse(
+        '{"ckActionId":"ck:x","__proto__":{"injected":true},"reason":"ok"}',
+      ),
+    });
+    const values = parsed!.values;
+    expect(values.injected).toBeUndefined();
+    expect(Object.keys(values).sort()).toEqual(["__proto__", "reason"]);
+    expect(values.reason).toBe("ok");
+  });
+
+  it("does not surface Object.prototype members through `values`", () => {
+    // A handler reading `ctx.values[someFieldId]` must get submitted data or
+    // nothing — never an inherited builtin.
+    const values = parseCardAction({ value: { ckActionId: "ck:x" } })!.values;
+    for (const builtin of ["constructor", "toString", "hasOwnProperty"]) {
+      expect(values[builtin]).toBeUndefined();
+    }
+  });
+
   it("keeps typed text as a string even when it parses as JSON", () => {
     // Teams delivers Input.Text values as strings; nothing may coerce them.
     for (const typed of ["42", "true", "null", '{"a":1}']) {

--- a/packages/channels-teams/src/interaction.test.ts
+++ b/packages/channels-teams/src/interaction.test.ts
@@ -30,7 +30,11 @@ describe("parseCardAction", () => {
     const parsed = parseCardAction({
       value: { ckActionId: "ck:approve-1", value: { confirmed: true } },
     });
-    expect(parsed).toEqual({ id: "ck:approve-1", value: { confirmed: true } });
+    expect(parsed).toEqual({
+      id: "ck:approve-1",
+      value: { confirmed: true },
+      values: {},
+    });
   });
 
   it("returns undefined for an ordinary chat message (no value)", () => {
@@ -49,6 +53,87 @@ describe("parseCardAction", () => {
     expect(parseCardAction({ value: { ckActionId: "ck:x" } })).toEqual({
       id: "ck:x",
       value: undefined,
+      values: {},
     });
+  });
+
+  it("carries merged card inputs as `values`, keyed by the element id", () => {
+    // Teams merges every Input.* on the card into the submit's `value` object.
+    // A button click must not discard what the user typed beside it.
+    expect(
+      parseCardAction({
+        value: {
+          ckActionId: "ck:approve",
+          value: { decision: "yes" },
+          "ck:note": "looks good",
+          reason: "shipping",
+        },
+      }),
+    ).toEqual({
+      id: "ck:approve",
+      value: { decision: "yes" },
+      values: { "ck:note": "looks good", reason: "shipping" },
+    });
+  });
+
+  it("takes the action value from `ckValueField` when the submit names one", () => {
+    // The synthesized submit for an Input-only card: the dispatched handler is
+    // an `<Input onSubmit>`, so `ctx.action.value` must be the typed text.
+    expect(
+      parseCardAction({
+        value: {
+          ckActionId: "ck:note",
+          ckValueField: "ck:note",
+          "ck:note": "ship it",
+        },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "ship it",
+      values: { "ck:note": "ship it" },
+    });
+  });
+
+  it("resolves `ckValueField` when an explicit <Input name> renamed the field", () => {
+    expect(
+      parseCardAction({
+        value: {
+          ckActionId: "ck:note",
+          ckValueField: "reason",
+          reason: "ship it",
+        },
+      }),
+    ).toEqual({
+      id: "ck:note",
+      value: "ship it",
+      values: { reason: "ship it" },
+    });
+  });
+
+  it("falls back to the button value when `ckValueField` names a missing field", () => {
+    expect(
+      parseCardAction({
+        value: {
+          ckActionId: "ck:note",
+          ckValueField: "gone",
+          value: "fallback",
+        },
+      }),
+    ).toEqual({ id: "ck:note", value: "fallback", values: {} });
+  });
+
+  it("keeps typed text as a string even when it parses as JSON", () => {
+    // Teams delivers Input.Text values as strings; nothing may coerce them.
+    for (const typed of ["42", "true", "null", '{"a":1}']) {
+      expect(
+        parseCardAction({
+          value: {
+            ckActionId: "ck:note",
+            ckValueField: "ck:note",
+            "ck:note": typed,
+          },
+        })?.value,
+      ).toBe(typed);
+    }
   });
 });

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -3,10 +3,16 @@
  *
  * A button rendered by {@link ../render/adaptive-card.renderButton} carries its
  * opaque minted action id (`ck:...`) and tiny `value` in the action's `data`.
- * When clicked, Teams delivers a **Message activity** whose `value` is that
+ * The submit `renderAdaptiveCard` synthesizes for a card with no dispatchable
+ * one (see `synthesizeSubmit`) carries a `ckValueField` instead of a `value`.
+ * When clicked, either delivers a **Message activity** whose `value` is that
  * `data` object (merged with any card inputs) and whose `text` is empty. These
  * helpers recognize and decode that activity so the engine's `awaitChoice`
  * waiter resolves.
+ *
+ * The wire contract these decode is documented in
+ * `docs/button-action-envelope.md`; out-of-band consumers decode it themselves,
+ * so keep the two in step.
  */
 
 /** Minimal shape of the inbound Teams activity we read for interaction decoding. */
@@ -15,16 +21,19 @@ export interface TeamsActivityLike {
   conversation?: { id?: string };
 }
 
-/** The `data` our buttons round-trip (see `render/adaptive-card.ts` `renderButton`). */
+/** The `data` our submits round-trip (see `render/adaptive-card.ts`). */
 interface CardActionData {
+  /** Opaque minted handler id. Emitted by `renderButton` for a `<Button onClick>`
+   *  and by `synthesizeSubmit` for the field it binds. */
   ckActionId?: string;
+  /** The clicked `<Button value>`, when it had one. Only `renderButton` emits it. */
   value?: unknown;
   /**
-   * Id of the card input whose text IS this submit's action value. Set only on
-   * the submit the renderer synthesizes for an input-only card (see
-   * `renderAdaptiveCard`), where the dispatched handler is an `<Input onSubmit>`
-   * and its `ClickHandler<string>` contract requires the typed text — not the
-   * (absent) button value.
+   * Id of the card field whose submitted value IS this submit's action value.
+   * Emitted ONLY by `synthesizeSubmit` — `renderButton` never sets it. It marks
+   * the submit the renderer adds to a card with no dispatchable one, where the
+   * dispatched handler is an `<Input onSubmit>` or `<Select onSelect>` whose
+   * contract is the submitted value, not the (absent) button value.
    */
   ckValueField?: string;
 }
@@ -61,8 +70,11 @@ export function conversationKeyOf(activity: TeamsActivityLike): string {
  * Teams merges every `Input.*` on the card into the submit's `data`, keyed by
  * the element's `id`. Those fields become the event's `values` (so a
  * `<Button onClick>` handler beside an `<Input>` can still read what was typed),
- * and, when the submit names a `ckValueField`, that field's text is also the
- * action's `value`.
+ * and, when the submit names a `ckValueField` that is present among them, that
+ * field's submitted value is also the action's `value`. A `ckValueField` naming
+ * an absent field (or one of the reserved envelope keys, which are stripped
+ * before the lookup) falls back to `data.value` — `undefined` on a synthesized
+ * submit, which carries no `value`.
  */
 export function parseCardAction(activity: TeamsActivityLike):
   | {

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -79,7 +79,14 @@ export function parseCardAction(activity: TeamsActivityLike):
   ) {
     return undefined;
   }
-  const values: Record<string, unknown> = {};
+  // Null-prototype, because `data` is an inbound payload and `__proto__`
+  // survives `JSON.parse` as an OWN key: assigning it onto a plain `{}` runs
+  // `Object.prototype`'s setter instead of creating a field, so the handler
+  // would receive an INVISIBLE inherited property (absent from `Object.keys`)
+  // in place of the submitted value. With no prototype every key lands as plain
+  // data and nothing is inherited, so `values` is exactly what was submitted —
+  // `constructor` and friends included.
+  const values: Record<string, unknown> = Object.create(null);
   for (const [key, fieldValue] of Object.entries(data)) {
     if (CARD_ENVELOPE_KEYS.includes(key)) continue;
     values[key] = fieldValue;

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -66,6 +66,41 @@ export function conversationKeyOf(activity: TeamsActivityLike): string {
 }
 
 /**
+ * Write one decoded field onto the `values` bag as an OWN data property.
+ *
+ * `key` comes from an inbound platform payload, and `__proto__` survives
+ * `JSON.parse` as an own key. A plain `bag[key] = value` for that key runs
+ * `Object.prototype`'s `__proto__` SETTER instead of creating a field: the
+ * submitted value disappears from `Object.keys(bag)` and — when it is an
+ * object — becomes the bag's prototype, so every property it carries reads
+ * back off `bag` as though the sender had submitted it. `defineProperty`
+ * writes the property itself and never consults a setter, so `__proto__`
+ * lands as ordinary enumerable data like any other field id.
+ *
+ * Deliberately a plain `{}` and NOT `Object.create(null)`. `values` is public
+ * API — it reaches application handlers as `ctx.values`, typed
+ * `Record<string, unknown>` (see channels-core's `InteractionContext`) — and
+ * `ctx.values.hasOwnProperty(...)`/`toString()` is ordinary consumer code that
+ * a prototype-less bag would break. Dropping the prototype buys only that an
+ * ABSENT field id spelled like a builtin reads back `undefined` rather than
+ * the builtin, which is true of every other `Record<string, unknown>` in this
+ * API and is not what the injection was about. A field that WAS submitted
+ * still wins: an own property shadows its `Object.prototype` namesake.
+ */
+function setField(
+  bag: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(bag, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+/**
  * Recognize and parse an Adaptive Card `Action.Submit`. Returns the opaque
  * action id, the action's value, and every submitted card input when the
  * activity carries our `ckActionId`, else `undefined` (i.e. it's an ordinary
@@ -97,17 +132,10 @@ export function parseCardAction(activity: TeamsActivityLike):
   ) {
     return undefined;
   }
-  // Null-prototype, because `data` is an inbound payload and `__proto__`
-  // survives `JSON.parse` as an OWN key: assigning it onto a plain `{}` runs
-  // `Object.prototype`'s setter instead of creating a field, so the handler
-  // would receive an INVISIBLE inherited property (absent from `Object.keys`)
-  // in place of the submitted value. With no prototype every key lands as plain
-  // data and nothing is inherited, so `values` is exactly what was submitted —
-  // `constructor` and friends included.
-  const values: Record<string, unknown> = Object.create(null);
+  const values: Record<string, unknown> = {};
   for (const [key, fieldValue] of Object.entries(data)) {
     if (CARD_ENVELOPE_KEYS.includes(key)) continue;
-    values[key] = fieldValue;
+    setField(values, key, fieldValue);
   }
   const valueField = data.ckValueField;
   const value =

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -23,8 +23,14 @@ export interface TeamsActivityLike {
 
 /** The `data` our submits round-trip (see `render/adaptive-card.ts`). */
 interface CardActionData {
-  /** Opaque minted handler id. Emitted by `renderButton` for a `<Button onClick>`
-   *  and by `synthesizeSubmit` for the field it binds. */
+  /**
+   * Opaque minted handler id. Emitted by `renderButton` for a `<Button onClick>`
+   * and by `synthesizeSubmit` for the field it binds. Every `Action.Submit` the
+   * renderer emits carries one — `renderButton` emits no action at all for a
+   * `<Button>` with no route — so an inbound payload without it is never one of
+   * our submits. Optional here because this types an INBOUND payload, which may
+   * be an ordinary chat message's `value`.
+   */
   ckActionId?: string;
   /** The clicked `<Button value>`, when it had one. Only `renderButton` emits it. */
   value?: unknown;

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -48,12 +48,31 @@ interface CardActionData {
  * Keys reserved by our own submit envelope. Teams merges every card input into
  * the submit's `data` object keyed by the input element's `id`, so these names
  * must never be minted as field ids nor read back as submitted fields.
+ *
+ * Frozen because it is public API and both of those guarantees read it live:
+ * `render/adaptive-card.ts` seeds its reserved-field-id set from it and
+ * `parseCardAction` strips it out of `values`. An in-process mutation would
+ * silently retarget both — dropping a genuinely submitted field or minting one
+ * under an envelope name. `as const` keeps the member names in the exported
+ * type; use {@link isCardEnvelopeKey} to test an arbitrary string against it.
  */
-export const CARD_ENVELOPE_KEYS: readonly string[] = [
+export const CARD_ENVELOPE_KEYS = Object.freeze([
   "ckActionId",
   "value",
   "ckValueField",
-];
+] as const);
+
+/** One of the {@link CARD_ENVELOPE_KEYS}. */
+export type CardEnvelopeKey = (typeof CARD_ENVELOPE_KEYS)[number];
+
+/**
+ * Is `key` reserved by the submit envelope? Narrows, so callers that hold a
+ * plain `string` (an inbound payload key, an author-supplied `name` prop) can
+ * still test it against the literal-typed {@link CARD_ENVELOPE_KEYS}.
+ */
+export function isCardEnvelopeKey(key: string): key is CardEnvelopeKey {
+  return CARD_ENVELOPE_KEYS.some((reserved) => reserved === key);
+}
 
 /**
  * Stable conversation key shared by ingress (`onTurn`) and interaction decoding
@@ -134,7 +153,7 @@ export function parseCardAction(activity: TeamsActivityLike):
   }
   const values: Record<string, unknown> = {};
   for (const [key, fieldValue] of Object.entries(data)) {
-    if (CARD_ENVELOPE_KEYS.includes(key)) continue;
+    if (isCardEnvelopeKey(key)) continue;
     setField(values, key, fieldValue);
   }
   const valueField = data.ckValueField;

--- a/packages/channels-teams/src/interaction.ts
+++ b/packages/channels-teams/src/interaction.ts
@@ -19,7 +19,26 @@ export interface TeamsActivityLike {
 interface CardActionData {
   ckActionId?: string;
   value?: unknown;
+  /**
+   * Id of the card input whose text IS this submit's action value. Set only on
+   * the submit the renderer synthesizes for an input-only card (see
+   * `renderAdaptiveCard`), where the dispatched handler is an `<Input onSubmit>`
+   * and its `ClickHandler<string>` contract requires the typed text — not the
+   * (absent) button value.
+   */
+  ckValueField?: string;
 }
+
+/**
+ * Keys reserved by our own submit envelope. Teams merges every card input into
+ * the submit's `data` object keyed by the input element's `id`, so these names
+ * must never be minted as field ids nor read back as submitted fields.
+ */
+export const CARD_ENVELOPE_KEYS: readonly string[] = [
+  "ckActionId",
+  "value",
+  "ckValueField",
+];
 
 /**
  * Stable conversation key shared by ingress (`onTurn`) and interaction decoding
@@ -33,14 +52,25 @@ export function conversationKeyOf(activity: TeamsActivityLike): string {
 
 /**
  * Recognize and parse an Adaptive Card `Action.Submit`. Returns the opaque
- * action id + button value when the activity carries our `ckActionId`, else
- * `undefined` (i.e. it's an ordinary chat message). Carries ONLY the opaque id
- * and the tiny button value: no resume-data smuggling; durability rides on the
+ * action id, the action's value, and every submitted card input when the
+ * activity carries our `ckActionId`, else `undefined` (i.e. it's an ordinary
+ * chat message). Carries ONLY the opaque id, the tiny button value and the
+ * user's own form input: no resume-data smuggling; durability rides on the
  * engine's ActionStore keyed by that id.
+ *
+ * Teams merges every `Input.*` on the card into the submit's `data`, keyed by
+ * the element's `id`. Those fields become the event's `values` (so a
+ * `<Button onClick>` handler beside an `<Input>` can still read what was typed),
+ * and, when the submit names a `ckValueField`, that field's text is also the
+ * action's `value`.
  */
-export function parseCardAction(
-  activity: TeamsActivityLike,
-): { id: string; value: unknown } | undefined {
+export function parseCardAction(activity: TeamsActivityLike):
+  | {
+      id: string;
+      value: unknown;
+      values: Record<string, unknown>;
+    }
+  | undefined {
   const data = activity.value as CardActionData | undefined;
   if (
     !data ||
@@ -49,5 +79,16 @@ export function parseCardAction(
   ) {
     return undefined;
   }
-  return { id: data.ckActionId, value: data.value };
+  const values: Record<string, unknown> = {};
+  for (const [key, fieldValue] of Object.entries(data)) {
+    if (CARD_ENVELOPE_KEYS.includes(key)) continue;
+    values[key] = fieldValue;
+  }
+  const valueField = data.ckValueField;
+  const value =
+    typeof valueField === "string" &&
+    Object.prototype.hasOwnProperty.call(values, valueField)
+      ? values[valueField]
+      : data.value;
+  return { id: data.ckActionId, value, values };
 }

--- a/packages/channels-teams/src/render/adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/adaptive-card.test.ts
@@ -313,6 +313,44 @@ describe("renderAdaptiveCard", () => {
     expect(card.actions).toBeUndefined();
   });
 
+  it("keeps the synthesized submit inside the top-level action ceiling", () => {
+    // The synthesized submit competes for the same budget as authored buttons.
+    // It is also the card's only route back into the engine, so it is the
+    // authored actions that give way, not the submit.
+    const links = Array.from({ length: TEAMS_LIMITS.actions }, (_, i) =>
+      el("button", [text(`l${i}`)], { url: `https://x.com/${i}` }),
+    );
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("actions", links),
+    ]);
+
+    expect(card.actions).toHaveLength(TEAMS_LIMITS.actions);
+    expect(card.actions!.at(-1)).toEqual({
+      type: "Action.Submit",
+      title: "Submit",
+      data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+    });
+  });
+
+  it("does not synthesize a submit when a dispatchable <Button> was clamped away", () => {
+    // The author did bind a handler; a submit synthesized from the input would
+    // dispatch the input's handler in the button's place.
+    const links = Array.from({ length: TEAMS_LIMITS.actions }, (_, i) =>
+      el("button", [text(`l${i}`)], { url: `https://x.com/${i}` }),
+    );
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("actions", [
+        ...links,
+        el("button", [text("Save")], { onClick: { id: "ck:save" } }),
+      ]),
+    ]);
+
+    expect(card.actions).toHaveLength(TEAMS_LIMITS.actions);
+    expect(card.actions!.every((a) => a.type === "Action.OpenUrl")).toBe(true);
+  });
+
   it("does not synthesize a submit when no input is bound to a handler", () => {
     // Nothing to dispatch: a submit would post an activity the engine ignores.
     const card = renderAdaptiveCard([el("input", [], { name: "reason" })]);
@@ -351,6 +389,17 @@ describe("renderAdaptiveCard", () => {
     const rows = table.rows as Array<Record<string, unknown>>;
     expect(rows).toHaveLength(2); // header + 1 data row
     expect(rows[0]!.type).toBe("TableRow");
+  });
+
+  it("counts the header row against the table row ceiling", () => {
+    const rows = Array.from({ length: TEAMS_LIMITS.tableRows }, (_, i) =>
+      el("row", [el("cell", [text(`r${i}`)])]),
+    );
+    const card = renderAdaptiveCard([
+      el("table", rows, { columns: [{ header: "A" }] }),
+    ]);
+    const table = card.body[0] as Record<string, unknown>;
+    expect(table.rows as unknown[]).toHaveLength(TEAMS_LIMITS.tableRows);
   });
 
   it("clamps top-level actions to the Teams ceiling", () => {

--- a/packages/channels-teams/src/render/adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/adaptive-card.test.ts
@@ -177,6 +177,79 @@ describe("renderAdaptiveCard", () => {
     ]);
   });
 
+  it("synthesizes an Action.Submit for a card whose only control is an <Input>", () => {
+    // Without it the card has zero actions and the user physically cannot
+    // submit it — `renderButton` is otherwise the only producer of a submit.
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" }, placeholder: "Why?" }),
+    ]);
+
+    expect(card.body[0]).toMatchObject({ type: "Input.Text", id: "ck:note" });
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
+  });
+
+  it("points the synthesized submit at the field id when <Input name> renames it", () => {
+    const card = renderAdaptiveCard([
+      el("input", [], { name: "reason", onSubmit: { id: "ck:note" } }),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "reason" },
+      },
+    ]);
+  });
+
+  it("does not synthesize a submit when the card already has a <Button>", () => {
+    // The button's own action id must stay the routed one; the input's text
+    // still rides along in the merged card inputs.
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("button", [text("Approve")], { onClick: { id: "ck:approve" } }),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Approve",
+        data: { ckActionId: "ck:approve" },
+      },
+    ]);
+  });
+
+  it("synthesizes a submit for a <Select>-only card too", () => {
+    // Same defect, same fix: without an action the choice can never be sent.
+    const card = renderAdaptiveCard([
+      el("select", [], {
+        onSelect: { id: "ck:pick" },
+        options: [{ label: "One", value: "1" }],
+      }),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:pick", ckValueField: "ck:pick" },
+      },
+    ]);
+  });
+
+  it("does not synthesize a submit when no input is bound to a handler", () => {
+    // Nothing to dispatch: a submit would post an activity the engine ignores.
+    const card = renderAdaptiveCard([el("input", [], { name: "reason" })]);
+
+    expect(card.actions).toBeUndefined();
+  });
+
   it("keeps form fields from overwriting Action.Submit routing data", () => {
     const card = renderAdaptiveCard([
       el("input", [], { onSubmit: { id: "ckActionId" } }),

--- a/packages/channels-teams/src/render/adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/adaptive-card.test.ts
@@ -263,19 +263,74 @@ describe("renderAdaptiveCard", () => {
     ]);
   });
 
-  it("synthesizes a submit beside a <Button> that routes nowhere", () => {
-    // A handler-less <Button> submits the card but carries no ckActionId, so
-    // the decode treats the click as an ordinary chat message and the input's
-    // text goes nowhere.
+  it("drops a <Button> with neither a url nor an onClick", () => {
+    // It would render as an Action.Submit with no ckActionId: clicking it
+    // submits the card, and Teams delivers that as a Message activity with
+    // empty text, which the decode reads as an ordinary chat message.
+    const card = renderAdaptiveCard([
+      el("actions", [el("button", [text("Dismiss")], {})]),
+    ]);
+
+    expect(card.actions).toBeUndefined();
+  });
+
+  it("drops a <Button> carrying a value but no onClick", () => {
+    // `value` is not a route: without a ckActionId the submit is rejected by
+    // `parseCardAction` exactly as a bare one is.
+    const card = renderAdaptiveCard([
+      el("button", [text("Later")], { value: "later" }),
+    ]);
+
+    expect(card.actions).toBeUndefined();
+  });
+
+  it("leaves only the synthesized submit when a <Button> routes nowhere", () => {
+    // The dead button is the path by which typed text is silently discarded:
+    // Teams merges the card's inputs into whichever submit fires, so clicking
+    // it would carry the input's text into a turn the engine reads as blank.
     const card = renderAdaptiveCard([
       el("input", [], { onSubmit: { id: "ck:note" } }),
       el("button", [text("Dismiss")], {}),
     ]);
 
-    expect(card.actions).toHaveLength(2);
-    expect(card.actions![1]).toMatchObject({
-      data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
+  });
+
+  it("does not synthesize a submit for an option-less <Select>", () => {
+    // An empty ChoiceSet has nothing to pick, so the submit would dispatch
+    // `undefined` to a handler whose contract is the chosen value.
+    const card = renderAdaptiveCard([
+      el("select", [], { onSelect: { id: "ck:pick" }, options: [] }),
+    ]);
+
+    expect(card.body[0]).toMatchObject({
+      type: "Input.ChoiceSet",
+      choices: [],
     });
+    expect(card.actions).toBeUndefined();
+  });
+
+  it("skips an option-less <Select> when picking the synthesized submit's field", () => {
+    // Only the first *usable* field backs the submit; an unpickable one must
+    // not consume the single binding and strand the field below it.
+    const card = renderAdaptiveCard([
+      el("select", [], { onSelect: { id: "ck:pick" } }),
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
   });
 
   it("binds the synthesized submit to only the FIRST input; the rest ride in `values`", () => {

--- a/packages/channels-teams/src/render/adaptive-card.test.ts
+++ b/packages/channels-teams/src/render/adaptive-card.test.ts
@@ -5,6 +5,7 @@ import {
   isPlainText,
   collectPlainText,
 } from "./adaptive-card.js";
+import { TEAMS_LIMITS } from "./budget.js";
 
 const text = (value: string): ChannelNode => ({
   type: "text",
@@ -241,6 +242,75 @@ describe("renderAdaptiveCard", () => {
         data: { ckActionId: "ck:pick", ckValueField: "ck:pick" },
       },
     ]);
+  });
+
+  it("synthesizes a submit beside a link <Button>, which submits nothing", () => {
+    // Action.OpenUrl opens a URL; it is not a submit. Counting actions rather
+    // than dispatchable submits would leave this card unsubmittable — the
+    // original defect, for a very ordinary "input + learn more link" shape.
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("actions", [el("button", [text("Docs")], { url: "https://x.com" })]),
+    ]);
+
+    expect(card.actions).toEqual([
+      { type: "Action.OpenUrl", title: "Docs", url: "https://x.com" },
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+      },
+    ]);
+  });
+
+  it("synthesizes a submit beside a <Button> that routes nowhere", () => {
+    // A handler-less <Button> submits the card but carries no ckActionId, so
+    // the decode treats the click as an ordinary chat message and the input's
+    // text goes nowhere.
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:note" } }),
+      el("button", [text("Dismiss")], {}),
+    ]);
+
+    expect(card.actions).toHaveLength(2);
+    expect(card.actions![1]).toMatchObject({
+      data: { ckActionId: "ck:note", ckValueField: "ck:note" },
+    });
+  });
+
+  it("binds the synthesized submit to only the FIRST input; the rest ride in `values`", () => {
+    // Adaptive Cards fires one action, and a Submit per input would be nonsense
+    // UI. Later handlers never fire — but Teams merges every input into this
+    // submit, so no typed text is lost.
+    const card = renderAdaptiveCard([
+      el("input", [], { onSubmit: { id: "ck:a" } }),
+      el("input", [], { onSubmit: { id: "ck:b" } }),
+    ]);
+
+    expect(card.actions).toEqual([
+      {
+        type: "Action.Submit",
+        title: "Submit",
+        data: { ckActionId: "ck:a", ckValueField: "ck:a" },
+      },
+    ]);
+  });
+
+  it("does not synthesize a submit for a field the body clamp dropped", () => {
+    // Otherwise the card shows a Submit with no input above it, and clicking it
+    // dispatches `undefined` to a `ClickHandler<string>`.
+    const overflow = Array.from({ length: TEAMS_LIMITS.bodyElements }, (_, i) =>
+      text(`t${i}`),
+    );
+    const card = renderAdaptiveCard([
+      ...overflow,
+      el("input", [], { onSubmit: { id: "ck:late" } }),
+    ]);
+
+    expect(card.body.some((element) => element.type === "Input.Text")).toBe(
+      false,
+    );
+    expect(card.actions).toBeUndefined();
   });
 
   it("does not synthesize a submit when no input is bound to a handler", () => {

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -24,7 +24,8 @@ interface RenderContext {
   /**
    * Inputs bound to a registry-minted handler, in render order: the card's
    * `id` for the element paired with the action id its handler was minted
-   * under. Used to synthesize a submit for an input-only card.
+   * under. Used to synthesize a submit for a card that has no dispatchable
+   * one. Only the first survivor is bound — see `renderAdaptiveCard`.
    */
   boundFields: { fieldId: string; actionId: string }[];
 }
@@ -64,34 +65,61 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
   };
   for (const node of ir) renderNode(node, body, actions, context);
 
+  const clampedBody = clampArray(body, TEAMS_LIMITS.bodyElements).items;
   const card: AdaptiveCard = {
     type: "AdaptiveCard",
     $schema: SCHEMA,
     version: VERSION,
-    body: clampArray(body, TEAMS_LIMITS.bodyElements).items,
+    body: clampedBody,
   };
   const clampedActions = clampArray(actions, TEAMS_LIMITS.actions).items;
   // Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches
   // us when some `Action.Submit` on the card fires, and Teams merges every input
-  // into that submit's payload. A card whose only controls are inputs therefore
-  // has zero actions and cannot be submitted at all — synthesize one bound to
-  // the first handler-bound field, naming it as the value field so the typed
-  // text (not an absent button value) arrives as the action's value.
+  // into that submit's payload. A card with no *dispatchable* submit therefore
+  // cannot deliver its inputs anywhere — synthesize one, naming the field whose
+  // text becomes the action's value (an absent button value would otherwise
+  // reach a `ClickHandler<string>` as `undefined`).
+  //
+  // "Dispatchable" is the test, not "has actions": a link `<Button>` renders as
+  // `Action.OpenUrl`, which opens a URL and submits nothing, and a `<Button>`
+  // with no `onClick` submits but routes nowhere. Either one beside an
+  // `<Input>` would otherwise reproduce the original defect.
   //
   // This covers `<Select>` too, since it is unsubmittable for the same reason.
   // Note a `<Select multi>` still arrives as Teams' comma-joined string rather
   // than the `string[]` `onSelect` declares — a pre-existing Teams fidelity gap
   // (see `renderSelect`) that this only makes reachable, not worse.
-  if (clampedActions.length === 0 && context.boundFields.length > 0) {
-    const field = context.boundFields[0]!;
-    clampedActions.push({
-      type: "Action.Submit",
-      title: SYNTHETIC_SUBMIT_TITLE,
-      data: { ckActionId: field.actionId, ckValueField: field.fieldId },
-    });
+  if (!clampedActions.some(isDispatchableSubmit)) {
+    // Only a field that survived the body clamp can back a submit; a dropped
+    // one would render a Submit with nothing above it.
+    const rendered = new Set(
+      clampedBody
+        .map((element) => element.id)
+        .filter((id): id is string => typeof id === "string"),
+    );
+    const field = context.boundFields.find((f) => rendered.has(f.fieldId));
+    // One submit per card, bound to the FIRST handler-bound field: Adaptive
+    // Cards fires a single action, and a button per input would be nonsense UI.
+    // Later fields' handlers therefore never fire — but their text is not lost,
+    // since Teams merges every input into this submit and `parseCardAction`
+    // surfaces them all as the event's `values`.
+    if (field) {
+      clampedActions.push({
+        type: "Action.Submit",
+        title: SYNTHETIC_SUBMIT_TITLE,
+        data: { ckActionId: field.actionId, ckValueField: field.fieldId },
+      });
+    }
   }
   if (clampedActions.length > 0) card.actions = clampedActions;
   return card;
+}
+
+/** Can this action route an interaction back into the engine when it fires? */
+function isDispatchableSubmit(action: CardAction): boolean {
+  if (action.type !== "Action.Submit") return false;
+  const data = action.data as { ckActionId?: unknown } | undefined;
+  return typeof data?.ckActionId === "string";
 }
 
 /** Render a single IR node, pushing body elements and/or top-level actions. */

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -51,6 +51,11 @@ const SYNTHETIC_SUBMIT_TITLE = "Submit";
  * are inputs gets a synthesized `Action.Submit`, without which Teams offers no
  * way to submit it at all.
  *
+ * A control that cannot route its interaction anywhere is not emitted as one: a
+ * `<Button>` with neither a `url` nor an `onClick` is dropped (see
+ * `renderButton`), and a field that cannot produce a value cannot back the
+ * synthesized submit (see `synthesizeSubmit`).
+ *
  * The renderer is total: unknown intrinsics are skipped. Collections clamp and
  * text truncates to {@link TEAMS_LIMITS} so the card stays within Teams' payload
  * ceiling.
@@ -105,14 +110,16 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
  * reach a `ClickHandler<string>` as `undefined`).
  *
  * "Dispatchable" is the caller's test, not "has actions": a link `<Button>`
- * renders as `Action.OpenUrl`, which opens a URL and submits nothing, and a
- * `<Button>` with no `onClick` submits but routes nowhere. Either one beside an
- * `<Input>` would otherwise reproduce the original defect.
+ * renders as `Action.OpenUrl`, which opens a URL and submits nothing, so one
+ * beside an `<Input>` would otherwise reproduce the original defect. (A
+ * `<Button>` that routes nowhere is not emitted at all — see `renderButton`.)
  *
- * This covers `<Select>` too, since it is unsubmittable for the same reason.
- * Note a `<Select multi>` still arrives as Teams' comma-joined string rather
- * than the `string[]` `onSelect` declares — a pre-existing Teams fidelity gap
- * (see `renderSelect`) that this only makes reachable, not worse.
+ * This covers `<Select>` too, since it is unsubmittable for the same reason,
+ * but only when it has something to pick: `renderNode` withholds an option-less
+ * one, whose (absent) choice would reach its handler as `undefined`. Note a
+ * `<Select multi>` still arrives as Teams' comma-joined string rather than the
+ * `string[]` `onSelect` declares — a pre-existing Teams fidelity gap (see
+ * `renderSelect`) that this only makes reachable, not worse.
  */
 function synthesizeSubmit(
   clampedBody: CardElement[],
@@ -139,7 +146,11 @@ function synthesizeSubmit(
   };
 }
 
-/** Can this action route an interaction back into the engine when it fires? */
+/**
+ * Can this action route an interaction back into the engine when it fires?
+ * `renderButton` only emits a submit that can, so the `data` test holds by
+ * construction; it is checked here so the predicate stands on its own.
+ */
 function isDispatchableSubmit(action: CardAction): boolean {
   if (action.type !== "Action.Submit") return false;
   const data = action.data as { ckActionId?: unknown } | undefined;
@@ -221,16 +232,31 @@ function renderNode(
       for (const child of childNodes(node))
         renderNode(child, body, actions, context);
       return;
-    case "button":
-      actions.push(renderButton(node));
+    case "button": {
+      // Absent for a button that can route nowhere — see `renderButton`.
+      const action = renderButton(node);
+      if (action) actions.push(action);
       return;
-    case "select":
+    }
+    case "select": {
+      // An option-less ChoiceSet offers nothing to pick, so it can never carry
+      // a value and must not back a synthesized submit.
+      const options = props.options;
+      const pickable = Array.isArray(options) && options.length > 0;
       body.push(
-        renderSelect(node, fieldId(node, "onSelect", "select", context)),
+        renderSelect(
+          node,
+          fieldId(node, "onSelect", "select", context, pickable),
+        ),
       );
       return;
+    }
     case "input":
-      body.push(renderInput(node, fieldId(node, "onSubmit", "input", context)));
+      // An Input.Text always submits a string (empty when untouched), so it is
+      // always a candidate to back a synthesized submit.
+      body.push(
+        renderInput(node, fieldId(node, "onSubmit", "input", context, true)),
+      );
       return;
     default:
       // Unknown intrinsic: skip (total renderer).
@@ -264,7 +290,18 @@ function factSet(fieldNodes: ChannelNode[]): CardElement {
   return { type: "FactSet", facts };
 }
 
-function renderButton(node: ChannelNode): CardAction {
+/**
+ * A `<Button>` → a top-level action, or `undefined` when it can route nowhere.
+ *
+ * A `<Button>` with neither a `url` nor an `onClick` has no destination, and
+ * there is no inert button in Adaptive Cards: emitted as an `Action.Submit` it
+ * would still submit the card, and Teams delivers that as an ordinary Message
+ * activity with empty `text`, which `parseCardAction` rejects (no `ckActionId`)
+ * and the adapter then drives as a blank user turn. Worse, Teams merges every
+ * card input into whichever submit fires, so the click also swallows what the
+ * user typed. Emitting nothing is the only shape that cannot do either.
+ */
+function renderButton(node: ChannelNode): CardAction | undefined {
   const props = node.props ?? {};
   // Link button → Action.OpenUrl (opens the URL; carries no submit data).
   if (typeof props.url === "string" && props.url.length > 0) {
@@ -274,17 +311,19 @@ function renderButton(node: ChannelNode): CardAction {
       url: props.url,
     };
   }
+  // The opaque action id is what routes the submit back into the engine, so a
+  // button without one is dropped. `value` alone is not a route: the decode
+  // keys on `ckActionId`.
+  const id = idFromHandler(props.onClick);
+  if (!id) return undefined;
   const action: CardAction = {
     type: "Action.Submit",
     title: truncateText(collectText(node), TEAMS_LIMITS.buttonText),
+    data: {
+      ckActionId: id,
+      ...(props.value !== undefined ? { value: props.value } : {}),
+    },
   };
-  // Forward-ready: carry the opaque action id + value so a later
-  // `decodeInteraction` can route the submit back into the engine.
-  const id = idFromHandler(props.onClick);
-  const data: Record<string, unknown> = {};
-  if (id) data.ckActionId = id;
-  if (props.value !== undefined) data.value = props.value;
-  if (Object.keys(data).length > 0) action.data = data;
   if (props.style === "danger" || props.style === "destructive") {
     action.style = "destructive";
   } else if (props.style === "primary") {
@@ -328,6 +367,8 @@ function fieldId(
   handlerProp: "onSelect" | "onSubmit",
   fallback: "select" | "input",
   context: RenderContext,
+  /** Can this field produce a value? Only then may it back a synthesized submit. */
+  canProduceValue: boolean,
 ): string {
   const props = node.props ?? {};
   const index = ++context.nextFieldIndex;
@@ -345,7 +386,9 @@ function fieldId(
   // An explicit `name` (or a dedupe suffix) makes the field id diverge from the
   // minted action id, so record both: dispatch needs the action id, reading the
   // submitted text needs the field id.
-  if (actionId) context.boundFields.push({ fieldId: candidate, actionId });
+  if (actionId && canProduceValue) {
+    context.boundFields.push({ fieldId: candidate, actionId });
+  }
   return candidate;
 }
 

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -25,7 +25,7 @@ interface RenderContext {
    * Inputs bound to a registry-minted handler, in render order: the card's
    * `id` for the element paired with the action id its handler was minted
    * under. Used to synthesize a submit for a card that has no dispatchable
-   * one. Only the first survivor is bound — see `renderAdaptiveCard`.
+   * one. Only the first survivor is bound — see `synthesizeSubmit`.
    */
   boundFields: { fieldId: string; actionId: string }[];
 }
@@ -72,47 +72,71 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
     version: VERSION,
     body: clampedBody,
   };
-  const clampedActions = clampArray(actions, TEAMS_LIMITS.actions).items;
-  // Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches
-  // us when some `Action.Submit` on the card fires, and Teams merges every input
-  // into that submit's payload. A card with no *dispatchable* submit therefore
-  // cannot deliver its inputs anywhere — synthesize one, naming the field whose
-  // text becomes the action's value (an absent button value would otherwise
-  // reach a `ClickHandler<string>` as `undefined`).
-  //
-  // "Dispatchable" is the test, not "has actions": a link `<Button>` renders as
-  // `Action.OpenUrl`, which opens a URL and submits nothing, and a `<Button>`
-  // with no `onClick` submits but routes nowhere. Either one beside an
-  // `<Input>` would otherwise reproduce the original defect.
-  //
-  // This covers `<Select>` too, since it is unsubmittable for the same reason.
-  // Note a `<Select multi>` still arrives as Teams' comma-joined string rather
-  // than the `string[]` `onSelect` declares — a pre-existing Teams fidelity gap
-  // (see `renderSelect`) that this only makes reachable, not worse.
-  if (!clampedActions.some(isDispatchableSubmit)) {
-    // Only a field that survived the body clamp can back a submit; a dropped
-    // one would render a Submit with nothing above it.
-    const rendered = new Set(
-      clampedBody
-        .map((element) => element.id)
-        .filter((id): id is string => typeof id === "string"),
-    );
-    const field = context.boundFields.find((f) => rendered.has(f.fieldId));
-    // One submit per card, bound to the FIRST handler-bound field: Adaptive
-    // Cards fires a single action, and a button per input would be nonsense UI.
-    // Later fields' handlers therefore never fire — but their text is not lost,
-    // since Teams merges every input into this submit and `parseCardAction`
-    // surfaces them all as the event's `values`.
-    if (field) {
-      clampedActions.push({
-        type: "Action.Submit",
-        title: SYNTHETIC_SUBMIT_TITLE,
-        data: { ckActionId: field.actionId, ckValueField: field.fieldId },
-      });
-    }
-  }
+  // Decide synthesis against the UNCLAMPED actions: a dispatchable `<Button>`
+  // pushed past the ceiling below is still the handler the author bound, and
+  // synthesizing from an input would dispatch the input's handler in its place.
+  // Such a card keeps the author's action order, so the overflowing button's
+  // handler still never fires — but a wrong dispatch is worse than none.
+  const synthesized = actions.some(isDispatchableSubmit)
+    ? undefined
+    : synthesizeSubmit(clampedBody, context);
+  // One clamp governs the emitted list, with the synthesized submit's slot
+  // reserved inside the ceiling: appending it afterwards would emit
+  // `TEAMS_LIMITS.actions + 1` actions, and letting the clamp choose between
+  // them could drop the card's only route back into the engine.
+  const clampedActions = clampArray(
+    actions,
+    TEAMS_LIMITS.actions - (synthesized ? 1 : 0),
+  ).items;
+  if (synthesized) clampedActions.push(synthesized);
   if (clampedActions.length > 0) card.actions = clampedActions;
   return card;
+}
+
+/**
+ * The `Action.Submit` to add to a card that has none it can dispatch, or
+ * `undefined` when no rendered field can back one.
+ *
+ * Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches
+ * us when some `Action.Submit` on the card fires, and Teams merges every input
+ * into that submit's payload. A card with no *dispatchable* submit therefore
+ * cannot deliver its inputs anywhere — synthesize one, naming the field whose
+ * text becomes the action's value (an absent button value would otherwise
+ * reach a `ClickHandler<string>` as `undefined`).
+ *
+ * "Dispatchable" is the caller's test, not "has actions": a link `<Button>`
+ * renders as `Action.OpenUrl`, which opens a URL and submits nothing, and a
+ * `<Button>` with no `onClick` submits but routes nowhere. Either one beside an
+ * `<Input>` would otherwise reproduce the original defect.
+ *
+ * This covers `<Select>` too, since it is unsubmittable for the same reason.
+ * Note a `<Select multi>` still arrives as Teams' comma-joined string rather
+ * than the `string[]` `onSelect` declares — a pre-existing Teams fidelity gap
+ * (see `renderSelect`) that this only makes reachable, not worse.
+ */
+function synthesizeSubmit(
+  clampedBody: CardElement[],
+  context: RenderContext,
+): CardAction | undefined {
+  // Only a field that survived the body clamp can back a submit; a dropped
+  // one would render a Submit with nothing above it.
+  const rendered = new Set(
+    clampedBody
+      .map((element) => element.id)
+      .filter((id): id is string => typeof id === "string"),
+  );
+  // One submit per card, bound to the FIRST handler-bound field: Adaptive
+  // Cards fires a single action, and a button per input would be nonsense UI.
+  // Later fields' handlers therefore never fire — but their text is not lost,
+  // since Teams merges every input into this submit and `parseCardAction`
+  // surfaces them all as the event's `values`.
+  const field = context.boundFields.find((f) => rendered.has(f.fieldId));
+  if (!field) return undefined;
+  return {
+    type: "Action.Submit",
+    title: SYNTHETIC_SUBMIT_TITLE,
+    data: { ckActionId: field.actionId, ckValueField: field.fieldId },
+  };
 }
 
 /** Can this action route an interaction back into the engine when it fires? */
@@ -347,15 +371,21 @@ function renderTable(node: ChannelNode): CardElement {
     ? clampArray(columnsProp, TEAMS_LIMITS.tableColumns).items
     : undefined;
 
+  const headerColumns = columns && columns.length > 0 ? columns : undefined;
   const rows: Record<string, unknown>[] = [];
-  if (columns && columns.length > 0) {
+  if (headerColumns) {
     rows.push({
       type: "TableRow",
-      cells: columns.map((c) => cell(c.header, true)),
+      cells: headerColumns.map((c) => cell(c.header, true)),
     });
   }
   const rowNodes = childNodes(node).filter((c) => c.type === "row");
-  const { items: dataRows } = clampArray(rowNodes, TEAMS_LIMITS.tableRows);
+  // The header is one of the emitted rows, so it takes a slot from the same
+  // budget rather than riding on top of a full set of data rows.
+  const { items: dataRows } = clampArray(
+    rowNodes,
+    TEAMS_LIMITS.tableRows - (headerColumns ? 1 : 0),
+  );
   for (const rowNode of dataRows) {
     const cells = childNodes(rowNode).filter((c) => c.type === "cell");
     rows.push({
@@ -373,7 +403,7 @@ function renderTable(node: ChannelNode): CardElement {
         : {}),
     })),
     rows,
-    firstRowAsHeader: !!(columns && columns.length > 0),
+    firstRowAsHeader: !!headerColumns,
     gridStyle: "default",
   };
   return table;

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -1,4 +1,5 @@
 import type { ChannelNode } from "@copilotkit/channels-ui";
+import { CARD_ENVELOPE_KEYS } from "../interaction.js";
 import { TEAMS_LIMITS, truncateText, clampArray } from "./budget.js";
 
 /** Teams attachment content type for an Adaptive Card. */
@@ -20,10 +21,18 @@ type CardAction = Record<string, unknown>;
 interface RenderContext {
   nextFieldIndex: number;
   usedFieldIds: Set<string>;
+  /**
+   * Inputs bound to a registry-minted handler, in render order: the card's
+   * `id` for the element paired with the action id its handler was minted
+   * under. Used to synthesize a submit for an input-only card.
+   */
+  boundFields: { fieldId: string; actionId: string }[];
 }
 
 const SCHEMA = "http://adaptivecards.io/schemas/adaptive-card.json";
 const VERSION = "1.5";
+/** Title of the submit synthesized for a card whose only controls are inputs. */
+const SYNTHETIC_SUBMIT_TITLE = "Submit";
 
 /**
  * Render a cross-platform component IR tree (already expanded by `renderToIR`
@@ -37,7 +46,9 @@ const VERSION = "1.5";
  * decision to use `Action.Submit`), while `<Input>`/`<Select>` become
  * `Input.Text`/`Input.ChoiceSet` in the body. Each action/input carries the
  * registry-stamped opaque id in its `data`/`id` so a later interaction can be
- * decoded back into the engine (round-trip is a follow-up; rendering is here).
+ * decoded back into the engine by `parseCardAction`. A card whose only controls
+ * are inputs gets a synthesized `Action.Submit`, without which Teams offers no
+ * way to submit it at all.
  *
  * The renderer is total: unknown intrinsics are skipped. Collections clamp and
  * text truncates to {@link TEAMS_LIMITS} so the card stays within Teams' payload
@@ -48,7 +59,8 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
   const actions: CardAction[] = [];
   const context: RenderContext = {
     nextFieldIndex: 0,
-    usedFieldIds: new Set(["ckActionId", "value"]),
+    usedFieldIds: new Set(CARD_ENVELOPE_KEYS),
+    boundFields: [],
   };
   for (const node of ir) renderNode(node, body, actions, context);
 
@@ -59,6 +71,25 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
     body: clampArray(body, TEAMS_LIMITS.bodyElements).items,
   };
   const clampedActions = clampArray(actions, TEAMS_LIMITS.actions).items;
+  // Adaptive Cards has no per-input submit affordance: an `Input.*` only reaches
+  // us when some `Action.Submit` on the card fires, and Teams merges every input
+  // into that submit's payload. A card whose only controls are inputs therefore
+  // has zero actions and cannot be submitted at all — synthesize one bound to
+  // the first handler-bound field, naming it as the value field so the typed
+  // text (not an absent button value) arrives as the action's value.
+  //
+  // This covers `<Select>` too, since it is unsubmittable for the same reason.
+  // Note a `<Select multi>` still arrives as Teams' comma-joined string rather
+  // than the `string[]` `onSelect` declares — a pre-existing Teams fidelity gap
+  // (see `renderSelect`) that this only makes reachable, not worse.
+  if (clampedActions.length === 0 && context.boundFields.length > 0) {
+    const field = context.boundFields[0]!;
+    clampedActions.push({
+      type: "Action.Submit",
+      title: SYNTHETIC_SUBMIT_TITLE,
+      data: { ckActionId: field.actionId, ckValueField: field.fieldId },
+    });
+  }
   if (clampedActions.length > 0) card.actions = clampedActions;
   return card;
 }
@@ -250,17 +281,19 @@ function fieldId(
   const index = ++context.nextFieldIndex;
   const rawName = typeof props.name === "string" ? props.name.trim() : "";
   const explicitName =
-    rawName && rawName !== "ckActionId" && rawName !== "value"
-      ? rawName
-      : undefined;
-  const base =
-    explicitName ?? idFromHandler(props[handlerProp]) ?? `${fallback}_${index}`;
+    rawName && !CARD_ENVELOPE_KEYS.includes(rawName) ? rawName : undefined;
+  const actionId = idFromHandler(props[handlerProp]);
+  const base = explicitName ?? actionId ?? `${fallback}_${index}`;
   let candidate = base;
   let suffix = 1;
   while (context.usedFieldIds.has(candidate)) {
     candidate = `${base}_${suffix++}`;
   }
   context.usedFieldIds.add(candidate);
+  // An explicit `name` (or a dedupe suffix) makes the field id diverge from the
+  // minted action id, so record both: dispatch needs the action id, reading the
+  // submitted text needs the field id.
+  if (actionId) context.boundFields.push({ fieldId: candidate, actionId });
   return candidate;
 }
 

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -22,10 +22,12 @@ interface RenderContext {
   nextFieldIndex: number;
   usedFieldIds: Set<string>;
   /**
-   * Inputs bound to a registry-minted handler, in render order: the card's
-   * `id` for the element paired with the action id its handler was minted
-   * under. Used to synthesize a submit for a card that has no dispatchable
-   * one. Only the first survivor is bound — see `synthesizeSubmit`.
+   * Fields (`<Input>`/`<Select>`) that both carry a registry-minted handler and
+   * can produce a value, in render order: the card `id` minted for the element
+   * paired with the action id its handler was stamped with (the two differ
+   * whenever `fieldId` used a `name` prop or a dedupe suffix). Used to
+   * synthesize a submit for a card that has no dispatchable one. Only the first
+   * entry that survived the body clamp is bound — see `synthesizeSubmit`.
    */
   boundFields: { fieldId: string; actionId: string }[];
 }
@@ -41,24 +43,39 @@ const SYNTHETIC_SUBMIT_TITLE = "Submit";
  * Teams **Adaptive Card** (1.5).
  *
  * Structural nodes map to body elements (`<Header>`→bold `TextBlock`,
- * `<Section>`/`<Markdown>`→wrapped `TextBlock`, `<Fields>`→`FactSet`,
- * `<Table>`→native `Table`, `<Image>`→`Image`). Interactive nodes split by
- * Adaptive Card shape: `<Button>`→a top-level `Action.Submit` (per the V1
- * decision to use `Action.Submit`), while `<Input>`/`<Select>` become
- * `Input.Text`/`Input.ChoiceSet` in the body. Each action/input carries the
- * registry-stamped opaque id in its `data`/`id` so a later interaction can be
- * decoded back into the engine by `parseCardAction`. A card whose only controls
- * are inputs gets a synthesized `Action.Submit`, without which Teams offers no
- * way to submit it at all.
+ * `<Section>`/`<Markdown>` and a bare text child→wrapped `TextBlock`,
+ * `<Context>`→small subtle `TextBlock`, `<Divider>`→a blank separated
+ * `TextBlock`, `<Fields>`/`<Field>`→`FactSet`, `<Table>`→native `Table`,
+ * `<Chart>`→a Teams `Chart.*` host element, `<Image>`→`Image`). Interactive
+ * nodes split by Adaptive Card shape: `<Button>`→a top-level action — an
+ * `Action.Submit` (per the V1 decision to use `Action.Submit`, not
+ * `Action.Execute`), or an `Action.OpenUrl` when it is a link button — while
+ * `<Input>`/`<Select>` become `Input.Text`/`Input.ChoiceSet` in the body.
+ *
+ * An emitted `Action.Submit` carries the registry-stamped opaque id in its
+ * `data.ckActionId`, so a later interaction can be decoded back into the engine
+ * by `parseCardAction`; an `Action.OpenUrl` carries no `data` and never
+ * round-trips. A field's `id` is a separate, card-local name minted by
+ * `fieldId` — the explicit `name` prop when given, else the stamped id, else a
+ * positional `input_N`/`select_N`, plus a `_1`, `_2`, … suffix on collision —
+ * so it coincides with the stamped id only in the middle case, and then only
+ * when no suffix was needed. A card whose only controls are inputs gets a
+ * synthesized `Action.Submit`, which carries both ids (see `synthesizeSubmit`)
+ * and without which Teams offers no way to submit the card at all.
  *
  * A control that cannot route its interaction anywhere is not emitted as one: a
  * `<Button>` with neither a `url` nor an `onClick` is dropped (see
- * `renderButton`), and a field that cannot produce a value cannot back the
- * synthesized submit (see `synthesizeSubmit`).
+ * `renderButton`). A field is different — it is always rendered, and only its
+ * candidacy to back the synthesized submit is conditional, on both carrying a
+ * stamped handler id and being able to produce a value (see `fieldId`).
  *
- * The renderer is total: unknown intrinsics are skipped. Collections clamp and
- * text truncates to {@link TEAMS_LIMITS} so the card stays within Teams' payload
- * ceiling.
+ * The renderer is total: unknown intrinsics are skipped. Collections clamp to
+ * {@link TEAMS_LIMITS} and displayed prose truncates to it — TextBlock text,
+ * fact titles/values, button titles, table cells, choice labels and chart
+ * titles/labels — so the card stays within Teams' payload ceiling. Other
+ * author-supplied strings pass through unbounded: `placeholder`, a choice's
+ * `value`, an `<Image>`'s `url`/`altText`, a chart's axis titles, and a
+ * `<Button value>`.
  */
 export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
   const body: CardElement[] = [];
@@ -115,11 +132,12 @@ export function renderAdaptiveCard(ir: ChannelNode[]): AdaptiveCard {
  * `<Button>` that routes nowhere is not emitted at all — see `renderButton`.)
  *
  * This covers `<Select>` too, since it is unsubmittable for the same reason,
- * but only when it has something to pick: `renderNode` withholds an option-less
- * one, whose (absent) choice would reach its handler as `undefined`. Note a
- * `<Select multi>` still arrives as Teams' comma-joined string rather than the
- * `string[]` `onSelect` declares — a pre-existing Teams fidelity gap (see
- * `renderSelect`) that this only makes reachable, not worse.
+ * but only when it has something to pick: an option-less one is still rendered
+ * as an empty `Input.ChoiceSet`, but `renderNode` withholds it from the
+ * candidate pool, since its (absent) choice would reach its handler as
+ * `undefined`. Note a `<Select multi>` still arrives as Teams' comma-joined
+ * string rather than the `string[]` `onSelect` declares — a pre-existing Teams
+ * fidelity gap (see `renderSelect`) that this only makes reachable, not worse.
  */
 function synthesizeSubmit(
   clampedBody: CardElement[],
@@ -252,8 +270,9 @@ function renderNode(
       return;
     }
     case "input":
-      // An Input.Text always submits a string (empty when untouched), so it is
-      // always a candidate to back a synthesized submit.
+      // An Input.Text always submits a string (empty when untouched), so it
+      // never fails the can-produce-a-value test. Candidacy still needs a
+      // minted handler id, which `fieldId` checks separately.
       body.push(
         renderInput(node, fieldId(node, "onSubmit", "input", context, true)),
       );

--- a/packages/channels-teams/src/render/adaptive-card.ts
+++ b/packages/channels-teams/src/render/adaptive-card.ts
@@ -1,5 +1,5 @@
 import type { ChannelNode } from "@copilotkit/channels-ui";
-import { CARD_ENVELOPE_KEYS } from "../interaction.js";
+import { CARD_ENVELOPE_KEYS, isCardEnvelopeKey } from "../interaction.js";
 import { TEAMS_LIMITS, truncateText, clampArray } from "./budget.js";
 
 /** Teams attachment content type for an Adaptive Card. */
@@ -393,7 +393,7 @@ function fieldId(
   const index = ++context.nextFieldIndex;
   const rawName = typeof props.name === "string" ? props.name.trim() : "";
   const explicitName =
-    rawName && !CARD_ENVELOPE_KEYS.includes(rawName) ? rawName : undefined;
+    rawName && !isCardEnvelopeKey(rawName) ? rawName : undefined;
   const actionId = idFromHandler(props[handlerProp]);
   const base = explicitName ?? actionId ?? `${fallback}_${index}`;
   let candidate = base;

--- a/showcase/shell-docs/src/content/docs/channels/rich-messages.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/rich-messages.mdx
@@ -106,9 +106,18 @@ optional visual must still carry the important result.
 
 `Select` and `Input` have different interaction behavior by provider. Managed
 Slack dispatches those controls directly. Managed Teams renders Adaptive Card
-fields and submits them with a `Button`'s `Action.Submit`; that Button callback
-receives the other named fields in `ctx.values`. Teams does not dispatch
-`Select.onSelect` or `Input.onSubmit` independently.
+fields and submits them together, because Adaptive Cards has no per-field
+submit: whichever `Action.Submit` fires carries every field on the card, and
+that callback receives the other named fields in `ctx.values`.
+
+So on Teams a card holding both a field and a `Button` runs the **Button's**
+callback, not `Select.onSelect` or `Input.onSubmit`. A card with no button
+would otherwise be unsubmittable, so Teams adds one for you, bound to the first
+field that has a handler — that field's callback runs and the rest still arrive
+in `ctx.values`. Only that first field's handler fires.
+
+On either provider, a field with no handler never dispatches on its own. Its
+value rides along in `ctx.values` when something else on the message is used.
 
 <FrontendOnly frontend="slack">
 


### PR DESCRIPTION
Fixes [OSS-716](https://linear.app/copilotkit/issue/OSS-716).

`<Input>` is a documented, exported `channels-ui` component. It did not work on
Teams at all, and corrupted the submitted value on Slack.

## The four original defects

**Teams — the component was inert.**

- `renderInput` produced no submit affordance. `renderButton` was the only
  producer of `Action.Submit`, and inputs go to the card `body` while buttons go
  to `actions`, so an Input-only card had zero actions and could not be
  submitted at all. Adaptive Cards has no per-field submit, so the renderer now
  synthesizes one bound to the first handler-bound field. It carries
  `ckValueField` naming the field whose text becomes the action value, because
  an explicit `<Input name>` (or a dedupe suffix) makes the card element id
  diverge from the minted handler id.
- `parseCardAction` discarded every merged card input. Teams merges each
  `Input.*` into the submit's `data`; those now surface as
  `InteractionEvent.values`, so a `<Button onClick>` beside an `<Input>` can
  read what was typed instead of only its own value.

**Slack — the value was corrupted, and one shape was dropped.**

- `plain_text_input` text is no longer JSON-parsed. `42`, `true`, `null` and
  `{"a":1}` reach the handler as those four strings. The coercion is kept only
  for values we serialize ourselves (button `value`).
- An `<Input>` nested inside `<Actions>` was silently dropped. Slack forbids
  `plain_text_input` in an actions block while requiring `<Button>` to be in
  one, so identical JSX diverged between the surfaces with no diagnostic. It is
  now peeled into its own dispatching input block, as multi-selects already
  were.
- `InteractionEvent.values` is populated on `block_actions`, keyed to match how
  Teams keys its merged card inputs.

Both adapters gained an end-to-end test — render, simulate the payload the
platform would post back, dispatch, resume the HITL waiter.

## Also fixed here, found while reviewing the above

- A card with no *dispatchable* submit is what triggers synthesis, not a card
  with no actions: a link `<Button>` renders `Action.OpenUrl`, which submits
  nothing. The synthesized action's slot is reserved inside the single action
  clamp, so it can neither overflow the ceiling nor be the entry the clamp drops.
- Inbound payload keys are written with `Object.defineProperty`, so a
  `__proto__` key from a crafted payload lands as own data rather than
  redirecting the bag's prototype. `values` stays an ordinary object —
  `ctx.values.hasOwnProperty(...)` keeps working.
- `<Select>` option values are no longer JSON-coerced. `SelectOption.value` is
  declared `string`, so the round trip was pure corruption.
- An empty Slack text input delivers `""` rather than `null`, matching Teams.
- Slack only sets `dispatch_action` on a handler-bound control. An unbound
  notes box previously dispatched an unroutable interaction, which the engine
  used to resolve a pending `thread.awaitChoice` — answering someone else's
  approval with whatever was typed. See the caveat below.
- `CARD_ENVELOPE_KEYS` is frozen and its guard exported; the envelope doc and
  the renderer docstrings were corrected against the code.

## Known limitations

- **A multiline `<Input onSubmit>` renders single-line on Slack.** Slack
  dispatches a `plain_text_input` only via `dispatch_action_config`, whose
  triggers are `on_enter_pressed` and `on_character_entered`. Enter inserts a
  newline in a tall box, and per-character dispatch would resolve a HITL waiter
  on the first keystroke. Where Slack cannot express both, the data contract
  wins over the presentation hint. An unbound `<Input multiline>` keeps its tall
  box.
- On Teams, only the first handler-bound field's callback fires — Adaptive Cards
  fires one action. Every field's value still arrives in `ctx.values`.
- A Teams `<Select multi>` arrives comma-joined rather than as `string[]`.

## Follow-ups filed, not fixed here

Review of this change surfaced a lot of adjacent and pre-existing work:

- [OSS-720](https://linear.app/copilotkit/issue/OSS-720) (Urgent) — a pending
  `awaitChoice` resolves on *any* interaction in the conversation, regardless of
  whether a handler dispatched. Root cause is in `channels-core` and affects
  more than `<Input>`; this PR only stops the Slack renderer handing it an easy
  trigger.
- [OSS-721](https://linear.app/copilotkit/issue/OSS-721) — Slack drops top-level
  `<Select>`/`<Button>`/`<Chart>`. The gap is pinned by passing tests, so the
  fix flips assertions.
- [OSS-722](https://linear.app/copilotkit/issue/OSS-722) — duplicate
  `action_id`s on handler-less buttons make Slack reject the whole message.
- [OSS-723](https://linear.app/copilotkit/issue/OSS-723) — audit discord,
  telegram and the Intelligence ingress for the same `__proto__` hole.
- [OSS-724](https://linear.app/copilotkit/issue/OSS-724),
  [OSS-725](https://linear.app/copilotkit/issue/OSS-725),
  [OSS-726](https://linear.app/copilotkit/issue/OSS-726) — pre-existing
  reliability, block-validity and packaging debt in files this PR touched.

## Verification

`check-types`, `build` and `test` pass across the channels packages with the Nx
cache disabled; `publint` and `attw` re-run uncached for the three published
packages.

One thing worth knowing for CI: `channels-slack:test` fails intermittently when
`channels-core` has not finished building, so tests must run against a fully
built tree. Nx flagged it as flaky during this work.