### PR TITLE
chore(examples): move the starters onto channels 0.6.1

### DIFF
--- a/examples/integrations/a2a-middleware/package-lock.json
+++ b/examples/integrations/a2a-middleware/package-lock.json
@@ -12,7 +12,7 @@
         "@ag-ui/a2a-middleware": "0.0.2",
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "dotenv": "^16.4.7",
@@ -901,18 +901,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -924,16 +924,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -946,14 +946,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -973,17 +973,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -1409,17 +1409,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -1429,36 +1429,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/a2a-middleware/package.json
+++ b/examples/integrations/a2a-middleware/package.json
@@ -20,7 +20,7 @@
     "@ag-ui/a2a-middleware": "0.0.2",
     "@ag-ui/client": "0.0.57",
     "@ag-ui/core": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "dotenv": "^16.4.7",

--- a/examples/integrations/adk/package-lock.json
+++ b/examples/integrations/adk/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@hono/node-server": "^1",
@@ -544,18 +544,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -567,16 +567,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -589,14 +589,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -616,17 +616,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -636,17 +636,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -656,36 +656,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/adk/package.json
+++ b/examples/integrations/adk/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@hono/node-server": "^1",

--- a/examples/integrations/agno/package-lock.json
+++ b/examples/integrations/agno/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@hono/node-server": "^1",
@@ -543,18 +543,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -566,16 +566,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -588,14 +588,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -615,17 +615,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -635,17 +635,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -655,36 +655,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/agno/package.json
+++ b/examples/integrations/agno/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@hono/node-server": "^1",

--- a/examples/integrations/claude-sdk-python/package-lock.json
+++ b/examples/integrations/claude-sdk-python/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@copilotkit/a2ui-renderer": "1.65.0",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -549,18 +549,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -572,16 +572,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -594,14 +594,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -621,17 +621,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -641,17 +641,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -661,36 +661,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/claude-sdk-python/package.json
+++ b/examples/integrations/claude-sdk-python/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@copilotkit/a2ui-renderer": "1.65.0",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/examples/integrations/claude-sdk-typescript/package-lock.json
+++ b/examples/integrations/claude-sdk-typescript/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@copilotkit/a2ui-renderer": "1.65.0",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -549,18 +549,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -572,16 +572,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -594,14 +594,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -621,17 +621,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -641,17 +641,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -661,36 +661,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/claude-sdk-typescript/package.json
+++ b/examples/integrations/claude-sdk-typescript/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@copilotkit/a2ui-renderer": "1.65.0",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/examples/integrations/crewai-flows/package-lock.json
+++ b/examples/integrations/crewai-flows/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "class-variance-authority": "^0.7.1",
@@ -586,18 +586,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -609,16 +609,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -631,14 +631,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -658,17 +658,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -678,17 +678,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -698,36 +698,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/crewai-flows/package.json
+++ b/examples/integrations/crewai-flows/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "class-variance-authority": "^0.7.1",

--- a/examples/integrations/langgraph-js/package-lock.json
+++ b/examples/integrations/langgraph-js/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@copilotkit/a2ui-renderer": "1.65.0",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -596,18 +596,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -619,16 +619,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -641,14 +641,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -668,17 +668,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -688,17 +688,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -708,36 +708,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/langgraph-js/package.json
+++ b/examples/integrations/langgraph-js/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@copilotkit/a2ui-renderer": "1.65.0",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/examples/integrations/langgraph-python/package-lock.json
+++ b/examples/integrations/langgraph-python/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@copilotkit/a2ui-renderer": "1.65.0",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -623,18 +623,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -646,16 +646,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -668,14 +668,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -695,17 +695,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -715,17 +715,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -735,36 +735,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/langgraph-python/package.json
+++ b/examples/integrations/langgraph-python/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@copilotkit/a2ui-renderer": "1.65.0",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/examples/integrations/llamaindex/package-lock.json
+++ b/examples/integrations/llamaindex/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/llamaindex": "0.1.5",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@hono/node-server": "^1",
@@ -554,18 +554,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -577,16 +577,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -599,14 +599,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -626,17 +626,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -646,17 +646,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -666,36 +666,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/llamaindex/package.json
+++ b/examples/integrations/llamaindex/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@ag-ui/llamaindex": "0.1.5",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@hono/node-server": "^1",

