### PR TITLE
fix(showcase/harness): reap chromium zombies, alarm on PID saturation, stop saturated workers claiming

### DIFF
--- a/showcase/harness/Dockerfile
+++ b/showcase/harness/Dockerfile
@@ -99,7 +99,18 @@ COPY --from=build /repo/showcase/harness/config ./config
 # (not via `npx playwright`) — pnpm's deploy output materialises a
 # hoisted node_modules but doesn't always produce a `.bin/playwright`
 # shim, so `npx playwright` would resolve to "not found".
+#
+# `tini` rides along in THIS layer (not its own RUN) deliberately: playwright's
+# `--with-deps` has just done the `apt-get update`, so the package lists are
+# already warm and installing tini costs one ~250KB package instead of a second
+# full index refresh. See the ENTRYPOINT block at the bottom for WHY tini exists
+# — it is the PID-1 zombie reaper. The `tini --version` call is a build-time
+# assertion on the binary path baked into ENTRYPOINT: if a future Debian moves
+# it off /usr/bin/tini, the BUILD fails here rather than the container failing
+# to start in prod.
 RUN node ./node_modules/playwright/cli.js install --with-deps chromium \
+ && apt-get install -y --no-install-recommends tini \
+ && /usr/bin/tini --version \
  && rm -rf /var/lib/apt/lists/*
 # version-drift probe: the pnpm-packages discovery source reads
 # pnpm-workspace.yaml + each workspace package manifest at probe-tick time.
@@ -197,16 +208,61 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
 #      circuit-breaker give-up + `pool-unrecoverable` alarm as the agnostic
 #      backstop that signals "redeploy required" when the ceiling does not relax.
 #
+# FIX #4 — SUPPLY SIDE: reap the orphans (see the ENTRYPOINT block below).
+# Mitigations 1 and 2 are both DEMAND-side: they cap the PEAK of `pids.current`.
+# They cannot stop a MONOTONIC leak, and a monotonic leak is what prod actually
+# died of — `zombieCount` climbed 70 → 757 and `pids.current` 286 → 1000/1000
+# over the 6d22h a single prod container stayed up, at which point no browser
+# could launch and ~295 d6 cells went `abort` fleet-wide. Every chromium crash
+# (the `Target crashed` path this file already describes) re-parents that
+# browser's zygote/renderer children onto PID 1; node as PID 1 only `waitpid()`s
+# processes IT spawned, so each crash permanently strands ~5 `<defunct>`
+# grandchildren that still occupy cgroup PID slots. No amount of peak-shaving
+# fixes that — the container needs a PID 1 that reaps.
+#
 # We KEEP the `ulimit -u $(ulimit -Hu)` line — it is HARMLESS (it lifts the soft
 # rlimit to the inherited hard rlimit) and removes the per-process rlimit as a
 # confound — but it must NOT be mistaken for a fix to the cgroup ceiling.
-# `exec` replaces the shell so node remains PID 1 (correct signal handling /
-# Railway shutdown). The fallback `|| true` keeps boot resilient if the runtime
-# forbids raising the soft limit.
+# `exec` replaces the shell so node is tini's DIRECT child and no bash lingers
+# in the tree. The fallback `|| true` keeps boot resilient if the runtime forbids
+# raising the soft limit.
 #
 # MUST run under bash, NOT the default `/bin/sh`. On this image (node:22-
 # bookworm-slim) `/bin/sh` is dash, whose builtin `ulimit` does NOT support the
 # `-u` (max-user-processes / nproc) flag — it errors `ulimit: Illegal option -u`,
 # which the `2>/dev/null || true` then SILENTLY swallows. bash IS present
 # (/usr/bin/bash) and its `ulimit -u` works.
+#
+# FIX #4 — tini as PID 1, so orphaned chromium grandchildren get REAPED.
+# Node is not an init. libuv's SIGCHLD handler only `waitpid()`s the pids Node
+# itself spawned, so any process re-parented onto Node-as-PID-1 becomes a
+# permanent `<defunct>` zombie holding a cgroup PID slot. Chromium re-parents
+# constantly here: kill/crash a browser process and its zygote + renderers land
+# on PID 1. Measured in this exact image at `--pids-limit 1000`: ~5 zombies
+# stranded per crashed browser, `pids.current` floor rising monotonically and
+# never falling, ending in `chromium.launch()` failures — i.e. the outage.
+# With tini as PID 1 the same run holds `zombieCount` at 0.
+#
+# WHY tini AND NOT the alternatives:
+#   * Docker's `--init` would do the same thing, but it is a RUN-time flag on the
+#     container runtime. Railway does not expose it (same reason `pids.max` is
+#     not settable from here), so the init has to be baked into the image.
+#   * There is no in-process option: Node has no `waitpid` binding, so an
+#     application-level `SIGCHLD` reaper is not implementable without a native
+#     addon. This is genuinely the platform's job, not the orchestrator's.
+#
+# EXEC FORM, AND SIGNALS/EXIT CODES MUST SURVIVE — this is load-bearing:
+#   * Exec form (no shell wrapper) so tini really is PID 1 and really receives
+#     Railway's SIGTERM.
+#   * tini forwards SIGTERM/SIGINT to its child, which is what drives
+#     orchestrator.ts's `process.once("SIGTERM", drainAndExit)` graceful drain.
+#     No `-g` (process-group broadcast) on purpose: signalling the whole group
+#     would hit the live chromium pool alongside node and pre-empt that drain.
+#     Delivery semantics stay byte-identical to the pre-tini behaviour.
+#   * tini exits with the CHILD's exit status (128+N when the child dies by
+#     signal), so a crashing orchestrator still surfaces a NON-ZERO container
+#     exit and Railway still restarts it. An init that swallowed signals or
+#     always exited 0 would silently disable that self-restart — strictly worse
+#     than the leak it fixes. Verify both properties before changing this line.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/bin/bash", "-c", "ulimit -u $(ulimit -Hu) 2>/dev/null || true; exec node dist/orchestrator.js"]

--- a/showcase/harness/src/fleet/contracts.ts
+++ b/showcase/harness/src/fleet/contracts.ts
@@ -709,6 +709,38 @@ export function deriveHealth(
  * invariant rather than leak the racy value to registry/heartbeat consumers.
  * Pure; unit-tested.
  */
+/**
+ * Compute the fraction of a worker's cgroup PID ceiling currently consumed
+ * (`pids.current / pids.max`), or `null` when the gauges are NOT MEASURED.
+ *
+ * The `null` case is load-bearing on BOTH sides of the fleet and must never be
+ * conflated with 0:
+ *   - `BrowserPool.budget()` degrades both gauges to the `-1` sentinel when the
+ *     cgroup PID controller is unreadable (off-Linux — every macOS dev machine
+ *     — or a missing controller), and the S9 registration writer maps that
+ *     sentinel to `null` on the PB row rather than storing -1.
+ *   - A non-positive `pids.max` means unbounded (cgroup's `max` sentinel) or
+ *     would divide by zero.
+ * In every one of those cases there is NO ratio: the control-plane alarm must
+ * stay quiet and the worker's claim gate must stay OPEN (a dev worker whose
+ * cgroup is unreadable has to keep claiming jobs).
+ *
+ * Shared by the control-plane's PID-saturation alarm (`fleet-health.ts`) and the
+ * worker's claim-time PID headroom gate (`worker/worker-loop.ts`) so the two
+ * cannot drift on what "saturated" arithmetically means. Pure; unit-tested.
+ */
+export function pidUsageRatio(
+  pidsCurrent: number | null | undefined,
+  pidsMax: number | null | undefined,
+): number | null {
+  if (typeof pidsCurrent !== "number" || !Number.isFinite(pidsCurrent)) {
+    return null;
+  }
+  if (typeof pidsMax !== "number" || !Number.isFinite(pidsMax)) return null;
+  if (pidsCurrent < 0 || pidsMax <= 0) return null;
+  return pidsCurrent / pidsMax;
+}
+
 export function workerCapacityFromBudget(
   budget: BrowserPoolBudget,
 ): WorkerCapacity {

--- a/showcase/harness/src/fleet/control-plane/control-plane.test.ts
+++ b/showcase/harness/src/fleet/control-plane/control-plane.test.ts
@@ -130,6 +130,7 @@ function emptyHealthResult(
     reclaimedOverlays: [],
     restartsAttempted: 0,
     gcDeleted: 0,
+    pidSaturated: [],
     ...over,
   };
 }

--- a/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.test.ts
@@ -3,7 +3,10 @@ import {
   createFleetHealthMonitor,
   DEFAULT_WORKER_STALE_AFTER_MS,
   DEFAULT_WORKER_GC_AFTER_MS,
+  DEFAULT_PID_SATURATION_RATIO,
+  DEFAULT_PID_SATURATION_CLEAR_RATIO,
 } from "./fleet-health.js";
+import type { PidSaturationReport } from "./fleet-health.js";
 import type {
   PbClient,
   ListOpts,
@@ -33,6 +36,9 @@ interface WorkerRow {
   worker_id: string;
   last_heartbeat_at: string;
   current_job_id?: string;
+  /** cgroup gauges the S9 heartbeat writes; null when unmeasurable. */
+  capacity_pids_current?: number | null;
+  capacity_pids_max?: number | null;
 }
 
 function jobView(over: Partial<JobView> = {}): JobView {
@@ -553,6 +559,7 @@ describe("createFleetHealthMonitor.checkOnce", () => {
       reclaimedOverlays: [],
       restartsAttempted: 0,
       gcDeleted: 0,
+      pidSaturated: [],
     });
     expect(claim.releases).toEqual([]);
   });
