### PR TITLE
fix(react-core): surface MCP app tool-call failures instead of an empty box

### DIFF
--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -286,6 +286,30 @@ function isNotification(msg: JSONRPCMessage): msg is JSONRPCNotification {
 }
 
 /**
+ * Join the human-readable text of an MCP tool result.
+ *
+ * `result.content` is a heterogeneous MCP content-block list (text, image,
+ * resource, …) so each block is narrowed before its `text` is read; anything
+ * that is not a text block is skipped.
+ */
+export function ɵmcpToolResultText(
+  result: MCPAppsActivityContent["result"],
+): string {
+  if (!Array.isArray(result.content)) return "";
+  return result.content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string",
+    )
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
+/**
  * Props for the activity renderer component
  */
 interface MCPAppsActivityRendererProps {
@@ -840,6 +864,28 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
       }
     }, [iframeReady, content.result, sendNotification]);
 
+    // The tool call that produced this activity can itself have failed
+    // (`isError: true` from the MCP server, e.g. rejected arguments). The
+    // result is still forwarded to the app above, but an app that has no data
+    // to draw typically renders nothing for it — leaving an empty box that
+    // reads as success. Surface the failure host-side so it is visible.
+    const toolFailed = content.result.isError === true;
+    const toolFailureMessage = toolFailed
+      ? ɵmcpToolResultText(content.result) ||
+        "The tool call reported an error but returned no message."
+      : null;
+
+    // Effect 5: Log tool failures. Kept out of Effect 4 so a failure is logged
+    // even if the app iframe never becomes ready.
+    useEffect(() => {
+      if (toolFailureMessage) {
+        console.error(
+          "[MCPAppsRenderer] Tool call failed:",
+          toolFailureMessage,
+        );
+      }
+    }, [toolFailureMessage]);
+
     // Determine border styling based on prefersBorder metadata from fetched resource
     // true = show border/background, false = none, undefined = host decides (we default to none)
     const prefersBorder = fetchedResource?._meta?.ui?.prefersBorder;
@@ -857,7 +903,12 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
         ref={containerRef}
         style={{
           width: "100%",
-          height: iframeSize.height ? `${iframeSize.height}px` : "auto",
+          // A failure notice is stacked above the app iframe, so the container
+          // must grow to fit both instead of being pinned to the app's height.
+          height:
+            iframeSize.height && !toolFailed
+              ? `${iframeSize.height}px`
+              : "auto",
           minHeight: "100px",
           overflow: "hidden",
           position: "relative",
@@ -870,6 +921,25 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
         {error && (
           <div style={{ color: "red", padding: "1rem" }}>
             Error: {error.message}
+          </div>
+        )}
+        {toolFailureMessage && (
+          <div
+            data-testid="copilot-mcp-apps-tool-error"
+            role="alert"
+            style={{
+              color: "#b91c1c",
+              backgroundColor: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: "8px",
+              padding: "0.75rem 1rem",
+              marginBottom: "0.5rem",
+              fontSize: "13px",
+              lineHeight: 1.45,
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            Tool call failed: {toolFailureMessage}
           </div>
         )}
       </div>

--- a/packages/react-core/src/v2/components/chat/__tests__/MCPAppsActivityRenderer.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/MCPAppsActivityRenderer.e2e.test.tsx
@@ -20,6 +20,7 @@ import {
 import {
   MCPAppsActivityType,
   MCPAppsActivityContentSchema,
+  ɵmcpToolResultText,
 } from "../../../components/MCPAppsActivityRenderer";
 import type { ReactActivityMessageRenderer } from "../../../types";
 import type { RunAgentInput, RunAgentResult, BaseEvent } from "@ag-ui/client";
@@ -973,6 +974,106 @@ describe("MCP Apps Activity Renderer E2E", () => {
         },
         { timeout: 2000 },
       );
+    });
+  });
+
+  // A tool call whose MCP result carries `isError: true` used to be forwarded
+  // to the app and otherwise ignored host-side: the activity rendered an empty
+  // box while the chat chip still read "Done". Captured verbatim off prod:
+  // mcp.excalidraw.com rejecting a malformed `elements` argument.
+  describe("Tool Failure Surfacing", () => {
+    const RECORDED_ERROR_TEXT =
+      "Invalid JSON in elements: Unexpected non-whitespace character after JSON " +
+      "at position 540 (line 1 column 541). Ensure no comments, no trailing " +
+      "commas, and proper quoting.";
+
+    async function renderActivityWithResult(result: {
+      content?: unknown[];
+      structuredContent?: unknown;
+      isError?: boolean;
+    }) {
+      const agent = new MockMCPProxyAgent();
+      const agentId = "mcp-test-agent";
+      agent.agentId = agentId;
+
+      renderWithCopilotKit({ agents: { [agentId]: agent }, agentId });
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Draw a flowchart" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Draw a flowchart")).toBeDefined();
+      });
+
+      agent.emit(runStartedEvent());
+      agent.emit(
+        activitySnapshotEvent({
+          messageId: testId("mcp-activity"),
+          activityType: MCPAppsActivityType,
+          content: mcpAppsActivityContent({
+            resourceUri: "ui://excalidraw/view",
+            serverHash: "excalidraw-hash",
+            result,
+          }),
+        }),
+      );
+      agent.emit(runFinishedEvent());
+    }
+
+    it("shows the failure message when the tool result has isError: true", async () => {
+      await renderActivityWithResult({
+        content: [{ type: "text", text: RECORDED_ERROR_TEXT }],
+        isError: true,
+      });
+
+      await waitFor(() => {
+        const banner = screen.getByTestId("copilot-mcp-apps-tool-error");
+        expect(banner.getAttribute("role")).toBe("alert");
+        expect(banner.textContent).toContain(RECORDED_ERROR_TEXT);
+      });
+    });
+
+    it("falls back to a generic message when the failed result carries no text", async () => {
+      await renderActivityWithResult({ content: [], isError: true });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("copilot-mcp-apps-tool-error").textContent,
+        ).toContain("returned no message");
+      });
+    });
+
+    it("shows nothing for a successful tool result", async () => {
+      await renderActivityWithResult({
+        content: [{ type: "text", text: "Diagram displayed!" }],
+        structuredContent: { checkpointId: "71a8a6d624df4e5281" },
+        isError: false,
+      });
+
+      // The app iframe must still be created — the happy path is untouched.
+      await waitFor(
+        () => {
+          expect(document.querySelector("iframe[srcdoc]")).not.toBeNull();
+        },
+        { timeout: 3000 },
+      );
+      expect(screen.queryByTestId("copilot-mcp-apps-tool-error")).toBeNull();
+    });
+
+    it("joins only the text blocks of a mixed-content failure", () => {
+      expect(
+        ɵmcpToolResultText({
+          content: [
+            { type: "text", text: "first line" },
+            { type: "image", data: "…", mimeType: "image/png" },
+            { type: "text", text: "second line" },
+          ],
+          isError: true,
+        }),
+      ).toBe("first line\nsecond line");
+
+      expect(ɵmcpToolResultText({ isError: true })).toBe("");
     });
   });
 