--- a/examples/integrations/mastra/package-lock.json
+++ b/examples/integrations/mastra/package-lock.json
@@ -11,7 +11,7 @@
         "@ag-ui/client": "0.0.57",
         "@ag-ui/mastra": "0.2.1-beta.2",
         "@ai-sdk/openai": "^2.0.42",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@libsql/client": "^0.15.15",
@@ -1281,18 +1281,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -1304,16 +1304,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -1326,14 +1326,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -1353,17 +1353,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -1373,17 +1373,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -1393,36 +1393,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/mastra/package.json
+++ b/examples/integrations/mastra/package.json
@@ -15,7 +15,7 @@
     "@ag-ui/client": "0.0.57",
     "@ag-ui/mastra": "0.2.1-beta.2",
     "@ai-sdk/openai": "^2.0.42",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@libsql/client": "^0.15.15",

--- a/examples/integrations/mcp-apps/package-lock.json
+++ b/examples/integrations/mcp-apps/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/mcp-apps-middleware": "^0.0.3",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/react-ui": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
@@ -638,18 +638,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -661,16 +661,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -683,14 +683,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -719,17 +719,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -748,17 +748,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -777,14 +777,14 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
@@ -799,23 +799,23 @@
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/mcp-apps/package.json
+++ b/examples/integrations/mcp-apps/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@ag-ui/mcp-apps-middleware": "^0.0.3",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/react-ui": "1.65.0",
     "@copilotkit/runtime": "1.65.0",

--- a/examples/integrations/ms-agent-framework-dotnet/package-lock.json
+++ b/examples/integrations/ms-agent-framework-dotnet/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "class-variance-authority": "^0.7.1",
@@ -542,18 +542,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -565,16 +565,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -587,14 +587,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -614,17 +614,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -634,17 +634,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -654,36 +654,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/ms-agent-framework-dotnet/package.json
+++ b/examples/integrations/ms-agent-framework-dotnet/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "class-variance-authority": "^0.7.1",

--- a/examples/integrations/ms-agent-framework-python/package-lock.json
+++ b/examples/integrations/ms-agent-framework-python/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "class-variance-authority": "^0.7.1",
@@ -542,18 +542,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -565,16 +565,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -587,14 +587,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -614,17 +614,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -634,17 +634,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -654,36 +654,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/ms-agent-framework-python/package.json
+++ b/examples/integrations/ms-agent-framework-python/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "class-variance-authority": "^0.7.1",

--- a/examples/integrations/pydantic-ai/package-lock.json
+++ b/examples/integrations/pydantic-ai/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "class-variance-authority": "^0.7.1",
@@ -542,18 +542,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -565,16 +565,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -587,14 +587,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -614,17 +614,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -634,17 +634,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -654,36 +654,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/pydantic-ai/package.json
+++ b/examples/integrations/pydantic-ai/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "class-variance-authority": "^0.7.1",

--- a/examples/integrations/strands-python/package-lock.json
+++ b/examples/integrations/strands-python/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@copilotkit/a2ui-renderer": "1.65.0",
-        "@copilotkit/channels": "0.6.0",
+        "@copilotkit/channels": "0.6.1",
         "@copilotkit/react-core": "1.65.0",
         "@copilotkit/runtime": "1.65.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -549,18 +549,18 @@
       }
     },
     "node_modules/@copilotkit/channels": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.0.tgz",
