### PR TITLE
fix(showcase/harness): make PID exhaustion and roll-up infra aborts visible in the signal path

### DIFF
--- a/showcase/harness/src/fleet/control-plane/d0-gone-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/d0-gone-monitor.test.ts
@@ -119,7 +119,16 @@ function makeFakes() {
     lastHeartbeatAt: new Date(T0).toISOString(),
     registeredAt: new Date(T0 - HOUR).toISOString(),
     currentJobId: null,
-    capacity: { inUse: 0, available: 1, max: 1 },
+    // Unknown cgroup PID gauges: these fixtures exercise gone-detection, not
+    // PID saturation.
+    capacity: {
+      inUse: 0,
+      available: 1,
+      max: 1,
+      pidsCurrent: null,
+      pidsMax: null,
+      pidsSaturated: false,
+    },
   };
 
   function liveProducer(atMs = clock): FamilySummaryResponse {
@@ -221,7 +230,16 @@ describe("isProducerLive (§2.5 acceptance)", () => {
     lastHeartbeatAt: new Date(T0).toISOString(),
     registeredAt: new Date(T0).toISOString(),
     currentJobId: null,
-    capacity: { inUse: 0, available: 1, max: 1 },
+    // Unknown cgroup PID gauges: these fixtures exercise gone-detection, not
+    // PID saturation.
+    capacity: {
+      inUse: 0,
+      available: 1,
+      max: 1,
+      pidsCurrent: null,
+      pidsMax: null,
+      pidsSaturated: false,
+    },
   });
 
   const inflightEntry = (): FamilySummaryEntry => ({

--- a/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
+++ b/showcase/harness/src/fleet/control-plane/family-silence-monitor.test.ts
@@ -156,7 +156,16 @@ function workerView(registeredAtMs: number): WorkerView {
     lastHeartbeatAt: iso(registeredAtMs),
     registeredAt: iso(registeredAtMs),
     currentJobId: null,
-    capacity: { inUse: 0, available: 24, max: 24 },
+    // Unknown cgroup PID gauges: these fixtures exercise silence detection,
+    // not PID saturation.
+    capacity: {
+      inUse: 0,
+      available: 24,
+      max: 24,
+      pidsCurrent: null,
+      pidsMax: null,
+      pidsSaturated: false,
+    },
   };
 }
 

--- a/showcase/harness/src/fleet/control-plane/run-view.test.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.test.ts
@@ -696,6 +696,70 @@ describe("projectWorker", () => {
     ).toBe("");
   });
 
+  // 2026-08-03 incident: the prod prober fleet sat pinned at cgroup
+  // `pids.current == pids.max == 1000` (~730 zombies) for hours and could not
+  // launch a browser, yet `/api/runs` reported `online, 4/40 contexts` because
+  // the projection dropped the PID gauges the heartbeat already persists. The
+  // context budget was never the binding constraint; the PID ceiling was.
+  describe("cgroup PID gauges (2026-08-03 PID-exhaustion blindness)", () => {
+    it("projects capacity_pids_current / capacity_pids_max onto the view", () => {
+      const projected = projectWorker(
+        workerRow({ capacity_pids_current: 640, capacity_pids_max: 1_000 }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      );
+      expect(projected.capacity.pidsCurrent).toBe(640);
+      expect(projected.capacity.pidsMax).toBe(1_000);
+    });
+
+    it("flags saturation at/above the threshold and not below it", () => {
+      // 0.85 is the canonical threshold: prod crossed it on 2026-08-01,
+      // ~36h before the flip that produced 428 abort cells.
+      const at = (current: number) =>
+        projectWorker(
+          workerRow({
+            capacity_pids_current: current,
+            capacity_pids_max: 1_000,
+          }),
+          STALE_AFTER_MS,
+          NOW_MS,
+        ).capacity.pidsSaturated;
+      expect(at(1_000)).toBe(true); // the incident reading
+      expect(at(850)).toBe(true); // exactly at the threshold
+      expect(at(849)).toBe(false); // just under
+      expect(at(199)).toBe(false); // post-restart healthy reading
+    });
+
+    it("reports unknown gauges as null and never as a saturated fleet", () => {
+      // `gaugeOrNull` (worker/registration.ts) writes null for the -1
+      // "unreadable cgroup" sentinel, and a pre-migration row has no column at
+      // all. Neither may read as "0 of 0 PIDs", and neither may claim
+      // saturation — an unreadable gauge is not evidence of exhaustion.
+      const projected = projectWorker(
+        workerRow({
+          capacity_pids_current: undefined,
+          capacity_pids_max: undefined,
+        }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      );
+      expect(projected.capacity.pidsCurrent).toBeNull();
+      expect(projected.capacity.pidsMax).toBeNull();
+      expect(projected.capacity.pidsSaturated).toBe(false);
+    });
+
+    it("treats a negative sentinel that reached the column as unknown", () => {
+      const projected = projectWorker(
+        workerRow({ capacity_pids_current: -1, capacity_pids_max: -1 }),
+        STALE_AFTER_MS,
+        NOW_MS,
+      );
+      expect(projected.capacity.pidsCurrent).toBeNull();
+      expect(projected.capacity.pidsMax).toBeNull();
+      expect(projected.capacity.pidsSaturated).toBe(false);
+    });
+  });
+
   it("maps an empty current_job_id to null and a set one to its value", () => {
     expect(
       projectWorker(workerRow({ current_job_id: "j9" }), STALE_AFTER_MS, NOW_MS)
@@ -1105,6 +1169,50 @@ describe("createMemoizedFamilySummary", () => {
       },
     ]);
     expect(JSON.stringify(summary.workers)).not.toContain("endpoint");
+  });
+
+  // The 2026-08-03 read-model reproduction, at the surface `/api/runs`
+  // actually serializes. During the incident this body read
+  // `{"health":"online","capacity":{"inUse":4,"available":36,"max":40}}` for a
+  // worker pinned at pids 1000/1000 — the exhaustion was persisted in PB and
+  // dropped in the projection, so no operator or watcher could see it.
+  it("serializes the cgroup PID gauges and saturation flag for a PID-exhausted worker", async () => {
+    const { pb } = makeFakePb({
+      workers: [
+        {
+          id: "w1",
+          worker_id: "worker-de14c95897c2",
+          endpoint: "http://worker-internal:8790",
+          capacity_in_use: 4,
+          capacity_available: 36,
+          capacity_max: 40,
+          // The verbatim incident reading (resource_snapshots, 16:19:51Z).
+          capacity_pids_current: 1_000,
+          capacity_pids_max: 1_000,
+          current_job_id: "",
+          last_heartbeat_at: iso(-1_000),
+          registered_at: iso(-5_000),
+        },
+      ],
+    });
+    const summary = await createMemoizedFamilySummary(
+      makeDeps({ pb, workerStaleAfterMs: 180_000 }),
+    ).get();
+    // Heartbeat freshness still says "online" and the context budget still
+    // looks roomy — that is correct and is exactly why the PID gauges have to
+    // be on the same object.
+    expect(summary.workers[0]!.health).toBe("online");
+    expect(summary.workers[0]!.capacity).toEqual({
+      inUse: 4,
+      available: 36,
+      max: 40,
+      pidsCurrent: 1_000,
+      pidsMax: 1_000,
+      pidsSaturated: true,
+    });
+    const body = JSON.stringify(summary.workers);
+    expect(body).toContain("pidsSaturated");
+    expect(body).not.toContain("endpoint");
   });
 
   it('a PB list failure for one family yields that entry as {error:"history_unavailable"} while other families project normally', async () => {

--- a/showcase/harness/src/fleet/control-plane/run-view.test.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.test.ts
@@ -672,7 +672,15 @@ describe("projectWorker", () => {
       lastHeartbeatAt: iso(-100),
       registeredAt: iso(-3_600_000),
       currentJobId: null,
-      capacity: { inUse: 1, available: 23, max: 24 },
+      capacity: {
+        inUse: 1,
+        available: 23,
+        max: 24,
+        // This fixture row has no PID columns, so both gauges are unknown.
+        pidsCurrent: null,
+        pidsMax: null,
+        pidsSaturated: false,
+      },
     });
   });
 
@@ -1165,7 +1173,14 @@ describe("createMemoizedFamilySummary", () => {
         // The bounce signal the §7.4 banner / §9 monitor grace off.
         registeredAt: iso(-5_000),
         currentJobId: null,
-        capacity: { inUse: 0, available: 24, max: 24 },
+        capacity: {
+          inUse: 0,
+          available: 24,
+          max: 24,
+          pidsCurrent: null,
+          pidsMax: null,
+          pidsSaturated: false,
+        },
       },
     ]);
     expect(JSON.stringify(summary.workers)).not.toContain("endpoint");

--- a/showcase/harness/src/fleet/control-plane/run-view.ts
+++ b/showcase/harness/src/fleet/control-plane/run-view.ts
@@ -139,6 +139,16 @@ export interface WorkerRow {
   capacity_in_use?: number;
   capacity_available?: number;
   capacity_max?: number;
+  /**
+   * cgroup `pids.current` / `pids.max` as of the last heartbeat (written by
+   * worker/registration.ts via `gaugeOrNull`, so the -1 "unreadable/unbounded"
+   * sentinel arrives as null). The context budget is NOT the only binding
+   * constraint on a worker: on 2026-08-03 the fleet sat at `pids 1000/1000`
+   * with ~730 zombies and could not launch a browser while still reporting
+   * `online` with 36 contexts free.
+   */
+  capacity_pids_current?: number | null;
+  capacity_pids_max?: number | null;
   current_job_id?: string;
   last_heartbeat_at?: string;
   /**
@@ -226,7 +236,27 @@ export interface WorkerView {
    */
   registeredAt: string;
   currentJobId: string | null;
-  capacity: { inUse: number; available: number; max: number };
+  capacity: {
+    inUse: number;
+    available: number;
+    max: number;
+    /**
+     * cgroup PID gauges, or null when the cgroup was unreadable / the column is
+     * absent. Null is NOT zero: "we could not read the ceiling" must not render
+     * as "0 PIDs in use", and it must never imply saturation.
+     */
+    pidsCurrent: number | null;
+    pidsMax: number | null;
+    /**
+     * Canonical PID-saturation verdict at `PIDS_SATURATION_THRESHOLD`. Derived
+     * server-side ON PURPOSE: every consumer (dashboard strip, external
+     * watcher) must read the same verdict rather than re-deriving a threshold
+     * and drifting, the same reason the cell model forbids re-deriving colour
+     * from `status.state` (cell-model.contribution.ts:536-541). False whenever
+     * either gauge is unknown — absence of evidence is not evidence.
+     */
+    pidsSaturated: boolean;
+  };
 }
 
 /**
@@ -722,6 +752,39 @@ function determineWorkerHealth(
 }
 
 /**
+ * Fraction of the cgroup PID ceiling at or above which a worker is reported
+ * saturated. Prod crossed 0.85 on 2026-08-01, roughly 36 hours before the
+ * 2026-08-03 flip in which every probe lost the ability to launch a browser —
+ * so this threshold is a warning with real lead time, not a post-hoc marker.
+ */
+export const PIDS_SATURATION_THRESHOLD = 0.85;
+
+/**
+ * Read one cgroup gauge column. Absent (pre-migration row), null (the -1
+ * unreadable/unbounded sentinel, normalized by `gaugeOrNull` at write time),
+ * negative, or non-finite all mean UNKNOWN, which is null — never 0.
+ */
+function readGauge(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Is this worker at or over the PID ceiling fraction? Requires BOTH gauges to
+ * be known and a positive ceiling: an unbounded or unreadable cgroup cannot be
+ * saturated by this measure, and reporting it as such would page on nothing.
+ */
+function isPidsSaturated(
+  pidsCurrent: number | null,
+  pidsMax: number | null,
+): boolean {
+  if (pidsCurrent === null || pidsMax === null || pidsMax <= 0) return false;
+  return pidsCurrent / pidsMax >= PIDS_SATURATION_THRESHOLD;
+}
+
+/**
  * Project one `workers` row into the §5.2.1 strip entry, deriving `health`
  * through `determineWorkerHealth` (the shared per-call-site wrapper around
  * `contracts.deriveHealth`) so this surface and `fleet-health.ts`'s cycle
@@ -736,6 +799,8 @@ export function projectWorker(
 ): WorkerView {
   const heartbeat = row.last_heartbeat_at ?? "";
   const health = determineWorkerHealth(row, nowMs, workerStaleAfterMs);
+  const pidsCurrent = readGauge(row.capacity_pids_current);
+  const pidsMax = readGauge(row.capacity_pids_max);
   return {
     workerId: row.worker_id,
     health,
@@ -749,6 +814,9 @@ export function projectWorker(
       inUse: row.capacity_in_use ?? 0,
       available: row.capacity_available ?? 0,
       max: row.capacity_max ?? 0,
+      pidsCurrent,
+      pidsMax,
+      pidsSaturated: isPidsSaturated(pidsCurrent, pidsMax),
     },
   };
 }

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -872,7 +872,9 @@ describe("e2e-full driver", () => {
     });
 
     it("returns undefined when ANY failure is product-classed or unknown", () => {
-      expect(rollupInfraErrorClass(["abort", "missing-script"])).toBeUndefined();
+      expect(
+        rollupInfraErrorClass(["abort", "missing-script"]),
+      ).toBeUndefined();
       expect(rollupInfraErrorClass(["abort", undefined])).toBeUndefined();
       expect(
         rollupInfraErrorClass(["abort", "promise-rejected"]),
@@ -919,7 +921,9 @@ describe("e2e-full driver", () => {
       registerD5Script(makeScript(["agentic-chat"]));
       const driver = createE2eFullDriver({
         launcher: async () => {
-          throw new Error("Failed to launch chromium: Resource temporarily unavailable");
+          throw new Error(
+            "Failed to launch chromium: Resource temporarily unavailable",
+          );
         },
         scriptLoader: noopScriptLoader(),
       });

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -8,10 +8,14 @@ import {
   FEATURE_CONCURRENCY_D6,
   openGuardedContext,
   parseFailureClassifier,
+  rollupInfraErrorClass,
   Semaphore,
 } from "./d6-all-pills.js";
 import { CVDIAG_FAILURE_CLASSIFIERS } from "../../cvdiag/index.js";
-import { signalHasInfraErrorClass } from "../../shared/cell-model/cell-model.contribution.js";
+import {
+  INFRA_ERROR_CLASSES,
+  signalHasInfraErrorClass,
+} from "../../shared/cell-model/cell-model.contribution.js";
 import type { GuardableBrowser } from "./d6-all-pills.js";
 import type {
   E2eFullAggregateSignal,
@@ -854,6 +858,39 @@ describe("e2e-full driver", () => {
     });
   });
 
+  describe("rollupInfraErrorClass", () => {
+    it("returns the shared class only when every failure is infra-classed", () => {
+      expect(rollupInfraErrorClass(["abort", "abort"])).toBe("abort");
+      expect(rollupInfraErrorClass(["driver-error"])).toBe("driver-error");
+      // Uniformly infra but mixed — either member classifies identically
+      // downstream; the first is reported for determinism.
+      expect(rollupInfraErrorClass(["abort", "driver-error"])).toBe("abort");
+    });
+
+    it("returns undefined for an empty set (a green roll-up claims nothing)", () => {
+      expect(rollupInfraErrorClass([])).toBeUndefined();
+    });
+
+    it("returns undefined when ANY failure is product-classed or unknown", () => {
+      expect(rollupInfraErrorClass(["abort", "missing-script"])).toBeUndefined();
+      expect(rollupInfraErrorClass(["abort", undefined])).toBeUndefined();
+      expect(
+        rollupInfraErrorClass(["abort", "promise-rejected"]),
+      ).toBeUndefined();
+    });
+
+    it("never launders feature-timeout into an infra verdict", () => {
+      // A genuinely hung demo produces exactly `feature-timeout`. It is
+      // deliberately absent from INFRA_ERROR_CLASSES, and this roll-up must
+      // inherit that judgement rather than quietly widen it.
+      expect(INFRA_ERROR_CLASSES.has("feature-timeout")).toBe(false);
+      expect(rollupInfraErrorClass(["feature-timeout"])).toBeUndefined();
+      expect(
+        rollupInfraErrorClass(["abort", "feature-timeout"]),
+      ).toBeUndefined();
+    });
+  });
+
   describe("launcher error", () => {
     it("returns red on launcher failure", async () => {
       registerD5Script(makeScript(["agentic-chat"]));
@@ -873,6 +910,27 @@ describe("e2e-full driver", () => {
 
       expect(result.state).toBe("red");
       expect(result.signal.errorDesc).toBe("launcher-error");
+    });
+
+    it("classifies a launcher failure as infra on the roll-up (nothing product ever ran)", async () => {
+      // A worker at its cgroup PID ceiling cannot fork a browser — this is the
+      // 2026-08-03 signature. Zero product code executes, so the red carries no
+      // information about the demo and must not read as a product outage.
+      registerD5Script(makeScript(["agentic-chat"]));
+      const driver = createE2eFullDriver({
+        launcher: async () => {
+          throw new Error("Failed to launch chromium: Resource temporarily unavailable");
+        },
+        scriptLoader: noopScriptLoader(),
+      });
+      const result = await driver.run(makeCtx(), {
+        key: "e2e_d6:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat"],
+      });
+      expect(result.state).toBe("red");
+      expect(result.signal.errorClass).toBe("driver-error");
+      expect(signalHasInfraErrorClass(result.signal)).toBe(true);
     });
   });
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -952,7 +952,9 @@ describe("e2e-full driver", () => {
     });
 
     it("returns undefined when ANY failure is product-classed or unknown", () => {
-      expect(rollupInfraErrorClass(["abort", "missing-script"])).toBeUndefined();
+      expect(
+        rollupInfraErrorClass(["abort", "missing-script"]),
+      ).toBeUndefined();
       expect(rollupInfraErrorClass(["abort", undefined])).toBeUndefined();
       expect(
         rollupInfraErrorClass(["abort", "promise-rejected"]),
@@ -999,7 +1001,9 @@ describe("e2e-full driver", () => {
       registerD5Script(makeScript(["agentic-chat"]));
       const driver = createE2eFullDriver({
         launcher: async () => {
-          throw new Error("Failed to launch chromium: Resource temporarily unavailable");
+          throw new Error(
+            "Failed to launch chromium: Resource temporarily unavailable",
+          );
         },
         scriptLoader: noopScriptLoader(),
       });

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -12,6 +12,7 @@ import {
   Semaphore,
 } from "./d6-all-pills.js";
 import { CVDIAG_FAILURE_CLASSIFIERS } from "../../cvdiag/index.js";
+import { signalHasInfraErrorClass } from "../../shared/cell-model/cell-model.contribution.js";
 import type { GuardableBrowser } from "./d6-all-pills.js";
 import type {
   E2eFullAggregateSignal,
@@ -682,6 +683,107 @@ describe("e2e-full driver", () => {
       const aggSignal = aggRow!.signal as E2eFullAggregateSignal;
       expect(aggSignal.slug).toBe("test-slug");
       expect(aggSignal.failed).toContain("agentic-chat");
+    });
+
+    // 2026-08-03 incident: the per-feature cells carried `errorClass: "abort"`
+    // and the cell model correctly folded them to gray, but the `d6:<slug>`
+    // roll-up's signal schema had no `errorClass` field at all — so
+    // `signalHasInfraErrorClass()` returned false for it unconditionally and
+    // the roll-up read as a PRODUCT red no matter what killed the run. That
+    // roll-up is the row a naive per-slug query lands on.
+    describe("roll-up infra classification", () => {
+      async function runAgg(opts: {
+        features: string[];
+        register: string[];
+        throwOnNewContext?: Error;
+      }): Promise<E2eFullAggregateSignal> {
+        for (const ft of opts.register) registerD5Script(makeScript([ft]));
+        const sideEmits: ProbeResult<unknown>[] = [];
+        const writer: ProbeResultWriter = {
+          write: async (r) => {
+            sideEmits.push(r);
+          },
+        };
+        const driver = createE2eFullDriver({
+          launcher: async () =>
+            makeBrowser({ throwOnNewContext: opts.throwOnNewContext }),
+          scriptLoader: noopScriptLoader(),
+        });
+        await driver.run(makeCtx({ writer }), {
+          key: "d6-all-pills-e2e:showcase-test-slug",
+          backendUrl: "https://test.example.com",
+          features: opts.features,
+        });
+        const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+        expect(aggRow).toBeDefined();
+        expect(aggRow!.state).toBe("red");
+        return aggRow!.signal as E2eFullAggregateSignal;
+      }
+
+      it("stamps an infra errorClass when EVERY failed feature is infra-classed", async () => {
+        // `newContext` throwing is the driver-error path — the same class the
+        // two prod `browserContext.newPage: Target page, context or browser has
+        // been closed` cells carried, and what PID exhaustion presents as.
+        const agg = await runAgg({
+          features: ["agentic-chat", "frontend-tools"],
+          register: ["agentic-chat", "frontend-tools"],
+          throwOnNewContext: new Error("browser has been closed"),
+        });
+        expect(agg.failed.sort()).toEqual(["agentic-chat", "frontend-tools"]);
+        expect(agg.errorClass).toBe("driver-error");
+        expect(signalHasInfraErrorClass(agg)).toBe(true);
+      });
+
+      it("leaves errorClass unset when a failure is NOT infra-classed (masks-real-red guard)", async () => {
+        // `missing-script` is a genuine product/config red. One non-infra
+        // failure must sink the whole roll-up's infra claim — the fold requires
+        // POSITIVE infra evidence for EVERY contributing failure, and graying a
+        // real red is the expensive direction (cell-model.contribution.ts:478).
+        const agg = await runAgg({
+          features: ["agentic-chat"],
+          register: [],
+        });
+        expect(agg.failed).toContain("agentic-chat");
+        expect(agg.errorClass).toBeUndefined();
+        expect(signalHasInfraErrorClass(agg)).toBe(false);
+      });
+
+      it("leaves errorClass unset on a MIXED infra + product failure set", async () => {
+        // `frontend-tools` has no script (missing-script, product) while the
+        // browser is also broken (driver-error, infra). Mixed ⇒ no infra claim.
+        const agg = await runAgg({
+          features: ["agentic-chat", "frontend-tools"],
+          register: ["agentic-chat"],
+          throwOnNewContext: new Error("browser has been closed"),
+        });
+        expect(agg.failed.sort()).toEqual(["agentic-chat", "frontend-tools"]);
+        expect(agg.errorClass).toBeUndefined();
+        expect(signalHasInfraErrorClass(agg)).toBe(false);
+      });
+
+      it("leaves errorClass unset on a green roll-up", async () => {
+        registerD5Script(makeScript(["agentic-chat"]));
+        const sideEmits: ProbeResult<unknown>[] = [];
+        const writer: ProbeResultWriter = {
+          write: async (r) => {
+            sideEmits.push(r);
+          },
+        };
+        const driver = createE2eFullDriver({
+          launcher: async () => makeBrowser(),
+          scriptLoader: noopScriptLoader(),
+        });
+        await driver.run(makeCtx({ writer }), {
+          key: "d6-all-pills-e2e:showcase-test-slug",
+          backendUrl: "https://test.example.com",
+          features: ["agentic-chat"],
+        });
+        const aggRow = sideEmits.find((r) => r.key === "d6:test-slug")!;
+        expect(aggRow.state).toBe("green");
+        expect(
+          (aggRow.signal as E2eFullAggregateSignal).errorClass,
+        ).toBeUndefined();
+      });
     });
   });
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -11,6 +11,7 @@ import {
   Semaphore,
 } from "./d6-all-pills.js";
 import { CVDIAG_FAILURE_CLASSIFIERS } from "../../cvdiag/index.js";
+import { signalHasInfraErrorClass } from "../../shared/cell-model/cell-model.contribution.js";
 import type { GuardableBrowser } from "./d6-all-pills.js";
 import type {
   E2eFullAggregateSignal,
@@ -602,6 +603,107 @@ describe("e2e-full driver", () => {
       const aggSignal = aggRow!.signal as E2eFullAggregateSignal;
       expect(aggSignal.slug).toBe("test-slug");
       expect(aggSignal.failed).toContain("agentic-chat");
+    });
+
+    // 2026-08-03 incident: the per-feature cells carried `errorClass: "abort"`
+    // and the cell model correctly folded them to gray, but the `d6:<slug>`
+    // roll-up's signal schema had no `errorClass` field at all — so
+    // `signalHasInfraErrorClass()` returned false for it unconditionally and
+    // the roll-up read as a PRODUCT red no matter what killed the run. That
+    // roll-up is the row a naive per-slug query lands on.
+    describe("roll-up infra classification", () => {
+      async function runAgg(opts: {
+        features: string[];
+        register: string[];
+        throwOnNewContext?: Error;
+      }): Promise<E2eFullAggregateSignal> {
+        for (const ft of opts.register) registerD5Script(makeScript([ft]));
+        const sideEmits: ProbeResult<unknown>[] = [];
+        const writer: ProbeResultWriter = {
+          write: async (r) => {
+            sideEmits.push(r);
+          },
+        };
+        const driver = createE2eFullDriver({
+          launcher: async () =>
+            makeBrowser({ throwOnNewContext: opts.throwOnNewContext }),
+          scriptLoader: noopScriptLoader(),
+        });
+        await driver.run(makeCtx({ writer }), {
+          key: "d6-all-pills-e2e:showcase-test-slug",
+          backendUrl: "https://test.example.com",
+          features: opts.features,
+        });
+        const aggRow = sideEmits.find((r) => r.key === "d6:test-slug");
+        expect(aggRow).toBeDefined();
+        expect(aggRow!.state).toBe("red");
+        return aggRow!.signal as E2eFullAggregateSignal;
+      }
+
+      it("stamps an infra errorClass when EVERY failed feature is infra-classed", async () => {
+        // `newContext` throwing is the driver-error path — the same class the
+        // two prod `browserContext.newPage: Target page, context or browser has
+        // been closed` cells carried, and what PID exhaustion presents as.
+        const agg = await runAgg({
+          features: ["agentic-chat", "frontend-tools"],
+          register: ["agentic-chat", "frontend-tools"],
+          throwOnNewContext: new Error("browser has been closed"),
+        });
+        expect(agg.failed.sort()).toEqual(["agentic-chat", "frontend-tools"]);
+        expect(agg.errorClass).toBe("driver-error");
+        expect(signalHasInfraErrorClass(agg)).toBe(true);
+      });
+
+      it("leaves errorClass unset when a failure is NOT infra-classed (masks-real-red guard)", async () => {
+        // `missing-script` is a genuine product/config red. One non-infra
+        // failure must sink the whole roll-up's infra claim — the fold requires
+        // POSITIVE infra evidence for EVERY contributing failure, and graying a
+        // real red is the expensive direction (cell-model.contribution.ts:478).
+        const agg = await runAgg({
+          features: ["agentic-chat"],
+          register: [],
+        });
+        expect(agg.failed).toContain("agentic-chat");
+        expect(agg.errorClass).toBeUndefined();
+        expect(signalHasInfraErrorClass(agg)).toBe(false);
+      });
+
+      it("leaves errorClass unset on a MIXED infra + product failure set", async () => {
+        // `frontend-tools` has no script (missing-script, product) while the
+        // browser is also broken (driver-error, infra). Mixed ⇒ no infra claim.
+        const agg = await runAgg({
+          features: ["agentic-chat", "frontend-tools"],
+          register: ["agentic-chat"],
+          throwOnNewContext: new Error("browser has been closed"),
+        });
+        expect(agg.failed.sort()).toEqual(["agentic-chat", "frontend-tools"]);
+        expect(agg.errorClass).toBeUndefined();
+        expect(signalHasInfraErrorClass(agg)).toBe(false);
+      });
+
+      it("leaves errorClass unset on a green roll-up", async () => {
+        registerD5Script(makeScript(["agentic-chat"]));
+        const sideEmits: ProbeResult<unknown>[] = [];
+        const writer: ProbeResultWriter = {
+          write: async (r) => {
+            sideEmits.push(r);
+          },
+        };
+        const driver = createE2eFullDriver({
+          launcher: async () => makeBrowser(),
+          scriptLoader: noopScriptLoader(),
+        });
+        await driver.run(makeCtx({ writer }), {
+          key: "d6-all-pills-e2e:showcase-test-slug",
+          backendUrl: "https://test.example.com",
+          features: ["agentic-chat"],
+        });
+        const aggRow = sideEmits.find((r) => r.key === "d6:test-slug")!;
+        expect(aggRow.state).toBe("green");
+        expect(
+          (aggRow.signal as E2eFullAggregateSignal).errorClass,
+        ).toBeUndefined();
+      });
     });
   });
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -9,10 +9,14 @@ import {
   openGuardedContext,
   parseFailureClassifier,
   resolveAimockStrictHeaders,
+  rollupInfraErrorClass,
   Semaphore,
 } from "./d6-all-pills.js";
 import { CVDIAG_FAILURE_CLASSIFIERS } from "../../cvdiag/index.js";
-import { signalHasInfraErrorClass } from "../../shared/cell-model/cell-model.contribution.js";
+import {
+  INFRA_ERROR_CLASSES,
+  signalHasInfraErrorClass,
+} from "../../shared/cell-model/cell-model.contribution.js";
 import type { GuardableBrowser } from "./d6-all-pills.js";
 import type {
   E2eFullAggregateSignal,
@@ -934,6 +938,39 @@ describe("e2e-full driver", () => {
     });
   });
 
+  describe("rollupInfraErrorClass", () => {
+    it("returns the shared class only when every failure is infra-classed", () => {
+      expect(rollupInfraErrorClass(["abort", "abort"])).toBe("abort");
+      expect(rollupInfraErrorClass(["driver-error"])).toBe("driver-error");
+      // Uniformly infra but mixed — either member classifies identically
+      // downstream; the first is reported for determinism.
+      expect(rollupInfraErrorClass(["abort", "driver-error"])).toBe("abort");
+    });
+
+    it("returns undefined for an empty set (a green roll-up claims nothing)", () => {
+      expect(rollupInfraErrorClass([])).toBeUndefined();
+    });
+
+    it("returns undefined when ANY failure is product-classed or unknown", () => {
+      expect(rollupInfraErrorClass(["abort", "missing-script"])).toBeUndefined();
+      expect(rollupInfraErrorClass(["abort", undefined])).toBeUndefined();
+      expect(
+        rollupInfraErrorClass(["abort", "promise-rejected"]),
+      ).toBeUndefined();
+    });
+
+    it("never launders feature-timeout into an infra verdict", () => {
+      // A genuinely hung demo produces exactly `feature-timeout`. It is
+      // deliberately absent from INFRA_ERROR_CLASSES, and this roll-up must
+      // inherit that judgement rather than quietly widen it.
+      expect(INFRA_ERROR_CLASSES.has("feature-timeout")).toBe(false);
+      expect(rollupInfraErrorClass(["feature-timeout"])).toBeUndefined();
+      expect(
+        rollupInfraErrorClass(["abort", "feature-timeout"]),
+      ).toBeUndefined();
+    });
+  });
+
   describe("launcher error", () => {
     it("returns red on launcher failure", async () => {
       registerD5Script(makeScript(["agentic-chat"]));
@@ -953,6 +990,27 @@ describe("e2e-full driver", () => {
 
       expect(result.state).toBe("red");
       expect(result.signal.errorDesc).toBe("launcher-error");
+    });
+
+    it("classifies a launcher failure as infra on the roll-up (nothing product ever ran)", async () => {
+      // A worker at its cgroup PID ceiling cannot fork a browser — this is the
+      // 2026-08-03 signature. Zero product code executes, so the red carries no
+      // information about the demo and must not read as a product outage.
+      registerD5Script(makeScript(["agentic-chat"]));
+      const driver = createE2eFullDriver({
+        launcher: async () => {
+          throw new Error("Failed to launch chromium: Resource temporarily unavailable");
+        },
+        scriptLoader: noopScriptLoader(),
+      });
+      const result = await driver.run(makeCtx(), {
+        key: "e2e_d6:showcase-test-slug",
+        backendUrl: "https://test.example.com",
+        features: ["agentic-chat"],
+      });
+      expect(result.state).toBe("red");
+      expect(result.signal.errorClass).toBe("driver-error");
+      expect(signalHasInfraErrorClass(result.signal)).toBe(true);
     });
   });
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
+import { INFRA_ERROR_CLASSES } from "../../shared/cell-model/cell-model.contribution.js";
 import { showcaseShapeSchema } from "../discovery/railway-services.js";
 import { D5_REGISTRY, isD5FeatureType } from "../helpers/d5-registry.js";
 import type {
@@ -197,6 +198,50 @@ export interface E2eFullAggregateSignal {
   note?: string;
   errorDesc?: string;
   failureSummary?: string;
+  /**
+   * Infra failure class for the ROLL-UP, set only when the roll-up's red is
+   * entirely attributable to harness infra — every failed feature carried an
+   * `INFRA_ERROR_CLASSES` member, or the browser launcher itself failed so no
+   * feature ever ran. Left UNSET otherwise, including on any mixed set.
+   *
+   * Without this field the roll-up was an unconditional PRODUCT red:
+   * `signalHasInfraErrorClass()` reads `errorClass`/`errorDesc`, the schema had
+   * neither in an infra-classed form, so the U7 gray fold could never fire on
+   * `d6:<slug>` however cleanly it fired on the cells underneath. On 2026-08-03
+   * that made the roll-up — the row a naive per-slug query lands on — read as a
+   * product outage for ~20 slugs whose demos were provably healthy.
+   *
+   * The polarity is the cell model's, deliberately: graying needs POSITIVE
+   * infra evidence for EVERY contributing failure, because hiding a real red
+   * costs far more than showing a false one (cell-model.contribution.ts:478).
+   */
+  errorClass?: string;
+}
+
+/**
+ * Roll-up infra verdict: the shared infra class when the failure set is
+ * NON-EMPTY and EVERY member carries a known `INFRA_ERROR_CLASSES` class,
+ * `undefined` otherwise.
+ *
+ * `classes` must hold one entry per failed feature. A feature whose class is
+ * absent (`undefined`) is UNKNOWN, and unknown is not infra evidence — one such
+ * entry, or one product class, sinks the whole verdict. That asymmetry is the
+ * point: it is the same masks-real-red guard the cell model applies, lifted to
+ * the roll-up unchanged.
+ *
+ * When the set is uniformly infra but mixed (`abort` + `driver-error`), the
+ * first failure's class is reported. Both members classify identically
+ * downstream, so the choice is cosmetic; taking the first keeps it deterministic
+ * in `failed[]` order.
+ */
+export function rollupInfraErrorClass(
+  classes: readonly (string | undefined)[],
+): string | undefined {
+  if (classes.length === 0) return undefined;
+  for (const cls of classes) {
+    if (cls === undefined || !INFRA_ERROR_CLASSES.has(cls)) return undefined;
+  }
+  return classes[0];
 }
 
 /**
@@ -1060,6 +1105,12 @@ export function createE2eFullDriver(
                   : undefined,
               errorDesc: "launcher-error",
               failureSummary: truncateUtf8(msg, 1200),
+              // The browser never launched, so ZERO product code was exercised
+              // — this red cannot be evidence about the demo, only about the
+              // harness. It is also the literal signature of a worker at its
+              // cgroup PID ceiling (2026-08-03): it cannot fork a browser.
+              // Classifying it infra therefore cannot mask a product defect.
+              errorClass: "driver-error",
             },
             observedAt,
           };
@@ -1487,6 +1538,10 @@ export function createE2eFullDriver(
                 ft,
                 ok: false as const,
                 errorDesc: featureResult.errorDesc,
+                // Carried up so the roll-up can classify itself the same way
+                // the side row above already does. Previously dropped here,
+                // which is why the roll-up had no class to aggregate.
+                errorClass: featureResult.errorClass,
               };
             }
           } finally {
@@ -1507,6 +1562,13 @@ export function createE2eFullDriver(
         // Aggregate results.
         let passed = 0;
         const failed: string[] = [...missingScript];
+        // One entry per `failed` member, same order — the roll-up infra verdict
+        // needs a class for EVERY failure. `missing-script` is a genuine
+        // product/config red, so seeding it here (rather than leaving a hole)
+        // both keeps the arrays aligned and correctly sinks the infra claim.
+        const failedClasses: (string | undefined)[] = missingScript.map(
+          () => "missing-script",
+        );
         const featureErrors: string[] = missingScript.map(
           (ft) => `${ft}: no script registered`,
         );
@@ -1517,6 +1579,7 @@ export function createE2eFullDriver(
               passed++;
             } else {
               failed.push(outcome.value.ft);
+              failedClasses.push(outcome.value.errorClass);
               if (outcome.value.errorDesc) {
                 featureErrors.push(
                   `${outcome.value.ft}: ${outcome.value.errorDesc}`,
@@ -1535,6 +1598,11 @@ export function createE2eFullDriver(
               err: errMsg,
             });
             failed.push(ft);
+            // A rejected feature promise is a driver-layer bug, not a product
+            // failure, but it is NOT in INFRA_ERROR_CLASSES and must not be
+            // laundered into one — record its real class so it sinks the
+            // roll-up's infra claim exactly as the side row does.
+            failedClasses.push("promise-rejected");
             featureErrors.push(`${ft}: ${errMsg}`);
             try {
               await sideEmit(ctx, {
@@ -1583,6 +1651,7 @@ export function createE2eFullDriver(
                 : undefined,
             failureSummary:
               featureErrors.length > 0 ? featureErrors.join("; ") : undefined,
+            errorClass: rollupInfraErrorClass(failedClasses),
           },
           observedAt,
         };

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { z } from "zod";
 import { truncateUtf8 } from "../../render/filters.js";
+import { INFRA_ERROR_CLASSES } from "../../shared/cell-model/cell-model.contribution.js";
 import { showcaseShapeSchema } from "../discovery/railway-services.js";
 import { D5_REGISTRY, isD5FeatureType } from "../helpers/d5-registry.js";
 import type {
@@ -198,6 +199,50 @@ export interface E2eFullAggregateSignal {
   note?: string;
   errorDesc?: string;
   failureSummary?: string;
+  /**
+   * Infra failure class for the ROLL-UP, set only when the roll-up's red is
+   * entirely attributable to harness infra — every failed feature carried an
+   * `INFRA_ERROR_CLASSES` member, or the browser launcher itself failed so no
+   * feature ever ran. Left UNSET otherwise, including on any mixed set.
+   *
+   * Without this field the roll-up was an unconditional PRODUCT red:
+   * `signalHasInfraErrorClass()` reads `errorClass`/`errorDesc`, the schema had
+   * neither in an infra-classed form, so the U7 gray fold could never fire on
+   * `d6:<slug>` however cleanly it fired on the cells underneath. On 2026-08-03
+   * that made the roll-up — the row a naive per-slug query lands on — read as a
+   * product outage for ~20 slugs whose demos were provably healthy.
+   *
+   * The polarity is the cell model's, deliberately: graying needs POSITIVE
+   * infra evidence for EVERY contributing failure, because hiding a real red
+   * costs far more than showing a false one (cell-model.contribution.ts:478).
+   */
+  errorClass?: string;
+}
+
+/**
+ * Roll-up infra verdict: the shared infra class when the failure set is
+ * NON-EMPTY and EVERY member carries a known `INFRA_ERROR_CLASSES` class,
+ * `undefined` otherwise.
+ *
+ * `classes` must hold one entry per failed feature. A feature whose class is
+ * absent (`undefined`) is UNKNOWN, and unknown is not infra evidence — one such
+ * entry, or one product class, sinks the whole verdict. That asymmetry is the
+ * point: it is the same masks-real-red guard the cell model applies, lifted to
+ * the roll-up unchanged.
+ *
+ * When the set is uniformly infra but mixed (`abort` + `driver-error`), the
+ * first failure's class is reported. Both members classify identically
+ * downstream, so the choice is cosmetic; taking the first keeps it deterministic
+ * in `failed[]` order.
+ */
+export function rollupInfraErrorClass(
+  classes: readonly (string | undefined)[],
+): string | undefined {
+  if (classes.length === 0) return undefined;
+  for (const cls of classes) {
+    if (cls === undefined || !INFRA_ERROR_CLASSES.has(cls)) return undefined;
+  }
+  return classes[0];
 }
 
 /**
@@ -1074,6 +1119,12 @@ export function createE2eFullDriver(
                   : undefined,
               errorDesc: "launcher-error",
               failureSummary: truncateUtf8(msg, 1200),
+              // The browser never launched, so ZERO product code was exercised
+              // — this red cannot be evidence about the demo, only about the
+              // harness. It is also the literal signature of a worker at its
+              // cgroup PID ceiling (2026-08-03): it cannot fork a browser.
+              // Classifying it infra therefore cannot mask a product defect.
+              errorClass: "driver-error",
             },
             observedAt,
           };
@@ -1501,6 +1552,10 @@ export function createE2eFullDriver(
                 ft,
                 ok: false as const,
                 errorDesc: featureResult.errorDesc,
+                // Carried up so the roll-up can classify itself the same way
+                // the side row above already does. Previously dropped here,
+                // which is why the roll-up had no class to aggregate.
+                errorClass: featureResult.errorClass,
               };
             }
           } finally {
@@ -1521,6 +1576,13 @@ export function createE2eFullDriver(
         // Aggregate results.
         let passed = 0;
         const failed: string[] = [...missingScript];
+        // One entry per `failed` member, same order — the roll-up infra verdict
+        // needs a class for EVERY failure. `missing-script` is a genuine
+        // product/config red, so seeding it here (rather than leaving a hole)
+        // both keeps the arrays aligned and correctly sinks the infra claim.
+        const failedClasses: (string | undefined)[] = missingScript.map(
+          () => "missing-script",
+        );
         const featureErrors: string[] = missingScript.map(
           (ft) => `${ft}: no script registered`,
         );
@@ -1531,6 +1593,7 @@ export function createE2eFullDriver(
               passed++;
             } else {
               failed.push(outcome.value.ft);
+              failedClasses.push(outcome.value.errorClass);
               if (outcome.value.errorDesc) {
                 featureErrors.push(
                   `${outcome.value.ft}: ${outcome.value.errorDesc}`,
@@ -1549,6 +1612,11 @@ export function createE2eFullDriver(
               err: errMsg,
             });
             failed.push(ft);
+            // A rejected feature promise is a driver-layer bug, not a product
+            // failure, but it is NOT in INFRA_ERROR_CLASSES and must not be
+            // laundered into one — record its real class so it sinks the
+            // roll-up's infra claim exactly as the side row does.
+            failedClasses.push("promise-rejected");
             featureErrors.push(`${ft}: ${errMsg}`);
             try {
               await sideEmit(ctx, {
@@ -1597,6 +1665,7 @@ export function createE2eFullDriver(
                 : undefined,
             failureSummary:
               featureErrors.length > 0 ? featureErrors.join("; ") : undefined,
+            errorClass: rollupInfraErrorClass(failedClasses),
           },
           observedAt,
         };

--- a/showcase/shell-dashboard/src/components/worker-runs-table.test.tsx
+++ b/showcase/shell-dashboard/src/components/worker-runs-table.test.tsx
@@ -243,6 +243,61 @@ describe("WorkerRunsTable", () => {
     expect(reds.textContent).toContain("−2");
   });
 
+  // 2026-08-03: this strip read `online · 4/40 contexts` — indistinguishable
+  // from healthy — for workers pinned at cgroup pids 1000/1000 that could not
+  // launch a single browser. The context budget was never the binding
+  // constraint, so the chip has to show the constraint that actually bound.
+  it("worker strip surfaces PID saturation next to the context count", () => {
+    const data = runsResponse({
+      workers: [
+        worker({
+          workerId: "worker-saturated",
+          capacity: {
+            inUse: 4,
+            available: 36,
+            max: 40,
+            pidsCurrent: 1_000,
+            pidsMax: 1_000,
+            pidsSaturated: true,
+          },
+        }),
+        worker({
+          workerId: "worker-healthy",
+          capacity: {
+            inUse: 4,
+            available: 36,
+            max: 40,
+            pidsCurrent: 199,
+            pidsMax: 1_000,
+            pidsSaturated: false,
+          },
+        }),
+      ],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const sat = getByTestId("worker-chip-worker-saturated");
+    expect(sat.getAttribute("data-pids-saturated")).toBe("true");
+    expect(sat.textContent).toContain("1000/1000 pids");
+    // A healthy worker stays quiet — no new noise on the normal path.
+    const ok = getByTestId("worker-chip-worker-healthy");
+    expect(ok.getAttribute("data-pids-saturated")).toBe("false");
+    expect(ok.textContent).not.toContain("pids");
+  });
+
+  it("worker strip omits the PID reading when the cgroup gauges are unknown", () => {
+    const data = runsResponse({
+      workers: [worker({ workerId: "worker-unknown" })],
+    });
+    const { getByTestId } = render(
+      <WorkerRunsTable data={data} probeEntries={null} />,
+    );
+    const chip = getByTestId("worker-chip-worker-unknown");
+    expect(chip.getAttribute("data-pids-saturated")).toBe("false");
+    expect(chip.textContent).not.toContain("pids");
+  });
+
   it("worker strip renders online/stale/offline verbatim with amber/red treatments", () => {
     const data = runsResponse({
       workers: [

--- a/showcase/shell-dashboard/src/components/worker-runs-table.tsx
+++ b/showcase/shell-dashboard/src/components/worker-runs-table.tsx
@@ -261,6 +261,7 @@ function WorkerStrip({ workers }: { workers: WorkerView[] }) {
           key={w.workerId}
           data-testid={`worker-chip-${w.workerId}`}
           data-health={w.health}
+          data-pids-saturated={String(w.capacity.pidsSaturated === true)}
           className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 ${HEALTH_CHIP_CLASS[w.health]}`}
         >
           <span className="font-mono">{w.workerId}</span>
@@ -270,6 +271,23 @@ function WorkerStrip({ workers }: { workers: WorkerView[] }) {
           <span className="tabular-nums">
             {w.capacity.inUse}/{w.capacity.max} contexts
           </span>
+          {/*
+            PID annotation appears ONLY when the fleet is saturated. `health`
+            is heartbeat freshness and the context count is the browser budget;
+            neither could see the 2026-08-03 PID ceiling, which is what
+            actually stopped every probe from launching a browser.
+          */}
+          {w.capacity.pidsSaturated === true && (
+            <>
+              <span>·</span>
+              <span
+                className="tabular-nums font-semibold"
+                title="cgroup pids.current/pids.max — at this ceiling a worker cannot fork a browser, however healthy its heartbeat and context budget look"
+              >
+                {w.capacity.pidsCurrent}/{w.capacity.pidsMax} pids
+              </span>
+            </>
+          )}
         </span>
       ))}
     </div>

