### PR TITLE
docs(channels): add copyable onboarding prompts

### DIFF
--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -6,6 +6,92 @@ description: Run one AG-UI agent in Slack, Microsoft Teams, and more through man
 doc_type: explanation
 ---
 
+<FrontendOnly frontend="slack">
+
+<Accordions>
+<Accordion title="Start building with your coding agent — copy this prompt">
+
+Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Slack.
+
+```text
+Help me create a new CopilotKit app from scratch, then connect its agent to Slack so it answers in a real channel.
+
+Use these skills as your instructions, in this order:
+- `copilotkit-setup` for creating the app and wiring managed Intelligence.
+- `copilotkit-channels` for the CLI-scaffolded Channel and its long-running host.
+- `setup-slack-channel` for the Slack app and managed Intelligence provider setup.
+
+Read all three before you plan anything, and follow them rather than working from memory. If any skill is not installed, stop and tell me to run `npx copilotkit@latest skills install` in the directory where I want the project, then wait for me. Do not attempt the setup without them.
+
+Use the CopilotKit CLI through `npx copilotkit@latest`; do not assume or require a global CLI installation. Before you start, verify that Node.js 20 or newer is available. If it is not, stop and tell me what I need to install.
+
+When you implement the plan:
+- Run `npx copilotkit@latest create` to scaffold a brand-new project. Ask me for the project name and framework instead of choosing them for me.
+- Choose managed Intelligence because Channels are not available in self-hosted SSE mode. Follow the CLI's current prompts rather than guessing undocumented flags.
+- Treat the CLI-generated `channel-host.mts` and `channels.mts` as the code half. Do not add a second Channel declaration or move the Channel into a serverless route.
+- Use `setup-slack-channel` for the provider half, including the dedicated Slack app, managed Channel, credentials, and real workspace verification. Do not replace the managed path with a direct Slack adapter.
+
+Before your first step, tell me which mode you are in:
+- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account — signing in, creating an Intelligence project, creating the Slack app, attaching the adapter, or issuing a key.
+- You cannot. Then say so plainly and walk me through the browser steps one at a time, waiting for me to confirm each before you continue.
+
+Do not guess which one you are. Check what tools you actually have.
+
+Rules for the whole run:
+- Never ask me to paste a token, signing secret, or API key into this conversation. They go into the Intelligence dashboard and my `.env`, typed by me.
+- Do not report success until all three gates in `setup-slack-channel` hold. "The runtime started" is not one of them.
+
+Start by reading the three skills, then tell me which are available, what you found in the current directory, which browser mode you are in, and what you plan to do.
+```
+
+</Accordion>
+</Accordions>
+
+</FrontendOnly>
+
+<FrontendOnly frontend="teams">
+
+<Accordions>
+<Accordion title="Start building with your coding agent — copy this prompt">
+
+Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Microsoft Teams.
+
+```text
+Help me create a new CopilotKit app from scratch, then connect its agent to Microsoft Teams so it answers in a real channel.
+
+Use these sources as your instructions, in this order:
+- `copilotkit-setup` for creating the app and wiring managed Intelligence.
+- `copilotkit-channels` for the CLI-scaffolded Channel and its long-running host.
+- The current Microsoft Teams Channels documentation at https://docs.copilotkit.ai/teams for the provider setup and end-to-end verification.
+
+Read both skills and the linked Teams documentation before you plan anything, and follow them rather than working from memory. If either skill is not installed, stop and tell me to run `npx copilotkit@latest skills install` in the directory where I want the project, then wait for me. Do not require a Teams-specific onboarding skill or substitute Slack setup instructions; use the linked Teams documentation as the provider source of truth.
+
+Use the CopilotKit CLI through `npx copilotkit@latest`; do not assume or require a global CLI installation. Before you start, verify that Node.js 22 or newer is available. If it is not, stop and tell me what I need to install.
+
+When you implement the plan:
+- Run `npx copilotkit@latest create` to scaffold a brand-new project. Ask me for the project name and framework instead of choosing them for me.
+- Choose managed Intelligence because Channels are not available in self-hosted SSE mode. Follow the CLI's current prompts rather than guessing undocumented flags.
+- Treat the CLI-generated `channel-host.mts` and `channels.mts` as the code half. Do not add a second Channel declaration or move the Channel into a serverless route.
+- Use the published Teams documentation as the provider half. Start at https://docs.copilotkit.ai/teams, select my agent backend in the docs, and follow the linked Intelligence configuration and Teams connection pages in order. Use the current documented steps instead of relying on memory of Azure Bot or Teams app setup.
+
+Before your first step, tell me which mode you are in:
+- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account — signing in, creating an Intelligence project, creating or changing an Azure Bot registration, attaching the Teams connection, issuing a key, or installing the app in Microsoft Teams.
+- You cannot. Then say so plainly and walk me through the browser steps one at a time, waiting for me to confirm each before you continue.
+
+Do not guess which one you are. Check what tools you actually have.
+
+Rules for the whole run:
+- Never ask me to paste a token, client secret, or API key into this conversation. They go into Azure, the Intelligence dashboard, and my `.env`, typed by me.
+- Do not report success until the app is installed in the intended Teams scope, Intelligence reports the Channel as Online, and a real Teams message or mention receives the agent's reply. "The runtime started" is not success.
+
+Start by reading the two skills and the Teams documentation, then tell me which skills are available, what you found in the current directory, which browser mode you are in, and what you plan to do.
+```
+
+</Accordion>
+</Accordions>
+
+</FrontendOnly>
+
 Channels brings your agent into the conversations where work already happens.
 Your agent still runs in your infrastructure. CopilotKit Intelligence owns the
 channel connection (Slack, Teams, Discord, etc.), delivers each turn to your

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -329,20 +329,101 @@ describe("Channels documentation journey", () => {
     expect(threads).toMatch(/not a synthetic user message/i);
   });
 
