### PR TITLE
fix(channels): echo the originating interrupt back as command.interruptEvent

### DIFF
--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -847,6 +847,9 @@ export function createChannel<
       registerWaiter: (k, r) => waiters.set(k, r),
       interruptHandlers,
       state: backend,
+      // Tie the retained interrupt value's lifetime to the action that resumes
+      // it — same knob, so they cannot drift apart.
+      interruptRetentionMs: cfg.actionRetentionMs,
       stateSchema: cfg.state,
       transcripts,
       message: extras?.message,

--- a/packages/channels-core/src/hitl-continuation.test.tsx
+++ b/packages/channels-core/src/hitl-continuation.test.tsx
@@ -497,8 +497,16 @@ test("normal runs write no continuation state and one resume consumes once", asy
 
   await turn("interrupt");
   const actionId = firstActionId(adapter);
-  expect(set).toHaveBeenCalledTimes(1);
-  expect(set.mock.calls[0]?.[0]).toBe(`action:${actionId}`);
+  // Asserted by KEY, not by call count. An interrupt turn writes exactly one
+  // action snapshot — that is the invariant this test is about — plus the
+  // retained interrupt value that `resume` echoes back as
+  // `command.interruptEvent` (see interrupt-event-echo.test.tsx). A bare count
+  // conflates the two and breaks on bookkeeping that is not continuation state.
+  const writes = set.mock.calls.map((call) => String(call[0]));
+  expect(writes.filter((key) => key.startsWith("action:"))).toEqual([
+    `action:${actionId}`,
+  ]);
+  expect(writes).toContain("interruptevent:thread-1");
   expect(consume).not.toHaveBeenCalled();
 
   const click = (eventId: string) =>
@@ -511,6 +519,11 @@ test("normal runs write no continuation state and one resume consumes once", asy
     });
   await click("bob-click");
   await click("bob-click-redelivery");
-  expect(consume).toHaveBeenCalledTimes(1);
-  expect(consume.mock.calls[0]?.[0]).toBe(`action:${actionId}`);
+  // The load-bearing part: the ACTION is consumed exactly once across the click
+  // and its redelivery. Filtered by key for the same reason as above — the resume
+  // also consumes the retained interrupt value, which is a separate one-use item.
+  const consumed = consume.mock.calls.map((call) => String(call[0]));
+  expect(consumed.filter((key) => key.startsWith("action:"))).toEqual([
+    `action:${actionId}`,
+  ]);
 });