--- a/showcase/shell-dashboard/src/lib/ops-api.ts
+++ b/showcase/shell-dashboard/src/lib/ops-api.ts
@@ -494,7 +494,21 @@ export interface WorkerView {
    */
   registeredAt: string;
   currentJobId: string | null;
-  capacity: { inUse: number; available: number; max: number };
+  capacity: {
+    inUse: number;
+    available: number;
+    max: number;
+    /**
+     * cgroup PID gauges, null when the cgroup was unreadable. Optional here
+     * (not in run-view's own `WorkerView`) so a body served by a harness
+     * predating the projection still parses — an old body simply reads
+     * "unknown", which renders as no PID annotation at all.
+     */
+    pidsCurrent?: number | null;
+    pidsMax?: number | null;
+    /** Server-derived saturation verdict; never re-derive a threshold here. */
+    pidsSaturated?: boolean;
+  };
 }
 
 /** GET /api/runs (§5.2.1). */


### PR DESCRIPTION
Three gaps the 2026-08-03 prod incident exposed in the harness signal path, ranked lightest first. Two are fixed here; the third turned out not to exist and is skipped with evidence.

**Background.** The prod prober fleet exhausted its cgroup PID limit (no PID-1 reaper; ~730 zombies after 7 days). Probes could not launch browsers, so 428 of 784 prod cells recorded `abort` across ~20 slugs while the demos were provably healthy. A scheduled watcher then paged a human with a false outage.

