### PR TITLE
Support Slack data visualization blocks

### DIFF
--- a/packages/channels-intelligence/src/delivery-provider-elements.test.ts
+++ b/packages/channels-intelligence/src/delivery-provider-elements.test.ts
@@ -125,6 +125,48 @@ test("managed Slack delivery serializes native JSX with fallback text", async ()
   });
 });
 
+test("managed Slack delivery preserves a data visualization chart", async () => {
+  const effect = vi.fn().mockResolvedValue({
+    providerReference: "pref_v1_slack_data_visualization_123",
+    providerMessageId: "pid_v1_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+  });
+  const chart = {
+    type: "line" as const,
+    series: [
+      {
+        name: "Temperature",
+        data: [
+          { label: "Mon", value: 62 },
+          { label: "Tue", value: 65 },
+        ],
+      },
+    ],
+    axis_config: {
+      categories: ["Mon", "Tue"],
+      y_label: "Temperature (F)",
+    },
+  };
+
+  await makeAdapter().post(target("slack", effect), [
+    Slack.Block.DataVisualization({
+      title: "San Francisco forecast",
+      chart,
+    }),
+  ]);
+
+  expect(effect).toHaveBeenCalledWith(expect.any(String), {
+    kind: "slack.message.create",
+    text: "San Francisco forecast",
+    blocks: [
+      {
+        type: "data_visualization",
+        title: "San Francisco forecast",
+        chart,
+      },
+    ],
+  });
+});
+
 test("managed Teams delivery serializes the native Adaptive Card root", async () => {
   const effect = vi.fn().mockResolvedValue({
     providerReference: "pref_v1_teams_native_jsx_123",

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -178,6 +178,60 @@ The generated [native catalog](../channels/native-catalogs.md) lists the 20
 message blocks and all exported elements and objects. Run
 `pnpm audit:channel-native-catalogs` to compare it with Slack's live docs.
 
+#### Data visualization blocks
+
+`Slack.Block.DataVisualization` implements Slack's full pie, bar, area, and
+line chart contract. The SDK checks the provider limits and cross-field rules
+before sending the message, including matching every series point to the
+ordered axis categories and allowing at most two charts per message.
+
+```tsx
+import { createChannel, defineChannelComponent } from "@copilotkit/channels";
+import { Slack } from "@copilotkit/channels-slack";
+import { z } from "zod";
+
+const WeatherCard = defineChannelComponent({
+  name: "show_weather",
+  description: "Show a three-day weather forecast.",
+  parameters: z.object({
+    city: z.string(),
+    monday: z.number(),
+    tuesday: z.number(),
+    wednesday: z.number(),
+  }),
+  render: ({ city, monday, tuesday, wednesday }) => (
+    <Slack.Block.DataVisualization
+      title={`${city} forecast`}
+      chart={{
+        type: "line",
+        series: [
+          {
+            name: "Temperature",
+            data: [
+              { label: "Mon", value: monday },
+              { label: "Tue", value: tuesday },
+              { label: "Wed", value: wednesday },
+            ],
+          },
+        ],
+        axis_config: {
+          categories: ["Mon", "Tue", "Wed"],
+          y_label: "Temperature (F)",
+        },
+      }}
+    />
+  ),
+});
+
+const bot = createChannel({
+  // ...existing options
+  components: [WeatherCard],
+});
+```
+
+See Slack's [data visualization block reference](https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block/)
+for the provider field definitions and limits.
+
 ### Per-element budget
 
 Slack caps every element. The renderer degrades by truncate-with-overflow /

--- a/packages/channels-slack/src/data-visualization.ts
+++ b/packages/channels-slack/src/data-visualization.ts
@@ -1,0 +1,145 @@
+/** Validate Slack's documented `data_visualization` block contract. */
+export function validateSlackDataVisualization(
+  value: Record<string, unknown>,
+  path: string,
+): void {
+  const blockPath = `${path}.DataVisualization`;
+  assertString(value.title, `${blockPath}.title`, 50);
+
+  const chart = assertRecord(value.chart, `${blockPath}.chart`);
+  switch (chart.type) {
+    case "pie":
+      validatePieChart(chart, `${blockPath}.chart`);
+      return;
+    case "bar":
+    case "area":
+    case "line":
+      validateSeriesChart(chart, `${blockPath}.chart`);
+      return;
+    default:
+      throw new Error(
+        `${blockPath}.chart.type must be pie, bar, area, or line.`,
+      );
+  }
+}
+
+function validatePieChart(chart: Record<string, unknown>, path: string): void {
+  const segments = assertArray(chart.segments, `${path}.segments`, 1, 12);
+  for (const [index, value] of segments.entries()) {
+    const segmentPath = `${path}.segments[${index}]`;
+    const segment = assertRecord(value, segmentPath);
+    assertString(segment.label, `${segmentPath}.label`, 20);
+    const number = assertFiniteNumber(segment.value, `${segmentPath}.value`);
+    if (number <= 0) {
+      throw new Error(`${segmentPath}.value must be greater than 0.`);
+    }
+  }
+}
+
+function validateSeriesChart(
+  chart: Record<string, unknown>,
+  path: string,
+): void {
+  const series = assertArray(chart.series, `${path}.series`, 1, 12);
+  const names: string[] = [];
+  const dataBySeries: readonly {
+    readonly path: string;
+    readonly points: readonly Record<string, unknown>[];
+  }[] = series.map((value, index) => {
+    const seriesPath = `${path}.series[${index}]`;
+    const current = assertRecord(value, seriesPath);
+    names.push(assertString(current.name, `${seriesPath}.name`, 20));
+    const data = assertArray(current.data, `${seriesPath}.data`, 1, 20);
+    return {
+      path: seriesPath,
+      points: data.map((point, pointIndex) => {
+        const pointPath = `${seriesPath}.data[${pointIndex}]`;
+        const currentPoint = assertRecord(point, pointPath);
+        assertString(currentPoint.label, `${pointPath}.label`, 20);
+        assertFiniteNumber(currentPoint.value, `${pointPath}.value`);
+        return currentPoint;
+      }),
+    };
+  });
+
+  if (new Set(names).size !== names.length) {
+    throw new Error(`${path}.series names must be unique.`);
+  }
+
+  const axis = assertRecord(chart.axis_config, `${path}.axis_config`);
+  const categoryValues = assertArray(
+    axis.categories,
+    `${path}.axis_config.categories`,
+    1,
+    20,
+  );
+  const categories = categoryValues.map((category, index) =>
+    assertString(category, `${path}.axis_config.categories[${index}]`, 20),
+  );
+  if (new Set(categories).size !== categories.length) {
+    throw new Error(`${path}.axis_config.categories must be unique.`);
+  }
+  if (axis.x_label !== undefined) {
+    assertString(axis.x_label, `${path}.axis_config.x_label`, 50);
+  }
+  if (axis.y_label !== undefined) {
+    assertString(axis.y_label, `${path}.axis_config.y_label`, 50);
+  }
+
+  for (const current of dataBySeries) {
+    const labels = current.points.map((point) => String(point.label));
+    if (
+      labels.length !== categories.length ||
+      new Set(labels).size !== labels.length ||
+      labels.some((label) => !categories.includes(label))
+    ) {
+      throw new Error(
+        `${current.path}.data labels must match axis_config.categories exactly.`,
+      );
+    }
+  }
+}
+
+function assertRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object.`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertArray(
+  value: unknown,
+  path: string,
+  minimum: number,
+  maximum: number,
+): readonly unknown[] {
+  if (
+    !Array.isArray(value) ||
+    value.length < minimum ||
+    value.length > maximum
+  ) {
+    throw new Error(`${path} must contain ${minimum} to ${maximum} items.`);
+  }
+  return value;
+}
+
+function assertString(value: unknown, path: string, maximum: number): string {
+  if (typeof value !== "string") {
+    throw new Error(`${path} must be a string.`);
+  }
+  if (value.length > maximum) {
+    throw new Error(`${path} must be at most ${maximum} characters.`);
+  }
+  return value;
+}
+
+function assertFiniteNumber(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${path} must be a finite number.`);
+  }
+  return value;
+}

--- a/packages/channels-slack/src/index.ts
+++ b/packages/channels-slack/src/index.ts
@@ -96,7 +96,18 @@ export {
 export { renderSlackModal } from "./render/modal.js";
 export { SLACK_LIMITS } from "./render/budget.js";
 export { Slack } from "./native.js";
-export type { SlackNativeProps, SlackRawProps } from "./native.js";
+export type {
+  SlackDataVisualizationAxisConfig,
+  SlackDataVisualizationChart,
+  SlackDataVisualizationDataPoint,
+  SlackDataVisualizationPieChart,
+  SlackDataVisualizationProps,
+  SlackDataVisualizationSegment,
+  SlackDataVisualizationSeries,
+  SlackDataVisualizationSeriesChart,
+  SlackNativeProps,
+  SlackRawProps,
+} from "./native.js";
 export {
   SLACK_NATIVE_MANIFEST,
   SLACK_BLOCK_MANIFEST,

--- a/packages/channels-slack/src/native-catalog.test.ts
+++ b/packages/channels-slack/src/native-catalog.test.ts
@@ -38,6 +38,15 @@ test("every Slack catalog entry serializes its fixed discriminator", () => {
 function requiredProps(type: string): Record<string, unknown> {
   if (type === "actions" || type === "context") return { elements: [] };
   if (type === "button" || type === "header") return { text: "text" };
+  if (type === "data_visualization") {
+    return {
+      title: "Weather",
+      chart: {
+        type: "pie",
+        segments: [{ label: "Sunny", value: 1 }],
+      },
+    };
+  }
   if (type === "image")
     return { image_url: "https://example.com/image.png", alt_text: "image" };
   if (type === "input") return { label: "label", element: {} };

--- a/packages/channels-slack/src/native-codec.ts
+++ b/packages/channels-slack/src/native-codec.ts
@@ -1,5 +1,6 @@
 import { isNativeNode } from "@copilotkit/channels-ui";
 import type { ChannelNode, NativeChannelNode } from "@copilotkit/channels-ui";
+import { validateSlackDataVisualization } from "./data-visualization.js";
 import { SLACK_NATIVE_MANIFEST } from "./native-manifest.js";
 
 const manifest = new Map(
@@ -10,6 +11,7 @@ const REQUIRED_FIELDS: Readonly<Record<string, readonly string[]>> = {
   actions: ["elements"],
   button: ["text"],
   context: ["elements"],
+  data_visualization: ["title", "chart"],
   header: ["text"],
   image: ["image_url", "alt_text"],
   input: ["label", "element"],
@@ -74,6 +76,9 @@ export function serializeSlackNativeNode(
     output.value = JSON.stringify(output.value);
   }
   validateRequiredFields(entry.component, entry.type, output, path);
+  if (entry.type === "data_visualization") {
+    validateSlackDataVisualization(output, path);
+  }
   return output;
 }
 

--- a/packages/channels-slack/src/native-data-visualization-validation.test.ts
+++ b/packages/channels-slack/src/native-data-visualization-validation.test.ts
@@ -1,0 +1,473 @@
+import { expect, test } from "vitest";
+import { createNativeNode } from "@copilotkit/channels-ui";
+import { serializeSlackNativeNode } from "./native-codec.js";
+
+const validationCases: readonly {
+  readonly name: string;
+  readonly props: () => Record<string, unknown>;
+  readonly error: RegExp;
+}[] = [
+  {
+    name: "rejects a non-string title",
+    props: () => ({ ...pieProps(), title: 72 }),
+    error: /DataVisualization\.title must be a string/u,
+  },
+  {
+    name: "rejects a title longer than 50 characters",
+    props: () => ({ ...pieProps(), title: "x".repeat(51) }),
+    error: /DataVisualization\.title must be at most 50 characters/u,
+  },
+  {
+    name: "rejects a non-object chart",
+    props: () => ({ title: "Weather", chart: [] }),
+    error: /DataVisualization\.chart must be an object/u,
+  },
+  {
+    name: "rejects an unsupported chart type",
+    props: () => ({ title: "Weather", chart: { type: "scatter" } }),
+    error: /DataVisualization\.chart\.type must be pie, bar, area, or line/u,
+  },
+  {
+    name: "rejects an empty pie segment list",
+    props: () => ({ title: "Weather", chart: { type: "pie", segments: [] } }),
+    error: /chart\.segments must contain 1 to 12 items/u,
+  },
+  {
+    name: "rejects more than 12 pie segments",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "pie",
+        segments: Array.from({ length: 13 }, (_, index) => ({
+          label: `Day ${index}`,
+          value: index + 1,
+        })),
+      },
+    }),
+    error: /chart\.segments must contain 1 to 12 items/u,
+  },
+  {
+    name: "rejects a non-object pie segment",
+    props: () => ({
+      title: "Weather",
+      chart: { type: "pie", segments: ["Sunny"] },
+    }),
+    error: /segments\[0\] must be an object/u,
+  },
+  {
+    name: "rejects a non-string pie segment label",
+    props: () => ({
+      title: "Weather",
+      chart: { type: "pie", segments: [{ label: 1, value: 1 }] },
+    }),
+    error: /segments\[0\]\.label must be a string/u,
+  },
+  {
+    name: "rejects a pie segment label longer than 20 characters",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "pie",
+        segments: [{ label: "x".repeat(21), value: 1 }],
+      },
+    }),
+    error: /segments\[0\]\.label must be at most 20 characters/u,
+  },
+  {
+    name: "rejects a non-numeric pie segment value",
+    props: () => ({
+      title: "Weather",
+      chart: { type: "pie", segments: [{ label: "Sunny", value: "five" }] },
+    }),
+    error: /segments\[0\]\.value must be a finite number/u,
+  },
+  {
+    name: "rejects a non-finite pie segment value",
+    props: () => ({
+      title: "Weather",
+      chart: { type: "pie", segments: [{ label: "Sunny", value: NaN }] },
+    }),
+    error: /segments\[0\]\.value must be a finite number/u,
+  },
+  {
+    name: "rejects a non-positive pie segment value",
+    props: () => ({
+      title: "Weather",
+      chart: { type: "pie", segments: [{ label: "Sunny", value: 0 }] },
+    }),
+    error: /segments\[0\]\.value must be greater than 0/u,
+  },
+  {
+    name: "rejects an empty data series list",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /chart\.series must contain 1 to 12 items/u,
+  },
+  {
+    name: "rejects more than 12 data series",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: Array.from({ length: 13 }, (_, index) => ({
+          name: `Series ${index}`,
+          data: [{ label: "Mon", value: index }],
+        })),
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /chart\.series must contain 1 to 12 items/u,
+  },
+  {
+    name: "rejects a non-object data series",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: ["Temperature"],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /series\[0\] must be an object/u,
+  },
+  {
+    name: "rejects a non-string series name",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: 1, data: [{ label: "Mon", value: 5 }] }],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /series\[0\]\.name must be a string/u,
+  },
+  {
+    name: "rejects a series name longer than 20 characters",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "x".repeat(21), data: [{ label: "Mon", value: 5 }] }],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /series\[0\]\.name must be at most 20 characters/u,
+  },
+  {
+    name: "rejects duplicate series names",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          { name: "Temperature", data: [{ label: "Mon", value: 5 }] },
+          { name: "Temperature", data: [{ label: "Mon", value: 6 }] },
+        ],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /chart\.series names must be unique/u,
+  },
+  {
+    name: "rejects an empty data point list",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [] }],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /series\[0\]\.data must contain 1 to 20 items/u,
+  },
+  {
+    name: "rejects more than 20 data points",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          {
+            name: "Temperature",
+            data: Array.from({ length: 21 }, (_, index) => ({
+              label: `D${index}`,
+              value: index,
+            })),
+          },
+        ],
+        axis_config: {
+          categories: Array.from({ length: 21 }, (_, index) => `D${index}`),
+        },
+      },
+    }),
+    error: /series\[0\]\.data must contain 1 to 20 items/u,
+  },
+  {
+    name: "rejects a non-object data point",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [5] }],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /data\[0\] must be an object/u,
+  },
+  {
+    name: "rejects a missing axis config",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+      },
+    }),
+    error: /chart\.axis_config must be an object/u,
+  },
+  {
+    name: "rejects a non-object axis config",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+        axis_config: [],
+      },
+    }),
+    error: /chart\.axis_config must be an object/u,
+  },
+  {
+    name: "rejects a missing category list",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+        axis_config: {},
+      },
+    }),
+    error: /axis_config\.categories must contain 1 to 20 items/u,
+  },
+  {
+    name: "rejects an empty category list",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+        axis_config: { categories: [] },
+      },
+    }),
+    error: /axis_config\.categories must contain 1 to 20 items/u,
+  },
+  {
+    name: "rejects a non-string category",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+        axis_config: { categories: [1] },
+      },
+    }),
+    error: /categories\[0\] must be a string/u,
+  },
+  {
+    name: "rejects a category longer than 20 characters",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          {
+            name: "Temperature",
+            data: [{ label: "Mon", value: 5 }],
+          },
+        ],
+        axis_config: { categories: ["x".repeat(21)] },
+      },
+    }),
+    error: /categories\[0\] must be at most 20 characters/u,
+  },
+  {
+    name: "rejects duplicate categories",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          {
+            name: "Temperature",
+            data: [
+              { label: "Mon", value: 5 },
+              { label: "Mon", value: 6 },
+            ],
+          },
+        ],
+        axis_config: { categories: ["Mon", "Mon"] },
+      },
+    }),
+    error: /axis_config\.categories must be unique/u,
+  },
+  {
+    name: "rejects an x-axis label longer than 50 characters",
+    props: () => ({
+      ...seriesProps(),
+      chart: {
+        ...seriesProps().chart,
+        axis_config: { categories: ["Mon"], x_label: "x".repeat(51) },
+      },
+    }),
+    error: /axis_config\.x_label must be at most 50 characters/u,
+  },
+  {
+    name: "rejects a non-string y-axis label",
+    props: () => ({
+      ...seriesProps(),
+      chart: {
+        ...seriesProps().chart,
+        axis_config: { categories: ["Mon"], y_label: 72 },
+      },
+    }),
+    error: /axis_config\.y_label must be a string/u,
+  },
+  {
+    name: "rejects a non-string data point label",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: 1, value: 5 }] }],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /data\[0\]\.label must be a string/u,
+  },
+  {
+    name: "rejects a data point label longer than 20 characters",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          {
+            name: "Temperature",
+            data: [{ label: "x".repeat(21), value: 5 }],
+          },
+        ],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /data\[0\]\.label must be at most 20 characters/u,
+  },
+  {
+    name: "rejects a non-numeric data point value",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          { name: "Temperature", data: [{ label: "Mon", value: "five" }] },
+        ],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /data\[0\]\.value must be a finite number/u,
+  },
+  {
+    name: "rejects a data point label absent from the categories",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Tue", value: 5 }] }],
+        axis_config: { categories: ["Mon"] },
+      },
+    }),
+    error: /data labels must match axis_config\.categories exactly/u,
+  },
+  {
+    name: "rejects a series that omits a category",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+        axis_config: { categories: ["Mon", "Tue"] },
+      },
+    }),
+    error: /data labels must match axis_config\.categories exactly/u,
+  },
+  {
+    name: "rejects duplicate data point labels",
+    props: () => ({
+      title: "Weather",
+      chart: {
+        type: "line",
+        series: [
+          {
+            name: "Temperature",
+            data: [
+              { label: "Mon", value: 5 },
+              { label: "Mon", value: 6 },
+            ],
+          },
+        ],
+        axis_config: { categories: ["Mon", "Tue"] },
+      },
+    }),
+    error: /data labels must match axis_config\.categories exactly/u,
+  },
+];
+
+test.each(validationCases)("$name", ({ props, error }) => {
+  const node = createNativeNode(
+    "slack",
+    "block",
+    "data_visualization",
+    props(),
+  );
+
+  expect(() => serializeSlackNativeNode(node)).toThrow(error);
+});
+
+test("Slack data visualization permits negative series values", () => {
+  const props = seriesProps();
+  props.chart.series[0]!.data[0]!.value = -4;
+  const node = createNativeNode("slack", "block", "data_visualization", props);
+
+  expect(serializeSlackNativeNode(node)).toMatchObject({ chart: props.chart });
+});
+
+function pieProps(): Record<string, unknown> {
+  return {
+    title: "Weather",
+    chart: { type: "pie", segments: [{ label: "Sunny", value: 5 }] },
+  };
+}
+
+function seriesProps(): {
+  title: string;
+  chart: {
+    type: string;
+    series: { name: string; data: { label: string; value: number }[] }[];
+    axis_config: { categories: string[] };
+  };
+} {
+  return {
+    title: "Weather",
+    chart: {
+      type: "line",
+      series: [{ name: "Temperature", data: [{ label: "Mon", value: 5 }] }],
+      axis_config: { categories: ["Mon"] },
+    },
+  };
+}

