### PR TITLE
fix(runtime): ignore late lock renewal failures

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/intelligence-lock-heartbeat.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/intelligence-lock-heartbeat.test.ts
@@ -1,0 +1,162 @@
+import type { BaseEvent, RunAgentInput, RunAgentResult } from "@ag-ui/client";
+import { AbstractAgent } from "@ag-ui/client";
+import type { Subscriber } from "rxjs";
+import { EMPTY, Observable } from "rxjs";
+import { expect, test, vi } from "vitest";
+
+import { CopilotIntelligenceRuntime } from "../core/runtime";
+import { handleIntelligenceRun } from "../handlers/intelligence/run";
+import { CopilotKitIntelligence } from "../intelligence-platform/client";
+import type {
+  AgentRunnerConnectRequest,
+  AgentRunnerIsRunningRequest,
+  AgentRunnerRunRequest,
+  AgentRunnerStopRequest,
+} from "../runner/agent-runner";
+import { AgentRunner } from "../runner/agent-runner";
+
+class HeartbeatTestAgent extends AbstractAgent {
+  readonly abortRun = vi.fn();
+
+  async runAgent(): Promise<RunAgentResult> {
+    return { result: undefined, newMessages: [] };
+  }
+
+  clone(): AbstractAgent {
+    return new HeartbeatTestAgent();
+  }
+
+  run(): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+
+  protected connect(): ReturnType<AbstractAgent["connect"]> {
+    return EMPTY;
+  }
+}
+
+class ControllableRunner extends AgentRunner {
+  private subscriber?: Subscriber<BaseEvent>;
+
+  run(_request: AgentRunnerRunRequest): Observable<BaseEvent> {
+    return new Observable<BaseEvent>((subscriber) => {
+      this.subscriber = subscriber;
+    });
+  }
+
+  connect(_request: AgentRunnerConnectRequest): Observable<BaseEvent> {
+    return EMPTY;
+  }
+
+  async isRunning(_request: AgentRunnerIsRunningRequest): Promise<boolean> {
+    return false;
+  }
+
+  async stop(_request: AgentRunnerStopRequest): Promise<boolean> {
+    return false;
+  }
+
+  complete(): void {
+    if (!this.subscriber) {
+      throw new Error("Runner has not started.");
+    }
+    this.subscriber.complete();
+  }
+}
+
+class DeferredRenewalIntelligence extends CopilotKitIntelligence {
+  readonly renewalStarted: Promise<void>;
+  private markRenewalStarted!: () => void;
+  private rejectPendingRenewal?: (error: Error) => void;
+
+  constructor() {
+    super({
+      apiKey: "test-api-key",
+      apiUrl: "https://intelligence.example",
+      wsUrl: "wss://intelligence.example",
+    });
+
+    this.renewalStarted = new Promise((resolve) => {
+      this.markRenewalStarted = resolve;
+    });
+  }
+
+  override async getOrCreateThread() {
+    return {
+      thread: { id: "thread-1", name: "Thread One" },
+      created: false,
+    };
+  }
+
+  override async getThreadMessages() {
+    return { messages: [] };
+  }
+
+  override async ɵacquireThreadLock() {
+    return {
+      threadId: "thread-1",
+      runId: "run-1",
+      joinToken: "join-token-1",
+    };
+  }
+
+  override async ɵrenewThreadLock() {
+    this.markRenewalStarted();
+    return new Promise<{ ttlSeconds: number }>((_resolve, reject) => {
+      this.rejectPendingRenewal = reject;
+    });
+  }
+
+  rejectRenewal(error: Error): void {
+    if (!this.rejectPendingRenewal) {
+      throw new Error("No renewal is pending.");
+    }
+    this.rejectPendingRenewal(error);
+  }
+}
+
+test("does not abort a completed run when an in-flight lock renewal fails", async () => {
+  vi.useFakeTimers();
+  const agent = new HeartbeatTestAgent();
+  const runner = new ControllableRunner();
+  const intelligence = new DeferredRenewalIntelligence();
+  const runtime = new CopilotIntelligenceRuntime({
+    agents: { "test-agent": agent },
+    intelligence,
+    identifyUser: async () => ({ id: "user-1", name: "User One" }),
+    lockHeartbeatIntervalSeconds: 1,
+    lockTtlSeconds: 5,
+  });
+  runtime.runner = runner;
+  const input: RunAgentInput = {
+    threadId: "thread-1",
+    runId: "run-1",
+    state: {},
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  };
+
+  try {
+    const response = await handleIntelligenceRun({
+      runtime,
+      request: new Request("https://runtime.example/agent/test-agent/run"),
+      agentId: "test-agent",
+      agent,
+      input,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await intelligence.renewalStarted;
+    runner.complete();
+
+    intelligence.rejectRenewal(new Error("lost lock"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(response.status).toBe(200);
+    expect(agent.abortRun).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -195,6 +195,7 @@ export async function handleIntelligenceRun({
   telemetry.capture("oss.runtime.agent_execution_stream_started", {});
 
   // Start heartbeat timer to renew the thread lock.
+  let heartbeatStopped = false;
   let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
   heartbeatTimer = setInterval(() => {
     runtime.intelligence
@@ -207,6 +208,10 @@ export async function handleIntelligenceRun({
           : {}),
       })
       .catch((err) => {
+        if (heartbeatStopped) {
+          return;
+        }
+
         logger.error("Failed to renew thread lock:", err);
         clearHeartbeat();
         try {
@@ -221,6 +226,7 @@ export async function handleIntelligenceRun({
   }, runtime.lockHeartbeatIntervalSeconds * 1_000);
 
   const clearHeartbeat = () => {
+    heartbeatStopped = true;
     if (heartbeatTimer !== undefined) {
       clearInterval(heartbeatTimer);
       heartbeatTimer = undefined;


### PR DESCRIPTION
## Summary

- stop handling in-flight lock renewal failures after the run has settled
- keep aborting when a renewal fails during an active run
- cover the completion-before-renewal race with a regression test

## Why

Intelligence releases the thread lock after it accepts a terminal run event. A renewal that was already in flight can then return a 409. Clearing the interval stops future renewals, but it does not cancel that pending promise, so Runtime logged an error and called `abortRun()` after the run had completed.

The lifecycle guard makes that late rejection a no-op. Active-run renewal failures still follow the existing abort path.

## Testing

- `pnpm nx test @copilotkit/runtime` — 1,866 tests passed
- `pnpm nx run @copilotkit/runtime:check-types`
- `pnpm nx build @copilotkit/runtime`
- `pnpm exec oxlint packages/runtime/src/v2/runtime/handlers/intelligence/run.ts packages/runtime/src/v2/runtime/__tests__/intelligence-lock-heartbeat.test.ts`
- `pnpm exec oxfmt --check packages/runtime/src/v2/runtime/handlers/intelligence/run.ts packages/runtime/src/v2/runtime/__tests__/intelligence-lock-heartbeat.test.ts`

The pre-commit hook also passed affected tests, `publint`, and `attw`. The repo-wide `pnpm check-format` still reports 25 unrelated files already present on `main`; both changed files pass the focused format check.