The information was **ignored, not destroyed** — `GET /api/matrix` correctly reported 4 red for `langgraph-python`, not 38, because the cell model already folds `abort`/`driver-error` to gray. But two surfaces genuinely could not see what was happening, and this PR fixes those.

**Explicit non-goal, not done here:** `feature-timeout` is *not* added to `INFRA_ERROR_CLASSES`. A real product hang produces exactly that class, so classifying it as infra would mask genuine defects. A test now pins it out of the set, so a future change in that direction fails loudly (see mutation F).

No existing assertion or predicate was weakened.

---

## Patch 1 — expose the cgroup PID gauges on the runs read-model

`pidsCurrent`/`pidsMax` have been on the worker heartbeat contract and in PocketBase since the `workers` collection was created, but the `/api/runs` projection dropped both. During the incident every consumer — the dashboard strip and the external watcher alike — read `online, 4/40 contexts` for workers pinned at `pids 1000/1000` and unable to fork a browser. The context budget was never the binding constraint; the PID ceiling was, and the PID ceiling was the field that got cut.

- `run-view.ts` — `WorkerRow` reads the two columns; `WorkerView.capacity` carries `pidsCurrent`, `pidsMax`, and a canonical `pidsSaturated` verdict at a `0.85` ceiling fraction.
- Unknown is **null, never 0**: `gaugeOrNull` writes null for the `-1` unreadable-cgroup sentinel, and a pre-migration row has no column at all. Neither may render as "0 PIDs", and neither may claim saturation — absence of evidence is not evidence.
- The verdict is derived **server-side on purpose** so consumers don't each re-derive a threshold and drift, the same reason the cell model forbids re-deriving colour from `status.state`.
- `worker-runs-table.tsx` annotates the PID reading **only when saturated**, so the normal path gains no noise.