--- a/packages/channels-slack/src/native-data-visualization.test.tsx
+++ b/packages/channels-slack/src/native-data-visualization.test.tsx
@@ -1,0 +1,146 @@
+/** @jsxImportSource @copilotkit/channels-ui */
+import { expect, test, vi } from "vitest";
+import { isNativeNode, renderToIR } from "@copilotkit/channels-ui";
+import { defineChannelComponent } from "@copilotkit/channels-core";
+import { z } from "zod";
+import { SlackAdapter } from "./adapter.js";
+import { serializeSlackNativeNode } from "./native-codec.js";
+import { Slack } from "./native.js";
+import { renderBlockKit } from "./render/block-kit.js";
+
+test("Slack data visualization requires a title", () => {
+  const [node] = renderToIR(<Slack.Block.DataVisualization />);
+
+  expect(isNativeNode(node)).toBe(true);
+  if (!isNativeNode(node)) throw new TypeError("expected native Slack node");
+  expect(() => serializeSlackNativeNode(node)).toThrow(
+    /Slack\.DataVisualization\.title is required/u,
+  );
+});
+
+test("Slack data visualization requires a chart", () => {
+  const [node] = renderToIR(
+    <Slack.Block.DataVisualization title="Weekly weather" />,
+  );
+
+  expect(isNativeNode(node)).toBe(true);
+  if (!isNativeNode(node)) throw new TypeError("expected native Slack node");
+  expect(() => serializeSlackNativeNode(node)).toThrow(
+    /Slack\.DataVisualization\.chart is required/u,
+  );
+});
+
+test("Slack permits two data visualization blocks per message", () => {
+  const ir = renderToIR(
+    Array.from({ length: 2 }, (_, index) => (
+      <Slack.Block.DataVisualization
+        key={`chart-${index}`}
+        title={`Weather ${index + 1}`}
+        chart={{
+          type: "pie",
+          segments: [{ label: "Sunny", value: 1 }],
+        }}
+      />
+    )),
+  );
+
+  expect(renderBlockKit(ir)).toHaveLength(2);
+});
+
+test("Slack rejects more than two data visualization blocks per message", () => {
+  const ir = renderToIR(
+    Array.from({ length: 3 }, (_, index) => (
+      <Slack.Block.DataVisualization
+        key={`chart-${index}`}
+        title={`Weather ${index + 1}`}
+        chart={{
+          type: "pie",
+          segments: [{ label: "Sunny", value: 1 }],
+        }}
+      />
+    )),
+  );
+
+  expect(() => renderBlockKit(ir)).toThrow(
+    /rendered 3 data visualization blocks; the message limit is 2/u,
+  );
+});
+
+test("a weather channel component reaches Slack as a data visualization block", async () => {
+  const WeatherCard = defineChannelComponent({
+    name: "show_weather",
+    description: "Show a three-day weather forecast.",
+    parameters: z.object({
+      city: z.string(),
+      temperatures: z.tuple([z.number(), z.number(), z.number()]),
+    }),
+    render: ({ city, temperatures }) => (
+      <Slack.Block.DataVisualization
+        title={`${city} forecast`}
+        chart={{
+          type: "line",
+          series: [
+            {
+              name: "Temperature",
+              data: [
+                { label: "Mon", value: temperatures[0] },
+                { label: "Tue", value: temperatures[1] },
+                { label: "Wed", value: temperatures[2] },
+              ],
+            },
+          ],
+          axis_config: {
+            categories: ["Mon", "Tue", "Wed"],
+            x_label: "Day",
+            y_label: "Temperature (F)",
+          },
+        }}
+      />
+    ),
+  });
+  const adapter = new SlackAdapter({ botToken: "x", appToken: "y" });
+  const postMessage = vi
+    .spyOn(adapter.client.chat, "postMessage")
+    .mockResolvedValue({ ok: true, channel: "C1", ts: "200.5" });
+  const rendered = await WeatherCard.render(
+    { city: "San Francisco", temperatures: [62, 65, 61] },
+    { platform: "slack", signal: new AbortController().signal },
+  );
+
+  await adapter.post(
+    { channel: "C1", threadTs: "100.0" },
+    renderToIR(rendered),
+  );
+
+  expect(postMessage).toHaveBeenCalledWith({
+    channel: "C1",
+    thread_ts: "100.0",
+    unfurl_links: false,
+    unfurl_media: false,
+    text: "San Francisco forecast",
+    blocks: [
+      {
+        type: "data_visualization",
+        title: "San Francisco forecast",
+        chart: {
+          type: "line",
+          series: [
+            {
+              name: "Temperature",
+              data: [
+                { label: "Mon", value: 62 },
+                { label: "Tue", value: 65 },
+                { label: "Wed", value: 61 },
+              ],
+            },
+          ],
+          axis_config: {
+            categories: ["Mon", "Tue", "Wed"],
+            x_label: "Day",
+            y_label: "Temperature (F)",
+          },
+        },
+      },
+    ],
+  });
+});

