### PR TITLE
chore(showcase): pin opentelemetry-api<1.44 for pydantic-ai v1

### DIFF
--- a/showcase/integrations/pydantic-ai/requirements.txt
+++ b/showcase/integrations/pydantic-ai/requirements.txt
@@ -6,3 +6,10 @@ fastapi>=0.115.0
 logfire>=4.10.0
 starlette<1.0.0
 pypdf>=4.0.0,<7.0.0
+# pydantic-ai 1.0.18 imports `opentelemetry._events`, which opentelemetry-api
+# removed in 1.44.0 (last present in 1.43.0). pydantic-ai's own floor is an
+# unbounded `opentelemetry-api>=1.28.0`, so a fresh resolve picks up 1.44.0 and
+# `import pydantic_ai` fails with ModuleNotFoundError. Until now this was masked
+# by the cached Docker pip layer, which predates 1.44.0 (released 2026-07-16).
+# Drop this ceiling when this package moves to pydantic-ai v2.
+opentelemetry-api<1.44


### PR DESCRIPTION
`showcase/integrations/pydantic-ai` cannot be installed from scratch today. A clean `pip install -r requirements.txt` produces an agent that dies on import:

```
ModuleNotFoundError: No module named 'opentelemetry._events'
```

pydantic-ai 1.0.18 imports `opentelemetry._events`. That module was removed in **opentelemetry-api 1.44.0** (last present in 1.43.0). pydantic-ai declares an unbounded `opentelemetry-api>=1.28.0`, so a fresh resolve picks 1.44.0 and the import fails.

## Why nothing was red

`Dockerfile:22-24` copies **only** `requirements.txt` before `pip install`, so that layer's cache key depends on nothing else. The agent image has been reusing a pip layer baked before 1.44.0 shipped (2026-07-16) — including a successful build earlier today. The failure was masked by Docker layer caching, not absent. Any change to `requirements.txt`, a cache eviction, or a `--no-cache` build surfaces it.

Note that this PR busts that cache by definition, so CI's image build is a genuine fresh-resolve test of the fix rather than a cached pass.

## Verification

Run with `pip` in a clean 3.12 venv, matching how the Dockerfile installs:

```
RED  (main)         opentelemetry-api 1.44.0 -> import pydantic_ai raises ModuleNotFoundError
GREEN (this branch) opentelemetry-api 1.43.0 -> import pydantic_ai + pydantic_ai.ag_ui OK
```

Only the ceiling is added; `opentelemetry-sdk` follows to 1.43.0 on its own, so a second pin isn't needed. No resolution conflict with `logfire>=4.10.0`.

Docker and the `--d6` probe stack aren't available in my environment, so the mandatory value-test per `showcase/AGENTS.md` rule 4 has not been run locally — CI's image build and the dojo cells are the real gate here.

## Scope

One line plus a comment recording why it exists and when to remove it. The comment matters: an undocumented pin is what caused the sibling `starlette==0.45.3` rot in #6363, where a correct-when-written pin outlived its reason and silently capped pydantic-ai a full major.

The ceiling should come off when this package moves to pydantic-ai v2, which requires `opentelemetry-api>=1.28.0` without needing `_events`.