Prod crossed `0.85` on **2026-08-01**, roughly 36 hours before the flip. This is a warning with real lead time, not a post-hoc marker.

### RED (before the change)

```
❯ src/fleet/control-plane/run-view.test.ts (43 tests | 5 failed | 38 skipped) 11ms
   × projectWorker > cgroup PID gauges > projects capacity_pids_current / capacity_pids_max onto the view
     → expected undefined to be 640 // Object.is equality
   × projectWorker > cgroup PID gauges > flags saturation at/above the threshold and not below it
     → expected undefined to be true // Object.is equality
   × projectWorker > cgroup PID gauges > reports unknown gauges as null and never as a saturated fleet
     → expected undefined to be null
   × projectWorker > cgroup PID gauges > treats a negative sentinel that reached the column as unknown
     → expected undefined to be null
```

And at the surface `/api/runs` actually serializes, with the verbatim incident reading:

```
 FAIL  createMemoizedFamilySummary > serializes the cgroup PID gauges and saturation flag for a PID-exhausted worker
AssertionError: expected { inUse: 4, available: 36, max: 40 } to deeply equal { inUse: 4, available: 36, …(4) }

  {
    "available": 36,
    "inUse": 4,
    "max": 40,
-   "pidsCurrent": 1000,
-   "pidsMax": 1000,
-   "pidsSaturated": true,
  }
```

