### PR TITLE
fix(channels): reconnect after clean gateway close

### DIFF
--- a/packages/channels-intelligence/src/realtime-gateway.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.test.ts
@@ -176,9 +176,15 @@ function makeFakeWebSocket(
       });
     }
 
+    serverClose(code: number): void {
+      this.closed = true;
+      this.readyState = FakeWebSocket.CLOSED;
+      this.onclose?.({ code });
+    }
+
     close(): void {
       this.closed = true;
-      this.readyState = 3;
+      this.readyState = FakeWebSocket.CLOSED;
       this.onclose?.();
     }
   }
@@ -526,6 +532,33 @@ describe("connectRealtimeGateway — connection-health state (OSS-473)", () => {
     // the rejoin re-fires the join-push "ok" hook, restoring online.
     await waitUntil(() => states.includes("online"));
     expect(states[states.length - 1]).toBe("online");
+
+    session.disconnect();
+  });
+
+  it("recovers after an unexpected clean socket close", async () => {
+    const { FakeWebSocket, instances } = makeFakeWebSocket("ok");
+    const session = await connectRealtimeGateway({
+      wsUrl: "wss://gateway.example/channels",
+      apiKey: "cpk-test",
+      projectId: 7,
+      join: {
+        protocol: "channel_delivery_v1",
+        runtimeInstanceId: "rti_1",
+        channels: [{ channelName: "opentag", adapter: "slack" }],
+      },
+      webSocket: FakeWebSocket,
+    });
+    const states: RealtimeGatewayConnectionState[] = [];
+    session.onStateChange((state) => states.push(state));
+
+    instances[0]!.serverClose(1000);
+
+    expect(states).toContain("reconnecting");
+    await waitUntil(
+      () => instances.length === 2 && states[states.length - 1] === "online",
+    );
+    expect(instances).toHaveLength(2);
 
     session.disconnect();
   });

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -949,9 +949,16 @@ export async function connectRealtimeGateway(
   // A socket-level drop begins a reconnect episode; the "back online" signal
   // comes from a successful (re)join (the join-push `"ok"` hook above), NOT from
   // the socket merely reopening — the channel may still be rejoining.
-  socket.onClose(() => {
+  socket.onClose((event) => {
     notifyClose();
     enterReconnecting();
+    // Phoenix treats code 1000 as terminal and does not schedule its reconnect
+    // timer. For a live managed session, only our own disconnect is terminal.
+    if (!closingIntentionally && event?.code === 1000) {
+      socket.disconnect(() => {
+        if (!closingIntentionally) socket.connect();
+      });
+    }
   });
   socket.onError(() => {
     notifyClose();


### PR DESCRIPTION
## Summary

- replace Phoenix's retained closed transport when a live managed session receives an unexpected WebSocket close with code 1000
- reconnect and rejoin through the existing Phoenix channel lifecycle
- preserve intentional session disconnects as terminal
- cover the clean-close recovery path with a regression test

## Root cause

Phoenix 1.8.4 does not schedule its reconnect timer for close code 1000. CopilotKit still transitioned the managed session to `reconnecting`, so the runtime reported that Phoenix was retrying indefinitely even though Phoenix never created another transport.

## Impact

A brief gateway interruption that cleanly closes an established socket can now recover once the gateway is healthy, instead of leaving the runtime stuck and repeatedly logging the managed-session-down warning.

## Verification

- `pnpm nx run @copilotkit/channels-intelligence:test` — 188 tests passed
- `pnpm nx run @copilotkit/channels-intelligence:check-types` — passed
- `pnpm nx format:check --files=packages/channels-intelligence/src/realtime-gateway.ts,packages/channels-intelligence/src/realtime-gateway.test.ts` — passed
- repository pre-commit test, package validation, and lint gates — passed