### PR DESCRIPTION
## What

On the `mcp-apps` demo, `create_view` intermittently comes back from
`mcp.excalidraw.com` with `isError: true` (a malformed `elements` argument —
roughly one call in five, measured over 9 prod runs). When that happens
`MCPAppsActivityRenderer` forwarded the result to the sandboxed app and rendered
**nothing** host-side. The Excalidraw widget has no data to draw, so it paints
nothing — and the user got a 585 px empty white box while the chat chip still
read **Done** with a green dot. No error text, no console error, no assistant
follow-up.

The upstream rejection is not the defect being fixed here. **The defect is that
the UI claimed success.** This PR makes the failure visible:

- `ɵmcpToolResultText()` joins the `text` blocks of an MCP result (the content
  list is heterogeneous, so each block is narrowed with a type predicate — no
  `as any`).
- When `content.result.isError` is true, the message is rendered above the app
  frame as a `role="alert"` notice and logged via `console.error` with the
  file's existing `[MCPAppsRenderer]` prefix. The log lives in its own effect so
  a failure is still logged if the app iframe never becomes ready.
- The container is only pinned to the app's reported height when there is no
  notice; otherwise it is `auto`, so the stacked notice is not clipped by the
  existing `overflow: hidden`.

Deliberately unchanged: the result is still forwarded to the app. Apps may render
their own error state, and suppressing the notification would break the
follow-up flows (`read_widget_context`, `Edit`).

Styling is inline to match this file's existing convention (it uses inline
styles throughout, not `cpk:` classes, and has no i18n layer — `Loading...` and
`Error:` are hardcoded the same way).

## Red-green proof

Real Chromium, real `CopilotChat` + real `CopilotKitProvider` + real
`MCPAppsActivityRenderer` + the real built-in tool-call chip, bundled straight
from `src/`. Fed the **real 432 KB Excalidraw MCP app resource** and the **real
tool payloads captured off production**. Driven by a scripted Playwright driver
with hard per-operation timeouts. The only stub is the agent transport answering
`resources/read`, so the run is deterministic instead of sampling the ~22 %
natural failure rate.

The failing case additionally feeds a malformed `elements` string — a valid
6-element array padded to offset 540 and then followed by `]}`. Local
`JSON.parse` on it yields
`Unexpected non-whitespace character after JSON at position 540 (line 1 column 541)`,
byte-identical to the substring in the recorded upstream rejection. (Prod's
failing runs had malformed elements in the tool *input* too — the widget paints
from `ui/notifications/tool-input`, so a valid input still paints even when the
result is an error.)

### RED — before any source change

