### PR TITLE
docs(reskinnable-demo): correct the reskin skill's layout, tools, theme, and canvas guidance

### DIFF
--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
@@ -57,6 +57,16 @@ variables, and import it as a **side-effect** from the skin's `layout.tsx`
 shell applies your block. Never invent new token names — only re-value existing
 ones.
 
+**Dark mode is an explicit opt-in — `--nw-dark-capable: 1`.**
+`src/hooks/use-theme.ts` forces any skin WITHOUT that flag to light and ignores
+the stored dark preference, so a skin that writes a `.dark .theme-<id>` block but
+forgets the flag stays stuck in light. To support dark you must do BOTH: set
+`--nw-dark-capable: 1` on the `.theme-<id>` root AND ship a `.dark .theme-<id>`
+block (which re-values only surfaces / ink / semantic tokens and lets the brand
+ramp and `--radius` inherit). Omit both to stay light-only — a legitimate choice
+(airline does exactly that). If you kept the theme toggle in your layout, note
+it is a **dead control** until this flag and the dark block both exist.
+
 **OGUI renders full-region on the shared canvas.** A `generateSandboxedUi` call
 becomes an `open-generative-ui` activity that the shell renders full-region on
 the canvas via the workspace `OpenGenerativeUIActivityRenderer` (this build ships
@@ -64,6 +74,16 @@ it). A skin does **not** supply an OGUI renderer — it only contributes
 `sandboxFunctions?` + `designSkill`, which the shell wires onto the provider. (An
 a2ui _report_ surface is different: a skin renders its own via the optional
 `CanvasSurface`.)
+
+**An a2ui `CanvasSurface` must be fed by a SERVER tool, never a client one.** If
+your skin ships a `CanvasSurface`, emit its `{ [A2UI_OPERATIONS_KEY]:
+buildOps(spec) }` payload from a **server-side `defineTool` on the `BuiltInAgent`
+in `agent.ts`** — not from a client `useFrontendTool`. The a2ui middleware only
+converts that payload into an `a2ui-surface` activity when it observes it in an
+in-stream `TOOL_CALL_RESULT` event, which a client frontend-tool result never
+produces — do it client-side and the canvas stays permanently blank. Both banking
+(`render_report`) and logistics (`renderBrief`) do it server-side; the `agent.ts`
+template shows the shape.
 
 ---
 
@@ -74,18 +94,18 @@ against that file; it wins.
 
 **Required:**
 
-| Field         | Type                                            | Purpose                                                                                 |
-| ------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `id`          | `string`                                        | Stable id — **MUST equal the route segment AND the agent id.**                          |
-| `identity`    | object (below)                                  | Brand identity the shell renders.                                                       |
-| `themeClass`  | `string`                                        | CSS class scoping this skin's tokens — set to `"theme-<id>"`.                           |
-| `Layout`      | `ComponentType<{ children: ReactNode }>`        | The app-shell chrome (nav/header) wrapping page content.                                |
-| `nav`         | `NavRoute[]`                                    | Nav entries; also the source of truth for valid segments.                               |
-| `resolvePage` | `(segments: string[]) => ComponentType \| null` | Maps URL segments (after `/[skin]`) to a page, or `null` → 404.                         |
-| `Tools`       | `ComponentType`                                 | Registers frontend tools / HITL / gen-UI + agent-context readables. **Renders `null`.** |
-| `catalog`     | `A2uiCatalog`                                   | The skin's a2ui catalog from `createCatalog()`.                                         |
-| `suggestions` | `Suggestion[]`                                  | Static suggestion pills (`{ title, message }`), shown `available:"always"`.             |
-| `designSkill` | `string`                                        | OGUI design brief — injected as agent context to style generated UIs.                   |
+| Field         | Type                                            | Purpose                                                                                         |
+| ------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `id`          | `string`                                        | Stable id — **MUST equal the route segment AND the agent id.**                                  |
+| `identity`    | object (below)                                  | Brand identity the shell renders.                                                               |
+| `themeClass`  | `string`                                        | CSS class scoping this skin's tokens — set to `"theme-<id>"`.                                   |
+| `Layout`      | `ComponentType<{ children: ReactNode }>`        | The app-shell chrome (nav/header) wrapping page content.                                        |
+| `nav`         | `NavRoute[]`                                    | Nav entries the layout renders. **Display-only — NOT the segment validator** (see below).       |
+| `resolvePage` | `(segments: string[]) => ComponentType \| null` | Maps URL segments (after `/[skin]`) to a page, or `null` → 404. **The sole segment validator.** |
+| `Tools`       | `ComponentType`                                 | Registers frontend tools / HITL / gen-UI + agent-context readables. **Renders `null`.**         |
+| `catalog`     | `A2uiCatalog`                                   | The skin's a2ui catalog from `createCatalog()`.                                                 |
+| `suggestions` | `Suggestion[]`                                  | Static suggestion pills (`{ title, message }`), shown `available:"always"`.                     |
+| `designSkill` | `string`                                        | OGUI design brief — injected as agent context to style generated UIs.                           |
 
 `identity` object:
 