### GREEN (after)

```
 Test Files  1 passed (1)
      Tests  5 passed | 38 skipped (43)
```

Dashboard render, same shape (RED → GREEN):

```
RED:   AssertionError: expected null to be 'false'   (data-pids-saturated absent)
       Tests  2 failed | 17 skipped (19)
GREEN: Tests  19 passed (19)
```

### Mutation check

| mutant | result |
|---|---|
| A — threshold `0.85` → `99.0` | **2 tests fail** ✅ |
| B — unknown gauge collapses to `0` instead of `null` | **4 tests fail** ✅ |
| C — dashboard PID annotation never rendered | **1 test fails** ✅ |

All restored afterwards.

---

## Patch 2 — let the d6 roll-up carry an infra error class

`E2eFullAggregateSignal` had **no `errorClass` field at all**, so `signalHasInfraErrorClass()` returned false for every `d6:<slug>` roll-up unconditionally and the U7 gray fold could never fire on it — however cleanly it fired on the cells underneath. Its `failureSummary` *contained* the classes as free text; nothing parsed that. On 2026-08-03 the roll-up — the row a naive per-slug query lands on, and the row whose `first_failure_at` the watcher quoted — read as a product outage for ~20 slugs whose demos were fine.

The per-feature `errorClass` was also being dropped on the way up to the aggregation loop, so there was nothing to aggregate even if the field had existed. It is now carried.

