### PR TITLE
docs: make Channels setup prompts easier to discover

### DIFF
--- a/showcase/shell-docs/src/components/mdx-components.tsx
+++ b/showcase/shell-docs/src/components/mdx-components.tsx
@@ -4,6 +4,7 @@ import {
   Card as FumadocsCard,
   Cards as FumadocsCards,
 } from "fumadocs-ui/components/card";
+import { ChevronDown, Copy, SquareTerminal } from "lucide-react";
 
 // Re-export fumadocs's default `<Callout>` so historical imports from
 // `@/components/mdx-components` keep working. Fumadocs supports the
@@ -98,11 +99,68 @@ export function Accordions({ children }: { children: React.ReactNode }) {
 
 export function Accordion({
   title,
+  description,
+  featured = false,
   children,
 }: {
   title: string;
+  description?: string;
+  featured?: boolean;
   children: React.ReactNode;
 }) {
+  if (featured) {
+    return (
+      <details
+        className="shell-docs-radius-surface group my-6 overflow-hidden border bg-[var(--bg-surface)]"
+        style={{
+          borderColor: "color-mix(in oklch, var(--accent) 32%, var(--border))",
+          background:
+            "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--bg-surface)) 0%, var(--bg-surface) 62%)",
+        }}
+      >
+        <summary className="not-prose cursor-pointer list-none select-none p-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)] sm:p-6 [&::-webkit-details-marker]:hidden">
+          <span className="flex flex-col gap-5 lg:flex-row lg:items-center">
+            <span className="flex min-w-0 flex-1 items-start gap-4">
+              <span
+                aria-hidden="true"
+                className="shell-docs-radius-control flex h-12 w-12 shrink-0 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] shadow-[var(--shadow-control)]"
+              >
+                <SquareTerminal className="h-5 w-5" />
+              </span>
+
+              <span className="min-w-0">
+                <span className="mb-1.5 block font-mono text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--accent)]">
+                  Ready-to-use starter prompt
+                </span>
+                <span className="block text-lg font-semibold leading-snug tracking-[-0.015em] text-[var(--text)] sm:text-xl">
+                  {title}
+                </span>
+                {description ? (
+                  <span className="mt-1.5 block max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
+                    {description}
+                  </span>
+                ) : null}
+              </span>
+            </span>
+
+            <span className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors group-hover:bg-[var(--accent-strong)] sm:w-auto">
+              <Copy aria-hidden="true" className="h-4 w-4" />
+              <span className="group-open:hidden">Open &amp; copy prompt</span>
+              <span className="hidden group-open:inline">Close prompt</span>
+              <ChevronDown
+                aria-hidden="true"
+                className="h-4 w-4 transition-transform duration-200 group-open:rotate-180"
+              />
+            </span>
+          </span>
+        </summary>
+        <div className="border-t border-[var(--border)] bg-[var(--bg-surface)] px-5 pb-5 pt-4 text-sm text-[var(--text-secondary)] sm:px-6 sm:pb-6 [&>p:first-child]:mt-0">
+          {children}
+        </div>
+      </details>
+    );
+  }
+
   return (
     <details className="shell-docs-radius-surface group border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-control)]">
       <summary className="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-[var(--text)] transition-colors hover:bg-[var(--bg-elevated)]">

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -9,7 +9,11 @@ doc_type: explanation
 <FrontendOnly frontend="slack">
 
 <Accordions>
-<Accordion title="Start building with your coding agent — copy this prompt">
+<Accordion
+  featured
+  title="Start building with your coding agent"
+  description="Give your local coding agent a guided path from a blank directory to a working Slack channel."
+>
 
 Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Slack.
 
@@ -32,7 +36,7 @@ When you implement the plan:
 - Use `setup-slack-channel` for the provider half, including the dedicated Slack app, managed Channel, credentials, and real workspace verification. Do not replace the managed path with a direct Slack adapter.
 
 Before your first step, tell me which mode you are in:
-- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account — signing in, creating an Intelligence project, creating the Slack app, attaching the adapter, or issuing a key.
+- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account: signing in, creating an Intelligence project, creating the Slack app, attaching the adapter, or issuing a key.
 - You cannot. Then say so plainly and walk me through the browser steps one at a time, waiting for me to confirm each before you continue.
 
 Do not guess which one you are. Check what tools you actually have.
@@ -52,7 +56,11 @@ Start by reading the three skills, then tell me which are available, what you fo
 <FrontendOnly frontend="teams">
 
 <Accordions>
-<Accordion title="Start building with your coding agent — copy this prompt">
+<Accordion
+  featured
+  title="Start building with your coding agent"
+  description="Give your local coding agent a guided path from a blank directory to a working Microsoft Teams channel."
+>
 
 Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Microsoft Teams.
 
@@ -75,7 +83,7 @@ When you implement the plan:
 - Use the published Teams documentation as the provider half. Start at https://docs.copilotkit.ai/teams, select my agent backend in the docs, and follow the linked Intelligence configuration and Teams connection pages in order. Use the current documented steps instead of relying on memory of Azure Bot or Teams app setup.
 
 Before your first step, tell me which mode you are in:
-- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account — signing in, creating an Intelligence project, creating or changing an Azure Bot registration, attaching the Teams connection, issuing a key, or installing the app in Microsoft Teams.
+- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account: signing in, creating an Intelligence project, creating or changing an Azure Bot registration, attaching the Teams connection, issuing a key, or installing the app in Microsoft Teams.
 - You cannot. Then say so plainly and walk me through the browser steps one at a time, waiting for me to confirm each before you continue.
 
 Do not guess which one you are. Check what tools you actually have.

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -345,8 +345,10 @@ describe("Channels documentation journey", () => {
       expect(source).not.toMatch(/\bcopilotkit\s+channels\b/i);
     }
 
+    expect(overview).toContain("<Accordion\n  featured");
+    expect(overview).toContain('title="Start building with your coding agent"');
     expect(overview).toContain(
-      '<Accordion title="Start building with your coding agent — copy this prompt">',
+      'description="Give your local coding agent a guided path from a blank directory to a working Slack channel."',
     );
     expect(overview).toContain(
       "Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Slack.",
@@ -388,8 +390,12 @@ describe("Channels documentation journey", () => {
     );
     expect(overview).toContain('"The runtime started" is not one of them.');
     expect(overview).not.toContain("npx copilotkit@latest channels setup");
+    expect(teamsOverview).toContain("<Accordion\n  featured");
     expect(teamsOverview).toContain(
-      '<Accordion title="Start building with your coding agent — copy this prompt">',
+      'title="Start building with your coding agent"',
+    );
+    expect(teamsOverview).toContain(
+      'description="Give your local coding agent a guided path from a blank directory to a working Microsoft Teams channel."',
     );
     expect(teamsOverview).toContain(
       "Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Microsoft Teams.",


### PR DESCRIPTION
## Summary

- add an opt-in featured treatment to the existing docs `Accordion` component
- use that treatment for the coding-agent starter prompts at the top of both the Slack and Microsoft Teams Channels overview pages
- replace the easily missed accordion label with a branded prompt panel, a terminal icon, platform-specific supporting copy, and a prominent **Open & copy prompt** action
- preserve the existing native `details` interaction and code-block copy control inside the expanded prompt
- update the Channels documentation regression test for the new featured markup and provider-specific descriptions

## Why

The existing “copy this prompt” accordion looked like ordinary supporting content and was easy to skip at the top of the overview pages. This change gives the starter prompt a clear visual hierarchy and action without changing the prompt content or introducing a new navigation concept.

The visual treatment deliberately uses a terminal icon rather than a generic sparkle so it reads as a developer workflow for a coding agent.

## User impact

People landing on either Channels overview page can now immediately recognize that there is a ready-to-use setup prompt. Slack and Teams retain their own provider-specific instructions, while the interaction remains familiar:

1. Open the featured prompt.
2. Review the provider-specific setup instructions.
3. Use the existing copy control on the prompt code block.

Unrelated accordions retain their current appearance because the new treatment is opt-in.

## Implementation notes

- reuses the existing CopilotKit docs design tokens for color, spacing, borders, radii, focus states, and dark mode
- keeps the native `details`/`summary` semantics and keyboard behavior
- adapts the header and action layout at narrower widths
- changes the action label to **Close prompt** while expanded
- leaves the published Slack and Teams prompt bodies unchanged apart from replacing two em dashes with colons for readability
- adds no new dependencies

## Validation

- `npm test -- src/lib/__tests__/channels-docs.test.ts --maxWorkers=1 --no-file-parallelism` — 29 tests passed
- `npm run typecheck`
- `pnpm exec oxfmt --check showcase/shell-docs/src/components/mdx-components.tsx showcase/shell-docs/src/content/docs/channels/index.mdx showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts`
- `git diff --check`
- pre-commit lint and commit-message hooks passed
- Impeccable design detector returned no findings
- manually reviewed Slack and Teams in collapsed and expanded states, light and dark themes, and a narrower responsive viewport
- confirmed no browser console errors during local review

## Scope

This PR is intentionally limited to the shared opt-in accordion treatment, the two Channels overview prompt instances, and their focused regression coverage. It does not restyle existing documentation accordions or alter the underlying setup guidance.