-  it("keeps the setup journey limited to released paths", () => {
-    const sources = [
-      bodyFor("channels/intelligence"),
+  it("offers provider-appropriate setup prompts for coding agents", () => {
+    const overviewSource = bodyFor("channels");
+    const overview = filterFrontendScopedBlocks(overviewSource, "slack");
+    const teamsOverview = filterFrontendScopedBlocks(overviewSource, "teams");
+    const intelligence = bodyFor("channels/intelligence");
+    const quickstarts = [
       bodyFor("frontends/slack"),
       bodyFor("frontends/teams"),
     ];
 
-    for (const source of sources) {
+    expect(intelligence).not.toMatch(/\bcopilotkit\s+channels\b/i);
+
+    for (const source of quickstarts) {
       expect(source).not.toMatch(/\bcopilotkit\s+channels\b/i);
     }
 
-    expect(bodyFor("channels/intelligence")).toMatch(
-      /browser wizard[\s\S]*released setup path/i,
+    expect(overview).toContain(
+      '<Accordion title="Start building with your coding agent — copy this prompt">',
     );
+    expect(overview).toContain(
+      "Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Slack.",
+    );
+    expect(overview).toContain("```text");
+    expect(overview).toContain(
+      "Help me create a new CopilotKit app from scratch, then connect its agent to Slack so it answers in a real channel.",
+    );
+    expect(overview).toContain(
+      "`copilotkit-setup` for creating the app and wiring managed Intelligence.",
+    );
+    expect(overview).toContain(
+      "`copilotkit-channels` for the CLI-scaffolded Channel and its long-running host.",
+    );
+    expect(overview).toContain(
+      "`setup-slack-channel` for the Slack app and managed Intelligence provider setup.",
+    );
+    expect(overview).toContain(
+      "`npx copilotkit@latest skills install` in the directory where I want the project",
+    );
+    expect(overview).toContain(
+      "Use the CopilotKit CLI through `npx copilotkit@latest`; do not assume or require a global CLI installation.",
+    );
+    expect(overview).toContain(
+      "Run `npx copilotkit@latest create` to scaffold a brand-new project.",
+    );
+    expect(overview).toContain(
+      "Choose managed Intelligence because Channels are not available in self-hosted SSE mode.",
+    );
+    expect(overview).toContain(
+      "Do not add a second Channel declaration or move the Channel into a serverless route.",
+    );
+    expect(overview).toContain("Do not guess which one you are.");
+    expect(overview).toContain(
+      "Never ask me to paste a token, signing secret, or API key into this conversation.",
+    );
+    expect(overview).toContain(
+      "Do not report success until all three gates in `setup-slack-channel` hold.",
+    );
+    expect(overview).toContain('"The runtime started" is not one of them.');
+    expect(overview).not.toContain("npx copilotkit@latest channels setup");
+    expect(teamsOverview).toContain(
+      '<Accordion title="Start building with your coding agent — copy this prompt">',
+    );
+    expect(teamsOverview).toContain(
+      "Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Microsoft Teams.",
+    );
+    expect(teamsOverview).toContain(
+      "Help me create a new CopilotKit app from scratch, then connect its agent to Microsoft Teams so it answers in a real channel.",
+    );
+    expect(teamsOverview).toContain(
+      "The current Microsoft Teams Channels documentation at https://docs.copilotkit.ai/teams",
+    );
+    expect(teamsOverview).toContain(
+      "Do not require a Teams-specific onboarding skill or substitute Slack setup instructions; use the linked Teams documentation as the provider source of truth.",
+    );
+    expect(teamsOverview).toContain(
+      "verify that Node.js 22 or newer is available",
+    );
+    expect(teamsOverview).toContain(
+      "Run `npx copilotkit@latest create` to scaffold a brand-new project.",
+    );
+    expect(teamsOverview).toContain(
+      "Treat the CLI-generated `channel-host.mts` and `channels.mts` as the code half.",
+    );
+    expect(teamsOverview).toContain(
+      "Use the published Teams documentation as the provider half.",
+    );
+    expect(teamsOverview).toContain("Do not guess which one you are.");
+    expect(teamsOverview).toContain(
+      "Never ask me to paste a token, client secret, or API key into this conversation.",
+    );
+    expect(teamsOverview).toContain(
+      "Do not report success until the app is installed in the intended Teams scope, Intelligence reports the Channel as Online, and a real Teams message or mention receives the agent's reply.",
+    );
+    expect(teamsOverview).not.toContain("`setup-slack-channel`");
+    expect(intelligence).toMatch(/browser wizard[\s\S]*released setup path/i);
   });
 
   it("documents provider-scoped identity and per-run Memory", () => {


### PR DESCRIPTION
## Summary

- add provider-aware coding-agent entry points to the Channels overviews at `/slack` and `/teams`
- present both onboarding flows in the site’s existing collapsed `Accordion` pattern, with fenced text blocks that provide the standard `Copy Text` control
- make each prompt start from an empty directory instead of assuming an existing CopilotKit agent
- use the Slack onboarding skill as the Slack provider source of truth and the published Teams documentation as the Teams provider source of truth
- add regression coverage for provider scoping, onboarding order, safety requirements, and end-to-end verification gates

## User experience

Both Channels overview routes now open with **Start building with your coding agent — copy this prompt**. The row stays collapsed until selected, keeping the existing overview readable while giving builders a complete prompt they can copy into a local coding agent.

The prompts share the same start-from-scratch foundation:

1. Read `copilotkit-setup` for new-application and managed-Intelligence onboarding.
2. Read `copilotkit-channels` for the CLI-scaffolded Channel declaration and long-running host.
3. Stop when a required generic skill is unavailable and direct the user to `npx copilotkit@latest skills install`.
4. Use the CopilotKit CLI through `npx copilotkit@latest`; neither prompt assumes or requires a global CLI installation.
5. Run `npx copilotkit@latest create`, asking the user for the project name and framework rather than silently choosing them.
6. Select managed Intelligence, since Channels are unavailable in self-hosted SSE mode.
7. Preserve the CLI-generated `channel-host.mts` and `channels.mts` as the code half instead of creating a duplicate Channel declaration or placing it in a serverless route.
8. Inspect actual browser capabilities and either drive the browser with confirmation before consequential live-account changes or guide the user one step at a time.
9. Keep credentials out of the conversation and report success only after the provider installation, managed runtime, and real-message path are verified.

## Slack prompt

The `/slack` prompt additionally:

- reads `setup-slack-channel` before planning
- delegates the Slack app, managed provider connection, and workspace verification to that skill
- verifies Node.js 20 or newer
- protects Slack tokens, signing secrets, and Intelligence API keys
- requires all three `setup-slack-channel` gates before reporting success

## Microsoft Teams prompt

The `/teams` prompt mirrors the complete start-from-scratch flow without inventing or requiring a Teams-specific onboarding skill. It instead:

- treats `https://docs.copilotkit.ai/teams` as the provider source of truth, following the documentation-based prompt pattern already used by the docs-root Channels CTA
- tells the agent to select the user’s backend in the docs and follow the linked Intelligence configuration and Teams connection pages in order
- rejects substituting Slack setup instructions or relying on remembered Azure Bot and Teams app setup
- verifies Node.js 22 or newer, matching the published managed Teams runner requirement
- requires confirmation before consequential Azure, Intelligence, and Teams account changes
- protects tokens, client secrets, and API keys
- requires the app to be installed in the intended Teams scope, the Intelligence Channel to be Online, and a real Teams message or mention to receive a reply before reporting success

## Provider scoping

The Channels overview source is shared by both routes. Separate `FrontendOnly` blocks ensure that:

- `/slack` receives only the Slack skill-driven prompt
- `/teams` receives only the Teams documentation-driven prompt
- neither route leaks the other provider’s onboarding source or instructions

## Research basis

The final flow follows responsibilities and requirements already documented in the repository:

- `copilotkit-setup` owns new-project and managed-Intelligence onboarding
- `copilotkit-channels` owns the generated Channels runtime and warns against duplicate/manual Channel wiring
- `setup-slack-channel` owns the Slack provider flow and its three success gates
- the docs-root Channels CTA already produces provider-specific coding-agent prompts that point to the selected Shell Docs guide URL
- the Teams guide documents Node.js 22+, managed Intelligence configuration, Azure Bot setup, installation in Teams, Online runtime status, and real-message verification
- the CLI docs consistently use `npx copilotkit@latest`; they do not require a global installation
- `npx copilotkit@latest skills install` is the documented skill installer, and `npx copilotkit@latest create` is the documented new-project scaffold

## Scope

This PR intentionally changes only:

- `showcase/shell-docs/src/content/docs/channels/index.mdx`
- `showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts`

It does not add a component, alter navigation, change either provider tutorial, modify the Intelligence browser setup flow, or claim a Teams-specific onboarding skill exists.

The branch is intentionally presented as one commit:

- `docs(channels): add copyable onboarding prompts`

## Validation

- full shell-docs suite: `npm test -- --maxWorkers=1 --no-file-parallelism`
- full Vitest suite confirmation: `npx vitest run --maxWorkers=1 --no-file-parallelism --reporter=dot`
- focused Channels docs suite: 29 tests passed
- `pnpm exec oxfmt --check showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts showcase/shell-docs/src/content/docs/channels/index.mdx`
- `git diff --check`
- rendered Slack verification at `http://localhost:3003/slack`: one provider-specific prompt with `setup-slack-channel`, no Teams docs URL, and one `Copy Text` control
- rendered Teams verification at `http://localhost:3003/teams`: one provider-specific prompt with the Teams docs URL, no `setup-slack-channel` reference, and one `Copy Text` control
- pre-commit and commit-message hooks passed

All test runs used one worker with file parallelism disabled to keep memory use bounded.