**Polarity is the cell model's, unchanged.** `rollupInfraErrorClass()` stamps a class only when the failure set is non-empty and **every** member is positively infra-classed. One product class, one promise-rejection, one missing script, or one *unknown* sinks the verdict. That asymmetry is the masks-real-red guard lifted to the roll-up: on 2026-07-24, 21 of 357 prod reds were infra-class against 336 product-class, so graying on absence of evidence would have hidden ~94 real failures to suppress ~6 false ones.

The launcher-error path is classified infra directly. If the browser never launched, zero product code ran, so the red carries no information about the demo — and that is the literal signature of a worker at its PID ceiling.

### RED (before)

```
 FAIL  e2e-full driver > aggregate d6:<slug> side row > roll-up infra classification
       > stamps an infra errorClass when EVERY failed feature is infra-classed
AssertionError: expected undefined to be 'driver-error' // Object.is equality

- Expected:  "driver-error"
+ Received:  undefined

 ❯ src/probes/drivers/d6-all-pills.test.ts:653:32
    653|         expect(agg.errorClass).toBe("driver-error");
    654|         expect(signalHasInfraErrorClass(agg)).toBe(true);
```

### GREEN (after)

```
 Test Files  1 passed (1)
      Tests  4 passed | 58 skipped (62)
```

