### PR TITLE
fix(channels): make managed Slack DM replies reliable

### DIFF
--- a/packages/channels-intelligence/src/delivery-adapter-final.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-final.test.ts
@@ -202,12 +202,12 @@ describe("DeliveryAdapter Slack cadence", () => {
       [
         expect.any(String),
         { kind: "slack.thread.status", status: "is thinking…" },
-        { charge: false },
+        { charge: false, bestEffort: true },
       ],
       [
         expect.any(String),
         { kind: "slack.thread.status", status: "" },
-        { charge: false },
+        { charge: false, bestEffort: true },
       ],
     ]);
   });

--- a/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
@@ -58,6 +58,7 @@ function setup(
     failStatus?: boolean;
     failStreamStart?: boolean;
     failStreamStop?: boolean;
+    dropStreamStartCapability?: boolean;
     surfaceKind?: PreparedChannelDelivery["surfaceKind"];
   } = {},
 ) {
@@ -94,6 +95,21 @@ function setup(
           packetId: value.packetId,
           phase: "failed",
           result: { error: "stream_start_failed", status: "failed" },
+        };
+      }
+      if (
+        options.dropStreamStartCapability &&
+        value.payload.kind === "slack.stream.start"
+      ) {
+        return {
+          deliveryId: value.deliveryId,
+          seq: value.seq,
+          packetId: value.packetId,
+          phase: "applied",
+          result: {
+            capabilityError: "slack_stream_unavailable",
+            surfaceKind: "direct_message",
+          },
         };
       }
       if (
@@ -286,6 +302,24 @@ test("preserves the managed Slack stream lifecycle without text chunks", async (
 
 test("falls back to legacy message creation when managed stream start fails", async () => {
   const fixture = setup(undefined, { failStreamStart: true });
+
+  try {
+    await fixture.adapter.stream(fixture.target, streamChunks("Hello"));
+
+    expect(fixture.payloads).toEqual([
+      { kind: "slack.stream.start", initialText: "Hello" },
+      { kind: "slack.message.create", text: "Hello" },
+    ]);
+  } finally {
+    fixture.teardown();
+  }
+});
+
+test("falls back to legacy creation when the gateway settles stream start as a dropped capability", async () => {
+  const fixture = setup(undefined, {
+    surfaceKind: "direct_message",
+    dropStreamStartCapability: true,
+  });
 
   try {
     await fixture.adapter.stream(fixture.target, streamChunks("Hello"));

--- a/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
+++ b/packages/channels-intelligence/src/delivery-adapter-slack-stream.test.ts
@@ -18,6 +18,7 @@ function preparedDelivery(
   capabilities: PreparedChannelDelivery["capabilities"] = [
     SLACK_STREAM_APPEND_FULL_TEXT_CAPABILITY,
   ],
+  surfaceKind: PreparedChannelDelivery["surfaceKind"] = "message",
 ): PreparedChannelDelivery {
   return {
     protocol: "channel_delivery_v1",
@@ -29,6 +30,7 @@ function preparedDelivery(
     appUserId: "slack:T1:U1",
     adapter: "slack",
     capabilities,
+    surfaceKind,
     turn: {
       eventId: "evt_slack_stream",
       receivedAt: "2026-07-29T17:00:00.000Z",
@@ -48,9 +50,20 @@ function preparedDelivery(
   };
 }
 
-function setup(capabilities?: PreparedChannelDelivery["capabilities"]) {
-  const delivery = preparedDelivery(capabilities);
+function setup(
+  capabilities?: PreparedChannelDelivery["capabilities"],
+  options: {
+    distinctMessageReferences?: boolean;
+    failStreamAppend?: boolean;
+    failStatus?: boolean;
+    failStreamStart?: boolean;
+    failStreamStop?: boolean;
+    surfaceKind?: PreparedChannelDelivery["surfaceKind"];
+  } = {},
+) {
+  const delivery = preparedDelivery(capabilities, options.surfaceKind);
   const payloads: ChannelProviderPayload[] = [];
+  let messageCreateCount = 0;
   const deliveryChannel: RealtimeGatewayDeliveryChannel = {
     joinReply: delivery,
     push: vi.fn(async (_event, value) => {
@@ -62,19 +75,76 @@ function setup(capabilities?: PreparedChannelDelivery["capabilities"]) {
         throw new TypeError("expected a provider delivery packet");
       }
       payloads.push(value.payload);
+      if (options.failStatus && value.payload.kind === "slack.thread.status") {
+        return {
+          deliveryId: value.deliveryId,
+          seq: value.seq,
+          packetId: value.packetId,
+          phase: "failed",
+          result: { error: "status_failed", status: "failed" },
+        };
+      }
+      if (
+        options.failStreamStart &&
+        value.payload.kind === "slack.stream.start"
+      ) {
+        return {
+          deliveryId: value.deliveryId,
+          seq: value.seq,
+          packetId: value.packetId,
+          phase: "failed",
+          result: { error: "stream_start_failed", status: "failed" },
+        };
+      }
+      if (
+        options.failStreamAppend &&
+        value.payload.kind === "slack.stream.append"
+      ) {
+        return {
+          deliveryId: value.deliveryId,
+          seq: value.seq,
+          packetId: value.packetId,
+          phase: "failed",
+          result: { error: "stream_append_failed", status: "failed" },
+        };
+      }
+      if (
+        options.failStreamStop &&
+        value.payload.kind === "slack.stream.stop"
+      ) {
+        return {
+          deliveryId: value.deliveryId,
+          seq: value.seq,
+          packetId: value.packetId,
+          phase: "failed",
+          result: { error: "stream_stop_failed", status: "failed" },
+        };
+      }
       return {
         deliveryId: value.deliveryId,
         seq: value.seq,
         packetId: value.packetId,
         phase: "applied",
-        result:
-          value.payload.kind === "slack.stream.start"
-            ? {
-                providerReference: "pref_v1_slack_stream_01",
-                providerMessageId:
-                  "pid_v1_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
-              }
-            : {},
+        result: (() => {
+          if (value.payload.kind === "slack.stream.start") {
+            return {
+              providerReference: "pref_v1_slack_stream_01",
+              providerMessageId:
+                "pid_v1_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+            };
+          }
+          if (value.payload.kind === "slack.message.create") {
+            messageCreateCount += 1;
+            return {
+              providerReference: options.distinctMessageReferences
+                ? `pref_v1_slack_legacy_${messageCreateCount}`
+                : "pref_v1_slack_stream_01",
+              providerMessageId:
+                "pid_v1_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ",
+            };
+          }
+          return {};
+        })(),
       };
     }),
     on: vi.fn(),
@@ -211,5 +281,260 @@ test("preserves the managed Slack stream lifecycle without text chunks", async (
     ]);
   } finally {
     fixture.teardown();
+  }
+});
+
+test("falls back to legacy message creation when managed stream start fails", async () => {
+  const fixture = setup(undefined, { failStreamStart: true });
+
+  try {
+    await fixture.adapter.stream(fixture.target, streamChunks("Hello"));
+
+    expect(fixture.payloads).toEqual([
+      { kind: "slack.stream.start", initialText: "Hello" },
+      { kind: "slack.message.create", text: "Hello" },
+    ]);
+  } finally {
+    fixture.teardown();
+  }
+});
+
+test("uses native streaming for a direct message surface", async () => {
+  const fixture = setup(undefined, { surfaceKind: "direct_message" });
+
+  try {
+    await fixture.adapter.stream(
+      fixture.target,
+      streamChunks("Hello", " world"),
+    );
+
+    expect(fixture.payloads).toEqual([
+      { kind: "slack.stream.start", initialText: "Hello" },
+      {
+        kind: "slack.stream.append",
+        providerReference: "pref_v1_slack_stream_01",
+        delta: " world",
+        fullText: "Hello world",
+      },
+      {
+        kind: "slack.stream.stop",
+        providerReference: "pref_v1_slack_stream_01",
+      },
+    ]);
+  } finally {
+    fixture.teardown();
+  }
+});
+
+test("starts direct-message status before a threaded native stream", async () => {
+  vi.useFakeTimers();
+  const fixture = setup(undefined, { surfaceKind: "direct_message" });
+
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+    await renderer.subscriber.onRunStartedEvent?.({ event: {} } as never);
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: "Hello",
+      },
+      textMessageBuffer: "",
+    } as never);
+    await renderer.finish?.();
+
+    expect(fixture.payloads[0]).toEqual({
+      kind: "slack.thread.status",
+      status: "is thinking…",
+    });
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.start",
+      initialText: "Hello",
+    });
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("continues a direct-message native reply after status failure", async () => {
+  vi.useFakeTimers();
+  const fixture = setup(undefined, {
+    failStatus: true,
+    surfaceKind: "direct_message",
+  });
+
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+    await renderer.subscriber.onRunStartedEvent?.({ event: {} } as never);
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: "Hello",
+      },
+      textMessageBuffer: "",
+    } as never);
+    await renderer.finish?.();
+
+    expect(fixture.payloads[0]).toEqual({
+      kind: "slack.thread.status",
+      status: "is thinking…",
+    });
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.start",
+      initialText: "Hello",
+    });
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("rejects a direct-message reply after a native append failure and stops the stream", async () => {
+  vi.useFakeTimers();
+  const fixture = setup(undefined, {
+    failStreamAppend: true,
+    surfaceKind: "direct_message",
+  });
+
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: "Hello",
+      },
+      textMessageBuffer: "",
+    } as never);
+    await vi.runAllTimersAsync();
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: " world",
+      },
+      textMessageBuffer: "Hello",
+    } as never);
+
+    await expect(renderer.finish?.()).rejects.toThrow("stream_append_failed");
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.start",
+      initialText: "Hello",
+    });
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.stop",
+      providerReference: "pref_v1_slack_stream_01",
+    });
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("rejects a direct-message reply when native stream stop fails", async () => {
+  vi.useFakeTimers();
+  const fixture = setup(undefined, {
+    failStreamStop: true,
+    surfaceKind: "direct_message",
+  });
+
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: "Hello",
+      },
+      textMessageBuffer: "",
+    } as never);
+
+    await expect(renderer.finish?.()).rejects.toThrow("stream_stop_failed");
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.start",
+      initialText: "Hello",
+    });
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.stop",
+      providerReference: "pref_v1_slack_stream_01",
+    });
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("starts a long direct-message reply through the native stream", async () => {
+  vi.useFakeTimers();
+  const fixture = setup(undefined, { surfaceKind: "direct_message" });
+  const text = "x".repeat(3_501);
+
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: text,
+      },
+      textMessageBuffer: "",
+    } as never);
+    await renderer.finish?.();
+
+    expect(fixture.payloads).toContainEqual({
+      kind: "slack.stream.start",
+      initialText: text,
+    });
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("uses matching legacy references for a long direct-message fallback", async () => {
+  vi.useFakeTimers();
+  const fixture = setup(undefined, {
+    distinctMessageReferences: true,
+    failStreamStart: true,
+    surfaceKind: "direct_message",
+  });
+  const text = "x".repeat(3_501);
+
+  try {
+    const renderer = fixture.adapter.createRunRenderer(fixture.target);
+    renderer.subscriber.onTextMessageContentEvent?.({
+      event: {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "message-1",
+        delta: text,
+      },
+      textMessageBuffer: "",
+    } as never);
+    await renderer.finish?.();
+
+    const creates = fixture.payloads.filter(
+      (payload) => payload.kind === "slack.message.create",
+    );
+    const replaces = fixture.payloads.filter(
+      (payload) => payload.kind === "slack.message.replace",
+    );
+    expect(creates).toHaveLength(2);
+    expect(replaces).toEqual([
+      {
+        kind: "slack.message.replace",
+        providerReference: "pref_v1_slack_legacy_1",
+        text: text.slice(0, 3_500),
+      },
+      {
+        kind: "slack.message.replace",
+        providerReference: "pref_v1_slack_legacy_2",
+        text: text.slice(3_500),
+      },
+    ]);
+  } finally {
+    fixture.teardown();
+    vi.useRealTimers();
   }
 });

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -574,6 +574,7 @@ export class DeliveryAdapter implements PlatformAdapter {
     let providerReference: string | undefined;
     let providerMessageId: string | undefined;
     if (target.delivery.adapter === "slack") {
+      let legacy = false;
       let bodyError: unknown;
       let bodyFailed = false;
       let streamStarted = false;
@@ -582,14 +583,46 @@ export class DeliveryAdapter implements PlatformAdapter {
         for await (const delta of chunks) {
           if (delta.length === 0) continue;
           fullText += delta;
+          if (legacy) {
+            const result = providerReference
+              ? await target.claimedDelivery.effect(responseId, {
+                  kind: "slack.message.replace",
+                  providerReference,
+                  text: fullText,
+                })
+              : await target.claimedDelivery.effect(responseId, {
+                  kind: "slack.message.create",
+                  text: fullText,
+                });
+            if (!providerReference) {
+              ({ providerReference, providerMessageId } =
+                providerMessageResultFromResult(result));
+            }
+            continue;
+          }
           if (!streamStarted) {
-            const startResult = await target.claimedDelivery.effect(
-              responseId,
-              {
-                kind: "slack.stream.start",
-                initialText: delta,
-              },
-            );
+            let startResult: Record<string, unknown>;
+            try {
+              startResult = await target.claimedDelivery.effect(
+                responseId,
+                {
+                  kind: "slack.stream.start",
+                  initialText: delta,
+                },
+                { bestEffort: true },
+              );
+            } catch {
+              // A start-only failure is recoverable because no native stream
+              // exists yet. The legacy create below remains a hard failure.
+              legacy = true;
+              const result = await target.claimedDelivery.effect(responseId, {
+                kind: "slack.message.create",
+                text: fullText,
+              });
+              ({ providerReference, providerMessageId } =
+                providerMessageResultFromResult(result));
+              continue;
+            }
             streamStarted = true;
             ({ providerReference, providerMessageId } =
               providerMessageResultFromResult(startResult));
@@ -606,13 +639,21 @@ export class DeliveryAdapter implements PlatformAdapter {
             ),
           );
         }
-        if (!streamStarted) {
-          const startResult = await target.claimedDelivery.effect(responseId, {
-            kind: "slack.stream.start",
-          });
-          streamStarted = true;
-          ({ providerReference, providerMessageId } =
-            providerMessageResultFromResult(startResult));
+        if (!streamStarted && !legacy) {
+          try {
+            const startResult = await target.claimedDelivery.effect(
+              responseId,
+              { kind: "slack.stream.start" },
+              { bestEffort: true },
+            );
+            streamStarted = true;
+            ({ providerReference, providerMessageId } =
+              providerMessageResultFromResult(startResult));
+          } catch {
+            // An empty start has no native output to preserve. The final
+            // message-create path below remains a hard failure.
+            legacy = true;
+          }
         }
       } catch (error) {
         bodyFailed = true;
@@ -904,6 +945,7 @@ export class DeliveryAdapter implements PlatformAdapter {
   ): RunRenderer {
     let providerReference: string | undefined;
     let fullText = "";
+    const legacyProviderReferences = new Map<string, string>();
     return createSlackRunRenderer({
       target: { channel: "managed", threadTs: "managed" },
       showToolStatus: this.options.showToolStatus ?? false,
@@ -917,23 +959,28 @@ export class DeliveryAdapter implements PlatformAdapter {
               status,
               ...(loadingMessages !== undefined ? { loadingMessages } : {}),
             },
-            { charge: false },
+            { charge: false, bestEffort: true },
           );
         },
         postMessage: async ({ text: message }) => {
-          providerReference = providerReferenceFromResult(
-            await claimedDelivery.effect(responseId, {
-              kind: "slack.message.create",
-              text: message,
-            }),
+          const localMessageId = mintId("slack_legacy_");
+          legacyProviderReferences.set(
+            localMessageId,
+            providerReferenceFromResult(
+              await claimedDelivery.effect(responseId, {
+                kind: "slack.message.create",
+                text: message,
+              }),
+            ),
           );
-          return { ts: responseId };
+          return { ts: localMessageId };
         },
-        updateMessage: async ({ text: message }) => {
-          assertProviderReference(providerReference);
+        updateMessage: async ({ ts, text: message }) => {
+          const legacyProviderReference = legacyProviderReferences.get(ts);
+          assertProviderReference(legacyProviderReference);
           await claimedDelivery.effect(responseId, {
             kind: "slack.message.replace",
-            providerReference,
+            providerReference: legacyProviderReference,
             text: message,
           });
         },
@@ -948,19 +995,22 @@ export class DeliveryAdapter implements PlatformAdapter {
           startStream: async () => {
             fullText = "";
             providerReference = providerReferenceFromResult(
-              await claimedDelivery.effect(responseId, {
-                kind: "slack.stream.start",
-              }),
+              await claimedDelivery.effect(
+                responseId,
+                { kind: "slack.stream.start" },
+                { bestEffort: true },
+              ),
             );
             return responseId;
           },
           startStreamWithText: async (initialText) => {
             fullText = initialText;
             providerReference = providerReferenceFromResult(
-              await claimedDelivery.effect(responseId, {
-                kind: "slack.stream.start",
-                initialText,
-              }),
+              await claimedDelivery.effect(
+                responseId,
+                { kind: "slack.stream.start", initialText },
+                { bestEffort: true },
+              ),
             );
             return responseId;
           },

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -601,9 +601,8 @@ export class DeliveryAdapter implements PlatformAdapter {
             continue;
           }
           if (!streamStarted) {
-            let startResult: Record<string, unknown>;
             try {
-              startResult = await target.claimedDelivery.effect(
+              const startResult = await target.claimedDelivery.effect(
                 responseId,
                 {
                   kind: "slack.stream.start",
@@ -611,6 +610,11 @@ export class DeliveryAdapter implements PlatformAdapter {
                 },
                 { bestEffort: true },
               );
+              // A gateway capability drop settles as applied without a
+              // provider reference; the parse throw takes the legacy path.
+              ({ providerReference, providerMessageId } =
+                providerMessageResultFromResult(startResult));
+              streamStarted = true;
             } catch {
               // A start-only failure is recoverable because no native stream
               // exists yet. The legacy create below remains a hard failure.
@@ -621,11 +625,7 @@ export class DeliveryAdapter implements PlatformAdapter {
               });
               ({ providerReference, providerMessageId } =
                 providerMessageResultFromResult(result));
-              continue;
             }
-            streamStarted = true;
-            ({ providerReference, providerMessageId } =
-              providerMessageResultFromResult(startResult));
             continue;
           }
           assertProviderReference(providerReference);
@@ -646,9 +646,9 @@ export class DeliveryAdapter implements PlatformAdapter {
               { kind: "slack.stream.start" },
               { bestEffort: true },
             );
-            streamStarted = true;
             ({ providerReference, providerMessageId } =
               providerMessageResultFromResult(startResult));
+            streamStarted = true;
           } catch {
             // An empty start has no native output to preserve. The final
             // message-create path below remains a hard failure.

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -1716,3 +1716,72 @@ test("surfaces a failed provider result as an already-terminal error", async () 
   });
   expect(session.hasProviderOutput()).toBe(false);
 });
+
+test("keeps effects open after a best-effort provider failure", async () => {
+  const deliveryChannel = channel();
+  vi.mocked(deliveryChannel.push)
+    .mockImplementationOnce((_event, packet) =>
+      Promise.resolve(
+        acknowledgement(packet, {
+          phase: "failed",
+          result: { error: "stream_start_failed", status: "failed" },
+        }),
+      ),
+    )
+    .mockImplementation((_event, packet) =>
+      Promise.resolve(acknowledgement(packet)),
+    );
+  const session = new ClaimedChannelDelivery(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  const error = await session
+    .effect("response_01", { kind: "slack.stream.start" }, { bestEffort: true })
+    .catch((caught: unknown) => caught);
+
+  expect(error).toBeInstanceOf(Error);
+  expect(error).not.toBeInstanceOf(ChannelDeliveryTerminatedError);
+  await expect(
+    session.effect("response_01", {
+      kind: "slack.message.create",
+      text: "Hello",
+    }),
+  ).resolves.toMatchObject({ providerReference: "pref_v1_message_01" });
+});
+
+test("does not terminate delivery after a failed Slack status", async () => {
+  const deliveryChannel = channel();
+  vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) =>
+    Promise.resolve(
+      acknowledgement(packet, {
+        phase: "failed",
+        result: { error: "status_failed", status: "failed" },
+      }),
+    ),
+  );
+  const session = new ClaimedChannelDelivery(
+    preparedDelivery(),
+    {
+      ownerGeneration: 7,
+      runtimeInstanceId: "rti_runtime_01",
+    },
+    deliveryChannel,
+    vi.fn(),
+  );
+
+  const error = await session
+    .effect("response_01", {
+      kind: "slack.thread.status",
+      status: "is thinking…",
+    })
+    .catch((caught: unknown) => caught);
+
+  expect(error).toBeInstanceOf(Error);
+  expect(error).not.toBeInstanceOf(ChannelDeliveryTerminatedError);
+});

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -345,7 +345,7 @@ export class ClaimedChannelDelivery {
   effect(
     _responseId: string,
     payload: ProviderPayloadInput,
-    options: { charge?: boolean } = {},
+    options: { charge?: boolean; bestEffort?: boolean } = {},
   ): Promise<Record<string, unknown>> {
     if (isVisibleProviderEffect(payload)) {
       this.providerOutputExpected = true;
@@ -363,7 +363,7 @@ export class ClaimedChannelDelivery {
     const charged =
       options.charge === false ? Promise.resolve() : this.charge();
     return charged
-      .then(() => this.enqueue(payload))
+      .then(() => this.enqueue(payload, options.bestEffort === true))
       .then((result) => {
         const error =
           typeof result.error === "string" ? result.error : undefined;
@@ -375,6 +375,14 @@ export class ClaimedChannelDelivery {
           status === "failed_before_output" ||
           status === "uncertain"
         ) {
+          if (
+            options.bestEffort === true ||
+            payload.kind === "slack.thread.status"
+          ) {
+            throw new Error(
+              `Channel provider effect failed with ${error ?? "provider_failed"}`,
+            );
+          }
           this.effectsClosed = true;
           throw new ChannelProviderDeliveryError(
             error ?? "provider_failed",
@@ -582,6 +590,7 @@ export class ClaimedChannelDelivery {
 
   private enqueue(
     payload: ChannelDeliveryPayload,
+    bestEffort = false,
   ): Promise<Record<string, unknown>> {
     const isTerminal = payload.kind === "channel.delivery.terminal";
     // Stream stop must remain sendable after mid-stream effect failure so
@@ -613,7 +622,11 @@ export class ClaimedChannelDelivery {
         return acknowledgement.result;
       } catch (error) {
         this.unacknowledgedPacket = undefined;
-        if (!isCleanupPacket) {
+        if (
+          !isCleanupPacket &&
+          !bestEffort &&
+          payload.kind !== "slack.thread.status"
+        ) {
           this.effectsClosed = true;
         }
         throw error;

--- a/packages/channels-slack/src/__tests__/native-stream.test.ts
+++ b/packages/channels-slack/src/__tests__/native-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { NativeMessageStream } from "../native-stream.js";
 import type { NativeStreamTransport, TextStream } from "../native-stream.js";
+import { ChunkedMessageStream } from "../chunked-message-stream.js";
 import type { AnyChunk, KnownBlock } from "@slack/types";
 
 type Event =
@@ -774,7 +775,38 @@ describe("NativeMessageStream", () => {
     expect(fallback.finished).toBe(true);
   });
 
-  it("strict mode rejects a start failure without creating a legacy bubble", async () => {
+  it("observes a rejected legacy fallback queue before finish drains it", async () => {
+    const { transport } = makeFakeTransport({ failStart: true });
+    const fallback = new ChunkedMessageStream({
+      minIntervalMs: 0,
+      postPlaceholder: async () => {
+        throw new Error("legacy post unavailable");
+      },
+      updateAt: async () => undefined,
+    });
+    const stream = new NativeMessageStream({
+      transport,
+      fallback: () => fallback,
+      minIntervalMs: 0,
+    });
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.prependListener("unhandledRejection", onUnhandled);
+
+    try {
+      stream.append("managed reply");
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandled).toEqual([]);
+      await expect(stream.finish()).rejects.toThrow("legacy post unavailable");
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  it("strict mode falls back before the first native stream opens", async () => {
     const { transport } = makeFakeTransport({ failStart: true });
     const fallback = makeFakeFallback();
     const stream = new NativeMessageStream({
@@ -786,12 +818,12 @@ describe("NativeMessageStream", () => {
 
     stream.append("managed reply");
 
-    await expect(stream.finish()).rejects.toThrow("startStream unavailable");
-    expect(fallback.last()).toBe("");
-    expect(fallback.finished).toBe(false);
+    await expect(stream.finish()).resolves.toBeUndefined();
+    expect(fallback.last()).toBe("managed reply");
+    expect(fallback.finished).toBe(true);
   });
 
-  it("observes a queued strict failure before finish drains it", async () => {
+  it("observes a queued strict start fallback before finish drains it", async () => {
     const { transport } = makeFakeTransport({ failStart: true });
     const stream = new NativeMessageStream({
       transport,
@@ -807,11 +839,11 @@ describe("NativeMessageStream", () => {
 
     try {
       stream.append("managed reply");
-      // Let the queued start failure reject before the owner reaches finish().
+      // Let the queued start fallback settle before the owner reaches finish().
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(unhandled).toEqual([]);
-      await expect(stream.finish()).rejects.toThrow("startStream unavailable");
+      await expect(stream.finish()).resolves.toBeUndefined();
     } finally {
       process.off("unhandledRejection", onUnhandled);
     }

--- a/packages/channels-slack/src/chunked-message-stream.ts
+++ b/packages/channels-slack/src/chunked-message-stream.ts
@@ -87,6 +87,9 @@ export class ChunkedMessageStream {
     this.setupPromise = this.setupPromise.then(() =>
       this.ensureStreamsAndDispatch(),
     );
+    // append() is synchronous, so observe rejection now. finish() still awaits
+    // the original promise and reports the same failure to the caller.
+    void this.setupPromise.catch(() => undefined);
   }
 
   async finish(): Promise<void> {

--- a/packages/channels-slack/src/event-renderer.ts
+++ b/packages/channels-slack/src/event-renderer.ts
@@ -111,8 +111,8 @@ export function createRunRenderer(args: {
   nativeStreaming?: {
     transport: NativeStreamTransport;
     /**
-     * Require native text delivery. Start, append, and stop failures propagate
-     * instead of creating or updating a second legacy message.
+     * Require native text delivery after the first native stream opens. A
+     * first-start failure still uses the legacy message transport.
      */
     strict?: boolean;
     /** Override the native text flush floor. */

--- a/packages/channels-slack/src/native-stream.ts
+++ b/packages/channels-slack/src/native-stream.ts
@@ -32,10 +32,10 @@
  * unavailable), the stream transparently rebuilds itself on the supplied
  * legacy `fallback()` transport and replays the buffer there. `onStartFailure`
  * lets the adapter mark the workspace legacy so subsequent streams skip the
- * native path entirely. Per-`appendStream` failures mid-stream are swallowed
- * (logged) like the legacy streamer's failed edits; a failing structured-chunk
- * append additionally fires `onChunkFailure` so the caller can degrade
- * tool-progress to its legacy surface.
+ * native path entirely. In strict mode, text append and stop failures after a
+ * native stream opens reject the caller. A failing structured-chunk append
+ * still fires `onChunkFailure` so the caller can degrade tool-progress to its
+ * legacy surface.
  *
  * Nothing here imports `@slack/web-api` — the Slack calls are injected as a
  * {@link NativeStreamTransport}, keeping the cadence logic unit-testable with
@@ -92,9 +92,9 @@ export interface NativeMessageStreamConfig {
    */
   onChunkFailure?: (err: unknown) => void;
   /**
-   * Fail the stream when required native text calls fail. This disables the
-   * legacy start fallback and makes append or stop failures visible to the
-   * caller. Structured task chunks remain optional and may still be dropped.
+   * Fail the stream when required native text calls fail after a native stream
+   * opens. The first native start always falls back to the legacy stream.
+   * Structured task chunks remain optional and may still be dropped.
    */
   strict?: boolean;
   /** Minimum gap between text flushes, in ms (defaults to 600). */
@@ -531,8 +531,8 @@ export class NativeMessageStream implements TextStream {
    * Open the message the next append should target — the reply's first message,
    * or a continuation after a {@link rollOver}.
    *
-   * A failure on the FIRST message falls back to the legacy transport ("opting
-   * in can never break a bot"). A failure on a *continuation* must not: the
+   * A failure on the FIRST message falls back to the legacy transport, even in
+   * strict mode. A failure on a *continuation* must not: the
    * legacy sink is seeded with the whole accumulated buffer, so failing over
    * mid-reply would re-post every character already streamed. It propagates
    * instead, leaving the boundary intact so the next flush retries the
@@ -572,7 +572,6 @@ export class NativeMessageStream implements TextStream {
       this.curMessageBytes = 0;
       return true;
     } catch (err) {
-      if (this.strict) throw err;
       this.failOverToLegacy(err);
       return false;
     }
@@ -685,7 +684,6 @@ export class NativeMessageStream implements TextStream {
       this.curMessageBytes = utf8Length(initialText);
       return true;
     } catch (err) {
-      if (this.strict) throw err;
       this.failOverToLegacy(err);
       return false;
     }


### PR DESCRIPTION
## Summary

- Start managed Slack DM status in the Slack thread. The server uses `messageTs` as the native status and streaming anchor.
- Use legacy message create and replace only when native stream start fails. After native output opens, append and stop errors fail the run.
- Keep a separate provider reference for each legacy long-message chunk.

## Test plan

- Fresh `@copilotkit/channels-slack` package tests: 383 passed.
- Fresh `@copilotkit/channels-intelligence` package tests: 192 passed.
- Type checks passed for both packages.
- Builds passed for both packages.
- Formatter check passed.
- `git diff --check` passed.

No live Slack testing was run.