### PR TITLE
fix(channels): default welcome agent prompt

### DIFF
--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -65,6 +65,7 @@ const pkg = createRequire(import.meta.url)("../package.json") as {
 };
 
 const ADAPTER_ROLLBACK_TIMEOUT_MS = 5_000;
+const DEFAULT_WELCOME_PROMPT = "Introduce yourself to the channel!";
 
 function storeKind(s: StateStore): "memory" | "postgres" | "redis" | "custom" {
   const n = s.constructor?.name;
@@ -824,6 +825,7 @@ export function createChannel<
     extras?: {
       platform?: string;
       message?: IncomingMessage;
+      defaultPrompt?: string;
       user?: ApplicationUser | null;
       actor?: ProviderActor;
       interactionActionId?: string;
@@ -850,6 +852,7 @@ export function createChannel<
       stateSchema: cfg.state,
       transcripts,
       message: extras?.message,
+      defaultPrompt: extras?.defaultPrompt,
       user: extras?.user ?? null,
       actor: extras?.actor ?? { id: "unknown", kind: "unknown" },
       channelName: opts.name ?? adapter.platform,
@@ -1155,7 +1158,12 @@ export function createChannel<
           adapter,
           evt.replyTarget,
           evt.conversationKey,
-          { platform, user, actor: identityContext.actor },
+          {
+            platform,
+            user,
+            actor: identityContext.actor,
+            defaultPrompt: DEFAULT_WELCOME_PROMPT,
+          },
         );
         for (const h of welcomeHandlers) {
           await h({ thread, user, actor: identityContext.actor, platform });

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -112,6 +112,8 @@ export interface ThreadDeps {
   transcripts?: Transcripts;
   /** The inbound message that triggered this turn (for transcript bridging). */
   message?: IncomingMessage;
+  /** Prompt used when this lifecycle thread runs an agent without an explicit prompt. */
+  defaultPrompt?: string;
   user: ApplicationUser | null;
   actor: ProviderActor;
   /** Declared Channel identity bound to one-use continuations. */
@@ -478,9 +480,11 @@ export class Thread implements ThreadInterface {
     /**
      * A user message to inject before running. When the adapter's conversation
      * store does not seed the in-flight turn, an omitted prompt defaults to
-     * non-empty inbound `message.contentParts` or `message.text`. Pass a prompt
-     * explicitly when input isn't in reconstructed history — e.g. slash-command
-     * args, which are never posted to the channel.
+     * non-empty inbound `message.contentParts` or `message.text`. Welcome
+     * handlers instead default to `"Introduce yourself to the channel!"`.
+     * Pass a prompt explicitly to override either default or when input isn't in
+     * reconstructed history — e.g. slash-command args, which are never posted to
+     * the channel.
      */
     prompt?: string | AgentContentPart[];
     /**
@@ -512,7 +516,7 @@ export class Thread implements ThreadInterface {
       this.trackOperation(async () => {
         const memory = this.resolveMemory(memoryRequest, this.deps.user);
         const message = this.deps.message;
-        const defaultPrompt =
+        const inboundPrompt =
           message?.contentParts && message.contentParts.length > 0
             ? message.contentParts
             : message?.text;
@@ -521,7 +525,7 @@ export class Thread implements ThreadInterface {
           !this.deps.adapter.conversationStore.seedsInboundTurn &&
           (!this.deps.adapter.injectInboundTurnOnce ||
             !this.implicitInboundConsumed);
-        if (implicitPrompt && defaultPrompt) {
+        if (implicitPrompt && inboundPrompt) {
           this.implicitInboundConsumed = true;
         }
         const continuation: ActionContinuationContext = {
@@ -537,7 +541,9 @@ export class Thread implements ThreadInterface {
             ...input,
             memory,
             prompt:
-              input?.prompt ?? (!implicitPrompt ? undefined : defaultPrompt),
+              input?.prompt ??
+              this.deps.defaultPrompt ??
+              (!implicitPrompt ? undefined : inboundPrompt),
           });
         } finally {
           if (this.activeContinuation === continuation) {

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -112,7 +112,7 @@ export interface ThreadDeps {
   transcripts?: Transcripts;
   /** The inbound message that triggered this turn (for transcript bridging). */
   message?: IncomingMessage;
-  /** Prompt used when this lifecycle thread runs an agent without an explicit prompt. */
+  /** Fallback prompt for agent runs with neither an explicit nor an inbound prompt. */
   defaultPrompt?: string;
   user: ApplicationUser | null;
   actor: ProviderActor;
@@ -542,8 +542,8 @@ export class Thread implements ThreadInterface {
             memory,
             prompt:
               input?.prompt ??
-              this.deps.defaultPrompt ??
-              (!implicitPrompt ? undefined : inboundPrompt),
+              (implicitPrompt ? inboundPrompt : undefined) ??
+              this.deps.defaultPrompt,
           });
         } finally {
           if (this.activeContinuation === continuation) {

--- a/packages/channels-core/src/welcome.test.ts
+++ b/packages/channels-core/src/welcome.test.ts
@@ -1,20 +1,35 @@
 import { expect, test, vi } from "vitest";
 import { createChannel } from "./create-channel.js";
+import { ActionRegistry } from "./action-registry.js";
+import { InMemoryActionStore } from "./action-store.js";
+import { MemoryStore } from "./state/memory-store.js";
 import { FakeAdapter } from "./testing/fake-adapter.js";
 import { FakeAgent } from "./testing/fake-agent.js";
+import { Thread } from "./thread.js";
 
 /** Run an agent from a welcome handler and return its resulting message history. */
-async function runWelcomeAgent(prompt?: string) {
+async function runWelcomeAgent(opts?: {
+  prompt?: string;
+  /** Force the shipping-adapter path where the conversation store seeds inbound turns. */
+  seedsInboundTurn?: boolean;
+}) {
   const adapter = new FakeAdapter();
   const agent = new FakeAgent();
   adapter.conversationStore.getOrCreate = async () => ({ agent });
+  if (opts?.seedsInboundTurn) {
+    Object.defineProperty(adapter.conversationStore, "seedsInboundTurn", {
+      value: true,
+    });
+  }
   const channel = createChannel({
     identifyUser: "platform",
     adapters: [adapter],
     agent,
   });
   channel.onWelcome(async ({ thread }) => {
-    await thread.runAgent(prompt === undefined ? undefined : { prompt });
+    await thread.runAgent(
+      opts?.prompt === undefined ? undefined : { prompt: opts.prompt },
+    );
   });
   await channel.ɵruntime.start();
 
@@ -28,7 +43,9 @@ async function runWelcomeAgent(prompt?: string) {
 
 test("defaults welcome agent runs to an introduction prompt unless overridden", async () => {
   const defaultMessages = await runWelcomeAgent();
-  const overriddenMessages = await runWelcomeAgent("Use my custom prompt");
+  const overriddenMessages = await runWelcomeAgent({
+    prompt: "Use my custom prompt",
+  });
 
   expect(defaultMessages).toEqual([
     expect.objectContaining({
@@ -41,6 +58,59 @@ test("defaults welcome agent runs to an introduction prompt unless overridden", 
       role: "user",
       content: "Use my custom prompt",
     }),
+  ]);
+});
+
+test("defaults the welcome prompt when the conversation store seeds inbound turns", async () => {
+  // Every shipping adapter's store sets seedsInboundTurn, but a welcome has no
+  // inbound turn to seed — the default must still be injected on that path.
+  const messages = await runWelcomeAgent({ seedsInboundTurn: true });
+
+  expect(messages).toEqual([
+    expect.objectContaining({
+      role: "user",
+      content: "Introduce yourself to the channel!",
+    }),
+  ]);
+});
+
+test("an inbound message outranks the thread's default prompt", async () => {
+  // No createChannel path reaches this combination today (only welcome threads
+  // carry a defaultPrompt, and they never carry a message), so pin the
+  // precedence at the Thread level for when a second producer appears.
+  const adapter = new FakeAdapter();
+  const agent = new FakeAgent();
+  adapter.conversationStore.getOrCreate = async () => ({ agent });
+  const thread = new Thread({
+    adapter,
+    replyTarget: {},
+    conversationKey: "c1",
+    channelName: "test",
+    threadId: "c1",
+    registry: new ActionRegistry({ store: new InMemoryActionStore() }),
+    agentFactory: () => agent,
+    tools: new Map(),
+    toolDescriptors: [],
+    context: [],
+    registerWaiter: () => {},
+    interruptHandlers: new Map(),
+    state: new MemoryStore(),
+    message: {
+      text: "Real user input",
+      user: null,
+      actor: { id: "provider-user-1", kind: "human" },
+      ref: { id: "m1" },
+      platform: "fake",
+    },
+    defaultPrompt: "Introduce yourself to the channel!",
+    user: null,
+    actor: { id: "provider-user-1", kind: "human" },
+  });
+
+  await thread.runAgent();
+
+  expect(agent.messages).toEqual([
+    expect.objectContaining({ role: "user", content: "Real user input" }),
   ]);
 });
 

--- a/packages/channels-core/src/welcome.test.ts
+++ b/packages/channels-core/src/welcome.test.ts
@@ -1,6 +1,48 @@
 import { expect, test, vi } from "vitest";
 import { createChannel } from "./create-channel.js";
 import { FakeAdapter } from "./testing/fake-adapter.js";
+import { FakeAgent } from "./testing/fake-agent.js";
+
+/** Run an agent from a welcome handler and return its resulting message history. */
+async function runWelcomeAgent(prompt?: string) {
+  const adapter = new FakeAdapter();
+  const agent = new FakeAgent();
+  adapter.conversationStore.getOrCreate = async () => ({ agent });
+  const channel = createChannel({
+    identifyUser: "platform",
+    adapters: [adapter],
+    agent,
+  });
+  channel.onWelcome(async ({ thread }) => {
+    await thread.runAgent(prompt === undefined ? undefined : { prompt });
+  });
+  await channel.ɵruntime.start();
+
+  try {
+    await adapter.emitWelcome();
+    return agent.messages;
+  } finally {
+    await channel.ɵruntime.stop();
+  }
+}
+
+test("defaults welcome agent runs to an introduction prompt unless overridden", async () => {
+  const defaultMessages = await runWelcomeAgent();
+  const overriddenMessages = await runWelcomeAgent("Use my custom prompt");
+
+  expect(defaultMessages).toEqual([
+    expect.objectContaining({
+      role: "user",
+      content: "Introduce yourself to the channel!",
+    }),
+  ]);
+  expect(overriddenMessages).toEqual([
+    expect.objectContaining({
+      role: "user",
+      content: "Use my custom prompt",
+    }),
+  ]);
+});
 
 test("routes a welcome lifecycle event without synthesizing a message turn", async () => {
   const adapter = new FakeAdapter();


### PR DESCRIPTION
## What does this PR do?

- Gives `thread.runAgent()` inside `onWelcome` the default prompt `"Introduce yourself to the channel!"`.
- Keeps an explicit `runAgent({ prompt })` ahead of the default.
- Adds regression coverage for the default and override paths.

Welcome deliveries have no inbound message. Before this change, `thread.runAgent()` passed an empty message list to the AI SDK, which rejected the run before it reached the model.

## Related PRs and Issues

- No linked issue.

## Testing

- `pnpm nx test @copilotkit/channels-core -- --run src/welcome.test.ts`
- `pnpm nx run-many -t test,check-types,build --projects=@copilotkit/channels-core`
- `pnpm run lint`
- `pnpm run check-format`
- `pnpm nx run-many -t publint,attw --projects=@copilotkit/channels-core`

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] Maintainers can edit this same-repository branch; GitHub only shows the "Allow edits by maintainers" control for forks
