### PR TITLE
fix(channels): preserve Slack provider diagnostics

### DIFF
--- a/packages/channels-core/src/canonical-run-loop.test.ts
+++ b/packages/channels-core/src/canonical-run-loop.test.ts
@@ -382,8 +382,19 @@ test("managed renderer failure freezes later rendering while canonical ingestion
 });
 
 test("terminal delivery tool failure stops the loop and closes renderer fanout", async () => {
+  const details = {
+    category: "validation",
+    provider: "slack",
+    operation: "chat.postMessage",
+    effectKind: "slack.message.create",
+    providerCode: "invalid_blocks",
+    validationMessages: ["invalid field at /blocks/2/elements/0/children"],
+    retryable: false,
+    deliveryId: "dlv_delivery_1",
+  } as const;
   const deliveryError = new ChannelDeliveryTerminatedError(
     "provider delivery timed out",
+    { cause: details, details },
   );
   let agent!: FakeAgent;
   agent = new FakeAgent([
@@ -455,6 +466,14 @@ test("terminal delivery tool failure stops the loop and closes renderer fanout",
       )
       .map(({ type }) => type),
   ).toEqual([EventType.RUN_STARTED, EventType.RUN_ERROR]);
+  expect(
+    ingestedEvents.find(({ type }) => type === EventType.RUN_ERROR),
+  ).toMatchObject({
+    message: "provider delivery timed out",
+    category: "validation",
+    details,
+    cause: details,
+  });
 });
 
 test("inner RUN_ERROR becomes one canonical outer RUN_ERROR", async () => {

--- a/packages/channels-core/src/delivery-error.ts
+++ b/packages/channels-core/src/delivery-error.ts
@@ -7,13 +7,41 @@
 const CHANNEL_DELIVERY_TERMINATED = Symbol.for(
   "copilotkit.channels.deliveryTerminated",
 );
+const CHANNEL_DELIVERY_ERROR_DETAILS = Symbol.for(
+  "copilotkit.channels.deliveryErrorDetails",
+);
+
+/** Safe provider diagnostics that may cross the canonical AG-UI error path. */
+export interface ChannelDeliveryErrorDetails {
+  readonly category: "validation";
+  readonly provider: "slack" | "teams";
+  readonly operation: string;
+  readonly effectKind: string;
+  readonly providerCode: "invalid_arguments" | "invalid_blocks";
+  readonly validationMessages: readonly string[];
+  readonly retryable: false;
+  readonly deliveryId: string;
+}
+
+export interface ChannelDeliveryTerminatedErrorOptions extends ErrorOptions {
+  readonly details?: ChannelDeliveryErrorDetails;
+}
 
 export class ChannelDeliveryTerminatedError extends Error {
   readonly [CHANNEL_DELIVERY_TERMINATED] = true;
+  readonly [CHANNEL_DELIVERY_ERROR_DETAILS]?: ChannelDeliveryErrorDetails;
+  readonly details?: ChannelDeliveryErrorDetails;
 
-  constructor(message: string, options?: ErrorOptions) {
+  constructor(
+    message: string,
+    options?: ChannelDeliveryTerminatedErrorOptions,
+  ) {
     super(message, options);
     this.name = "ChannelDeliveryTerminatedError";
+    if (isChannelDeliveryErrorDetails(options?.details)) {
+      this.details = options.details;
+      this[CHANNEL_DELIVERY_ERROR_DETAILS] = options.details;
+    }
   }
 }
 
@@ -29,5 +57,57 @@ export function isChannelDeliveryTerminatedError(
     (error as { [CHANNEL_DELIVERY_TERMINATED]?: unknown })[
       CHANNEL_DELIVERY_TERMINATED
     ] === true
+  );
+}
+
+/** Return only diagnostics stamped by the Channel delivery boundary. */
+export function channelDeliveryErrorDetails(
+  error: unknown,
+): ChannelDeliveryErrorDetails | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  return (error as { [CHANNEL_DELIVERY_ERROR_DETAILS]?: unknown })[
+    CHANNEL_DELIVERY_ERROR_DETAILS
+  ] as ChannelDeliveryErrorDetails | undefined;
+}
+
+function isChannelDeliveryErrorDetails(
+  value: unknown,
+): value is ChannelDeliveryErrorDetails {
+  if (typeof value !== "object" || value === null) return false;
+  const details = value as Record<string, unknown>;
+  const allowed = new Set([
+    "category",
+    "provider",
+    "operation",
+    "effectKind",
+    "providerCode",
+    "validationMessages",
+    "retryable",
+    "deliveryId",
+  ]);
+  return (
+    Object.keys(details).every((field) => allowed.has(field)) &&
+    details.category === "validation" &&
+    (details.provider === "slack" || details.provider === "teams") &&
+    boundedString(details.operation, 80) &&
+    boundedString(details.effectKind, 80) &&
+    (details.providerCode === "invalid_arguments" ||
+      details.providerCode === "invalid_blocks") &&
+    details.retryable === false &&
+    boundedString(details.deliveryId, 512) &&
+    Array.isArray(details.validationMessages) &&
+    details.validationMessages.length <= 5 &&
+    details.validationMessages.every(
+      (message) =>
+        typeof message === "string" &&
+        message.length <= 256 &&
+        message.startsWith("invalid field at /"),
+    )
+  );
+}
+
+function boundedString(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && value.length <= maxLength
   );
 }

--- a/packages/channels-core/src/index.ts
+++ b/packages/channels-core/src/index.ts
@@ -158,8 +158,13 @@ export {
   ChannelMemoryUserRequiredError,
 } from "./thread.js";
 export {
+  channelDeliveryErrorDetails,
   ChannelDeliveryTerminatedError,
   isChannelDeliveryTerminatedError,
+} from "./delivery-error.js";
+export type {
+  ChannelDeliveryErrorDetails,
+  ChannelDeliveryTerminatedErrorOptions,
 } from "./delivery-error.js";
 
 // Pure per-platform codec seam shared with managed Intelligence delivery.

--- a/packages/channels-core/src/run-loop.ts
+++ b/packages/channels-core/src/run-loop.ts
@@ -21,7 +21,10 @@ import type {
   ContextEntry,
 } from "./tools.js";
 import { parseToolArgs, stringifyHandlerResult } from "./tools.js";
-import { isChannelDeliveryTerminatedError } from "./delivery-error.js";
+import {
+  channelDeliveryErrorDetails,
+  isChannelDeliveryTerminatedError,
+} from "./delivery-error.js";
 
 export interface RunLoopArgs {
   agent: AbstractAgent;
@@ -454,6 +457,7 @@ export async function runAgentLoop(
     );
     return hasDeliveryError ? { ...result, deliveryError } : result;
   } catch (error) {
+    const details = channelDeliveryErrorDetails(error);
     const runError: RunErrorEvent = {
       type: EventType.RUN_ERROR,
       threadId: args.canonicalRun.threadId,
@@ -465,7 +469,21 @@ export async function runAgentLoop(
       typeof error.code === "string"
         ? { code: error.code }
         : {}),
-    };
+      ...(details
+        ? {
+            category: details.category,
+            provider: details.provider,
+            operation: details.operation,
+            effectKind: details.effectKind,
+            providerCode: details.providerCode,
+            validationMessages: details.validationMessages,
+            retryable: details.retryable,
+            deliveryId: details.deliveryId,
+            details,
+            cause: details,
+          }
+        : {}),
+    } as RunErrorEvent;
     try {
       await emitCanonicalLifecycleEvent(
         runError,

--- a/packages/channels-intelligence/src/delivery-transport.test.ts
+++ b/packages/channels-intelligence/src/delivery-transport.test.ts
@@ -5,6 +5,7 @@ import {
   ChannelProviderDeliveryError,
   ClaimedChannelDelivery,
   ChannelDeliveryTransport,
+  safeChannelErrorMetadata,
 } from "./delivery-transport.js";
 import type { PreparedChannelDelivery } from "./delivery-transport.js";
 import type {
@@ -1446,7 +1447,6 @@ test("does not count stream.stop alone as provider output", async () => {
 });
 
 test("classifies timeout/expiry errors from message text", async () => {
-  const { safeChannelErrorMetadata } = await import("./delivery-transport.js");
   expect(
     safeChannelErrorMetadata(
       new Error("realtime gateway delivery join timed out"),
@@ -1649,12 +1649,27 @@ test("rejects raw provider ids in prepared text operations", async () => {
 });
 
 test("surfaces a failed provider result as an already-terminal error", async () => {
+  const details = {
+    category: "validation",
+    provider: "slack",
+    operation: "chat.postMessage",
+    effectKind: "slack.message.create",
+    providerCode: "invalid_blocks",
+    validationMessages: ["invalid field at /blocks/2/elements/0/children"],
+    retryable: false,
+    deliveryId: "dlv_delivery_01",
+  } as const;
   const deliveryChannel = channel();
   vi.mocked(deliveryChannel.push).mockImplementation((_event, packet) =>
     Promise.resolve(
       acknowledgement(packet, {
         phase: "failed",
-        result: { error: "provider_call_failed", status: "failed" },
+        result: {
+          error: "provider_call_failed",
+          status: "failed",
+          details,
+          unsafeProviderResponse: "must not escape the gateway",
+        },
       }),
     ),
   );
@@ -1676,5 +1691,28 @@ test("surfaces a failed provider result as an already-terminal error", async () 
     .catch((caught: unknown) => caught);
   expect(error).toBeInstanceOf(ChannelProviderDeliveryError);
   expect(error).toBeInstanceOf(ChannelDeliveryTerminatedError);
+  expect(error).toMatchObject({
+    code: "provider_call_failed",
+    status: "failed",
+    details,
+    category: "validation",
+    provider: "slack",
+    operation: "chat.postMessage",
+    effectKind: "slack.message.create",
+    providerCode: "invalid_blocks",
+    validationMessages: ["invalid field at /blocks/2/elements/0/children"],
+    retryable: false,
+    deliveryId: "dlv_delivery_01",
+    cause: details,
+  });
+  expect(error).not.toHaveProperty("unsafeProviderResponse");
+  expect(safeChannelErrorMetadata(error)).toEqual({
+    errorCategory: "validation",
+    provider: "slack",
+    operation: "chat.postMessage",
+    effectKind: "slack.message.create",
+    providerCode: "invalid_blocks",
+    retryable: false,
+  });
   expect(session.hasProviderOutput()).toBe(false);
 });

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -120,6 +120,17 @@ export interface PreparedChannelDelivery {
 
 type ProviderPayloadInput = ChannelProviderPayload;
 
+export interface ChannelProviderDeliveryDetails {
+  readonly category: "validation";
+  readonly provider: "slack" | "teams";
+  readonly operation: string;
+  readonly effectKind: string;
+  readonly providerCode: "invalid_arguments" | "invalid_blocks";
+  readonly validationMessages: readonly string[];
+  readonly retryable: false;
+  readonly deliveryId: string;
+}
+
 interface DeliveryOwner {
   readonly ownerGeneration: number;
   readonly runtimeInstanceId: string;
@@ -127,12 +138,35 @@ interface DeliveryOwner {
 
 /** Gateway result for a provider call that already recorded delivery terminal state. */
 export class ChannelProviderDeliveryError extends ChannelDeliveryTerminatedError {
+  readonly category?: ChannelProviderDeliveryDetails["category"];
+  readonly provider?: ChannelProviderDeliveryDetails["provider"];
+  readonly operation?: string;
+  readonly effectKind?: string;
+  readonly providerCode?: ChannelProviderDeliveryDetails["providerCode"];
+  readonly validationMessages?: readonly string[];
+  readonly retryable?: false;
+  readonly deliveryId?: string;
+
   constructor(
     readonly code: string,
     readonly status: string,
+    readonly details?: ChannelProviderDeliveryDetails,
   ) {
-    super(`Channel provider delivery ended with ${code}`);
+    super(
+      `Channel provider delivery ended with ${code}`,
+      details ? { cause: details, details } : undefined,
+    );
     this.name = "ChannelProviderDeliveryError";
+    if (details) {
+      this.category = details.category;
+      this.provider = details.provider;
+      this.operation = details.operation;
+      this.effectKind = details.effectKind;
+      this.providerCode = details.providerCode;
+      this.validationMessages = details.validationMessages;
+      this.retryable = details.retryable;
+      this.deliveryId = details.deliveryId;
+    }
   }
 }
 
@@ -345,6 +379,7 @@ export class ClaimedChannelDelivery {
           throw new ChannelProviderDeliveryError(
             error ?? "provider_failed",
             status,
+            parseProviderDeliveryDetails(result.details),
           );
         }
         const capabilityError =
@@ -704,7 +739,58 @@ export class ClaimedChannelDelivery {
     if (providerMessageId !== undefined) {
       assertProviderMessageId(providerMessageId);
     }
+    if (acknowledgement.result.details !== undefined) {
+      const details = parseProviderDeliveryDetails(
+        acknowledgement.result.details,
+      );
+      if (!details || details.deliveryId !== packet.deliveryId) {
+        throw new TypeError("Gateway returned unsafe provider diagnostics");
+      }
+    }
   }
+}
+
+function parseProviderDeliveryDetails(
+  value: unknown,
+): ChannelProviderDeliveryDetails | undefined {
+  if (
+    !isRecord(value) ||
+    !hasExactFields(value, [
+      "category",
+      "provider",
+      "operation",
+      "effectKind",
+      "providerCode",
+      "validationMessages",
+      "retryable",
+      "deliveryId",
+    ]) ||
+    value.category !== "validation" ||
+    (value.provider !== "slack" && value.provider !== "teams") ||
+    typeof value.operation !== "string" ||
+    value.operation.length === 0 ||
+    value.operation.length > 80 ||
+    typeof value.effectKind !== "string" ||
+    value.effectKind.length === 0 ||
+    value.effectKind.length > 80 ||
+    (value.providerCode !== "invalid_arguments" &&
+      value.providerCode !== "invalid_blocks") ||
+    value.retryable !== false ||
+    typeof value.deliveryId !== "string" ||
+    value.deliveryId.length === 0 ||
+    value.deliveryId.length > 512 ||
+    !Array.isArray(value.validationMessages) ||
+    value.validationMessages.length > 5 ||
+    !value.validationMessages.every(
+      (message) =>
+        typeof message === "string" &&
+        message.length <= 256 &&
+        message.startsWith("invalid field at /"),
+    )
+  ) {
+    return undefined;
+  }
+  return value as unknown as ChannelProviderDeliveryDetails;
 }
 
 function restorePreparedTriggerFiles(
@@ -1195,7 +1281,22 @@ export function safeChannelErrorMetadata(error: unknown): {
     | "validation"
     | "conflict"
     | "unknown";
+  provider?: "slack" | "teams";
+  operation?: string;
+  effectKind?: string;
+  providerCode?: "invalid_arguments" | "invalid_blocks";
+  retryable?: false;
 } {
+  if (error instanceof ChannelProviderDeliveryError && error.details) {
+    return {
+      errorCategory: error.details.category,
+      provider: error.details.provider,
+      operation: error.details.operation,
+      effectKind: error.details.effectKind,
+      providerCode: error.details.providerCode,
+      retryable: error.details.retryable,
+    };
+  }
   const value = error as {
     name?: unknown;
     code?: unknown;

--- a/packages/channels-intelligence/src/index.ts
+++ b/packages/channels-intelligence/src/index.ts
@@ -52,7 +52,11 @@ export { IntelligenceStateStore } from "./intelligence-state-store.js";
 export type { IntelligenceStateStoreConfig } from "./intelligence-state-store.js";
 
 export { ChannelDeliveryTranscriptError } from "./delivery-transcript.js";
-export { ChannelProviderMismatchError } from "./delivery-transport.js";
+export {
+  ChannelProviderDeliveryError,
+  ChannelProviderMismatchError,
+} from "./delivery-transport.js";
+export type { ChannelProviderDeliveryDetails } from "./delivery-transport.js";
 export { ChannelFileDeliveryUnknownError } from "./delivery-adapter.js";
 export type {
   ChannelDeliveryTranscript,

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -174,6 +174,22 @@ top-level elements, and messages over Slack's 50-block limit. `Slack.Raw`
 accepts a reviewed Block Kit object but does not bind callbacks. Direct Slack
 and managed Slack use the same serializer and fallback-text rules.
 
+Card buttons belong in `actions`, and Carousel cards belong in `elements`.
+The shared renderer checks both shapes before direct or managed delivery and
+reports invalid fields with a JSON pointer.
+
+```tsx
+const approve = Slack.Element.Button({
+  text: <Slack.Object.PlainText text="Approve" />,
+});
+const card = Slack.Block.Card({
+  title: <Slack.Object.MarkdownText text="*Deploy ready*" />,
+  actions: [approve],
+});
+
+await thread.post(<Slack.Block.Carousel elements={[card]} />);
+```
+
 The generated [native catalog](../channels/native-catalogs.md) lists the 20
 message blocks and all exported elements and objects. Run
 `pnpm audit:channel-native-catalogs` to compare it with Slack's live docs.

--- a/packages/channels-slack/src/__tests__/event-renderer.test.ts
+++ b/packages/channels-slack/src/__tests__/event-renderer.test.ts
@@ -317,6 +317,32 @@ describe("createRunRenderer", () => {
     expect(fake.posts[0]?.thread_ts).toBe("100.0");
   });
 
+  it("logs a failed best-effort error notice at debug level", async () => {
+    const failure = new Error("Slack cleanup failed");
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const transport: SlackRenderTransport = {
+      postMessage: vi.fn(async () => Promise.reject(failure)),
+      updateMessage: vi.fn(async () => {}),
+    };
+    const { subscriber } = createRunRenderer({
+      transport,
+      target: { channel: "C1", threadTs: "100.0" },
+    });
+
+    await subscriber.onRunErrorEvent!({
+      event: { message: "primary failure" },
+    } as never);
+
+    expect(debug).toHaveBeenCalledWith(
+      "[slack-renderer] error notice failed:",
+      failure,
+    );
+    expect(error).not.toHaveBeenCalled();
+    debug.mockRestore();
+    error.mockRestore();
+  });
+
   it("markInterrupted: appends _(interrupted)_ to a partial reply and finalises", async () => {
     const fake = makeFakeClient();
     const { subscriber, markInterrupted } = createRunRenderer({
@@ -485,6 +511,32 @@ describe("createRunRenderer — native status mode", () => {
       loading_messages: ["a"],
       thread_ts: "100.0",
     });
+  });
+
+  it("logs a failed best-effort status update at debug level", async () => {
+    const failure = new Error("Slack status cleanup failed");
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const transport: SlackRenderTransport = {
+      setStatus: vi.fn(async () => Promise.reject(failure)),
+      postMessage: vi.fn(async () => ({ ts: "1.000" })),
+      updateMessage: vi.fn(async () => {}),
+    };
+    const { subscriber } = createRunRenderer({
+      transport,
+      target: { channel: "D1" },
+      status: { threadTs: "100.0", isPane: true, config: {} },
+    });
+
+    await subscriber.onRunStartedEvent!({} as never);
+
+    expect(debug).toHaveBeenCalledWith(
+      "[slack-renderer] setStatus failed:",
+      failure,
+    );
+    expect(error).not.toHaveBeenCalled();
+    debug.mockRestore();
+    error.mockRestore();
   });
 
   it("surfaces tool calls as live status, not :wrench: rows", async () => {

--- a/packages/channels-slack/src/block-kit-validation.ts
+++ b/packages/channels-slack/src/block-kit-validation.ts
@@ -1,0 +1,102 @@
+const CARD_FIELDS = new Set([
+  "type",
+  "block_id",
+  "hero_image",
+  "icon",
+  "title",
+  "subtitle",
+  "body",
+  "actions",
+  "slack_icon",
+  "subtext",
+]);
+const CAROUSEL_FIELDS = new Set(["type", "block_id", "elements"]);
+
+/** Validate Card and Carousel blocks before any Slack provider call. */
+export function validateSlackBlockKit(blocks: readonly unknown[]): void {
+  blocks.forEach((block, index) => validateBlock(block, `/blocks/${index}`));
+}
+
+function validateBlock(value: unknown, path: string): void {
+  if (!isRecord(value)) return;
+  if (value.type === "card") validateCard(value, path);
+  if (value.type === "carousel") validateCarousel(value, path);
+}
+
+function validateCard(card: Record<string, unknown>, path: string): void {
+  rejectUnknownFields(card, CARD_FIELDS, path);
+  if (
+    card.hero_image === undefined &&
+    card.title === undefined &&
+    card.actions === undefined &&
+    card.body === undefined
+  ) {
+    throw new TypeError(
+      `${path}: card requires hero_image, title, actions, or body`,
+    );
+  }
+  if (card.actions !== undefined) {
+    if (!Array.isArray(card.actions)) invalidField(`${path}/actions`);
+    if (card.actions.length > 3) invalidField(`${path}/actions`);
+    card.actions.forEach((action, index) => {
+      if (!isRecord(action) || action.type !== "button") {
+        invalidField(`${path}/actions/${index}`);
+      }
+    });
+  }
+}
+
+function validateCarousel(
+  carousel: Record<string, unknown>,
+  path: string,
+): void {
+  rejectUnknownFields(carousel, CAROUSEL_FIELDS, path);
+  if (
+    !Array.isArray(carousel.elements) ||
+    carousel.elements.length < 1 ||
+    carousel.elements.length > 10
+  ) {
+    invalidField(`${path}/elements`);
+  }
+  carousel.elements.forEach((card, index) => {
+    const cardPath = `${path}/elements/${index}`;
+    if (!isRecord(card) || card.type !== "card") invalidField(cardPath);
+    validateCard(card, cardPath);
+  });
+}
+
+function rejectUnknownFields(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const field of Object.keys(value)) {
+    if (!allowed.has(field)) {
+      const fieldPath = `${path}/${jsonPointer(field)}`;
+      if (value.type === "card" && field === "children") {
+        invalidField(fieldPath, "Card buttons belong in actions");
+      }
+      if (
+        value.type === "carousel" &&
+        (field === "cards" || field === "children")
+      ) {
+        invalidField(fieldPath, "Carousel cards belong in elements");
+      }
+      invalidField(fieldPath);
+    }
+  }
+}
+
+function invalidField(path: string, expected?: string): never {
+  throw new TypeError(
+    `invalid field at ${path}${expected ? `; ${expected}` : ""}`,
+  );
+}
+
+function jsonPointer(value: string): string {
+  return value.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/channels-slack/src/event-renderer.ts
+++ b/packages/channels-slack/src/event-renderer.ts
@@ -166,7 +166,7 @@ export function createRunRenderer(args: {
           : {}),
       });
     } catch (err) {
-      console.error("[slack-renderer] setStatus failed:", err);
+      console.debug("[slack-renderer] setStatus failed:", err);
     }
   };
   /** Clear the native status (best-effort). */
@@ -571,7 +571,7 @@ export function createRunRenderer(args: {
           text: `:warning: Agent error: ${event.message ?? "unknown error"}`,
         });
       } catch (err) {
-        console.error("[slack-renderer] error notice failed:", err);
+        console.debug("[slack-renderer] error notice failed:", err);
       }
     },
   };

--- a/packages/channels-slack/src/native-catalog.test.ts
+++ b/packages/channels-slack/src/native-catalog.test.ts
@@ -35,13 +35,13 @@ test("every Slack catalog entry serializes its fixed discriminator", () => {
   }
 });
 
-test("Slack carousel serializes card children as elements", () => {
+test("Slack carousel serializes cards from its elements field", () => {
   const title = createNativeNode("slack", "object", "plain_text", {
     text: "First card",
   });
   const card = createNativeNode("slack", "block", "card", { title });
   const carousel = createNativeNode("slack", "block", "carousel", {
-    children: [card],
+    elements: [card],
   });
 
   const serialized = serializeSlackNativeNode(carousel);

--- a/packages/channels-slack/src/native-catalog.test.ts
+++ b/packages/channels-slack/src/native-catalog.test.ts
@@ -35,6 +35,28 @@ test("every Slack catalog entry serializes its fixed discriminator", () => {
   }
 });
 
+test("Slack carousel serializes card children as elements", () => {
+  const title = createNativeNode("slack", "object", "plain_text", {
+    text: "First card",
+  });
+  const card = createNativeNode("slack", "block", "card", { title });
+  const carousel = createNativeNode("slack", "block", "carousel", {
+    children: [card],
+  });
+
+  const serialized = serializeSlackNativeNode(carousel);
+
+  expect(serialized).toEqual({
+    type: "carousel",
+    elements: [
+      {
+        type: "card",
+        title: { type: "plain_text", text: "First card" },
+      },
+    ],
+  });
+});
+
 function requiredProps(type: string): Record<string, unknown> {
   if (type === "actions" || type === "context") return { elements: [] };
   if (type === "button" || type === "header") return { text: "text" };

--- a/packages/channels-slack/src/native-data-visualization.types.test.ts
+++ b/packages/channels-slack/src/native-data-visualization.types.test.ts
@@ -101,6 +101,20 @@ const __typeGuards = () => {
     // @ts-expect-error data visualization blocks do not accept children
     children: Slack.Block.Divider({}),
   });
+  const card = Slack.Block.Card({
+    title: Slack.Object.PlainText({ text: "Deploy ready" }),
+    actions: [Slack.Element.Button({ text: "Approve" })],
+  });
+  Slack.Block.Carousel({ elements: [card] });
+  Slack.Block.Card({
+    title: Slack.Object.PlainText({ text: "Deploy ready" }),
+    // @ts-expect-error card blocks use actions, not children
+    children: Slack.Element.Button({ text: "Approve" }),
+  });
+  Slack.Block.Carousel({
+    // @ts-expect-error carousel blocks use elements, not cards
+    cards: [card],
+  });
 };
 void __typeGuards;
 

--- a/packages/channels-slack/src/native-jsx.test.tsx
+++ b/packages/channels-slack/src/native-jsx.test.tsx
@@ -90,3 +90,70 @@ test("native Slack JSX rejects more than 50 message blocks", () => {
 
   expect(() => renderBlockKit(ir)).toThrow(/51.*50|50.*51/);
 });
+
+test("native Slack JSX rejects an invalid card before the provider call", async () => {
+  const postMessage = vi.fn();
+  const adapter = new SlackAdapter({ botToken: "x", appToken: "y" });
+  (adapter as unknown as { client: unknown }).client = {
+    chat: { postMessage },
+  };
+  const ir = renderToIR(
+    <>
+      <Slack.Block.Divider />
+      <Slack.Block.Divider />
+      <Slack.Raw
+        value={{
+          type: "carousel",
+          elements: [
+            {
+              type: "card",
+              title: { type: "plain_text", text: "Deploy ready" },
+              children: [{ type: "button", text: "Approve" }],
+            },
+          ],
+        }}
+      />
+    </>,
+  );
+
+  await expect(adapter.post({ channel: "C1" }, ir)).rejects.toThrow(
+    "invalid field at /blocks/2/elements/0/children; Card buttons belong in actions",
+  );
+  expect(postMessage).not.toHaveBeenCalled();
+});
+
+test("native Slack JSX accepts interactive cards inside a carousel", () => {
+  const approve = (
+    <Slack.Element.Button
+      text={<Slack.Object.PlainText text="Approve" />}
+      onClick={{ id: "ck:approve" } as unknown as ClickHandler}
+    />
+  );
+  const card = (
+    <Slack.Block.Card
+      title={<Slack.Object.MarkdownText text="*Deploy ready*" />}
+      actions={[approve]}
+    />
+  );
+
+  expect(
+    renderBlockKit(renderToIR(<Slack.Block.Carousel elements={[card]} />)),
+  ).toEqual([
+    {
+      type: "carousel",
+      elements: [
+        {
+          type: "card",
+          title: { type: "mrkdwn", text: "*Deploy ready*" },
+          actions: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Approve" },
+              action_id: "ck:approve",
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+});

--- a/packages/channels-slack/src/native-manifest.ts
+++ b/packages/channels-slack/src/native-manifest.ts
@@ -17,7 +17,7 @@ const OBJECTS =
 /** Reviewed message-valid Slack Block Kit catalog. */
 export const SLACK_BLOCK_MANIFEST = [
   ["Actions", "actions", "elements"],
-  ["Card", "card", "children"],
+  ["Card", "card"],
   ["Carousel", "carousel", "elements"],
   ["Container", "container", "blocks"],
   ["Context", "context", "elements"],

--- a/packages/channels-slack/src/native-manifest.ts
+++ b/packages/channels-slack/src/native-manifest.ts
@@ -18,7 +18,7 @@ const OBJECTS =
 export const SLACK_BLOCK_MANIFEST = [
   ["Actions", "actions", "elements"],
   ["Card", "card", "children"],
-  ["Carousel", "carousel", "cards"],
+  ["Carousel", "carousel", "elements"],
   ["Container", "container", "blocks"],
   ["Context", "context", "elements"],
   ["ContextActions", "context_actions", "elements"],

--- a/packages/channels-slack/src/native.ts
+++ b/packages/channels-slack/src/native.ts
@@ -109,6 +109,27 @@ export interface SlackDataVisualizationProps {
   readonly children?: never;
 }
 
+/** Props accepted by Slack's Card block. */
+export interface SlackCardProps {
+  readonly block_id?: string;
+  readonly hero_image?: ChannelNode;
+  readonly icon?: ChannelNode;
+  readonly title?: ChannelNode;
+  readonly subtitle?: ChannelNode;
+  readonly body?: ChannelNode;
+  readonly actions?: readonly ChannelNode[];
+  readonly slack_icon?: ChannelNode;
+  readonly subtext?: ChannelNode;
+  readonly children?: never;
+}
+
+/** Props accepted by Slack's Carousel block. */
+export interface SlackCarouselProps {
+  readonly block_id?: string;
+  readonly elements: readonly ChannelNode[];
+  readonly children?: never;
+}
+
 type NativeComponent = <TValue = unknown>(
   props: SlackNativeProps<TValue>,
 ) => ChannelNode;
@@ -153,9 +174,32 @@ function dataVisualization(props: SlackDataVisualizationProps): ChannelNode {
   );
 }
 
+function card(props: SlackCardProps): ChannelNode {
+  return createNativeNode(
+    "slack",
+    "block",
+    "card",
+    props as unknown as Record<string, unknown>,
+  );
+}
+
+function carousel(props: SlackCarouselProps): ChannelNode {
+  return createNativeNode(
+    "slack",
+    "block",
+    "carousel",
+    props as unknown as Record<string, unknown>,
+  );
+}
+
 /** Complete message-surface Slack JSX namespace. */
 export const Slack = {
-  Block: { ...blocks, DataVisualization: dataVisualization },
+  Block: {
+    ...blocks,
+    Card: card,
+    Carousel: carousel,
+    DataVisualization: dataVisualization,
+  },
   Element: group("element", SLACK_ELEMENT_MANIFEST),
   Object: group("object", SLACK_OBJECT_MANIFEST),
   Raw: (props: SlackRawProps): ChannelNode =>

--- a/packages/channels-slack/src/native.ts
+++ b/packages/channels-slack/src/native.ts
@@ -22,7 +22,6 @@ export interface SlackNativeProps<TValue = unknown> {
   fields?: ChannelNode | ChannelNode[];
   options?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;
   option_groups?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;
-  cards?: ChannelNode[];
   blocks?: ChannelNode[];
   rows?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;
   tasks?: ChannelNode[] | ReadonlyArray<Record<string, unknown>>;

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -4,6 +4,7 @@ import type { ContextActionsBlock, KnownBlock } from "@slack/types";
 import { markdownToMrkdwn } from "../markdown-to-mrkdwn.js";
 import { SLACK_LIMITS, clampArray, truncateText } from "./budget.js";
 import { serializeSlackNativeNode } from "../native-codec.js";
+import { validateSlackBlockKit } from "../block-kit-validation.js";
 
 /**
  * Stable `action_id` of the native AI feedback row's `feedback_buttons`
@@ -85,6 +86,8 @@ export function renderBlockKit(ir: ChannelNode[]): KnownBlock[] {
       `Slack native JSX rendered ${blocks.length} blocks; the message limit is ${SLACK_LIMITS.blocksPerMessage}.`,
     );
   }
+
+  validateSlackBlockKit(blocks);
 
   // Top-level budget: clamp to the per-message block ceiling, leaving room for
   // an overflow-signal context block when we had to drop anything.

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-canonical-run.test.ts
@@ -149,6 +149,16 @@ function runArgs(
 }
 
 test("runCanonical rejects a RUN_ERROR event even when the runner completes", async () => {
+  const details = {
+    category: "validation",
+    provider: "slack",
+    operation: "chat.postMessage",
+    effectKind: "slack.message.create",
+    providerCode: "invalid_blocks",
+    validationMessages: ["invalid field at /blocks/2/elements/0/children"],
+    retryable: false,
+    deliveryId: "dlv_delivery_1",
+  } as const;
   const intelligence = new CopilotKitIntelligence({
     apiUrl: "https://runtime.example",
     wsUrl: "wss://runtime.example",
@@ -161,14 +171,35 @@ test("runCanonical rejects a RUN_ERROR event even when the runner completes", as
     of({
       type: EventType.RUN_ERROR,
       message: "agent failed",
-      code: "AGENT_FAILED",
+      code: "provider_call_failed",
+      category: "validation",
+      provider: "slack",
+      operation: "chat.postMessage",
+      effectKind: "slack.message.create",
+      providerCode: "invalid_blocks",
+      validationMessages: ["invalid field at /blocks/2/elements/0/children"],
+      retryable: false,
+      deliveryId: "dlv_delivery_1",
+      details,
+      cause: details,
     }),
   );
   const runCanonical = await captureRunCanonical(runner, { intelligence });
 
   await expect(runCanonical(runArgs())).rejects.toMatchObject({
     message: "agent failed",
-    code: "AGENT_FAILED",
+    name: "ChannelCanonicalRunError",
+    code: "provider_call_failed",
+    category: "validation",
+    provider: "slack",
+    operation: "chat.postMessage",
+    effectKind: "slack.message.create",
+    providerCode: "invalid_blocks",
+    validationMessages: ["invalid field at /blocks/2/elements/0/children"],
+    retryable: false,
+    deliveryId: "dlv_delivery_1",
+    details,
+    cause: details,
   });
   expect(cleanup).toHaveBeenCalledWith(canonicalIdentity);
 });

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -76,6 +76,17 @@ export interface ChannelsControl {
   stop(): Promise<void>;
 }
 
+interface ChannelRunErrorDetails {
+  readonly category: "validation";
+  readonly provider: "slack" | "teams";
+  readonly operation: string;
+  readonly effectKind: string;
+  readonly providerCode: "invalid_arguments" | "invalid_blocks";
+  readonly validationMessages: readonly string[];
+  readonly retryable: false;
+  readonly deliveryId: string;
+}
+
 /**
  * Signals that a declared Channel cannot be activated because no managed
  * provider exists for it yet. The engine throws this (or any error whose
@@ -550,7 +561,20 @@ async function runCanonicalChannelAgent(
 
   try {
     await new Promise<void>((resolve, reject) => {
-      let terminalError: (Error & { code?: string }) | undefined;
+      let terminalError:
+        | (Error & {
+            code?: string;
+            category?: string;
+            provider?: string;
+            operation?: string;
+            effectKind?: string;
+            providerCode?: string;
+            validationMessages?: readonly string[];
+            retryable?: boolean;
+            deliveryId?: string;
+            details?: unknown;
+          })
+        | undefined;
       const stream = runner.run({
         threadId: canonicalThreadId,
         agent: outer,
@@ -572,7 +596,11 @@ async function runCanonicalChannelAgent(
             "message" in event && typeof event.message === "string"
               ? event.message
               : "Canonical Channel agent run failed";
-          terminalError = new Error(message);
+          const details = safeChannelRunErrorDetails(event);
+          terminalError = new Error(
+            message,
+            details ? { cause: details } : undefined,
+          );
           terminalError.name = "ChannelCanonicalRunError";
           if (
             "code" in event &&
@@ -580,6 +608,17 @@ async function runCanonicalChannelAgent(
             event.code.length > 0
           ) {
             terminalError.code = event.code;
+          }
+          if (details) {
+            terminalError.category = details.category;
+            terminalError.provider = details.provider;
+            terminalError.operation = details.operation;
+            terminalError.effectKind = details.effectKind;
+            terminalError.providerCode = details.providerCode;
+            terminalError.validationMessages = details.validationMessages;
+            terminalError.retryable = details.retryable;
+            terminalError.deliveryId = details.deliveryId;
+            terminalError.details = details;
           }
         },
         error: reject,
@@ -617,6 +656,58 @@ async function runCanonicalChannelAgent(
     throw heartbeatError;
   }
   return result;
+}
+
+function safeChannelRunErrorDetails(
+  event: BaseEvent,
+): ChannelRunErrorDetails | undefined {
+  if (
+    !("details" in event) ||
+    typeof event.details !== "object" ||
+    event.details === null ||
+    Array.isArray(event.details)
+  ) {
+    return undefined;
+  }
+  const details = event.details as Record<string, unknown>;
+  const allowed = new Set([
+    "category",
+    "provider",
+    "operation",
+    "effectKind",
+    "providerCode",
+    "validationMessages",
+    "retryable",
+    "deliveryId",
+  ]);
+  if (
+    !Object.keys(details).every((field) => allowed.has(field)) ||
+    details.category !== "validation" ||
+    (details.provider !== "slack" && details.provider !== "teams") ||
+    !boundedString(details.operation, 80) ||
+    !boundedString(details.effectKind, 80) ||
+    (details.providerCode !== "invalid_arguments" &&
+      details.providerCode !== "invalid_blocks") ||
+    details.retryable !== false ||
+    !boundedString(details.deliveryId, 512) ||
+    !Array.isArray(details.validationMessages) ||
+    details.validationMessages.length > 5 ||
+    !details.validationMessages.every(
+      (validationMessage) =>
+        typeof validationMessage === "string" &&
+        validationMessage.length <= 256 &&
+        validationMessage.startsWith("invalid field at /"),
+    )
+  ) {
+    return undefined;
+  }
+  return details as unknown as ChannelRunErrorDetails;
+}
+
+function boundedString(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && value.length <= maxLength
+  );
 }
 
 /** Convert canonical Intelligence history into AG-UI messages. */


### PR DESCRIPTION
## Summary

- serialize Slack Carousel cards through elements and validate Card and Carousel payloads before provider calls
- keep bounded provider diagnostics from ChannelDeliveryError through RUN_ERROR and ChannelCanonicalRunError
- log low-cardinality error fields without validation messages or provider bodies
- move best-effort Slack status cleanup failures to debug logs

## Why

Invalid nested Slack Card payloads failed at the provider with no useful path at the application boundary. This change catches known Card and Carousel shape errors locally and preserves safe JSON pointers when Slack rejects a payload.

## Compatibility

The new error details are optional. Existing consumers keep their current behavior, so no protocol version bump is needed.

## Validation

- NX_DAEMON=false pnpm nx run-many -t test,check-types,build --projects=@copilotkit/channels-core,@copilotkit/channels-intelligence,@copilotkit/channels-slack,@copilotkit/runtime --skip-nx-cache
- pnpm lint
- pnpm check:channel-native-catalogs
- targeted oxfmt and oxlint checks
- git diff --check
- pre-commit test, publint, and attw checks for affected packages

Companion Intelligence PR: https://github.com/CopilotKit/Intelligence/pull/759