### PR TITLE
fix(channels-intelligence): restore inbound trigger files

### DIFF
--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -244,7 +244,10 @@ export class DeliveryAdapter implements PlatformAdapter {
   private async loadProviderAgentHistory(
     target: DeliveryReplyTarget,
   ): Promise<{ messages: Message[]; historyIds: ReadonlySet<string> }> {
-    const transcript = await target.claimedDelivery.getTranscript();
+    const transcript = restorePreparedTriggerFiles(
+      await target.claimedDelivery.getTranscript(),
+      target.delivery.turn.input,
+    );
     const messages = await transcriptAgentMessages(
       transcript,
       target,
@@ -1187,6 +1190,29 @@ async function transcriptContent(
   );
   const parts = await target.claimedDelivery.getContentParts(managedFiles, log);
   return parts.length > 0 ? [{ type: "text", text }, ...parts] : text;
+}
+
+function restorePreparedTriggerFiles(
+  transcript: ChannelDeliveryTranscript,
+  input: PreparedChannelDelivery["turn"]["input"],
+): ChannelDeliveryTranscript {
+  if (input.kind !== "text" || !input.files?.length) return transcript;
+  const files = input.files.map((file) => ({
+    providerFileId: `managed:${file.handle}`.slice(0, 512),
+    name: file.filename,
+    mimeType: file.mimeType ?? null,
+    byteSize: file.byteSize ?? null,
+    availability: "managed" as const,
+    handle: file.handle,
+  }));
+  return {
+    ...transcript,
+    messages: transcript.messages.map((message) =>
+      message.currentTrigger && message.files.length === 0
+        ? { ...message, files }
+        : message,
+    ),
+  };
 }
 
 async function transcriptAgentMessages(

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -244,10 +244,7 @@ export class DeliveryAdapter implements PlatformAdapter {
   private async loadProviderAgentHistory(
     target: DeliveryReplyTarget,
   ): Promise<{ messages: Message[]; historyIds: ReadonlySet<string> }> {
-    const transcript = restorePreparedTriggerFiles(
-      await target.claimedDelivery.getTranscript(),
-      target.delivery.turn.input,
-    );
+    const transcript = await target.claimedDelivery.getTranscript();
     const messages = await transcriptAgentMessages(
       transcript,
       target,
@@ -1190,29 +1187,6 @@ async function transcriptContent(
   );
   const parts = await target.claimedDelivery.getContentParts(managedFiles, log);
   return parts.length > 0 ? [{ type: "text", text }, ...parts] : text;
-}
-
-function restorePreparedTriggerFiles(
-  transcript: ChannelDeliveryTranscript,
-  input: PreparedChannelDelivery["turn"]["input"],
-): ChannelDeliveryTranscript {
-  if (input.kind !== "text" || !input.files?.length) return transcript;
-  const files = input.files.map((file) => ({
-    providerFileId: `managed:${file.handle}`.slice(0, 512),
-    name: file.filename,
-    mimeType: file.mimeType ?? null,
-    byteSize: file.byteSize ?? null,
-    availability: "managed" as const,
-    handle: file.handle,
-  }));
-  return {
-    ...transcript,
-    messages: transcript.messages.map((message) =>
-      message.currentTrigger && message.files.length === 0
-        ? { ...message, files }
-        : message,
-    ),
-  };
 }
 
 async function transcriptAgentMessages(

--- a/packages/channels-intelligence/src/delivery-transcript.test.ts
+++ b/packages/channels-intelligence/src/delivery-transcript.test.ts
@@ -91,104 +91,167 @@ test("transcript client calls the delivery-scoped route with runtime auth", asyn
   );
 });
 
-test("prepared delivery restores current-trigger files omitted by the transcript", async () => {
-  const imageBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
-  const imageHandle = "fileref_current_image";
-  const fetch = vi.fn(async (input: string | URL | Request) => {
-    const url = String(input);
-    if (url.endsWith(`/api/channels/files/${imageHandle}`)) {
-      return new Response(imageBytes, {
-        headers: { "content-type": "image/png" },
-      });
-    }
-    return new Response(JSON.stringify(transcript));
-  });
-  const delivery: PreparedChannelDelivery = {
-    protocol: "channel_delivery_v1",
-    deliveryId: "dlv_transcript_file_01",
-    deliveryExpiresAt: "2099-07-30T20:00:00.000Z",
-    canonicalThreadId: "thread_transcript_file",
-    appUserId: "slack:T1:U1",
-    channelId: "channel_transcript_file",
-    channelName: "support",
-    adapter: "slack",
-    turn: {
-      eventId: "evt_transcript_file",
-      receivedAt: "2026-07-30T20:00:00.000Z",
-      input: {
-        kind: "text",
-        text: "Can you help again?",
-        messageRef: { id: "pref_v1_message_transcript_file_123" },
-        files: [
+test.each([
+  ["omitted", undefined],
+  [
+    "already supplied",
+    {
+      providerFileId: "provider-current-image",
+      name: "provider-image.png",
+      mimeType: "image/png",
+      byteSize: 8,
+      availability: "managed" as const,
+      handle: "fileref_current_image",
+    },
+  ],
+])(
+  "current-trigger files are hydrated when %s by the transcript",
+  async (_case, transcriptFile) => {
+    const imageBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+    const imageHandle = "fileref_current_image";
+    const expectedFile = transcriptFile ?? {
+      providerFileId: `managed:${imageHandle}`,
+      name: "image.png",
+      mimeType: "image/png",
+      byteSize: imageBytes.byteLength,
+      availability: "managed" as const,
+      handle: imageHandle,
+    };
+    const providerTranscript = {
+      ...transcript,
+      messages: transcript.messages.map((message) =>
+        message.currentTrigger
+          ? { ...message, files: transcriptFile ? [transcriptFile] : [] }
+          : message,
+      ),
+    };
+    const fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith(`/api/channels/files/${imageHandle}`)) {
+        return new Response(imageBytes, {
+          headers: { "content-type": "image/png" },
+        });
+      }
+      return new Response(JSON.stringify(providerTranscript));
+    });
+    const delivery: PreparedChannelDelivery = {
+      protocol: "channel_delivery_v1",
+      deliveryId: "dlv_transcript_file_01",
+      deliveryExpiresAt: "2099-07-30T20:00:00.000Z",
+      canonicalThreadId: "thread_transcript_file",
+      appUserId: "slack:T1:U1",
+      channelId: "channel_transcript_file",
+      channelName: "support",
+      adapter: "slack",
+      turn: {
+        eventId: "evt_transcript_file",
+        receivedAt: "2026-07-30T20:00:00.000Z",
+        input: {
+          kind: "text",
+          text: "Can you help again?",
+          messageRef: { id: "pref_v1_message_transcript_file_123" },
+          files: [
+            {
+              handle: imageHandle,
+              filename: "image.png",
+              mimeType: "image/png",
+              byteSize: imageBytes.byteLength,
+            },
+          ],
+          operation: {
+            kind: "created",
+            logicalMessageId:
+              "pid_v1_0123456789abcdefghijklmnopqrstuvwxyzABCDEFG",
+            revisionId: "pid_v1_0123456789abcdefghijklmnopqrstuvwxyzABCDEFG",
+            mentioned: true,
+          },
+        },
+        actor: { externalUserId: "U1", kind: "human", displayName: "Ada" },
+      },
+    };
+    const claimed = new ClaimedChannelDelivery(
+      delivery,
+      { ownerGeneration: 1, runtimeInstanceId: "rti_transcript_file_01" },
+      {
+        joinReply: delivery,
+        push: vi.fn(),
+        on: vi.fn(),
+        onClose: vi.fn(),
+        leave: vi.fn(),
+      },
+      vi.fn(),
+      new ChannelDeliveryFileClient({
+        baseUrl: "https://api.example",
+        apiKey: "cpk-runtime",
+        fetch,
+      }),
+      new ChannelDeliveryTranscriptClient({
+        baseUrl: "https://api.example",
+        apiKey: "cpk-runtime",
+        fetch,
+      }),
+    );
+    const adapter = new DeliveryAdapter({
+      channelName: "support",
+      transport: {} as never,
+      loadHistory: vi.fn(async () => []),
+      runCanonical: async () => ({ iterations: 0, interrupted: false }),
+    });
+    const target = { claimedDelivery: claimed, delivery };
+
+    await expect(claimed.getTranscript()).resolves.toEqual({
+      ...providerTranscript,
+      messages: providerTranscript.messages.map((message) =>
+        message.currentTrigger
+          ? { ...message, files: [expectedFile] }
+          : message,
+      ),
+    });
+
+    const threadMessages = await adapter.getMessages(target);
+    expect(threadMessages.at(-1)).toEqual(
+      expect.objectContaining({
+        content: [
           {
-            handle: imageHandle,
-            filename: "image.png",
-            mimeType: "image/png",
-            byteSize: imageBytes.byteLength,
+            type: "text",
+            text: `${adaActorEnvelope}\nCan you help again?`,
+          },
+          {
+            type: "image",
+            source: {
+              type: "data",
+              value: Buffer.from(imageBytes).toString("base64"),
+              mimeType: "image/png",
+            },
           },
         ],
-        operation: {
-          kind: "created",
-          logicalMessageId:
-            "pid_v1_0123456789abcdefghijklmnopqrstuvwxyzABCDEFG",
-          revisionId: "pid_v1_0123456789abcdefghijklmnopqrstuvwxyzABCDEFG",
-          mentioned: true,
+        providerMessage: expect.objectContaining({ files: [expectedFile] }),
+      }),
+    );
+
+    const session = await adapter.conversationStore.getOrCreate(
+      delivery.canonicalThreadId,
+      target,
+      () => new FakeAgent(),
+    );
+
+    expect(session.agent.messages.at(-1)?.content).toEqual([
+      {
+        type: "text",
+        text: `${adaActorEnvelope}\nCan you help again?`,
+      },
+      {
+        type: "image",
+        source: {
+          type: "data",
+          value: Buffer.from(imageBytes).toString("base64"),
+          mimeType: "image/png",
         },
       },
-      actor: { externalUserId: "U1", kind: "human", displayName: "Ada" },
-    },
-  };
-  const claimed = new ClaimedChannelDelivery(
-    delivery,
-    { ownerGeneration: 1, runtimeInstanceId: "rti_transcript_file_01" },
-    {
-      joinReply: delivery,
-      push: vi.fn(),
-      on: vi.fn(),
-      onClose: vi.fn(),
-      leave: vi.fn(),
-    },
-    vi.fn(),
-    new ChannelDeliveryFileClient({
-      baseUrl: "https://api.example",
-      apiKey: "cpk-runtime",
-      fetch,
-    }),
-    new ChannelDeliveryTranscriptClient({
-      baseUrl: "https://api.example",
-      apiKey: "cpk-runtime",
-      fetch,
-    }),
-  );
-  const adapter = new DeliveryAdapter({
-    channelName: "support",
-    transport: {} as never,
-    loadHistory: vi.fn(async () => []),
-    runCanonical: async () => ({ iterations: 0, interrupted: false }),
-  });
-
-  const session = await adapter.conversationStore.getOrCreate(
-    delivery.canonicalThreadId,
-    { claimedDelivery: claimed, delivery },
-    () => new FakeAgent(),
-  );
-
-  expect(session.agent.messages.at(-1)?.content).toEqual([
-    {
-      type: "text",
-      text: `${adaActorEnvelope}\nCan you help again?`,
-    },
-    {
-      type: "image",
-      source: {
-        type: "data",
-        value: Buffer.from(imageBytes).toString("base64"),
-        mimeType: "image/png",
-      },
-    },
-  ]);
-  session.release?.();
-});
+    ]);
+    session.release?.();
+  },
+);
 
 test("transcript client makes three total attempts for retryable failures", async () => {
   const fetch = vi

--- a/packages/channels-intelligence/src/delivery-transcript.test.ts
+++ b/packages/channels-intelligence/src/delivery-transcript.test.ts
@@ -1,6 +1,7 @@
 import { expect, test, vi } from "vitest";
 import { FakeAgent } from "@copilotkit/channels-core";
 import { DeliveryAdapter } from "./delivery-adapter.js";
+import { ChannelDeliveryFileClient } from "./delivery-files.js";
 import { ClaimedChannelDelivery } from "./delivery-transport.js";
 import type { PreparedChannelDelivery } from "./delivery-transport.js";
 import { ChannelDeliveryTranscriptClient } from "./delivery-transcript.js";
@@ -88,6 +89,105 @@ test("transcript client calls the delivery-scoped route with runtime auth", asyn
       headers: { authorization: "Bearer cpk-runtime" },
     },
   );
+});
+
+test("prepared delivery restores current-trigger files omitted by the transcript", async () => {
+  const imageBytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+  const imageHandle = "fileref_current_image";
+  const fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.endsWith(`/api/channels/files/${imageHandle}`)) {
+      return new Response(imageBytes, {
+        headers: { "content-type": "image/png" },
+      });
+    }
+    return new Response(JSON.stringify(transcript));
+  });
+  const delivery: PreparedChannelDelivery = {
+    protocol: "channel_delivery_v1",
+    deliveryId: "dlv_transcript_file_01",
+    deliveryExpiresAt: "2099-07-30T20:00:00.000Z",
+    canonicalThreadId: "thread_transcript_file",
+    appUserId: "slack:T1:U1",
+    channelId: "channel_transcript_file",
+    channelName: "support",
+    adapter: "slack",
+    turn: {
+      eventId: "evt_transcript_file",
+      receivedAt: "2026-07-30T20:00:00.000Z",
+      input: {
+        kind: "text",
+        text: "Can you help again?",
+        messageRef: { id: "pref_v1_message_transcript_file_123" },
+        files: [
+          {
+            handle: imageHandle,
+            filename: "image.png",
+            mimeType: "image/png",
+            byteSize: imageBytes.byteLength,
+          },
+        ],
+        operation: {
+          kind: "created",
+          logicalMessageId:
+            "pid_v1_0123456789abcdefghijklmnopqrstuvwxyzABCDEFG",
+          revisionId: "pid_v1_0123456789abcdefghijklmnopqrstuvwxyzABCDEFG",
+          mentioned: true,
+        },
+      },
+      actor: { externalUserId: "U1", kind: "human", displayName: "Ada" },
+    },
+  };
+  const claimed = new ClaimedChannelDelivery(
+    delivery,
+    { ownerGeneration: 1, runtimeInstanceId: "rti_transcript_file_01" },
+    {
+      joinReply: delivery,
+      push: vi.fn(),
+      on: vi.fn(),
+      onClose: vi.fn(),
+      leave: vi.fn(),
+    },
+    vi.fn(),
+    new ChannelDeliveryFileClient({
+      baseUrl: "https://api.example",
+      apiKey: "cpk-runtime",
+      fetch,
+    }),
+    new ChannelDeliveryTranscriptClient({
+      baseUrl: "https://api.example",
+      apiKey: "cpk-runtime",
+      fetch,
+    }),
+  );
+  const adapter = new DeliveryAdapter({
+    channelName: "support",
+    transport: {} as never,
+    loadHistory: vi.fn(async () => []),
+    runCanonical: async () => ({ iterations: 0, interrupted: false }),
+  });
+
+  const session = await adapter.conversationStore.getOrCreate(
+    delivery.canonicalThreadId,
+    { claimedDelivery: claimed, delivery },
+    () => new FakeAgent(),
+  );
+
+  expect(session.agent.messages.at(-1)?.content).toEqual([
+    {
+      type: "text",
+      text: `${adaActorEnvelope}\nCan you help again?`,
+    },
+    {
+      type: "image",
+      source: {
+        type: "data",
+        value: Buffer.from(imageBytes).toString("base64"),
+        mimeType: "image/png",
+      },
+    },
+  ]);
+  session.release?.();
 });
 
 test("transcript client makes three total attempts for retryable failures", async () => {

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -474,9 +474,11 @@ export class ClaimedChannelDelivery {
         new Error("Channel transcript requires both appApiBaseUrl and apiKey"),
       );
     }
-    this.transcriptPromise ??= this.transcripts.fetchTranscript(
-      this.delivery.deliveryId,
-    );
+    this.transcriptPromise ??= this.transcripts
+      .fetchTranscript(this.delivery.deliveryId)
+      .then((transcript) =>
+        restorePreparedTriggerFiles(transcript, this.delivery.turn.input),
+      );
     return this.transcriptPromise;
   }
 