@@ -134,6 +154,84 @@ export type A2uiCatalog = ReturnType<typeof createCatalog>;
 
 > The agent is deliberately absent from this interface — see the boundary
 > section above. It lives in `agent.ts` and registers separately.
+
+**`nav` does not decide what resolves.** It is display-only — the list the layout
+draws as navigation. `resolvePage` is the single source of truth for which
+segments are valid (the contract says so, `skin-contract.ts` around lines 86-92),
+and it may accept segments `nav` omits (banking's `resolvePage` accepts a `cards`
+index alias its `nav` never lists). So every segment a user can reach — nav
+entries, aliases, deep links — must be handled in `resolvePage`; anything it
+returns `null` for is a 404, regardless of what `nav` contains.
+
+---
+
+## The layout contract (viewport height + nav insets)
+
+Two things every shipped `Layout` gets right and the naive version gets wrong —
+both fixed once in `src/skins/logistics/layout.tsx`, which the template mirrors:
+
+- **The root is `h-screen overflow-hidden`, not `min-h-screen`.** `min-h-screen`
+  is a MINIMUM: on a page taller than the viewport the container grows, the whole
+  document scrolls, and the pinned nav scrolls away with it — worse, `<main>`'s
+  own `overflow-y-auto` goes inert because its parent is unbounded. Make the shell
+  exactly one viewport tall (`h-screen overflow-hidden`, plus `h-full` on the
+  `<aside>`) so only `<main>` scrolls.
+- **Publish the nav insets, and remove them on cleanup.** In a `useEffect`, set
+  `--nw-nav-inset-left` / `--nw-nav-inset-right` on `document.documentElement` to
+  the width your nav reserves, so the shell's floating skin selector docks in the
+  content band instead of on top of your nav. Return a cleanup that REMOVES both —
+  a missing cleanup leaks your inset into whatever skin the user switches to next.
+
+## The meta-utility strip
+
+The presenter/dev utilities — Reset, theme toggle, Help — are **skin-authored
+chrome, not shell-provided**. A new skin gets none of them for free; you add them
+in the layout (the template puts them in an `mt-auto` group at the bottom of the
+sidebar). Three controls:
+
+- **Reset** (`RotateCcw`) — render it only when `usePresenterReset()` (from
+  `@/shell/presenter-reset-context`) is true; on click, `window.confirm` then
+  `POST /api/<id>/v1/dev/reset` then `window.location.assign(`/${skin.id}`)` for a
+  pristine slate. Keep the button and the endpoint in agreement: your skin's own
+  `dev/reset` route should allow the reset when `presenterResetEnabled() ||
+process.env.NODE_ENV !== "production"` (mirror
+  `src/app/api/logistics/v1/dev/reset/route.ts`), or a production booth shows a
+  button that 403s.
+- **ThemeToggle** — `import { ThemeToggle } from "@/components/ui/theme-toggle"`.
+  It is a SHARED component under `src/components/ui`, so importing it is fine and
+  is NOT a cross-skin import. Remember it is a dead control unless your skin also
+  ships a dark palette (`--nw-dark-capable: 1` + a `.dark .theme-<id>` block — see
+  the theming rules above).
+- **Help** (`HelpCircle`) — calls a `useAskCopilot()` that opens the panel and
+  sends a message as the user. **Port** it into your own
+  `src/skins/<id>/components/use-ask-copilot.ts` (copy logistics'); do NOT import
+  from `src/skins/banking/**` — a skin's only inbound dependency is the contract.
+
+## Registering tools: the deps array + render signatures
+
+Two rules that the `tools.tsx` template bakes in; miss either and the failure is
+silent.
+
+- **Every `useComponent` / `useFrontendTool` / `useHumanInTheLoop` registration
+  closes with a deps array.** Each takes an **optional deps array as a second
+  argument** (`useFrontendTool(tool, deps?: ReadonlyArray<unknown>)`,
+  `useHumanInTheLoop(tool, deps?)`, `useComponent(spec, deps?)` — the installed
+  types in `@copilotkit/react-core/dist/copilotkit-CBCT7BlL.d.cts` confirm it).
+  Omit it and the closure captures whatever the data was at REGISTRATION time —
+  for a REST-backed skin, the EMPTY array from before the first fetch — forever.
+  This is the nastiest bug in the app because it **compiles, lints, and passes
+  every test**: the agent narrates confidently ("the trade-offs are on screen")
+  while the component renders its "not found" branch over stale data. Banking
+  documents the same trap in a code comment (search "closure captures empty
+  arrays" in `src/skins/banking/tools.tsx`); logistics passes deps on every
+  registration.
+- **A parameterized `useComponent` render receives the schema output DIRECTLY** —
+  `render: ({ myParam }) => …`, NOT wrapped in `{ args }`. Per the installed
+  types, `InferRenderProps<T> = T extends StandardSchemaV1 ? InferSchemaOutput<T>
+: any` and `render: ComponentType<NoInfer<InferRenderProps<TSchema>>>`. By
+  contrast `useHumanInTheLoop` and `useFrontendTool` renders DO receive `{ args,
+status, respond }`. Airline has no parameterized `useComponent`, so don't learn
+  the render shape from it — see the template and logistics' `showShipment`.
 
 ---
 
@@ -201,11 +299,13 @@ src/skins/<id>/
 └── agent.ts          # SERVER-ONLY: export const <id>Agent = () => new BuiltInAgent(...)
 ```
 
-Optional slots you may omit — airline omits all of these EXCEPT `toolLabels`:
-`providers.tsx` (→ `Providers` and/or `RuntimeProviders` + `useRuntimeProperties`),
-`intelligence/user-id.ts` (→ server `identifyUser`), `canvas-surface.tsx`
-(→ `CanvasSurface`), `data/` (→ `useData` — banking omits it and reads REST +
-auth directly), `sandboxFunctions`, `chatHeaderActions`, `onSuggestionSelect`.
+Optional slots you may omit — airline omits all of these EXCEPT `toolLabels` and
+`useData`: `providers.tsx` (→ `Providers` and/or `RuntimeProviders` +
+`useRuntimeProperties`), `intelligence/user-id.ts` (→ server `identifyUser`),
+`canvas-surface.tsx` (→ `CanvasSurface`), `sandboxFunctions`,
+`chatHeaderActions`, `onSuggestionSelect`. (`useData` / `data/` is where the two
+shipped skins split: airline SETS `useData: useAirlineData`; banking omits it and
+reads REST + auth directly, so its `useSkinData<T>()` returns `undefined`.)
 Airline DOES set `toolLabels` (a 9-entry map) so its tool-activity chips read as
 human phrases ("Pulling up your flight") instead of raw tool names (`showFlight`)
 — treat `toolLabels` as expected for any skin with named frontend tools, not

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
@@ -61,6 +61,14 @@ for a full, working example): `--brand`, `--brand-violet`, `--brand-indigo`,
 .theme-<id > {
   --radius: 1.125rem;
 
+  /* OPT-IN dark mode. `src/hooks/use-theme.ts` forces any skin WITHOUT this flag
+     to light and ignores the stored dark preference, so a `.dark .theme-<id>`
+     block below does NOTHING unless you also set this. Set it (and ship the dark
+     block) to make the theme toggle a real control; omit BOTH to stay light-only
+     — a legitimate choice (airline does it). Without the flag the toggle in your
+     layout is a dead button. */
+  --nw-dark-capable: 1;
+
   --brand: 252 83% 67%;
   --brand-violet: 252 83% 67%;
   --brand-indigo: 248 84% 60%;
@@ -81,6 +89,31 @@ for a full, working example): `--brand`, `--brand-violet`, `--brand-indigo`,
   --negative: 349 78% 56%;
   --negative-soft: 349 90% 96%;
 }
+
+/* DARK — ship this ONLY if you set `--nw-dark-capable: 1` above. `.dark` lands on
+   <html> (an ancestor of the `.theme-<id>` root), so this descendant selector
+   re-values only the tokens that DIFFER — surfaces, ink, and semantic tokens —
+   and lets the brand ramp and `--radius` inherit from the light block.
+   (Mirror `src/skins/logistics/theme.css` / `src/skins/banking/theme.css`.) */
+.dark .theme-<id > {
+  color-scheme: dark;
+
+  --background: 252 20% 8%;
+  --foreground: 255 30% 95%;
+  --canvas: 252 20% 8%;
+  --surface: 252 16% 12%;
+  --surface-muted: 252 14% 15%;
+  --ink: 255 30% 95%;
+  --ink-muted: 250 10% 62%;
+  --hairline: 252 12% 22%;
+
+  --brand-soft: 252 40% 20%;
+
+  --positive: 152 52% 50%;
+  --positive-soft: 152 35% 15%;
+  --negative: 349 76% 64%;
+  --negative-soft: 349 40% 18%;
+}
 ```
 
 ## `layout.tsx`
@@ -88,28 +121,87 @@ for a full, working example): `--brand`, `--brand-violet`, `--brand-indigo`,
 Side-effect-import `./theme.css` here so the block loads when the skin mounts.
 Style with the shared semantic utilities (`bg-canvas`, `text-ink`,
 `border-hairline`, `bg-surface`, `text-brand`, …) so the skin reskins with the
-theme. Read the active skin via `useSkin()`.
+theme. Read the active skin via `useSkin()`. Mirror `src/skins/logistics/layout.tsx`
+— it is the debugged reference for the three non-obvious things this chrome MUST
+get right:
+
+- **Root is `h-screen overflow-hidden`, not `min-h-screen`, and the `<aside>` is
+  `h-full`.** `min-h-screen` is a MINIMUM: on a page taller than the viewport the
+  container grows, the whole document scrolls, and the nav scrolls away with it —
+  and `<main>`'s own `overflow-y-auto` goes inert because its parent is
+  unbounded. `h-screen overflow-hidden` pins the shell to exactly one viewport so
+  `<main>` scrolls INSIDE it.
+- **Publish the nav insets.** The `useEffect` below tells the shell how wide this
+  skin's nav is via `--nw-nav-inset-left` / `--nw-nav-inset-right` on
+  `document.documentElement`, so the shell's floating skin selector docks in the
+  content band instead of landing on top of your nav. It MUST remove both on
+  cleanup — a missing cleanup leaks the inset into whatever skin the user
+  switches to next.
+- **The meta-utility strip is skin-authored chrome, not shell-provided.** A new
+  skin gets no Reset / theme toggle / Help for free — you add them here (see the
+  `mt-auto` group). Details in SKILL.md § "The meta-utility strip".
 
 ```tsx
 "use client";
 import "./theme.css"; // side-effect import registers the .theme-<id> block
+import { useEffect } from "react";
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { HelpCircle, RotateCcw } from "lucide-react";
 import { useSkin } from "@/shell/skin-provider";
+import { usePresenterReset } from "@/shell/presenter-reset-context";
+import { ThemeToggle } from "@/components/ui/theme-toggle"; // SHARED shell component — importing it is fine
+import { useAskCopilot } from "./components/use-ask-copilot"; // PORT this into your skin (see below)
+import { cn } from "@/lib/utils";
+
+// The sidebar width doubles as the shell's nav inset — keep them the same value.
+const SIDEBAR_WIDTH_PX = 240;
 
 export function <Id>Layout({ children }: { children: ReactNode }) {
   const skin = useSkin();
   const pathname = usePathname();
+  const resetEnabled = usePresenterReset();
+  const askCopilot = useAskCopilot();
   const Logo = skin.identity.logo;
+
+  const handleReset = async () => {
+    if (!window.confirm("Reset demo state? This restores the seeded scenario.")) return;
+    const res = await fetch(`/api/${skin.id}/v1/dev/reset`, { method: "POST" });
+    if (res.ok) {
+      // Hard-navigate to the skin root for a pristine slate (fresh store, cleared
+      // canvas, new thread on the next message) AND the clean starting URL.
+      window.location.assign(`/${skin.id}`);
+    } else {
+      window.alert(`Reset failed (HTTP ${res.status}). See the server logs.`);
+    }
+  };
+
+  // Publish the nav insets so the shell's floating selector never docks on top of
+  // this nav. Remove BOTH on cleanup, or the inset leaks into the next skin.
+  useEffect(() => {
+    const root = document.documentElement;
+    root.style.setProperty("--nw-nav-inset-left", `${SIDEBAR_WIDTH_PX}px`);
+    root.style.setProperty("--nw-nav-inset-right", "0px");
+    return () => {
+      root.style.removeProperty("--nw-nav-inset-left");
+      root.style.removeProperty("--nw-nav-inset-right");
+    };
+  }, []);
+
   return (
-    <div className="flex min-h-screen bg-canvas text-ink">
-      <aside className="hidden w-64 shrink-0 flex-col border-r border-hairline bg-surface px-4 py-6 md:flex">
-        <div className="mb-8 flex items-center gap-2.5 px-2 text-brand">
+    // h-screen + overflow-hidden (NOT min-h-screen): the shell is exactly one
+    // viewport tall so the nav stays pinned and <main> scrolls INSIDE it.
+    <div className="flex h-screen overflow-hidden bg-canvas text-ink">
+      <aside
+        className="hidden h-full shrink-0 flex-col border-r border-hairline bg-surface px-3 py-5 md:flex"
+        style={{ width: SIDEBAR_WIDTH_PX }}
+      >
+        <div className="mb-7 flex items-center gap-2.5 px-2 text-brand">
           <Logo className="h-7 w-7" />
-          <span className="text-lg font-bold text-ink">{skin.identity.brand}</span>
+          <span className="text-base font-bold tracking-tight text-ink">{skin.identity.brand}</span>
         </div>
-        <nav className="flex flex-col gap-1">
+        <nav className="flex flex-col gap-0.5">
           {skin.nav.map((route) => {
             const href = route.segment ? `/${skin.id}/${route.segment}` : `/${skin.id}`;
             const active = pathname === href;
@@ -119,20 +211,61 @@ export function <Id>Layout({ children }: { children: ReactNode }) {
                 key={route.segment || "index"}
                 href={href}
                 aria-current={active ? "page" : undefined}
-                className={active ? "bg-brand-soft text-brand rounded-xl px-3 py-2.5 text-sm font-medium" : "text-ink-muted hover:bg-surface-muted rounded-xl px-3 py-2.5 text-sm font-medium"}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-brand-soft text-brand"
+                    : "text-ink-muted hover:bg-surface-muted hover:text-ink",
+                )}
               >
-                {Icon ? <Icon className="mr-3 inline h-4 w-4" /> : null}
+                {Icon ? <Icon className="h-4 w-4" /> : null}
                 {route.label}
               </Link>
             );
           })}
         </nav>
+
+        {/* Meta-utility strip — skin-authored chrome, pinned to the bottom.
+            Reset is presenter-gated; the theme toggle is a dead control unless
+            your theme.css also ships a dark palette (see `--nw-dark-capable`). */}
+        <div className="mt-auto flex items-center gap-1 border-t border-hairline px-1 pt-3">
+          {resetEnabled && (
+            <button
+              type="button"
+              onClick={handleReset}
+              aria-label="Reset demo state"
+              className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand"
+            >
+              <RotateCcw className="h-4 w-4" />
+            </button>
+          )}
+          <ThemeToggle />
+          <button
+            type="button"
+            aria-label="Ask the copilot for help"
+            onClick={() => void askCopilot("What can you help me with here? Give me a short list.")}
+            className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand"
+          >
+            <HelpCircle className="h-4 w-4" />
+          </button>
+        </div>
       </aside>
       <main className="flex-1 overflow-y-auto px-5 py-6">{children}</main>
     </div>
   );
 }
 ```
+
+`useAskCopilot` (the Help control's handler) is **ported, not imported** — copy
+`src/skins/logistics/components/use-ask-copilot.ts` into your own
+`src/skins/<id>/components/`. A skin's only inbound dependency is the `Skin`
+contract, so it must never reach into `src/skins/banking/**` or any other skin.
+`ThemeToggle`, by contrast, lives in the SHARED `src/components/ui/` and is fair
+to import directly. And keep the button and the endpoint in agreement: your
+skin's `dev/reset` route should allow the reset when
+`presenterResetEnabled() || process.env.NODE_ENV !== "production"` (mirror
+`src/app/api/logistics/v1/dev/reset/route.ts`) — otherwise a production booth
+shows a Reset button that 403s.
 
 ## `data/use-data.ts` (OPTIONAL → `useData`)
 
@@ -176,20 +309,90 @@ export function <Id>HomePage() {
 ## `tools.tsx`
 
 Renders `null`. Register frontend tools / HITL / gen-UI components and
-`useAgentContext` readables here (all from `@copilotkit/react-core/v2`). See
-`src/skins/airline/tools.tsx` for `useComponent` / `useFrontendTool` /
-`useHumanInTheLoop` patterns.
+`useAgentContext` readables here (all from `@copilotkit/react-core/v2`). Mirror
+`src/skins/logistics/tools.tsx` — it is the debugged reference for the two things
+this file MUST get right.
+
+**1. Every registration closes with a deps array.** `useComponent`,
+`useFrontendTool`, and `useHumanInTheLoop` each take an **optional deps array as
+a second argument** (`useFrontendTool(tool, deps?: ReadonlyArray<unknown>)`,
+`useHumanInTheLoop(tool, deps?)`, `useComponent(spec, deps?)` — see the installed
+types in `@copilotkit/react-core/dist/copilotkit-CBCT7BlL.d.cts`). Omit it and
+the render/handler closure captures whatever the data was at REGISTRATION time —
+for a REST-backed skin, the EMPTY array from before the first fetch — **forever**.
+This is the worst class of bug because it **compiles, lints, and passes every
+test**: the agent narrates confidently ("the trade-offs are on screen") while the
+component renders its "not found" branch over stale/empty data. Banking documents
+the same trap in a code comment (search "closure captures empty arrays" in
+`src/skins/banking/tools.tsx`). Pass the data each closure reads.
+
+**2. A parameterized `useComponent` render receives the schema output DIRECTLY.**
+`render: ({ myParam }) => …` — NOT `{ args }`. Per the installed types,
+`InferRenderProps<T> = T extends StandardSchemaV1 ? InferSchemaOutput<T> : any`
+and `render: ComponentType<NoInfer<InferRenderProps<TSchema>>>`. By contrast
+`useHumanInTheLoop` and `useFrontendTool` renders DO receive `{ args, status,
+respond }`. Do not copy the HITL `{ args }` shape into a `useComponent`.
 
 ```tsx
 "use client";
-import { useAgentContext } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+import {
+  useAgentContext,
+  useComponent,
+  useFrontendTool,
+  ToolCallStatus,
+} from "@copilotkit/react-core/v2";
 import { useSkinData } from "@/shell/skin-provider";
 import type { <Id>Data } from "./data/use-data";
 
 export function <Id>Tools() {
+  // If your skin sets `useData`, read it here. For a NO-DATA skin (banking /
+  // logistics path) `useSkinData` returns undefined — never feed that raw into
+  // useAgentContext; guard it (or read your own REST hook / auth context here).
   const data = useSkinData<<Id>Data>();
-  useAgentContext({ description: "<what the agent should know>", value: data });
-  // Register useComponent / useFrontendTool / useHumanInTheLoop here as needed.
+
+  useAgentContext({
+    description: "<what the agent should know>",
+    value: JSON.stringify(data ?? {}), // ?? {} — data is undefined for a no-data skin
+  });
+
+  // Gen-UI, NO parameters → render takes no schema arg.
+  useComponent(
+    {
+      name: "showThing",
+      description: "Display the current thing.",
+      render: () => <div className="text-ink">{/* render from `data` */}</div>,
+    },
+    [data], // ← deps: re-register when data changes, or the closure captures stale data
+  );
+
+  // Gen-UI, PARAMETERIZED → render receives the schema output DIRECTLY, not { args }.
+  useComponent(
+    {
+      name: "showThingById",
+      description: "Display one thing by id.",
+      parameters: z.object({ id: z.string().describe("The thing's id.") }),
+      render: ({ id }) => <div className="text-ink">{/* look `id` up in `data` */}</div>,
+    },
+    [data],
+  );
+
+  // Frontend tool (a write) → render DOES receive { args, status, respond }.
+  useFrontendTool(
+    {
+      name: "doThing",
+      description: "Do the thing.",
+      parameters: z.object({ id: z.string() }),
+      handler: async ({ id }) => `Did the thing to ${id}.`,
+      render: ({ status }) => (
+        <div className="text-ink-muted">
+          {status === ToolCallStatus.Complete ? "Done." : "Working…"}
+        </div>
+      ),
+    },
+    [data], // ← deps here too
+  );
+
   return null;
 }
 ```
@@ -285,8 +488,9 @@ export const <id>IdentifyUser: IdentifyRunUser = (properties) => {
 
 ## `agent.ts` — SERVER-ONLY (no "use client", no JSX)
 
-Mirror `src/skins/airline/agent.ts`. Imported ONLY by
-`src/shell/agent-registry.ts`; the client skin never imports it.
+Mirror `src/skins/airline/agent.ts` (minimal) or `src/skins/logistics/agent.ts`
+(with a canvas tool). Imported ONLY by `src/shell/agent-registry.ts`; the client
+skin never imports it.
 
 ```ts
 import { BuiltInAgent } from "@copilotkit/runtime/v2";
@@ -297,6 +501,37 @@ export const <id>Agent = () =>
     prompt: "You are the <Brand> agent. ...",
     // tools: [...]       // optional server-side agent tools (defineTool)
     // temperature: 0,    // optional
+  });
+```
+
+**If your skin has a `CanvasSurface`, emit its a2ui operations from a SERVER tool
+here — never from a client `useFrontendTool`.** The a2ui middleware only converts
+the `{ [A2UI_OPERATIONS_KEY]: buildOps(spec) }` payload into an `a2ui-surface`
+activity when it observes it in an in-stream `TOOL_CALL_RESULT` event, which a
+client frontend-tool result does NOT produce — do it client-side and the canvas
+stays permanently blank. Both banking (`render_report`) and logistics
+(`renderBrief`) do it server-side. Register the tool on the `BuiltInAgent` with
+`defineTool` (read `src/skins/logistics/agent.ts` for the full worked pattern —
+the tool takes agent-chosen selections + LABEL-only text and deterministically
+expands them into ops, so numbers bind to live client data, never the model):
+
+```ts
+import { BuiltInAgent, defineTool } from "@copilotkit/runtime/v2";
+// build-*-ops.ts is server-safe (plain Zod + string constants — no React/.tsx):
+import { renderReportParams, buildReportOps, A2UI_OPERATIONS_KEY } from "./build-report-ops";
+
+const renderReportTool = defineTool({
+  name: "renderReport",
+  description: "Build the report on the canvas. Supply selections + LABEL-ONLY text — never numbers.",
+  parameters: renderReportParams,
+  execute: async (spec) => ({ [A2UI_OPERATIONS_KEY]: buildReportOps(spec) }),
+});
+
+export const <id>Agent = () =>
+  new BuiltInAgent({
+    model: "openai/gpt-5.4",
+    prompt: "You are the <Brand> agent. ...",
+    tools: [renderReportTool],
   });
 ```
 
@@ -313,7 +548,7 @@ import { <Id>Tools } from "./tools";
 import { <id>Catalog } from "./catalog";
 import { <id>Suggestions } from "./suggestions";
 import { <ID>_DESIGN_SKILL } from "./design-skill";
-import { use<Id>Data } from "./data/use-data";
+import { use<Id>Data } from "./data/use-data"; // NO-DATA skin: delete this import AND the `useData` field below
 // import { <Id>Providers, <Id>RuntimeProviders, use<Id>RuntimeProperties } from "./providers";
 
 const PAGES: Record<string, ComponentType> = {


### PR DESCRIPTION
Corrects the repo-local `reskin` skill (`.claude/skills/reskin/`), which in several places teaches guidance that produces a broken or subtly defective skin when followed literally.

Docs only — no application source changes.

## Why now

The `logistics` skin (#6302) was built by following this skill and then debugged against a live app. Every fix below is a defect that build actually surfaced, or that an audit of the skill against the three shipped skins turned up. Where the skill and `src/skins/logistics/**` disagreed, the skill was the one that was wrong.

## The two that shipped a visibly broken skin

**The layout template taught `min-h-screen`.** That is a *minimum*, so on any page taller than the viewport the container grows, the whole document scrolls, and the pinned nav scrolls away with it — and `<main>`'s `overflow-y-auto` goes inert, because its parent is unbounded. Now `h-screen overflow-hidden` on the root plus `h-full` on the `<aside>`.

**The template never published `--nw-nav-inset-left` / `--nw-nav-inset-right`.** Every shipped skin does. Without them the shell's floating skin selector docks on top of the new skin's nav. Added, including the cleanup that removes both — a missing cleanup leaks the inset into whatever skin the user switches to next.

## The one that is invisible to every gate

**No mention of the dependency array** on `useComponent` / `useFrontendTool` / `useHumanInTheLoop`. Omit it and the render closure captures whatever the data was at registration time — for a REST-backed skin, the empty array from before the first fetch — permanently.

This is the nastiest bug in the app because it **compiles, lints, and passes every test**. The symptom is the agent narrating confidently over a broken surface:

```
agent: "PO-88213 trade-offs are on screen."
UI:    "No shipment matches that reference."
```

Banking already documented the trap in a code comment; the skill never did. Every template registration now closes with its deps array.

## Also fixed

- **Meta-utility strip** — new section documenting that the presenter reset / theme toggle / help controls are *skin-authored*, not shell-provided. Covers the `usePresenterReset()` gate, that `ThemeToggle` is a shared component (fair to import) while `useAskCopilot` must be *ported* (a skin may not import from another skin), and that the skin's own `dev/reset` route must gate on `presenterResetEnabled() || NODE_ENV !== "production"` so the button and the endpoint agree.
- **`--nw-dark-capable`** — previously unmentioned. A skin that ships a `.dark .theme-<id>` block but omits the flag stays stuck in light, because the shell's reconciler forces it. Documented as an explicit opt-in, and paired with the note that a theme toggle without a dark palette is a dead control.
- **a2ui surface ops must be emitted from a server `defineTool`** — previously silent. A client `useFrontendTool` result never produces the in-stream `TOOL_CALL_RESULT` the a2ui middleware needs, so the canvas stays permanently blank. This one cost real debugging time on #6302.
- **Parameterized `useComponent` render signature** — receives the schema output *directly*, not wrapped in `{ args }`, unlike HITL / frontend-tool renders. Airline has no parameterized example to learn from, so the skill now shows one and contrasts the two.
- **`nav` is not the segment validator** — the skill claimed it was "the source of truth for which segments are valid"; the frozen contract says the opposite and names `resolvePage`. Following the skill got you a 404.
- **Airline `useData` contradiction** — SKILL.md listed `data/` among the slots airline omits; airline sets it, and templates.md already said so.
- Two nits: the `tools.tsx` template would NPE for a no-data skin (`useSkinData` returns `undefined`), and `skin.tsx` left a dangling `use<Id>Data` import for skins that omit the slot.

## Verification

Every code sample was diffed against the corresponding real file in `src/skins/logistics/`, and every API-signature claim against the installed types in `packages/react-core/dist/`. Markdown only, so no build/lint/test surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