-      "integrity": "sha512-kIj6FmjhYDRr64MpN+cdT87ol3O0nboe22ovFzUGsskGlKxH4BB3kw7BrZLChg9R/yKNcPIgHJygcTu+eWL+1A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels/-/channels-0.6.1.tgz",
+      "integrity": "sha512-ydNAZ/jKsAScUsc8g4pM63iuEF6UBbIXYzAjCisAz3XsweMewAB8wsl4kFhic/U3u7mlbVjCUu+HD8cWpFTaoA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/channels-core": "0.6.0",
-        "@copilotkit/channels-discord": "0.6.0",
-        "@copilotkit/channels-slack": "0.6.0",
-        "@copilotkit/channels-teams": "0.6.0",
-        "@copilotkit/channels-telegram": "0.6.0",
-        "@copilotkit/channels-ui": "0.6.0",
-        "@copilotkit/channels-whatsapp": "0.6.0"
+        "@copilotkit/channels-core": "0.6.1",
+        "@copilotkit/channels-discord": "0.6.1",
+        "@copilotkit/channels-slack": "0.6.1",
+        "@copilotkit/channels-teams": "0.6.1",
+        "@copilotkit/channels-telegram": "0.6.1",
+        "@copilotkit/channels-ui": "0.6.1",
+        "@copilotkit/channels-whatsapp": "0.6.1"
       },
       "peerDependencies": {
         "vitest": "^4.0.0"
@@ -572,16 +572,16 @@
       }
     },
     "node_modules/@copilotkit/channels-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.0.tgz",
-      "integrity": "sha512-5d7az8Hn+Ty5pyhj41QJKU9b6e8yElpQ6iz+vcxeu6pkoDv+pqBsJ/o+QxJyo1oMEHao+6oO4/ZLgRoo6cqC0Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-core/-/channels-core-0.6.1.tgz",
+      "integrity": "sha512-Kt0HwenZ8YgYUMJMLZCic1fDvnk5aRClAuYqZm9fkNkzmI8VSi2vrhrTKOUPnC3KWsXu3dgOAW8UxgE553fN9g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-ui": "~0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-ui": "~0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "zod-to-json-schema": "^3.24.1"
       },
       "peerDependencies": {
@@ -594,14 +594,14 @@
       }
     },
     "node_modules/@copilotkit/channels-discord": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.0.tgz",
-      "integrity": "sha512-EAy77B2m+dCMT6bioTSn/Ll03AlSHlKDrdWc32eujQ2zkL/7J4Aenuk08t0wQOUKrJ28cM1iv1dHwtVn0Qkckg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-discord/-/channels-discord-0.6.1.tgz",
+      "integrity": "sha512-xqxaDYgWZHb+6ijt1NRKjVUFJ05tTe4A7X3CZKL2ctpbI7gEtzJ0m4tcp7pVvk1zMj6tG2sfJgV+xVxVyFjXDw==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "discord.js": "^14.16.0",
         "zod": "^3.25.76"
       }
@@ -621,17 +621,17 @@
       }
     },
     "node_modules/@copilotkit/channels-slack": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.0.tgz",
-      "integrity": "sha512-D0zm6Dm6zHrX8wLor8Vh663qgVq2YMTCWLW6Gh7WnvFrV9/dSpA8xgR9T8wKGbJj/qm8BlDP1LTrleIZ+E6dLg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-slack/-/channels-slack-0.6.1.tgz",
+      "integrity": "sha512-bMPriQ7NGt0Zcb4TuJPhyt51uKP1BBCtYuqngClmVGk9yWM/S0+4Pj57J768FYO3a6uYfkLt0IZRJAJxMqx07g==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@slack/bolt": "^4.2.0",
         "@slack/types": "^2.21.1",
         "@slack/web-api": "^7.16.0",
@@ -641,17 +641,17 @@
       }
     },
     "node_modules/@copilotkit/channels-teams": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.0.tgz",
-      "integrity": "sha512-/53YPIK/LrWpW9PmruXwWpDc82zJDdmcKT8IjexpB+dxhyG9GqEOv3OwLXOJozhmkHDFnp69Px6aJ82MsEVIiQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.6.1.tgz",
+      "integrity": "sha512-vnjgsEZFkL3lzlg87WrJH7Mtfg6N6YOncYusCwCYvWRbRRiCUf3vKz44PGGykb+SUpWJlfhj2oB3PZsCOxYv5Q==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
         "@ag-ui/core": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
-        "@copilotkit/core": "^1.64.2",
-        "@copilotkit/shared": "^1.64.2",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
+        "@copilotkit/core": "^1.65.0",
+        "@copilotkit/shared": "^1.65.0",
         "@microsoft/agents-activity": "^1.5.3",
         "@microsoft/agents-hosting": "^1.5.3",
         "express": "^4.21.2",