@@ -671,6 +673,29 @@ export class ClaimedChannelDelivery {
       assertProviderMessageId(providerMessageId);
     }
   }
+}
+
+function restorePreparedTriggerFiles(
+  transcript: ChannelDeliveryTranscript,
+  input: PreparedChannelDelivery["turn"]["input"],
+): ChannelDeliveryTranscript {
+  if (input.kind !== "text" || !input.files?.length) return transcript;
+  const files = input.files.map((file) => ({
+    providerFileId: `managed:${file.handle}`.slice(0, 512),
+    name: file.filename,
+    mimeType: file.mimeType ?? null,
+    byteSize: file.byteSize ?? null,
+    availability: "managed" as const,
+    handle: file.handle,
+  }));
+  return {
+    ...transcript,
+    messages: transcript.messages.map((message) =>
+      message.currentTrigger && message.files.length === 0
+        ? { ...message, files }
+        : message,
+    ),
+  };
 }
 
 type ClaimResult =


### PR DESCRIPTION
## Problem

Channel agents lose inbound files whenever the current-trigger transcript omits attachments. The currently deployed Intelligence path always omits those files because normalized_payload never contains their handles.

## Why

The delivery adapter seeds the current inbound turn from the transcript, and core then deduplicates the explicit prepared input. Files present only on the prepared delivery therefore never reach either the agent-history consumer or channel.getMessages during version skew.

## Fix

Restore a missing current-trigger transcript file list from the prepared delivery inside ClaimedChannelDelivery.getTranscript(), where the result is shared and memoized for both consumers. Existing transcript files are preserved, so the Intelligence fix and this fallback cannot duplicate attachments.

Either PR independently repairs the agent path. Coverage proves both an omitted transcript and an already-correct transcript hydrate the image for getMessages and agent seeding.