--- a/packages/channels-slack/src/native-data-visualization.types.test.ts
+++ b/packages/channels-slack/src/native-data-visualization.types.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "vitest";
+import { isNativeNode } from "@copilotkit/channels-ui";
+import type { ChannelNode } from "@copilotkit/channels-ui";
+import { serializeSlackNativeNode } from "./native-codec.js";
+import { Slack } from "./native.js";
+
+const chartCases = [
+  {
+    name: "pie",
+    chart: {
+      type: "pie",
+      segments: [
+        { label: "Sunny", value: 5 },
+        { label: "Rainy", value: 2 },
+      ],
+    },
+  },
+  {
+    name: "bar",
+    chart: {
+      type: "bar",
+      series: [
+        {
+          name: "High",
+          data: [
+            { label: "Mon", value: 72 },
+            { label: "Tue", value: 68 },
+          ],
+        },
+      ],
+      axis_config: {
+        categories: ["Mon", "Tue"],
+        x_label: "Day",
+        y_label: "Temperature (F)",
+      },
+    },
+  },
+  {
+    name: "area",
+    chart: {
+      type: "area",
+      series: [
+        {
+          name: "Rainfall",
+          data: [
+            { label: "Mon", value: 0.2 },
+            { label: "Tue", value: 0.8 },
+          ],
+        },
+      ],
+      axis_config: { categories: ["Mon", "Tue"] },
+    },
+  },
+  {
+    name: "line",
+    chart: {
+      type: "line",
+      series: [
+        {
+          name: "Temperature",
+          data: [
+            { label: "Mon", value: 62 },
+            { label: "Tue", value: 65 },
+          ],
+        },
+      ],
+      axis_config: { categories: ["Mon", "Tue"] },
+    },
+  },
+] as const;
+
+const __typeGuards = () => {
+  // @ts-expect-error chart is required
+  Slack.Block.DataVisualization({ title: "Weather" });
+  // @ts-expect-error title is required
+  Slack.Block.DataVisualization({
+    chart: { type: "pie", segments: [{ label: "Sunny", value: 1 }] },
+  });
+  Slack.Block.DataVisualization({
+    title: "Weather",
+    chart: {
+      // @ts-expect-error scatter is not a supported chart type
+      type: "scatter",
+      series: [],
+      axis_config: { categories: [] },
+    },
+  });
+  Slack.Block.DataVisualization({
+    title: "Weather",
+    // @ts-expect-error pie charts require segments
+    chart: { type: "pie" },
+  });
+  Slack.Block.DataVisualization({
+    title: "Weather",
+    // @ts-expect-error series charts require axis_config
+    chart: { type: "line", series: [] },
+  });
+  Slack.Block.DataVisualization({
+    title: "Weather",
+    chart: { type: "pie", segments: [{ label: "Sunny", value: 1 }] },
+    // @ts-expect-error data visualization blocks do not accept children
+    children: Slack.Block.Divider({}),
+  });
+};
+void __typeGuards;
+
+test.each(chartCases)(
+  "Slack data visualization serializes a $name chart",
+  ({ chart }) => {
+    const node = Slack.Block.DataVisualization({
+      title: "Weekly weather",
+      chart,
+    });
+
+    expect(serialize(node)).toEqual({
+      type: "data_visualization",
+      title: "Weekly weather",
+      chart,
+    });
+  },
+);
+
+function serialize(node: ChannelNode): Record<string, unknown> {
+  expect(isNativeNode(node)).toBe(true);
+  if (!isNativeNode(node)) throw new TypeError("expected native Slack node");
+  return serializeSlackNativeNode(node);
+}