@@ -778,5 +785,240 @@ describe("createFleetHealthMonitor.checkOnce", () => {
     expect(DEFAULT_WORKER_GC_AFTER_MS).toBeGreaterThan(
       DEFAULT_WORKER_STALE_AFTER_MS,
     );
+  });
+});
+
+/**
+ * PID-SATURATION alarm (the second fleet-health leg). Pins the four properties
+ * the 2026-08-03 / 2026-08-10 worker-starvation incidents needed and nothing
+ * provided: an ONLINE worker whose cgroup PID gauges cross the threshold raises
+ * an alarm, a sub-threshold worker stays silent, an UNMEASURED worker stays
+ * silent, and a sustained saturation alarms ONCE rather than on every 15s cycle.
+ */
+describe("createFleetHealthMonitor PID saturation", () => {
+  function saturationHarness(
+    rows: Array<Partial<WorkerRow> & { worker_id: string }>,
+    over: Partial<Parameters<typeof createFleetHealthMonitor>[0]> = {},
+  ): {
+    monitor: ReturnType<typeof createFleetHealthMonitor>;
+    alarms: PidSaturationReport[];
+  } {
+    const { pb } = makeFakePb({
+      workers: rows.map((r, i) => ({
+        id: `w${i + 1}`,
+        last_heartbeat_at: FRESH,
+        ...r,
+      })) as WorkerRow[],
+      jobs: [],
+    });
+    const alarms: PidSaturationReport[] = [];
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim: makeFakeClaim(),
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+      onPidSaturation: (r) => {
+        alarms.push(r);
+      },
+      ...over,
+    });
+    return { monitor, alarms };
+  }
+
+  it("alarms on an ONLINE worker whose PID gauges cross the threshold", async () => {
+    // The measured prod condition: heartbeating fine (so the stale/offline leg
+    // never sees it) while the cgroup is at 90% of its ceiling.
+    const { monitor, alarms } = saturationHarness([
+      {
+        worker_id: "worker-hot",
+        capacity_pids_current: 900,
+        capacity_pids_max: 1000,
+      },
+    ]);
+
+    const out = await monitor.checkOnce();
+
+    expect(out.online).toBe(1);
+    expect(out.pidSaturated).toHaveLength(1);
+    expect(alarms).toHaveLength(1);
+    expect(alarms[0]).toMatchObject({
+      workerId: "worker-hot",
+      pidsCurrent: 900,
+      pidsMax: 1000,
+      ratio: 0.9,
+      threshold: DEFAULT_PID_SATURATION_RATIO,
+    });
+  });
+
+  it("stays silent below the threshold, including just under it", async () => {
+    for (const pids of [10, 500, 740]) {
+      const { monitor, alarms } = saturationHarness([
+        {
+          worker_id: "worker-ok",
+          capacity_pids_current: pids,
+          capacity_pids_max: 1000,
+        },
+      ]);
+      const out = await monitor.checkOnce();
+      expect(out.pidSaturated, `pids=${pids}`).toEqual([]);
+      expect(alarms, `pids=${pids}`).toEqual([]);
+    }
+  });
+
+  it("stays silent when the gauges are UNMEASURED (null / unbounded max)", async () => {
+    // `registration.ts` writes null — never -1 — when the cgroup PID controller
+    // is unreadable (off-Linux). Null must never be read as "0 of 0" and must
+    // never alarm; a `pids.max` of 0 would otherwise divide by zero.
+    const { monitor, alarms } = saturationHarness([
+      {
+        worker_id: "worker-null",
+        capacity_pids_current: null,
+        capacity_pids_max: null,
+      },
+      { worker_id: "worker-absent" },
+      {
+        worker_id: "worker-zero-max",
+        capacity_pids_current: 900,
+        capacity_pids_max: 0,
+      },
+    ]);
+
+    const out = await monitor.checkOnce();
+
+    expect(out.online).toBe(3);
+    expect(out.pidSaturated).toEqual([]);
+    expect(alarms).toEqual([]);
+  });
+
+  it("is EDGE-triggered: a sustained saturation alarms once, not every cycle", async () => {
+    // The monitor ticks every DEFAULT_FLEET_HEALTH_INTERVAL_MS (15s). Without
+    // the latch a worker sitting saturated for the ~36h of lead time this alarm
+    // buys would emit ~8600 alerts.
+    const { monitor, alarms } = saturationHarness([
+      {
+        worker_id: "worker-hot",
+        capacity_pids_current: 950,
+        capacity_pids_max: 1000,
+      },
+    ]);
+
+    for (let i = 0; i < 10; i++) await monitor.checkOnce();
+
+    expect(alarms).toHaveLength(1);
+  });
+
+  it("re-arms only after the worker drops below the CLEAR ratio", async () => {
+    // Mutating row: saturate → sit just under the alarm (still latched, no
+    // re-alarm) → drop under the clear ratio (re-arm) → saturate again.
+    const row: WorkerRow & {
+      capacity_pids_current: number;
+      capacity_pids_max: number;
+    } = {
+      id: "w1",
+      worker_id: "worker-flap",
+      last_heartbeat_at: FRESH,
+      capacity_pids_current: 800,
+      capacity_pids_max: 1000,
+    };
+    const { pb } = makeFakePb({ workers: [row], jobs: [] });
+    const alarms: PidSaturationReport[] = [];
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim: makeFakeClaim(),
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+      onPidSaturation: (r) => {
+        alarms.push(r);
+      },
+    });
+
+    await monitor.checkOnce();
+    expect(alarms).toHaveLength(1);
+
+    // 0.70: below the 0.75 alarm but ABOVE the 0.65 clear — still latched.
+    row.capacity_pids_current = 700;
+    await monitor.checkOnce();
+    expect(alarms).toHaveLength(1);
+
+    // 0.60: below the clear ratio — latch releases.
+    row.capacity_pids_current = 600;
+    await monitor.checkOnce();
+    expect(alarms).toHaveLength(1);
+
+    // Saturating again after a genuine recovery must alarm again.
+    row.capacity_pids_current = 900;
+    await monitor.checkOnce();
+    expect(alarms).toHaveLength(2);
+    expect(alarms[1].pidsCurrent).toBe(900);
+  });
+
+  it("never lets a throwing alarm hook abort the cycle", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        {
+          id: "w1",
+          worker_id: "worker-hot",
+          last_heartbeat_at: FRESH,
+          capacity_pids_current: 900,
+          capacity_pids_max: 1000,
+        } as WorkerRow,
+        { id: "w2", worker_id: "worker-fine", last_heartbeat_at: FRESH },
+      ],
+      jobs: [],
+    });
+    const monitor = createFleetHealthMonitor({
+      pb,
+      claim: makeFakeClaim(),
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+      onPidSaturation: () => {
+        throw new Error("slack exploded");
+      },
+    });
+
+    // The second worker must still be counted — a failed operator ping cannot
+    // cost the rest of the roster its health cycle.
+    const out = await monitor.checkOnce();
+    expect(out.online).toBe(2);
+    expect(out.pidSaturated).toHaveLength(1);
+  });
+
+  it("fails loud on a ratio config that would alarm every cycle", async () => {
+    const { pb } = makeFakePb({ workers: [], jobs: [] });
+    const base = {
+      pb,
+      claim: makeFakeClaim(),
+      logger: SILENT_LOGGER,
+      now: () => NOW,
+    };
+
+    // No hysteresis gap → a worker at the threshold re-alarms forever.
+    expect(() =>
+      createFleetHealthMonitor({
+        ...base,
+        pidSaturationRatio: 0.75,
+        pidSaturationClearRatio: 0.75,
+      }),
+    ).toThrow(/pidSaturationClearRatio.*STRICTLY below/s);
+    expect(() =>
+      createFleetHealthMonitor({
+        ...base,
+        pidSaturationRatio: 0.75,
+        pidSaturationClearRatio: 0.8,
+      }),
+    ).toThrow(/pidSaturationClearRatio/);
+    // An out-of-range alarm ratio is permanently-on or unreachable.
+    expect(() =>
+      createFleetHealthMonitor({ ...base, pidSaturationRatio: 0 }),
+    ).toThrow(/pidSaturationRatio/);
+    expect(() =>
+      createFleetHealthMonitor({ ...base, pidSaturationRatio: 1.5 }),
+    ).toThrow(/pidSaturationRatio/);
+
+    // The shipped defaults must satisfy their own guard.
+    expect(DEFAULT_PID_SATURATION_CLEAR_RATIO).toBeLessThan(
+      DEFAULT_PID_SATURATION_RATIO,
+    );
+    expect(() => createFleetHealthMonitor(base)).not.toThrow();
   });
 });

--- a/showcase/harness/src/fleet/control-plane/fleet-health.ts
+++ b/showcase/harness/src/fleet/control-plane/fleet-health.ts
@@ -30,6 +30,16 @@
  *             (N=1, docker) the default is a NO-OP — docker / the worker's own
  *             relaunch handles recovery, so local runs need no Railway wiring.
  *
+ * ── PID-SATURATION ALARM (the second leg) ──────────────────────────────
+ * The same roster read carries each worker's `capacity_pids_current` /
+ * `capacity_pids_max` gauges (written by S9's ~75s heartbeat off
+ * `BrowserPool.budget()`). Until now nothing in non-test source compared them,
+ * so a worker leaking PIDs toward its cgroup ceiling was invisible: it kept
+ * heartbeating (so DETECT above saw `online`), kept claiming jobs, and every one
+ * of them aborted on timeout. This module now alarms on the RISING EDGE of
+ * `pids.current / pids.max >= pidSaturationRatio`, latched per worker with a
+ * hysteresis clear so a saturated worker pages once, not every 15s cycle.
+ *
  * ── RELATIONSHIP TO THE PRODUCER'S sweepExpired ────────────────────────
  * The producer's `sweepExpired` (S4) reclaims jobs whose LEASE has expired —
  * it is lease-timeout-driven and worker-agnostic. fleet-health is the
@@ -57,8 +67,9 @@ import {
   heartbeatParseable,
   isWorkerStale,
   deriveHealth,
-  type PoolCommError,
+  pidUsageRatio,
 } from "../contracts.js";
+import type { PoolCommError } from "../contracts.js";
 
 /**
  * Default staleness window: a worker whose `last_heartbeat_at` is older than
@@ -82,6 +93,41 @@ export const DEFAULT_WORKER_STALE_AFTER_MS = 180_000;
  */
 export const DEFAULT_WORKER_GC_AFTER_MS = 86_400_000;
 
+/**
+ * Default PID-SATURATION alarm threshold, as a fraction of a worker's cgroup
+ * `pids.max` ceiling. A worker whose `capacity_pids_current / capacity_pids_max`
+ * crosses this fires the saturation hook.
+ *
+ * WHY THIS EXISTS: prod `harness-workers` replicas accumulate zombie chromium
+ * PIDs until they hit the platform-fixed `pids.max=1000` ceiling, at which point
+ * the worker cannot fork and every probe it claims aborts on timeout. Measured
+ * at the 2026-08-03 and 2026-08-10 incidents: `pids=1000/1000`, `837/1000`,
+ * hundreds of `timeout after 600000ms` abort rows, and jobs sitting pending for
+ * 42 minutes on a 15-minute cadence. NOTHING alarmed — the `pool-unrecoverable`
+ * signal only fires when the self-heal breaker gives up, which a PID-starved
+ * (but still heartbeating) worker never reaches, and the capacity gauges the
+ * worker heartbeats here were read by nobody.
+ *
+ * WHY 0.75: at the observed leak rate (~1000 PIDs over ~7 days) 75% leaves
+ * roughly 36 hours of operator lead time before the ceiling, which is more than
+ * one working day — early enough to act, late enough that ordinary busy-worker
+ * churn (a full context budget is nowhere near 750 PIDs) never trips it.
+ * Env-overridable by the wiring slot via WORKER_PID_SATURATION_RATIO.
+ */
+export const DEFAULT_PID_SATURATION_RATIO = 0.75;
+
+/**
+ * Default CLEAR threshold for the PID-saturation latch (hysteresis). The alarm
+ * is EDGE-triggered: it fires once when a worker crosses
+ * `pidSaturationRatio` and stays latched — silent — until that worker drops back
+ * below THIS ratio. Without the gap, a worker parked exactly at the threshold
+ * would re-alarm on every cycle (the monitor ticks every
+ * DEFAULT_FLEET_HEALTH_INTERVAL_MS = 15s, i.e. 4 alerts/minute for the ~36h
+ * lead-time window — an alarm that fires constantly is worse than none).
+ * Env-overridable via WORKER_PID_SATURATION_CLEAR_RATIO.
+ */
+export const DEFAULT_PID_SATURATION_CLEAR_RATIO = 0.65;
+
 /** Max worker rows scanned per monitor cycle — bounds the roster read cost. */
 const WORKERS_PAGE = 100;
 
@@ -91,14 +137,60 @@ const RECLAIM_PAGE = 100;
 /**
  * The persisted `workers` row shape fleet-health reads. Snake-case columns as
  * the PB records API returns them (see the create_workers migration). Only the
- * fields fleet-health consumes are typed; the capacity gauges are ignored here.
+ * fields fleet-health consumes are typed.
+ *
+ * The two `capacity_pids_*` gauges are written by the worker's ~75s heartbeat
+ * (`worker/registration.ts` `capacityRecord`) off `BrowserPool.budget()`. They
+ * are `null` — never `-1` — when the cgroup PID controller is unreadable
+ * (off-Linux, missing controller): the registration writer maps the pool's `-1`
+ * sentinel to null precisely so a MEASURED count is distinguishable from an
+ * UNAVAILABLE one. The saturation check honours that convention and treats
+ * null/absent as "not measured", never as 0.
  */
 interface WorkerRecord {
   id: string;
   worker_id: string;
   last_heartbeat_at: string;
   current_job_id?: string;
+  /** cgroup `pids.current` at the last heartbeat; null when unmeasurable. */
+  capacity_pids_current?: number | null;
+  /** cgroup `pids.max` ceiling at the last heartbeat; null when unmeasurable. */
+  capacity_pids_max?: number | null;
 }
