### PR TITLE
fix(vue,angular): surface failed MCP Apps tool calls in the activity UI

### DIFF
--- a/packages/angular/src/mcp-apps/lib/__tests__/mcp-apps-widget.spec.ts
+++ b/packages/angular/src/mcp-apps/lib/__tests__/mcp-apps-widget.spec.ts
@@ -571,3 +571,153 @@ test("provideMCPApps registers a lower-precedence built-in renderer", () => {
     CopilotMCPAppsActivityRenderer,
   ]);
 });
+
+// A tool call whose MCP result carries `isError: true` used to be forwarded to
+// the app and otherwise ignored host-side: the widget rendered an empty frame
+// while the chat chip still read "Done". Captured verbatim off prod:
+// mcp.excalidraw.com rejecting a malformed `elements` argument.
+const TOOL_ERROR_SELECTOR = "[data-testid='copilot-mcp-apps-tool-error']";
+const RECORDED_ERROR_TEXT =
+  "Invalid JSON in elements: Unexpected non-whitespace character after JSON " +
+  "at position 540 (line 1 column 541). Ensure no comments, no trailing " +
+  "commas, and proper quoting.";
+
+async function bootWidgetWithResult(
+  result: MCPAppsSnapshotContent["result"],
+): Promise<{
+  fixture: ReturnType<typeof TestBed.createComponent<CopilotMCPAppsWidget>>;
+  frame: HTMLIFrameElement;
+  postMessage: ReturnType<typeof vi.spyOn>;
+}> {
+  const fixture = TestBed.createComponent(CopilotMCPAppsWidget);
+  fixture.componentRef.setInput("data", { ...snapshot, result });
+  fixture.componentRef.setInput("agent", createAgent());
+  await settle(fixture);
+
+  const frame = fixture.nativeElement.querySelector<HTMLIFrameElement>(
+    "[data-testid='mcp-app-iframe']",
+  );
+  if (!frame?.contentWindow) throw new Error("MCP Apps iframe was not created");
+  await waitFor(
+    () => frame.srcdoc.includes("sandbox-proxy-ready"),
+    "sandbox proxy was not installed",
+  );
+
+  const postMessage = vi.spyOn(frame.contentWindow, "postMessage");
+  dispatchFrameMessage(frame, {
+    jsonrpc: "2.0",
+    method: "ui/notifications/sandbox-proxy-ready",
+    params: {},
+  });
+  await settle(fixture);
+  dispatchFrameMessage(frame, {
+    jsonrpc: "2.0",
+    method: "ui/notifications/initialized",
+    params: {},
+  });
+  await settle(fixture);
+
+  return { fixture, frame, postMessage };
+}
+
+test("shows the failure message when the tool result has isError: true", async () => {
+  configureTestingModule();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const { fixture } = await bootWidgetWithResult({
+    content: [{ type: "text", text: RECORDED_ERROR_TEXT }],
+    isError: true,
+  });
+
+  const notice =
+    fixture.nativeElement.querySelector<HTMLElement>(TOOL_ERROR_SELECTOR);
+  expect(notice).not.toBeNull();
+  expect(notice!.getAttribute("role")).toBe("alert");
+  expect(notice!.textContent).toContain(RECORDED_ERROR_TEXT);
+  expect(consoleError).toHaveBeenCalledWith(
+    "[CopilotKit MCP App] Tool call failed:",
+    RECORDED_ERROR_TEXT,
+  );
+
+  consoleError.mockRestore();
+});
+
+test("falls back to a generic message when the failed result carries no text", async () => {
+  configureTestingModule();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const { fixture } = await bootWidgetWithResult({
+    content: [],
+    isError: true,
+  });
+
+  expect(
+    fixture.nativeElement.querySelector<HTMLElement>(TOOL_ERROR_SELECTOR)!
+      .textContent,
+  ).toContain("returned no message");
+
+  consoleError.mockRestore();
+});
+
+test("joins only the text blocks of a mixed-content failure", async () => {
+  configureTestingModule();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const { fixture } = await bootWidgetWithResult({
+    content: [
+      { type: "text", text: "first line" },
+      { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+      { type: "text", text: "second line" },
+    ],
+    isError: true,
+  });
+
+  expect(
+    fixture.nativeElement
+      .querySelector<HTMLElement>(TOOL_ERROR_SELECTOR)!
+      .textContent!.replace(/\s+/g, " ")
+      .trim(),
+  ).toBe("Tool call failed: first line second line");
+
+  consoleError.mockRestore();
+});
+
+test("still forwards a failed tool result to the app", async () => {
+  configureTestingModule();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  const failedResult: MCPAppsSnapshotContent["result"] = {
+    content: [{ type: "text", text: RECORDED_ERROR_TEXT }],
+    isError: true,
+  };
+
+  const { postMessage } = await bootWidgetWithResult(failedResult);
+
+  expect(postMessage).toHaveBeenCalledWith(
+    {
+      jsonrpc: "2.0",
+      method: "ui/notifications/tool-result",
+      params: failedResult,
+    },
+    "*",
+  );
+
+  consoleError.mockRestore();
+});
+
+test("shows nothing for a successful tool result", async () => {
+  configureTestingModule();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const { fixture, frame } = await bootWidgetWithResult({
+    content: [{ type: "text", text: "Diagram displayed!" }],
+    structuredContent: { checkpointId: "71a8a6d624df4e5281" },
+    isError: false,
+  });
+
+  // The app frame must still be booted — the happy path is untouched.
+  expect(frame.srcdoc).toContain("Content-Security-Policy");
+  expect(fixture.nativeElement.querySelector(TOOL_ERROR_SELECTOR)).toBeNull();
+  expect(consoleError).not.toHaveBeenCalled();
+
+  consoleError.mockRestore();
+});

--- a/packages/angular/src/mcp-apps/lib/mcp-apps-widget.ts
+++ b/packages/angular/src/mcp-apps/lib/mcp-apps-widget.ts
@@ -7,6 +7,7 @@ import {
   PLATFORM_ID,
   afterRenderEffect,
   computed,
+  effect,
   inject,
   input,
   signal,
@@ -64,6 +65,15 @@ interface JSONRPCMessage {
       @if (error()) {
         <p class="copilot-mcp-apps-error" role="alert">{{ error() }}</p>
       }
+      @if (toolFailureMessage(); as toolFailure) {
+        <p
+          class="copilot-mcp-apps-tool-error"
+          data-testid="copilot-mcp-apps-tool-error"
+          role="alert"
+        >
+          Tool call failed: {{ toolFailure }}
+        </p>
+      }
       <iframe
         #appFrame
         class="copilot-mcp-apps-frame"
@@ -101,6 +111,18 @@ interface JSONRPCMessage {
     .copilot-mcp-apps-error {
       color: #991b1b;
     }
+
+    .copilot-mcp-apps-tool-error {
+      margin: 0 0 8px;
+      padding: 12px 16px;
+      border: 1px solid #fecaca;
+      border-radius: 8px;
+      background: #fef2f2;
+      color: #b91c1c;
+      font-size: 13px;
+      line-height: 1.45;
+      white-space: pre-wrap;
+    }
   `,
 })
 export class CopilotMCPAppsWidget {
@@ -128,7 +150,36 @@ export class CopilotMCPAppsWidget {
   protected readonly loading = signal(true);
   protected readonly error = signal("");
 
+  /**
+   * The tool call that produced this snapshot can itself have failed
+   * (`isError: true` from the MCP server, e.g. rejected arguments). The result is
+   * still forwarded to the app, but an app that has no data to draw typically
+   * renders nothing for it — leaving an empty frame that reads as success.
+   * Surface the failure host-side so it is visible.
+   *
+   * Deliberately separate from `error()`: that one reports a host-side failure to
+   * load the app at all and tears the frame down, whereas a failed tool call
+   * still gets a live app.
+   */
+  protected readonly toolFailureMessage = computed(() => {
+    const result = this.data().result;
+    if (!result || result.isError !== true) return "";
+    return (
+      mcpToolResultText(result) ||
+      "The tool call reported an error but returned no message."
+    );
+  });
+
   constructor() {
+    // Logged from its own effect so a failure is reported even if the app frame
+    // never becomes ready.
+    effect(() => {
+      const message = this.toolFailureMessage();
+      if (message) {
+        console.error("[CopilotKit MCP App] Tool call failed:", message);
+      }
+    });
+
     afterRenderEffect((onCleanup) => {
       const frame = this.appFrame().nativeElement;
       const { data, agent } = this.renderSession();
@@ -559,6 +610,22 @@ function isTextContent(
   return (
     isRecord(value) && value.type === "text" && typeof value.text === "string"
   );
+}
+
+/**
+ * Join the human-readable text of an MCP tool result.
+ *
+ * `result.content` is a heterogeneous MCP content-block list (text, image,
+ * audio, resource, …) so each block is narrowed before its `text` is read;
+ * anything that is not a text block is skipped.
+ */
+function mcpToolResultText(result: MCPAppsSnapshotContent["result"]): string {
+  if (!Array.isArray(result.content)) return "";
+  return result.content
+    .filter(isTextContent)
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
 }
 
 function safeExternalURL(value: unknown): string | undefined {

--- a/packages/vue/src/v2/components/MCPAppsActivityRenderer.ts
+++ b/packages/vue/src/v2/components/MCPAppsActivityRenderer.ts
@@ -232,6 +232,35 @@ function isNotification(
   return !("id" in message) && "method" in message;
 }
 
+function isTextContentBlock(
+  block: unknown,
+): block is { type: "text"; text: string } {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
+}
+
+/**
+ * Join the human-readable text of an MCP tool result.
+ *
+ * `result.content` is a heterogeneous MCP content-block list (text, image,
+ * resource, …) so each block is narrowed before its `text` is read; anything
+ * that is not a text block is skipped.
+ */
+export function ɵmcpToolResultText(
+  result: MCPAppsActivityContent["result"],
+): string {
+  if (!Array.isArray(result.content)) return "";
+  return result.content
+    .filter(isTextContentBlock)
+    .map((block) => block.text)
+    .join("\n")
+    .trim();
+}
+
 export const MCPAppsActivityRenderer = defineComponent({
   name: "MCPAppsActivityRenderer",
   props: {
@@ -721,6 +750,31 @@ export const MCPAppsActivityRenderer = defineComponent({
       { deep: true },
     );
 
+    // The tool call that produced this activity can itself have failed
+    // (`isError: true` from the MCP server, e.g. rejected arguments). The result
+    // is still forwarded to the app above, but an app that has no data to draw
+    // typically renders nothing for it — leaving an empty box that reads as
+    // success. Surface the failure host-side so it is visible.
+    const toolFailed = computed(() => props.content.result.isError === true);
+    const toolFailureMessage = computed(() =>
+      toolFailed.value
+        ? ɵmcpToolResultText(props.content.result) ||
+          "The tool call reported an error but returned no message."
+        : null,
+    );
+
+    // Logged from its own watcher so a failure is reported even if the app
+    // iframe never becomes ready.
+    watch(
+      toolFailureMessage,
+      (message) => {
+        if (message) {
+          console.error("[MCPAppsRenderer] Tool call failed:", message);
+        }
+      },
+      { immediate: true },
+    );
+
     const borderStyle = computed(() => {
       const prefersBorder = fetchedResource.value?._meta?.ui?.prefersBorder;
       if (prefersBorder !== true) return {};
@@ -743,8 +797,10 @@ export const MCPAppsActivityRenderer = defineComponent({
           ref: containerRef,
           style: {
             width: "100%",
+            // A failure notice is stacked above the app iframe, so the container
+            // must grow to fit both instead of being pinned to the app's height.
             height:
-              iframeSize.value.height !== undefined
+              iframeSize.value.height !== undefined && !toolFailed.value
                 ? `${iframeSize.value.height}px`
                 : "auto",
             minHeight: "100px",
@@ -766,6 +822,27 @@ export const MCPAppsActivityRenderer = defineComponent({
                 "div",
                 { style: { color: "red", padding: "1rem" } },
                 `Error: ${error.value.message}`,
+              )
+            : null,
+          toolFailureMessage.value
+            ? h(
+                "div",
+                {
+                  "data-testid": "copilot-mcp-apps-tool-error",
+                  role: "alert",
+                  style: {
+                    color: "#b91c1c",
+                    backgroundColor: "#fef2f2",
+                    border: "1px solid #fecaca",
+                    borderRadius: "8px",
+                    padding: "0.75rem 1rem",
+                    marginBottom: "0.5rem",
+                    fontSize: "13px",
+                    lineHeight: 1.45,
+                    whiteSpace: "pre-wrap",
+                  },
+                },
+                `Tool call failed: ${toolFailureMessage.value}`,
               )
             : null,
         ],

--- a/packages/vue/src/v2/components/__tests__/MCPAppsActivityRenderer.test.ts
+++ b/packages/vue/src/v2/components/__tests__/MCPAppsActivityRenderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { nextTick } from "vue";
 import { mount } from "@vue/test-utils";
 import type { AbstractAgent } from "@ag-ui/client";
@@ -6,6 +6,7 @@ import {
   MCPAppsActivityContentSchema,
   MCPAppsActivityRenderer,
   MCPAppsActivityType,
+  ɵmcpToolResultText,
 } from "../MCPAppsActivityRenderer";
 
 const runCopilotAgent = vi.fn();
@@ -233,5 +234,120 @@ describe("MCPAppsActivityRenderer", () => {
       "frame-src * blob: data: http://localhost:* https://localhost:*;",
     );
     expect(iframe.srcdoc).not.toContain("widgets.example.com");
+  });
+
+  // A tool call whose MCP result carries `isError: true` used to be forwarded to
+  // the app and otherwise ignored host-side: the activity rendered an empty box
+  // while the chat chip still read "Done". Captured verbatim off prod:
+  // mcp.excalidraw.com rejecting a malformed `elements` argument.
+  describe("Tool Failure Surfacing", () => {
+    const TOOL_ERROR_TESTID = '[data-testid="copilot-mcp-apps-tool-error"]';
+    const RECORDED_ERROR_TEXT =
+      "Invalid JSON in elements: Unexpected non-whitespace character after JSON " +
+      "at position 540 (line 1 column 541). Ensure no comments, no trailing " +
+      "commas, and proper quoting.";
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    async function mountWithResult(result: {
+      content?: unknown[];
+      structuredContent?: unknown;
+      isError?: boolean;
+    }) {
+      const agent = createAgentMock({
+        runResult: {
+          result: {
+            contents: [
+              { uri: "ui://excalidraw/view", text: "<div>excalidraw</div>" },
+            ],
+          },
+        },
+        threadId: `tool-failure-${Math.random()}`,
+      });
+
+      const wrapper = mount(MCPAppsActivityRenderer, {
+        props: {
+          activityType: MCPAppsActivityType,
+          content: {
+            resourceUri: "ui://excalidraw/view",
+            serverHash: "excalidraw-hash",
+            result,
+          },
+          message: {
+            id: "activity-tool-failure",
+            role: "assistant",
+            content: "",
+            activityType: MCPAppsActivityType,
+          },
+          agent,
+        },
+      });
+
+      await flushAsync();
+      await flushAsync();
+      return wrapper;
+    }
+
+    it("shows the failure message when the tool result has isError: true", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const wrapper = await mountWithResult({
+        content: [{ type: "text", text: RECORDED_ERROR_TEXT }],
+        isError: true,
+      });
+
+      const notice = wrapper.find(TOOL_ERROR_TESTID);
+      expect(notice.exists()).toBe(true);
+      expect(notice.attributes("role")).toBe("alert");
+      expect(notice.text()).toContain(RECORDED_ERROR_TEXT);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[MCPAppsRenderer] Tool call failed:",
+        RECORDED_ERROR_TEXT,
+      );
+    });
+
+    it("falls back to a generic message when the failed result carries no text", async () => {
+      const wrapper = await mountWithResult({ content: [], isError: true });
+
+      expect(wrapper.find(TOOL_ERROR_TESTID).text()).toContain(
+        "returned no message",
+      );
+    });
+
+    it("shows nothing for a successful tool result", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const wrapper = await mountWithResult({
+        content: [{ type: "text", text: "Diagram displayed!" }],
+        structuredContent: { checkpointId: "71a8a6d624df4e5281" },
+        isError: false,
+      });
+
+      // The app iframe must still be created — the happy path is untouched.
+      expect(wrapper.find("iframe").exists()).toBe(true);
+      expect(wrapper.find(TOOL_ERROR_TESTID).exists()).toBe(false);
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    it("joins only the text blocks of a mixed-content failure", () => {
+      expect(
+        ɵmcpToolResultText({
+          content: [
+            { type: "text", text: "first line" },
+            { type: "image", data: "…", mimeType: "image/png" },
+            { type: "text", text: "second line" },
+          ],
+          isError: true,
+        }),
+      ).toBe("first line\nsecond line");
+
+      expect(ɵmcpToolResultText({ isError: true })).toBe("");
+    });
   });
 });


### PR DESCRIPTION
Vue + Angular parity for #6337.

## The defect

When an MCP Apps tool call returns `isError: true`, the UI showed **no error at all**: the result was forwarded to the sandboxed app and otherwise ignored host-side, so an app with no data to draw painted nothing — an empty ~780×585 white box, byte-identical to success, with **zero console errors**. On prod that is ~22% of `create_view` calls (`mcp.excalidraw.com` rejecting the model's malformed `elements` JSON).

#6337 fixed this for React only and flagged Vue and Angular as still broken. This is those two.

Angular already had an `error()` signal rendered as `role="alert"`, but it is only driven by host-side load/queue failures and it **tears the app frame down** — it never saw the tool result.

## The change

Same shape as #6337 in both frameworks, each in its own idiom:

| | Vue | Angular |
|---|---|---|
| text join | `ɵmcpToolResultText` + `isTextContentBlock` predicate (no `as any`) | `mcpToolResultText` reusing the file's existing `isTextContent` guard |
| derived state | `computed` `toolFailed` / `toolFailureMessage` | `computed` `toolFailureMessage` |
| notice | `role="alert"` div above the frame, `data-testid="copilot-mcp-apps-tool-error"`, inline-styled like the rest of the file | `@if` block rendering `<p role="alert" data-testid="…">`, styled in the component's `styles:` |
| logging | `console.error("[MCPAppsRenderer] Tool call failed:", …)` from its own `watch(…, { immediate: true })` | `console.error("[CopilotKit MCP App] Tool call failed:", …)` from its own `effect()` — the tag this file already uses |
| height | container `auto` instead of pinned to the app height while a notice is stacked, so the existing `overflow: hidden` cannot clip it | not needed, and **verified** rather than assumed: this container's height is already auto (the height goes on the *frame*), so it grows; `bannerClipped: false` below |

Logging lives in its own effect in both so a failure is reported even if the app frame never becomes ready.

**Deliberately unchanged:** the result is still forwarded to the app. Apps are entitled to render their own error state and follow-up flows depend on it — the Angular suite now pins that with an explicit test.

## Red-green proof (real browser, real components)

Per-framework Playwright harnesses (headless Chromium, bounded per-op timeouts, 150s wall cap + SIGKILL watchdog, bounded 30s first-paint poll). **Vue** mounts the real `MCPAppsActivityRenderer` inside the real `CopilotKitProvider` from `src/`. **Angular** drives the real *ng-packagr-built* `CopilotMCPAppsWidget` — the shipped `dist/fesm2022/copilotkit-angular-mcp-apps.mjs` — via `createComponent` + `setInput` under `provideZonelessChangeDetection()`, so the package is rebuilt between RED and GREEN and the proof is against the artifact, not just source.

Fixtures are the recorded prod payloads (transcribed from #6337's notes), plus #6337's reconstructed malformed `elements` reused byte-for-byte — local `JSON.parse` on it prints `Unexpected non-whitespace character after JSON at position 540 (line 1 column 541)`, re-verified here. Only the agent transport (`resources/read`) is stubbed, so runs are deterministic instead of sampling the ~22% failure rate.

<details>
<summary><b>RED — Vue and Angular, byte-identical (before any change)</b></summary>

```json
=== ERROR ===
{
  "errorBannerPresent": false,
  "errorBannerText": null,
  "allRoleAlertText": [],
  "iframeRect": { "w": 780, "h": 585 },
  "containerRect": { "w": 780, "h": 585 },
  "containerOverflow": "hidden",
  "bodyText": ""
}
svg: { "present": false }
consoleErrors: []
=== SUCCESS ===
{
  "errorBannerPresent": false,
  "allRoleAlertText": [],
  "iframeRect": { "w": 780, "h": 585 }
}
svg: { "present": true, "w": 780, "h": 585, "viewBox": "0 0 600 450" }
consoleErrors: []
```

A blank 585px box in both frameworks: no `role="alert"` anywhere, no visible text at all, zero console errors.
</details>

<details>
<summary><b>GREEN — Vue</b></summary>

```json
=== ERROR ===
{
  "errorBannerPresent": true,
  "errorBannerText": "Tool call failed: Invalid JSON in elements: Unexpected non-whitespace character after JSON at position 540 (line 1 column 541). Ensure no comments, no trailing commas, and proper quoting.",
  "allRoleAlertText": ["Tool call failed: Invalid JSON in elements: …"],
  "iframeRect": { "w": 780, "h": 585 },
  "containerRect": { "w": 780, "h": 657 },
  "containerOverflow": "hidden",
  "bannerClipped": false
}
svg: { "present": false }
consoleErrors: ["error: [MCPAppsRenderer] Tool call failed: Invalid JSON in elements: …"]
=== SUCCESS ===
{ "errorBannerPresent": false, "allRoleAlertText": [], "iframeRect": { "w": 780, "h": 585 } }
svg: { "present": true, "w": 780, "h": 585, "viewBox": "0 0 600 450" }
consoleErrors: []
```
</details>

<details>
<summary><b>GREEN — Angular</b></summary>

```json
=== ERROR ===
{
  "errorBannerPresent": true,
  "errorBannerText": "Tool call failed: Invalid JSON in elements: Unexpected non-whitespace character after JSON at position 540 (line 1 column 541). Ensure no comments, no trailing commas, and proper quoting.",
  "iframeRect": { "w": 780, "h": 585 },
  "containerRect": { "w": 780, "h": 657 },
  "containerOverflow": "hidden",
  "bannerClipped": false
}
svg: { "present": false }
consoleErrors: ["error: [CopilotKit MCP App] Tool call failed: Invalid JSON in elements: …"]
=== SUCCESS ===
{ "errorBannerPresent": false, "allRoleAlertText": [], "iframeRect": { "w": 780, "h": 585 } }
svg: { "present": true, "w": 780, "h": 585, "viewBox": "0 0 600 450" }
consoleErrors: []
```
</details>

**Happy path unregressed, both frameworks:** the app frame is still 780×585, the widget's `.svg-wrapper > svg` is still present at 780×585 with the same viewBox, no notice, no console error, and the success screenshot still renders the three-box flowchart. The container only grows (585 → 657) in the failing case, where the notice is stacked. Screenshots were inspected visually, not just measured.

## Tests + mutation check

Vue: 4 cases in `MCPAppsActivityRenderer.test.ts` (`Tool Failure Surfacing`) — 9/9 pass in that file. Angular: 5 cases in `mcp-apps-widget.spec.ts`, including one that pins the failed result *still being forwarded* to the app — 18/18 pass in that file.

Guarding the notice with `false &&` in each framework flips exactly the notice-rendering assertions, so they are not vacuous:

```
VUE      × shows the failure message when the tool result has isError: true
         × falls back to a generic message when the failed result carries no text
         ✓ shows nothing for a successful tool result
         ✓ joins only the text blocks of a mixed-content failure
         (2 failed | 7 passed)

ANGULAR  × shows the failure message when the tool result has isError: true
         × falls back to a generic message when the failed result carries no text
         × joins only the text blocks of a mixed-content failure
         ✓ still forwards a failed tool result to the app
         ✓ shows nothing for a successful tool result
         (3 failed | 15 passed — all 13 pre-existing tests still green)
```

## Local checks (hooks enabled, from the worktree)

- pre-commit on both commits: `check-binaries`, `lint-fix`, `test-and-check-packages` pass; `commit-msg` commitlint passes.
- `oxlint` on the 4 changed files: **0 warnings, 0 errors**. `oxfmt --check`: **clean**.
- `nx run-many -t test,check-types,build,publint,attw --projects=@copilotkit/vue,@copilotkit/angular --skip-nx-cache`: **exit 0**, `Successfully ran targets test, check-types, build, publint, attw for 2 projects and 10 tasks they depend on`. Angular 45/45 files, 294/294 tests. Vue 100/100 files, 1077/1077 tests. publint and attw clean for both.

Nothing failed, so no pristine-baseline comparison was needed.

## Out of scope

- **The chip still reads `Done` on a failed call** — `DefaultToolCallRenderer`, a separate design question being handled elsewhere.
- **`packages/react-core` untouched** (#6337's territory).
- **A shared helper is worth extracting but was not done here.** react-core, vue and angular now hold three copies of the same 10-line text-block join. `@copilotkit/shared` is already a dependency of all three, so `packages/shared/src/mcp/tool-result-text.ts` would collapse them — proposed as a follow-up rather than done mid-flight, since it would touch react-core and widen a shared package's API.
- The upstream malformed-JSON rejection, retry logic, and the `2025-11-21`/`2025-06-18` protocol-version mismatch.
- The real 432 KB Excalidraw widget resource is not preserved in the sibling proof bundle and was not re-harvested (no external service touched). The harnesses use a faithful stand-in that implements the same app-side protocol and, like the real app, paints from the tool *input* so malformed `elements` silently draws nothing. Its viewBox is `0 0 600 450` where the real app's is `-200 -60 600 450`; the load-bearing property is that the SVG is present at the same 780×585 rect before and after.
- Nothing deployed; prod and staging untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KX8HzrWkdbKx5YYn8sHWy
