### PR TITLE
feat(runtime): split Channel status into transport and provider legs (refs OSS-739)

### DIFF
--- a/packages/channels-intelligence/src/realtime-gateway-launcher-provider-seam.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher-provider-seam.test.ts
@@ -27,10 +27,15 @@ async function startOverSession(
   });
 }
 
-/** A session that exposes the provider seam, with a test-flippable value. */
+/**
+ * A session that exposes the provider seam, with a test-flippable value.
+ *
+ * `providerStates` reads `this`, so the assertions below also cover the launcher
+ * calling the seam ON the session: a detached reference would throw here rather
+ * than answer.
+ */
 class ProviderStateGateway extends DeliveryTestGateway {
   states: Record<string, string> | undefined = { support: "not_attached" };
-  /** Reads `this`, so a detached reference would throw rather than answer. */
   providerStates(): Readonly<Record<string, string>> | undefined {
     return this.states;
   }
@@ -62,33 +67,6 @@ describe("startChannelsWithGatewayControl provider seam", () => {
       // start would still say `not_attached` forever.
       gateway.states = { support: "attached" };
       expect(handle.providerStates?.()).toEqual({ support: "attached" });
-    } finally {
-      await handle.stop();
-    }
-  });
-
-  it("calls the seam ON the session, so a class-based session reading `this` works", async () => {
-    const gateway = new ProviderStateGateway();
-    const handle = await startOverSession(gateway, "rti_seam_this");
-
-    try {
-      // `ProviderStateGateway.providerStates` reads `this.states`; a detached
-      // reference (`const f = session.providerStates; f()`) would throw here.
-      expect(() => handle.providerStates?.()).not.toThrow();
-      expect(handle.providerStates?.()).toEqual({ support: "not_attached" });
-    } finally {
-      await handle.stop();
-    }
-  });
-
-  it("omits providerStates for a session without the seam", async () => {
-    const gateway = new DeliveryTestGateway();
-    const handle = await startOverSession(gateway, "rti_seam_absent");
-
-    try {
-      // Absent rather than a stub returning `undefined`: the manager treats both
-      // as `unknown`, but the handle must not advertise a seam it cannot serve.
-      expect(handle.providerStates).toBeUndefined();
     } finally {
       await handle.stop();
     }

--- a/packages/channels-intelligence/src/realtime-gateway-launcher-provider-seam.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher-provider-seam.test.ts
@@ -1,0 +1,96 @@
+import { createChannel } from "@copilotkit/channels-core";
+import { describe, expect, it } from "vitest";
+import { DeliveryTestGateway } from "./delivery-test-gateway.js";
+import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
+
+/**
+ * `startChannelsWithGatewayControl` is exported so a caller can compose over a
+ * Realtime Gateway session it owns itself. That makes the provider seam a PUBLIC
+ * contract, not an internal detail of the socket-owning wrapper: a handle
+ * returned without `providerStates` makes `ChannelManager` fall back to
+ * `unknown`, which keeps the transport-derived status and so reports `online`
+ * for a Channel with no Slack/Teams app bound — the precise false green OSS-739
+ * removes, reached through a public export rather than the default path.
+ */
+async function startOverSession(
+  session: DeliveryTestGateway,
+  runtimeInstanceId: string,
+) {
+  const channel = createChannel({ identifyUser: "platform", name: "support" });
+  channel.onMessage(() => undefined);
+  return startChannelsWithGatewayControl([channel], {
+    session,
+    scope: { projectId: 1, channelName: "support" },
+    runtimeInstanceId,
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+}
+
+/** A session that exposes the provider seam, with a test-flippable value. */
+class ProviderStateGateway extends DeliveryTestGateway {
+  states: Record<string, string> | undefined = { support: "not_attached" };
+  /** Reads `this`, so a detached reference would throw rather than answer. */
+  providerStates(): Readonly<Record<string, string>> | undefined {
+    return this.states;
+  }
+}
+
+describe("startChannelsWithGatewayControl provider seam", () => {
+  it("forwards providerStates off a session that exposes it", async () => {
+    const gateway = new ProviderStateGateway();
+    const handle = await startOverSession(gateway, "rti_seam_forward");
+
+    try {
+      // Without the forward this is `undefined` and the manager reports `online`
+      // for an unprovisioned Channel.
+      expect(handle.providerStates?.()).toEqual({ support: "not_attached" });
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it("forwards as a getter, so a value that changes after start is observed", async () => {
+    const gateway = new ProviderStateGateway();
+    const handle = await startOverSession(gateway, "rti_seam_getter");
+
+    try {
+      expect(handle.providerStates?.()).toEqual({ support: "not_attached" });
+
+      // The Channel is provisioned while the runtime is already running (or a
+      // Phoenix auto-rejoin refreshed the control reply). A snapshot captured at
+      // start would still say `not_attached` forever.
+      gateway.states = { support: "attached" };
+      expect(handle.providerStates?.()).toEqual({ support: "attached" });
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it("calls the seam ON the session, so a class-based session reading `this` works", async () => {
+    const gateway = new ProviderStateGateway();
+    const handle = await startOverSession(gateway, "rti_seam_this");
+
+    try {
+      // `ProviderStateGateway.providerStates` reads `this.states`; a detached
+      // reference (`const f = session.providerStates; f()`) would throw here.
+      expect(() => handle.providerStates?.()).not.toThrow();
+      expect(handle.providerStates?.()).toEqual({ support: "not_attached" });
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  it("omits providerStates for a session without the seam", async () => {
+    const gateway = new DeliveryTestGateway();
+    const handle = await startOverSession(gateway, "rti_seam_absent");
+
+    try {
+      // Absent rather than a stub returning `undefined`: the manager treats both
+      // as `unknown`, but the handle must not advertise a seam it cannot serve.
+      expect(handle.providerStates).toBeUndefined();
+    } finally {
+      await handle.stop();
+    }
+  });
+});

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -364,6 +364,10 @@ export async function startChannelsOverRealtimeGateway(
         detail?: { reason?: string; code?: string },
       ) => void,
     ) => session.onStateChange(cb),
+    // Delegated as a getter, not a captured snapshot: the control join hooks
+    // re-fire on every Phoenix auto-rejoin, so a Channel provisioned while the
+    // runtime was disconnected is reflected on the next read.
+    providerStates: () => session.providerStates(),
     stop: async () => {
       // Always close the connection even if stopping the channels throws — the
       // launcher owns the socket (the transport is handed the session and does

--- a/packages/channels-intelligence/src/realtime-gateway-launcher.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-launcher.ts
@@ -184,6 +184,13 @@ export async function startChannelsWithGatewayControl(
   // own teardown either way — the caller's session decides when `onClose`
   // fires), so callers composing over a session they manage themselves still
   // get reconnect signaling.
+  //
+  // `providerStates` is forwarded for the same reason and MUST NOT be omitted:
+  // this helper is exported precisely so callers can compose over a session they
+  // manage themselves, and a handle without the provider seam makes
+  // `ChannelManager.providerLeg` fall back to `unknown` — which keeps the
+  // transport-derived status and so reports `online` for a Channel with no
+  // provider bound. That is exactly the false green OSS-739 exists to remove.
   const observableSession = opts.session as Partial<{
     onClose(cb: () => void): void;
     onStateChange(
@@ -192,12 +199,18 @@ export async function startChannelsWithGatewayControl(
         detail?: { reason?: string; code?: string },
       ) => void,
     ): void;
+    providerStates(): Readonly<Record<string, string>> | undefined;
   }>;
   // Call the seams ON the session (not via detached references) so a
-  // class-based RealtimeGatewaySession whose `onClose`/`onStateChange` read
-  // `this` still works — the interface permits class-based implementations even
-  // though the concrete closure-based session happens not to need `this`.
-  if (observableSession.onClose || observableSession.onStateChange) {
+  // class-based RealtimeGatewaySession whose `onClose`/`onStateChange`/
+  // `providerStates` read `this` still works — the interface permits class-based
+  // implementations even though the concrete closure-based session happens not to
+  // need `this`.
+  if (
+    observableSession.onClose ||
+    observableSession.onStateChange ||
+    observableSession.providerStates
+  ) {
     return {
       ...handle,
       ...(observableSession.onClose
@@ -212,6 +225,12 @@ export async function startChannelsWithGatewayControl(
               ) => void,
             ) => observableSession.onStateChange!(cb),
           }
+        : {}),
+      // Delegated as a getter, not a captured snapshot: the control join hooks
+      // re-fire on every Phoenix auto-rejoin, so a Channel provisioned while the
+      // runtime was disconnected is reflected on the next read.
+      ...(observableSession.providerStates
+        ? { providerStates: () => observableSession.providerStates!() }
         : {}),
     };
   }

--- a/packages/channels-intelligence/src/realtime-gateway-project-join.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-project-join.test.ts
@@ -20,6 +20,8 @@ function setup() {
     disconnect,
     onClose: vi.fn(),
     onStateChange: vi.fn(),
+    // A real session always reports this (undefined = the gateway said nothing).
+    providerStates: vi.fn(() => undefined),
   };
   connectRealtimeGatewayMock.mockReset();
   connectRealtimeGatewayMock.mockResolvedValue(session);

--- a/packages/channels-intelligence/src/realtime-gateway-provider-states.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-provider-states.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { parseChannelProviderStates } from "./realtime-gateway.js";
+
+describe("parseChannelProviderStates", () => {
+  it("reads the channels map off a control join reply", () => {
+    expect(
+      parseChannelProviderStates({
+        protocol: "channel_delivery_v1",
+        runtimeInstanceId: "rti_x",
+        channels: { support: "attached", sales: "not_attached" },
+      }),
+    ).toEqual({ support: "attached", sales: "not_attached" });
+  });
+
+  it("accepts every state the gateway can report", () => {
+    expect(
+      parseChannelProviderStates({
+        channels: {
+          a: "attached",
+          b: "unhealthy",
+          c: "not_attached",
+          d: "disabled",
+          e: "channel_not_declared",
+        },
+      }),
+    ).toEqual({
+      a: "attached",
+      b: "unhealthy",
+      c: "not_attached",
+      d: "disabled",
+      e: "channel_not_declared",
+    });
+  });
+
+  describe("returns undefined — 'not reported', never 'no provider'", () => {
+    // An older gateway and a gateway whose database read failed both omit the
+    // key. Reading either as "unprovisioned" would turn a healthy fleet's status
+    // into setup_required on a transient blip.
+    it("when the key is absent (older gateway or failed lookup)", () => {
+      expect(
+        parseChannelProviderStates({
+          protocol: "channel_delivery_v1",
+          runtimeInstanceId: "rti_x",
+        }),
+      ).toBeUndefined();
+    });
+
+    it("when the reply is not an object", () => {
+      for (const reply of [undefined, null, "channels", 7, true, []]) {
+        expect(parseChannelProviderStates(reply)).toBeUndefined();
+      }
+    });
+
+    it("when channels is not a plain object", () => {
+      for (const channels of [null, "support", 7, ["support"]]) {
+        expect(parseChannelProviderStates({ channels })).toBeUndefined();
+      }
+    });
+
+    it("when channels is empty", () => {
+      expect(parseChannelProviderStates({ channels: {} })).toBeUndefined();
+    });
+
+    it("when no entry carries a recognised state", () => {
+      expect(
+        parseChannelProviderStates({
+          channels: { support: "brand_new_state", sales: 7 },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("drops only the unrecognised entries, keeping the ones that parsed", () => {
+    // A future gateway adding a state must not blind a caller to the Channels it
+    // still understands.
+    expect(
+      parseChannelProviderStates({
+        channels: {
+          support: "attached",
+          sales: "brand_new_state",
+          billing: 7,
+          ops: null,
+        },
+      }),
+    ).toEqual({ support: "attached" });
+  });
+});

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -30,8 +30,17 @@ interface FakeControl {
 function makeFakeWebSocket(
   mode: JoinMode,
   pushErrorResponse?: Record<string, unknown>,
-  /** Body of a successful `phx_reply` to `phx_join`. Defaults to `{}`. */
-  joinOkResponse?: Record<string, unknown>,
+  /**
+   * Body of a successful `phx_reply` to `phx_join`. Defaults to `{}`.
+   *
+   * A function form receives the 1-based join count, so a test can make a REJOIN
+   * reply differ from the initial one — the gateway reports provider attachment
+   * on this reply, and it legitimately changes between joins (a Channel
+   * provisioned while the runtime was disconnected).
+   */
+  joinOkResponse?:
+    | Record<string, unknown>
+    | ((joinCount: number) => Record<string, unknown>),
 ) {
   const instances: FakeWebSocket[] = [];
   const control: FakeControl = { recover: false };
@@ -128,9 +137,15 @@ function makeFakeWebSocket(
         mode === "ok-then-silent" ||
         mode === "give-up-then-recover";
       const status = isOkMode ? "ok" : "error";
+      // Resolved per join (not once at construction) so the function form can
+      // vary the reply across the initial join and each rejoin.
+      const okResponse =
+        typeof joinOkResponse === "function"
+          ? joinOkResponse(joinCount)
+          : joinOkResponse;
       const reply =
         status === "ok"
-          ? { status, response: joinOkResponse ?? {} }
+          ? { status, response: okResponse ?? {} }
           : {
               status,
               ...(errorResponse() ? { response: errorResponse() } : {}),
@@ -1357,6 +1372,132 @@ describe("connectRealtimeGateway provider states", () => {
     // An older gateway omits the key; this must stay "not reported" so callers
     // fall back to transport-only status.
     expect(session.providerStates()).toBeUndefined();
+
+    session.disconnect();
+  });
+
+  // These two are the load-bearing tests for the "getter, not a snapshot"
+  // design. The claim they defend is that Phoenix's `Push.resend` (used by
+  // `channel.rejoin`) resets the received response but PRESERVES `recHooks`, so
+  // the join-push "ok" hook re-fires on every auto-rejoin and refreshes
+  // `controlJoinReply`. Without them, `providerStates` could be a captured
+  // snapshot — or `Push.resend` could stop preserving hooks upstream — and every
+  // other test in this area would still pass while a Channel provisioned during
+  // a disconnect stayed `setup_required` forever.
+  //
+  // Note this asserts the SESSION's value actually changes across a reconnect,
+  // which is distinct from (and not implied by) the manager re-reading the getter
+  // on each `status()` call.
+  it("refreshes provider states from the rejoin reply after a channel-level error", async () => {
+    // Initial join: nothing bound. Rejoin: a Slack app has since been attached.
+    const { FakeWebSocket, instances } = makeFakeWebSocket(
+      "ok",
+      undefined,
+      (joinCount) => ({
+        protocol: "channel_delivery_v1",
+        runtimeInstanceId: "rti_1",
+        channels: {
+          opentag: joinCount === 1 ? "not_attached" : "attached",
+        },
+      }),
+    );
+
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: JOIN,
+      webSocket: FakeWebSocket,
+    });
+
+    expect(session.providerStates()).toEqual({ opentag: "not_attached" });
+
+    const states: RealtimeGatewayConnectionState[] = [];
+    session.onStateChange((s) => states.push(s));
+
+    // Channel-level error over a still-open socket → Phoenix auto-rejoins.
+    instances[0]!.triggerChannelError();
+    await waitUntil(() => states.includes("online"), 8000);
+
+    // The rejoin's reply must have replaced the captured one.
+    expect(session.providerStates()).toEqual({ opentag: "attached" });
+
+    session.disconnect();
+  });
+
+  it("refreshes provider states from the rejoin reply after a transport drop", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket(
+      "ok",
+      undefined,
+      (joinCount) => ({
+        protocol: "channel_delivery_v1",
+        runtimeInstanceId: "rti_1",
+        channels: {
+          opentag: joinCount === 1 ? "not_attached" : "attached",
+        },
+      }),
+    );
+
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: JOIN,
+      webSocket: FakeWebSocket,
+    });
+
+    expect(session.providerStates()).toEqual({ opentag: "not_attached" });
+
+    const states: RealtimeGatewayConnectionState[] = [];
+    session.onStateChange((s) => states.push(s));
+
+    // Full transport drop: Phoenix reconnects on a FRESH socket and rejoins.
+    instances[0]!.onclose?.();
+    expect(states).toContain("reconnecting");
+    await waitUntil(() => states.includes("online"), 8000);
+    // Prove the reconnect really used a new socket, so this covers a genuinely
+    // different path from the channel-error case above.
+    expect(instances.length).toBeGreaterThan(1);
+
+    expect(session.providerStates()).toEqual({ opentag: "attached" });
+
+    session.disconnect();
+  });
+
+  it("keeps the last reported states while a rejoin has not yet succeeded", async () => {
+    // Provider attachment does not change on a drop — the gateway simply has not
+    // spoken yet. The fold makes the transport leg dominate while offline, so the
+    // stale-but-last-known provider value is correct to keep here rather than
+    // clearing it to `undefined` (which would read as "not reported" and could
+    // flip a Channel's certified status mid-outage).
+    const { FakeWebSocket, instances } = makeFakeWebSocket(
+      "ok-then-silent",
+      undefined,
+      {
+        protocol: "channel_delivery_v1",
+        runtimeInstanceId: "rti_1",
+        channels: { opentag: "attached" },
+      },
+    );
+
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: JOIN,
+      webSocket: FakeWebSocket,
+    });
+
+    expect(session.providerStates()).toEqual({ opentag: "attached" });
+
+    const states: RealtimeGatewayConnectionState[] = [];
+    session.onStateChange((s) => states.push(s));
+
+    instances[0]!.onclose?.();
+    await waitUntil(() => states.includes("reconnecting"));
+
+    // Rejoins stay silent, so no new reply has arrived.
+    expect(session.providerStates()).toEqual({ opentag: "attached" });
 
     session.disconnect();
   });

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -30,6 +30,8 @@ interface FakeControl {
 function makeFakeWebSocket(
   mode: JoinMode,
   pushErrorResponse?: Record<string, unknown>,
+  /** Body of a successful `phx_reply` to `phx_join`. Defaults to `{}`. */
+  joinOkResponse?: Record<string, unknown>,
 ) {
   const instances: FakeWebSocket[] = [];
   const control: FakeControl = { recover: false };
@@ -128,7 +130,7 @@ function makeFakeWebSocket(
       const status = isOkMode ? "ok" : "error";
       const reply =
         status === "ok"
-          ? { status, response: {} }
+          ? { status, response: joinOkResponse ?? {} }
           : {
               status,
               ...(errorResponse() ? { response: errorResponse() } : {}),
@@ -1313,6 +1315,48 @@ describe("connection-health detail (OSS-670)", () => {
     )!;
     expect(named.detail!.reason).toContain("403");
     expect(named.detail!.reason).toMatch(/API key/i);
+
+    session.disconnect();
+  });
+});
+
+describe("connectRealtimeGateway provider states", () => {
+  it("exposes the provider states the gateway reported on the control join reply", async () => {
+    const { FakeWebSocket } = makeFakeWebSocket("ok", undefined, {
+      protocol: "channel_delivery_v1",
+      runtimeInstanceId: "rti_1",
+      channels: { opentag: "not_attached" },
+    });
+
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: JOIN,
+      webSocket: FakeWebSocket,
+    });
+
+    // Proves the whole wiring: the reply argument is captured off the join hook
+    // (it used to be discarded) and surfaced through the session.
+    expect(session.providerStates()).toEqual({ opentag: "not_attached" });
+
+    session.disconnect();
+  });
+
+  it("reports undefined when the gateway sends no channels map", async () => {
+    const { FakeWebSocket } = makeFakeWebSocket("ok");
+
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: JOIN,
+      webSocket: FakeWebSocket,
+    });
+
+    // An older gateway omits the key; this must stay "not reported" so callers
+    // fall back to transport-only status.
+    expect(session.providerStates()).toBeUndefined();
 
     session.disconnect();
   });

--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -1376,55 +1376,18 @@ describe("connectRealtimeGateway provider states", () => {
     session.disconnect();
   });
 
-  // These two are the load-bearing tests for the "getter, not a snapshot"
-  // design. The claim they defend is that Phoenix's `Push.resend` (used by
-  // `channel.rejoin`) resets the received response but PRESERVES `recHooks`, so
-  // the join-push "ok" hook re-fires on every auto-rejoin and refreshes
-  // `controlJoinReply`. Without them, `providerStates` could be a captured
-  // snapshot — or `Push.resend` could stop preserving hooks upstream — and every
-  // other test in this area would still pass while a Channel provisioned during
-  // a disconnect stayed `setup_required` forever.
+  // The load-bearing test for the "getter, not a snapshot" design. The claim it
+  // defends is that Phoenix's `Push.resend` (used by `channel.rejoin`) resets the
+  // received response but PRESERVES `recHooks`, so the join-push "ok" hook
+  // re-fires on every auto-rejoin and refreshes `controlJoinReply`. Without it,
+  // `providerStates` could be a captured snapshot — or `Push.resend` could stop
+  // preserving hooks upstream — and every other test in this area would still
+  // pass while a Channel provisioned during a disconnect stayed
+  // `setup_required` forever.
   //
   // Note this asserts the SESSION's value actually changes across a reconnect,
   // which is distinct from (and not implied by) the manager re-reading the getter
   // on each `status()` call.
-  it("refreshes provider states from the rejoin reply after a channel-level error", async () => {
-    // Initial join: nothing bound. Rejoin: a Slack app has since been attached.
-    const { FakeWebSocket, instances } = makeFakeWebSocket(
-      "ok",
-      undefined,
-      (joinCount) => ({
-        protocol: "channel_delivery_v1",
-        runtimeInstanceId: "rti_1",
-        channels: {
-          opentag: joinCount === 1 ? "not_attached" : "attached",
-        },
-      }),
-    );
-
-    const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/channels",
-      apiKey: "cpk-test",
-      projectId: 7,
-      join: JOIN,
-      webSocket: FakeWebSocket,
-    });
-
-    expect(session.providerStates()).toEqual({ opentag: "not_attached" });
-
-    const states: RealtimeGatewayConnectionState[] = [];
-    session.onStateChange((s) => states.push(s));
-
-    // Channel-level error over a still-open socket → Phoenix auto-rejoins.
-    instances[0]!.triggerChannelError();
-    await waitUntil(() => states.includes("online"), 8000);
-
-    // The rejoin's reply must have replaced the captured one.
-    expect(session.providerStates()).toEqual({ opentag: "attached" });
-
-    session.disconnect();
-  });
-
   it("refreshes provider states from the rejoin reply after a transport drop", async () => {
     const { FakeWebSocket, instances } = makeFakeWebSocket(
       "ok",
@@ -1459,44 +1422,6 @@ describe("connectRealtimeGateway provider states", () => {
     // different path from the channel-error case above.
     expect(instances.length).toBeGreaterThan(1);
 
-    expect(session.providerStates()).toEqual({ opentag: "attached" });
-
-    session.disconnect();
-  });
-
-  it("keeps the last reported states while a rejoin has not yet succeeded", async () => {
-    // Provider attachment does not change on a drop — the gateway simply has not
-    // spoken yet. The fold makes the transport leg dominate while offline, so the
-    // stale-but-last-known provider value is correct to keep here rather than
-    // clearing it to `undefined` (which would read as "not reported" and could
-    // flip a Channel's certified status mid-outage).
-    const { FakeWebSocket, instances } = makeFakeWebSocket(
-      "ok-then-silent",
-      undefined,
-      {
-        protocol: "channel_delivery_v1",
-        runtimeInstanceId: "rti_1",
-        channels: { opentag: "attached" },
-      },
-    );
-
-    const session = await connectRealtimeGateway({
-      wsUrl: "wss://gateway.example/channels",
-      apiKey: "cpk-test",
-      projectId: 7,
-      join: JOIN,
-      webSocket: FakeWebSocket,
-    });
-
-    expect(session.providerStates()).toEqual({ opentag: "attached" });
-
-    const states: RealtimeGatewayConnectionState[] = [];
-    session.onStateChange((s) => states.push(s));
-
-    instances[0]!.onclose?.();
-    await waitUntil(() => states.includes("reconnecting"));
-
-    // Rejoins stay silent, so no new reply has arrived.
     expect(session.providerStates()).toEqual({ opentag: "attached" });
 
     session.disconnect();

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -17,6 +17,69 @@ export interface RealtimeGatewaySession {
   ): Promise<RealtimeGatewayDeliveryChannel>;
 }
 
+/**
+ * Managed provider attachment state the Gateway reports for one declared
+ * Channel on the control join reply.
+ *
+ * - `attached`: a declared adapter is configured and its last health check did
+ *   not fail — the Channel can actually receive provider traffic.
+ * - `unhealthy`: a declared adapter is configured but its last health check
+ *   failed.
+ * - `not_attached`: the Channel exists on the project but no declared adapter is
+ *   configured — the normal state while setup is still in progress.
+ * - `disabled`: the Channel is disabled on the project.
+ * - `channel_not_declared`: the project has no Channel with that name.
+ */
+export type ChannelProviderState =
+  | "attached"
+  | "unhealthy"
+  | "not_attached"
+  | "disabled"
+  | "channel_not_declared";
+
+/** Provider attachment state keyed by declared Channel name. */
+export type ChannelProviderStates = Readonly<
+  Record<string, ChannelProviderState>
+>;
+
+const PROVIDER_STATES: ReadonlySet<string> = new Set<ChannelProviderState>([
+  "attached",
+  "unhealthy",
+  "not_attached",
+  "disabled",
+  "channel_not_declared",
+]);
+
+/**
+ * Read the `channels` map off a control join reply.
+ *
+ * Returns `undefined` — meaning "the Gateway did not tell us" — when the key is
+ * absent, malformed, or carries an unrecognised state. A Gateway older than the
+ * provider-state contract and a Gateway whose database read failed both omit the
+ * key, and both must degrade to transport-only status rather than be mistaken
+ * for "no provider attached". Unknown values are dropped individually so one bad
+ * entry cannot hide the states that did parse.
+ *
+ * @param reply - Raw control-topic join reply.
+ * @returns Parsed provider states, or `undefined` when none were reported.
+ */
+export function parseChannelProviderStates(
+  reply: unknown,
+): ChannelProviderStates | undefined {
+  if (typeof reply !== "object" || reply === null) return undefined;
+  const raw = (reply as { channels?: unknown }).channels;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+  const states: Record<string, ChannelProviderState> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (typeof value === "string" && PROVIDER_STATES.has(value)) {
+      states[name] = value as ChannelProviderState;
+    }
+  }
+  return Object.keys(states).length > 0 ? states : undefined;
+}
+
 /** One joined delivery topic. */
 export interface RealtimeGatewayDeliveryChannel extends RealtimeGatewaySession {
   /** Prepared delivery returned by the token-consuming join. */
@@ -402,6 +465,22 @@ export interface ConnectedRealtimeGatewaySession extends RealtimeGatewaySession 
       detail?: RealtimeGatewayConnectionDetail,
     ) => void,
   ): void;
+  /**
+   * Managed provider attachment state per declared Channel, as reported on the
+   * newest control join reply — or `undefined` when the Gateway did not report
+   * it.
+   *
+   * A GETTER rather than a snapshot so callers always read the current value:
+   * the join hooks re-fire on every Phoenix auto-rejoin, so a Channel
+   * provisioned while the runtime was disconnected reports `attached` after the
+   * next rejoin with no extra plumbing.
+   *
+   * `undefined` means "not reported", NOT "no provider attached". A Gateway
+   * predating this contract and one whose database read failed both omit the
+   * key, and a caller must degrade to transport-only status in both cases rather
+   * than claim a Channel is unprovisioned.
+   */
+  providerStates(): ChannelProviderStates | undefined;
 }
 
 /**
@@ -475,6 +554,9 @@ export async function connectRealtimeGateway(
   let closingIntentionally = false;
   let everConnected = false;
   let initialJoinSettled = false;
+  // Newest control-topic join reply, refreshed on every successful (re)join.
+  // Read through `providerStates()` below rather than exposed raw.
+  let controlJoinReply: unknown;
   let lastTransportError: string | undefined;
   let lastTransportCode: string | undefined;
   let lastTransportRaw: unknown;
@@ -752,7 +834,12 @@ export async function connectRealtimeGateway(
   // promise vs. the ongoing health transitions.
   const joinPush = channel.join(timeout);
   joinPush
-    .receive("ok", () => {
+    .receive("ok", (reply: unknown) => {
+      // Keep the newest control reply. Because these hooks re-fire on every
+      // Phoenix auto-rejoin, provider attachment state refreshes for free when
+      // the socket recovers — a Channel provisioned while the runtime was
+      // disconnected stops reporting `setup_required` after the next rejoin.
+      controlJoinReply = reply;
       if (!initialJoinSettled) {
         initialJoinSettled = true;
         clearConnectDeadline();
@@ -916,6 +1003,7 @@ export async function connectRealtimeGateway(
 
   return {
     ...wrapChannel(channel, undefined),
+    providerStates: () => parseChannelProviderStates(controlJoinReply),
     onClose: (cb) => {
       closeCallbacks.push(cb);
     },

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -21,14 +21,32 @@ export interface RealtimeGatewaySession {
  * Managed provider attachment state the Gateway reports for one declared
  * Channel on the control join reply.
  *
- * - `attached`: a declared adapter is configured and its last health check did
- *   not fail — the Channel can actually receive provider traffic.
- * - `unhealthy`: a declared adapter is configured but its last health check
- *   failed.
- * - `not_attached`: the Channel exists on the project but no declared adapter is
- *   configured — the normal state while setup is still in progress.
- * - `disabled`: the Channel is disabled on the project.
+ * Mirrors `RealtimeGateway.Channels.ChannelProviderStateStore`, which is
+ * authoritative. Keep these descriptions in step with it — the whole reason this
+ * seam exists is that a state's description outlived its mechanism once already.
+ *
+ * - `attached`: a declared adapter is `active` AND finished setup, and its last
+ *   health check did not fail — the Channel can actually receive provider
+ *   traffic. The adapter's own `status` is part of the predicate, not just its
+ *   setup state: Slack ingress only resolves an inbound event through an
+ *   `active` adapter, so reporting `attached` for a `draft`, `disabled`, or
+ *   `error` adapter would reintroduce the false green one state further along.
+ * - `unhealthy`: a declared adapter is bound but broken — either `active` and
+ *   set up with a failed health check, or set up with the adapter row itself in
+ *   `error` (which is `unhealthy` even with no failed health check recorded).
+ * - `not_attached`: the Channel exists on the project but no declared adapter
+ *   has a row, none has finished setup, or none is `active` — the normal state
+ *   while setup is still in progress.
+ * - `disabled`: the Channel row itself is disabled on the project.
  * - `channel_not_declared`: the project has no Channel with that name.
+ *
+ * A Runtime declares EVERY supported adapter per Channel (the launcher emits a
+ * `slack` and a `teams` pair unconditionally), so the Gateway folds the adapter
+ * states BEST-of — `attached` > `unhealthy` > `not_attached` — answering "is at
+ * least one provider bound?". A correctly configured Slack-only Channel is
+ * therefore `attached`, not dragged to `not_attached` by the Teams adapter
+ * nobody asked for. The two Channel-level states above are properties of the
+ * Channel row and dominate every adapter state.
  */
 export type ChannelProviderState =
   | "attached"
@@ -42,6 +60,19 @@ export type ChannelProviderStates = Readonly<
   Record<string, ChannelProviderState>
 >;
 
+/**
+ * Every state {@link parseChannelProviderStates} will accept.
+ *
+ * The runtime's `channel-manager.ts` duplicates this set as `PROVIDER_LEGS`,
+ * because that package must not take a static dependency on this one (it reaches
+ * this module only through a dynamic import), so the `providerStates` seam
+ * between them is deliberately duck-typed as `Record<string, string>`.
+ *
+ * Adding a state here therefore needs the same addition THERE, plus a `case` in
+ * that file's `foldChannelLegs`. Until both land, the new state fails open to
+ * `unknown` on the consuming side — the Channel keeps its transport-derived
+ * status rather than being wrongly certified or condemned. Safe, but silent.
+ */
 const PROVIDER_STATES: ReadonlySet<string> = new Set<ChannelProviderState>([
   "attached",
   "unhealthy",

--- a/packages/channels-intelligence/src/runtime.ts
+++ b/packages/channels-intelligence/src/runtime.ts
@@ -136,4 +136,20 @@ export interface ChannelsHandle {
       detail?: { reason?: string; code?: string },
     ) => void,
   ): void;
+  /**
+   * Optional seam: managed provider attachment state per declared Channel, as
+   * reported on the newest gateway control join reply — so a supervising
+   * `ChannelManager` can tell "the control socket is up" from "a Slack/Teams app
+   * is actually bound to this Channel".
+   *
+   * A getter, not a snapshot: the gateway's join hooks re-fire on every Phoenix
+   * auto-rejoin, so a Channel provisioned while the runtime was disconnected is
+   * reflected on the next read.
+   *
+   * `undefined` means "not reported", NOT "no provider attached" — a gateway
+   * predating this contract and one whose lookup failed both omit it. Present
+   * when the underlying session supports it (see
+   * `ConnectedRealtimeGatewaySession.providerStates` in `realtime-gateway.ts`).
+   */
+  providerStates?(): Readonly<Record<string, string>> | undefined;
 }

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-provider-leg.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-manager-provider-leg.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi } from "vitest";
+import { createChannel } from "@copilotkit/channels";
+import { CopilotKitIntelligence } from "../../intelligence-platform";
+import { ChannelManager, foldChannelLegs } from "../channel-manager";
+import type {
+  ActivateChannelEngine,
+  ChannelsHandle,
+  ChannelProviderLeg,
+} from "../channel-manager";
+
+/** A CopilotKitIntelligence whose runner API key carries a parseable project id. */
+function fakeIntelligence(): CopilotKitIntelligence {
+  return new CopilotKitIntelligence({
+    apiUrl: "https://runtime.example",
+    wsUrl: "wss://runtime.example",
+    apiKey: "cpk-42_short_long",
+  });
+}
+
+/**
+ * A handle that reports provider states, as the gateway launcher's handle does.
+ *
+ * `states` is read through a callback so a test can change what the gateway
+ * "reports" between `status()` calls — the real handle delegates to a getter for
+ * exactly that reason (a rejoin refreshes the reply).
+ */
+function handleReporting(
+  states: () => Record<string, string> | undefined,
+): ChannelsHandle {
+  return {
+    metadata: {},
+    stop: vi.fn(async () => {}),
+    providerStates: () => states(),
+  };
+}
+
+/** A handle with no provider-state seam at all (a non-gateway/test handle). */
+function handleWithoutSeam(): ChannelsHandle {
+  return { metadata: {}, stop: vi.fn(async () => {}) };
+}
+
+async function managerWith(handle: ChannelsHandle, names = ["support"]) {
+  const channels = names.map((name) =>
+    createChannel({ identifyUser: "platform", name }),
+  );
+  const engine: ActivateChannelEngine = vi.fn(async () => handle);
+  const mgr = new ChannelManager({
+    intelligence: fakeIntelligence(),
+    channels,
+    activateChannel: engine,
+  });
+  mgr.activate();
+  await mgr.ready();
+  return mgr;
+}
+
+describe("foldChannelLegs", () => {
+  it("lets a non-online transport dominate whatever the provider said", () => {
+    // A Channel mid-reconnect must read as an outage, not as a setup problem.
+    for (const transport of [
+      "connecting",
+      "reconnecting",
+      "stopped",
+      "error",
+    ] as const) {
+      expect(foldChannelLegs(transport, "not_attached")).toBe(transport);
+      expect(foldChannelLegs(transport, "attached")).toBe(transport);
+    }
+  });
+
+  it("maps each provider state once the transport is online", () => {
+    const cases: [ChannelProviderLeg, string][] = [
+      ["attached", "online"],
+      ["unknown", "online"],
+      ["unhealthy", "error"],
+      ["not_attached", "setup_required"],
+      ["disabled", "setup_required"],
+      ["channel_not_declared", "setup_required"],
+    ];
+    for (const [provider, expected] of cases) {
+      expect(foldChannelLegs("online", provider)).toBe(expected);
+    }
+  });
+});
+
+describe("ChannelManager provider leg", () => {
+  it("reports setup_required for a joined Channel with no provider attached", async () => {
+    // THE regression test this contract exists for. Before the legs were split,
+    // a Channel with no Slack app created at all reported `online`, and every
+    // version of our onboarding guidance used `overall === "online"` as gate 2 to
+    // certify end-to-end success.
+    const mgr = await managerWith(
+      handleReporting(() => ({ support: "not_attached" })),
+    );
+
+    const status = mgr.status();
+
+    expect(status.overall).toBe("setup_required");
+    expect(status.channels.support).toBe("setup_required");
+    expect(status.detail.support).toEqual({
+      status: "setup_required",
+      transport: "online",
+      provider: "not_attached",
+    });
+  });
+
+  it("separates the two legs so a caller can assert the one it cares about", async () => {
+    const mgr = await managerWith(
+      handleReporting(() => ({ support: "not_attached" })),
+    );
+
+    // The socket really is up; only the provider binding is missing. A caller
+    // debugging connectivity must be able to see that distinction.
+    expect(mgr.status().detail.support.transport).toBe("online");
+    expect(mgr.status().detail.support.provider).toBe("not_attached");
+  });
+
+  it("reports online when a provider is attached", async () => {
+    const mgr = await managerWith(
+      handleReporting(() => ({ support: "attached" })),
+    );
+
+    const status = mgr.status();
+
+    expect(status.overall).toBe("online");
+    expect(status.detail.support).toEqual({
+      status: "online",
+      transport: "online",
+      provider: "attached",
+    });
+  });
+
+  it("treats a configured-but-unhealthy provider as an error", async () => {
+    const mgr = await managerWith(
+      handleReporting(() => ({ support: "unhealthy" })),
+    );
+
+    expect(mgr.status().overall).toBe("error");
+    expect(mgr.status().detail.support.provider).toBe("unhealthy");
+  });
+
+  it("re-reads provider state on each call, so a rejoin picks up new provisioning", async () => {
+    let reported = "not_attached";
+    const mgr = await managerWith(
+      handleReporting(() => ({
+        support: reported,
+      })),
+    );
+
+    expect(mgr.status().overall).toBe("setup_required");
+
+    // The gateway's join hooks re-fire on auto-rejoin, so the newest reply wins
+    // without the manager re-activating anything.
+    reported = "attached";
+
+    expect(mgr.status().overall).toBe("online");
+  });
+
+  describe("degrades to transport-only status rather than claiming no provider", () => {
+    it("when the handle has no provider-state seam (older gateway package)", async () => {
+      const mgr = await managerWith(handleWithoutSeam());
+
+      expect(mgr.status().overall).toBe("online");
+      expect(mgr.status().detail.support.provider).toBe("unknown");
+    });
+
+    it("when the gateway reported nothing (older gateway or failed lookup)", async () => {
+      const mgr = await managerWith(handleReporting(() => undefined));
+
+      expect(mgr.status().overall).toBe("online");
+      expect(mgr.status().detail.support.provider).toBe("unknown");
+    });
+
+    it("when the gateway did not mention this Channel", async () => {
+      const mgr = await managerWith(
+        handleReporting(() => ({ somethingElse: "not_attached" })),
+      );
+
+      expect(mgr.status().overall).toBe("online");
+      expect(mgr.status().detail.support.provider).toBe("unknown");
+    });
+
+    it("when the gateway sent an unrecognised state", async () => {
+      const mgr = await managerWith(
+        handleReporting(() => ({ support: "brand_new_state" })),
+      );
+
+      expect(mgr.status().overall).toBe("online");
+      expect(mgr.status().detail.support.provider).toBe("unknown");
+    });
+
+    it("when the getter throws", async () => {
+      const mgr = await managerWith(
+        handleReporting(() => {
+          throw new Error("handle exploded");
+        }),
+      );
+
+      // A misbehaving handle must never break a status snapshot.
+      expect(() => mgr.status()).not.toThrow();
+      expect(mgr.status().overall).toBe("online");
+      expect(mgr.status().detail.support.provider).toBe("unknown");
+    });
+  });
+
+  it("folds the worst Channel into overall while keeping each Channel's legs", async () => {
+    const mgr = await managerWith(
+      handleReporting(() => ({
+        support: "attached",
+        sales: "not_attached",
+      })),
+      ["support", "sales"],
+    );
+
+    const status = mgr.status();
+
+    expect(status.overall).toBe("setup_required");
+    expect(status.channels).toEqual({
+      support: "online",
+      sales: "setup_required",
+    });
+    expect(status.detail.support.provider).toBe("attached");
+    expect(status.detail.sales.provider).toBe("not_attached");
+  });
+
+  it("keeps detail present and consistent after stop()", async () => {
+    const mgr = await managerWith(
+      handleReporting(() => ({ support: "attached" })),
+    );
+
+    await mgr.stop();
+    const status = mgr.status();
+
+    expect(status.overall).toBe("stopped");
+    expect(status.detail.support.status).toBe("stopped");
+    expect(status.detail.support.transport).toBe("stopped");
+  });
+});

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -33,11 +33,21 @@ import type {
  * Lifecycle status of a single Channel activation, or of the manager overall.
  *
  * - `connecting`: activation in flight, not yet settled.
- * - `online`: activation resolved AND the managed session can currently send.
- *   A drop moves the Channel to `reconnecting` (not `online`); a successful
- *   rejoin restores `online`.
+ * - `online`: activation resolved, the managed session can currently send, AND
+ *   the gateway did not report the Channel as missing a managed provider. A drop
+ *   moves the Channel to `reconnecting` (not `online`); a successful rejoin
+ *   restores `online`.
  * - `setup_required`: the Channel is declared but has no managed provider yet —
- *   a valid degraded state, not a failure.
+ *   a valid degraded state, not a failure. Reached when the gateway reports the
+ *   provider as unattached/disabled/undeclared on the control join reply (see
+ *   {@link ChannelLegs}), or when the activation engine throws a
+ *   `SETUP_REQUIRED` error.
+ *
+ *   NOTE: between the 2026-07-29 realtime-boundary cutover and the introduction
+ *   of {@link ChannelLegs}, this state had NO producer — the engine stopped
+ *   classifying it and nothing else set it, so a Channel with no Slack app at
+ *   all reported `online`. Do not reintroduce a code path that describes
+ *   `setup_required` without one that can actually emit it.
  * - `reconnecting`: the managed session dropped and Phoenix is retrying — not
  *   currently sendable. The manager does NOT re-activate (reconnection is
  *   delegated to the Phoenix connection layer); it only reflects the health the
@@ -60,6 +70,93 @@ export type ChannelStatus =
   | "error";
 
 /**
+ * Managed provider attachment state for one Channel, as reported by the gateway
+ * on the control join reply.
+ *
+ * `unknown` is this package's own value for "the gateway did not tell us" — a
+ * gateway predating the provider-state contract, one whose lookup failed, or a
+ * non-gateway handle. It must never be read as "no provider attached".
+ */
+export type ChannelProviderLeg =
+  | "attached"
+  | "unhealthy"
+  | "not_attached"
+  | "disabled"
+  | "channel_not_declared"
+  | "unknown";
+
+/**
+ * The two independent things that have to be true for a managed Channel to
+ * work, reported separately so a caller can assert the one it cares about.
+ *
+ * `status` is the fold of the two and matches this Channel's entry in
+ * {@link ChannelsControl.status}'s `channels` map.
+ *
+ * The legs exist because they are genuinely separable: the control socket can be
+ * joined and sendable while no Slack/Teams app is bound to the Channel at all.
+ * Before they were split, `overall: "online"` proved only the socket, and
+ * onboarding guidance used it to certify end-to-end success.
+ */
+export interface ChannelLegs {
+  /** Fold of {@link transport} and {@link provider}. */
+  status: ChannelStatus;
+  /** Runtime ⇄ Gateway control socket for this Channel. */
+  transport: ChannelStatus;
+  /** Whether a managed provider is bound to this Channel. */
+  provider: ChannelProviderLeg;
+}
+
+const PROVIDER_LEGS: ReadonlySet<string> = new Set<ChannelProviderLeg>([
+  "attached",
+  "unhealthy",
+  "not_attached",
+  "disabled",
+  "channel_not_declared",
+]);
+
+/**
+ * Fold a Channel's transport and provider legs into its single status.
+ *
+ * The transport leg dominates whenever it is not `online`: while the control
+ * socket is connecting, retrying, stopped, or failed, whatever the gateway last
+ * said about the provider is stale or irrelevant — the Channel cannot serve a
+ * turn either way, and reporting `setup_required` for a Channel that is actually
+ * mid-reconnect would hide the outage.
+ *
+ * Once the transport is `online` the provider leg decides, which is the whole
+ * point of the split: a joined socket with no provider bound is
+ * `setup_required`, not `online`.
+ *
+ * `unknown` keeps the transport-derived answer. That is what makes an older
+ * gateway (or a gateway whose lookup failed) behave exactly as it did before
+ * provider states existed, instead of turning every Channel into
+ * `setup_required`.
+ *
+ * @param transport - Control-socket status for the Channel.
+ * @param provider - Reported provider attachment state.
+ * @returns The folded Channel status.
+ */
+export function foldChannelLegs(
+  transport: ChannelStatus,
+  provider: ChannelProviderLeg,
+): ChannelStatus {
+  if (transport !== "online") {
+    return transport;
+  }
+  switch (provider) {
+    case "attached":
+    case "unknown":
+      return "online";
+    case "unhealthy":
+      return "error";
+    case "not_attached":
+    case "disabled":
+    case "channel_not_declared":
+      return "setup_required";
+  }
+}
+
+/**
  * The lifecycle control surface a Channel host uses to drive and observe
  * managed Channel activation.
  */
@@ -70,8 +167,20 @@ export interface ChannelsControl {
    * or — when `timeoutMs` is given — if the whole set has not settled in time.
    */
   ready(opts?: { timeoutMs?: number }): Promise<void>;
-  /** Snapshot the overall status and the per-Channel status map. */
-  status(): { overall: ChannelStatus; channels: Record<string, ChannelStatus> };
+  /**
+   * Snapshot the overall status, the per-Channel status map, and the per-Channel
+   * transport/provider legs.
+   *
+   * `overall === "online"` does NOT by itself prove a Channel can receive
+   * provider traffic unless the provider leg is `attached`: read `detail` when
+   * you need to assert that a Channel is genuinely reachable from Slack/Teams,
+   * because a `provider` of `unknown` leaves `status` transport-derived.
+   */
+  status(): {
+    overall: ChannelStatus;
+    channels: Record<string, ChannelStatus>;
+    detail: Record<string, ChannelLegs>;
+  };
   /** Tear down every activated Channel. Idempotent. */
   stop(): Promise<void>;
 }
@@ -135,6 +244,20 @@ export interface ChannelsHandle {
       detail?: { reason?: string; code?: string },
     ) => void,
   ): void;
+  /**
+   * Optional seam: managed provider attachment state per declared Channel, as
+   * reported on the newest gateway control join reply.
+   *
+   * A getter, so each read reflects the current join reply — the gateway's join
+   * hooks re-fire on every auto-rejoin, so a Channel provisioned while the
+   * runtime was disconnected is picked up without re-activating.
+   *
+   * `undefined` (or an absent method) means "not reported", NOT "no provider".
+   * A gateway predating this contract, a gateway whose database read failed, and
+   * a non-gateway/test handle all land here, and all must fall back to
+   * transport-only status rather than claim a Channel is unprovisioned.
+   */
+  providerStates?(): Readonly<Record<string, string>> | undefined;
 }
 
 /** Constructor arguments for {@link ChannelManager}. */
@@ -1104,21 +1227,37 @@ export class ChannelManager implements ChannelsControl {
    * Snapshot status. Every declared Channel appears keyed by name in
    * `channels` after its combined adapter lifecycle starts.
    *
+   * Each Channel's entry is the fold of its transport and provider legs (see
+   * {@link foldChannelLegs}), and `detail` reports those legs separately so a
+   * caller can assert the one it cares about.
+   *
    * `overall` is folded over ALL declared Channels (see {@link computeOverall}),
    * by precedence `error` > `reconnecting` > `setup_required` > `connecting` >
-   * `online`. `online` means every Channel can currently send. `reconnecting`
-   * outranks `setup_required` because a dropped-but-retrying Channel is an active
-   * outage, louder than a steadily-degraded unprovisioned one. With no declared
-   * Channels at all, `overall` is `online` (nothing
-   * is degraded); once every Channel has been stopped, `overall` is `stopped`.
+   * `online`. `online` means every Channel can currently send AND none was
+   * reported as missing its managed provider. `reconnecting` outranks
+   * `setup_required` because a dropped-but-retrying Channel is an active outage,
+   * louder than a steadily-degraded unprovisioned one. With no declared Channels
+   * at all, `overall` is `online` (nothing is degraded); once every Channel has
+   * been stopped, `overall` is `stopped`.
+   *
+   * `overall === "online"` is only end-to-end proof when every Channel's
+   * `provider` leg is `attached`. A gateway that reports no provider state leaves
+   * the legs `unknown` and `overall` transport-derived, exactly as before this
+   * contract existed — so a caller that must be certain checks `detail`.
    */
   status(): {
     overall: ChannelStatus;
     channels: Record<string, ChannelStatus>;
+    detail: Record<string, ChannelLegs>;
   } {
     const channels: Record<string, ChannelStatus> = {};
+    const detail: Record<string, ChannelLegs> = {};
     for (const [name, entry] of this.entries) {
-      channels[name] = entry.status;
+      const transport = entry.status;
+      const provider = this.providerLeg(name, entry);
+      const status = foldChannelLegs(transport, provider);
+      channels[name] = status;
+      detail[name] = { status, transport, provider };
     }
     // A stopped manager is `stopped` regardless of whether it was ever activated.
     // stop() before activate() (e.g. SIGTERM during startup) leaves `entries`
@@ -1127,7 +1266,7 @@ export class ChannelManager implements ChannelsControl {
     // activate→stop, every entry is already `stopped` and the fold agrees, so
     // this is also consistent with the populated case.)
     if (this.stopped) {
-      return { overall: "stopped", channels };
+      return { overall: "stopped", channels, detail };
     }
     // Before activate() has run, `entries` is empty. Folding an empty set gives
     // `online` — correct for a manager that declares NO channels (nothing is
@@ -1137,9 +1276,40 @@ export class ChannelManager implements ChannelsControl {
     // Report `connecting` ("not started") for that case so `status()` is honest
     // before any `ready()`.
     if (!this.activated && this.channels.length > 0) {
-      return { overall: "connecting", channels };
+      return { overall: "connecting", channels, detail };
     }
-    return { overall: this.computeOverall(Object.values(channels)), channels };
+    return {
+      overall: this.computeOverall(Object.values(channels)),
+      channels,
+      detail,
+    };
+  }
+
+  /**
+   * Read one Channel's provider leg from its handle.
+   *
+   * Defensive on every axis, because a wrong answer here silently changes what
+   * `status()` certifies: a handle without the seam, a gateway that reported
+   * nothing, a name the gateway did not mention, an unrecognised value, or a
+   * throwing getter all yield `unknown` — which {@link foldChannelLegs} treats as
+   * "keep the transport-derived status", i.e. pre-provider-state behaviour.
+   *
+   * @param name - The Channel name (map key).
+   * @param entry - The Channel's activation entry.
+   * @returns The provider leg, or `"unknown"` when it cannot be established.
+   */
+  private providerLeg(name: string, entry: ChannelEntry): ChannelProviderLeg {
+    let states: Readonly<Record<string, string>> | undefined;
+    try {
+      states = entry.handle?.providerStates?.();
+    } catch {
+      // A misbehaving handle must never break a status snapshot.
+      return "unknown";
+    }
+    const reported = states?.[name];
+    return reported !== undefined && PROVIDER_LEGS.has(reported)
+      ? (reported as ChannelProviderLeg)
+      : "unknown";
   }
 
   /**

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -106,6 +106,28 @@ export interface ChannelLegs {
   provider: ChannelProviderLeg;
 }
 
+/**
+ * Recognised provider states, used to validate what crosses the seam.
+ *
+ * Deliberately duplicates `PROVIDER_STATES` in
+ * `@copilotkit/channels-intelligence`'s `realtime-gateway.ts` rather than
+ * importing it. This package must not take a static dependency on
+ * channels-intelligence (see {@link CHANNELS_INTELLIGENCE_SPECIFIER} — it is
+ * reached only through a dynamic import), so every cross-package shape here is a
+ * duck-typed structural view; the `providerStates` seam is typed
+ * `Record<string, string>` for the same reason.
+ *
+ * Drift therefore fails OPEN: a state this set does not know becomes `unknown`,
+ * which keeps the transport-derived status. That is quiet, but it is the safe
+ * direction — the alternative (trusting an unrecognised string) would let a
+ * future Gateway state silently certify or condemn a Channel.
+ *
+ * A state added on the Gateway side needs adding here too, plus a `case` in
+ * {@link foldChannelLegs}. There is intentionally NO automated drift guard: one
+ * would have to import channels-intelligence, which resolves to that package's
+ * BUILT output from here, coupling this package's tests to another package's
+ * build for a divergence that already fails safe.
+ */
 const PROVIDER_LEGS: ReadonlySet<string> = new Set<ChannelProviderLeg>([
   "attached",
   "unhealthy",
@@ -162,9 +184,18 @@ export function foldChannelLegs(
  */
 export interface ChannelsControl {
   /**
-   * Resolve once every declared Channel has settled to a terminal, non-connecting
-   * state (`online` or `setup_required`). Rejects if any Channel is in `error`,
-   * or — when `timeoutMs` is given — if the whole set has not settled in time.
+   * Resolve once every declared Channel has settled its ACTIVATION — that is,
+   * each Channel either activated or failed to. Rejects if any Channel failed to
+   * activate, or — when `timeoutMs` is given — if the whole set has not settled
+   * in time.
+   *
+   * Readiness is about activation, NOT about provider health: a Channel whose
+   * transport joined but whose provider leg is `unhealthy` folds to a status of
+   * `error` (see {@link foldChannelLegs}) while its activation settled normally.
+   * So `ready()` resolving and `status().overall === "error"` can both be true at
+   * once, by design — provider attachment is the Gateway's answer to a question
+   * asked after activation, and it can change at any later rejoin. Assert
+   * end-to-end reachability with {@link ChannelsControl.status}, not here.
    */
   ready(opts?: { timeoutMs?: number }): Promise<void>;
   /**
@@ -1253,6 +1284,19 @@ export class ChannelManager implements ChannelsControl {
     const channels: Record<string, ChannelStatus> = {};
     const detail: Record<string, ChannelLegs> = {};
     for (const [name, entry] of this.entries) {
+      // KNOWN LIMITATION (no producer today, so no behaviour depends on it):
+      // `entry.status` is reported verbatim as the transport leg, but the legacy
+      // `ChannelSetupRequiredError` / `code === "SETUP_REQUIRED"` path writes
+      // `setup_required` into it — a PROVIDER condition parked on the transport
+      // leg, read back as `transport: "setup_required", provider: "unknown"`.
+      // Nothing emits that today (the activation engine stopped throwing it at
+      // the 2026-07-29 realtime-boundary cutover), and the folded `status` is
+      // still correct either way, so the misattribution is cosmetic. It is left
+      // as-is rather than guessed at: such a Channel has no transport at all (the
+      // launcher never returned a handle), so there is no honest value to move
+      // there. A future producer of `setup_required` should report provider
+      // attachment through the `providerStates` seam instead of `entry.status`,
+      // at which point this note comes out.
       const transport = entry.status;
       const provider = this.providerLeg(name, entry);
       const status = foldChannelLegs(transport, provider);

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -111,22 +111,14 @@ export interface ChannelLegs {
  *
  * Deliberately duplicates `PROVIDER_STATES` in
  * `@copilotkit/channels-intelligence`'s `realtime-gateway.ts` rather than
- * importing it. This package must not take a static dependency on
- * channels-intelligence (see {@link CHANNELS_INTELLIGENCE_SPECIFIER} — it is
- * reached only through a dynamic import), so every cross-package shape here is a
- * duck-typed structural view; the `providerStates` seam is typed
- * `Record<string, string>` for the same reason.
+ * importing it: this package must not take a static dependency on
+ * channels-intelligence (it is reached only through a dynamic import), so the
+ * `providerStates` seam is duck-typed as `Record<string, string>`.
  *
- * Drift therefore fails OPEN: a state this set does not know becomes `unknown`,
- * which keeps the transport-derived status. That is quiet, but it is the safe
- * direction — the alternative (trusting an unrecognised string) would let a
- * future Gateway state silently certify or condemn a Channel.
- *
- * A state added on the Gateway side needs adding here too, plus a `case` in
- * {@link foldChannelLegs}. There is intentionally NO automated drift guard: one
- * would have to import channels-intelligence, which resolves to that package's
- * BUILT output from here, coupling this package's tests to another package's
- * build for a divergence that already fails safe.
+ * A state added there needs adding here too, plus a `case` in
+ * {@link foldChannelLegs}. Until both land it fails OPEN — an unrecognised state
+ * becomes `unknown` and the Channel keeps its transport-derived status, rather
+ * than being wrongly certified or condemned.
  */
 const PROVIDER_LEGS: ReadonlySet<string> = new Set<ChannelProviderLeg>([
   "attached",
@@ -1284,19 +1276,15 @@ export class ChannelManager implements ChannelsControl {
     const channels: Record<string, ChannelStatus> = {};
     const detail: Record<string, ChannelLegs> = {};
     for (const [name, entry] of this.entries) {
-      // KNOWN LIMITATION (no producer today, so no behaviour depends on it):
-      // `entry.status` is reported verbatim as the transport leg, but the legacy
-      // `ChannelSetupRequiredError` / `code === "SETUP_REQUIRED"` path writes
-      // `setup_required` into it — a PROVIDER condition parked on the transport
-      // leg, read back as `transport: "setup_required", provider: "unknown"`.
-      // Nothing emits that today (the activation engine stopped throwing it at
-      // the 2026-07-29 realtime-boundary cutover), and the folded `status` is
-      // still correct either way, so the misattribution is cosmetic. It is left
-      // as-is rather than guessed at: such a Channel has no transport at all (the
-      // launcher never returned a handle), so there is no honest value to move
-      // there. A future producer of `setup_required` should report provider
-      // attachment through the `providerStates` seam instead of `entry.status`,
-      // at which point this note comes out.
+      // KNOWN LIMITATION, dead today: the legacy `ChannelSetupRequiredError` /
+      // `code === "SETUP_REQUIRED"` path writes `setup_required` into
+      // `entry.status`, which is reported verbatim as the transport leg — so such
+      // a Channel reads `transport: "setup_required", provider: "unknown"`, a
+      // provider condition parked on the transport leg. Nothing emits it (the
+      // activation engine stopped throwing it at the 2026-07-29
+      // realtime-boundary cutover) and the folded `status` is right either way,
+      // so this is cosmetic. A future producer should report provider attachment
+      // through the `providerStates` seam rather than `entry.status`.
       const transport = entry.status;
       const provider = this.providerLeg(name, entry);
       const status = foldChannelLegs(transport, provider);


### PR DESCRIPTION
**Half 2 of 2 for OSS-739.** Gateway half ships first: CopilotKit/Intelligence#746.

## Why

`status().overall === "online"` proved only that the runtime reached the Gateway with a valid project API key. It said nothing about whether a Slack/Teams app was bound to the Channel, so **a Channel with no provider at all reported `online`** — and every version of our Channels onboarding guidance used that value to certify end-to-end success.

`setup_required` had **no producer**. The manager set it only when the activation engine threw `SETUP_REQUIRED`, and the engine stopped doing that at the 2026-07-29 realtime-boundary cutover (`8f166577ce`). In published `@copilotkit/channels-intelligence@0.7.0` the string survives in exactly one file — a shipped *test*. The 15 doc comments describing the state outlived the mechanism, which is why nobody noticed for a week.

## Change

- `connectRealtimeGateway` captures the control join reply (it was **discarded**) and exposes `providerStates()`. Phoenix's `Push.resend` preserves `recHooks`, so the hook re-fires on every auto-rejoin — a Channel provisioned while the runtime was disconnected is picked up with no extra plumbing.
- The launcher and the manager's handle view delegate it as a **getter**, not a captured snapshot, for that same reason.
- `status()` gains `detail`, reporting `transport` and `provider` separately so a caller can assert the leg it cares about:

```ts
status() → {
  overall: "setup_required",
  channels: { support: "setup_required" },
  detail: { support: { status: "setup_required", transport: "online", provider: "not_attached" } },
}
```

`channels` keeps its shape — turning its values into objects would break the CLI's `channels-report` and the starter channel-host — but its values are now the fold of the two legs, which is what makes `overall` honest.

- The stale `setup_required` doc comments are corrected, with a note not to describe the state again without a path that can emit it.

## Back-compat: `unknown` is load-bearing

An older Gateway, a Gateway whose lookup failed, a handle without the seam, a Channel the Gateway did not mention, an unrecognised state, and a throwing getter **all** yield `unknown`, which keeps the transport-derived status — exactly today's behaviour. Only a *positively reported* absence downgrades a Channel, so no existing deployment turns amber on upgrade.

The **41 pre-existing channel-manager tests pass unchanged**, which is that guarantee.

## Testing

- `channel-manager-provider-leg.test.ts` — 14, incl. the regression test that never existed ("reports setup_required for a joined Channel with no provider attached") and one case per degradation path
- `realtime-gateway-provider-states.test.ts` — 8 parser cases
- `realtime-gateway.test.ts` — +2 proving the wiring end-to-end through real Phoenix framing, not just the parser
- Full suites: runtime **1874/1874**, channels-intelligence **192/192**; `check-types` and `build` clean for both packages

**I mutation-tested the fold** — neutralising it fails 5 tests including the linchpin — so these assert behaviour rather than passing vacuously.

Worth noting: two type errors (`ChannelsHandle` in `runtime.ts`, a session mock) were invisible to vitest, which transpiles without typechecking. The pre-commit build gate caught them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)