+
+/**
+ * One worker's PID-saturation alarm payload, handed to `onPidSaturation` on the
+ * rising edge. Pure counters — safe to put in a Slack message or a public-read
+ * status row.
+ */
+export interface PidSaturationReport {
+  /** The saturating worker's id (joins the roster row and its claims). */
+  workerId: string;
+  /** cgroup `pids.current` read from the worker's last heartbeat. */
+  pidsCurrent: number;
+  /** cgroup `pids.max` ceiling read from the worker's last heartbeat. */
+  pidsMax: number;
+  /** `pidsCurrent / pidsMax`, the value that crossed the threshold. */
+  ratio: number;
+  /** The threshold ratio that was crossed (echoed so the alarm is self-describing). */
+  threshold: number;
+  /** Heartbeat timestamp the saturating gauges were read from. */
+  lastHeartbeatAt: string;
+  /** ISO timestamp of the cycle that detected the crossing. */
+  observedAt: string;
+}
+
+/**
+ * Best-effort alarm hook fired ONCE per worker on the rising edge of PID
+ * saturation (and again only after that worker has recovered below the clear
+ * ratio). The wiring slot routes it to the operator channel; the default is
+ * undefined (detection still counts into `FleetHealthResult.pidSaturated`, which
+ * is what the unit tests and the /health surface read). MUST never throw into
+ * the monitor loop — the monitor wraps it anyway, mirroring `restartWorker`.
+ */
+export type PidSaturationHook = (
+  report: PidSaturationReport,
+) => void | Promise<void>;
 
 /**
  * Best-effort hook to RESTART a wedged worker (staging: Railway
@@ -152,6 +244,14 @@ export interface FleetHealthResult {
    * generations being pruned so the roster stops accumulating ghost rows.
    */
   gcDeleted: number;
+  /**
+   * Workers that crossed the PID-saturation threshold ON THIS CYCLE (the rising
+   * edge only — a worker already latched saturated reports once, then stays out
+   * of this list until it recovers below the clear ratio). One entry per fired
+   * `onPidSaturation` invocation, so a caller can count alarms without
+   * re-deriving the edge.
+   */
+  pidSaturated: PidSaturationReport[];
 }
 
 export interface FleetHealthDeps {
@@ -177,6 +277,23 @@ export interface FleetHealthDeps {
    * Default no-op — local docker / the worker's own relaunch handles recovery.
    */
   restartWorker?: RestartWorkerHook;
+  /**
+   * PID-saturation alarm threshold (fraction of `pids.max`). Default
+   * `DEFAULT_PID_SATURATION_RATIO` (0.75). Must be in (0, 1].
+   */
+  pidSaturationRatio?: number;
+  /**
+   * Latch-clear threshold (fraction of `pids.max`). Default
+   * `DEFAULT_PID_SATURATION_CLEAR_RATIO` (0.65). MUST be strictly below
+   * `pidSaturationRatio` — ENFORCED at construction, see below.
+   */
+  pidSaturationClearRatio?: number;
+  /**
+   * Best-effort PID-saturation alarm hook. Default undefined (detection still
+   * counts into `FleetHealthResult.pidSaturated`); the wiring slot injects the
+   * operator alert.
+   */
+  onPidSaturation?: PidSaturationHook;
 }
 
 /** The control-plane's fleet-health monitor — drives the detect/requeue cycle. */
@@ -210,6 +327,37 @@ export function createFleetHealthMonitor(
       `Unsafe fleet-health config: gcAfterMs (${gcAfterMs}, env WORKER_GC_AFTER_MS) must be > staleAfterMs (${staleAfterMs}, env WORKER_STALE_AFTER_MS); otherwise GC deletes a merely-stale (recoverable) worker's roster row before its in-flight jobs are reclaimed, wedging those jobs until lease expiry with no crashed-worker overlay.`,
     );
   }
+  const pidRatio = deps.pidSaturationRatio ?? DEFAULT_PID_SATURATION_RATIO;
+  const pidClearRatio =
+    deps.pidSaturationClearRatio ?? DEFAULT_PID_SATURATION_CLEAR_RATIO;
+  // Fail-loud at construction, same idiom as the gc/stale guard above. Both
+  // ratios are independently env-overridable by the wiring slot
+  // (WORKER_PID_SATURATION_RATIO / WORKER_PID_SATURATION_CLEAR_RATIO), so an
+  // unsafe combo is a misconfiguration. A non-positive or >1 alarm ratio makes
+  // the alarm either permanently-on or unreachable; a clear ratio that does not
+  // sit STRICTLY BELOW it removes the hysteresis gap, so a worker parked at the
+  // threshold latches and unlatches on alternating cycles and re-alarms every
+  // 15s forever — the exact "fires constantly is worse than none" failure the
+  // latch exists to prevent. Die immediately (visible in deploy CI / Railway
+  // health-check) rather than page an operator four times a minute.
+  if (!(pidRatio > 0) || pidRatio > 1) {
+    throw new Error(
+      `Unsafe fleet-health config: pidSaturationRatio (${pidRatio}, env WORKER_PID_SATURATION_RATIO) must be in (0, 1]; outside that range the PID-saturation alarm is either permanently firing or can never fire.`,
+    );
+  }
+  if (!(pidClearRatio < pidRatio) || pidClearRatio < 0) {
+    throw new Error(
+      `Unsafe fleet-health config: pidSaturationClearRatio (${pidClearRatio}, env WORKER_PID_SATURATION_CLEAR_RATIO) must be >= 0 and STRICTLY below pidSaturationRatio (${pidRatio}, env WORKER_PID_SATURATION_RATIO); without a hysteresis gap a worker sitting at the threshold re-alarms on every monitor cycle.`,
+    );
+  }
+  const onPidSaturation = deps.onPidSaturation;
+  // EDGE-TRIGGER LATCH: worker ids currently alarmed. A worker enters on the
+  // rising edge (ratio >= pidRatio) and leaves only when it recovers below
+  // `pidClearRatio` or its roster row is GC'd — so the alarm fires ONCE per
+  // saturation episode rather than once per 15s cycle. In-memory by design: a
+  // control-plane restart re-arms every worker, which is the correct posture
+  // (a fresh control-plane has told nobody anything yet).
+  const pidSaturationLatched = new Set<string>();
   const now = deps.now ?? Date.now;
   // Whether a REAL restart hook was injected (staging Railway redeploy) vs the
   // default no-op. Used to demote the misleading `restartsAttempted` metric: a
@@ -336,6 +484,7 @@ export function createFleetHealthMonitor(
           reclaimedOverlays: [],
           restartsAttempted: 0,
           gcDeleted: 0,
+          pidSaturated: [],
         };
       }
 
@@ -351,6 +500,7 @@ export function createFleetHealthMonitor(
       let unparseableHeartbeats = 0;
       const commErrors: PoolCommError[] = [];
       const reclaimedOverlays: ReclaimedCommError[] = [];
+      const pidSaturated: PidSaturationReport[] = [];
 
       for (const row of page.items) {
         // GC FIRST — even before the missing-worker-id guard: a row whose
@@ -388,6 +538,14 @@ export function createFleetHealthMonitor(
               err: err instanceof Error ? err.message : String(err),
             });
           }
+          // Release this worker's saturation latch alongside its roster row —
+          // otherwise the in-memory Set accumulates one entry per retired
+          // deploy generation for the control-plane's whole lifetime. Safe to
+          // do even when the delete threw: the row survives to the next cycle,
+          // where an un-recovered gauge simply re-arms the latch.
+          if (typeof row.worker_id === "string") {
+            pidSaturationLatched.delete(row.worker_id);
+          }
           continue;
         }
         const workerId = row.worker_id;
@@ -417,6 +575,74 @@ export function createFleetHealthMonitor(
             lastHeartbeatAt: row.last_heartbeat_at,
           });
         }
+        // PID-SATURATION alarm. Evaluated BEFORE the online/stale branch on
+        // purpose: the incident this exists for is a worker that is perfectly
+        // ONLINE — heartbeating on time, passing every liveness check — while
+        // its cgroup PID count climbs to the ceiling and every probe it claims
+        // aborts on timeout. Putting the check after the `online` early-continue
+        // would make it blind to the exact failure it targets.
+        //
+        // Detection only. The reclaim/restart machinery below stays reserved for
+        // the stale/offline case: a saturating worker still holds live leases we
+        // must not yank, and it may yet be reaped back below the line.
+        const ratio = pidUsageRatio(
+          row.capacity_pids_current,
+          row.capacity_pids_max,
+        );
+        if (ratio !== null) {
+          const wasLatched = pidSaturationLatched.has(workerId);
+          if (ratio >= pidRatio && !wasLatched) {
+            pidSaturationLatched.add(workerId);
+            // Non-null by construction: `pidSaturationRatio` returns a number
+            // only when both gauges are finite numbers in range.
+            const report: PidSaturationReport = {
+              workerId,
+              pidsCurrent: Number(row.capacity_pids_current),
+              pidsMax: Number(row.capacity_pids_max),
+              ratio,
+              threshold: pidRatio,
+              lastHeartbeatAt: row.last_heartbeat_at,
+              observedAt: new Date(nowMs).toISOString(),
+            };
+            pidSaturated.push(report);
+            // `error`, not `warn`: warn/error route to stderr → Sentry (see the
+            // PoolLogger note in browser-pool.ts), and PID saturation is the
+            // fleet-starvation precursor, not routine noise.
+            logger.error("fleet.health.worker-pid-saturated", {
+              workerId,
+              pidsCurrent: report.pidsCurrent,
+              pidsMax: report.pidsMax,
+              ratio: Number(ratio.toFixed(4)),
+              threshold: pidRatio,
+              health: deriveHealth(row.last_heartbeat_at, nowMs, staleAfterMs),
+            });
+            if (onPidSaturation) {
+              try {
+                await onPidSaturation(report);
+              } catch (err) {
+                // Best-effort, same discipline as restartWorker: a failed
+                // operator ping must never abort the cycle (which would skip
+                // every subsequent worker's reclamation).
+                logger.warn("fleet.health.pid-saturation-hook-failed", {
+                  workerId,
+                  err: err instanceof Error ? err.message : String(err),
+                });
+              }
+            }
+          } else if (ratio < pidClearRatio && wasLatched) {
+            // Recovered past the hysteresis gap — re-arm so the NEXT saturation
+            // episode (e.g. after a reaper deploy regresses) alarms again.
+            pidSaturationLatched.delete(workerId);
+            logger.info("fleet.health.worker-pid-recovered", {
+              workerId,
+              pidsCurrent: row.capacity_pids_current,
+              pidsMax: row.capacity_pids_max,
+              ratio: Number(ratio.toFixed(4)),
+              clearThreshold: pidClearRatio,
+            });
+          }
+        }
+
         const health = deriveHealth(row.last_heartbeat_at, nowMs, staleAfterMs);
         if (health === "online") {
           online += 1;
@@ -472,7 +698,8 @@ export function createFleetHealthMonitor(
         unhealthy > 0 ||
         reclaimed > 0 ||
         gcDeleted > 0 ||
-        unparseableHeartbeats > 0
+        unparseableHeartbeats > 0 ||
+        pidSaturated.length > 0
       ) {
         logger.info("fleet.health.cycle", {
           online,
@@ -481,6 +708,11 @@ export function createFleetHealthMonitor(
           restartsAttempted,
           gcDeleted,
           unparseableHeartbeats,
+          // Rising-edge alarms this cycle; `pidLatched` is the standing count
+          // (workers still above the clear ratio), which is what an operator
+          // watching the fleet actually wants to see.
+          pidSaturated: pidSaturated.length,
+          pidLatched: pidSaturationLatched.size,
         });
       }
 
@@ -492,6 +724,7 @@ export function createFleetHealthMonitor(
         reclaimedOverlays,
         restartsAttempted,
         gcDeleted,
+        pidSaturated,
       };
     },
   };

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -2950,3 +2950,121 @@ describe("driver registry (driverKind → driver)", () => {
     expect(queue.reports[0]!.aggregateKey).toBe("e2e_demos:routed");
   });
 });