Full driver file: **62 passed**.

### Mutation check

| mutant | result |
|---|---|
| D — all-infra guard → any-infra-wins | **3 tests fail** ✅ |
| E — per-feature `errorClass` not propagated | **1 test fails** ✅ |
| F — `feature-timeout` added to `INFRA_ERROR_CLASSES` (the forbidden change) | **1 test fails** ✅ |

Mutant F is the load-bearing one: the non-goal is now enforced by a test, not by a comment.

---

## Patch 3 — SKIPPED: there is no canvas-based probe predicate

The brief asked to correct any canvas-based probe predicate for the mcp-apps inline surface, since that surface uses `exportToSvg` and has no `<canvas>` element ever. **No such predicate exists**, so there was nothing to fix and I did not invent a change.

- `grep -rn canvas showcase/harness/src/` → **zero hits**.
- The only mcp-apps probe, `d5-mcp-apps.ts`, asserts on an **iframe** cascade: `[data-testid="mcp-app-iframe"]` then `iframe[sandbox]`. Correct for the real surface.
- No `integrations/*/tests/e2e/mcp-apps.spec.ts` mentions canvas.
- Every remaining `canvas` hit under `showcase/` is unrelated: shell-docs landing copy, `beautiful-todo-canvas`, and the `research-canvas` demo links.

