### PR TITLE
feat(skills): add channels-setup pointing at the hosted onboarding guide

### DIFF
--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -137,7 +137,8 @@ describe("syncPluginSkills", () => {
     // deletes it.
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("copilotkit-channels");
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("setup-slack-channel");
-    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(10);
+    expect(RESERVED_LIFECYCLE_SLUGS).toContain("channels-setup");
+    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(11);
   });
 
   // Version sync — the plugin version tracks packages/runtime/package.json.

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -18,6 +18,7 @@ export const RESERVED_LIFECYCLE_SLUGS: ReadonlySet<string> = new Set([
   "copilotkit-contribute",
   "copilotkit-self-update",
   "setup-slack-channel",
+  "channels-setup",
 ]);
 
 // Version sync — plugin version tracks this package's version.

--- a/skills/channels-setup/SKILL.md
+++ b/skills/channels-setup/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: channels-setup
+description: >
+  Use when a developer wants to build their first CopilotKit Channels agent and
+  get it answering in Slack or Microsoft Teams — "set up a channel", "connect my
+  agent to Slack", "get my agent into Teams", or starting from nothing and
+  wanting a working channel end to end. Covers the whole path: inspecting or
+  scaffolding the project, building the AG-UI agent, creating and reconciling
+  the managed Channel with the public CopilotKit CLI, running the long-running
+  host, and proving a real provider mention gets a reply. The workflow is not in
+  this file — it is fetched from https://copilotkit.ai/channels-guide.md at run
+  time, so it cannot go stale against the CLI.
+version: 1.0.0
+---
+
+# Set up a CopilotKit Channel
+
+The workflow is **not written down here**. It lives at one canonical URL so it
+is corrected in one place instead of on every surface that describes it:
+
+**https://copilotkit.ai/channels-guide.md**
+
+## Do this
+
+1. Fetch `https://copilotkit.ai/channels-guide.md`.
+2. Verify you actually got the guide (below).
+3. Follow it exactly, start to finish.
+
+The guide asks for its own inputs — the target project, the agent's real job,
+Slack or Microsoft Teams, and the agent framework and model. Do not pre-empt
+those questions, and do not substitute remembered channel-setup steps for what
+the guide says. Remembered steps are the reason this file is a pointer.
+
+## Verify you actually got the guide
+
+**A missing guide does not return 404.** The site answers unknown paths with a
+"Page not found" HTML page under HTTP 200, so a successful status code proves
+nothing. Check the body instead:
+
+- It is markdown, not HTML.
+- It begins with `# Build and prove a CopilotKit Channels agent`.
+- It contains five `## Phase` headings.
+
+If any of those fail, you did not get the guide — treat it as unavailable no
+matter what the status code said.
+
+## If you did not get the guide
+
+Stop. Tell the user you could not reach the guide, show them the URL, and ask
+them to paste its contents or retry.
+
+Do not improvise the workflow from memory. It spans the CopilotKit CLI, a
+managed Channel, provider setup performed by the user in Slack or Azure, and a
+long-running runtime host. A half-remembered version produces a project that
+installs cleanly and answers nothing, which is the most expensive failure
+available here — it looks finished.


### PR DESCRIPTION
## Summary

The Channels onboarding workflow is served at **https://copilotkit.ai/channels-guide.md**, and every other entry point now copies one line that points there — the docs surfaces in #6357, the website strip in [website#444](https://github.com/CopilotKit/website/pull/444), the README in [channels-sdk#15](https://github.com/CopilotKit/channels-sdk/pull/15).

Coding agents reached through a **skill** had no such pointer. They matched `setup-slack-channel`, which is scoped to Slack, to the provider half, and to an OpenTag checkout — so "help me get my agent into Teams" landed on a workflow that does not cover it.

`channels-setup` closes that gap as a **pointer, not a copy**. The workflow stays in one place and is corrected there, instead of becoming a seventh surface that drifts against the CLI on its own schedule.

## Verifying the fetch is the substance of the file

A thin pointer has one non-obvious failure mode, and it is the reason this skill is more than two sentences:

```
$ curl -sL -o /dev/null -w "%{http_code} %{content_type}\n" https://copilotkit.ai/channels-guide.md
200 text/html; charset=utf-8
$ curl -sL https://www.copilotkit.ai/channels-guide.md | grep -o "<title>[^<]*</title>"
<title>Page not found | CopilotKit | ...</title>
```

**A missing guide does not return 404.** The site answers unknown paths with a "Page not found" HTML page under HTTP 200. An agent that keys on the status code gets a 73KB marketing page, concludes the fetch succeeded, and improvises channel setup from memory — which is exactly what the guide's boundaries exist to prevent, and it fails in the most expensive way available here: the project installs cleanly and answers nothing.

So the skill checks the **body**: markdown rather than HTML, the guide's `# Build and prove a CopilotKit Channels agent` H1, and five `## Phase` headings. If any fail it stops and hands the user the URL, no matter what the status code said.

## Notes

- **`RESERVED_LIFECYCLE_SLUGS` is not optional.** Standalone skills are not generated from `packages/*/skills`, so without the entry `sync-plugin-skills` treats the directory as an orphan and deletes it. Test updated alongside, including the hard-coded `size` (10 → 11).
- **No existing skill is modified.** `setup-slack-channel` and `copilotkit-channels` keep their descriptions and bodies. Three skills now match channel work; if that proves too ambiguous in practice, narrowing the other two's `description` frontmatter is a follow-up, not a body rewrite.
- **No manifest change.** `plugin.json` and `marketplace.json` do not enumerate skills individually.
- No changeset — `packages/**` is untouched.

## Blocked on

**The guide is not live yet.** [website#444](https://github.com/CopilotKit/website/pull/444) is still open, so the URL currently serves the 404 page shown above. This skill is inert until that merges and deploys — at which point it works with no further change here. The sentinel means the pre-deploy state is a clean stop rather than a wrong answer, so merging early is safe; it just isn't useful yet.

## Validation

- `npx vitest run scripts/__tests__/sync-plugin-skills.test.ts` — 10 passed
- `pnpm run check:plugin-skills` — `plugin skill mirror in sync`, exit 0; `skills/channels-setup/` survives the orphan pass
- `npx oxfmt --check` on both changed TS files — clean
- `npx oxlint scripts/` — 0 errors
- `SKILL.md` frontmatter parsed with js-yaml: `name=channels-setup`, `version=1.0.0`, description 660 chars
- Soft-404 behaviour confirmed against production with the `curl` commands above

🤖 Generated with [Claude Code](https://claude.com/claude-code)