@@ -661,36 +661,36 @@
       }
     },
     "node_modules/@copilotkit/channels-telegram": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.0.tgz",
-      "integrity": "sha512-O6Z2VpHhvJOd4ZQB4GOqhBdpVnpsI4nAfS59bXqeoTn5EQeIfo0V8DFYw+BqG+OnCGoXBXy1ncA1q3hopzpmoA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-telegram/-/channels-telegram-0.6.1.tgz",
+      "integrity": "sha512-XhyhZc11mIy2Zeuitxo+HoDXIkU3jKIE6Wl0gQ0uBWoo//fjKWpESf0gfRn6R92naqiOOoMJpFNs8ACj1XvCUQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0",
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1",
         "grammy": "^1.30.0",
         "zod": "^3.25.76"
       }
     },
     "node_modules/@copilotkit/channels-ui": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.0.tgz",
-      "integrity": "sha512-es+OGGnB3nfCRC+0mgOLh8fVRZEgV4V7yAiS1ufV9aWkDsWvgZgs+OYucBpl3jBYaIJpmAJYl3BlL5lMfjFvNg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.6.1.tgz",
+      "integrity": "sha512-z0KsTxlEmMqUNP+fFlKZInfdnXxFf9d7z2hqkOcSHgZvW5QxbpGAmvFNTXMzT4Zec5Pt9JoOQuW9LACBVpt9LQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "^1.64.2"
+        "@copilotkit/shared": "^1.65.0"
       }
     },
     "node_modules/@copilotkit/channels-whatsapp": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.0.tgz",