```json
=== ERROR CASE ===
{
  "chipText": "create_view\nDone",
  "chipStatusLabel": "Done",
  "chipDotClass": "cpk:inline-block cpk:h-2 cpk:w-2 cpk:flex-shrink-0 cpk:rounded-full cpk:bg-emerald-500",
  "errorBannerPresent": false,
  "errorBannerText": null,
  "iframeRect": { "w": 780, "h": 585 },
  "bodyText": "Use Excalidraw to draw a simple flowchart with three steps. | Drawing a flowchart. | create_view | Done | AI can make mistakes. Please verify important information."
}
svg: {"present":false}
console errors: (none)

=== SUCCESS CASE ===
{
  "chipText": "create_view\nDone",
  "chipStatusLabel": "Done",
  "chipDotClass": "cpk:inline-block cpk:h-2 cpk:w-2 cpk:flex-shrink-0 cpk:rounded-full cpk:bg-emerald-500",
  "errorBannerPresent": false,
  "errorBannerText": null,
  "iframeRect": { "w": 780, "h": 585 }
}
svg: {"present":true,"w":780,"h":585,"viewBox":"-200 -60 600 450"}
```

Chip text is byte-identical on success and failure. The failing run shows a
585 px empty box with nothing in it and no console error. (Screenshot confirmed
visually: `create_view / Done` above a blank white area.)

### GREEN — same repro, same fixtures, after the fix

```json
=== ERROR CASE ===
{
  "chipText": "create_view\nDone",
  "chipStatusLabel": "Done",
  "errorBannerPresent": true,
  "errorBannerText": "Tool call failed: Invalid JSON in elements: Unexpected non-whitespace character after JSON at position 540 (line 1 column 541). Ensure no comments, no trailing commas, and proper quoting.",
  "iframeRect": { "w": 780, "h": 585 }
}
svg: {"present":false}
console errors: error: [MCPAppsRenderer] Tool call failed: Invalid JSON in elements: Unexpected non-whitespace character after JSON at position 540 (line 1 column 541). Ensure no comments, no trailing commas, and proper quoting.

=== SUCCESS CASE — happy path not regressed ===
{
  "errorBannerPresent": false,
  "errorBannerText": null,
  "iframeRect": { "w": 780, "h": 585 }
}
svg: {"present":true,"w":780,"h":585,"viewBox":"-200 -60 600 450"}
console errors: (none)
```

`.svg-wrapper > svg` is still present at 780×585 with the same viewBox on the
success path, no notice and no console error; the screenshot still shows the
three-box flowchart. (Note there is no `<canvas>` on this demo in any run — the
inline view is an `exportToSvg` surface.)

### Unit-layer tests + mutation check

Four cases added under `Tool Failure Surfacing`: the recorded error text is
surfaced with `role="alert"`; a text-less failure falls back to a generic
message; a success result renders no notice and still creates the app iframe;
and `ɵmcpToolResultText` joins only text blocks. 20/20 pass in that file.

Guarding the notice with `false &&` flipped exactly the two banner-rendering
cases to failing, so the assertions are not vacuous:

```
× Tool Failure Surfacing > shows the failure message when the tool result has isError: true
× Tool Failure Surfacing > falls back to a generic message when the failed result carries no text
✓ Tool Failure Surfacing > shows nothing for a successful tool result
```

## Local checks (hooks enabled)

- pre-commit hook: `check-binaries`, `lint-fix`, `test-and-check-packages` — all pass; `commit-msg` commitlint passes.
- `oxlint` on the changed files: 0 errors (2 warnings, both pre-existing on untouched lines).
- `oxfmt --check`: clean.
- `nx build @copilotkit/react-core`: pass.
- `nx run-many -t test,publint,attw --projects=@copilotkit/react-core`: 119/119 test files, 1446/1446 tests pass; publint and attw pass.
  - One run flagged 2 post-teardown unhandled rejections (`customElements is not defined`, from `web-inspector` inside the unrelated `CopilotListeners.defaultAgentAbsent.test.tsx`). Clean on re-run with `--skip-nx-cache`; a flake, not caused by this change.

## Not in this PR

- **The chip still reads `Done` on a failed tool call.** That is
  `DefaultToolCallRenderer` in `use-default-render-tool.tsx`, where
  `statusLabel` is derived from `status` alone and the `DefaultRenderProps`
  contract has no error input. Changing it affects the generic chip for every
  tool in every framework — a separate concern.
- **Vue and Angular have the same defect.**
  `packages/vue/src/v2/components/MCPAppsActivityRenderer.ts` and
  `packages/angular/src/mcp-apps/lib/mcp-apps-widget.ts` (the latter already has
  an `error` signal and a `role="alert"` slot, driven only by fetch/queue
  failures). Each needs its own framework-level proof.
- The malformed model output itself, retry/repair logic, and the
  `2025-11-21` vs `2025-06-18` protocol-version mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KX8HzrWkdbKx5YYn8sHWy