--- a/packages/channels-core/src/interrupt-event-echo.test.tsx
+++ b/packages/channels-core/src/interrupt-event-echo.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * `thread.resume` echoes the originating interrupt back to the agent as
+ * `forwardedProps.command.interruptEvent`.
+ *
+ * WHY: channels only ever sent `command = { resume }`. LangGraph needs nothing
+ * more — it correlates by `thread_id` — so the gap was invisible. Other AG-UI
+ * bridges correlate by ids carried IN the interrupt: `@ag-ui/mastra` gates its
+ * resume on `command.interruptEvent` and needs `{toolCallId, runId}` from it. A
+ * resume without it is not an error there, it is a SILENT no-op: the run proceeds
+ * as an ordinary new turn and the suspended tool never completes.
+ *
+ * The value is treated as opaque — channels does not parse or reshape it, it just
+ * hands back what the agent sent. That keeps this framework-agnostic.
+ *
+ * The last test is the compatibility guarantee: when no interrupt value was
+ * captured, the wire shape is byte-identical to before.
+ */
+import type { AgentSubscriber, RunAgentParameters } from "@ag-ui/client";
+import { Button } from "@copilotkit/channels-ui";
+import { afterEach, expect, test } from "vitest";
+import { createChannel } from "./create-channel.js";
+import { MemoryStore } from "./state/memory-store.js";
+import { FakeAdapter } from "./testing/fake-adapter.js";
+import { FakeAgent } from "./testing/fake-agent.js";
+import type { FakeAgentScriptStep } from "./testing/fake-agent.js";
+
+const activeChannels: Array<{ stop(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(activeChannels.splice(0).map((channel) => channel.stop()));
+});
+
+/** The correlation-bearing shape a Mastra-style bridge sends and requires back. */
+const MASTRA_LIKE_VALUE = {
+  type: "mastra_suspend",
+  toolCallId: "call_abc123",
+  runId: "run_xyz789",
+  suspendPayload: {
+    kind: "confirm_create_thing",
+    action: "Create thing: widget",
+  },
+};
+
+/**
+ * Records the `RunAgentParameters` of every run so the wire shape is assertable.
+ *
+ * `clone()` is overridden for two reasons, both enforced by createChannel's
+ * clone guard: `FakeAgent.clone()` returns a base `FakeAgent` (which would strip
+ * this recorder entirely), and every turn runs on a fresh clone — so `params`
+ * must be SHARED, not copied, or the resume run's parameters land on an instance
+ * the test never sees.
+ */
+class RecordingAgent extends FakeAgent {
+  params: Array<RunAgentParameters | undefined>;
+  private readonly script0: FakeAgentScriptStep[];
+
+  constructor(
+    script: FakeAgentScriptStep[],
+    params: Array<RunAgentParameters | undefined> = [],
+  ) {
+    super(script);
+    this.script0 = script;
+    this.params = params;
+  }
+
+  override clone(): RecordingAgent {
+    const cloned = new RecordingAgent(this.script0, this.params);
+    cloned.threadId = this.threadId;
+    cloned.agentId = this.agentId;
+    return cloned;
+  }
+
+  override async runAgent(
+    parameters?: RunAgentParameters,
+    subscriber?: AgentSubscriber,
+  ) {
+    this.params.push(parameters);
+    return super.runAgent(parameters, subscriber);
+  }
+}
+
+type Command = { resume?: unknown; interruptEvent?: unknown } | undefined;
+
+/** The `forwardedProps.command` of the first run that carried one. */
+function sentCommand(agent: RecordingAgent): Command {
+  for (const p of agent.params) {
+    const command = (p?.forwardedProps as { command?: Command } | undefined)
+      ?.command;
+    if (command) return command;
+  }
+  return undefined;
+}
+
+function firstActionId(adapter: FakeAdapter): string {
+  const button = adapter.posted.flat().find((node) => node.type === "button");
+  const action = button?.props.onClick as { id?: unknown } | undefined;
+  if (typeof action?.id !== "string") throw new Error("missing action id");
+  return action.id;
+}
+
+/**
+ * Drives one interrupt → picker → click → resume cycle.
+ * `interruptValue: undefined` emits a named custom event with NO value, which is
+ * how the "nothing captured" case is reached.
+ */
+async function runCycle(interruptValue: unknown) {
+  const adapter = new FakeAdapter();
+  const state = new MemoryStore();
+  // Interrupt on the FIRST run only. Clones restart the script (the shift happens
+  // on the clone, not the original), so without this shared counter the resume run
+  // would interrupt again — re-storing the value straight after the resume consumed
+  // it, and quietly invalidating the one-use assertion below.
+  const runs = { count: 0 };
+  const agent = new RecordingAgent([
+    (subscriber) => {
+      if (runs.count++ === 0) {
+        subscriber.onCustomEvent?.({
+          event: { name: "approval", value: interruptValue },
+        } as never);
+      }
+      subscriber.onRunFinishedEvent?.({ event: {} } as never);
+    },
+  ]);
+
+  function Approval() {
+    return (
+      <Button
+        value={{ approved: true }}
+        onClick={async ({ thread }) => {
+          await thread.resume({ approved: true });
+        }}
+      >
+        Approve
+      </Button>
+    );
+  }
+
+  const channel = createChannel({
+    name: "approvals",
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent,
+    components: [Approval],
+    store: { adapter: state },
+  });
+  channel.onMessage(async ({ thread }) => {
+    await thread.runAgent();
+  });
+  channel.onInterrupt("approval", async ({ thread }) => {
+    await thread.post(<Approval />);
+  });
+  await channel.ɵruntime.start();
+  activeChannels.push({ stop: () => channel.ɵruntime.stop() });
+
+  await adapter.getSink().onTurn({
+    conversationKey: "thread-1",
+    replyTarget: {},
+    userText: "start",
+    platform: "fake",
+    actor: { id: "alice", kind: "human", name: "Alice" },
+  });
+
+  return { adapter, agent, state, Approval };
+}
+
+async function click(adapter: FakeAdapter): Promise<void> {
+  await adapter.getSink().onInteraction({
+    id: firstActionId(adapter),
+    conversationKey: "thread-1",
+    replyTarget: {},
+    eventId: "click-1",
+    actor: { id: "alice", kind: "human", name: "Alice" },
+  });
+}
+
+test("resume echoes the captured interrupt value as command.interruptEvent", async () => {
+  const { adapter, agent } = await runCycle(MASTRA_LIKE_VALUE);
+  await click(adapter);
+
+  const command = sentCommand(agent);
+  expect(command).toBeDefined();
+  expect(command?.resume).toEqual({ approved: true });
+  // Opaque round-trip: byte-for-byte what the agent sent, not a reshaped subset.
+  expect(command?.interruptEvent).toEqual(MASTRA_LIKE_VALUE);
+});
+
+test("the interrupt value is persisted, so a resume can survive a restart", async () => {
+  const { state } = await runCycle(MASTRA_LIKE_VALUE);
+  // In the DURABLE store, not process memory — the click can arrive in a later
+  // process, which is the entire point of the interrupt path over awaitChoice.
+  await expect(state.kv.get("interruptevent:thread-1")).resolves.toEqual(
+    MASTRA_LIKE_VALUE,
+  );
+});
+
+test("the retained value is one-use: consumed by the resume that sends it", async () => {
+  const { adapter, state } = await runCycle(MASTRA_LIKE_VALUE);
+  await click(adapter);
+  // Matches the one-use continuation the resume already claims: a replayed click
+  // must not resurrect a spent resume.
+  await expect(
+    state.kv.get("interruptevent:thread-1"),
+  ).resolves.toBeUndefined();
+});
+
+test("omits interruptEvent entirely when no value was captured", async () => {
+  const { adapter, agent } = await runCycle(undefined);
+  await click(adapter);
+
+  const command = sentCommand(agent);
+  expect(command?.resume).toEqual({ approved: true });
+  // The compatibility guarantee: not `interruptEvent: undefined` — absent. The
+  // serialized command is identical to what channels sent before this change,
+  // so agents that never carry correlation data see no difference at all.
+  expect(command).not.toHaveProperty("interruptEvent");
+  expect(Object.keys(command ?? {})).toEqual(["resume"]);
+});

