### PR TITLE
fix(web-inspector): show step lifecycle events

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -328,6 +328,30 @@ describe("WebInspectorElement", () => {
     );
   });
 
+  it("records step lifecycle events", async () => {
+    const { agent, controller } = createMockAgent("alpha");
+    const { core, emitAgentsChanged } = createMockCore({ alpha: agent });
+    const inspector = createInspectorWithCore(core);
+
+    emitAgentsChanged();
+    await inspector.updateComplete;
+
+    controller.emit("onStepStartedEvent", {
+      event: { stepName: "test-step" },
+    });
+    controller.emit("onStepFinishedEvent", {
+      event: { stepName: "test-step" },
+    });
+    await inspector.updateComplete;
+
+    const internals = getInternals(inspector);
+
+    expect(internals.flattenedEvents.map((event) => event.type)).toEqual([
+      "STEP_FINISHED",
+      "STEP_STARTED",
+    ]);
+  });
+
   it("normalizes context, persists state, and copies context values", async () => {
     const { core, emitContextChanged } = createMockCore();
     const inspector = createInspectorWithCore(core);

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -159,6 +159,8 @@ type InspectorAgentEventType =
   | "RUN_STARTED"
   | "RUN_FINISHED"
   | "RUN_ERROR"
+  | "STEP_STARTED"
+  | "STEP_FINISHED"
   | "TEXT_MESSAGE_START"
   | "TEXT_MESSAGE_CONTENT"
   | "TEXT_MESSAGE_END"
@@ -184,6 +186,8 @@ const AGENT_EVENT_TYPES: readonly InspectorAgentEventType[] = [
   "RUN_STARTED",
   "RUN_FINISHED",
   "RUN_ERROR",
+  "STEP_STARTED",
+  "STEP_FINISHED",
   "TEXT_MESSAGE_START",
   "TEXT_MESSAGE_CONTENT",
   "TEXT_MESSAGE_END",
@@ -5319,6 +5323,12 @@ export class WebInspectorElement extends LitElement {
       },
       onRunErrorEvent: ({ event }) => {
         this.recordAgentEvent(agentId, "RUN_ERROR", event);
+      },
+      onStepStartedEvent: ({ event }) => {
+        this.recordAgentEvent(agentId, "STEP_STARTED", event);
+      },
+      onStepFinishedEvent: ({ event }) => {
+        this.recordAgentEvent(agentId, "STEP_FINISHED", event);
       },
       onTextMessageStartEvent: ({ event }) => {
         this.recordAgentEvent(agentId, "TEXT_MESSAGE_START", event);


### PR DESCRIPTION
## What does this PR do?

The Web Inspector did not record `STEP_STARTED` or `STEP_FINISHED` from live agent events.

This PR:

- records both step lifecycle events
- adds both events to the Inspector filter
- adds a regression test

## Related PRs and Issues

- Fixes #6324

## Testing

- `pnpm nx test @copilotkit/web-inspector --skip-nx-cache`
- `pnpm nx run @copilotkit/web-inspector:check-types --skip-nx-cache`
- `pnpm nx run @copilotkit/web-inspector:build --skip-nx-cache`
- repository pre-commit checks

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] No documentation update is needed because this fixes existing behavior without changing the public API
- [x] "Allow edits by maintainers" is checked