Worth recording for whoever picks up the mcp-apps work: the sibling report measured a healthy render painting at **6–8s**, so a probe giving up before ~10s would see blank on a healthy run. `d5-mcp-apps.ts` allows 15s, which is adequate.

---

## Verification

- **Harness typecheck** — clean. Only remaining error is pre-existing at baseline: `Cannot find module 'axe-core'` (missing from the lockfile, which is why `npm ci` refuses to run in this tree).
- **Harness suite** — 3673 passed, 3 failed. All 3 (`frontend-matrix`, `d5-mapping-drift`, `d5-representatives`) fail identically on unmodified `main` in a separate checkout at the same commit. Two others initially failed on missing generated artifacts (`registry.json`) and one on a timing threshold under load; all pass once the generators run.
- **Dashboard suite** — **1409 passed, 0 failed** (via `npm test`, which runs the registry/probe-docs generators first).
- **oxfmt** — all 9 changed files correctly formatted.
- **oxlint** — 5 warnings, 0 errors; byte-identical to the same 9 files at baseline. Every warning is in pre-existing code.
- **No `as any` / `as unknown as`** anywhere in the diff.

## Not proven

- No change here was exercised against prod or staging — deliberately out of scope, and the deployed prober image (`033b0ae2`) is ahead of this tree's base (`bde2d99a5b`), so the patches are not verified against the running build.
- `e2e-parity.ts` / `d3-readiness.ts` aggregates were not audited for the same missing-`errorClass` gap.
- Whether `system:browser-pool-degraded` (green and eight weeks stale) can be made to trip on PID saturation. Separate, larger work; this PR makes the saturation *readable*, which is the prerequisite.
- Neither patch prevents the outage itself. The cure is reaping the zombies (PID-1 init), owned by a sibling PR. Patch 1 makes the outage visible ~36h earlier; patch 2 stops the roll-up misreporting it as a product failure.