+
+// ── startWorkerLoop: claim-time PID headroom gate ──────────────────────────
+
+/**
+ * Pins the dispatch defect the 2026-08-10 worker-starvation incident exposed:
+ * `budget.available` counts free browser CONTEXT slots and is blind to the
+ * container's cgroup PID ceiling, so a worker at `pids=1000/1000` kept winning
+ * claims it could not run and burned each one to a 600000ms abort. The gate must
+ * decline the claim WITHOUT dropping or requeueing the job, and must stay inert
+ * whenever the gauges are unmeasurable (every non-Linux dev box).
+ */
+describe("startWorkerLoop PID headroom gate", () => {
+  /** Runs a loop for a few poll turns and reports whether it claimed. */
+  async function runGate(budget: Partial<BrowserPoolBudget>): Promise<{
+    claimNextCalls: number;
+    reports: number;
+  }> {
+    let claimNextCalls = 0;
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const innerClaimNext = queue.claimNext.bind(queue);
+    queue.claimNext = async (...args: Parameters<typeof innerClaimNext>) => {
+      claimNextCalls++;
+      return innerClaimNext(...args);
+    };
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      // Full context budget on purpose: the ONLY thing that may stop this
+      // worker in the saturated cases is the PID gate.
+      pool: budgetWith(24, budget),
+      driver: makeDriver({
+        slug: "langgraph-python",
+        cells: [{ featureId: "tools", state: "green" }],
+        aggregateState: "green",
+      }),
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+    });
+    // Give the loop room to make several claim decisions.
+    await new Promise((r) => setTimeout(r, 40));
+    await handle.stop();
+    return { claimNextCalls, reports: queue.reports.length };
+  }
+
+  it("declines to claim at the PID ceiling — the job is never claimed, so it stays pending", async () => {
+    // The measured prod condition: 1000/1000 PIDs, full context budget.
+    const out = await runGate({ pidsCurrent: 1000, pidsMax: 1000 });
+    expect(out.claimNextCalls).toBe(0);
+    expect(out.reports).toBe(0);
+  });
+
+  it("declines at the gate ratio boundary (0.90)", async () => {
+    const out = await runGate({ pidsCurrent: 900, pidsMax: 1000 });
+    expect(out.claimNextCalls).toBe(0);
+  });
+
+  it("still claims just BELOW the gate — the alarm's 0.75 must not withhold capacity", async () => {
+    // 0.89 is above the control-plane's 0.75 saturation ALARM but below this
+    // gate: the operator has been paged, and the worker keeps working. If these
+    // two thresholds were equal, alarming would cost ~36h of fleet capacity.
+    const out = await runGate({ pidsCurrent: 890, pidsMax: 1000 });
+    expect(out.claimNextCalls).toBeGreaterThan(0);
+    expect(out.reports).toBeGreaterThan(0);
+  });
+
+  it("claims normally on a healthy worker", async () => {
+    const out = await runGate({ pidsCurrent: 100, pidsMax: 1000 });
+    expect(out.claimNextCalls).toBeGreaterThan(0);
+    expect(out.reports).toBe(1);
+  });
+
+  it("stays INERT when the cgroup gauges are unreadable (-1 sentinel, off-Linux)", async () => {
+    // Every macOS dev box and any container without the PID controller reports
+    // -1/-1. A gate that engaged there would stop the local fleet dead.
+    const out = await runGate({ pidsCurrent: -1, pidsMax: -1 });
+    expect(out.claimNextCalls).toBeGreaterThan(0);
+    expect(out.reports).toBe(1);
+  });
+
+  it("honours an injected gate ratio", async () => {
+    let claimNextCalls = 0;
+    const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+    const inner = queue.claimNext.bind(queue);
+    queue.claimNext = async (...args: Parameters<typeof inner>) => {
+      claimNextCalls++;
+      return inner(...args);
+    };
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(24, { pidsCurrent: 500, pidsMax: 1000 }),
+      driver: makeDriver({
+        slug: "langgraph-python",
+        cells: [{ featureId: "tools", state: "green" }],
+        aggregateState: "green",
+      }),
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      // 0.50 would pass the default 0.90 gate; an explicit 0.40 must decline.
+      pidClaimGateRatio: 0.4,
+    });
+    await new Promise((r) => setTimeout(r, 40));
+    await handle.stop();
+    expect(claimNextCalls).toBe(0);
+  });
+});

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -42,6 +42,7 @@
 
 import type { ProbeState, ProbeResult, Logger } from "../../types/index.js";
 import type { BrowserPoolBudget } from "../../probes/helpers/browser-pool.js";
