### PR TITLE
fix(channels): report a clone that drops subclass state, do not refuse the turn

### DIFF
--- a/packages/channels-core/src/create-channel.test.ts
+++ b/packages/channels-core/src/create-channel.test.ts
@@ -1134,8 +1134,9 @@ describe("createChannel", () => {
     expect(shared.messages).toEqual([]);
   });
 
-  it("agent whose clone() drops subclass state fails loud", async () => {
+  it("agent whose clone() drops subclass state warns and still runs the turn", async () => {
     const state = new MemoryStore();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     // Inherits `FakeAgent.clone()`, which builds a plain `FakeAgent` and so
     // cannot carry this field — the same shape as a subclass inheriting
@@ -1158,6 +1159,8 @@ describe("createChannel", () => {
 
     await channel.ɵruntime.start();
     const sink = fake.getSink();
+    // Reports it, and does not refuse the turn: whether a dropped field matters
+    // depends on what it holds, and this cannot tell config from per-run state.
     await expect(
       sink.onTurn({
         conversationKey: "c1",
@@ -1166,7 +1169,49 @@ describe("createChannel", () => {
         platform: "fake" as const,
         eventId: "E1",
       }),
-    ).rejects.toThrow(/StatefulAgent\.clone\(\) dropped authClient/);
+    ).resolves.not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(/StatefulAgent\.clone\(\) dropped authClient/),
+    );
+
+    warn.mockRestore();
+  });
+
+  it("the dropped-state warning names every field, once per turn", async () => {
+    const state = new MemoryStore();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    class TwoFieldAgent extends FakeAgent {
+      authClient = { token: "secret" };
+      cache = new Map<string, string>();
+    }
+
+    const fake = new FakeAdapter();
+    const channel = createChannel({
+      identifyUser: "platform",
+      adapters: [fake],
+      agent: () => new TwoFieldAgent(),
+      store: { adapter: state },
+    });
+    channel.onMention(async ({ thread }) => {
+      await thread.runAgent({ prompt: "hi" });
+    });
+
+    await channel.ɵruntime.start();
+    await fake.getSink().onTurn({
+      conversationKey: "c1",
+      replyTarget: {},
+      userText: "hi",
+      platform: "fake" as const,
+      eventId: "E1",
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("authClient, cache"),
+    );
+
+    warn.mockRestore();
   });
 
   it("does not fail loud when clone() drops an instance-patched method", async () => {

--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -115,7 +115,8 @@ export type ChannelConcurrency = "parallel" | "serial" | "drop";
  *
  * Fails loud on all three ways cloning can fail to isolate: a missing `clone()`,
  * a `clone()` that hands back the same object, and a `clone()` that silently
- * drops subclass state (see {@link assertCloneKeptOwnFields}).
+ * drops subclass state (see {@link warnOnCloneDroppedOwnFields}, which reports
+ * rather than refuses).
  */
 export function isolateAgentInstance(
   prototype: AbstractAgent,
@@ -134,7 +135,7 @@ export function isolateAgentInstance(
       "createChannel: agent.clone() must return a distinct instance for concurrent turns",
     );
   }
-  assertCloneKeptOwnFields(prototype, cloned);
+  warnOnCloneDroppedOwnFields(prototype, cloned);
   cloned.threadId = threadId;
   // `clone()` copies `isRunning` from the source, and a source that has already
   // run can be mid-run at the moment it is cloned. A fresh turn is not.
@@ -157,7 +158,7 @@ export function isolateAgentInstance(
 }
 
 /**
- * Fail loud when `clone()` silently drops subclass state.
+ * Report — but do not refuse — a `clone()` that drops subclass state.
  *
  * `AbstractAgent.prototype.clone()` copies a fixed field list, so a subclass
  * that declares its own fields (an auth client, config, a cache) gets them back
@@ -165,17 +166,37 @@ export function isolateAgentInstance(
  * exists and returns a correctly-typed instance, nothing else surfaces it. The
  * agent just runs gutted.
  *
- * Comparing own enumerable keys catches exactly that and stays quiet for the
- * agents that do override `clone()` (`HttpAgent`, `LangGraphAgent`,
- * `BuiltInAgent`, `IntelligenceAgent`). Symbol-keyed and non-enumerable fields
- * are not covered.
+ * This used to throw. It no longer does, because whether a dropped field matters
+ * depends on what the field HOLDS, and from here the two cases are
+ * indistinguishable:
+ *
+ * - **Config** (`orchestrationAgentUrl`, an auth client) is read during the run
+ *   and never rewritten, so losing it does gut the agent.
+ * - **Per-run scratch state** is re-initialized at the start of every run, so
+ *   losing it changes nothing. `LangGraphAgent`'s `emittedToolCallStartIds` and
+ *   `eventsStreamActive` are exactly this: both are reset when a run binds its
+ *   subscriber, before anything reads them.
+ *
+ * Throwing on the second case took a Channel that works and refused every turn
+ * — while the identical clone happens on every ordinary runtime request
+ * (`agent-utils.ts` clones per request) with no ill effect at all, which is why
+ * it had never been noticed outside Channels. A warning keeps the signal for the
+ * config case without failing the harmless one.
+ *
+ * Deliberately NOT done: copying the dropped fields onto the clone. That would
+ * share one mutable object across concurrent turns, which is the exact hazard
+ * this isolation exists to prevent.
+ *
+ * Comparing own enumerable keys stays quiet for the agents that override
+ * `clone()` fully (`HttpAgent`, `BuiltInAgent`, `IntelligenceAgent`).
+ * Symbol-keyed and non-enumerable fields are not covered.
  *
  * Own *functions* are deliberately exempt. Assigning a method on the instance is
  * how spies and instrumentation wrap an agent, and losing that wrapper leaves
  * the class's prototype method intact — the clone still behaves correctly, it
  * just isn't wrapped. Only dropped state leaves an agent genuinely gutted.
  */
-function assertCloneKeptOwnFields(
+function warnOnCloneDroppedOwnFields(
   prototype: AbstractAgent,
   cloned: AbstractAgent,
 ): void {
@@ -187,11 +208,13 @@ function assertCloneKeptOwnFields(
   );
   if (dropped.length === 0) return;
   const name = prototype.constructor?.name ?? "the configured agent";
-  throw new Error(
+  console.warn(
     `createChannel: ${name}.clone() dropped ${dropped.join(", ")}. ` +
       "Every turn runs on a clone, and AbstractAgent's clone() only copies its " +
-      `own fixed field list, so those fields would read as undefined. Override ` +
-      `clone() on ${name} to copy them (HttpAgent.clone() is the reference).`,
+      "own fixed field list, so those fields read as undefined on the clone. " +
+      "That is harmless for state a run re-initializes, and gutting for anything " +
+      `read as configuration — override clone() on ${name} to carry them if it is ` +
+      "the latter (HttpAgent.clone() is the reference).",
   );
 }
 


### PR DESCRIPTION
A Channel built with `LangGraphAgent` cannot answer a single message today. `isolateAgentInstance` throws when an agent's `clone()` does not carry the subclass' own fields, and `LangGraphAgent.clone()` drops `emittedToolCallStartIds` and `eventsStreamActive` — so every turn is refused before the agent runs.

## Why refusing was the wrong call

Whether a dropped field matters depends on what it **holds**, and the check cannot see that:

- **Config** read during the run and never rewritten (an auth client, a URL) genuinely guts the agent when lost.
- **Per-run scratch state** is re-initialized at the start of every run, so losing it changes nothing. `LangGraphAgent`'s two fields are exactly this — both are reset when a run binds its subscriber, before anything reads them.

The tell is that the identical clone happens on **every ordinary runtime request** (`agent-utils.ts` clones per request, SSE and Intelligence alike) and has never caused a problem. Channels differed only in asserting at clone time, before the run that would have repopulated the fields.

## Verified against a real Slack round trip

With the throw downgraded locally, the same Channel that could not take a turn ran the agent and replied in Slack — inbound delivery, agent execution, and egress all working. The only thing that had changed was this check.

## What it does now

Warns, naming the dropped fields and both readings, and continues. The check still earns its place: `A2AMiddlewareAgent`'s base `clone()` drops `orchestrationAgent`, `agentClients` and `agentCards`, which **are** config, and that is worth seeing.

I checked every agent class the starters build, by instantiating each and diffing own keys against its clone:

| Class | Result |
| --- | --- |
| `HttpAgent`, `LlamaIndexAgent`, `BuiltInAgent`, `MastraAgent` | clean |
| `LangGraphAgent` | drops `emittedToolCallStartIds`, `eventsStreamActive` (per-run scratch) |
| `A2AMiddlewareAgent` (base) | drops `orchestrationAgent`, `agentClients`, `agentCards`, `instructions` (config) |

## Deliberately not done

Copying the dropped fields onto the clone. That shares one mutable object across concurrent turns — the exact hazard this isolation exists to prevent.

## Follow-up

The real fix belongs in `@ag-ui/langgraph`, whose `clone()` should carry those fields. Tracked separately; this unblocks the release in the meantime.

## Tests

`nx test @copilotkit/channels-core` — 38 files / 257 tests, including a rewritten case asserting the warn-and-continue contract and a new one asserting every dropped field is named once per turn. `tsc --noEmit` clean.

Note: `@copilotkit/channels-intelligence:test` fails in my checkout with unresolved `rxjs` / `@copilotkit/channels-slack/render` — identical failures with this change stashed, so it is a local workspace install issue, not this PR.