--- a/packages/channels-core/src/run-loop.ts
+++ b/packages/channels-core/src/run-loop.ts
@@ -36,8 +36,13 @@ export interface RunLoopArgs {
   isAborted?: () => boolean;
   /** Hard cap on loop iterations. Default 6. */
   maxIterations?: number;
-  /** When re-entering via thread.resume, the resume command to replay. */
-  initialResume?: { resume: unknown };
+  /**
+   * When re-entering via thread.resume, the resume command to replay. Sent
+   * verbatim as `forwardedProps.command`, so any field here reaches the agent.
+   * `interruptEvent` echoes the originating interrupt back for bridges that key
+   * their resume off it (@ag-ui/mastra); it is absent unless one was captured.
+   */
+  initialResume?: { resume: unknown; interruptEvent?: unknown };
   /** Subscriber used for each underlying agent step. Defaults to the renderer. */
   subscriber?: AgentSubscriber;
   /**

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -35,6 +35,16 @@ import { hasMemoryAccess, resolveMemoryGrant } from "./memory.js";
 import type { MemoryGrant, ResolvedChannelMemory } from "./memory.js";
 import type { ChannelComponentRenderContext } from "./channel-component.js";
 
+/**
+ * Default retention for a captured interrupt value (7 days) — deliberately the
+ * same default the action store uses, so the retained value and the button that
+ * consumes it expire together. If a channel configures a LONGER
+ * `actionRetentionMs`, the value can lapse before the button does; a resume then
+ * simply omits `command.interruptEvent`, which is exactly the pre-existing
+ * behaviour rather than a new failure.
+ */
+const DEFAULT_INTERRUPT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
 /** A Channel run requested Memory without an attached Intelligence backend. */
 export class ChannelMemoryUnavailableError extends Error {
   readonly code = "channel_memory_unavailable";
@@ -103,6 +113,13 @@ export interface ThreadDeps {
   >;
   /** Pluggable persistence. Injected by createChannel; always required. */
   state: StateStore;
+  /**
+   * How long a captured interrupt value is retained so `resume` can echo it back
+   * as `command.interruptEvent`. Should match the action retention, since the
+   * button that triggers the resume is what bounds its useful life. Defaults to
+   * {@link DEFAULT_INTERRUPT_RETENTION_MS}.
+   */
+  interruptRetentionMs?: number;
   /**
    * Optional Standard Schema for per-thread state. When set, `setState`
    * validates its argument before persisting and throws on a schema mismatch.
@@ -442,6 +459,40 @@ export class Thread implements ThreadInterface {
     );
   }
 
+  private interruptEventKey(): string {
+    return `interruptevent:${this.deps.conversationKey}`;
+  }
+
+  /**
+   * Retain the raw value of a captured interrupt so a later {@link resume} can
+   * echo it back to the agent as `command.interruptEvent`.
+   *
+   * PERSISTED, not in-memory, because the resume arrives in a DIFFERENT run —
+   * possibly in a different process after a restart, which is the whole reason
+   * this HITL path exists. Stored per conversation, matching the fact that a
+   * renderer tracks a single pending interrupt: a second interrupt in the same
+   * conversation legitimately supersedes the first.
+   *
+   * Best-effort: an agent that needs no correlation data (LangGraph) resumes
+   * fine without this, so a store failure must not take the interrupt down.
+   */
+  private async rememberInterruptEvent(value: unknown): Promise<void> {
+    if (value === undefined) return;
+    try {
+      await this.store.kv.set(
+        this.interruptEventKey(),
+        value,
+        this.deps.interruptRetentionMs ?? DEFAULT_INTERRUPT_RETENTION_MS,
+      );
+    } catch (err) {
+      console.warn(
+        "[channel] could not retain the interrupt value; a resume will omit " +
+          "command.interruptEvent (fine for LangGraph, breaks Mastra):",
+        err,
+      );
+    }
+  }
+
   /** Read the conversation's messages (returns `[]` when the adapter can't read history). */
   getMessages(): Promise<ThreadMessage[]> {
     return this.trackOperation(
@@ -592,8 +643,33 @@ export class Thread implements ThreadInterface {
         initiator: claimed.initiator,
       };
       this.activeContinuation = continuation;
+      // Echo the originating interrupt back to the agent. Some AG-UI bridges
+      // (e.g. @ag-ui/mastra) key their resume off it — it carries the correlation
+      // ids identifying WHICH suspended call to continue — and silently ignore a
+      // resume without it. LangGraph needs no correlation data and ignores the
+      // extra field, so this is additive for existing agents.
+      //
+      // `consume` is atomic take-and-delete, matching the one-use continuation
+      // claimed just above: a replayed click must not resurrect a spent resume.
+      // Omitted entirely when absent, so the wire shape is byte-identical to
+      // before for any flow that never captured an interrupt value.
+      let interruptEvent: unknown;
       try {
-        return await this.run({ resume: value }, { memory });
+        interruptEvent = await this.store.kv.consume(this.interruptEventKey());
+      } catch (err) {
+        console.warn(
+          "[channel] could not read the retained interrupt value; resuming " +
+            "without command.interruptEvent:",
+          err,
+        );
+      }
+      try {
+        return await this.run(
+          interruptEvent === undefined
+            ? { resume: value }
+            : { resume: value, interruptEvent },
+          { memory },
+        );
       } finally {
         if (this.activeContinuation === continuation) {
           this.activeContinuation = undefined;
@@ -651,7 +727,7 @@ export class Thread implements ThreadInterface {
   }
 
   private async run(
-    initialResume?: { resume: unknown },
+    initialResume?: { resume: unknown; interruptEvent?: unknown },
     extra?: {
       context?: ContextEntry[];
       tools?: ChannelTool[];
@@ -771,6 +847,10 @@ export class Thread implements ThreadInterface {
             platform: this.platform,
           }),
           handleInterrupt: async (interrupt) => {
+            // Retain BEFORE dispatching: the handler posts the picker, and the
+            // click that resumes it can arrive at any later moment, so the value
+            // has to already be durable by the time the button exists.
+            await this.rememberInterruptEvent(interrupt.value);
             const h = this.deps.interruptHandlers.get(interrupt.eventName);
             if (h)
               await h({


### PR DESCRIPTION
## Problem

`thread.resume()` sends `forwardedProps.command = { resume }` and nothing else.

LangGraph needs nothing more — it correlates a resume by `thread_id` — so this gap has been invisible. Bridges that correlate by ids carried **inside the interrupt** cannot work at all. `@ag-ui/mastra` gates its resume on `command.interruptEvent` and needs `{toolCallId, runId}` out of it:

```js
let o = input.forwardedProps?.command;
if (!o?.interruptEvent && Array.isArray(input.resume)) { /* standard path */ }
if (o?.resume === false && o?.interruptEvent) { /* cancelled */ }
if (o?.resume != null && o?.interruptEvent) { /* resume */ }
```

With no `interruptEvent`, **every branch is skipped**. The resume is not an error — it is a silent no-op: the run proceeds as an ordinary new turn, no `RUN_ERROR`, no tool result, and the suspended tool never completes. That is the entire Mastra HITL story through Channels today: the picker appears, the click lands, nothing resumes.

## Change

`Thread` retains the captured interrupt value when the interrupt fires, and `resume` echoes it back.

- **Opaque.** Channels neither parses nor reshapes the value — it hands back exactly what the agent sent, so no framework specifics leak in. This mirrors what `useInterrupt` in `react-core` already does for legacy interrupts.
- **Durable, not in-memory.** The click that resumes can arrive in a later run, possibly after a restart — which is the entire reason this path exists rather than `awaitChoice`.
- **One-use.** Read back with `kv.consume` (atomic take-and-delete), matching the one-use continuation the resume already claims, so a replayed click cannot resurrect a spent resume.
- **Retention tied to `actionRetentionMs`**, so the value and the button that consumes it expire together. Configure a longer action retention and the value can lapse first; the resume then omits the field, which is the pre-existing behaviour rather than a new failure.
- **Best-effort store touches.** An agent that needs no correlation data must not lose its interrupt to a store hiccup.

## Why this is additive

The field is **omitted** when no interrupt value was captured, so the serialized command is byte-identical for agents that carry no correlation data, and a normal (non-interrupt) run still writes nothing at all. LangGraph ignores the extra field.

`interrupt-event-echo.test.tsx` covers all four properties — echo, durability, one-use, omission. The echo test fails without the fix (verified by reverting it).

## Verification

- `channels-core`: 268/268 tests, typecheck clean, `oxfmt` clean, `oxlint` 0 errors.
- Verified end to end against a real Mastra agent driven through Slack: two full cycles (approve, then decline), each producing a matching `SUSPENDING` → `RESUMED` pair agent-side. Before the fix the same rig produced suspends with zero resumes.
- The LangGraph interrupt path was re-checked against the same harness and is unchanged.

## Reviewer note

One existing assertion in `hitl-continuation.test.tsx` moves from counting `kv.set` / `kv.consume` calls to matching them by **key**. The invariant it protects is "an interrupt turn writes exactly one action snapshot, and one resume consumes it once" — both still asserted, now stated directly rather than via a total that conflates action state with unrelated bookkeeping. Flagging it because it is the one pre-existing test this change edits.

## Out of scope

Channels ignores the standard AG-UI interrupt path (`RUN_FINISHED` with `outcome.type === "interrupt"`, resumed via a top-level `resume` array). Mastra emits it today alongside the legacy event, and it carries interrupt ids and expiry the legacy event lacks. Worth a follow-up.