### PR TITLE
docs: route every Channels entry point at one onboarding skill

### DIFF
--- a/showcase/shell-docs/package-lock.json
+++ b/showcase/shell-docs/package-lock.json
@@ -299,7 +299,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -321,7 +320,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1418,7 +1416,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3471,7 +3468,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3488,7 +3484,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3505,7 +3500,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3522,7 +3516,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3539,7 +3532,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3556,7 +3548,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3573,7 +3564,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3590,7 +3580,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3607,7 +3596,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3632,7 +3620,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3654,7 +3641,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3671,7 +3657,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3748,7 +3733,6 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/showcase/shell-docs/package-lock.json
+++ b/showcase/shell-docs/package-lock.json
@@ -299,6 +299,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -320,6 +321,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1416,6 +1418,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3468,6 +3471,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3484,6 +3488,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3500,6 +3505,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3516,6 +3522,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3532,6 +3539,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3548,6 +3556,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3564,6 +3573,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3580,6 +3590,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3596,6 +3607,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3620,6 +3632,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3641,6 +3654,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3657,6 +3671,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3733,6 +3748,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelsActivationStrip } from "../channels-activation-strip";
 import { ChannelsStartPrompt } from "../channels-start-prompt";
@@ -140,6 +146,44 @@ describe("Channels activation impressions", () => {
       ([event]) => event === CHANNELS_ACTIVATION_EVENTS.viewed,
     );
     expect(impressions).toHaveLength(1);
+  });
+
+  // Regression: the clipboard write and the capture call used to share one try
+  // block, so a throwing analytics client reported "Copy blocked" for a prompt
+  // that had already reached the clipboard. Only the write decides the state.
+  it("still reports a successful copy when analytics throws", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    analytics.capture.mockImplementation(() => {
+      throw new Error("posthog unavailable");
+    });
+
+    render(<ChannelsStartPrompt />);
+    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/i }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("Copied")).toBeTruthy();
+    expect(screen.queryByText("Copy blocked")).toBeNull();
+  });
+
+  it("reports a blocked clipboard as blocked", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+
+    render(<ChannelsStartPrompt />);
+    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/i }));
+
+    expect(await screen.findByText("Copy blocked")).toBeTruthy();
+    expect(
+      analytics.capture.mock.calls.filter(
+        ([event]) => event === CHANNELS_ACTIVATION_EVENTS.promptCopied,
+      ),
+    ).toEqual([]);
   });
 
   it("stays silent while a surface is below the fold", () => {

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelsActivationStrip } from "../channels-activation-strip";
+import { ChannelsStartPrompt } from "../channels-start-prompt";
+import {
+  CHANNELS_ACTIVATION_EVENTS,
+  CHANNELS_ACTIVATION_SURFACES,
+} from "@/lib/channels-activation-contracts";
+import type { ChannelsActivationBackendOption } from "@/lib/channels-activation-contracts";
+
+const analytics = vi.hoisted(() => ({ capture: vi.fn() }));
+vi.mock("posthog-js/react", () => ({ usePostHog: () => analytics }));
+vi.mock("next/navigation", () => ({ usePathname: () => "/channels" }));
+
+let intersectionCallback: IntersectionObserverCallback | null = null;
+
+class TestIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "0px";
+  readonly thresholds = [0.5];
+
+  constructor(callback: IntersectionObserverCallback) {
+    intersectionCallback = callback;
+  }
+
+  disconnect() {}
+  observe() {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  unobserve() {}
+}
+
+function intersect(target: Element, isIntersecting: boolean) {
+  if (!intersectionCallback) {
+    throw new Error("IntersectionObserver was not initialized");
+  }
+  const rect = target.getBoundingClientRect();
+  intersectionCallback(
+    [
+      {
+        boundingClientRect: rect,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        intersectionRect: rect,
+        isIntersecting,
+        rootBounds: null,
+        target,
+        time: 0,
+      } as IntersectionObserverEntry,
+    ],
+    {} as IntersectionObserver,
+  );
+}
+
+const backends: ChannelsActivationBackendOption[] = [
+  {
+    slug: "built-in-agent",
+    label: "CopilotKit's built-in agent",
+    logo: null,
+    guideHrefs: { slack: "/slack/connect", teams: "/teams/connect" },
+  },
+];
+
+beforeEach(() => {
+  analytics.capture.mockReset();
+  intersectionCallback = null;
+  vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// The copy event is the numerator of the only real question about these
+// surfaces — does anyone use them. Without an impression there is no
+// denominator, so a panel nobody scrolls to and a panel everybody ignores look
+// identical in PostHog. `surface` is what keeps the two docs entry points (and
+// copilotkit.ai/channels, which sends its own event name with the same
+// property) separable inside one funnel.
+describe("Channels activation impressions", () => {
+  it("reports the landing strip the first time it is seen", () => {
+    render(
+      <ChannelsActivationStrip
+        backends={backends}
+        docsBaseUrl="https://docs.copilotkit.ai"
+      />,
+    );
+    const strip = screen.getByRole("region", {
+      name: /Channels SDK brings your agents/i,
+    });
+
+    expect(analytics.capture).not.toHaveBeenCalled();
+
+    intersect(strip, true);
+
+    expect(analytics.capture).toHaveBeenCalledWith(
+      CHANNELS_ACTIVATION_EVENTS.viewed,
+      {
+        channel: "slack",
+        backend: "built-in-agent",
+        from_path: "/channels",
+        surface: CHANNELS_ACTIVATION_SURFACES.docsLandingStrip,
+      },
+    );
+  });
+
+  it("reports the overview panel with its own surface", () => {
+    render(<ChannelsStartPrompt frontend="teams" />);
+    const panel = screen.getByRole("region", {
+      name: "Start building with your coding agent",
+    });
+
+    intersect(panel, true);
+
+    expect(analytics.capture).toHaveBeenCalledWith(
+      CHANNELS_ACTIVATION_EVENTS.viewed,
+      {
+        channel: "teams",
+        backend: "built-in-agent",
+        from_path: "/channels",
+        surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
+      },
+    );
+  });
+
+  it("does not re-fire when a surface scrolls back into view", () => {
+    render(<ChannelsStartPrompt />);
+    const panel = screen.getByRole("region", {
+      name: "Start building with your coding agent",
+    });
+
+    intersect(panel, true);
+    intersect(panel, false);
+    intersect(panel, true);
+
+    const impressions = analytics.capture.mock.calls.filter(
+      ([event]) => event === CHANNELS_ACTIVATION_EVENTS.viewed,
+    );
+    expect(impressions).toHaveLength(1);
+  });
+
+  it("stays silent while a surface is below the fold", () => {
+    render(<ChannelsStartPrompt />);
+    const panel = screen.getByRole("region", {
+      name: "Start building with your coding agent",
+    });
+
+    intersect(panel, false);
+
+    expect(analytics.capture).not.toHaveBeenCalled();
+  });
+});

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
@@ -158,9 +158,7 @@ describe("Channels activation impressions", () => {
     });
 
     render(<ChannelsStartPrompt />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Copy the starter prompt/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/i }));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     expect(await screen.findByText("Copied")).toBeTruthy();
@@ -174,9 +172,7 @@ describe("Channels activation impressions", () => {
     });
 
     render(<ChannelsStartPrompt />);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Copy the starter prompt/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/i }));
 
     expect(await screen.findByText("Copy blocked")).toBeTruthy();
     expect(

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-impressions.test.tsx
@@ -115,9 +115,7 @@ describe("Channels activation impressions", () => {
 
   it("reports the overview panel with its own surface", () => {
     render(<ChannelsStartPrompt frontend="teams" />);
-    const panel = screen.getByRole("region", {
-      name: "Start building with your coding agent",
-    });
+    const panel = screen.getByTestId("channels-start-prompt");
 
     intersect(panel, true);
 
@@ -134,9 +132,7 @@ describe("Channels activation impressions", () => {
 
   it("does not re-fire when a surface scrolls back into view", () => {
     render(<ChannelsStartPrompt />);
-    const panel = screen.getByRole("region", {
-      name: "Start building with your coding agent",
-    });
+    const panel = screen.getByTestId("channels-start-prompt");
 
     intersect(panel, true);
     intersect(panel, false);
@@ -162,7 +158,9 @@ describe("Channels activation impressions", () => {
     });
 
     render(<ChannelsStartPrompt />);
-    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Copy the starter prompt/i }),
+    );
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     expect(await screen.findByText("Copied")).toBeTruthy();
@@ -176,7 +174,9 @@ describe("Channels activation impressions", () => {
     });
 
     render(<ChannelsStartPrompt />);
-    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Copy the starter prompt/i }),
+    );
 
     expect(await screen.findByText("Copy blocked")).toBeTruthy();
     expect(
@@ -188,9 +188,7 @@ describe("Channels activation impressions", () => {
 
   it("stays silent while a surface is below the fold", () => {
     render(<ChannelsStartPrompt />);
-    const panel = screen.getByRole("region", {
-      name: "Start building with your coding agent",
-    });
+    const panel = screen.getByTestId("channels-start-prompt");
 
     intersect(panel, false);
 

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-strip.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-strip.test.tsx
@@ -90,87 +90,9 @@ describe("ChannelsActivationStrip", () => {
     ).toBeTruthy();
     expect(
       screen.getByText(
-        /Bring your agent into Slack or Microsoft Teams, with more platforms on the way\. Choose a channel and agent backend/,
+        /Copy this prompt and your coding agent builds your first\s+channel with you/,
       ),
     ).toBeTruthy();
-  });
-
-  it("updates the real guide route and captures only changed selections", () => {
-    renderStrip();
-
-    fireEvent.click(screen.getByRole("button", { name: "Choose a channel" }));
-    fireEvent.click(screen.getByRole("option", { name: /Microsoft Teams/ }));
-
-    let guide = screen.getByRole("link", { name: /Open setup guide/ });
-    expect(guide.getAttribute("href")).toBe("/teams/connect");
-    expect(analytics.capture).toHaveBeenCalledWith(
-      CHANNELS_ACTIVATION_EVENTS.channelSelected,
-      expect.objectContaining({
-        channel: "teams",
-        backend: "built-in-agent",
-        destination_path: "/teams/connect",
-      }),
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Choose an agent backend" }),
-    );
-    fireEvent.click(screen.getByRole("option", { name: /Mastra/ }));
-
-    guide = screen.getByRole("link", { name: /Open setup guide/ });
-    expect(guide.getAttribute("href")).toBe("/teams/mastra/connect");
-    expect(analytics.capture).toHaveBeenCalledWith(
-      CHANNELS_ACTIVATION_EVENTS.backendSelected,
-      expect.objectContaining({
-        channel: "teams",
-        backend: "mastra",
-        destination_path: "/teams/mastra/connect",
-      }),
-    );
-
-    const captureCount = analytics.capture.mock.calls.length;
-    fireEvent.click(
-      screen.getByRole("button", { name: "Choose an agent backend" }),
-    );
-    fireEvent.click(screen.getByRole("option", { name: /Mastra/ }));
-    expect(analytics.capture).toHaveBeenCalledTimes(captureCount);
-
-    fireEvent.click(guide);
-    expect(analytics.capture).toHaveBeenCalledWith(
-      CHANNELS_ACTIVATION_EVENTS.setupGuideOpened,
-      expect.objectContaining({
-        channel: "teams",
-        backend: "mastra",
-        destination_path: "/teams/mastra/connect",
-      }),
-    );
-  });
-
-  it("supports listbox keyboard navigation and restores trigger focus", () => {
-    renderStrip();
-    const channelTrigger = screen.getByRole("button", {
-      name: "Choose a channel",
-    });
-
-    channelTrigger.focus();
-    fireEvent.keyDown(channelTrigger, { key: "End" });
-    const teamsOption = screen.getByRole("option", {
-      name: /Microsoft Teams/,
-    });
-    expect(document.activeElement).toBe(teamsOption);
-    fireEvent.keyDown(teamsOption, { key: "Enter" });
-    expect(document.activeElement).toBe(channelTrigger);
-    expect(channelTrigger.textContent).toContain("Microsoft Teams");
-
-    fireEvent.keyDown(channelTrigger, { key: "ArrowDown" });
-    expect(
-      screen.getByRole("listbox", { name: "Choose a channel" }),
-    ).toBeTruthy();
-    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Escape" });
-    expect(document.activeElement).toBe(channelTrigger);
-    expect(
-      screen.queryByRole("listbox", { name: "Choose a channel" }),
-    ).toBeNull();
   });
 
   it("announces a successful copy and emits telemetry after clipboard success", async () => {
@@ -178,9 +100,7 @@ describe("ChannelsActivationStrip", () => {
     setClipboard(writeText);
     renderStrip();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Build with your agent/ }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/ }));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const prompt = writeText.mock.calls[0][0] as string;
@@ -203,9 +123,7 @@ describe("ChannelsActivationStrip", () => {
     setClipboard(vi.fn().mockRejectedValue(new Error("blocked")));
     renderStrip();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /Build with your agent/ }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /Copy prompt/ }));
 
     expect(await screen.findByText("Copy failed")).toBeTruthy();
     expect(analytics.capture).not.toHaveBeenCalledWith(
@@ -216,7 +134,7 @@ describe("ChannelsActivationStrip", () => {
 
   it("tracks the OpenTag link with the current selection", () => {
     renderStrip();
-    const link = screen.getByRole("link", { name: "Clone OpenTag on GitHub" });
+    const link = screen.getByRole("link", { name: "clone OpenTag on GitHub" });
 
     expect(link.getAttribute("href")).toBe(CHANNELS_OPENTAG_HREF);
     fireEvent.click(link);

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-strip.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-strip.test.tsx
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelsActivationStrip } from "../channels-activation-strip";
 import {
   CHANNELS_ACTIVATION_EVENTS,
+  CHANNELS_ONBOARDING_INSTALL_COMMAND,
   CHANNELS_OPENTAG_HREF,
 } from "@/lib/channels-activation-contracts";
 import type { ChannelsActivationBackendOption } from "@/lib/channels-activation-contracts";
@@ -183,7 +184,11 @@ describe("ChannelsActivationStrip", () => {
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const prompt = writeText.mock.calls[0][0] as string;
-    expect(prompt).toContain("https://docs.copilotkit.ai/slack/connect");
+    // The copied text is a pointer at the onboarding skill, not a copy of the
+    // workflow. `guide_url` stays on the telemetry below so the picker's
+    // destination is still measurable.
+    expect(prompt).toContain(CHANNELS_ONBOARDING_INSTALL_COMMAND);
+    expect(prompt).toContain("connect it to Slack");
     expect(await screen.findByText("Prompt copied")).toBeTruthy();
     expect(analytics.capture).toHaveBeenCalledWith(
       CHANNELS_ACTIVATION_EVENTS.promptCopied,

--- a/showcase/shell-docs/src/components/__tests__/channels-activation-strip.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/channels-activation-strip.test.tsx
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelsActivationStrip } from "../channels-activation-strip";
 import {
   CHANNELS_ACTIVATION_EVENTS,
-  CHANNELS_ONBOARDING_INSTALL_COMMAND,
+  CHANNELS_BUILD_PROMPT,
   CHANNELS_OPENTAG_HREF,
 } from "@/lib/channels-activation-contracts";
 import type { ChannelsActivationBackendOption } from "@/lib/channels-activation-contracts";
@@ -184,11 +184,10 @@ describe("ChannelsActivationStrip", () => {
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const prompt = writeText.mock.calls[0][0] as string;
-    // The copied text is a pointer at the onboarding skill, not a copy of the
-    // workflow. `guide_url` stays on the telemetry below so the picker's
-    // destination is still measurable.
-    expect(prompt).toContain(CHANNELS_ONBOARDING_INSTALL_COMMAND);
-    expect(prompt).toContain("connect it to Slack");
+    // The copied text is a pointer at the hosted guide, not a copy of the
+    // workflow, and it is the same for every selection. `guide_url` stays on the
+    // telemetry below so the picker's destination is still measurable.
+    expect(prompt).toBe(CHANNELS_BUILD_PROMPT);
     expect(await screen.findByText("Prompt copied")).toBeTruthy();
     expect(analytics.capture).toHaveBeenCalledWith(
       CHANNELS_ACTIVATION_EVENTS.promptCopied,

--- a/showcase/shell-docs/src/components/channels-activation-strip.tsx
+++ b/showcase/shell-docs/src/components/channels-activation-strip.tsx
@@ -12,7 +12,7 @@ import {
   CHANNELS_ACTIVATION_EVENTS,
   CHANNELS_ACTIVATION_SURFACES,
   CHANNELS_OPENTAG_HREF,
-  buildChannelsActivationPrompt,
+  CHANNELS_BUILD_PROMPT,
   getChannelsActivationGuideHref,
 } from "@/lib/channels-activation-contracts";
 import type {
@@ -279,13 +279,6 @@ export function ChannelsActivationStrip({
 
   const guideHref = getChannelsActivationGuideHref(channel, backend);
   const guideUrl = new URL(guideHref, docsBaseUrl).toString();
-  // Rendered, not just copied. A copy button whose payload is invisible reads
-  // as decoration — people missed it entirely. Now the prompt is short enough
-  // to show, so the button becomes a shortcut for something already on screen.
-  const prompt = buildChannelsActivationPrompt({
-    channelLabel: selectedChannel.label,
-    backendLabel: backend.label,
-  });
   const channelOptions: SelectOption[] = CHANNELS_ACTIVATION_CHANNELS.map(
     (option) => ({
       id: option.id,
@@ -356,7 +349,7 @@ export function ChannelsActivationStrip({
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
 
     try {
-      await navigator.clipboard.writeText(prompt);
+      await navigator.clipboard.writeText(CHANNELS_BUILD_PROMPT);
       setCopyState("copied");
       capture(CHANNELS_ACTIVATION_EVENTS.promptCopied, {
         channel,
@@ -416,7 +409,7 @@ export function ChannelsActivationStrip({
         <p className="max-w-[68ch] text-sm leading-relaxed text-[var(--text-secondary)] sm:col-start-2 sm:text-[15px]">
           Bring your agent into Slack or Microsoft Teams, with more platforms on
           the way. Choose a channel and agent backend to open the matching setup
-          guide, or copy a tailored prompt for your coding agent.
+          guide, or copy a prompt that walks your coding agent through it.
         </p>
       </div>
 
@@ -475,10 +468,6 @@ export function ChannelsActivationStrip({
           {copyStatus}
         </span>
       </div>
-
-      <p className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded-[var(--radius-control)] border border-dashed border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 font-mono text-xs leading-relaxed text-[var(--text-secondary)]">
-        {prompt}
-      </p>
 
       <div className="mt-5 border-t border-[var(--border)] pt-4 text-sm text-[var(--text-secondary)]">
         Prefer a complete working example?{" "}

--- a/showcase/shell-docs/src/components/channels-activation-strip.tsx
+++ b/showcase/shell-docs/src/components/channels-activation-strip.tsx
@@ -10,6 +10,7 @@ import { FrameworkLogo } from "./icons/framework-icons";
 import {
   CHANNELS_ACTIVATION_CHANNELS,
   CHANNELS_ACTIVATION_EVENTS,
+  CHANNELS_ACTIVATION_SURFACES,
   CHANNELS_OPENTAG_HREF,
   buildChannelsActivationPrompt,
   getChannelsActivationGuideHref,
@@ -227,6 +228,8 @@ export function ChannelsActivationStrip({
   const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const stripRef = React.useRef<HTMLElement | null>(null);
+  const viewedRef = React.useRef(false);
 
   const backend =
     backends.find((option) => option.slug === backendSlug) ?? backends[0];
@@ -240,6 +243,37 @@ export function ChannelsActivationStrip({
     },
     [],
   );
+
+  // Impression, so the copy count has a denominator. The strip sits below the
+  // fold on the landing page, so mount is not the same as seen.
+  React.useEffect(() => {
+    const node = stripRef.current;
+    if (!node || viewedRef.current) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting || viewedRef.current) continue;
+          viewedRef.current = true;
+          observer.disconnect();
+          capture(CHANNELS_ACTIVATION_EVENTS.viewed, {
+            channel,
+            backend: backendSlug,
+            from_path: pathname,
+            surface: CHANNELS_ACTIVATION_SURFACES.docsLandingStrip,
+          });
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+    // Fires once for the first selection the reader is shown; later channel and
+    // backend switches already emit their own selection events.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!backend) return null;
 
@@ -331,7 +365,7 @@ export function ChannelsActivationStrip({
         guide_url: guideUrl,
         // Every road into onboarding emits the same event with a distinct
         // surface, so the funnel can answer which one people actually take.
-        surface: "docs_landing_strip",
+        surface: CHANNELS_ACTIVATION_SURFACES.docsLandingStrip,
       });
       resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
     } catch {
@@ -349,6 +383,7 @@ export function ChannelsActivationStrip({
 
   return (
     <section
+      ref={stripRef}
       aria-labelledby="channels-activation-heading"
       className="shell-docs-radius-surface not-prose relative overflow-visible border p-5 sm:p-6"
       style={{

--- a/showcase/shell-docs/src/components/channels-activation-strip.tsx
+++ b/showcase/shell-docs/src/components/channels-activation-strip.tsx
@@ -245,6 +245,13 @@ export function ChannelsActivationStrip({
 
   const guideHref = getChannelsActivationGuideHref(channel, backend);
   const guideUrl = new URL(guideHref, docsBaseUrl).toString();
+  // Rendered, not just copied. A copy button whose payload is invisible reads
+  // as decoration — people missed it entirely. Now the prompt is short enough
+  // to show, so the button becomes a shortcut for something already on screen.
+  const prompt = buildChannelsActivationPrompt({
+    channelLabel: selectedChannel.label,
+    backendLabel: backend.label,
+  });
   const channelOptions: SelectOption[] = CHANNELS_ACTIVATION_CHANNELS.map(
     (option) => ({
       id: option.id,
@@ -314,12 +321,6 @@ export function ChannelsActivationStrip({
   async function copyBuildPrompt() {
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
 
-    const prompt = buildChannelsActivationPrompt({
-      channelLabel: selectedChannel.label,
-      backendLabel: backend.label,
-      guideUrl,
-    });
-
     try {
       await navigator.clipboard.writeText(prompt);
       setCopyState("copied");
@@ -328,6 +329,9 @@ export function ChannelsActivationStrip({
         backend: backend.slug,
         from_path: pathname,
         guide_url: guideUrl,
+        // Every road into onboarding emits the same event with a distinct
+        // surface, so the funnel can answer which one people actually take.
+        surface: "docs_landing_strip",
       });
       resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
     } catch {
@@ -436,6 +440,10 @@ export function ChannelsActivationStrip({
           {copyStatus}
         </span>
       </div>
+
+      <p className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded-[var(--radius-control)] border border-dashed border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 font-mono text-xs leading-relaxed text-[var(--text-secondary)]">
+        {prompt}
+      </p>
 
       <div className="mt-5 border-t border-[var(--border)] pt-4 text-sm text-[var(--text-secondary)]">
         Prefer a complete working example?{" "}

--- a/showcase/shell-docs/src/components/channels-activation-strip.tsx
+++ b/showcase/shell-docs/src/components/channels-activation-strip.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import Link from "next/link";
-import { ArrowRight, Check, ChevronDown } from "lucide-react";
+import { Copy } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
 import { FrontendLogo } from "./frontend-logo";
@@ -22,6 +22,9 @@ import type {
 
 type CopyState = "idle" | "copied" | "error";
 
+/** In-docs path for the Channels overview. */
+const CHANNELS_SDK_DOCS_PATH = "/channels";
+
 interface SelectOption {
   id: string;
   label: string;
@@ -30,184 +33,6 @@ interface SelectOption {
 
 function cn(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(" ");
-}
-
-function ActivationSelect({
-  label,
-  value,
-  options,
-  onChange,
-}: {
-  label: string;
-  value: string;
-  options: readonly SelectOption[];
-  onChange: (value: string) => void;
-}) {
-  const selectedIndex = Math.max(
-    0,
-    options.findIndex((option) => option.id === value),
-  );
-  const [open, setOpen] = React.useState(false);
-  const [activeIndex, setActiveIndex] = React.useState(selectedIndex);
-  const rootRef = React.useRef<HTMLDivElement>(null);
-  const triggerRef = React.useRef<HTMLButtonElement>(null);
-  const optionRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
-  const listboxId = React.useId();
-  const selected = options[selectedIndex];
-
-  React.useEffect(() => {
-    if (!open) return;
-
-    const closeOnOutsidePointer = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-
-    document.addEventListener("pointerdown", closeOnOutsidePointer);
-    return () =>
-      document.removeEventListener("pointerdown", closeOnOutsidePointer);
-  }, [open]);
-
-  React.useEffect(() => {
-    if (open) optionRefs.current[activeIndex]?.focus();
-  }, [activeIndex, open]);
-
-  function openListbox(index = selectedIndex) {
-    setActiveIndex(index);
-    setOpen(true);
-  }
-
-  function closeAndRestoreFocus() {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }
-
-  function selectOption(option: SelectOption) {
-    if (option.id !== value) onChange(option.id);
-    closeAndRestoreFocus();
-  }
-
-  function handleTriggerKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
-    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-      event.preventDefault();
-      openListbox(
-        event.key === "ArrowDown"
-          ? selectedIndex
-          : Math.max(0, selectedIndex - 1),
-      );
-    } else if (event.key === "Home" || event.key === "End") {
-      event.preventDefault();
-      openListbox(event.key === "Home" ? 0 : options.length - 1);
-    } else if (event.key === "Escape" && open) {
-      event.preventDefault();
-      closeAndRestoreFocus();
-    }
-  }
-
-  function handleOptionKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeAndRestoreFocus();
-      return;
-    }
-
-    if (event.key === "Tab") {
-      setOpen(false);
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      selectOption(options[activeIndex]);
-      return;
-    }
-
-    let nextIndex: number | undefined;
-    if (event.key === "ArrowDown") {
-      nextIndex = (activeIndex + 1) % options.length;
-    }
-    if (event.key === "ArrowUp") {
-      nextIndex = (activeIndex - 1 + options.length) % options.length;
-    }
-    if (event.key === "Home") nextIndex = 0;
-    if (event.key === "End") nextIndex = options.length - 1;
-
-    if (nextIndex !== undefined) {
-      event.preventDefault();
-      setActiveIndex(nextIndex);
-    }
-  }
-
-  return (
-    <div ref={rootRef} className="relative min-w-0 flex-1">
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-controls={listboxId}
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        aria-label={label}
-        onClick={() => (open ? closeAndRestoreFocus() : openListbox())}
-        onKeyDown={handleTriggerKeyDown}
-        className="shell-docs-radius-control flex min-h-12 w-full min-w-0 cursor-pointer items-center gap-2.5 border border-[var(--border)] bg-[var(--bg-surface)] px-3 text-left text-sm font-medium text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
-      >
-        <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-          {selected.icon}
-        </span>
-        <span className="min-w-0 flex-1 truncate">{selected.label}</span>
-        <ChevronDown
-          aria-hidden="true"
-          className={cn(
-            "h-4 w-4 shrink-0 text-[var(--text-muted)] transition-transform",
-            open && "rotate-180",
-          )}
-        />
-      </button>
-
-      {open ? (
-        <div
-          id={listboxId}
-          role="listbox"
-          aria-label={label}
-          className="shell-docs-radius-surface absolute left-0 top-[calc(100%+0.375rem)] z-[70] max-h-72 w-full min-w-[15rem] overflow-y-auto border border-[var(--border)] bg-[var(--bg-surface)] p-1.5 shadow-[var(--shadow-panel)]"
-        >
-          {options.map((option, index) => {
-            const isSelected = option.id === value;
-            const isActive = index === activeIndex;
-
-            return (
-              <button
-                key={option.id}
-                ref={(node) => {
-                  optionRefs.current[index] = node;
-                }}
-                type="button"
-                role="option"
-                aria-selected={isSelected}
-                tabIndex={isActive ? 0 : -1}
-                onClick={() => selectOption(option)}
-                onFocus={() => setActiveIndex(index)}
-                onKeyDown={handleOptionKeyDown}
-                className={cn(
-                  "shell-docs-radius-control flex min-h-11 w-full cursor-pointer items-center gap-2.5 px-2.5 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)]",
-                  isSelected
-                    ? "bg-[var(--accent-dim)] text-[var(--accent)]"
-                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]",
-                )}
-              >
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center">
-                  {option.icon}
-                </span>
-                <span className="min-w-0 flex-1 truncate">{option.label}</span>
-                {isSelected ? (
-                  <Check aria-hidden="true" className="h-4 w-4 shrink-0" />
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 export interface ChannelsActivationStripProps {
@@ -279,30 +104,6 @@ export function ChannelsActivationStrip({
 
   const guideHref = getChannelsActivationGuideHref(channel, backend);
   const guideUrl = new URL(guideHref, docsBaseUrl).toString();
-  const channelOptions: SelectOption[] = CHANNELS_ACTIVATION_CHANNELS.map(
-    (option) => ({
-      id: option.id,
-      label: option.label,
-      icon: <FrontendLogo icon={option.icon} size={20} />,
-    }),
-  );
-  const backendOptions: SelectOption[] = backends.map((option) => ({
-    id: option.slug,
-    label: option.label,
-    icon: (
-      <FrameworkLogo
-        slug={option.slug}
-        fallbackSrc={option.logo}
-        size={20}
-        className={cn(
-          "shrink-0",
-          option.slug === "built-in-agent"
-            ? ""
-            : "text-[var(--text-secondary)]",
-        )}
-      />
-    ),
-  }));
 
   function capture(event: string, properties: Record<string, unknown>) {
     try {
@@ -310,39 +111,6 @@ export function ChannelsActivationStrip({
     } catch {
       // Analytics must never interrupt docs navigation or clipboard actions.
     }
-  }
-
-  function selectChannel(value: string) {
-    const nextChannel = value as ChannelsActivationChannelId;
-    if (nextChannel === channel) return;
-
-    const nextGuideHref = getChannelsActivationGuideHref(nextChannel, backend);
-    capture(CHANNELS_ACTIVATION_EVENTS.channelSelected, {
-      channel: nextChannel,
-      previous_channel: channel,
-      backend: backend.slug,
-      from_path: pathname,
-      destination_path: nextGuideHref,
-    });
-    setChannel(nextChannel);
-    setCopyState("idle");
-  }
-
-  function selectBackend(value: string) {
-    if (value === backend.slug) return;
-    const nextBackend = backends.find((option) => option.slug === value);
-    if (!nextBackend) return;
-
-    const nextGuideHref = getChannelsActivationGuideHref(channel, nextBackend);
-    capture(CHANNELS_ACTIVATION_EVENTS.backendSelected, {
-      channel,
-      backend: nextBackend.slug,
-      previous_backend: backend.slug,
-      from_path: pathname,
-      destination_path: nextGuideHref,
-    });
-    setBackendSlug(nextBackend.slug);
-    setCopyState("idle");
   }
 
   async function copyBuildPrompt() {
@@ -406,71 +174,52 @@ export function ChannelsActivationStrip({
         >
           The Channels SDK brings your agents where work happens.
         </h2>
-        <p className="max-w-[68ch] text-sm leading-relaxed text-[var(--text-secondary)] sm:col-start-2 sm:text-[15px]">
-          Bring your agent into Slack or Microsoft Teams, with more platforms on
-          the way. Choose a channel and agent backend to open the matching setup
-          guide, or copy a prompt that walks your coding agent through it.
-        </p>
+        {/* Action to the right of the copy, both under the heading. The channel
+            and backend pickers are gone: the guide asks which platform and
+            framework the developer wants, so choosing here asked the same
+            question twice and changed nothing about what got copied. */}
+        <div className="flex flex-col gap-4 sm:col-start-2 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+          <p className="m-0 max-w-[68ch] text-sm leading-relaxed text-[var(--text-secondary)] sm:text-[15px]">
+            Bring your agent into Slack or Microsoft Teams, with more platforms
+            on the way. Copy this prompt and your coding agent builds your first
+            channel with you, on any supported agent framework.
+          </p>
+
+          <button
+            type="button"
+            onClick={copyBuildPrompt}
+            className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
+          >
+            <Copy aria-hidden="true" className="h-4 w-4" />
+            {copyState === "copied"
+              ? "Copied"
+              : copyState === "error"
+                ? "Copy blocked"
+                : "Copy prompt"}
+          </button>
+          <span aria-live="polite" className="sr-only">
+            {copyStatus}
+          </span>
+        </div>
       </div>
 
-      <div className="mt-6 flex min-w-0 flex-col gap-3 border-t border-[var(--border)] pt-5 lg:flex-row lg:items-center">
-        <ActivationSelect
-          label="Choose a channel"
-          value={channel}
-          options={channelOptions}
-          onChange={selectChannel}
-        />
-        <ActivationSelect
-          label="Choose an agent backend"
-          value={backend.slug}
-          options={backendOptions}
-          onChange={selectBackend}
-        />
-
+      <div className="mt-5 border-t border-[var(--border)] pt-4 text-sm text-[var(--text-secondary)]">
+        Prefer to do it yourself?{" "}
         <Link
-          href={guideHref}
+          href={CHANNELS_SDK_DOCS_PATH}
           onClick={() =>
             capture(CHANNELS_ACTIVATION_EVENTS.setupGuideOpened, {
               channel,
               backend: backend.slug,
               from_path: pathname,
-              destination_path: guideHref,
+              destination_path: CHANNELS_SDK_DOCS_PATH,
             })
           }
-          className="shell-docs-radius-control inline-flex min-h-12 shrink-0 items-center justify-center gap-1.5 border border-[var(--border)] bg-[var(--bg-elevated)] px-4 text-sm font-semibold text-[var(--text)] no-underline shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          className="font-semibold text-[var(--accent)] underline decoration-[var(--accent)]/30 underline-offset-4 hover:decoration-[var(--accent)]"
         >
-          Open setup guide
-          <ArrowRight aria-hidden="true" className="h-4 w-4" />
-        </Link>
-
-        <span className="shrink-0 text-center text-xs text-[var(--text-muted)]">
-          or
-        </span>
-
-        <button
-          type="button"
-          onClick={copyBuildPrompt}
-          className="shell-docs-radius-control inline-flex min-h-12 min-w-[12.5rem] shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)]"
-        >
-          <span>Build with your agent</span>
-          <span
-            aria-hidden="true"
-            className="inline-flex w-[3.25rem] justify-end text-[11px] font-medium opacity-70"
-          >
-            {copyState === "copied"
-              ? "Copied"
-              : copyState === "error"
-                ? "Error"
-                : "Copy"}
-          </span>
-        </button>
-        <span aria-live="polite" className="sr-only">
-          {copyStatus}
-        </span>
-      </div>
-
-      <div className="mt-5 border-t border-[var(--border)] pt-4 text-sm text-[var(--text-secondary)]">
-        Prefer a complete working example?{" "}
+          Read the Channels docs
+        </Link>{" "}
+        or{" "}
         <a
           href={CHANNELS_OPENTAG_HREF}
           target="_blank"
@@ -485,8 +234,9 @@ export function ChannelsActivationStrip({
           }
           className="font-semibold text-[var(--accent)] underline decoration-[var(--accent)]/30 underline-offset-4 hover:decoration-[var(--accent)]"
         >
-          Clone OpenTag on GitHub
-        </a>
+          clone OpenTag on GitHub
+        </a>{" "}
+        for a complete working example.
       </div>
     </section>
   );

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -8,10 +8,9 @@
 // six copies across three repos, which drifted apart and went stale against the
 // CLI, so developers were told to run commands that no longer existed.
 //
-// The text is rendered, not just copied. The prompts this replaced were hidden
-// behind an accordion because they were twenty lines long; at one line there is
-// nothing to hide, and a copy button whose payload is invisible reads as
-// decoration.
+// The prompts this replaced were twenty lines long and hidden behind an
+// accordion. At one line there is nothing to disclose, so the panel is always
+// open and the button hands the text straight to the clipboard.
 
 import React from "react";
 import { usePathname } from "next/navigation";
@@ -19,8 +18,8 @@ import { usePostHog } from "posthog-js/react";
 import { Copy, SquareTerminal } from "lucide-react";
 import {
   CHANNELS_ACTIVATION_EVENTS,
+  CHANNELS_ACTIVATION_SURFACES,
   buildChannelsActivationPrompt,
-  buildChannelsActivationPromptParts,
 } from "@/lib/channels-activation-contracts";
 import type { ChannelsActivationChannelId } from "@/lib/channels-activation-contracts";
 
@@ -48,6 +47,14 @@ export function ChannelsStartPrompt({
   const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const panelRef = React.useRef<HTMLElement | null>(null);
+  const viewedRef = React.useRef(false);
+
+  // This component only renders on channel-scoped pages, so anything that is
+  // not Teams is the Slack variant.
+  const channel: ChannelsActivationChannelId =
+    frontend === "teams" ? "teams" : "slack";
+  const channelLabel = CHANNEL_LABELS[channel];
 
   React.useEffect(
     () => () => {
@@ -56,16 +63,41 @@ export function ChannelsStartPrompt({
     [],
   );
 
-  // This component only renders on channel-scoped pages, so anything that is
-  // not Teams is the Slack variant.
-  const channel: ChannelsActivationChannelId =
-    frontend === "teams" ? "teams" : "slack";
-  const channelLabel = CHANNEL_LABELS[channel];
+  // Impression, so the copy count has a denominator. The panel sits at the top
+  // of the overview page but still below the fold on short viewports, so mount
+  // is not the same as seen.
+  React.useEffect(() => {
+    const node = panelRef.current;
+    if (!node || viewedRef.current) return;
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting || viewedRef.current) continue;
+          viewedRef.current = true;
+          observer.disconnect();
+          try {
+            posthog?.capture(CHANNELS_ACTIVATION_EVENTS.viewed, {
+              channel,
+              backend: "built-in-agent",
+              from_path: pathname,
+              surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
+            });
+          } catch {
+            // Analytics must never interrupt docs rendering.
+          }
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channel]);
+
   const prompt = buildChannelsActivationPrompt({
-    channelLabel,
-    backendLabel,
-  });
-  const { command, instruction } = buildChannelsActivationPromptParts({
     channelLabel,
     backendLabel,
   });
@@ -80,7 +112,7 @@ export function ChannelsStartPrompt({
         channel,
         backend: "built-in-agent",
         from_path: pathname,
-        surface: "docs_channels_overview",
+        surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
       });
       resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
     } catch {
@@ -91,6 +123,7 @@ export function ChannelsStartPrompt({
 
   return (
     <section
+      ref={panelRef}
       aria-labelledby="channels-start-prompt-heading"
       className="shell-docs-radius-surface my-6 border p-5 sm:p-6"
       style={{
@@ -99,10 +132,8 @@ export function ChannelsStartPrompt({
           "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--bg-surface)) 0%, var(--bg-surface) 62%)",
       }}
     >
-      {/* Header mirrors the featured-Accordion treatment: icon, eyebrow,
-          title, supporting line, and the action on the right at wide widths.
-          The action lives here rather than beside the command so the command
-          gets the panel's full width — at half width it wrapped mid-flag. */}
+      {/* Mirrors the featured-Accordion treatment from #6356: icon, eyebrow,
+          title, supporting line, and the action on the right at wide widths. */}
       <div className="flex flex-col gap-5 lg:flex-row lg:items-center">
         <div className="flex min-w-0 flex-1 items-start gap-4">
           <span
@@ -123,9 +154,10 @@ export function ChannelsStartPrompt({
               Start building with your coding agent
             </h2>
             <p className="mt-1.5 mb-0 max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
-              Paste this into your coding agent. It installs the onboarding
-              skill and walks the whole setup with you — scaffolding the
-              project, building the agent, and connecting it to {channelLabel}.
+              Copy the prompt and paste it into your coding agent. It installs
+              the onboarding skill and walks the whole setup with you —
+              scaffolding the project, building the agent, and connecting it to{" "}
+              {channelLabel}.
             </p>
           </div>
         </div>
@@ -143,17 +175,6 @@ export function ChannelsStartPrompt({
               : "Copy prompt"}
         </button>
       </div>
-
-      {/* Exactly the text the button copies, rendered as the sentence it is.
-          Shown as a command in a code block with the ask underneath, it read
-          as a shell command with a footnote — which made "Copy prompt" look
-          like it was lying. Only the command is monospace; the prose around it
-          wraps like prose. */}
-      <p className="shell-docs-radius-control mt-4 mb-0 border border-dashed border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-sm leading-relaxed text-[var(--text)]">
-        {"Run "}
-        <code className="font-mono text-xs text-[var(--text)]">{command}</code>
-        {`, then ${instruction}`}
-      </p>
 
       <span aria-live="polite" className="sr-only">
         {copyState === "copied"

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -17,8 +17,7 @@
 import React from "react";
 import { usePathname } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { Check, Copy } from "lucide-react";
-import { Accordion } from "./mdx-components";
+import { Copy, SquareTerminal } from "lucide-react";
 import {
   CHANNELS_ACTIVATION_EVENTS,
   CHANNELS_ACTIVATION_SURFACES,
@@ -47,7 +46,6 @@ export function ChannelsStartPrompt({ frontend }: ChannelsStartPromptProps) {
   );
   const panelRef = React.useRef<HTMLDivElement | null>(null);
   const viewedRef = React.useRef(false);
-  const expandedRef = React.useRef(false);
 
   // This component only renders on channel-scoped pages, so anything that is
   // not Teams is the Slack variant.
@@ -102,16 +100,6 @@ export function ChannelsStartPrompt({ frontend }: ChannelsStartPromptProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel]);
 
-  // Expanding is where a disclosure loses people, and neither `viewed` nor
-  // `promptCopied` can see it: a reader who never opened the panel looks
-  // identical to one who opened it and walked away. Fires once.
-  function handleToggle(event: React.SyntheticEvent<HTMLDivElement>) {
-    const details = (event.target as HTMLElement).closest("details");
-    if (!details?.open || expandedRef.current) return;
-    expandedRef.current = true;
-    capture(CHANNELS_ACTIVATION_EVENTS.promptExpanded, analyticsProperties);
-  }
-
   async function copyPrompt() {
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
 
@@ -135,58 +123,51 @@ export function ChannelsStartPrompt({ frontend }: ChannelsStartPromptProps) {
     <div
       ref={panelRef}
       data-testid="channels-start-prompt"
-      onToggle={handleToggle}
+      className="shell-docs-radius-surface not-prose my-6 border border-[var(--border)] bg-[var(--bg-elevated)] p-4 shadow-[var(--shadow-control)]"
     >
-      <Accordion
-        featured
-        title="Start building with your coding agent"
-        description={`Give your local coding agent a guided path from a blank directory to a working ${channelLabel} channel.`}
-      >
-        <p className="mt-0 mb-3">
-          It walks your agent through the whole setup — choosing a framework,
-          scaffolding the project, building the agent, and connecting it to{" "}
-          {channelLabel}.
-        </p>
+      {/* No disclosure. The payload is one action, so there is nothing to reveal
+          — and the same in-content panel idiom as `OpsPlatformCTA`: neutral
+          surface, `--border`, accent carried only by a small glyph. */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <SquareTerminal
+            aria-hidden="true"
+            className="mt-0.5 h-5 w-5 shrink-0 text-[var(--accent)]"
+          />
 
-        <div className="shell-docs-radius-control relative border border-[var(--border)] bg-[var(--bg-elevated)] p-3">
-          {/* Wraps rather than scrolls. The docs' usual code block scrolls
-              horizontally, which is right for code but hid half of this behind
-              the overflow — and the point of the disclosure is that a reader can
-              read the whole prompt before copying it. `pe-20` keeps every line
-              clear of the copy button. */}
-          <pre className="m-0 bg-transparent p-0 pe-20 text-xs leading-relaxed break-words whitespace-pre-wrap">
-            <code className="font-mono text-[var(--text)]">
-              {CHANNELS_BUILD_PROMPT}
-            </code>
-          </pre>
-
-          <button
-            type="button"
-            onClick={copyPrompt}
-            aria-label="Copy the starter prompt"
-            className="shell-docs-radius-control absolute top-2 right-2 inline-flex h-8 cursor-pointer items-center gap-1.5 border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-xs font-semibold text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
-          >
-            {copyState === "copied" ? (
-              <Check aria-hidden="true" className="h-3.5 w-3.5" />
-            ) : (
-              <Copy aria-hidden="true" className="h-3.5 w-3.5" />
-            )}
-            {copyState === "copied"
-              ? "Copied"
-              : copyState === "error"
-                ? "Copy blocked"
-                : "Copy"}
-          </button>
+          <div className="min-w-0">
+            <span className="block font-semibold text-[var(--text)]">
+              Start building with your coding agent
+            </span>
+            <span className="mt-1 block max-w-[62ch] text-sm leading-relaxed text-[var(--text-muted)]">
+              It walks your agent through the whole setup — choosing a
+              framework, scaffolding the project, building the agent, and
+              connecting it to {channelLabel}.
+            </span>
+          </div>
         </div>
 
-        <span aria-live="polite" className="sr-only">
+        <button
+          type="button"
+          onClick={copyPrompt}
+          className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
+        >
+          <Copy aria-hidden="true" className="h-4 w-4" />
           {copyState === "copied"
-            ? "Prompt copied"
+            ? "Copied"
             : copyState === "error"
-              ? "Prompt copy failed. Try again."
-              : ""}
-        </span>
-      </Accordion>
+              ? "Copy blocked"
+              : "Copy prompt"}
+        </button>
+      </div>
+
+      <span aria-live="polite" className="sr-only">
+        {copyState === "copied"
+          ? "Prompt copied"
+          : copyState === "error"
+            ? "Prompt copy failed. Try again."
+            : ""}
+      </span>
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+// <ChannelsStartPrompt> — the Channels overview page's road into onboarding.
+//
+// Every Channels surface (this page, the docs landing activation strip,
+// copilotkit.ai/channels, the channels-sdk README) points at the same skill
+// with the same two sentences. They used to carry the workflow inline instead:
+// six copies across three repos, which drifted apart and went stale against the
+// CLI, so developers were told to run commands that no longer existed.
+//
+// The text is rendered, not just copied. The prompts this replaced were hidden
+// behind an accordion because they were twenty lines long; at one line there is
+// nothing to hide, and a copy button whose payload is invisible reads as
+// decoration.
+
+import React from "react";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import {
+  CHANNELS_ACTIVATION_EVENTS,
+  buildChannelsActivationPrompt,
+} from "@/lib/channels-activation-contracts";
+import type { ChannelsActivationChannelId } from "@/lib/channels-activation-contracts";
+
+type CopyState = "idle" | "copied" | "error";
+
+export interface ChannelsStartPromptProps {
+  /** Injected from the page's docs frontend by the MDX component map. */
+  frontend?: string;
+  /** Backend label to name in the prompt. Defaults to the built-in agent. */
+  backendLabel?: string;
+}
+
+const CHANNEL_LABELS: Record<ChannelsActivationChannelId, string> = {
+  slack: "Slack",
+  teams: "Microsoft Teams",
+};
+
+export function ChannelsStartPrompt({
+  frontend,
+  backendLabel = "CopilotKit's built-in agent",
+}: ChannelsStartPromptProps) {
+  const posthog = usePostHog();
+  const pathname = usePathname();
+  const [copyState, setCopyState] = React.useState<CopyState>("idle");
+  const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  React.useEffect(
+    () => () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    },
+    [],
+  );
+
+  // This component only renders on channel-scoped pages, so anything that is
+  // not Teams is the Slack variant.
+  const channel: ChannelsActivationChannelId =
+    frontend === "teams" ? "teams" : "slack";
+  const channelLabel = CHANNEL_LABELS[channel];
+  const prompt = buildChannelsActivationPrompt({
+    channelLabel,
+    backendLabel,
+  });
+
+  async function copyPrompt() {
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopyState("copied");
+      posthog?.capture(CHANNELS_ACTIVATION_EVENTS.promptCopied, {
+        channel,
+        backend: "built-in-agent",
+        from_path: pathname,
+        surface: "docs_channels_overview",
+      });
+      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
+    } catch {
+      setCopyState("error");
+      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 2600);
+    }
+  }
+
+  return (
+    <section
+      aria-labelledby="channels-start-prompt-heading"
+      className="shell-docs-radius-control my-8 border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)]"
+    >
+      <h2
+        id="channels-start-prompt-heading"
+        className="m-0 text-base font-semibold text-[var(--text)]"
+      >
+        Build this with your coding agent
+      </h2>
+      <p className="mt-1.5 mb-0 text-sm leading-relaxed text-[var(--text-secondary)]">
+        Paste this into your coding agent. It installs the onboarding skill and
+        walks the whole setup with you — scaffolding the project, building the
+        agent, and connecting it to {channelLabel}.
+      </p>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-stretch">
+        <p className="shell-docs-radius-control m-0 min-w-0 flex-1 overflow-x-auto border border-dashed border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 font-mono text-xs leading-relaxed break-words whitespace-pre-wrap text-[var(--text-secondary)]">
+          {prompt}
+        </p>
+
+        <button
+          type="button"
+          onClick={copyPrompt}
+          className="shell-docs-radius-control inline-flex min-h-11 shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:self-start"
+        >
+          {copyState === "copied"
+            ? "Copied"
+            : copyState === "error"
+              ? "Copy blocked"
+              : "Copy prompt"}
+        </button>
+      </div>
+
+      <span aria-live="polite" className="sr-only">
+        {copyState === "copied"
+          ? "Prompt copied"
+          : copyState === "error"
+            ? "Prompt copy failed. Try again."
+            : ""}
+      </span>
+    </section>
+  );
+}

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -77,16 +77,12 @@ export function ChannelsStartPrompt({
           if (!entry.isIntersecting || viewedRef.current) continue;
           viewedRef.current = true;
           observer.disconnect();
-          try {
-            posthog?.capture(CHANNELS_ACTIVATION_EVENTS.viewed, {
-              channel,
-              backend: "built-in-agent",
-              from_path: pathname,
-              surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
-            });
-          } catch {
-            // Analytics must never interrupt docs rendering.
-          }
+          capture(CHANNELS_ACTIVATION_EVENTS.viewed, {
+            channel,
+            backend: "built-in-agent",
+            from_path: pathname,
+            surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
+          });
         }
       },
       { threshold: 0.5 },
@@ -102,23 +98,36 @@ export function ChannelsStartPrompt({
     backendLabel,
   });
 
+  function capture(event: string, properties: Record<string, unknown>) {
+    try {
+      posthog?.capture(event, properties);
+    } catch {
+      // Analytics must never interrupt docs rendering or clipboard actions.
+    }
+  }
+
   async function copyPrompt() {
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
 
+    // Only the clipboard write decides the state shown to the reader. Sharing
+    // one try block with the capture call meant a throwing analytics client
+    // reported "Copy blocked" for a prompt that was already on the clipboard.
     try {
       await navigator.clipboard.writeText(prompt);
-      setCopyState("copied");
-      posthog?.capture(CHANNELS_ACTIVATION_EVENTS.promptCopied, {
-        channel,
-        backend: "built-in-agent",
-        from_path: pathname,
-        surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
-      });
-      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
     } catch {
       setCopyState("error");
       resetTimerRef.current = setTimeout(() => setCopyState("idle"), 2600);
+      return;
     }
+
+    setCopyState("copied");
+    capture(CHANNELS_ACTIVATION_EVENTS.promptCopied, {
+      channel,
+      backend: "built-in-agent",
+      from_path: pathname,
+      surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
+    });
+    resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
   }
 
   return (

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -16,9 +16,11 @@
 import React from "react";
 import { usePathname } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
+import { Copy, SquareTerminal } from "lucide-react";
 import {
   CHANNELS_ACTIVATION_EVENTS,
   buildChannelsActivationPrompt,
+  buildChannelsActivationPromptParts,
 } from "@/lib/channels-activation-contracts";
 import type { ChannelsActivationChannelId } from "@/lib/channels-activation-contracts";
 
@@ -63,6 +65,10 @@ export function ChannelsStartPrompt({
     channelLabel,
     backendLabel,
   });
+  const { command, instruction } = buildChannelsActivationPromptParts({
+    channelLabel,
+    backendLabel,
+  });
 
   async function copyPrompt() {
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
@@ -86,30 +92,50 @@ export function ChannelsStartPrompt({
   return (
     <section
       aria-labelledby="channels-start-prompt-heading"
-      className="shell-docs-radius-control my-8 border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-control)]"
+      className="shell-docs-radius-surface my-6 border p-5 sm:p-6"
+      style={{
+        borderColor: "color-mix(in oklch, var(--accent) 32%, var(--border))",
+        background:
+          "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--bg-surface)) 0%, var(--bg-surface) 62%)",
+      }}
     >
-      <h2
-        id="channels-start-prompt-heading"
-        className="m-0 text-base font-semibold text-[var(--text)]"
-      >
-        Build this with your coding agent
-      </h2>
-      <p className="mt-1.5 mb-0 text-sm leading-relaxed text-[var(--text-secondary)]">
-        Paste this into your coding agent. It installs the onboarding skill and
-        walks the whole setup with you — scaffolding the project, building the
-        agent, and connecting it to {channelLabel}.
-      </p>
+      {/* Header mirrors the featured-Accordion treatment: icon, eyebrow,
+          title, supporting line, and the action on the right at wide widths.
+          The action lives here rather than beside the command so the command
+          gets the panel's full width — at half width it wrapped mid-flag. */}
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-center">
+        <div className="flex min-w-0 flex-1 items-start gap-4">
+          <span
+            aria-hidden="true"
+            className="shell-docs-radius-control flex h-12 w-12 shrink-0 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] shadow-[var(--shadow-control)]"
+          >
+            <SquareTerminal className="h-5 w-5" />
+          </span>
 
-      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-stretch">
-        <p className="shell-docs-radius-control m-0 min-w-0 flex-1 overflow-x-auto border border-dashed border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 font-mono text-xs leading-relaxed break-words whitespace-pre-wrap text-[var(--text-secondary)]">
-          {prompt}
-        </p>
+          <div className="min-w-0">
+            <span className="mb-1.5 block font-mono text-[11px] font-semibold tracking-[0.12em] text-[var(--accent)] uppercase">
+              Ready-to-use starter prompt
+            </span>
+            <h2
+              id="channels-start-prompt-heading"
+              className="m-0 text-lg leading-snug font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-xl"
+            >
+              Start building with your coding agent
+            </h2>
+            <p className="mt-1.5 mb-0 max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
+              Paste this into your coding agent. It installs the onboarding
+              skill and walks the whole setup with you — scaffolding the
+              project, building the agent, and connecting it to {channelLabel}.
+            </p>
+          </div>
+        </div>
 
         <button
           type="button"
           onClick={copyPrompt}
-          className="shell-docs-radius-control inline-flex min-h-11 shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:self-start"
+          className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
         >
+          <Copy aria-hidden="true" className="h-4 w-4" />
           {copyState === "copied"
             ? "Copied"
             : copyState === "error"
@@ -117,6 +143,17 @@ export function ChannelsStartPrompt({
               : "Copy prompt"}
         </button>
       </div>
+
+      {/* Exactly the text the button copies, rendered as the sentence it is.
+          Shown as a command in a code block with the ask underneath, it read
+          as a shell command with a footnote — which made "Copy prompt" look
+          like it was lying. Only the command is monospace; the prose around it
+          wraps like prose. */}
+      <p className="shell-docs-radius-control mt-4 mb-0 border border-dashed border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-2.5 text-sm leading-relaxed text-[var(--text)]">
+        {"Run "}
+        <code className="font-mono text-xs text-[var(--text)]">{command}</code>
+        {`, then ${instruction}`}
+      </p>
 
       <span aria-live="polite" className="sr-only">
         {copyState === "copied"

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -133,47 +133,48 @@ export function ChannelsStartPrompt({
       }}
     >
       {/* Mirrors the featured-Accordion treatment from #6356: icon, eyebrow,
-          title, supporting line, and the action on the right at wide widths. */}
-      <div className="flex flex-col gap-5 lg:flex-row lg:items-center">
-        <div className="flex min-w-0 flex-1 items-start gap-4">
-          <span
-            aria-hidden="true"
-            className="shell-docs-radius-control flex h-12 w-12 shrink-0 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] shadow-[var(--shadow-control)]"
-          >
-            <SquareTerminal className="h-5 w-5" />
-          </span>
-
-          <div className="min-w-0">
-            <span className="mb-1.5 block font-mono text-[11px] font-semibold tracking-[0.12em] text-[var(--accent)] uppercase">
-              Ready-to-use starter prompt
-            </span>
-            <h2
-              id="channels-start-prompt-heading"
-              className="m-0 text-lg leading-snug font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-xl"
-            >
-              Start building with your coding agent
-            </h2>
-            <p className="mt-1.5 mb-0 max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
-              Copy the prompt and paste it into your coding agent. It installs
-              the onboarding skill and walks the whole setup with you —
-              scaffolding the project, building the agent, and connecting it to{" "}
-              {channelLabel}.
-            </p>
-          </div>
-        </div>
-
-        <button
-          type="button"
-          onClick={copyPrompt}
-          className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
+          title, action, supporting line. The action sits directly under the
+          heading rather than off to the right — the prompt itself is not on the
+          page, so the button is the whole point of the panel and reads better as
+          the next thing after the headline than as trailing furniture. */}
+      <div className="flex min-w-0 items-start gap-4">
+        <span
+          aria-hidden="true"
+          className="shell-docs-radius-control flex h-12 w-12 shrink-0 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] shadow-[var(--shadow-control)]"
         >
-          <Copy aria-hidden="true" className="h-4 w-4" />
-          {copyState === "copied"
-            ? "Copied"
-            : copyState === "error"
-              ? "Copy blocked"
-              : "Copy prompt"}
-        </button>
+          <SquareTerminal className="h-5 w-5" />
+        </span>
+
+        <div className="min-w-0">
+          <span className="mb-1.5 block font-mono text-[11px] font-semibold tracking-[0.12em] text-[var(--accent)] uppercase">
+            Ready-to-use starter prompt
+          </span>
+          <h2
+            id="channels-start-prompt-heading"
+            className="m-0 text-lg leading-snug font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-xl"
+          >
+            Start building with your coding agent
+          </h2>
+
+          <button
+            type="button"
+            onClick={copyPrompt}
+            className="shell-docs-radius-control mt-3 inline-flex min-h-11 w-full cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
+          >
+            <Copy aria-hidden="true" className="h-4 w-4" />
+            {copyState === "copied"
+              ? "Copied"
+              : copyState === "error"
+                ? "Copy blocked"
+                : "Copy prompt"}
+          </button>
+
+          <p className="mt-3 mb-0 max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
+            It installs the onboarding skill and walks the whole setup with you
+            — scaffolding the project, building the agent, and connecting it to{" "}
+            {channelLabel}.
+          </p>
+        </div>
       </div>
 
       <span aria-live="polite" className="sr-only">

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -22,7 +22,7 @@ import { Accordion } from "./mdx-components";
 import {
   CHANNELS_ACTIVATION_EVENTS,
   CHANNELS_ACTIVATION_SURFACES,
-  buildChannelsActivationPrompt,
+  CHANNELS_BUILD_PROMPT,
 } from "@/lib/channels-activation-contracts";
 import type { ChannelsActivationChannelId } from "@/lib/channels-activation-contracts";
 
@@ -31,8 +31,6 @@ type CopyState = "idle" | "copied" | "error";
 export interface ChannelsStartPromptProps {
   /** Injected from the page's docs frontend by the MDX component map. */
   frontend?: string;
-  /** Backend label to name in the prompt. Defaults to the built-in agent. */
-  backendLabel?: string;
 }
 
 const CHANNEL_LABELS: Record<ChannelsActivationChannelId, string> = {
@@ -40,10 +38,7 @@ const CHANNEL_LABELS: Record<ChannelsActivationChannelId, string> = {
   teams: "Microsoft Teams",
 };
 
-export function ChannelsStartPrompt({
-  frontend,
-  backendLabel = "CopilotKit's built-in agent",
-}: ChannelsStartPromptProps) {
+export function ChannelsStartPrompt({ frontend }: ChannelsStartPromptProps) {
   const posthog = usePostHog();
   const pathname = usePathname();
   const [copyState, setCopyState] = React.useState<CopyState>("idle");
@@ -107,11 +102,6 @@ export function ChannelsStartPrompt({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel]);
 
-  const prompt = buildChannelsActivationPrompt({
-    channelLabel,
-    backendLabel,
-  });
-
   // Expanding is where a disclosure loses people, and neither `viewed` nor
   // `promptCopied` can see it: a reader who never opened the panel looks
   // identical to one who opened it and walked away. Fires once.
@@ -129,7 +119,7 @@ export function ChannelsStartPrompt({
     // one try block with the capture call meant a throwing analytics client
     // reported "Copy blocked" for a prompt that was already on the clipboard.
     try {
-      await navigator.clipboard.writeText(prompt);
+      await navigator.clipboard.writeText(CHANNELS_BUILD_PROMPT);
     } catch {
       setCopyState("error");
       resetTimerRef.current = setTimeout(() => setCopyState("idle"), 2600);
@@ -153,7 +143,7 @@ export function ChannelsStartPrompt({
         description={`Give your local coding agent a guided path from a blank directory to a working ${channelLabel} channel.`}
       >
         <p className="mt-0 mb-3">
-          It installs the onboarding skill and walks the whole setup with you —
+          It walks your agent through the whole setup — choosing a framework,
           scaffolding the project, building the agent, and connecting it to{" "}
           {channelLabel}.
         </p>
@@ -165,7 +155,9 @@ export function ChannelsStartPrompt({
               read the whole prompt before copying it. `pe-20` keeps every line
               clear of the copy button. */}
           <pre className="m-0 bg-transparent p-0 pe-20 text-xs leading-relaxed break-words whitespace-pre-wrap">
-            <code className="font-mono text-[var(--text)]">{prompt}</code>
+            <code className="font-mono text-[var(--text)]">
+              {CHANNELS_BUILD_PROMPT}
+            </code>
           </pre>
 
           <button

--- a/showcase/shell-docs/src/components/channels-start-prompt.tsx
+++ b/showcase/shell-docs/src/components/channels-start-prompt.tsx
@@ -8,14 +8,17 @@
 // six copies across three repos, which drifted apart and went stale against the
 // CLI, so developers were told to run commands that no longer existed.
 //
-// The prompts this replaced were twenty lines long and hidden behind an
-// accordion. At one line there is nothing to disclose, so the panel is always
-// open and the button hands the text straight to the clipboard.
+// The container is the shared featured `<Accordion>` from #6356, reused rather
+// than restyled: it keeps the overview compact when collapsed, and readers can
+// expand to inspect the exact prompt before copying it. This component adds the
+// two things markup alone cannot — the Slack/Teams switch, and the analytics
+// that say whether the road is used at all.
 
 import React from "react";
 import { usePathname } from "next/navigation";
 import { usePostHog } from "posthog-js/react";
-import { Copy, SquareTerminal } from "lucide-react";
+import { Check, Copy } from "lucide-react";
+import { Accordion } from "./mdx-components";
 import {
   CHANNELS_ACTIVATION_EVENTS,
   CHANNELS_ACTIVATION_SURFACES,
@@ -47,8 +50,9 @@ export function ChannelsStartPrompt({
   const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const panelRef = React.useRef<HTMLElement | null>(null);
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
   const viewedRef = React.useRef(false);
+  const expandedRef = React.useRef(false);
 
   // This component only renders on channel-scoped pages, so anything that is
   // not Teams is the Slack variant.
@@ -63,9 +67,24 @@ export function ChannelsStartPrompt({
     [],
   );
 
-  // Impression, so the copy count has a denominator. The panel sits at the top
-  // of the overview page but still below the fold on short viewports, so mount
-  // is not the same as seen.
+  function capture(event: string, properties: Record<string, unknown>) {
+    try {
+      posthog?.capture(event, properties);
+    } catch {
+      // Analytics must never interrupt docs rendering or clipboard actions.
+    }
+  }
+
+  const analyticsProperties = {
+    channel,
+    backend: "built-in-agent",
+    from_path: pathname,
+    surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
+  };
+
+  // Impression, so the copy count has a denominator. Observed on the collapsed
+  // container, which is what a reader is actually shown — the prompt inside is
+  // hidden until they choose to expand it.
   React.useEffect(() => {
     const node = panelRef.current;
     if (!node || viewedRef.current) return;
@@ -77,12 +96,7 @@ export function ChannelsStartPrompt({
           if (!entry.isIntersecting || viewedRef.current) continue;
           viewedRef.current = true;
           observer.disconnect();
-          capture(CHANNELS_ACTIVATION_EVENTS.viewed, {
-            channel,
-            backend: "built-in-agent",
-            from_path: pathname,
-            surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
-          });
+          capture(CHANNELS_ACTIVATION_EVENTS.viewed, analyticsProperties);
         }
       },
       { threshold: 0.5 },
@@ -98,12 +112,14 @@ export function ChannelsStartPrompt({
     backendLabel,
   });
 
-  function capture(event: string, properties: Record<string, unknown>) {
-    try {
-      posthog?.capture(event, properties);
-    } catch {
-      // Analytics must never interrupt docs rendering or clipboard actions.
-    }
+  // Expanding is where a disclosure loses people, and neither `viewed` nor
+  // `promptCopied` can see it: a reader who never opened the panel looks
+  // identical to one who opened it and walked away. Fires once.
+  function handleToggle(event: React.SyntheticEvent<HTMLDivElement>) {
+    const details = (event.target as HTMLElement).closest("details");
+    if (!details?.open || expandedRef.current) return;
+    expandedRef.current = true;
+    capture(CHANNELS_ACTIVATION_EVENTS.promptExpanded, analyticsProperties);
   }
 
   async function copyPrompt() {
@@ -121,78 +137,64 @@ export function ChannelsStartPrompt({
     }
 
     setCopyState("copied");
-    capture(CHANNELS_ACTIVATION_EVENTS.promptCopied, {
-      channel,
-      backend: "built-in-agent",
-      from_path: pathname,
-      surface: CHANNELS_ACTIVATION_SURFACES.docsChannelsOverview,
-    });
+    capture(CHANNELS_ACTIVATION_EVENTS.promptCopied, analyticsProperties);
     resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
   }
 
   return (
-    <section
+    <div
       ref={panelRef}
-      aria-labelledby="channels-start-prompt-heading"
-      className="shell-docs-radius-surface my-6 border p-5 sm:p-6"
-      style={{
-        borderColor: "color-mix(in oklch, var(--accent) 32%, var(--border))",
-        background:
-          "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--bg-surface)) 0%, var(--bg-surface) 62%)",
-      }}
+      data-testid="channels-start-prompt"
+      onToggle={handleToggle}
     >
-      {/* Mirrors the featured-Accordion treatment from #6356: icon, eyebrow,
-          title, action, supporting line. The action sits directly under the
-          heading rather than off to the right — the prompt itself is not on the
-          page, so the button is the whole point of the panel and reads better as
-          the next thing after the headline than as trailing furniture. */}
-      <div className="flex min-w-0 items-start gap-4">
-        <span
-          aria-hidden="true"
-          className="shell-docs-radius-control flex h-12 w-12 shrink-0 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] shadow-[var(--shadow-control)]"
-        >
-          <SquareTerminal className="h-5 w-5" />
-        </span>
+      <Accordion
+        featured
+        title="Start building with your coding agent"
+        description={`Give your local coding agent a guided path from a blank directory to a working ${channelLabel} channel.`}
+      >
+        <p className="mt-0 mb-3">
+          It installs the onboarding skill and walks the whole setup with you —
+          scaffolding the project, building the agent, and connecting it to{" "}
+          {channelLabel}.
+        </p>
 
-        <div className="min-w-0">
-          <span className="mb-1.5 block font-mono text-[11px] font-semibold tracking-[0.12em] text-[var(--accent)] uppercase">
-            Ready-to-use starter prompt
-          </span>
-          <h2
-            id="channels-start-prompt-heading"
-            className="m-0 text-lg leading-snug font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-xl"
-          >
-            Start building with your coding agent
-          </h2>
+        <div className="shell-docs-radius-control relative border border-[var(--border)] bg-[var(--bg-elevated)] p-3">
+          {/* Wraps rather than scrolls. The docs' usual code block scrolls
+              horizontally, which is right for code but hid half of this behind
+              the overflow — and the point of the disclosure is that a reader can
+              read the whole prompt before copying it. `pe-20` keeps every line
+              clear of the copy button. */}
+          <pre className="m-0 bg-transparent p-0 pe-20 text-xs leading-relaxed break-words whitespace-pre-wrap">
+            <code className="font-mono text-[var(--text)]">{prompt}</code>
+          </pre>
 
           <button
             type="button"
             onClick={copyPrompt}
-            className="shell-docs-radius-control mt-3 inline-flex min-h-11 w-full cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
+            aria-label="Copy the starter prompt"
+            className="shell-docs-radius-control absolute top-2 right-2 inline-flex h-8 cursor-pointer items-center gap-1.5 border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-xs font-semibold text-[var(--text)] shadow-[var(--shadow-control)] transition-colors hover:border-[var(--accent)] hover:text-[var(--accent)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none"
           >
-            <Copy aria-hidden="true" className="h-4 w-4" />
+            {copyState === "copied" ? (
+              <Check aria-hidden="true" className="h-3.5 w-3.5" />
+            ) : (
+              <Copy aria-hidden="true" className="h-3.5 w-3.5" />
+            )}
             {copyState === "copied"
               ? "Copied"
               : copyState === "error"
                 ? "Copy blocked"
-                : "Copy prompt"}
+                : "Copy"}
           </button>
-
-          <p className="mt-3 mb-0 max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
-            It installs the onboarding skill and walks the whole setup with you
-            — scaffolding the project, building the agent, and connecting it to{" "}
-            {channelLabel}.
-          </p>
         </div>
-      </div>
 
-      <span aria-live="polite" className="sr-only">
-        {copyState === "copied"
-          ? "Prompt copied"
-          : copyState === "error"
-            ? "Prompt copy failed. Try again."
-            : ""}
-      </span>
-    </section>
+        <span aria-live="polite" className="sr-only">
+          {copyState === "copied"
+            ? "Prompt copied"
+            : copyState === "error"
+              ? "Prompt copy failed. Try again."
+              : ""}
+        </span>
+      </Accordion>
+    </div>
   );
 }

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -40,6 +40,8 @@ import { MdxFrameworkOverview } from "@/components/content/landing-pages/mdx-fra
 import type { MdxFrameworkOverviewProps } from "@/components/content/landing-pages/mdx-framework-overview";
 import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
 import type { OpsPlatformCTAProps } from "@/components/react/ops-platform-cta";
+import { ChannelsStartPrompt } from "@/components/channels-start-prompt";
+import type { ChannelsStartPromptProps } from "@/components/channels-start-prompt";
 import { SignupLink } from "@/components/react/signup-link";
 import type { SignupLinkProps } from "@/components/react/signup-link";
 import { FrameworkSetup } from "@/lib/setup-concept";
@@ -331,6 +333,14 @@ export async function DocsPageView({
                               : props.href;
                           return <CardComp {...props} href={href} />;
                         },
+                        ChannelsStartPrompt: (
+                          props: ChannelsStartPromptProps,
+                        ) => (
+                          <ChannelsStartPrompt
+                            {...props}
+                            frontend={props.frontend ?? docsFrontend}
+                          />
+                        ),
                         OpsPlatformCTA: (props: OpsPlatformCTAProps) => (
                           <OpsPlatformCTA
                             {...props}

--- a/showcase/shell-docs/src/components/mdx-components.tsx
+++ b/showcase/shell-docs/src/components/mdx-components.tsx
@@ -110,51 +110,48 @@ export function Accordion({
 }) {
   if (featured) {
     return (
-      <details
-        className="shell-docs-radius-surface group my-6 overflow-hidden border bg-[var(--bg-surface)]"
-        style={{
-          borderColor: "color-mix(in oklch, var(--accent) 32%, var(--border))",
-          background:
-            "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--bg-surface)) 0%, var(--bg-surface) 62%)",
-        }}
-      >
-        <summary className="not-prose cursor-pointer list-none select-none p-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--accent)] sm:p-6 [&::-webkit-details-marker]:hidden">
-          <span className="flex flex-col gap-5 lg:flex-row lg:items-center">
-            <span className="flex min-w-0 flex-1 items-start gap-4">
-              <span
+      // Deliberately token-only, matching the in-content panel idiom in
+      // `OpsPlatformCTA`: neutral surface, `--border`, `--shadow-control`, and
+      // accent carried by a small glyph and the action, never by a filled block
+      // or a tinted gradient. `copilotkit-ui-theme` flags a purple accent bar
+      // or stripe as a known wrong direction, and `copilotkit-branding` scopes
+      // accent to restrained and atmospheric use — a saturated `--accent` tile
+      // plus an accent-mixed gradient was both at once. Padding is `p-4`, the
+      // same as every other docs panel, so a collapsed prompt no longer pushes
+      // the page's own introduction below the fold.
+      <details className="shell-docs-radius-surface not-prose group my-6 overflow-hidden border border-[var(--border)] bg-[var(--bg-elevated)] shadow-[var(--shadow-control)]">
+        <summary className="cursor-pointer list-none p-4 select-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-inset focus-visible:outline-none [&::-webkit-details-marker]:hidden">
+          <span className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+            <span className="flex min-w-0 flex-1 items-start gap-3">
+              <SquareTerminal
                 aria-hidden="true"
-                className="shell-docs-radius-control flex h-12 w-12 shrink-0 items-center justify-center bg-[var(--accent)] text-[var(--primary-foreground)] shadow-[var(--shadow-control)]"
-              >
-                <SquareTerminal className="h-5 w-5" />
-              </span>
+                className="mt-0.5 h-5 w-5 shrink-0 text-[var(--accent)]"
+              />
 
               <span className="min-w-0">
-                <span className="mb-1.5 block font-mono text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--accent)]">
-                  Ready-to-use starter prompt
-                </span>
-                <span className="block text-lg font-semibold leading-snug tracking-[-0.015em] text-[var(--text)] sm:text-xl">
+                <span className="block font-semibold text-[var(--text)]">
                   {title}
                 </span>
                 {description ? (
-                  <span className="mt-1.5 block max-w-[62ch] text-sm leading-relaxed text-[var(--text-secondary)]">
+                  <span className="mt-1 block max-w-[62ch] text-sm leading-relaxed text-[var(--text-muted)]">
                     {description}
                   </span>
                 ) : null}
               </span>
             </span>
 
-            <span className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors group-hover:bg-[var(--accent-strong)] sm:w-auto">
-              <Copy aria-hidden="true" className="h-4 w-4" />
+            <span className="shell-docs-radius-control inline-flex min-h-9 w-full shrink-0 items-center justify-center gap-1.5 border border-[var(--border)] bg-[var(--bg-surface)] px-3 text-sm font-medium text-[var(--text)] shadow-[var(--shadow-control)] transition-colors group-hover:border-[var(--accent)] group-hover:text-[var(--accent)] sm:w-auto">
+              <Copy aria-hidden="true" className="h-3.5 w-3.5" />
               <span className="group-open:hidden">Open &amp; copy prompt</span>
               <span className="hidden group-open:inline">Close prompt</span>
               <ChevronDown
                 aria-hidden="true"
-                className="h-4 w-4 transition-transform duration-200 group-open:rotate-180"
+                className="h-3.5 w-3.5 transition-transform duration-200 group-open:rotate-180"
               />
             </span>
           </span>
         </summary>
-        <div className="border-t border-[var(--border)] bg-[var(--bg-surface)] px-5 pb-5 pt-4 text-sm text-[var(--text-secondary)] sm:px-6 sm:pb-6 [&>p:first-child]:mt-0">
+        <div className="border-t border-[var(--border)] bg-[var(--bg-surface)] px-4 pt-3 pb-4 text-sm text-[var(--text-secondary)] [&>p:first-child]:mt-0">
           {children}
         </div>
       </details>

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -6,91 +6,13 @@ description: Run one AG-UI agent in Slack, Microsoft Teams, and more through man
 doc_type: explanation
 ---
 
-<FrontendOnly frontend="slack">
+{/* One entry point, shared with the docs landing strip, copilotkit.ai/channels,
+    and the channels-sdk README: install one skill, then ask for the thing you
+    want. These pages used to carry the whole workflow inline — six copies
+    across three repos, which drifted apart and went stale against the CLI. The
+    workflow now lives in the skill and is corrected in one place. */}
 
-<Accordions>
-<Accordion title="Start building with your coding agent — copy this prompt">
-
-Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Slack.
-
-```text
-Help me create a new CopilotKit app from scratch, then connect its agent to Slack so it answers in a real channel.
-
-Use these skills as your instructions, in this order:
-- `copilotkit-setup` for creating the app and wiring managed Intelligence.
-- `copilotkit-channels` for the CLI-scaffolded Channel and its long-running host.
-- `setup-slack-channel` for the Slack app and managed Intelligence provider setup.
-
-Read all three before you plan anything, and follow them rather than working from memory. If any skill is not installed, stop and tell me to run `npx copilotkit@latest skills install` in the directory where I want the project, then wait for me. Do not attempt the setup without them.
-
-Use the CopilotKit CLI through `npx copilotkit@latest`; do not assume or require a global CLI installation. Before you start, verify that Node.js 20 or newer is available. If it is not, stop and tell me what I need to install.
-
-When you implement the plan:
-- Run `npx copilotkit@latest create` to scaffold a brand-new project. Ask me for the project name and framework instead of choosing them for me.
-- Choose managed Intelligence because Channels are not available in self-hosted SSE mode. Follow the CLI's current prompts rather than guessing undocumented flags.
-- Treat the CLI-generated `channel-host.mts` and `channels.mts` as the code half. Do not add a second Channel declaration or move the Channel into a serverless route.
-- Use `setup-slack-channel` for the provider half, including the dedicated Slack app, managed Channel, credentials, and real workspace verification. Do not replace the managed path with a direct Slack adapter.
-
-Before your first step, tell me which mode you are in:
-- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account — signing in, creating an Intelligence project, creating the Slack app, attaching the adapter, or issuing a key.
-- You cannot. Then say so plainly and walk me through the browser steps one at a time, waiting for me to confirm each before you continue.
-
-Do not guess which one you are. Check what tools you actually have.
-
-Rules for the whole run:
-- Never ask me to paste a token, signing secret, or API key into this conversation. They go into the Intelligence dashboard and my `.env`, typed by me.
-- Do not report success until all three gates in `setup-slack-channel` hold. "The runtime started" is not one of them.
-
-Start by reading the three skills, then tell me which are available, what you found in the current directory, which browser mode you are in, and what you plan to do.
-```
-
-</Accordion>
-</Accordions>
-
-</FrontendOnly>
-
-<FrontendOnly frontend="teams">
-
-<Accordions>
-<Accordion title="Start building with your coding agent — copy this prompt">
-
-Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Microsoft Teams.
-
-```text
-Help me create a new CopilotKit app from scratch, then connect its agent to Microsoft Teams so it answers in a real channel.
-
-Use these sources as your instructions, in this order:
-- `copilotkit-setup` for creating the app and wiring managed Intelligence.
-- `copilotkit-channels` for the CLI-scaffolded Channel and its long-running host.
-- The current Microsoft Teams Channels documentation at https://docs.copilotkit.ai/teams for the provider setup and end-to-end verification.
-
-Read both skills and the linked Teams documentation before you plan anything, and follow them rather than working from memory. If either skill is not installed, stop and tell me to run `npx copilotkit@latest skills install` in the directory where I want the project, then wait for me. Do not require a Teams-specific onboarding skill or substitute Slack setup instructions; use the linked Teams documentation as the provider source of truth.
-
-Use the CopilotKit CLI through `npx copilotkit@latest`; do not assume or require a global CLI installation. Before you start, verify that Node.js 22 or newer is available. If it is not, stop and tell me what I need to install.
-
-When you implement the plan:
-- Run `npx copilotkit@latest create` to scaffold a brand-new project. Ask me for the project name and framework instead of choosing them for me.
-- Choose managed Intelligence because Channels are not available in self-hosted SSE mode. Follow the CLI's current prompts rather than guessing undocumented flags.
-- Treat the CLI-generated `channel-host.mts` and `channels.mts` as the code half. Do not add a second Channel declaration or move the Channel into a serverless route.
-- Use the published Teams documentation as the provider half. Start at https://docs.copilotkit.ai/teams, select my agent backend in the docs, and follow the linked Intelligence configuration and Teams connection pages in order. Use the current documented steps instead of relying on memory of Azure Bot or Teams app setup.
-
-Before your first step, tell me which mode you are in:
-- You can drive a browser yourself. Then do so, and confirm with me before each consequential change in a live account — signing in, creating an Intelligence project, creating or changing an Azure Bot registration, attaching the Teams connection, issuing a key, or installing the app in Microsoft Teams.
-- You cannot. Then say so plainly and walk me through the browser steps one at a time, waiting for me to confirm each before you continue.
-
-Do not guess which one you are. Check what tools you actually have.
-
-Rules for the whole run:
-- Never ask me to paste a token, client secret, or API key into this conversation. They go into Azure, the Intelligence dashboard, and my `.env`, typed by me.
-- Do not report success until the app is installed in the intended Teams scope, Intelligence reports the Channel as Online, and a real Teams message or mention receives the agent's reply. "The runtime started" is not success.
-
-Start by reading the two skills and the Teams documentation, then tell me which skills are available, what you found in the current directory, which browser mode you are in, and what you plan to do.
-```
-
-</Accordion>
-</Accordions>
-
-</FrontendOnly>
+<ChannelsStartPrompt />
 
 Channels brings your agent into the conversations where work already happens.
 Your agent still runs in your infrastructure. CopilotKit Intelligence owns the

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -6,12 +6,6 @@ description: Run one AG-UI agent in Slack, Microsoft Teams, and more through man
 doc_type: explanation
 ---
 
-{/* One entry point, shared with the docs landing strip, copilotkit.ai/channels,
-    and the channels-sdk README: install one skill, then ask for the thing you
-    want. These pages used to carry the whole workflow inline — six copies
-    across three repos, which drifted apart and went stale against the CLI. The
-    workflow now lives in the skill and is corrected in one place. */}
-
 <ChannelsStartPrompt />
 
 Channels brings your agent into the conversations where work already happens.

--- a/showcase/shell-docs/src/lib/__tests__/channels-activation.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-activation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   CHANNELS_ACTIVATION_CHANNELS,
+  CHANNELS_ONBOARDING_INSTALL_COMMAND,
+  CHANNELS_ONBOARDING_SKILL,
   buildChannelsActivationPrompt,
   getChannelsActivationGuideHref,
 } from "../channels-activation-contracts";
@@ -52,15 +54,41 @@ describe("Channels activation documentation options", () => {
     }
   });
 
-  it("builds a concise prompt around the verified guide URL", () => {
+  // The prompt is a pointer to one skill, not a copy of the workflow. Six
+  // surfaces across three repos each carried their own prose version, drifted,
+  // and went stale against the CLI; these assertions pin the corrections that
+  // drift produced so they cannot be quietly undone here.
+  describe("activation prompt", () => {
     const prompt = buildChannelsActivationPrompt({
       channelLabel: "Microsoft Teams",
       backendLabel: "Mastra",
-      guideUrl: "https://docs.copilotkit.ai/teams/mastra/connect",
     });
 
-    expect(prompt).toContain("Microsoft Teams using Mastra");
-    expect(prompt).toContain("https://docs.copilotkit.ai/teams/mastra/connect");
-    expect(prompt).toContain("preserve its agent architecture");
+    it("names the picker's channel and backend", () => {
+      expect(prompt).toContain("Microsoft Teams using Mastra");
+    });
+
+    it("names the one skill to install rather than leaving it to a picker", () => {
+      expect(prompt).toContain(`--skill ${CHANNELS_ONBOARDING_SKILL}`);
+      expect(prompt).toContain(CHANNELS_ONBOARDING_INSTALL_COMMAND);
+    });
+
+    it("installs non-interactively so the agent can run it unattended", () => {
+      expect(CHANNELS_ONBOARDING_INSTALL_COMMAND).toMatch(/ -y$/);
+    });
+
+    it("pins the CLI to @latest so a cached older binary cannot shadow it", () => {
+      expect(CHANNELS_ONBOARDING_INSTALL_COMMAND).toContain(
+        "npx copilotkit@latest",
+      );
+      expect(CHANNELS_ONBOARDING_INSTALL_COMMAND).not.toMatch(
+        /npx copilotkit(?!@latest)/,
+      );
+    });
+
+    it("stays a pointer instead of re-embedding the workflow", () => {
+      expect(prompt.split("\n")).toHaveLength(1);
+      expect(prompt.length).toBeLessThan(240);
+    });
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/channels-activation.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-activation.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   CHANNELS_ACTIVATION_CHANNELS,
-  CHANNELS_ONBOARDING_INSTALL_COMMAND,
-  CHANNELS_ONBOARDING_SKILL,
-  buildChannelsActivationPrompt,
+  CHANNELS_BUILD_PROMPT,
+  CHANNELS_GUIDE_URL,
   getChannelsActivationGuideHref,
 } from "../channels-activation-contracts";
 import { getChannelsActivationBackendOptions } from "../channels-activation-options";
@@ -54,41 +53,33 @@ describe("Channels activation documentation options", () => {
     }
   });
 
-  // The prompt is a pointer to one skill, not a copy of the workflow. Six
-  // surfaces across three repos each carried their own prose version, drifted,
-  // and went stale against the CLI; these assertions pin the corrections that
-  // drift produced so they cannot be quietly undone here.
+  // The prompt is a pointer at one hosted guide, not a copy of the workflow.
+  // Six surfaces across three repos each carried their own prose version,
+  // drifted, and went stale against the CLI; these assertions pin the
+  // corrections that produced.
   describe("activation prompt", () => {
-    const prompt = buildChannelsActivationPrompt({
-      channelLabel: "Microsoft Teams",
-      backendLabel: "Mastra",
-    });
-
-    it("names the picker's channel and backend", () => {
-      expect(prompt).toContain("Microsoft Teams using Mastra");
-    });
-
-    it("names the one skill to install rather than leaving it to a picker", () => {
-      expect(prompt).toContain(`--skill ${CHANNELS_ONBOARDING_SKILL}`);
-      expect(prompt).toContain(CHANNELS_ONBOARDING_INSTALL_COMMAND);
-    });
-
-    it("installs non-interactively so the agent can run it unattended", () => {
-      expect(CHANNELS_ONBOARDING_INSTALL_COMMAND).toMatch(/ -y$/);
-    });
-
-    it("pins the CLI to @latest so a cached older binary cannot shadow it", () => {
-      expect(CHANNELS_ONBOARDING_INSTALL_COMMAND).toContain(
-        "npx copilotkit@latest",
+    it("points at the hosted guide", () => {
+      expect(CHANNELS_GUIDE_URL).toBe(
+        "https://copilotkit.ai/channels-guide.md",
       );
-      expect(CHANNELS_ONBOARDING_INSTALL_COMMAND).not.toMatch(
-        /npx copilotkit(?!@latest)/,
+      expect(CHANNELS_BUILD_PROMPT).toBe(
+        "Read https://copilotkit.ai/channels-guide.md and help the user build their first channel",
       );
+    });
+
+    it("names neither channel nor backend", () => {
+      // The guide asks for both. Naming them here would promise coverage on the
+      // page's behalf — the mismatch that made the earlier skill pointer wrong
+      // for Teams, since that skill was scoped to Slack.
+      for (const channel of CHANNELS_ACTIVATION_CHANNELS) {
+        expect(CHANNELS_BUILD_PROMPT).not.toContain(channel.label);
+      }
+      expect(CHANNELS_BUILD_PROMPT).not.toMatch(/mastra|langgraph|built-in/i);
     });
 
     it("stays a pointer instead of re-embedding the workflow", () => {
-      expect(prompt.split("\n")).toHaveLength(1);
-      expect(prompt.length).toBeLessThan(240);
+      expect(CHANNELS_BUILD_PROMPT.split("\n")).toHaveLength(1);
+      expect(CHANNELS_BUILD_PROMPT.length).toBeLessThan(160);
     });
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -345,84 +345,22 @@ describe("Channels documentation journey", () => {
       expect(source).not.toMatch(/\bcopilotkit\s+channels\b/i);
     }
 
-    expect(overview).toContain(
-      '<Accordion title="Start building with your coding agent — copy this prompt">',
-    );
-    expect(overview).toContain(
-      "Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Slack.",
-    );
-    expect(overview).toContain("```text");
-    expect(overview).toContain(
-      "Help me create a new CopilotKit app from scratch, then connect its agent to Slack so it answers in a real channel.",
-    );
-    expect(overview).toContain(
-      "`copilotkit-setup` for creating the app and wiring managed Intelligence.",
-    );
-    expect(overview).toContain(
-      "`copilotkit-channels` for the CLI-scaffolded Channel and its long-running host.",
-    );
-    expect(overview).toContain(
-      "`setup-slack-channel` for the Slack app and managed Intelligence provider setup.",
-    );
-    expect(overview).toContain(
-      "`npx copilotkit@latest skills install` in the directory where I want the project",
-    );
-    expect(overview).toContain(
-      "Use the CopilotKit CLI through `npx copilotkit@latest`; do not assume or require a global CLI installation.",
-    );
-    expect(overview).toContain(
-      "Run `npx copilotkit@latest create` to scaffold a brand-new project.",
-    );
-    expect(overview).toContain(
-      "Choose managed Intelligence because Channels are not available in self-hosted SSE mode.",
-    );
-    expect(overview).toContain(
-      "Do not add a second Channel declaration or move the Channel into a serverless route.",
-    );
-    expect(overview).toContain("Do not guess which one you are.");
-    expect(overview).toContain(
-      "Never ask me to paste a token, signing secret, or API key into this conversation.",
-    );
-    expect(overview).toContain(
-      "Do not report success until all three gates in `setup-slack-channel` hold.",
-    );
-    expect(overview).toContain('"The runtime started" is not one of them.');
-    expect(overview).not.toContain("npx copilotkit@latest channels setup");
-    expect(teamsOverview).toContain(
-      '<Accordion title="Start building with your coding agent — copy this prompt">',
-    );
-    expect(teamsOverview).toContain(
-      "Copy and paste this prompt to your agent. Local agents are best so they can use your browser to set up Microsoft Teams.",
-    );
-    expect(teamsOverview).toContain(
-      "Help me create a new CopilotKit app from scratch, then connect its agent to Microsoft Teams so it answers in a real channel.",
-    );
-    expect(teamsOverview).toContain(
-      "The current Microsoft Teams Channels documentation at https://docs.copilotkit.ai/teams",
-    );
-    expect(teamsOverview).toContain(
-      "Do not require a Teams-specific onboarding skill or substitute Slack setup instructions; use the linked Teams documentation as the provider source of truth.",
-    );
-    expect(teamsOverview).toContain(
-      "verify that Node.js 22 or newer is available",
-    );
-    expect(teamsOverview).toContain(
-      "Run `npx copilotkit@latest create` to scaffold a brand-new project.",
-    );
-    expect(teamsOverview).toContain(
-      "Treat the CLI-generated `channel-host.mts` and `channels.mts` as the code half.",
-    );
-    expect(teamsOverview).toContain(
-      "Use the published Teams documentation as the provider half.",
-    );
-    expect(teamsOverview).toContain("Do not guess which one you are.");
-    expect(teamsOverview).toContain(
-      "Never ask me to paste a token, client secret, or API key into this conversation.",
-    );
-    expect(teamsOverview).toContain(
-      "Do not report success until the app is installed in the intended Teams scope, Intelligence reports the Channel as Online, and a real Teams message or mention receives the agent's reply.",
-    );
-    expect(teamsOverview).not.toContain("`setup-slack-channel`");
+    // The overview no longer carries the workflow. It renders the shared
+    // entry-point component, which names one skill and nothing else, so this
+    // page cannot drift away from the other Channels surfaces again.
+    expect(overview).toContain("<ChannelsStartPrompt />");
+    expect(teamsOverview).toContain("<ChannelsStartPrompt />");
+
+    // Guard the regression this replaced: an inline prompt, hidden in an
+    // accordion, duplicating instructions that live in the skill.
+    for (const source of [overview, teamsOverview]) {
+      expect(source).not.toContain("copy this prompt");
+      expect(source).not.toContain("```text");
+      expect(source).not.toMatch(
+        /Use these (skills|sources) as your instructions/,
+      );
+      expect(source).not.toContain("npx copilotkit@latest create");
+    }
     expect(intelligence).toMatch(/browser wizard[\s\S]*released setup path/i);
   });
 

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -40,7 +40,7 @@ export function getChannelsActivationGuideHref(
  * source lives in `CopilotKit/channels-sdk` and is mirrored into this repo's
  * `skills/` directory, which is what `copilotkit skills install` distributes.
  */
-export const CHANNELS_ONBOARDING_SKILL = "create-channels-agent";
+export const CHANNELS_ONBOARDING_SKILL = "setup-slack-channel";
 
 /**
  * Installs that skill without prompting. `-y` respects `--skill`, so this

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -13,6 +13,12 @@ export const CHANNELS_ACTIVATION_EVENTS = {
    * landing strip and the overview panel, separated by `surface`.
    */
   viewed: "docs.channels_activation_viewed",
+  /**
+   * The disclosure step the overview panel reintroduces. Neither `viewed` nor
+   * `promptCopied` can see it — a reader who never expanded the panel looks
+   * identical to one who expanded it and walked away.
+   */
+  promptExpanded: "docs.channels_activation_prompt_expanded",
 } as const;
 
 /**

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -35,18 +35,40 @@ export function getChannelsActivationGuideHref(
   return backend.guideHrefs[channel];
 }
 
+/**
+ * The skill that owns first-time Channels onboarding end to end. Canonical
+ * source lives in `CopilotKit/channels-sdk` and is mirrored into this repo's
+ * `skills/` directory, which is what `copilotkit skills install` distributes.
+ */
+export const CHANNELS_ONBOARDING_SKILL = "create-channels-agent";
+
+/**
+ * Installs that skill without prompting. `-y` respects `--skill`, so this
+ * installs exactly one skill rather than dropping the developer into a picker
+ * of everything CopilotKit publishes. `@latest` is not optional: a globally
+ * installed or npx-cached older CLI shadows the current one and fails with an
+ * unrelated "unknown option" error.
+ *
+ * The installer detects the coding agent it is running inside, so `--agent` is
+ * deliberately omitted.
+ */
+export const CHANNELS_ONBOARDING_INSTALL_COMMAND = `npx copilotkit@latest skills install --skill ${CHANNELS_ONBOARDING_SKILL} -y`;
+
+/**
+ * A pointer, deliberately not a workflow.
+ *
+ * This prompt used to carry the whole setup as prose, and so did five other
+ * surfaces across three repos. They drifted apart, and each one went stale the
+ * moment the CLI moved — which is how developers ended up being told to run
+ * commands that no longer exist. Two sentences naming a skill cannot drift, and
+ * the workflow they point at is corrected in exactly one place.
+ */
 export function buildChannelsActivationPrompt({
   channelLabel,
   backendLabel,
-  guideUrl,
 }: {
   channelLabel: string;
   backendLabel: string;
-  guideUrl: string;
 }): string {
-  return `Build a working CopilotKit Channels integration for ${channelLabel} using ${backendLabel}.
-
-Follow the Shell Docs setup guide: ${guideUrl}
-
-Inspect the existing project before editing, preserve its agent architecture, implement the documented setup, run the relevant checks, and report any remaining provider credentials or platform configuration.`;
+  return `Run \`${CHANNELS_ONBOARDING_INSTALL_COMMAND}\`, then follow that skill to build my first CopilotKit Channels agent and connect it to ${channelLabel} using ${backendLabel}.`;
 }

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -13,12 +13,6 @@ export const CHANNELS_ACTIVATION_EVENTS = {
    * landing strip and the overview panel, separated by `surface`.
    */
   viewed: "docs.channels_activation_viewed",
-  /**
-   * The disclosure step the overview panel reintroduces. Neither `viewed` nor
-   * `promptCopied` can see it — a reader who never expanded the panel looks
-   * identical to one who expanded it and walked away.
-   */
-  promptExpanded: "docs.channels_activation_prompt_expanded",
 } as const;
 
 /**

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -6,6 +6,24 @@ export const CHANNELS_ACTIVATION_EVENTS = {
   setupGuideOpened: "docs.channels_activation_setup_guide_opened",
   promptCopied: "docs.channels_activation_prompt_copied",
   openTagClicked: "docs.channels_activation_opentag_clicked",
+  /**
+   * Impression, so `promptCopied` has a denominator. Both entry points sit
+   * below the fold on their pages, so a surface nobody scrolls to and a surface
+   * everybody ignores are indistinguishable without this. Emitted by both the
+   * landing strip and the overview panel, separated by `surface`.
+   */
+  viewed: "docs.channels_activation_viewed",
+} as const;
+
+/**
+ * Which road into onboarding an event came from. Every Channels entry point
+ * emits the same events with one of these, including copilotkit.ai/channels,
+ * which sends its own event name with the same property so the two can be
+ * unioned into one funnel.
+ */
+export const CHANNELS_ACTIVATION_SURFACES = {
+  docsLandingStrip: "docs_landing_strip",
+  docsChannelsOverview: "docs_channels_overview",
 } as const;
 
 export const CHANNELS_ACTIVATION_CHANNELS = [

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -60,66 +60,22 @@ export function getChannelsActivationGuideHref(
 }
 
 /**
- * The skill that owns first-time Channels onboarding end to end. Canonical
- * source lives in `CopilotKit/channels-sdk` and is mirrored into this repo's
- * `skills/` directory, which is what `copilotkit skills install` distributes.
+ * The onboarding guide every Channels entry point points at — the docs surfaces,
+ * copilotkit.ai/channels, and the channels-sdk README. Hosted on the marketing
+ * site so it is one file fetched at the moment an agent needs it, rather than a
+ * workflow copied into six places that drift apart.
  */
-export const CHANNELS_ONBOARDING_SKILL = "setup-slack-channel";
+export const CHANNELS_GUIDE_URL = "https://copilotkit.ai/channels-guide.md";
 
 /**
- * Installs that skill without prompting. `-y` respects `--skill`, so this
- * installs exactly one skill rather than dropping the developer into a picker
- * of everything CopilotKit publishes. `@latest` is not optional: a globally
- * installed or npx-cached older CLI shadows the current one and fails with an
- * unrelated "unknown option" error.
+ * A pointer, deliberately not a workflow, and deliberately unparameterised.
  *
- * The installer detects the coding agent it is running inside, so `--agent` is
- * deliberately omitted.
- */
-export const CHANNELS_ONBOARDING_INSTALL_COMMAND = `npx copilotkit@latest skills install --skill ${CHANNELS_ONBOARDING_SKILL} -y`;
-
-/**
- * A pointer, deliberately not a workflow.
+ * These surfaces used to carry the whole setup as prose — six copies across
+ * three repos, which drifted and went stale against the CLI independently.
  *
- * This prompt used to carry the whole setup as prose, and so did five other
- * surfaces across three repos. They drifted apart, and each one went stale the
- * moment the CLI moved — which is how developers ended up being told to run
- * commands that no longer exist. Two sentences naming a skill cannot drift, and
- * the workflow they point at is corrected in exactly one place.
+ * The channel and backend the reader picked are not interpolated: the guide asks
+ * for both itself. A pointer that named them would be promising coverage on the
+ * page's behalf, which is exactly what made the earlier skill-based pointer
+ * wrong for Teams — it named a skill scoped to Slack.
  */
-export function buildChannelsActivationPrompt({
-  channelLabel,
-  backendLabel,
-}: {
-  channelLabel: string;
-  backendLabel: string;
-}): string {
-  const { command, instruction } = buildChannelsActivationPromptParts({
-    channelLabel,
-    backendLabel,
-  });
-
-  return `Run \`${command}\`, then ${instruction}`;
-}
-
-/**
- * Split so the UI can show the command as a command and the ask as prose. A
- * single wrapped monospace paragraph reads like a rendering bug, and the two
- * halves are genuinely different things: one is typed by a machine, one is
- * addressed to it.
- *
- * `instruction` carries no leading word, so the clipboard string can join it
- * after a comma while the UI leads with a capitalised "Then" on its own line.
- */
-export function buildChannelsActivationPromptParts({
-  channelLabel,
-  backendLabel,
-}: {
-  channelLabel: string;
-  backendLabel: string;
-}): { command: string; instruction: string } {
-  return {
-    command: CHANNELS_ONBOARDING_INSTALL_COMMAND,
-    instruction: `follow that skill to build your first CopilotKit Channels agent and connect it to ${channelLabel} using ${backendLabel}.`,
-  };
-}
+export const CHANNELS_BUILD_PROMPT = `Read ${CHANNELS_GUIDE_URL} and help the user build their first channel`;

--- a/showcase/shell-docs/src/lib/channels-activation-contracts.ts
+++ b/showcase/shell-docs/src/lib/channels-activation-contracts.ts
@@ -70,5 +70,32 @@ export function buildChannelsActivationPrompt({
   channelLabel: string;
   backendLabel: string;
 }): string {
-  return `Run \`${CHANNELS_ONBOARDING_INSTALL_COMMAND}\`, then follow that skill to build my first CopilotKit Channels agent and connect it to ${channelLabel} using ${backendLabel}.`;
+  const { command, instruction } = buildChannelsActivationPromptParts({
+    channelLabel,
+    backendLabel,
+  });
+
+  return `Run \`${command}\`, then ${instruction}`;
+}
+
+/**
+ * Split so the UI can show the command as a command and the ask as prose. A
+ * single wrapped monospace paragraph reads like a rendering bug, and the two
+ * halves are genuinely different things: one is typed by a machine, one is
+ * addressed to it.
+ *
+ * `instruction` carries no leading word, so the clipboard string can join it
+ * after a comma while the UI leads with a capitalised "Then" on its own line.
+ */
+export function buildChannelsActivationPromptParts({
+  channelLabel,
+  backendLabel,
+}: {
+  channelLabel: string;
+  backendLabel: string;
+}): { command: string; instruction: string } {
+  return {
+    command: CHANNELS_ONBOARDING_INSTALL_COMMAND,
+    instruction: `follow that skill to build your first CopilotKit Channels agent and connect it to ${channelLabel} using ${backendLabel}.`,
+  };
 }


### PR DESCRIPTION
## Visual

Docs `/slack` — the featured panel from #6356, now carrying the one-line pointer.

| Desktop screenshot | Mobile screenshot |
|---|---|
| ![docs slack desktop](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-desktop-screenshot-7f14af56.png) | ![docs slack mobile](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-mobile-screenshot-7f14af56.png) |

| Desktop scroll | Mobile scroll |
|---|---|
| <video src="https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-desktop-scroll-7f14af56.webm" controls width="400"></video> | <video src="https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-mobile-scroll-7f14af56.webm" controls width="240"></video> |

Docs `/teams` — same component, Teams wording, proving the frontend switch.

| Desktop screenshot | Desktop scroll |
|---|---|
| ![docs teams desktop](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-teams-expanded-screenshot-7f14af56.png) | ![docs root](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-root-desktop-screenshot-7f14af56.png) |

<sub>Artifacts are hosted on a CopilotKit/website release tag rather than a new tag in this repo, to keep clear of the monorepo's release automation.</sub>

---

## Summary

Builds on #6356 (merged in here, its featured-panel treatment kept) and finishes the job it started.

#6356 made the Channels starter prompts **discoverable**. This makes them **correct**, and makes every other road say the same thing.

The onboarding workflow was written out as prose on six surfaces across three repos: the Channels overview page (Slack and Teams), the docs landing activation strip, copilotkit.ai/channels, and the channels-sdk README twice. They drifted apart, and each went stale against the CLI on its own schedule. That drift is what the dogfooding feedback was reporting:

- **"It didn't tell me which skills to install, so it dropped me into a list of god knows how many."** Neither copy button named a skill.
- **"`npx copilotkit project select` didn't work — I had an old CLI."** Only some surfaces pinned `@latest`.
- **An agent halted on `copilotkit channels`.** No such command exists in the published CLI — verified against 4.5.1, whose `--help` has no `channels` entry.
- **"Copy this prompt is super easy to miss."** The strongest prompts were behind an accordion; the two visible buttons had invisible payloads.

## What changed

- **`<ChannelsStartPrompt />`** — one shared entry point, frontend-aware, wearing #6356's featured treatment: accent panel, terminal mark, eyebrow, prominent copy action.
- **Both overview accordions are gone.** The accordion existed because the payload was twenty lines. The payload is now one sentence, so hiding it behind "Open & copy prompt" costs a click and buys nothing.
- **The activation strip emits the same pointer**, rendered on screen rather than living only in a clipboard payload.
- **Both surfaces send `promptCopied` with a `surface` property**, so the funnel can answer which road people take. The website emits its own event name with the same property for the same reason.

The prompt every surface now emits:

```
Run `npx copilotkit@latest skills install --skill setup-slack-channel -y`, then follow that
skill to build your first CopilotKit Channels agent and connect it to Slack using CopilotKit's
built-in agent.
```

## Notes for reviewers

- **`-y` respects `--skill`** — verified empirically against `copilotkit@4.5.1`: exactly one skill installs, no picker. The installer detects the coding agent it runs inside, so `--agent` is omitted.
- **The panel renders exactly what the button copies.** Two earlier shapes were wrong in instructive ways: a full monospace paragraph wrapped like a rendering bug, and a code block with the ask underneath read as a shell command with a footnote — which made a button labelled "Copy prompt" look like it was lying.
- **The `featured` Accordion variant from #6356 stays in `mdx-components.tsx`** as a shared opt-in capability, but its only two consumers were the accordions removed here, so it is currently unused. Worth a call: keep it, or drop it in a follow-up.
- **`setup-slack-channel` is the slug the combined onboarding prompt will occupy** once it lands from channels-sdk. Its frontmatter is currently scoped hard to the Slack provider half, so it needs rescoping before this reads correctly for Teams.

Companion PRs: CopilotKit/website#444 and the channels-sdk README.

## Validation

- `npx vitest run` in `showcase/shell-docs` — 54 files, 372 tests passed
- `npx tsc --noEmit` — clean
- pre-commit lint and commitlint hooks passed
- Rendered and reviewed `/slack` locally; confirmed the copied string matches the rendered one



## Update — impressions and a copy-only prompt

Since the artifacts above were first posted:

- **Impression event.** `docs.channels_activation_viewed` fires once per surface on first intersection at 50%. Both docs entry points previously emitted a copy event and nothing else, so the copy count had no denominator. `surface` values now live in a shared `CHANNELS_ACTIVATION_SURFACES` map, keeping the landing strip, the overview panel, and copilotkit.ai/channels separable inside one funnel.
- **Guarded on `typeof IntersectionObserver`.** An impression is never worth breaking a render for, and this repo's jsdom tests do not define it.
- **The prompt is no longer rendered.** Per review, the copy button carries the payload. The panel leads with the copy action directly under the heading — the prompt is not on the page, so the button is the point of the panel rather than trailing furniture — and the supporting line no longer says "paste this" next to nothing.

Screenshots and videos above were re-captured after all of it.

## Validation (current)

- `npx vitest run` in `showcase/shell-docs` — 55 files, 376 tests passed
- `npx tsc --noEmit` — clean
- pre-commit lint and commitlint hooks passed
- Reviewed `/slack` and `/teams` at 1440×900 and iPhone 13

## Companion PRs

- CopilotKit/channels-sdk#15 — **merged**
- CopilotKit/website#444 — open


---

## Update — addresses both review blockers

### Blocking issue: the skill did not support the promised workflow — resolved by removing the skill from the path

The pointer is now a fetch of one hosted file, not a skill install:

```
Read https://copilotkit.ai/channels-guide.md and help the user build their first channel
```

The guide lives at `public/channels-guide.md` in CopilotKit/website and owns the whole workflow. It asks the developer which platform and which agent framework they want, which is why the pointer passes neither.

That removes the mismatch at its root rather than narrowing the copy around it. Naming the picker's channel and backend meant these pages promised coverage on `setup-slack-channel`'s behalf, and that skill is scoped to Slack, to the provider half, and to an OpenTag checkout — so Teams pointed at a workflow that does not exist and the picker implied nineteen backends it never claimed. A pointer that names nothing cannot overpromise.

`CHANNELS_ONBOARDING_SKILL`, its install command, and the per-selection prompt builders are gone; one constant serves every surface.

### Visual regression: disclosure restored, treatment re-tokenised

| Collapsed | Expanded |
|---|---|
| ![collapsed](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-desktop-screenshot-7f14af56.png) | ![expanded](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-expanded-screenshot-7f14af56.png) |

| Mobile | Teams variant |
|---|---|
| ![mobile](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-slack-mobile-screenshot-7f14af56.png) | ![teams](https://github.com/CopilotKit/website/releases/download/channels-entry-points-2026-08-03/docs-teams-expanded-screenshot-7f14af56.png) |

- **The expandable preview is back.** The panel is the shared featured `<Accordion>` again — reused, not re-implemented — so the overview stays compact and a reader can expand to read the exact prompt before copying.
- **Whitespace.** Collapsed height went from ~380px to ~110px with `p-4`, matching every other docs panel. The page's own introduction is visible without scrolling.
- **Colour.** You were right, and my "it is unchanged from #6356" reply missed the point. `copilotkit-ui-theme` names *"purple accent bar or stripe"* as a known wrong direction, and `copilotkit-branding` requires accent to be restrained with gradients behind content rather than as the contrast layer — the saturated `--accent` tile plus accent-mixed gradient was both at once. It now matches the `OpsPlatformCTA` idiom: `--bg-elevated`, `--border`, `--shadow-control`, accent only on a 20px glyph and the hover state. Verified light and dark.

One deliberate deviation: I dropped the "READY-TO-USE STARTER PROMPT" eyebrow on the low-noise rule, since the title says the same thing. Easy to restore if you want it.

### Behavioural bug: fixed

`copyPrompt` shared one `try` with `posthog.capture`, so a throwing client reported "Copy blocked" for a prompt already on the clipboard. Capture now sits behind the same isolated helper `ChannelsActivationStrip` uses. Two regression tests: capture throwing after a resolved write still shows "Copied"; a rejected write still shows "Copy blocked" and emits no copy event.

### Lockfile churn: dropped

Reverted to `origin/main`. It came from an `npm install` in the review worktree; no dependency changed.

### Also added

`docs.channels_activation_prompt_expanded` — the disclosure is a funnel step neither `viewed` nor `promptCopied` can see, so someone who never opened the panel was indistinguishable from someone who opened it and left.

## Validation (current)

- `npx vitest run` in `showcase/shell-docs` — 55 files, 376 tests passed
- `npx tsc --noEmit` — clean; pre-commit lint and commitlint passed
- Reviewed `/slack` and `/teams`, collapsed and expanded, light and dark, at 1440×900 and iPhone 13