--- a/packages/channels-slack/src/native-manifest.ts
+++ b/packages/channels-slack/src/native-manifest.ts
@@ -23,7 +23,7 @@ export const SLACK_BLOCK_MANIFEST = [
   ["Context", "context", "elements"],
   ["ContextActions", "context_actions", "elements"],
   ["DataTable", "data_table", "rows"],
-  ["DataVisualization", "data_visualization", "visualizations"],
+  ["DataVisualization", "data_visualization"],
   ["Divider", "divider"],
   ["File", "file"],
   ["Header", "header", "text"],

--- a/packages/channels-slack/src/native.ts
+++ b/packages/channels-slack/src/native.ts
@@ -26,7 +26,6 @@ export interface SlackNativeProps<TValue = unknown> {
   blocks?: ChannelNode[];
   rows?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;
   tasks?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;
-  visualizations?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;
   title?: string | ChannelNode;
   label?: string | ChannelNode;
   description?: string | ChannelNode;
@@ -58,6 +57,57 @@ export interface SlackNativeProps<TValue = unknown> {
   onClick?: ClickHandler<TValue>;
   onSelect?: ClickHandler<TValue>;
   onSubmit?: ClickHandler<TValue>;
+}
+
+/** One positive slice in a Slack pie chart. */
+export interface SlackDataVisualizationSegment {
+  readonly label: string;
+  readonly value: number;
+}
+
+/** One labeled numeric value in a Slack bar, area, or line chart. */
+export interface SlackDataVisualizationDataPoint {
+  readonly label: string;
+  readonly value: number;
+}
+
+/** One uniquely named data series in a Slack bar, area, or line chart. */
+export interface SlackDataVisualizationSeries {
+  readonly name: string;
+  readonly data: readonly SlackDataVisualizationDataPoint[];
+}
+
+/** Ordered categories and optional axis labels for a series chart. */
+export interface SlackDataVisualizationAxisConfig {
+  readonly categories: readonly string[];
+  readonly x_label?: string;
+  readonly y_label?: string;
+}
+
+/** Slack pie chart payload with 1 to 12 positive segments. */
+export interface SlackDataVisualizationPieChart {
+  readonly type: "pie";
+  readonly segments: readonly SlackDataVisualizationSegment[];
+}
+
+/** Slack bar, area, or line chart payload with 1 to 12 series. */
+export interface SlackDataVisualizationSeriesChart {
+  readonly type: "bar" | "area" | "line";
+  readonly series: readonly SlackDataVisualizationSeries[];
+  readonly axis_config: SlackDataVisualizationAxisConfig;
+}
+
+/** Every chart payload accepted by a Slack data visualization block. */
+export type SlackDataVisualizationChart =
+  | SlackDataVisualizationPieChart
+  | SlackDataVisualizationSeriesChart;
+
+/** Props for `Slack.Block.DataVisualization`. */
+export interface SlackDataVisualizationProps {
+  readonly title: string;
+  readonly chart: SlackDataVisualizationChart;
+  readonly block_id?: string;
+  readonly children?: never;
 }
 
 type NativeComponent = <TValue = unknown>(
@@ -93,9 +143,20 @@ export interface SlackRawProps {
   children?: never;
 }
 
+const blocks = group("block", SLACK_BLOCK_MANIFEST);
+
+function dataVisualization(props: SlackDataVisualizationProps): ChannelNode {
+  return createNativeNode(
+    "slack",
+    "block",
+    "data_visualization",
+    props as unknown as Record<string, unknown>,
+  );
+}
+
 /** Complete message-surface Slack JSX namespace. */
 export const Slack = {
-  Block: group("block", SLACK_BLOCK_MANIFEST),
+  Block: { ...blocks, DataVisualization: dataVisualization },
   Element: group("element", SLACK_ELEMENT_MANIFEST),
   Object: group("object", SLACK_OBJECT_MANIFEST),
   Raw: (props: SlackRawProps): ChannelNode =>

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -71,6 +71,15 @@ export function renderBlockKit(ir: ChannelNode[]): KnownBlock[] {
     renderNode(node, blocks);
   }
 
+  const dataVisualizations = blocks.filter(
+    (block) => String(block.type) === "data_visualization",
+  ).length;
+  if (dataVisualizations > 2) {
+    throw new Error(
+      `Slack native JSX rendered ${dataVisualizations} data visualization blocks; the message limit is 2.`,
+    );
+  }
+
   if (native && blocks.length > SLACK_LIMITS.blocksPerMessage) {
     throw new Error(
       `Slack native JSX rendered ${blocks.length} blocks; the message limit is ${SLACK_LIMITS.blocksPerMessage}.`,


### PR DESCRIPTION
## What does this PR do?

Slack data visualization blocks were listed in the native catalog, but the JSX surface emitted a non-Slack `visualizations` field and had no typed `chart` prop. This PR makes `Slack.Block.DataVisualization` produce the payload that Slack documents.

- Adds public types for pie, bar, area, and line chart payloads.
- Requires `title` and `chart` at compile time and runtime.
- Checks Slack limits for titles, labels, segments, series, points, categories, axis labels, positive pie values, unique series names, and exact category coverage.
- Rejects more than two data visualization blocks in one message.
- Preserves the chart through direct Slack `chat.postMessage` delivery and managed Intelligence delivery.
- Documents a small `defineChannelComponent` weather chart example.

Slack contract: https://docs.slack.dev/reference/block-kit/blocks/data-visualization-block/

## Review path

1. Start with `packages/channels-slack/src/native.ts` for the public JSX and TypeScript contract.
2. Read `packages/channels-slack/src/data-visualization.ts` for runtime checks.
3. Read `packages/channels-slack/src/native-data-visualization.test.tsx` for the weather component through the real adapter boundary.
4. Read `packages/channels-slack/src/native-data-visualization-validation.test.ts` for provider limit and cross-field cases.
5. Read `packages/channels-intelligence/src/delivery-provider-elements.test.ts` for the managed effect payload.

## Test coverage

- All four chart variants serialize to exact Slack JSON.
- Invalid nested payloads fail before a network request.
- Two charts pass and three charts fail.
- Negative values pass for series charts; non-positive values fail for pie charts.
- Compile-time tests reject missing fields, unsupported chart types, wrong chart shapes, and children.
- A `defineChannelComponent` weather card reaches `SlackAdapter.client.chat.postMessage` with the expected Block Kit request.

## Validation

- `NX_DAEMON=false pnpm nx run-many -t test,check-types,build --projects=@copilotkit/channels-slack,@copilotkit/channels-intelligence`
- `NX_DAEMON=false pnpm nx run-many -t publint,attw --projects=@copilotkit/channels-slack,@copilotkit/channels-intelligence`
- `NX_DAEMON=false pnpm verify:channels-umbrella`
- `pnpm check:channel-native-catalogs && pnpm audit:channel-native-catalogs`
- `pnpm exec oxfmt --check packages/channels-slack/README.md`

This checkout has no `docs:check` script. The changed README passes the repo formatter, and its executable example is covered by the adapter test.

## Related PRs and Issues

- Follows the native Slack JSX surface merged in https://github.com/CopilotKit/CopilotKit/pull/6331

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] Allow edits by maintainers is enabled