### PR TITLE
docs: fix typo "Retreive" -> "Retrieve" in LangGraph tutorial

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/ai-travel-app/step-2-langgraph-agent.mdx
@@ -26,7 +26,7 @@ To install LangGraph Studio, checkout the [setup guide](https://docs.langchain.c
 
 </Step>
 <Step>
-### Retreive API keys
+### Retrieve API keys
 
 For this application, we'll need two API keys:
 


### PR DESCRIPTION
Fixes a typo in the AI travel app LangGraph tutorial: the step heading "Retreive API keys" should read "Retrieve API keys".