+import { pidUsageRatio } from "../contracts.js";
 import type {
   FleetQueueClient,
   JobLease,
@@ -193,6 +194,13 @@ export interface WorkerLoopDeps {
   /** Idle poll interval when there's no work / no budget. */
   pollIntervalMs?: number;
   /**
+   * Claim-time PID headroom gate ratio. Defaults to the
+   * WORKER_PID_CLAIM_GATE_RATIO env override, else
+   * `DEFAULT_PID_CLAIM_GATE_RATIO`. Injectable so a test can drive the gate
+   * without touching process.env.
+   */
+  pidClaimGateRatio?: number;
+  /**
    * Optional hook fired when the worker's current job changes: the claimed
    * `jobId` when a job is won, then `null` when it settles (reported/failed).
    * The entrypoint wires this to the registration heartbeat so the worker's
@@ -238,6 +246,58 @@ export const DEFAULT_LEASE_SECONDS = 300;
 export const DEFAULT_HEARTBEAT_MS = 60_000;
 /** Default idle poll interval when there's no work / no budget. */
 export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Claim-time PID HEADROOM gate: a worker declines to claim while
+ * `pids.current / pids.max` is at or above this fraction of its cgroup ceiling.
+ *
+ * WHY THIS EXISTS: `budget.available` counts free Playwright CONTEXT slots
+ * (`browser-pool.ts` — `maxContexts - liveContextCount`) and nothing else. A
+ * worker whose container has leaked PIDs to the 1000-PID ceiling still reports
+ * full context budget, so it kept winning claims it could not possibly run: the
+ * driver cannot fork, and the job burns its whole 600000ms lease before aborting.
+ * Measured at the 2026-08-10 incident: workers at `pids=1000/1000` with 758-761
+ * zombies, and 320 `timeout after 600000ms` abort rows. Declining the claim
+ * leaves the job PENDING for a healthy worker instead of converting it into a
+ * ten-minute abort.
+ *
+ * WHY 0.90 (and why it is much higher than the control-plane's 0.75 alarm):
+ * these two thresholds do DIFFERENT jobs and must not be equal. 0.75 alarms an
+ * operator early (~36h of lead time at the observed leak rate) while the worker
+ * is still perfectly capable of running jobs — gating dispatch that early would
+ * convert a warning into a day-and-a-half of lost fleet capacity. 0.90 is the
+ * point at which we stop trusting the worker to fork a browser tree at all; at
+ * the prod ceiling of `pids.max=1000` it leaves 100 free PIDs. The per-job PID
+ * cost of a chromium context tree is NOT MEASURED, so 100 is a chosen reserve,
+ * not a derived one — hence the env override. The ordering invariant that DOES
+ * matter is that the alarm fires strictly before the gate engages, so an
+ * operator is always told before capacity is withdrawn.
+ *
+ * Env-overridable via WORKER_PID_CLAIM_GATE_RATIO. Note the gate is INERT when
+ * the cgroup gauges are unreadable (`pidUsageRatio` → null: off-Linux, every
+ * macOS dev box) — an unmeasurable worker keeps claiming exactly as before.
+ */
+export const DEFAULT_PID_CLAIM_GATE_RATIO = 0.9;
+
+/**
+ * Resolve the claim-time PID headroom gate ratio from the environment. An
+ * unparseable or out-of-(0,1] override falls back to the default rather than
+ * either wedging the fleet (a 0 gate declines every claim forever) or silently
+ * disabling the gate.
+ */
+function resolvePidClaimGateRatio(logger: Logger): number {
+  const raw = process.env.WORKER_PID_CLAIM_GATE_RATIO;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_PID_CLAIM_GATE_RATIO;
+  }
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0 && parsed <= 1) return parsed;
+  safeLog(logger, "warn", "fleet.worker.pid-claim-gate-ratio-invalid", {
+    raw,
+    fallback: DEFAULT_PID_CLAIM_GATE_RATIO,
+  });
+  return DEFAULT_PID_CLAIM_GATE_RATIO;
+}
 /**
  * Bound on the roster-row deregister await inside the orchestrator's
  * `drainFleetWorker` (which re-exports this constant).
@@ -1088,6 +1148,12 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
   const heartbeatMs = deps.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
   const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const { workerId, queue, pool, logger } = deps;
+  // Claim-time PID headroom gate (see DEFAULT_PID_CLAIM_GATE_RATIO). Resolved
+  // ONCE at construction alongside the other knobs; `pidGateLatched` makes the
+  // decline log edge-triggered so a long saturation warns once, not every poll.
+  const pidClaimGateRatio =
+    deps.pidClaimGateRatio ?? resolvePidClaimGateRatio(logger);
+  let pidGateLatched = false;
 
   // Fail-loud at construction: the heartbeat must fire (and renew) BEFORE the
   // lease expires, or the sweeper reclaims a live worker's job and synthesizes a
@@ -1255,6 +1321,63 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
         });
         await safeSleep(pollIntervalMs);
         continue;
+      }
+
+      // 1b. PID HEADROOM gate. `budget.available` above counts free browser
+      //     CONTEXT slots and is blind to the container's PID ceiling, so a
+      //     worker whose cgroup is exhausted reports full capacity and keeps
+      //     winning claims it cannot run — the job then burns its entire lease
+      //     and lands as a `timeout after 600000ms` abort. Decline instead.
+      //
+      //     BLAST RADIUS — deliberately the SAME decline-and-idle path as the
+      //     no-budget branch above, which is what makes this safe when EVERY
+      //     worker is saturated:
+      //       - the job is never claimed, so it is never dropped and never
+      //         requeued — it simply stays `pending` for a healthy worker (or
+      //         for this one, post-redeploy);
+      //       - the loop sleeps a full `pollIntervalMs` before re-checking, so a
+      //         fully-saturated fleet idles at the poll cadence rather than
+      //         spinning;
+      //       - the queue therefore STALLS VISIBLY: `probe_jobs` rows pile up
+      //         pending, and the reason is stated by the rising-edge warn below
+      //         plus the control-plane's `system:worker-pid-saturation` alarm,
+      //         which by construction fired at 0.75 before this gate engaged at
+      //         0.90.
+      //     A stalled, alarmed queue is recoverable by redeploy; the pre-fix
+      //     behaviour (claim, fail, repeat) silently burned the whole cadence.
+      //
+      //     `pidUsageRatio` returns null when the cgroup gauges are unreadable
+      //     (off-Linux/dev), and a null ratio leaves the gate OPEN.
+      const pidRatio = pidUsageRatio(budget.pidsCurrent, budget.pidsMax);
+      if (pidRatio !== null && pidRatio >= pidClaimGateRatio) {
+        // Rising edge at WARN (stderr → Sentry) so a fleet that has stopped
+        // claiming says why exactly once; steady state drops to debug so a
+        // multi-hour saturation doesn't emit a warn every `pollIntervalMs`.
+        safeLog(
+          logger,
+          pidGateLatched ? "debug" : "warn",
+          "fleet.worker.pid-headroom-exhausted",
+          {
+            workerId,
+            pidsCurrent: budget.pidsCurrent,
+            pidsMax: budget.pidsMax,
+            ratio: Number(pidRatio.toFixed(4)),
+            gateRatio: pidClaimGateRatio,
+            msg: "declining to claim — cgroup PID headroom exhausted; jobs stay pending for a healthy worker",
+          },
+        );
+        pidGateLatched = true;
+        await safeSleep(pollIntervalMs);
+        continue;
+      }
+      if (pidGateLatched) {
+        safeLog(logger, "info", "fleet.worker.pid-headroom-recovered", {
+          workerId,
+          pidsCurrent: budget.pidsCurrent,
+          pidsMax: budget.pidsMax,
+          gateRatio: pidClaimGateRatio,
+        });
+        pidGateLatched = false;
       }
 
       // 2. Attempt a claim.

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -109,6 +109,8 @@ import {
   createFleetHealthMonitor,
   DEFAULT_WORKER_STALE_AFTER_MS,
   DEFAULT_WORKER_GC_AFTER_MS,
+  DEFAULT_PID_SATURATION_RATIO,
+  DEFAULT_PID_SATURATION_CLEAR_RATIO,
 } from "./fleet/control-plane/fleet-health.js";
 import type { RestartWorkerHook } from "./fleet/control-plane/fleet-health.js";
 import {
@@ -1752,6 +1754,17 @@ export const BROWSER_POOL_UNRECOVERABLE_KEY =
 export const BROWSER_POOL_ALERT_WEBHOOK_ENV =
   "SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE";
 
+/**
+ * PB status key the control-plane's WORKER PID-SATURATION alarm is written
+ * under. Kept separate from the two browser-pool keys because it describes a
+ * different failure: the pool is fine (it launches, it serves contexts) while
+ * the CONTAINER is running out of PIDs underneath it. The browser-pool keys only
+ * go red once the pool itself can no longer function, which a PID-starved worker
+ * reaches long after its probes have started aborting on timeout — the ~36h of
+ * lead time this key exists to surface.
+ */
+export const WORKER_PID_SATURATION_KEY = "system:worker-pid-saturation";
+
 /** Breaker counters + resource gauges surfaced in the terminal alarm so an
  *  operator sees how hard the pool tried before giving up AND the PROVEN wedge
  *  signal (the cgroup PID/thread ceiling) that caused it. */
@@ -2764,6 +2777,24 @@ export async function runControlPlane(
   // §9 family-silence monitor below) must judge worker staleness against the
   // SAME window, never the DEFAULT_ constant.
   const workerStaleAfterMs = resolveWorkerStaleAfterMs();
+  // #oss-alerts plumbing, constructed HERE (ahead of its other two consumers,
+  // the §9 family-silence monitor and the D0-gone monitor further down) because
+  // fleet-health's PID-saturation hook is the first thing that needs it. Both
+  // are pure constructions over `pb` / `logger` with no ordering constraints of
+  // their own; the webhook URL resolves from SLACK_WEBHOOK_OSS_ALERTS at SEND
+  // time, so hoisting cannot change what the later consumers see.
+  const alertStateStore = createAlertStateStore(pb);
+  const ossAlertsTarget = createSlackWebhookTarget({ logger });
+  const postOssAlert = async (text: string): Promise<void> => {
+    await ossAlertsTarget.send(
+      { payload: { text }, contentType: "application/json" },
+      { kind: "slack_webhook", webhook: "oss_alerts" },
+    );
+  };
+  const pidSaturationRatio = resolveRatioEnv(
+    "WORKER_PID_SATURATION_RATIO",
+    DEFAULT_PID_SATURATION_RATIO,
+  );
   const fleetHealth = createFleetHealthMonitor({
     pb,
     claim,
@@ -2771,6 +2802,69 @@ export async function runControlPlane(
     staleAfterMs: workerStaleAfterMs,
     gcAfterMs: resolveWorkerGcAfterMs(),
     restartWorker: resolveWorkerRestartHook(logger),
+    pidSaturationRatio,
+    pidSaturationClearRatio: resolveRatioEnv(
+      "WORKER_PID_SATURATION_CLEAR_RATIO",
+      DEFAULT_PID_SATURATION_CLEAR_RATIO,
+    ),
+    // PID-SATURATION ALARM ROUTING. Mirrors the browser-pool terminal alarm's
+    // shape — a durable `system:` status row PLUS an operator ping — with one
+    // deliberate difference: the ping goes to #oss-alerts (the channel the
+    // family-silence and D0-gone monitors already post to, wired from the
+    // SLACK_WEBHOOK_OSS_ALERTS secret that exists), NOT to
+    // SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE, which is referenced nowhere in
+    // this repo outside its own definition and is therefore unset everywhere.
+    // An alarm nobody receives is the gap this PR closes; routing it to a
+    // known-unwired webhook would reproduce that gap exactly.
+    //
+    // Both legs are best-effort and INDEPENDENT: a failed Slack post must not
+    // cost us the durable row (the dashboard signal), and vice versa. The
+    // monitor wraps the whole hook anyway, so a throw here can never abort the
+    // health cycle — but each leg carries its own catch so one failure doesn't
+    // silently skip the other.
+    onPidSaturation: async (report) => {
+      const message =
+        `worker ${report.workerId} PID-SATURATED — ` +
+        `pids.current=${report.pidsCurrent}/pids.max=${report.pidsMax} ` +
+        `(${(report.ratio * 100).toFixed(1)}%, alarm at ${(report.threshold * 100).toFixed(0)}%). ` +
+        "This worker's probes will abort on timeout once it can no longer fork; " +
+        "redeploy harness-workers to clear it.";
+      try {
+        await statusWriter.write({
+          key: WORKER_PID_SATURATION_KEY,
+          state: "red",
+          signal: {
+            severity: "critical",
+            errorMessage: message,
+            workerId: report.workerId,
+            pidsCurrent: report.pidsCurrent,
+            pidsMax: report.pidsMax,
+            ratio: report.ratio,
+            threshold: report.threshold,
+            lastHeartbeatAt: report.lastHeartbeatAt,
+            saturatedSince: report.observedAt,
+          },
+          observedAt: report.observedAt,
+        });
+      } catch (err) {
+        logger.warn("fleet.control-plane.pid-saturation-status-write-failed", {
+          workerId: report.workerId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+      try {
+        await postOssAlert(`:rotating_light: ${message}`);
+      } catch (err) {
+        // `createSlackWebhookTarget` THROWS when SLACK_WEBHOOK_OSS_ALERTS is
+        // unset (it logs `slack-webhook.env-unset` first) — same posture the
+        // family-silence monitor swallows. Alerting ships disabled locally;
+        // the durable status row above still lands.
+        logger.warn("fleet.control-plane.pid-saturation-alert-failed", {
+          workerId: report.workerId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
   });
 
   // CATALOG-AWARE ENUMERATION: the per-service unit enumerator resolves the
@@ -2967,18 +3061,13 @@ export async function runControlPlane(
   // which the monitor swallows per its post-failure discipline — alerting
   // ships disabled, the monitor still evaluates (so /health's
   // fleetRuns.lastEvaluatedAt stays live).
-  const alertStateStore = createAlertStateStore(pb);
-  const ossAlertsTarget = createSlackWebhookTarget({ logger });
+  // `alertStateStore` + `ossAlertsTarget` are constructed above (hoisted so
+  // fleet-health's PID-saturation hook can share the SAME #oss-alerts target).
   const familySilence = createFamilySilenceMonitor({
     summary: familySummary,
     schedules,
     alertStore: alertStateStore,
-    postAlert: async (text: string): Promise<void> => {
-      await ossAlertsTarget.send(
-        { payload: { text }, contentType: "application/json" },
-        { kind: "slack_webhook", webhook: "oss_alerts" },
-      );
-    },
+    postAlert: postOssAlert,
     // Boot grace (1× resolved period per family) anchored at construction.
     bootAtMs: Date.now(),
     logger,
@@ -3005,12 +3094,7 @@ export async function runControlPlane(
       // Reuse the SAME #oss-alerts webhook target the family-silence monitor
       // posts through — throws on send failure so `last_alert_at` never advances
       // on a dropped Slack post (§7 dedupe discipline).
-      postAlert: async (text: string): Promise<void> => {
-        await ossAlertsTarget.send(
-          { payload: { text }, contentType: "application/json" },
-          { kind: "slack_webhook", webhook: "oss_alerts" },
-        );
-      },
+      postAlert: postOssAlert,
       // The SAME shared memoized family-summary the routes + silence monitor use
       // — the §2.5 producer-liveness source.
       summary: familySummary,
@@ -3585,6 +3669,21 @@ function resolveWorkerGcAfterMs(): number {
   const parsed = raw ? parseInt(raw, 10) : NaN;
   if (Number.isFinite(parsed) && parsed > 0) return parsed;
   return DEFAULT_WORKER_GC_AFTER_MS;
+}
+
+/**
+ * Resolve a fleet-health PID-saturation RATIO knob (a fraction of a worker's
+ * cgroup `pids.max`). Shared by the alarm threshold and its hysteresis clear
+ * threshold since both parse identically. An unparseable or out-of-(0,1)
+ * override falls back to the default rather than handing
+ * `createFleetHealthMonitor` a value that trips its fail-loud guard and takes
+ * the whole control-plane down over a typo'd env var.
+ */
+function resolveRatioEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0 && parsed < 1) return parsed;
+  return fallback;
 }
 
 /**


### PR DESCRIPTION
> **This PR carries three changes to the same prod incident.** Change 1 fixes
> the PID leak itself; changes 2 and 3 fix the two reasons the leak was able to
> starve the fleet unannounced. Each has its own RED → GREEN below.
>
> | # | Commit | What it fixes |
> |---|---|---|
> | 1 | `e66fb1af13` | **The leak.** No PID-1 reaper, so crashed chromium grandchildren become permanent zombies holding cgroup PID slots. |
> | 2 | `7f28e9bd39` | **Nothing alarmed.** The worker heartbeats its cgroup PID gauges and no non-test code read them. |
> | 3 | `63ef4081c2` | **Saturated workers kept claiming.** The claim gate only checked free browser-context slots, so a worker at 1000/1000 PIDs won jobs it could not run and burned each to a 600000ms abort. |

---

# CHANGE 1 — the leak (tini as PID 1)

## The bug

`harness-workers` has **no PID-1 zombie reaper**, so it leaks cgroup PID slots until it cannot launch a browser.

libuv's `SIGCHLD` handler only `waitpid()`s the pids **Node itself spawned**. Playwright spawns the chromium *browser* process (reaped fine), but that browser's **zygote/renderer/GPU children are grandchildren**. When a browser process dies — prod's `Target crashed` path, or a pool self-heal relaunch — those grandchildren are re-parented onto PID 1 and exit. Node-as-PID-1 never waits on them, so each becomes a permanent `<defunct>` still holding a cgroup PID slot.

Prod, on a single container up 6d22h: `zombieCount` 70 → **757**, `cgroupPidsCurrent` 286 → **1000/1000**. Once saturated, probes could not launch browsers (`Target crashed`, `browserContext.newPage: … has been closed`, `feature exceeded 300000ms wall-clock`) and **295 of 414 red prod d6 cells went `abort`, fleet-wide across ~20 slugs.**

This Dockerfile already documented the outage mode in a 40-line `FIX #3` block — but **both of its stated mitigations are demand-side** (`BROWSER_POOL_MAX_CONTEXTS` 40→24, resource-gauge warning logs). Those cap the *peak* of `pids.current`. They cannot stop a *monotonic* leak, and prod died of a monotonic leak. `resource-gauges.ts` only ever **measured** zombies (`if (s.state === "Z") zombieCount += 1`); nothing reaped them.

## The change

One file, +59/-3. `tini` as PID 1.

```dockerfile
RUN node ./node_modules/playwright/cli.js install --with-deps chromium \
 && apt-get install -y --no-install-recommends tini \
 && /usr/bin/tini --version \
 && rm -rf /var/lib/apt/lists/*
…
ENTRYPOINT ["/usr/bin/tini", "--"]
CMD ["/bin/bash", "-c", "ulimit -u $(ulimit -Hu) 2>/dev/null || true; exec node dist/orchestrator.js"]
```

Why this form:

- **`tini` baked into the image, not Docker `--init`** — `--init` is a *runtime* flag and Railway does not expose it, the same reason `pids.max` isn't settable from here (already documented in this file).
- **Not an in-process reaper** — Node has no `waitpid` binding, so an application `SIGCHLD` handler would need a native addon. This is the platform's job.
- **Rides the existing apt layer** — playwright's `--with-deps` just ran `apt-get update`, so this costs one ~267KB package download instead of a second index refresh. The `tini --version` call is a build-time assertion on the path baked into `ENTRYPOINT`: if a future Debian moves the binary, the **build** fails rather than the container failing to start in prod.
- **No `-g`** — tini's process-group broadcast would signal the live chromium pool alongside node and pre-empt `orchestrator.ts`'s `process.once("SIGTERM", drainAndExit)`. Without it, delivery is byte-identical to today: exactly one process gets the signal.
- **Exec form, `exec` kept in CMD** — tini really is PID 1 and really receives Railway's SIGTERM; node is tini's direct child with no bash lingering in the tree.

No existing convention to match: `grep` for `tini`/`dumb-init`/`--init` across every Dockerfile in the repo returns zero hits. Nothing in the repo asserts on this image's `CMD`/`ENTRYPOINT`, and nothing outside the CI build step `docker run`s it, so adding an `ENTRYPOINT` breaks no consumer.

---

# RED → GREEN

Real container, real chromium, real zombies. **Identical argv for both**; only the image differs, and the image supplies PID 1:

```
docker run --rm --pids-limit 1000 -e REPRO_CYCLES=230 \
  -v <repro>:/repro:ro <image> /bin/bash -c "exec node /repro/zombie-repro.mjs"
```

`--pids-limit 1000` mirrors Railway's platform-fixed ceiling. Each cycle launches chromium with the exact args `browser-pool.ts` uses (`headless`, `--no-sandbox`, `--disable-dev-shm-usage`), opens a context+page, then **SIGKILLs the browser process** — prod's `Target crashed` path, orphaning its children onto PID 1.

**Measurement is container-wide on purpose.** The harness's own `sampleResourceGauges()` walks the tree from `process.pid`; under a real init the orphans re-parent to the *init*, not to node, so a node-rooted walk would report zero zombies **whether or not they were reaped** — a vacuous GREEN. Counting every state-`Z` process in `/proc` plus the cgroup counter is blind to which process is PID 1, so it is honest in both directions.

## RED (unmodified `main`, `pid1=node`)

20 cycles — exactly **+5 permanent zombies per crashed browser**:

```
baseline zombieCount=0 procCount=1 threadCount=7 cgroupPidsCurrent=7 cgroupPidsMax=1000 selfPid=1 pid1=node
  PID  PPID S THR COMMAND
    1     0 R   7 node
cycle=1 pre-kill zombieCount=0 procCount=7 threadCount=76 cgroupPidsCurrent=76 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=1 zombieCount=5 procCount=6 threadCount=16 cgroupPidsCurrent=16 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=2 zombieCount=10 procCount=11 threadCount=21 cgroupPidsCurrent=21 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=3 zombieCount=15 procCount=16 threadCount=26 cgroupPidsCurrent=26 cgroupPidsMax=1000 selfPid=1 pid1=node
…
cycle=20 zombieCount=100 procCount=101 threadCount=111 cgroupPidsCurrent=111 cgroupPidsMax=1000 selfPid=1 pid1=node
final    zombieCount=100 procCount=101 threadCount=111 cgroupPidsCurrent=111 cgroupPidsMax=1000 selfPid=1 pid1=node
SUMMARY cycles=20 zombiesBefore=0 zombiesAfter=100 pidsBefore=7 pidsAfter=111 launchFailure=none
```

The leaked processes, verbatim from the final `/proc` table — all `ppid=1`, all `Z`:

```
   21     1 Z   1 headless_shell <defunct>
   22     1 Z   1 headless_shell <defunct>
   36     1 Z   1 headless_shell <defunct>
   61     1 Z   1 headless_shell <defunct>
   77     1 Z   1 headless_shell <defunct>
   87     1 Z   1 headless_shell <defunct>
   88     1 Z   1 headless_shell <defunct>
  104     1 Z   1 headless_shell <defunct>
```

`cgroupPidsCurrent` after each cycle never returns to 7 — it is `7 + 5×cycles`. A monotonic ratchet, the same curve prod walked over 7 days.

### RED, driven to saturation (started before the Dockerfile was touched)

```
baseline  zombieCount=0    cgroupPidsCurrent=7    /1000
cycle=25  zombieCount=125  cgroupPidsCurrent=136  /1000
cycle=50  zombieCount=250  cgroupPidsCurrent=261  /1000
cycle=75  zombieCount=375  cgroupPidsCurrent=386  /1000
cycle=100 zombieCount=500  cgroupPidsCurrent=511  /1000
cycle=125 zombieCount=625  cgroupPidsCurrent=636  /1000
cycle=150 zombieCount=750  cgroupPidsCurrent=761  /1000     ← prod's ~757 reproduced
cycle=175 zombieCount=875  cgroupPidsCurrent=886  /1000
cycle=184 pre-kill  zombieCount=915  cgroupPidsCurrent=993  /1000
cycle=185 pre-kill  zombieCount=920  cgroupPidsCurrent=996  /1000
cycle=185           zombieCount=925  cgroupPidsCurrent=936  /1000
   ← no further output. Cycle 186 never completed.
```

The run **wedged** at cycle 185 with no output for >12 minutes: `chromium.launch()` could not get PIDs and never returned — it did not even surface Playwright's 30s launch timeout, which is exactly why prod shows 300s feature timeouts and 1200s run aborts instead of a clean launch error. `docker ps`: `Up 17 minutes (unhealthy)`.

```
$ docker exec red-sat cat /sys/fs/cgroup/pids.current /sys/fs/cgroup/pids.max
1000
1000
```

And the errno-11 signature this Dockerfile's own comment names — the container could no longer `fork()` at all:

```
$ docker exec red-sat /bin/bash -c 'for i in 1 2 3; do cat /proc/uptime; done'
/bin/bash: fork: retry: Resource temporarily unavailable
/bin/bash: fork: retry: Resource temporarily unavailable
/bin/bash: fork: retry: Resource temporarily unavailable
/bin/bash: fork: retry: Resource temporarily unavailable
/bin/bash: fork: Resource temporarily unavailable
```

That is the prod outage, end to end, in a local container.

## GREEN (this PR's image, `pid1=tini`) — same repro, same argv, 230 cycles

```
baseline zombieCount=0 procCount=2 threadCount=8 cgroupPidsCurrent=8 cgroupPidsMax=1000 selfPid=7 pid1=tini
  PID  PPID S THR COMMAND
    1     0 S   1 tini
    7     1 R   7 node
cycle=1   pre-kill zombieCount=0 procCount=8 threadCount=76 cgroupPidsCurrent=76 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=1            zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=50           zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=100          zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=150          zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=200          zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=230 pre-kill zombieCount=0 procCount=8 threadCount=77 cgroupPidsCurrent=77 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=230          zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
final              zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
SUMMARY cycles=230 zombiesBefore=0 zombiesAfter=0 pidsBefore=8 pidsAfter=12 launchFailure=none
```

`procCount` returning to **2** (tini + node) after every single cycle is the reap actually happening: the browser's 6 processes appear pre-kill (`procCount=8`) and are fully gone post-kill.

|  | RED (`pid1=node`) | GREEN (`pid1=tini`) |
| --- | --- | --- |
| zombies after 20 cycles | 100 | **0** |
| zombies at cycle 185 | 925 | **0** |
| `pids.current` floor at cycle 185 | 936, peaking 996/1000 | **12** |
| reached cycle 230? | **no — wedged at 185** | yes |
| `chromium.launch()` | hangs; `fork: Resource temporarily unavailable` | fine, `launchFailure=none` |
| leak per crashed browser | **+5** | **0** |

---

## Signals and non-zero exit still work

The prober's container must still self-restart on crash, so this was proven, not assumed. `signal-child.mjs` installs the same `process.once("SIGTERM", …)` shape `orchestrator.ts` uses; run on **both** images:

```
--- GREEN (ENTRYPOINT tini, pid1=tini) ---
[showcase-harness:green MODE=term-graceful] exitCode=0
    CHILD mode=term-graceful pid=7 ppid=1
    CHILD ready — idling until signalled
    CHILD received SIGTERM at pid=7 — draining        ← tini FORWARDED it to node
[showcase-harness:green MODE=exit-42] exitCode=42     ← non-zero preserved
[showcase-harness:green MODE=abort]   exitCode=134    ← 128+6 (SIGABRT), non-zero
--- RED (no ENTRYPOINT, pid1=node) — baseline ---
[showcase-harness:red MODE=term-graceful] exitCode=0
    CHILD received SIGTERM at pid=1 — draining
[showcase-harness:red MODE=exit-42] exitCode=42
[showcase-harness:red MODE=abort]   exitCode=133
```

- **SIGTERM reaches node, not just tini** — the handler fires at `pid=7`, so `docker stop`'s SIGTERM was forwarded into the process that owns the graceful drain. `orchestrator.ts`'s `drainControlPlaneAndExit("SIGTERM")` path is intact.
- **Non-zero exits survive** — `exit(42)` → container `42`; a crash still exits non-zero, so Railway still restarts. The HEALTHCHECK restart-on-sustained-503 behaviour this Dockerfile calls "THE INTENDED OUTCOME" is untouched.
- **tini is strictly *more* correct here**: note RED's abort → **133** vs GREEN's → **134**. A process running as PID 1 in a namespace has default signal actions *ignored* by the kernel, so node-as-PID-1 was distorting its own fatal-signal exit code (128+SIGTRAP instead of 128+SIGABRT). Both non-zero, so no regression — but the fixed image reports crashes accurately.

## Cross-arch check

Local images are arm64; prod builds amd64. `tini` availability was verified on amd64 explicitly rather than assumed — same path the build-time assertion checks:

```
Package: tini
Architecture: amd64
Version: 0.19.0-1+b3
-rwxr-xr-x 1 root root 27792 Jun  6  2025 /usr/bin/tini
tini version 0.19.0
```

## Pre-push checks

| Check | Result |
| --- | --- |
| `docker buildx build -f showcase/harness/Dockerfile` (== CI's build check) | **PASS**, both images |
| `nx run @copilotkit/showcase-harness:typecheck` | **PASS** |
| `nx run @copilotkit/showcase-harness:test:ci` | 3677 passed, 18 skipped, 1 failed — **environmental**, see below |
| commitlint | **PASS** |
| lefthook `pre-commit` + `commit-msg` | **PASS** |
| `git status` | clean |

The single failure is `d0-gone-predicate.test.ts > resolves the real generated registry.json…`, failing on `ENOENT … showcase/shell/src/data/registry.json`. That file is **gitignored and generated at build time** — this Dockerfile's own comment says so, which is why the image generates it via `generate-registry.ts`. Proven environmental rather than assumed: generated the file, re-ran that exact spec, **11/11 passed**. A Dockerfile-only diff cannot affect a vitest run.

No formatter/linter covers this file: lefthook's `lint-fix` glob is `*.{js,jsx,ts,tsx,mjs,cjs,md,css,yml,yaml,html,vue,py}`, and there is no hadolint anywhere in CI.

## Not in this PR

- **This does not fix prod by itself.** Prod is digest-pinned and still running the leaking container; it needs the live mitigation restart (owned by a separate worker — **prod was not touched here**) and then a promote to pick this image up.
- **The ≥3-cell value test is not done and cannot be done from this PR** — confirming red cells flip requires the prod restart plus a fleet sweep. Note the ~20 `conversation-error` and ~16 `goto-error` cells are almost certainly unrelated real bugs this will **not** fix; only the `abort`/`feature-timeout`/`driver-error` population is in scope.
- **Alerting / scheduled recycle is deliberately out of scope** (one concern per change). Still worth doing: the documented `pool-unrecoverable` alarm demonstrably never fired at 1000/1000, and `cgroupPidsCurrent/cgroupPidsMax > 0.75` would have given ~36h of warning before the flip.
- Leak rate on the **graceful** `browser.close()` path was not measured — irrelevant to the fix (tini reaps either way), but it means prod's exact 757 can't be attributed to crashes alone.



---

# RE-VERIFICATION 2026-08-12 — rebased onto `origin/main`, red-green re-run from scratch

The proof above was produced 2026-08-03 against a base that predates
`ced993447f` ("copy patches/ into harness build context"), which touches THIS
Dockerfile. The branch has been rebased onto current `origin/main` and the
whole red-green was re-run on freshly built images so the numbers describe the
actual merge candidate.

**Both images built locally from this repo, same machine, same context, ~3 min apart:**

```
showcase-harness:red-main    sha256:b86686e9a06d51f884d5e59e9d15d667fd298284efe7a15622ff3bf2575a3ffd created=2026-08-12T20:15:50Z  (origin/main Dockerfile, /usr/bin/tini ABSENT, Entrypoint=["docker-entrypoint.sh"])
showcase-harness:green-tini  sha256:d666b823f16bda07bf62d35f1d72ef099d13406a61e2f0cd51c99bf51eb14df4 created=2026-08-12T20:18:54Z  (this branch,          /usr/bin/tini present, Entrypoint=["/usr/bin/tini","--"])
```

Identical driver, identical argv, 40 cycles each, runs 18 seconds apart:

```
docker run --rm --pids-limit 1000 -e REPRO_CYCLES=40 -v <repro>:/repro:ro <image> \
  /bin/bash -c "exec node /repro/zombie-repro.mjs"
```

## RED — `showcase-harness:red-main`, `pid1=node` (2026-08-12T20:19:28Z)

```
baseline zombieCount=0 procCount=1 threadCount=7 cgroupPidsCurrent=7 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=1 pre-kill zombieCount=0 procCount=7 threadCount=76 cgroupPidsCurrent=76 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=1 zombieCount=5 procCount=6 threadCount=16 cgroupPidsCurrent=16 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=2 pre-kill zombieCount=5 procCount=12 threadCount=83 cgroupPidsCurrent=83 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=2 zombieCount=10 procCount=11 threadCount=21 cgroupPidsCurrent=21 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=10 pre-kill zombieCount=45 procCount=52 threadCount=120 cgroupPidsCurrent=120 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=10 zombieCount=50 procCount=51 threadCount=61 cgroupPidsCurrent=61 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=20 pre-kill zombieCount=95 procCount=102 threadCount=174 cgroupPidsCurrent=174 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=20 zombieCount=100 procCount=101 threadCount=111 cgroupPidsCurrent=111 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=30 pre-kill zombieCount=145 procCount=152 threadCount=219 cgroupPidsCurrent=219 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=30 zombieCount=150 procCount=151 threadCount=161 cgroupPidsCurrent=161 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=40 pre-kill zombieCount=195 procCount=202 threadCount=271 cgroupPidsCurrent=271 cgroupPidsMax=1000 selfPid=1 pid1=node
cycle=40 zombieCount=200 procCount=201 threadCount=211 cgroupPidsCurrent=211 cgroupPidsMax=1000 selfPid=1 pid1=node
final zombieCount=200 procCount=201 threadCount=211 cgroupPidsCurrent=211 cgroupPidsMax=1000 selfPid=1 pid1=node
SUMMARY cycles=40 zombiesBefore=0 zombiesAfter=200 pidsBefore=7 pidsAfter=211 launchFailure=none
```

All 200 leaked processes are `ppid=1`, state `Z` (tail of the final `/proc` table):

```
 2610     1 Z   1 headless_shell <defunct>
 2612     1 Z   1 headless_shell <defunct>
 2646     1 Z   1 headless_shell <defunct>
 2661     1 Z   1 headless_shell <defunct>
 2662     1 Z   1 headless_shell <defunct>
 2678     1 Z   1 headless_shell <defunct>
 2680     1 Z   1 headless_shell <defunct>
 2717     1 Z   1 headless_shell <defunct>
```

## GREEN — `showcase-harness:green-tini`, `pid1=tini` (2026-08-12T20:19:46Z)

```
baseline zombieCount=0 procCount=2 threadCount=8 cgroupPidsCurrent=8 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=1 pre-kill zombieCount=0 procCount=8 threadCount=76 cgroupPidsCurrent=76 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=1 zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=2 pre-kill zombieCount=0 procCount=8 threadCount=78 cgroupPidsCurrent=78 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=2 zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=10 pre-kill zombieCount=0 procCount=8 threadCount=79 cgroupPidsCurrent=79 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=10 zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=20 pre-kill zombieCount=0 procCount=8 threadCount=76 cgroupPidsCurrent=76 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=20 zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=30 pre-kill zombieCount=0 procCount=8 threadCount=77 cgroupPidsCurrent=77 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=30 zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=40 pre-kill zombieCount=0 procCount=8 threadCount=79 cgroupPidsCurrent=79 cgroupPidsMax=1000 selfPid=7 pid1=tini
cycle=40 zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
final zombieCount=0 procCount=2 threadCount=12 cgroupPidsCurrent=12 cgroupPidsMax=1000 selfPid=7 pid1=tini
SUMMARY cycles=40 zombiesBefore=0 zombiesAfter=0 pidsBefore=8 pidsAfter=12 launchFailure=none
```

`grep -c defunct` over the GREEN run: **0**. `procCount` returns to **2**
(tini + node) after every cycle — the browser's 6 processes appear pre-kill
(`procCount=8`, `threadCount` 76–79) and are fully gone post-kill.

|  | RED (`pid1=node`) | GREEN (`pid1=tini`) |
| --- | --- | --- |
| image id | `b86686e9a06d` | `d666b823f16b` |
| cycles | 40 | 40 |
| zombies after | **200** | **0** |
| zombies per crashed browser | **+5** | **0** |
| `pids.current` before → after | 7 → **211** | 8 → **12** |
| `<defunct>` rows in final table | **200** | **0** |
| `launchFailure` | none | none |

## Signals / non-zero exit, both images, this run

```
[showcase-harness:RED   MODE=term-graceful] exitCode=0
    CHILD mode=term-graceful pid=1 ppid=0
    CHILD received SIGTERM at pid=1 — draining
[showcase-harness:RED   MODE=exit-42]   exitCode=42
[showcase-harness:RED   MODE=abort]     exitCode=133
    RED  /proc/1/comm = bash

[showcase-harness:GREEN MODE=term-graceful] exitCode=0
    CHILD mode=term-graceful pid=7 ppid=1
    CHILD received SIGTERM at pid=7 — draining     <- tini FORWARDED it to node
[showcase-harness:GREEN MODE=exit-42]   exitCode=42
[showcase-harness:GREEN MODE=abort]     exitCode=134
    GREEN /proc/1/comm = tini, child self=7
```

SIGTERM reaches node (handler fires at `pid=7`), non-zero exits survive
(42 → 42; abort → 134 = 128+6), so Railway's restart-on-crash is intact.

## The prod leak, measured live the same day

`resource_snapshots` in prod PocketBase, immediately before the mitigation
restart on the unfixed digest `sha256:80a0c5c2…`:

```
2026-08-12 20:10:00.674Z worker-7abf6 heartbeat pids=1000/1000 zombies=758 procs=778 threads=1000
2026-08-12 20:09:59.783Z worker-5a213 heartbeat pids=1000/1000 zombies=761 procs=781 threads=1000
2026-08-12 20:09:54.868Z worker-de14c heartbeat pids=837/1000  zombies=744 procs=753 threads=837
```

and immediately after it (`init` rows): `pids=164–169/1000 zombies=0 procs=16`.
A new zombie was already recorded at `2026-08-12 20:12:27.182Z worker-de14c … zombies=1`.

## Cross-arch

Local images are arm64 (`/usr/bin/tini` 68592 bytes); prod builds amd64.
Measured on amd64 directly: `Package: tini / Architecture: amd64 /
Version: 0.19.0-1+b3`, `/usr/bin/tini` 27792 bytes, `tini version 0.19.0`;
package download 267,204 bytes, 749 kB on disk.

## Deploy note

`computePromoteClosure(["showcase-harness"])` = `pocketbase(0), harness(1),
dashboard(1), harness-workers(1)` — the workers are in the promote scope.
Prod `startCommand` is `null` and no repo consumer overrides the entrypoint,
so Railway uses the image's ENTRYPOINT+CMD. **PR #5750 is CLOSED unmerged**, so
promoting `harness-workers` resets `multiRegionConfig.us-west2.numReplicas` to
1 and it must be re-asserted to 6 and read back after the promote.


---

# CHANGE 2 — nothing alarmed (worker PID-saturation alarm)

Commit `7f28e9bd39`.

## The gap

The measured prod condition on 2026-08-12 20:09–20:10Z was `pids=1000/1000`,
`1000/1000`, `837/1000` across three workers, 320 `timeout after 600000ms`
abort rows, an `e2e-smoke` run 42 minutes into a 15-minute cadence with 3 jobs
still pending, prod d6 534/784 vs staging 744/788. **No alarm fired**, and this
was the second occurrence (2026-08-03, 2026-08-10).

The documented `pool-unrecoverable` alarm did not fire *by construction*: it is
raised only when `BrowserPool`'s self-heal circuit-breaker exhausts
`selfHealMaxHardRecoveries`. A worker that is PID-starved but still heartbeating
never reaches that state — it launches browsers fine, it just cannot fork the
process tree a probe needs.

The signal was already on the wire and read by nobody:

- `worker/registration.ts:192` writes `capacity_pids_current` /
  `capacity_pids_max` onto the worker's `workers` row on its ~75s heartbeat
  (`DEFAULT_WORKER_HEARTBEAT_MS = 75_000`).
- `control-plane/fleet-health.ts` lists that entire roster every 15s
  (`DEFAULT_FLEET_HEALTH_INTERVAL_MS`) — and its own comment on the row type
  said *"the capacity gauges are ignored here."*
- Nothing in non-test source compared `pidsCurrent` to `pidsMax`.

## Where the alarm goes, and why

**Control-plane, not worker.** `writers/status-writer.ts` documents `fleet-cp`
as *"the only authoritative fleet writer; workers never write status directly"*,
so a worker cannot raise a `system:` health key. `fleet-health` already holds
the roster read this needs, on a 15s cadence, so the alarm costs zero extra PB
traffic.

**Routed to `#oss-alerts`, not to the browser-pool webhook.**
`SLACK_WEBHOOK_BROWSER_POOL_UNRECOVERABLE` appears **nowhere in this repo
outside its own definition** — `grep` finds it only in `orchestrator.ts` — so it
is unset everywhere and that alarm has no receiver even when it does fire.
`SLACK_WEBHOOK_OSS_ALERTS` is a real wired secret that the family-silence
monitor and the D0-gone monitor already post through. Routing a new alarm to a
known-unwired webhook would reproduce the exact gap this closes.

## Thresholds

- **Alarm at `pids.current / pids.max >= 0.75`.** At the observed leak rate
  (~1000 PIDs over ~7 days) that is roughly 36 hours of lead time — more than a
  working day. A busy worker's context budget is nowhere near 750 PIDs.
- **Latched per worker, clearing at 0.65.** The monitor ticks every 15s; an
  unlatched alarm would page ~8600 times across that 36-hour window. An alarm
  that fires constantly is worse than none, so `createFleetHealthMonitor` now
  **fails loud at construction** on a ratio pair with no hysteresis gap.
- **Evaluated before the online/stale branch**, because the failing worker is
  fully `online` — it heartbeats on time throughout.
- **Unmeasured gauges never alarm.** `registration.ts` maps the pool's `-1`
  sentinel to `null`; `pidUsageRatio` returns `null` for null/absent/negative
  current or non-positive max, and null is never read as zero.

---

## RED → GREEN (change 2)

Driver exercises the **real chain end-to-end**, faking only the OS cgroup read
(`BrowserPoolOptions.cgroupPidsReader`, an existing injectable seam) and the PB
transport. The column names are whatever the real registration writer emits and
whatever the real fleet-health reader consumes, so a column drift fails this
driver:

```
BrowserPool.budget()            [real, probes/helpers/browser-pool.ts]
  -> workerCapacityFromBudget   [real, fleet/contracts.ts]
  -> registerWorker()           [real, fleet/worker/registration.ts]
  -> workers row
  -> createFleetHealthMonitor().checkOnce()
                                [real, fleet/control-plane/fleet-health.ts]
  -> alarm sink
```

Identical command both sides; only the source differs:

```
./node_modules/.bin/tsx <scratch>/drive-alarm.mts
```

### RED — unmodified source

```
=== A1 SATURATED 900/1000 (ratio 0.90) ===
  pool.budget() pids      : 900/1000
  workers row gauges      : capacity_pids_current=900 capacity_pids_max=1000
  fleet-health cycles run : 1
  ALARM HOOK CALLS        : 0
  result.pidSaturated     : <field does not exist>
  error-level log events  : <none>

=== A2 CEILING   1000/1000 (ratio 1.00) ===
  pool.budget() pids      : 1000/1000
  workers row gauges      : capacity_pids_current=1000 capacity_pids_max=1000
  fleet-health cycles run : 1
  ALARM HOOK CALLS        : 0
  result.pidSaturated     : <field does not exist>
  error-level log events  : <none>

=== A6 LATCH     900/1000 over 5 cycles ===
  fleet-health cycles run : 5
  ALARM HOOK CALLS        : 0
  result.pidSaturated     : <field does not exist>
  error-level log events  : <none>
```

The exact prod condition — a worker at the ceiling — produces **zero** alarms.

### GREEN — with this change

```
=== A1 SATURATED 900/1000 (ratio 0.90) ===
  pool.budget() pids      : 900/1000
  workers row gauges      : capacity_pids_current=900 capacity_pids_max=1000
  fleet-health cycles run : 1
  ALARM HOOK CALLS        : 1
  result.pidSaturated     : 1
  error-level log events  : ["fleet.health.worker-pid-saturated"]
  ALARM PAYLOAD           : {"workerId":"worker-drv","pidsCurrent":900,"pidsMax":1000,"ratio":0.9,"threshold":0.75,"lastHeartbeatAt":"2026-08-12T20:44:54.244Z","observedAt":"2026-08-12T20:44:54.244Z"}

=== A2 CEILING   1000/1000 (ratio 1.00) ===
  ALARM HOOK CALLS        : 1
  result.pidSaturated     : 1
  error-level log events  : ["fleet.health.worker-pid-saturated"]
  ALARM PAYLOAD           : {"workerId":"worker-drv","pidsCurrent":1000,"pidsMax":1000,"ratio":1,"threshold":0.75,"lastHeartbeatAt":"2026-08-12T20:44:54.253Z","observedAt":"2026-08-12T20:44:54.253Z"}
```

### The alarm must also stay QUIET — same run, same command

```
=== A3 QUIET     500/1000 (ratio 0.50) ===
  ALARM HOOK CALLS        : 0
  result.pidSaturated     : 0
  error-level log events  : <none>

=== A4 QUIET     740/1000 (ratio 0.74, just under) ===
  ALARM HOOK CALLS        : 0
  result.pidSaturated     : 0
  error-level log events  : <none>

=== A5 QUIET     -1/-1 (cgroup unreadable) ===
  pool.budget() pids      : -1/-1
  workers row gauges      : capacity_pids_current=null capacity_pids_max=null
  ALARM HOOK CALLS        : 0
  result.pidSaturated     : 0
  error-level log events  : <none>

=== A6 LATCH     900/1000 over 5 cycles ===
  fleet-health cycles run : 5
  ALARM HOOK CALLS        : 1        <- once, not five times
```

`A4` pins the boundary at 0.74. `A5` pins the off-Linux case: the `-1` sentinel
lands as `null` on the row and stays silent rather than reading as `0`. `A6`
pins the latch — 5 saturated cycles, 1 alarm.

---

# CHANGE 3 — saturated workers kept claiming (PID headroom claim gate)

Commit `63ef4081c2`.

## The defect

`fleet/worker/worker-loop.ts` had exactly one conditional in the claim loop:

```ts
if (budget.available <= 0) { … idle … }
```

and `available` is free Playwright **browser-context** slots and nothing else —
`browser-pool.ts`: `available: Math.max(0, this.maxContexts - this.liveContextCount)`.
Context slots have no relationship to cgroup PIDs. A worker whose container has
leaked to `pids=1000/1000` therefore still advertises **full** capacity, keeps
winning claims, cannot fork the browser tree, and burns each job's entire
600000ms lease before aborting. That is the mechanism behind the 320 abort rows.

## Blast radius — what happens when ALL workers are saturated

The gate deliberately reuses the **same decline-and-idle path** as the existing
no-budget branch, which is what makes total saturation safe:

- the job is **never claimed**, so it is never dropped and never requeued — it
  stays `pending` for a healthy worker, or for this one after a redeploy;
- the loop then sleeps a full `pollIntervalMs`, so a fully-saturated fleet
  **idles at the poll cadence** instead of spinning;
- the queue **stalls visibly**: `probe_jobs` rows pile up pending, a rising-edge
  `fleet.worker.pid-headroom-exhausted` warn says why (warn → stderr → Sentry;
  steady state drops to debug so a multi-hour stall does not flood), and
  change 2's `system:worker-pid-saturation` alarm fired at 0.75 **before** this
  gate engaged at 0.90.

A stalled, alarmed queue is recoverable by redeploy. Claim-fail-repeat silently
burned the whole cadence.

## Why the gate is 0.90 and the alarm is 0.75

They do different jobs and must not be equal. 0.75 pages an operator while the
worker is still perfectly able to run jobs; gating dispatch that early would
convert a warning into ~36 hours of withheld fleet capacity. 0.90 is where we
stop trusting the worker to fork at all — 100 free PIDs at the prod ceiling.
**That reserve is chosen, not derived: the per-job PID cost of a chromium
context tree is not measured**, hence the `WORKER_PID_CLAIM_GATE_RATIO`
override. The invariant that matters is ordering — the alarm always fires before
capacity is withdrawn.

The gate is **inert** when the cgroup gauges are unreadable (`pidUsageRatio` →
`null`: off-Linux, every macOS dev box), so local workers claim exactly as
before.

---

## RED → GREEN (change 3)

Driver runs the **real `startWorkerLoop`** against the **real `BrowserPool`**
budget path, faking only the cgroup read and the queue transport. The queue fake
holds a real `pending` list, so *"was the job dropped / does it stay pending"* is
directly observed, not inferred. `budget()` calls are counted as a
loop-iteration proxy for the spin check.

Identical command both sides:

```
./node_modules/.bin/tsx <scratch>/drive-gate.mts
```

### RED — unmodified source

```
=== B1 SATURATED  1 worker @ 1000/1000, 3 jobs pending ===
  workers=1  cgroup pids=1000/1000  contexts available=24
  window                  : 600ms @ poll 50ms
  queue.claimNext CALLS   : 15
  jobs CLAIMED            : 3 ["job-1","job-2","job-3"]
  jobs STILL PENDING      : 0 []
  jobs REPORTED           : 3
  loop iterations         : 15

=== B2 ALL-SATURATED  3 workers @ 1000/1000, 3 jobs pending ===
  workers=3  cgroup pids=1000/1000  contexts available=24
  queue.claimNext CALLS   : 39
  jobs CLAIMED            : 3 ["job-1","job-2","job-3"]
  jobs STILL PENDING      : 0 []
  jobs REPORTED           : 3
  loop iterations         : 39
```

A worker at the PID ceiling claims **all three jobs**. In prod each of those
becomes a 600000ms abort.

### GREEN — with this change

```
=== B1 SATURATED  1 worker @ 1000/1000, 3 jobs pending ===
  workers=1  cgroup pids=1000/1000  contexts available=24
  window                  : 600ms @ poll 50ms
  queue.claimNext CALLS   : 0
  jobs CLAIMED            : 0 []
  jobs STILL PENDING      : 3 ["job-1","job-2","job-3"]
  jobs REPORTED           : 0
  loop iterations         : 12 (spin check: bounded by window/poll)
```

`claimNext` is never called; all three jobs are **still pending** — not dropped,
not requeued.

### ALL workers saturated — the blast-radius case

```
=== B2 ALL-SATURATED  3 workers @ 1000/1000, 3 jobs pending ===
  workers=3  cgroup pids=1000/1000  contexts available=24
  window                  : 600ms @ poll 50ms
  queue.claimNext CALLS   : 0
  jobs CLAIMED            : 0 []
  jobs STILL PENDING      : 3 ["job-1","job-2","job-3"]
  jobs REPORTED           : 0
  loop iterations         : 36 (spin check: bounded by window/poll)
```

Zero claims, **3 of 3 jobs still pending**, and 36 iterations across 3 workers
over a 600ms window at a 50ms poll — i.e. 12 per worker, the poll cadence. No
spin, no loss.

### The gate must NOT engage below threshold — same run, same command

```
=== B3 HEALTHY  1 worker @ 100/1000, 3 jobs pending ===
  queue.claimNext CALLS   : 15
  jobs CLAIMED            : 3   jobs STILL PENDING : 0   jobs REPORTED : 3

=== B4 UNDER-GATE  1 worker @ 890/1000, 3 jobs pending ===
  queue.claimNext CALLS   : 15
  jobs CLAIMED            : 3   jobs STILL PENDING : 0   jobs REPORTED : 3

=== B5 UNMEASURED  1 worker @ -1/-1, 3 jobs pending ===
  queue.claimNext CALLS   : 15
  jobs CLAIMED            : 3   jobs STILL PENDING : 0   jobs REPORTED : 3
```

`B4` is the load-bearing one: 0.89 is **above** change 2's 0.75 alarm and below
this gate. The operator has been paged and the worker keeps working — which is
the whole reason the two thresholds differ. `B5` pins the off-Linux case.

---

# Tests and gates (changes 2 and 3)

`showcase/harness`, on the pushed head `63ef4081c2`:

| Gate | Command | Result |
|---|---|---|
| Typecheck | `npx tsc --noEmit -p tsconfig.json` | exit 0 |
| Lint | `npx oxlint src/fleet src/orchestrator.ts` | 0 errors; warning count unchanged vs base (2 on `fleet-health.ts` before and after) |
| Format | `npx oxfmt --write` | clean |
| Unit suite | `vitest run` | **3696 passed, 18 skipped, 1 failed** — 175/178 files pass |

The single failure is `src/probes/frontend-matrix.test.ts` — **pre-existing**.
Verified by stashing this branch's changes and re-running it on the unmodified
tree, where it fails identically (`1 failed | 5 passed`).

14 tests are new (`3682 → 3696`).

**Mutation-tested for vacuity.** With the four source files reverted to
`e66fb1af13` and the new test files kept, **11 of the new tests fail**:

```
Test Files  2 failed (2)
     Tests  11 failed | 80 passed (91)

FAIL fleet-health.test.ts > PID saturation > alarms on an ONLINE worker whose PID gauges cross the threshold
FAIL fleet-health.test.ts > PID saturation > stays silent below the threshold, including just under it
FAIL fleet-health.test.ts > PID saturation > stays silent when the gauges are UNMEASURED (null / unbounded max)
FAIL fleet-health.test.ts > PID saturation > is EDGE-triggered: a sustained saturation alarms once, not every cycle
FAIL fleet-health.test.ts > PID saturation > re-arms only after the worker drops below the CLEAR ratio
FAIL fleet-health.test.ts > PID saturation > never lets a throwing alarm hook abort the cycle
FAIL fleet-health.test.ts > PID saturation > fails loud on a ratio config that would alarm every cycle
FAIL worker-loop.test.ts  > PID headroom gate > declines to claim at the PID ceiling — the job is never claimed, so it stays pending
FAIL worker-loop.test.ts  > PID headroom gate > declines at the gate ratio boundary (0.90)
FAIL worker-loop.test.ts  > PID headroom gate > honours an injected gate ratio
FAIL fleet-health.test.ts > checkOnce > never throws when the roster read fails — returns an empty cycle
```

The three that pass on both sides are the sub-threshold controls (`still claims
just BELOW the gate`, `claims normally on a healthy worker`, `stays INERT when
the cgroup gauges are unreadable`) — they are supposed to be unchanged by the
fix, and they are.

# New env knobs (all optional, all defaulted)

| Var | Default | Effect |
|---|---|---|
| `WORKER_PID_SATURATION_RATIO` | `0.75` | Control-plane alarm threshold. |
| `WORKER_PID_SATURATION_CLEAR_RATIO` | `0.65` | Alarm latch hysteresis clear. |
| `WORKER_PID_CLAIM_GATE_RATIO` | `0.90` | Worker claim-gate threshold. |

An out-of-range override on the two alarm ratios falls back to the default
rather than tripping the fail-loud guard and taking the control-plane down over
a typo'd env var.

# Not verified

- Neither change 2 nor change 3 has been exercised against **live prod or
  staging PocketBase**; both red-greens are local, on the real modules with the
  cgroup read and PB/queue transport injected.
- **No Slack post was sent.** `SLACK_WEBHOOK_OSS_ALERTS` was not set in the
  driver, so the send leg was not exercised end-to-end — only that its failure
  is swallowed without costing the durable status row.
- The per-job PID cost of a chromium context tree is **not measured**, so the
  0.90 gate's 100-PID reserve is a chosen value.
