### PR TITLE
fix(channels): recover from transient gateway outages

### DIFF
--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -16,6 +16,7 @@ export type {
 
 export {
   connectRealtimeGateway,
+  RealtimeGatewayJoinError,
   RealtimeGatewayUnreachableError,
 } from "./realtime-gateway.js";
 export type {

--- a/packages/channels-intelligence/src/realtime-gateway-retryability.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-retryability.test.ts
@@ -9,8 +9,71 @@ interface RetryabilitySetup {
   diagnosticFetch: ReturnType<typeof vi.fn<typeof fetch>>;
 }
 
+/** Build one socket that opens but rejects or never answers its join. */
+function setupJoinFailure(
+  response?: Record<string, unknown>,
+): ReturnType<typeof connectRealtimeGateway> {
+  class RejectedWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = RejectedWebSocket.CONNECTING;
+    binaryType = "arraybuffer";
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onerror: ((error: Error) => void) | null = null;
+    onclose: ((event: { code: number }) => void) | null = null;
+
+    constructor() {
+      queueMicrotask(() => {
+        this.readyState = RejectedWebSocket.OPEN;
+        this.onopen?.();
+      });
+    }
+
+    send(data: string): void {
+      const frame = JSON.parse(data) as [string, string, string, string];
+      const [joinRef, ref, topic, event] = frame;
+      if (event !== "phx_join" || response === undefined) return;
+      queueMicrotask(() =>
+        this.onmessage?.({
+          data: JSON.stringify([
+            joinRef,
+            ref,
+            topic,
+            "phx_reply",
+            { status: "error", response },
+          ]),
+        }),
+      );
+    }
+
+    close(): void {
+      this.readyState = RejectedWebSocket.CLOSED;
+      queueMicrotask(() => this.onclose?.({ code: 1000 }));
+    }
+  }
+
+  return connectRealtimeGateway({
+    wsUrl: "wss://gateway.example/channels",
+    apiKey: "cpk-test",
+    projectId: 7,
+    join: {
+      protocol: "channel_delivery_v1",
+      runtimeInstanceId: "rti_1",
+      channels: [{ channelName: "support", adapter: "slack" }],
+    },
+    timeoutMs: 10,
+    webSocket: RejectedWebSocket,
+  });
+}
+
 /** Build one socket that cannot upgrade and an HTTP diagnosis for its host. */
-function setupRetryability(status: number): RetryabilitySetup {
+function setupRetryability(
+  status: number,
+  transportError: Error = new Error("upgrade refused"),
+): RetryabilitySetup {
   class RefusedWebSocket {
     static readonly CONNECTING = 0;
     static readonly OPEN = 1;
@@ -24,7 +87,7 @@ function setupRetryability(status: number): RetryabilitySetup {
     onclose: ((event: { code: number }) => void) | null = null;
 
     constructor() {
-      queueMicrotask(() => this.onerror?.(new Error("upgrade refused")));
+      queueMicrotask(() => this.onerror?.(transportError));
     }
 
     send(): void {}
@@ -73,4 +136,46 @@ test("an HTTP 403 gateway diagnosis is terminal", async () => {
   expect(diagnosticFetch).toHaveBeenCalledOnce();
   expect(error).toBeInstanceOf(RealtimeGatewayUnreachableError);
   expect((error as RealtimeGatewayUnreachableError).retryable).toBe(false);
+});
+
+test("an ENOTFOUND transport failure is terminal without an HTTP probe", async () => {
+  const transportError = Object.assign(
+    new Error("getaddrinfo ENOTFOUND gateway.example"),
+    { code: "ENOTFOUND" },
+  );
+  const { connection, diagnosticFetch } = setupRetryability(
+    502,
+    transportError,
+  );
+
+  const error = await connection.catch((cause: unknown) => cause);
+
+  expect(diagnosticFetch).not.toHaveBeenCalled();
+  expect(error).toBeInstanceOf(RealtimeGatewayUnreachableError);
+  expect((error as RealtimeGatewayUnreachableError).retryable).toBe(false);
+});
+
+test("a gateway_draining join rejection preserves its retry classification", async () => {
+  const response = { reason: "gateway_draining", retryable: true };
+
+  const error = await setupJoinFailure(response).catch(
+    (cause: unknown) => cause,
+  );
+
+  expect(error).toMatchObject({
+    code: "GATEWAY_JOIN_FAILED",
+    reason: response,
+    retryable: true,
+  });
+  expect((error as Error).message).toMatch(/gateway_draining/);
+});
+
+test("an initial gateway join timeout is retryable", async () => {
+  const error = await setupJoinFailure().catch((cause: unknown) => cause);
+
+  expect(error).toMatchObject({
+    code: "GATEWAY_JOIN_FAILED",
+    retryable: true,
+  });
+  expect((error as Error).message).toMatch(/join timed out/);
 });

--- a/packages/channels-intelligence/src/realtime-gateway-retryability.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-retryability.test.ts
@@ -1,0 +1,76 @@
+import { expect, test, vi } from "vitest";
+import {
+  connectRealtimeGateway,
+  RealtimeGatewayUnreachableError,
+} from "./realtime-gateway.js";
+
+interface RetryabilitySetup {
+  connection: ReturnType<typeof connectRealtimeGateway>;
+  diagnosticFetch: ReturnType<typeof vi.fn<typeof fetch>>;
+}
+
+/** Build one socket that cannot upgrade and an HTTP diagnosis for its host. */
+function setupRetryability(status: number): RetryabilitySetup {
+  class RefusedWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = RefusedWebSocket.CONNECTING;
+    binaryType = "arraybuffer";
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onerror: ((error: Error) => void) | null = null;
+    onclose: ((event: { code: number }) => void) | null = null;
+
+    constructor() {
+      queueMicrotask(() => this.onerror?.(new Error("upgrade refused")));
+    }
+
+    send(): void {}
+
+    close(): void {
+      this.readyState = RefusedWebSocket.CLOSED;
+      queueMicrotask(() => this.onclose?.({ code: 1000 }));
+    }
+  }
+
+  const diagnosticFetch = vi.fn<typeof fetch>(async () =>
+    Promise.resolve(new Response(null, { status })),
+  );
+  const connection = connectRealtimeGateway({
+    wsUrl: "wss://gateway.example/channels",
+    apiKey: "cpk-test",
+    projectId: 7,
+    join: {
+      protocol: "channel_delivery_v1",
+      runtimeInstanceId: "rti_1",
+      channels: [{ channelName: "support", adapter: "slack" }],
+    },
+    connectTimeoutMs: 10,
+    diagnosticFetch,
+    webSocket: RefusedWebSocket,
+  });
+
+  return { connection, diagnosticFetch };
+}
+
+test("an HTTP 502 gateway diagnosis is retryable", async () => {
+  const { connection, diagnosticFetch } = setupRetryability(502);
+
+  const error = await connection.catch((cause: unknown) => cause);
+
+  expect(diagnosticFetch).toHaveBeenCalledOnce();
+  expect(error).toBeInstanceOf(RealtimeGatewayUnreachableError);
+  expect((error as RealtimeGatewayUnreachableError).retryable).toBe(true);
+});
+
+test("an HTTP 403 gateway diagnosis is terminal", async () => {
+  const { connection, diagnosticFetch } = setupRetryability(403);
+
+  const error = await connection.catch((cause: unknown) => cause);
+
+  expect(diagnosticFetch).toHaveBeenCalledOnce();
+  expect(error).toBeInstanceOf(RealtimeGatewayUnreachableError);
+  expect((error as RealtimeGatewayUnreachableError).retryable).toBe(false);
+});

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -82,11 +82,10 @@ export interface ConnectRealtimeGatewayOptions {
    *
    * The window exists rather than failing on the first transport error because
    * a refused connect is often just a gateway that has not finished booting,
-   * and a supervising `ChannelManager` does NOT retry activation — a
-   * fail-on-first-error rule would turn a boot race into a permanently errored
-   * Channel. The default is deliberately long enough to outlast a rolling
-   * restart of the gateway. Causes that CANNOT resolve themselves (a host that
-   * does not exist) skip the window entirely; see {@link diagnoseEndpoint}.
+   * and a supervising `ChannelManager` retries classified transient failures.
+   * The window avoids opening a new socket for every failed attempt during a
+   * short boot race. Causes that CANNOT resolve themselves (a host that does
+   * not exist) skip the window entirely; see {@link diagnoseEndpoint}.
    */
   connectTimeoutMs?: number;
   /**
@@ -182,6 +181,50 @@ export class RealtimeGatewayUnreachableError extends Error {
     this.transportError = transportError;
     this.retryable = options?.retryable ?? false;
   }
+}
+
+/**
+ * Signals that the gateway accepted the socket but rejected its initial
+ * logical join. Structured retry hints survive this boundary so a supervising
+ * runtime can distinguish a draining gateway from a permanent rejection.
+ */
+export class RealtimeGatewayJoinError extends Error {
+  /** Cross-package marker used by the runtime activation retry policy. */
+  readonly code = "GATEWAY_JOIN_FAILED";
+  /** Gateway response returned with the failed join. */
+  readonly reason: unknown;
+  /** Whether a fresh activation can succeed without a configuration change. */
+  readonly retryable: boolean;
+
+  /**
+   * @param reason - Structured gateway join rejection.
+   * @param options - Optional retry override and timeout-specific message.
+   */
+  constructor(
+    reason: unknown,
+    options?: { message?: string; retryable?: boolean },
+  ) {
+    super(
+      options?.message ??
+        `realtime gateway session join failed: ${safeReason(reason)}`,
+      { cause: reason },
+    );
+    this.name = "RealtimeGatewayJoinError";
+    this.reason = reason;
+    this.retryable = options?.retryable ?? isRetryableJoinRejection(reason);
+  }
+}
+
+/** Whether a structured gateway join rejection asks the client to retry. */
+function isRetryableJoinRejection(reason: unknown): boolean {
+  if (typeof reason !== "object" || reason === null) {
+    return false;
+  }
+  const response = reason as { reason?: unknown; retryable?: unknown };
+  if (response.retryable === false) {
+    return false;
+  }
+  return response.retryable === true || response.reason === "gateway_draining";
 }
 
 /** Typed rejection returned by a joined realtime gateway channel push. */
@@ -574,9 +617,13 @@ export async function connectRealtimeGateway(
           : await startDiagnosis();
       const cause = probed?.cause ?? lastTransportRaw;
       const retryable =
-        probed === undefined ||
-        (!probed.nonRetryable &&
-          (probed.status === undefined || probed.status >= 500));
+        !(
+          lastTransportCode !== undefined &&
+          NON_RETRYABLE_TRANSPORT_CODES.has(lastTransportCode)
+        ) &&
+        (probed === undefined ||
+          (!probed.nonRetryable &&
+            (probed.status === undefined || probed.status >= 500)));
       failConnect(
         new RealtimeGatewayUnreachableError(
           endpoint,
@@ -783,11 +830,7 @@ export async function connectRealtimeGateway(
         socket.disconnect();
         // The hard-cut control topic has one join-error path and no compatibility
         // mapping for prior setup or listener-generation states.
-        failConnect(
-          new Error(
-            `realtime gateway session join failed: ${safeReason(reason)}`,
-          ),
-        );
+        failConnect(new RealtimeGatewayJoinError(reason));
       } else {
         // A rejoin failed (e.g. credentials revoked server-side). Phoenix
         // keeps retrying; surface reconnecting and let the window bound it.
@@ -800,7 +843,12 @@ export async function connectRealtimeGateway(
         clearConnectDeadline();
         closingIntentionally = true;
         socket.disconnect();
-        failConnect(new Error("realtime gateway session join timed out"));
+        failConnect(
+          new RealtimeGatewayJoinError(undefined, {
+            message: "realtime gateway session join timed out",
+            retryable: true,
+          }),
+        );
       } else {
         enterReconnecting();
       }

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -139,12 +139,15 @@ export interface RealtimeGatewayConnectionDetail {
  * endpoint that was tried and the underlying transport error so the message
  * points at the misconfigured URL rather than at a stopwatch (OSS-623).
  *
- * An unreachable host is a caller configuration error that must reject
- * `ready()`.
+ * Permanent reachability failures such as NXDOMAIN reject `ready()`. Transient
+ * failures such as an HTTP 5xx response carry `retryable=true`, allowing the
+ * runtime manager to attempt a fresh initial connection with backoff.
  */
 export class RealtimeGatewayUnreachableError extends Error {
   /** Cross-package marker, mirroring the `code` convention of its siblings. */
   readonly code = "GATEWAY_UNREACHABLE";
+  /** Whether reconnecting later can succeed without changing configuration. */
+  readonly retryable: boolean;
   /** The gateway endpoint that was tried, minus any query string. */
   readonly endpoint: string;
   /**
@@ -158,14 +161,13 @@ export class RealtimeGatewayUnreachableError extends Error {
    * @param transportError - Rendered transport failure, if one was reported.
    * @param connectTimeoutMs - The elapsed connect window, named when no
    *   transport error was reported (the only signal the caller has left).
-   * @param options - Standard error options; carries the raw transport error
-   *   as `cause`.
+   * @param options - Retry classification plus the raw transport error.
    */
   constructor(
     endpoint: string,
     transportError: string | undefined,
     connectTimeoutMs: number,
-    options?: { cause?: unknown },
+    options?: { cause?: unknown; retryable?: boolean },
   ) {
     super(
       `realtime gateway unreachable: the socket never connected to ${endpoint} ` +
@@ -178,6 +180,7 @@ export class RealtimeGatewayUnreachableError extends Error {
     this.name = "RealtimeGatewayUnreachableError";
     this.endpoint = endpoint;
     this.transportError = transportError;
+    this.retryable = options?.retryable ?? false;
   }
 }
 
@@ -570,12 +573,19 @@ export async function connectRealtimeGateway(
           ? await diagnosis
           : await startDiagnosis();
       const cause = probed?.cause ?? lastTransportRaw;
+      const retryable =
+        probed === undefined ||
+        (!probed.nonRetryable &&
+          (probed.status === undefined || probed.status >= 500));
       failConnect(
         new RealtimeGatewayUnreachableError(
           endpoint,
           probed?.text ?? lastTransportError,
           connectTimeoutMs,
-          cause !== undefined ? { cause } : undefined,
+          {
+            ...(cause !== undefined ? { cause } : {}),
+            retryable,
+          },
         ),
       );
     })();

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
@@ -155,8 +155,7 @@ describe("ChannelManager connection health (onStateChange)", () => {
     expect(mgr.status().overall).toBe("stopped");
   });
 
-  it("logs the drop cause and backs off while the session stays down (OSS-670)", async () => {
-    vi.useFakeTimers();
+  it("logs the drop cause and keeps logging while the session is down (OSS-670)", async () => {
     const handle = observableHandle();
     const engine: ActivateChannelEngine = vi.fn(async () => handle);
     const logs: string[] = [];
@@ -166,46 +165,31 @@ describe("ChannelManager connection health (onStateChange)", () => {
       channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
       log: (m: string) => logs.push(m),
-      reconnectLogIntervalMs: 30_000,
+      reconnectLogIntervalMs: 5,
     });
-    try {
-      mgr.activate();
-      await mgr.ready();
+    mgr.activate();
+    await mgr.ready();
 
-      handle.fireState("reconnecting", {
-        reason: "read ECONNRESET",
-        code: "ECONNRESET",
-      });
-      expect(logs.some((m) => m.includes("ECONNRESET"))).toBe(true);
+    handle.fireState("reconnecting", {
+      reason: "read ECONNRESET",
+      code: "ECONNRESET",
+    });
+    expect(logs.some((m) => m.includes("ECONNRESET"))).toBe(true);
 
-      const stillDownLogs = () => logs.filter((m) => m.includes("still down"));
+    // Still down: the operator must keep hearing about it.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(logs.filter((m) => m.includes("still down")).length).toBeGreaterThan(
+      0,
+    );
 
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(stillDownLogs()).toHaveLength(1);
-
-      // The next reminder waits twice as long instead of repeating every 30s.
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(stillDownLogs()).toHaveLength(1);
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(stillDownLogs()).toHaveLength(2);
-
-      // Each reminder doubles the delay again: 30s, 60s, then 120s.
-      await vi.advanceTimersByTimeAsync(119_999);
-      expect(stillDownLogs()).toHaveLength(2);
-      await vi.advanceTimersByTimeAsync(1);
-      expect(stillDownLogs()).toHaveLength(3);
-
-      const before = logs.length;
-      handle.fireState("online");
-      await vi.advanceTimersByTimeAsync(15 * 60_000);
-      // Recovery cancels future reminders; only "back online" lands after it.
-      expect(
-        logs.slice(before).filter((m) => m.includes("still down")),
-      ).toHaveLength(0);
-      await mgr.stop();
-    } finally {
-      vi.useRealTimers();
-    }
+    const before = logs.length;
+    handle.fireState("online");
+    await new Promise((r) => setTimeout(r, 20));
+    // Recovery stops the repeat: only the "back online" line lands after it.
+    expect(
+      logs.slice(before).filter((m) => m.includes("still down")),
+    ).toHaveLength(0);
+    await mgr.stop();
   });
 
   it("says retries continue when the give-up window elapses (OSS-670)", async () => {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-reconnect.test.ts
@@ -155,7 +155,8 @@ describe("ChannelManager connection health (onStateChange)", () => {
     expect(mgr.status().overall).toBe("stopped");
   });
 
-  it("logs the drop cause and keeps logging while the session is down (OSS-670)", async () => {
+  it("logs the drop cause and backs off while the session stays down (OSS-670)", async () => {
+    vi.useFakeTimers();
     const handle = observableHandle();
     const engine: ActivateChannelEngine = vi.fn(async () => handle);
     const logs: string[] = [];
@@ -165,31 +166,46 @@ describe("ChannelManager connection health (onStateChange)", () => {
       channels: [createChannel({ identifyUser: "platform", name: "support" })],
       activateChannel: engine,
       log: (m: string) => logs.push(m),
-      reconnectLogIntervalMs: 5,
+      reconnectLogIntervalMs: 30_000,
     });
-    mgr.activate();
-    await mgr.ready();
+    try {
+      mgr.activate();
+      await mgr.ready();
 
-    handle.fireState("reconnecting", {
-      reason: "read ECONNRESET",
-      code: "ECONNRESET",
-    });
-    expect(logs.some((m) => m.includes("ECONNRESET"))).toBe(true);
+      handle.fireState("reconnecting", {
+        reason: "read ECONNRESET",
+        code: "ECONNRESET",
+      });
+      expect(logs.some((m) => m.includes("ECONNRESET"))).toBe(true);
 
-    // Still down: the operator must keep hearing about it.
-    await new Promise((r) => setTimeout(r, 20));
-    expect(logs.filter((m) => m.includes("still down")).length).toBeGreaterThan(
-      0,
-    );
+      const stillDownLogs = () => logs.filter((m) => m.includes("still down"));
 
-    const before = logs.length;
-    handle.fireState("online");
-    await new Promise((r) => setTimeout(r, 20));
-    // Recovery stops the repeat: only the "back online" line lands after it.
-    expect(
-      logs.slice(before).filter((m) => m.includes("still down")),
-    ).toHaveLength(0);
-    await mgr.stop();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(stillDownLogs()).toHaveLength(1);
+
+      // The next reminder waits twice as long instead of repeating every 30s.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(stillDownLogs()).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(stillDownLogs()).toHaveLength(2);
+
+      // Each reminder doubles the delay again: 30s, 60s, then 120s.
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(stillDownLogs()).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stillDownLogs()).toHaveLength(3);
+
+      const before = logs.length;
+      handle.fireState("online");
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+      // Recovery cancels future reminders; only "back online" lands after it.
+      expect(
+        logs.slice(before).filter((m) => m.includes("still down")),
+      ).toHaveLength(0);
+      await mgr.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("says retries continue when the give-up window elapses (OSS-670)", async () => {

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-recovery.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-recovery.test.ts
@@ -1,0 +1,187 @@
+import { expect, test, vi } from "vitest";
+import { createChannel } from "@copilotkit/channels";
+import { RealtimeGatewayUnreachableError } from "@copilotkit/channels-intelligence";
+import { CopilotKitIntelligence } from "../../intelligence-platform";
+import { ChannelManager } from "../channel-manager";
+import type { ActivateChannelEngine, ChannelsHandle } from "../channel-manager";
+
+interface RecoverySetup {
+  manager: ChannelManager;
+  activateChannel: ReturnType<typeof vi.fn<ActivateChannelEngine>>;
+  cleanup(): Promise<void>;
+}
+
+type ConnectionState = "online" | "reconnecting" | "gave_up";
+
+interface ReconnectLoggingSetup {
+  manager: ChannelManager;
+  logs: string[];
+  fireState(state: ConnectionState): void;
+  cleanup(): Promise<void>;
+}
+
+/** Create a gateway error with the cross-package retry contract. */
+function gatewayError(retryable: boolean): Error {
+  return new RealtimeGatewayUnreachableError(
+    "wss://runtime.example/channels",
+    "the gateway host answered HTTP 502",
+    30_000,
+    { retryable },
+  );
+}
+
+/** Build one isolated manager whose first gateway activation is unavailable. */
+function setupRecovery(firstError = gatewayError(true)): RecoverySetup {
+  vi.useFakeTimers();
+  const handle: ChannelsHandle = {
+    metadata: {},
+    stop: vi.fn(async () => {}),
+  };
+  const activateChannel = vi
+    .fn<ActivateChannelEngine>()
+    .mockRejectedValueOnce(firstError)
+    .mockResolvedValue(handle);
+  const manager = new ChannelManager({
+    intelligence: new CopilotKitIntelligence({
+      apiUrl: "https://runtime.example",
+      wsUrl: "wss://runtime.example",
+      apiKey: "cpk-42_short_long",
+    }),
+    channels: [createChannel({ identifyUser: "platform", name: "support" })],
+    activateChannel,
+  });
+
+  return {
+    manager,
+    activateChannel,
+    async cleanup() {
+      await manager.stop();
+      vi.useRealTimers();
+    },
+  };
+}
+
+/** Build one isolated online manager whose connection state is test-driven. */
+function setupReconnectLogging(): ReconnectLoggingSetup {
+  vi.useFakeTimers();
+  let stateListener: ((state: ConnectionState) => void) | undefined;
+  const handle: ChannelsHandle = {
+    metadata: {},
+    stop: vi.fn(async () => {}),
+    onStateChange(listener: (state: ConnectionState) => void) {
+      stateListener = listener;
+    },
+  };
+  const logs: string[] = [];
+  const manager = new ChannelManager({
+    intelligence: new CopilotKitIntelligence({
+      apiUrl: "https://runtime.example",
+      wsUrl: "wss://runtime.example",
+      apiKey: "cpk-42_short_long",
+    }),
+    channels: [createChannel({ identifyUser: "platform", name: "support" })],
+    activateChannel: vi.fn(async () => handle),
+    log: (message: string) => logs.push(message),
+  });
+
+  return {
+    manager,
+    logs,
+    fireState(state: ConnectionState) {
+      stateListener?.(state);
+    },
+    async cleanup() {
+      await manager.stop();
+      vi.useRealTimers();
+    },
+  };
+}
+
+test("a transient initial gateway outage retries until the channel is online", async () => {
+  const { manager, activateChannel, cleanup } = setupRecovery();
+
+  try {
+    manager.activate();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(activateChannel).toHaveBeenCalledTimes(1);
+    expect(manager.status().channels.support).toBe("reconnecting");
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(activateChannel).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(manager.ready()).resolves.toBeUndefined();
+    expect(activateChannel).toHaveBeenCalledTimes(2);
+    expect(manager.status().channels.support).toBe("online");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("a permanent initial gateway error remains terminal", async () => {
+  const { manager, activateChannel, cleanup } = setupRecovery(
+    gatewayError(false),
+  );
+
+  try {
+    manager.activate();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(manager.status().channels.support).toBe("error");
+    await expect(manager.ready()).rejects.toThrow(AggregateError);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(activateChannel).toHaveBeenCalledTimes(1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("stopping the manager cancels a pending activation retry", async () => {
+  const { manager, activateChannel, cleanup } = setupRecovery();
+
+  try {
+    manager.activate();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(manager.status().channels.support).toBe("reconnecting");
+
+    await manager.stop();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(activateChannel).toHaveBeenCalledTimes(1);
+    expect(manager.status().channels.support).toBe("stopped");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("a prolonged established-session outage backs off reminder logs", async () => {
+  const { manager, logs, fireState, cleanup } = setupReconnectLogging();
+
+  try {
+    manager.activate();
+    await manager.ready();
+    fireState("reconnecting");
+    const stillDownLogs = () =>
+      logs.filter((line) => line.includes("still down"));
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(stillDownLogs()).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(stillDownLogs()).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(stillDownLogs()).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(stillDownLogs()).toHaveLength(3);
+
+    fireState("online");
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
+    expect(stillDownLogs()).toHaveLength(3);
+  } finally {
+    await cleanup();
+  }
+});

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-recovery.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-recovery.test.ts
@@ -1,6 +1,9 @@
 import { expect, test, vi } from "vitest";
 import { createChannel } from "@copilotkit/channels";
-import { RealtimeGatewayUnreachableError } from "@copilotkit/channels-intelligence";
+import {
+  RealtimeGatewayJoinError,
+  RealtimeGatewayUnreachableError,
+} from "@copilotkit/channels-intelligence";
 import { CopilotKitIntelligence } from "../../intelligence-platform";
 import { ChannelManager } from "../channel-manager";
 import type { ActivateChannelEngine, ChannelsHandle } from "../channel-manager";
@@ -28,6 +31,14 @@ function gatewayError(retryable: boolean): Error {
     30_000,
     { retryable },
   );
+}
+
+/** Create a structured gateway drain rejection from a connected socket. */
+function gatewayDrainError(): Error {
+  return new RealtimeGatewayJoinError({
+    reason: "gateway_draining",
+    retryable: true,
+  });
 }
 
 /** Build one isolated manager whose first gateway activation is unavailable. */
@@ -111,6 +122,25 @@ test("a transient initial gateway outage retries until the channel is online", a
     expect(activateChannel).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
+    await expect(manager.ready()).resolves.toBeUndefined();
+    expect(activateChannel).toHaveBeenCalledTimes(2);
+    expect(manager.status().channels.support).toBe("online");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("a retryable initial gateway drain join retries until online", async () => {
+  const { manager, activateChannel, cleanup } =
+    setupRecovery(gatewayDrainError());
+
+  try {
+    manager.activate();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(manager.status().channels.support).toBe("reconnecting");
+
+    await vi.advanceTimersByTimeAsync(1_000);
     await expect(manager.ready()).resolves.toBeUndefined();
     expect(activateChannel).toHaveBeenCalledTimes(2);
     expect(manager.status().channels.support).toBe("online");

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -164,10 +164,10 @@ export interface ChannelManagerArgs {
    * path (not just activation-level events). */
   log?: (msg: string, meta?: unknown) => void;
   /**
-   * How often (ms) to repeat a "still down" log while a managed session is
-   * disconnected. A dropped session was previously silent for as long as the
-   * outage lasted, which made a dead bot indistinguishable from an idle one
-   * (OSS-670). Injectable so tests need no fake timers. Default 30000.
+   * Initial delay (ms) before a "still down" log while a managed session is
+   * disconnected. Later reminders back off exponentially to a 15-minute cap,
+   * keeping a prolonged outage visible without flooding logs. Injectable so
+   * tests can use a shorter first delay. Default 30000.
    */
   reconnectLogIntervalMs?: number;
   /** Per-handle deadline (ms) for `handle.stop()` during {@link ChannelManager.stop}
@@ -190,8 +190,10 @@ interface ChannelEntry {
   handleStopped: boolean;
   /** Epoch ms this outage episode began; unset while the session is healthy. */
   downSince?: number;
-  /** Repeating "still down" logger for this outage; cleared on recovery/teardown. */
-  reconnectLogTimer?: ReturnType<typeof setInterval>;
+  /** Next "still down" logger for this outage; cleared on recovery/teardown. */
+  reconnectLogTimer?: ReturnType<typeof setTimeout>;
+  /** Delay before the next reminder; doubles after each emitted reminder. */
+  reconnectLogDelayMs?: number;
 }
 
 /**
@@ -732,8 +734,11 @@ export function isModuleNotFound(err: unknown): boolean {
 /** Default deadline (ms) for a single `handle.stop()` during teardown. */
 const DEFAULT_STOP_HANDLE_TIMEOUT_MS = 5_000;
 
-/** Default cadence (ms) for the "still down" log while a session is dropped. */
+/** First delay (ms) before logging that a dropped session is still down. */
 const DEFAULT_RECONNECT_LOG_INTERVAL_MS = 30_000;
+
+/** Longest delay (ms) between reminders during one continuous outage. */
+const DEFAULT_RECONNECT_LOG_MAX_INTERVAL_MS = 15 * 60_000;
 
 /**
  * Reject with `timeoutMessage` after `timeoutMs` if `inner` has not settled,
@@ -1232,14 +1237,17 @@ export class ChannelManager implements ChannelsControl {
   }
 
   /**
-   * Repeat a "still down" line for as long as this outage lasts. Runs THROUGH
-   * `gave_up` on purpose: that transition is where the old behavior went quiet,
-   * and an operator watching a silent process cannot tell a dead bot from an
-   * idle one.
+   * Repeat a "still down" line for as long as this outage lasts, with an
+   * exponential delay capped at 15 minutes. Runs THROUGH `gave_up` on purpose:
+   * that transition is where the old behavior went quiet, and an operator
+   * watching a silent process cannot tell a dead bot from an idle one.
    */
   private startReconnectLog(name: string, entry: ChannelEntry): void {
     if (entry.reconnectLogTimer !== undefined) return;
-    const timer = setInterval(() => {
+
+    const delayMs = entry.reconnectLogDelayMs ?? this.reconnectLogIntervalMs;
+    const timer = setTimeout(() => {
+      entry.reconnectLogTimer = undefined;
       if (this.stopped || entry.status === "stopped") {
         this.clearReconnectLog(entry);
         return;
@@ -1247,7 +1255,15 @@ export class ChannelManager implements ChannelsControl {
       this.log?.(
         `channel "${name}" managed session still down after ${this.downFor(entry)}; Phoenix is retrying`,
       );
-    }, this.reconnectLogIntervalMs);
+      entry.reconnectLogDelayMs = Math.min(
+        delayMs * 2,
+        Math.max(
+          this.reconnectLogIntervalMs,
+          DEFAULT_RECONNECT_LOG_MAX_INTERVAL_MS,
+        ),
+      );
+      this.startReconnectLog(name, entry);
+    }, delayMs);
     (timer as unknown as { unref?: () => void }).unref?.();
     entry.reconnectLogTimer = timer;
   }
@@ -1255,9 +1271,10 @@ export class ChannelManager implements ChannelsControl {
   /** Stop this entry's "still down" repeat, if one is running. */
   private clearReconnectLog(entry: ChannelEntry): void {
     if (entry.reconnectLogTimer !== undefined) {
-      clearInterval(entry.reconnectLogTimer);
+      clearTimeout(entry.reconnectLogTimer);
       entry.reconnectLogTimer = undefined;
     }
+    entry.reconnectLogDelayMs = undefined;
   }
 
   /**

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -194,6 +194,12 @@ interface ChannelEntry {
   reconnectLogTimer?: ReturnType<typeof setTimeout>;
   /** Delay before the next reminder; doubles after each emitted reminder. */
   reconnectLogDelayMs?: number;
+  /** Next retry after a transient initial activation failure. */
+  activationRetryTimer?: ReturnType<typeof setTimeout>;
+  /** Delay before the next activation retry; doubles after each failed attempt. */
+  activationRetryDelayMs?: number;
+  /** Reject the retry wrapper when teardown cancels a pending retry. */
+  cancelActivationRetry?: () => void;
 }
 
 /**
@@ -717,6 +723,16 @@ function isSetupRequired(err: unknown): boolean {
   );
 }
 
+/** Whether a failed initial activation can recover without new configuration. */
+function isRetryableActivationError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "GATEWAY_UNREACHABLE" &&
+    (err as { retryable?: unknown }).retryable === true
+  );
+}
+
 /**
  * Whether `err` is a Node/runtime module-resolution failure — i.e. the error
  * a dynamic `import()` throws when the target package is not installed.
@@ -739,6 +755,12 @@ const DEFAULT_RECONNECT_LOG_INTERVAL_MS = 30_000;
 
 /** Longest delay (ms) between reminders during one continuous outage. */
 const DEFAULT_RECONNECT_LOG_MAX_INTERVAL_MS = 15 * 60_000;
+
+/** First delay (ms) before retrying a transient initial activation failure. */
+const DEFAULT_ACTIVATION_RETRY_DELAY_MS = 1_000;
+
+/** Longest delay (ms) between transient initial activation attempts. */
+const DEFAULT_ACTIVATION_RETRY_MAX_DELAY_MS = 30_000;
 
 /**
  * Reject with `timeoutMessage` after `timeoutMs` if `inner` has not settled,
@@ -785,17 +807,18 @@ function withTimeout<T>(
  * {@link activate} starts it and a second call is a no-op. Activation throws
  * SYNCHRONOUSLY (a {@link ChannelConfigError}) only for a misconfiguration it
  * can detect up front — a duplicate or missing Channel name. Every OTHER
- * activation failure is recorded as the Channel's status (`error`, or
- * `setup_required` for a missing provider) and surfaced through {@link status}
- * and {@link ready} rather than thrown.
+ * permanent activation failure is recorded as the Channel's status (`error`,
+ * or `setup_required` for a missing provider) and surfaced through
+ * {@link status} and {@link ready} rather than thrown. A retryable initial
+ * gateway outage stays unsettled and retries until it connects or the manager
+ * stops.
  *
- * Reconnection is NOT handled here — it is delegated to the Phoenix connection
+ * Established-session reconnection is delegated to the Phoenix connection
  * layer that backs the launcher. When a managed control socket drops, Phoenix's
- * `Socket` reconnects and rejoins with the same Runtime declaration. Active
- * deliveries request fresh one-use join tokens through that control link. A
- * re-activation here would be both redundant AND broken: re-invoking the engine
- * on an already-started `Channel` throws in `channel.addAdapter` (started=true).
- * The manager therefore never re-activates on a drop.
+ * `Socket` reconnects and rejoins with the same Runtime declaration. The manager
+ * never re-activates an already-started Channel. It does retry a transient
+ * INITIAL gateway activation failure: that happens before the launcher adds or
+ * starts the managed adapter, so a later attempt is safe.
  *
  * It DOES, however, reflect real connection health through the session's
  * `onStateChange` observer so {@link ChannelManager.status} stays honest rather
@@ -865,8 +888,8 @@ export class ChannelManager implements ChannelsControl {
   /**
    * Start activation of every declared Channel (lazy + idempotent). Mints a
    * distinct runtime instance id per Channel, derives its activation config,
-   * and calls the engine. Records each Channel as `connecting`, transitioning
-   * to `online`/`setup_required`/`error` as its activation settles.
+   * and calls the engine. Transient gateway failures retry with exponential
+   * backoff; other outcomes transition to `online`/`setup_required`/`error`.
    */
   activate(): void {
     // Short-circuit on BOTH latches: `activated` makes activation idempotent,
@@ -903,32 +926,29 @@ export class ChannelManager implements ChannelsControl {
       // promise is always considered handled — ready() still sees the reason.
       settled.catch(() => {});
 
-      // Invoke the engine synchronously so activation is observably started the
-      // moment activate() returns (callers assert the engine was called and see
-      // `connecting` before awaiting ready). A synchronous config/engine throw is
-      // turned into a rejected activation so it becomes this channel's status
-      // rather than throwing out of activate().
-      let activation: Promise<ChannelsHandle>;
-      let config: ChannelActivationConfig | undefined;
-      try {
-        config = deriveChannelActivationConfig({
-          intelligence: this.intelligence,
-          channel,
-          runtimeInstanceId,
-        });
-        activation = this.activateChannel(config, channel);
-      } catch (err) {
-        activation = Promise.reject(err);
-      }
-
-      // The deferred `.then` callbacks capture `entry` and run only after the
-      // literal has fully initialized, so referencing it here is safe.
+      // The deferred activation callbacks capture `entry` and run only after
+      // the literal has fully initialized, so referencing it there is safe.
       const entry: ChannelEntry = {
         status: "connecting",
         handle: undefined,
         handleStopped: false,
         settled,
       };
+
+      // Invoke the engine synchronously so activation is observably started the
+      // moment activate() returns. Only a typed transient gateway failure is
+      // retried; config errors stay on the existing terminal path.
+      let activation: Promise<ChannelsHandle>;
+      try {
+        const config = deriveChannelActivationConfig({
+          intelligence: this.intelligence,
+          channel,
+          runtimeInstanceId,
+        });
+        activation = this.activateWithRetry(config, channel, name, entry);
+      } catch (err) {
+        activation = Promise.reject(err);
+      }
 
       // Anchor the settle handlers. Both branches route every teardown through
       // the idempotent `stopEntry`, so a late settle can never resurrect a
@@ -1010,6 +1030,72 @@ export class ChannelManager implements ChannelsControl {
 
       this.entries.set(name, entry);
     }
+  }
+
+  /**
+   * Retry only transient failures from the pre-adapter gateway connection.
+   * Permanent errors reject on the first attempt; teardown cancels a pending
+   * timer while preserving the existing late-settle handling for in-flight work.
+   */
+  private activateWithRetry(
+    config: ChannelActivationConfig,
+    channel: Channel,
+    name: string,
+    entry: ChannelEntry,
+  ): Promise<ChannelsHandle> {
+    return new Promise<ChannelsHandle>((resolve, reject) => {
+      const attempt = (): void => {
+        let activation: Promise<ChannelsHandle>;
+        try {
+          activation = this.activateChannel(config, channel);
+        } catch (err) {
+          activation = Promise.reject(err);
+        }
+        activation.then(
+          (handle) => {
+            this.clearActivationRetry(entry);
+            resolve(handle);
+          },
+          (err: unknown) => {
+            if (this.stopped || !isRetryableActivationError(err)) {
+              this.clearActivationRetry(entry);
+              reject(err);
+              return;
+            }
+
+            const delayMs =
+              entry.activationRetryDelayMs ?? DEFAULT_ACTIVATION_RETRY_DELAY_MS;
+            entry.status = "reconnecting";
+            entry.activationRetryDelayMs = Math.min(
+              delayMs * 2,
+              DEFAULT_ACTIVATION_RETRY_MAX_DELAY_MS,
+            );
+            this.log?.(
+              `channel "${name}" failed to activate; retrying in ${delayMs}ms`,
+              err,
+            );
+            const timer = setTimeout(() => {
+              entry.activationRetryTimer = undefined;
+              entry.cancelActivationRetry = undefined;
+              if (this.stopped || entry.status === "stopped") {
+                reject(err);
+                return;
+              }
+              entry.status = "connecting";
+              attempt();
+            }, delayMs);
+            (timer as unknown as { unref?: () => void }).unref?.();
+            entry.activationRetryTimer = timer;
+            entry.cancelActivationRetry = () => {
+              this.clearActivationRetry(entry);
+              reject(err);
+            };
+          },
+        );
+      };
+
+      attempt();
+    });
   }
 
   /**
@@ -1277,6 +1363,26 @@ export class ChannelManager implements ChannelsControl {
     entry.reconnectLogDelayMs = undefined;
   }
 
+  /** Cancel a pending transient activation retry and reset its backoff. */
+  private clearActivationRetry(entry: ChannelEntry): void {
+    if (entry.activationRetryTimer !== undefined) {
+      clearTimeout(entry.activationRetryTimer);
+      entry.activationRetryTimer = undefined;
+    }
+    entry.activationRetryDelayMs = undefined;
+    entry.cancelActivationRetry = undefined;
+  }
+
+  /** Cancel a scheduled activation retry and settle its wrapper. */
+  private cancelActivationRetry(entry: ChannelEntry): void {
+    const cancel = entry.cancelActivationRetry;
+    if (cancel) {
+      cancel();
+    } else {
+      this.clearActivationRetry(entry);
+    }
+  }
+
   /**
    * Drive a single entry to its terminal `stopped` state, tearing down its
    * handle AT MOST ONCE. Idempotent: it always sets `status = "stopped"`, and
@@ -1314,6 +1420,7 @@ export class ChannelManager implements ChannelsControl {
     // An unref'd interval would not hold the process open, but a stopped
     // manager must not keep logging about a session it no longer owns.
     this.clearReconnectLog(entry);
+    this.cancelActivationRetry(entry);
     if (entry.handle && !entry.handleStopped) {
       entry.handleStopped = true;
       const handle = entry.handle;

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -725,11 +725,14 @@ function isSetupRequired(err: unknown): boolean {
 
 /** Whether a failed initial activation can recover without new configuration. */
 function isRetryableActivationError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) {
+    return false;
+  }
+  const value = err as { code?: unknown; retryable?: unknown };
   return (
-    typeof err === "object" &&
-    err !== null &&
-    (err as { code?: unknown }).code === "GATEWAY_UNREACHABLE" &&
-    (err as { retryable?: unknown }).retryable === true
+    (value.code === "GATEWAY_UNREACHABLE" ||
+      value.code === "GATEWAY_JOIN_FAILED") &&
+    value.retryable === true
   );
 }
 


### PR DESCRIPTION
## What changed

- Mark initial gateway HTTP 5xx and transient transport failures as retryable.
- Retry initial managed Channel activation with exponential backoff from 1 second to a 30-second cap until it connects or the manager stops.
- Preserve retry hints from `gateway_draining` join replies and retry initial join timeouts.
- Keep HTTP 4xx and NXDOMAIN failures terminal.
- Back off established-session outage reminders from 30 seconds to a 15-minute cap while Phoenix continues reconnecting.

## Why

The OpenTag Railway runtime saw the gateway host return HTTP 502 during an outage. Established Phoenix sessions keep retrying, but a runtime that starts during the outage stops after its one initial connect window. It cannot recover when the gateway comes back unless the process restarts. Fixed 30-second reminder logs also flood long outages.

The gateway drain work now rejects new joins with a structured retryable response. The client must preserve that response so the runtime can retry instead of leaving the Channel in a terminal error state.

## Companion change

CopilotKit/OpenTag#25 keeps the Railway HTTP server alive while an initial Channel retry is pending. OpenTag must consume a CopilotKit release containing this PR before that companion change can recover by itself.

## Validation

- `pnpm nx run-many -t test,check-types,build -p @copilotkit/runtime,@copilotkit/channels-intelligence`
- `pnpm nx run-many -t publint,attw -p @copilotkit/runtime,@copilotkit/channels-intelligence`
- pre-commit tests and package checks for all affected projects
- `pnpm exec oxfmt --check` on all five changed files
- `pnpm exec oxlint` on all five changed files
- `git diff --check`