-      "integrity": "sha512-rxAYMkF91vHUoXpW5p8EXyojjdJSHM1jzkUESQddoTqf2p5TAjk1jg1haqLCMq5Fqi7Qdf4xCYa/mF76x6+rTg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/channels-whatsapp/-/channels-whatsapp-0.6.1.tgz",
+      "integrity": "sha512-02uiAeyzXr4BG3tWhf3XqFO+9oZ7PKj7MqT2DZJn80kh0mVLCvNmbuY2rY5ZLGQicjR/FPm+2XlrpgLy1XUQZA==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.57",
-        "@copilotkit/channels-core": "^0.6.0",
-        "@copilotkit/channels-ui": "^0.6.0"
+        "@copilotkit/channels-core": "^0.6.1",
+        "@copilotkit/channels-ui": "^0.6.1"
       }
     },
     "node_modules/@copilotkit/core": {

--- a/examples/integrations/strands-python/package.json
+++ b/examples/integrations/strands-python/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@copilotkit/a2ui-renderer": "1.65.0",
-    "@copilotkit/channels": "0.6.0",
+    "@copilotkit/channels": "0.6.1",
     "@copilotkit/react-core": "1.65.0",
     "@copilotkit/runtime": "1.65.0",
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## What

Bumps `@copilotkit/channels` from `0.6.0` to `0.6.1` in all 15 integration starters that host a Channel, with lockfiles regenerated to match. Nothing else changes — `@copilotkit/*` stays on `1.65.0`.

`examples/slack` and `examples/teams` are untouched: they consume the workspace copy (`workspace:*`), so they already track the fix.

## Why

`channels@0.6.1` carries exactly one change — [#6322](https://github.com/CopilotKit/CopilotKit/pull/6322), where `createChannel`'s clone check warns instead of throwing when `clone()` drops subclass state. On `0.6.0`, a starter hosting a Channel through `@ag-ui/langgraph` **refuses every turn**, because `LangGraphAgent.clone()` leaves `emittedToolCallStartIds` and `eventsStreamActive` behind — both per-run scratch that is re-initialized before anything reads it. The starters are where that failure is user-visible, so they shouldn't sit on the release that has it.

## No runtime release needed

The question came up whether `@copilotkit/runtime` has to be re-released so the pins don't conflict. It does not. The fix lives entirely in `@copilotkit/channels-core`, and every path to it is a caret range:

| consumer | asks for | resolves to |
| --- | --- | --- |
| `@copilotkit/channels@0.6.1` (umbrella) | `channels-core` exactly `0.6.1` | 0.6.1 |
| `@copilotkit/runtime@1.65.0` | `channels-core: ^0.6.0` | 0.6.1 |
| `@copilotkit/channels-intelligence@0.6.0` (runtime's one exact channels pin) | `channels-core: ^0.6.0` | 0.6.1 |

The umbrella does not depend on `channels-intelligence`, so nothing pulls a second copy of it in alongside the runtime. Everything dedupes onto one `channels-core@0.6.1`, which is what makes the runtime's own channel path pick up the fix without a release of its own.

## Testing

**1. Every regenerated lock resolves exactly one `channels-core`, at 0.6.1** — verified rather than reasoned, since a second nested copy is the failure mode that would have forced a runtime release:

```
a2a-middleware: node_modules/@copilotkit/channels-core@0.6.1
adk: node_modules/@copilotkit/channels-core@0.6.1
claude-sdk-python: node_modules/@copilotkit/channels-core@0.6.1
agno: node_modules/@copilotkit/channels-core@0.6.1
claude-sdk-typescript: node_modules/@copilotkit/channels-core@0.6.1
langgraph-python: node_modules/@copilotkit/channels-core@0.6.1
crewai-flows: node_modules/@copilotkit/channels-core@0.6.1
langgraph-js: node_modules/@copilotkit/channels-core@0.6.1
mastra: node_modules/@copilotkit/channels-core@0.6.1
llamaindex: node_modules/@copilotkit/channels-core@0.6.1
ms-agent-framework-dotnet: node_modules/@copilotkit/channels-core@0.6.1
pydantic-ai: node_modules/@copilotkit/channels-core@0.6.1
mcp-apps: node_modules/@copilotkit/channels-core@0.6.1
ms-agent-framework-python: node_modules/@copilotkit/channels-core@0.6.1
strands-python: node_modules/@copilotkit/channels-core@0.6.1
```

**2. The full `@copilotkit/*` resolution in the reference starter (`langgraph-python`)** — `channels-intelligence` correctly stays at `0.6.0` (runtime's exact pin) while consuming the 0.6.1 core:

```
1.65.0 @copilotkit/a2ui-renderer     0.6.1 @copilotkit/channels
0.6.1  @copilotkit/channels-core     0.6.1 @copilotkit/channels-discord
0.6.0  @copilotkit/channels-intelligence
0.6.1  @copilotkit/channels-slack    0.6.1 @copilotkit/channels-teams
0.6.1  @copilotkit/channels-telegram 0.6.1 @copilotkit/channels-ui
0.6.1  @copilotkit/channels-whatsapp 1.65.0 @copilotkit/core
1.65.0 @copilotkit/react-core        1.65.0 @copilotkit/runtime
1.65.0 @copilotkit/shared            1.65.0 @copilotkit/web-components
```

**3. Reference starter installs and typechecks its channel host** — real `npm install`, not lock-only:

```
> copilotkit-langgraph-template@0.1.0 typecheck:channel
> tsc -p tsconfig.channel.json --noEmit
EXIT=0

installed core: 0.6.1 | intelligence: 0.6.0
```

**4. The published 0.6.1 tarball actually carries the fix** — checked the installed dist, not just the version number, so a mis-built release would not pass as fixed:

```
node_modules/@copilotkit/channels-core/dist/create-channel.js
74:    warnOnCloneDroppedOwnFields(prototype, cloned);
132: function warnOnCloneDroppedOwnFields(prototype, cloned) {
139:    console.warn(`createChannel: ${name}.clone() dropped ${dropped.join(", ")}. ` +
```

`console.warn`, not `throw` — the 0.6.0 behaviour is gone.

**5. No unrelated dependency drifted.** Filtering every non-`@copilotkit/channels*` line out of a regenerated lock diff leaves nothing:

```
$ git diff examples/integrations/adk/package-lock.json | grep -E "^[+-]" \
    | grep -vE "integrity|resolved|@copilotkit/channels" | grep -E '"[a-z]' | sort | uniq -c
   8 +      "version": "0.6.1",
   8 -      "version": "0.6.0",
```

**Not tested:** no starter was run end-to-end against a live Channel here — the change is a version pin, and the behaviour it unblocks was verified in #6322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)