### PR TITLE
fix(reskinnable-demo): put real data behind the banking report, and fix the six defects it was hiding

### DIFF
--- a/examples/showcases/reskinnable-demo/src/skins/banking/actions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/actions.ts
@@ -6,7 +6,7 @@ import type {
   Transaction,
   PolicyException,
 } from "@/skins/banking/data/data";
-import { MemberRole } from "@/skins/banking/data/data";
+import { MemberRole, policyForTeam } from "@/skins/banking/data/data";
 import { randomDigits } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { useAuthContext } from "@/skins/banking/components/auth-context";
@@ -301,7 +301,11 @@ export default function useCreditCards() {
             const policy = policies.find(
               (policy) => policy.id === card.expensePolicyId,
             );
-            return policy?.type === currentUser.team;
+            // Joined through `policyForTeam`, not compared directly: the member
+            // carries an ORG team ("Marketing") while the policy carries a
+            // budget envelope ("Go-to-Market"), so an equality test between the
+            // two can never match and would hide every card from a non-admin.
+            return policy?.type === policyForTeam(currentUser.team);
           }),
     policies,
     transactions,

--- a/examples/showcases/reskinnable-demo/src/skins/banking/catalog/renderers.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/catalog/renderers.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { RendererProps } from "@copilotkit/a2ui-renderer";
-import { ExpenseRole } from "@/skins/banking/data/data";
+import { PolicyType } from "@/skins/banking/data/data";
 import type { ExpensePolicy, Transaction } from "@/skins/banking/data/data";
 import { formatCurrency } from "@/lib/utils";
 import { ReportDataProvider } from "../report-data";
@@ -27,7 +27,7 @@ function makeTransaction(overrides: Partial<Transaction>): Transaction {
 function makePolicy(overrides: Partial<ExpensePolicy>): ExpensePolicy {
   return {
     id: "p1",
-    type: ExpenseRole.Engineering,
+    type: PolicyType.Technology,
     limit: 1000,
     spent: 0,
     ...overrides,

--- a/examples/showcases/reskinnable-demo/src/skins/banking/components/analytics-charts.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/components/analytics-charts.tsx
@@ -78,20 +78,32 @@ export function SpendingTrendChart({
       const [by, bm] = b.split("-").map(Number);
       return ay - by || am - bm;
     });
-    if (sorted.length >= 3) {
-      return {
-        stats: sorted.map(([, v]) => v),
-        labels: sorted.map(([k]) => {
-          const [y, m] = k.split("-").map(Number);
-          return monthFmt.format(new Date(y, m, 1));
-        }),
-      };
-    }
+    // Chart whatever months the ledger actually has — even one or two.
+    //
+    // This used to substitute a hard-coded [3200, 4100, 3600, 5200, 4800, 6400]
+    // Jan–Jun series whenever fewer than three months were present. That was
+    // meant as an empty-state placeholder, but the seeded ledger only ever
+    // spanned two months, so the fallback was the DEFAULT path: the report
+    // rendered six invented figures under a card whose own contract promises
+    // "every number is computed from the live ledger", and they were ~20x
+    // smaller than the total shown directly above them. A sparse honest chart
+    // beats a dense invented one.
     return {
-      stats: [3200, 4100, 3600, 5200, 4800, 6400],
-      labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+      stats: sorted.map(([, v]) => v),
+      labels: sorted.map(([k]) => {
+        const [y, m] = k.split("-").map(Number);
+        return monthFmt.format(new Date(y, m, 1));
+      }),
     };
   }, [transactions]);
+
+  if (!stats.length) {
+    return (
+      <div className="flex h-[120px] items-center justify-center rounded-xl border border-dashed border-hairline text-xs text-ink-muted">
+        No spend recorded yet
+      </div>
+    );
+  }
 
   return <StatisticsChart data={stats} labels={labels} />;
 }
@@ -210,9 +222,12 @@ export function TopChargesChart({
         id: t.id,
         title: t.title,
         amount: Math.abs(t.amount),
-        // Charges folded in from an attached document have no policyId; they
-        // carry their team in the title the report generated for them.
-        team: teamOf.get(t.policyId ?? "") ?? "",
+        // Every charge carries a policyId, including ones folded in from an
+        // attached document — `augmentForReport` resolves the addition's team to
+        // a policy so its bar colours by the same rule as a ledger charge. The
+        // fallback covers an addition whose team matches no policy, which is
+        // possible because that field is model-authored free text.
+        team: teamOf.get(t.policyId) ?? "",
         pending: t.status === "pending",
       }))
       .sort((a, b) => b.amount - a.amount)
@@ -351,9 +366,16 @@ export function SpendByTeamBars({
  * legend. Built with stroke-dasharray segments on a rotated circle (no arc
  * math, no dependency); the total sits in the center hole.
  *
- * Still used by the in-chat "where is the money going?" answer, where the teams
- * are comparable. The REPORT uses SpendByTeamBars instead, because an attached
- * invoice can push one team to ~96% and a donut cannot survive that.
+ * Used by BOTH the in-chat "where is the money going?" answer and the report.
+ *
+ * This used to warn that the report must use SpendByTeamBars instead, "because
+ * an attached invoice can push one team to ~96% and a donut cannot survive
+ * that" — while the report rendered the donut anyway. The warning was real but
+ * its cause was the thin ledger, not the chart: against the old $137,000 base a
+ * $900,000 invoice took one slice to 89%. The ledger now carries the full
+ * ~$533,000 of approved Q2 spend across three policy envelopes, so reaching 89%
+ * would take an invoice near $2.8M. Robust because the data is real, not
+ * because a floor was added to the arc.
  */
 export function SpendBreakdownChart({
   policies,

--- a/examples/showcases/reskinnable-demo/src/skins/banking/components/recording-context.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/components/recording-context.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { ExpenseRole } from "@/skins/banking/data/data";
+import { PolicyType } from "@/skins/banking/data/data";
 import type { ExpensePolicy, Transaction } from "@/skins/banking/data/data";
 import { PendingApprovalsChat } from "./wow/pending-approvals-chat";
 import { RecordingProvider, useRecording } from "./recording-context";
@@ -68,7 +68,7 @@ describe("PendingApprovalsChat.handleApprove narration", () => {
     // truthy (the mutation "took effect"), which is what unlocks narration.
     const policy: ExpensePolicy = {
       id: "pol-1",
-      type: ExpenseRole.Engineering,
+      type: PolicyType.Technology,
       limit: 1000,
       spent: 0,
     };

--- a/examples/showcases/reskinnable-demo/src/skins/banking/components/wow/report-card.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/components/wow/report-card.tsx
@@ -7,6 +7,7 @@ import type {
   Report,
   Transaction,
 } from "@/skins/banking/data/data";
+import { PolicyType, policyForTeam } from "@/skins/banking/data/data";
 import {
   SpendBreakdownChart,
   SpendingTrendChart,
@@ -30,41 +31,52 @@ function augmentForReport(
   const additions = report.additions ?? [];
   if (!additions.length) return { policies, transactions };
 
-  const byTeam = new Map<string, number>();
-  for (const a of additions)
-    byTeam.set(a.team, (byTeam.get(a.team) ?? 0) + a.amount);
-
-  const augPolicies: ExpensePolicy[] = policies.map((p) =>
-    byTeam.has(p.type) ? { ...p, spent: p.spent + byTeam.get(p.type)! } : p,
-  );
-  for (const [team, amount] of byTeam) {
-    if (!policies.some((p) => p.type === team)) {
-      augPolicies.push({
-        id: `add-${team}`,
-        type: team as ExpensePolicy["type"],
-        limit: 0,
-        spent: amount,
-      });
-    }
+  // An addition's `team` is model-authored free text naming an ORG team
+  // ("Marketing"), while a policy is a budget envelope ("Go-to-Market"), so the
+  // two are joined through `policyForTeam` rather than compared directly.
+  // Additions whose team maps to no envelope are grouped under one
+  // "Unattributed" segment instead of inventing an envelope per stray name.
+  const byPolicy = new Map<string, number>();
+  for (const a of additions) {
+    const key = policyForTeam(a.team) ?? PolicyType.Unattributed;
+    byPolicy.set(key, (byPolicy.get(key) ?? 0) + a.amount);
   }
 
+  const augPolicies: ExpensePolicy[] = policies.map((p) =>
+    byPolicy.has(p.type) ? { ...p, spent: p.spent + byPolicy.get(p.type)! } : p,
+  );
+  const unattributed = byPolicy.get(PolicyType.Unattributed);
+  if (unattributed) {
+    augPolicies.push({
+      id: "add-unattributed",
+      type: PolicyType.Unattributed,
+      limit: 0,
+      spent: unattributed,
+    });
+  }
+
+  // No `as Transaction` here on purpose. The cast this replaces was hiding a
+  // real hole: `policyId` came from an `?.id` lookup, so it could be undefined
+  // where the field is a required string, and the cast stopped the compiler
+  // saying so. Resolving the policy up front and defaulting keeps it a string,
+  // which is why the annotation alone now type-checks.
   const augTransactions: Transaction[] = [
     ...transactions,
-    ...additions.map(
-      (a, i) =>
-        ({
-          id: `add-tx-${report.id}-${i}`,
-          title: a.label ?? `${a.team} (attached document)`,
-          amount: -Math.abs(a.amount),
-          date: report.createdAt,
-          // Carry the owning policy so charts key colour off the team the same
-          // way ledger transactions do. Without it, invoice line items fall
-          // back to a generic swatch and a Marketing charge stops matching
-          // Marketing's slice in the donut.
-          policyId: augPolicies.find((p) => p.type === a.team)?.id,
-          status: "approved",
-        }) as Transaction,
-    ),
+    ...additions.map((a, i) => {
+      const type = policyForTeam(a.team) ?? PolicyType.Unattributed;
+      const policy = augPolicies.find((p) => p.type === type);
+      return {
+        id: `add-tx-${report.id}-${i}`,
+        title: a.label ?? `${a.team} (attached document)`,
+        amount: -Math.abs(a.amount),
+        date: report.createdAt,
+        // Carry the owning envelope so an invoice line colours by the same rule
+        // as a ledger charge instead of falling back to a generic swatch.
+        policyId: policy?.id ?? "add-unattributed",
+        cardId: "",
+        status: "approved" as const,
+      };
+    }),
   ];
 
   return { policies: augPolicies, transactions: augTransactions };
@@ -229,7 +241,7 @@ export function ReportCard({
       <div className="grid gap-5 border-t border-hairline pt-5 lg:grid-cols-3">
         <div>
           <p className="mb-2 text-xs font-medium text-ink-muted">
-            Spend by team
+            Spend by policy
           </p>
           <SpendBreakdownChart policies={chart.policies} />
         </div>

--- a/examples/showcases/reskinnable-demo/src/skins/banking/data/data.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/data/data.ts
@@ -38,10 +38,89 @@ export interface Member {
   team: ExpenseRole;
 }
 
+/**
+ * The org units a charge can belong to.
+ *
+ * Deliberately WIDER than `ExpenseRole` (which types a team member's own team)
+ * and separate from `PolicyType` below: a charge's team is an org unit, while a
+ * policy is a budget envelope, and several teams share one envelope. Collapsing
+ * the two is what previously forced a choice between a seven-slice donut and
+ * discarding real charges.
+ */
+export const CHARGE_TEAMS = [
+  "Engineering",
+  "Marketing",
+  "Sales",
+  "Executive",
+  "Operations",
+  "Finance",
+  "People",
+] as const;
+export type ChargeTeam = (typeof CHARGE_TEAMS)[number];
+
+export const CHARGE_CATEGORIES = [
+  "Cloud Infrastructure",
+  "Advertising",
+  "SaaS & Software",
+  "Travel",
+  "Payroll & Benefits",
+  "Office & Facilities",
+  "Professional Services",
+  "Marketing Events",
+  "Hardware",
+  "Meals & Entertainment",
+] as const;
+export type ChargeCategory = (typeof CHARGE_CATEGORIES)[number];
+
+/**
+ * The three expense-policy envelopes every charge is governed by.
+ *
+ * Separate from `ExpenseRole` on purpose — see `CHARGE_TEAMS`. Renaming these
+ * away from team names is what stops the two axes reading as one thing.
+ */
+export enum PolicyType {
+  Technology = "Technology",
+  GoToMarket = "Go-to-Market",
+  GeneralAndAdmin = "G&A",
+  /**
+   * Not a seeded envelope. The report groups document-sourced additions here
+   * when their model-authored team maps to no real envelope, so one stray team
+   * name cannot mint a policy segment of its own.
+   */
+  Unattributed = "Unattributed",
+}
+
+/** Which policy envelope governs a given org team. Many-to-one. */
+const TEAM_POLICY: Record<ChargeTeam, PolicyType> = {
+  Engineering: PolicyType.Technology,
+  Operations: PolicyType.Technology,
+  Marketing: PolicyType.GoToMarket,
+  Sales: PolicyType.GoToMarket,
+  Executive: PolicyType.GeneralAndAdmin,
+  Finance: PolicyType.GeneralAndAdmin,
+  People: PolicyType.GeneralAndAdmin,
+};
+
+/**
+ * Resolve the policy envelope for a team name.
+ *
+ * Takes a plain string rather than `ChargeTeam` because one caller is the
+ * agent: `ReportAddition.team` is model-authored free text, so an unknown team
+ * has to degrade rather than throw. Returns `undefined` when unmapped, and the
+ * caller decides what an unattributable charge means.
+ */
+export const policyForTeam = (team: string): PolicyType | undefined =>
+  TEAM_POLICY[team as ChargeTeam];
+
 export interface ExpensePolicy {
   id: string;
-  type: ExpenseRole;
+  type: PolicyType;
   limit: number;
+  /**
+   * Approved spend against this policy. DERIVED from the ledger by
+   * `store.policies()` on every read — never authored and never stored in the
+   * seed, so it cannot drift from the transactions it summarises.
+   */
   spent: number;
 }
 
@@ -67,7 +146,24 @@ export interface Transaction {
   date: string;
   policyId: string;
   cardId: string;
-  status: "pending" | "denied" | "approved";
+  /**
+   * The org unit that incurred the charge. Distinct from the charge's policy
+   * (`policyId`) — see `CHARGE_TEAMS`.
+   *
+   * Optional because not every Transaction is a real card charge: the report
+   * folds document-sourced additions in as synthetic transactions, and those
+   * have a policy but no org team or merchant category. Every charge in the
+   * seeded ledger carries both.
+   */
+  team?: ChargeTeam;
+  category?: ChargeCategory;
+  /**
+   * Note there is no `"over-limit"` member: over-limit is DERIVED from the
+   * charge's amount against its policy's remaining headroom (`isOverLimit`),
+   * never stored, so it cannot contradict the numbers it is drawn from.
+   * `"flagged"` is a review state that does not gate approval.
+   */
+  status: "pending" | "denied" | "approved" | "flagged";
   activeExceptionId?: string | null;
 }
 

--- a/examples/showcases/reskinnable-demo/src/skins/banking/data/derived-spend.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/data/derived-spend.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import * as store from "@/skins/banking/data/store";
+import { isOverLimit } from "@/skins/banking/data/over-limit";
+
+/**
+ * Invariants of the single-ledger model.
+ *
+ * These lock in the property that made the report trustworthy: every spend
+ * figure on every surface is a projection of ONE transaction list. Before this,
+ * the report's KPI summed static `policies[].spent` ($137,000) while its charts
+ * read the transactions ($30,089), and the two drifted silently.
+ */
+describe("policies[].spent is derived from the ledger", () => {
+  it("equals the sum of APPROVED charges against each policy", () => {
+    const txs = store.transactions();
+    for (const p of store.policies()) {
+      const expected = txs
+        .filter((t) => t.status === "approved" && t.policyId === p.id)
+        .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+      expect(p.spent).toBeCloseTo(expected, 2);
+    }
+  });
+
+  // Pending spend must stay OUT of `spent`: isOverLimit asks "would approving
+  // this charge breach the limit?", which double-counts if the charge is already
+  // inside the figure it is being compared against.
+  it("excludes pending and flagged charges", () => {
+    const notApproved = store
+      .transactions()
+      .filter((t) => t.status !== "approved");
+    expect(notApproved.length).toBeGreaterThan(0);
+
+    const derived = store.policies().reduce((sum, p) => sum + p.spent, 0);
+    const everything = store
+      .transactions()
+      .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+    expect(derived).toBeLessThan(everything);
+  });
+
+  it("reports the same figure through policies() and findPolicy()", () => {
+    for (const p of store.policies()) {
+      expect(store.findPolicy(p.id)?.spent).toBeCloseTo(p.spent, 2);
+    }
+  });
+});
+
+describe("the seeded ledger supports the report honestly", () => {
+  // The reason a1 existed: SpendingTrendChart substituted a hard-coded Jan–Jun
+  // series whenever fewer than three distinct months were present, and the old
+  // seed spanned exactly two — so the fallback was the default path and the
+  // report showed invented figures. Three or more real months means the honest
+  // branch is the only one the demo ever takes.
+  it("spans at least three distinct months", () => {
+    const months = new Set(
+      store
+        .transactions()
+        .filter((t) => t.amount < 0)
+        .map((t) => t.date.slice(0, 7)),
+    );
+    expect(months.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps the scripted over-limit demo intact", () => {
+    const policies = store.policies();
+    const overLimit = store
+      .transactions()
+      .filter((t) => t.status === "pending" && isOverLimit(t, policies));
+
+    // The teach-mode pill says "Approve the $15,000 AWS charge", so that charge
+    // must exist, be pending, and genuinely derive over-limit.
+    const aws = overLimit.find((t) => t.title === "AWS");
+    expect(aws).toBeDefined();
+    expect(Math.abs(aws!.amount)).toBe(15_000);
+  });
+
+  it("leaves exactly one Delta charge for the 'I don't recognize' pill", () => {
+    const delta = store
+      .transactions()
+      .filter((t) => t.title.toLowerCase().includes("delta"));
+    expect(delta).toHaveLength(1);
+  });
+
+  it("gives every ledger charge a team and category for the Charges table", () => {
+    for (const t of store.transactions()) {
+      expect(t.team, `${t.id} ${t.title}`).toBeDefined();
+      expect(t.category, `${t.id} ${t.title}`).toBeDefined();
+    }
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/banking/data/over-limit.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/data/over-limit.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { isOverLimit, withOverLimit } from "./over-limit";
-import { ExpenseRole } from "@/skins/banking/data/data";
+import { PolicyType } from "@/skins/banking/data/data";
 import type { ExpensePolicy, Transaction } from "@/skins/banking/data/data";
 
 const policies: ExpensePolicy[] = [
-  { id: "pol-mkt", type: ExpenseRole.Marketing, limit: 5000, spent: 500 },
-  { id: "pol-eng", type: ExpenseRole.Engineering, limit: 15000, spent: 1500 },
+  { id: "pol-mkt", type: PolicyType.GoToMarket, limit: 5000, spent: 500 },
+  { id: "pol-eng", type: PolicyType.Technology, limit: 15000, spent: 1500 },
 ];
 
 const base: Omit<

--- a/examples/showcases/reskinnable-demo/src/skins/banking/data/seed.json
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/data/seed.json
@@ -29,13 +29,20 @@
     }
   ],
   "policies": [
-    { "id": "7f3b3c4d5e", "type": "Marketing", "limit": 25000, "spent": 22000 },
-    { "id": "8r5c3m4n5o", "type": "Executive", "limit": 60000, "spent": 55000 },
     {
-      "id": "9a8b7c6d5e",
-      "type": "Engineering",
-      "limit": 68000,
-      "spent": 60000
+      "id": "pol-technology",
+      "type": "Technology",
+      "limit": 270000
+    },
+    {
+      "id": "pol-gtm",
+      "type": "Go-to-Market",
+      "limit": 150000
+    },
+    {
+      "id": "pol-gna",
+      "type": "G&A",
+      "limit": 135000
     }
   ],
   "team": [
@@ -60,41 +67,544 @@
       "title": "Google Ads",
       "amount": -5000,
       "date": "2026-05-28",
-      "policyId": "7f3b3c4d5e",
+      "policyId": "pol-gtm",
       "cardId": "wr197z5ilg",
-      "status": "pending"
+      "status": "pending",
+      "team": "Marketing",
+      "category": "Advertising"
     },
     {
       "id": "t-2",
       "title": "AWS",
       "amount": -15000,
       "date": "2026-05-20",
-      "policyId": "9a8b7c6d5e",
+      "policyId": "pol-technology",
       "cardId": "fA5b7c6d5e",
-      "status": "pending"
+      "status": "pending",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
     },
     {
       "id": "t-3",
       "title": "Microsoft 365",
       "amount": -10000,
       "date": "2026-05-12",
-      "policyId": "8r5c3m4n5o",
+      "policyId": "pol-gna",
       "cardId": "5tf3rmlcyg3",
-      "status": "pending"
+      "status": "pending",
+      "team": "Executive",
+      "category": "SaaS & Software"
     },
     {
       "id": "t-4",
       "title": "Delta Airlines",
       "amount": -89.99,
       "date": "2026-04-22",
-      "policyId": "8r5c3m4n5o",
+      "policyId": "pol-gna",
       "cardId": "5tf3rmlcyg3",
       "note": {
         "content": "SF Executive Offsite",
         "userId": "9g5h2j1k4l",
         "date": "2026-04-25"
       },
-      "status": "approved"
+      "status": "approved",
+      "team": "Executive",
+      "category": "Travel"
+    },
+    {
+      "id": "t-100",
+      "title": "Amazon Web Services",
+      "amount": -91800,
+      "date": "2026-06-01",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
+    },
+    {
+      "id": "t-101",
+      "title": "ADP Payroll",
+      "amount": -74200,
+      "date": "2026-06-15",
+      "policyId": "pol-gna",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "People",
+      "category": "Payroll & Benefits"
+    },
+    {
+      "id": "t-102",
+      "title": "Wilson Sonsini",
+      "amount": -58400,
+      "date": "2026-05-22",
+      "policyId": "pol-gna",
+      "cardId": "fA5b7c6d5e",
+      "status": "flagged",
+      "team": "Executive",
+      "category": "Professional Services"
+    },
+    {
+      "id": "t-103",
+      "title": "Snowflake",
+      "amount": -43250,
+      "date": "2026-05-04",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
+    },
+    {
+      "id": "t-104",
+      "title": "Google Ads",
+      "amount": -38600,
+      "date": "2026-06-09",
+      "policyId": "pol-gtm",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Advertising"
+    },
+    {
+      "id": "t-105",
+      "title": "Deloitte",
+      "amount": -34900,
+      "date": "2026-04-28",
+      "policyId": "pol-gna",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Finance",
+      "category": "Professional Services"
+    },
+    {
+      "id": "t-106",
+      "title": "Salesforce",
+      "amount": -31200,
+      "date": "2026-05-18",
+      "policyId": "pol-gtm",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Sales",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-107",
+      "title": "Meta Ads",
+      "amount": -27450,
+      "date": "2026-06-11",
+      "policyId": "pol-gtm",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Advertising"
+    },
+    {
+      "id": "t-108",
+      "title": "Cvent",
+      "amount": -24800,
+      "date": "2026-05-30",
+      "policyId": "pol-gtm",
+      "cardId": "fA5b7c6d5e",
+      "status": "flagged",
+      "team": "Marketing",
+      "category": "Marketing Events"
+    },
+    {
+      "id": "t-109",
+      "title": "Microsoft Azure",
+      "amount": -22100,
+      "date": "2026-04-12",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
+    },
+    {
+      "id": "t-110",
+      "title": "Dell Technologies",
+      "amount": -18750,
+      "date": "2026-05-07",
+      "policyId": "pol-technology",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Operations",
+      "category": "Hardware"
+    },
+    {
+      "id": "t-111",
+      "title": "Google Cloud",
+      "amount": -17300,
+      "date": "2026-06-02",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
+    },
+    {
+      "id": "t-112",
+      "title": "HubSpot",
+      "amount": -15900,
+      "date": "2026-04-19",
+      "policyId": "pol-gtm",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-113",
+      "title": "WeWork",
+      "amount": -14200,
+      "date": "2026-06-01",
+      "policyId": "pol-technology",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Operations",
+      "category": "Office & Facilities"
+    },
+    {
+      "id": "t-114",
+      "title": "LinkedIn Ads",
+      "amount": -12650,
+      "date": "2026-05-14",
+      "policyId": "pol-gtm",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Advertising"
+    },
+    {
+      "id": "t-115",
+      "title": "Apple",
+      "amount": -11480,
+      "date": "2026-04-25",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Hardware"
+    },
+    {
+      "id": "t-116",
+      "title": "Marriott",
+      "amount": -9820,
+      "date": "2026-06-06",
+      "policyId": "pol-gtm",
+      "cardId": "wr197z5ilg",
+      "status": "flagged",
+      "team": "Sales",
+      "category": "Travel"
+    },
+    {
+      "id": "t-117",
+      "title": "Datadog",
+      "amount": -8760,
+      "date": "2026-05-11",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
+    },
+    {
+      "id": "t-118",
+      "title": "Gusto",
+      "amount": -8100,
+      "date": "2026-04-15",
+      "policyId": "pol-gna",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "People",
+      "category": "Payroll & Benefits"
+    },
+    {
+      "id": "t-119",
+      "title": "United Airlines",
+      "amount": -7450,
+      "date": "2026-05-27",
+      "policyId": "pol-gna",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Executive",
+      "category": "Travel"
+    },
+    {
+      "id": "t-120",
+      "title": "Cloudflare",
+      "amount": -6900,
+      "date": "2026-06-03",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Cloud Infrastructure"
+    },
+    {
+      "id": "t-121",
+      "title": "CDW",
+      "amount": -6320,
+      "date": "2026-04-30",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Operations",
+      "category": "Hardware"
+    },
+    {
+      "id": "t-122",
+      "title": "United Airlines",
+      "amount": -5980,
+      "date": "2026-06-08",
+      "policyId": "pol-gtm",
+      "cardId": "wr197z5ilg",
+      "status": "flagged",
+      "team": "Sales",
+      "category": "Travel"
+    },
+    {
+      "id": "t-123",
+      "title": "Reddit Ads",
+      "amount": -5400,
+      "date": "2026-05-19",
+      "policyId": "pol-gtm",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Advertising"
+    },
+    {
+      "id": "t-124",
+      "title": "Hopin",
+      "amount": -4950,
+      "date": "2026-04-22",
+      "policyId": "pol-gtm",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Marketing Events"
+    },
+    {
+      "id": "t-125",
+      "title": "Hilton",
+      "amount": -4380,
+      "date": "2026-05-25",
+      "policyId": "pol-gna",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Executive",
+      "category": "Travel"
+    },
+    {
+      "id": "t-126",
+      "title": "GitHub",
+      "amount": -3900,
+      "date": "2026-06-01",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-127",
+      "title": "TikTok Ads",
+      "amount": -3610,
+      "date": "2026-05-16",
+      "policyId": "pol-gtm",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Advertising"
+    },
+    {
+      "id": "t-128",
+      "title": "Vercel",
+      "amount": -3200,
+      "date": "2026-04-18",
+      "policyId": "pol-technology",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-129",
+      "title": "Airbnb",
+      "amount": -2870,
+      "date": "2026-06-05",
+      "policyId": "pol-gtm",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Sales",
+      "category": "Travel"
+    },
+    {
+      "id": "t-130",
+      "title": "Notion",
+      "amount": -2450,
+      "date": "2026-05-02",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Operations",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-131",
+      "title": "Figma",
+      "amount": -2180,
+      "date": "2026-04-11",
+      "policyId": "pol-technology",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-132",
+      "title": "Eventbrite",
+      "amount": -1990,
+      "date": "2026-06-07",
+      "policyId": "pol-gtm",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Marketing Events"
+    },
+    {
+      "id": "t-133",
+      "title": "Slack",
+      "amount": -1720,
+      "date": "2026-05-09",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Operations",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-134",
+      "title": "Staples",
+      "amount": -1440,
+      "date": "2026-04-16",
+      "policyId": "pol-technology",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Operations",
+      "category": "Office & Facilities"
+    },
+    {
+      "id": "t-135",
+      "title": "Linear",
+      "amount": -1180,
+      "date": "2026-06-04",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "SaaS & Software"
+    },
+    {
+      "id": "t-136",
+      "title": "Amazon Business",
+      "amount": -960,
+      "date": "2026-05-13",
+      "policyId": "pol-technology",
+      "cardId": "5tf3rmlcyg3",
+      "status": "pending",
+      "team": "Operations",
+      "category": "Office & Facilities"
+    },
+    {
+      "id": "t-137",
+      "title": "Uber",
+      "amount": -740,
+      "date": "2026-06-10",
+      "policyId": "pol-gtm",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Sales",
+      "category": "Travel"
+    },
+    {
+      "id": "t-138",
+      "title": "DoorDash",
+      "amount": -520,
+      "date": "2026-05-21",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Meals & Entertainment"
+    },
+    {
+      "id": "t-139",
+      "title": "Sweetgreen",
+      "amount": -380,
+      "date": "2026-04-23",
+      "policyId": "pol-gna",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "People",
+      "category": "Meals & Entertainment"
+    },
+    {
+      "id": "t-140",
+      "title": "Uber",
+      "amount": -290,
+      "date": "2026-06-12",
+      "policyId": "pol-gna",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Executive",
+      "category": "Travel"
+    },
+    {
+      "id": "t-141",
+      "title": "Blue Bottle Coffee",
+      "amount": -148,
+      "date": "2026-05-06",
+      "policyId": "pol-gtm",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Marketing",
+      "category": "Meals & Entertainment"
+    },
+    {
+      "id": "t-142",
+      "title": "DoorDash",
+      "amount": -96,
+      "date": "2026-06-13",
+      "policyId": "pol-gtm",
+      "cardId": "5tf3rmlcyg3",
+      "status": "approved",
+      "team": "Sales",
+      "category": "Meals & Entertainment"
+    },
+    {
+      "id": "t-143",
+      "title": "Sweetgreen",
+      "amount": -64,
+      "date": "2026-04-27",
+      "policyId": "pol-technology",
+      "cardId": "wr197z5ilg",
+      "status": "approved",
+      "team": "Engineering",
+      "category": "Meals & Entertainment"
+    },
+    {
+      "id": "t-144",
+      "title": "Blue Bottle Coffee",
+      "amount": -28,
+      "date": "2026-05-29",
+      "policyId": "pol-technology",
+      "cardId": "fA5b7c6d5e",
+      "status": "approved",
+      "team": "Operations",
+      "category": "Meals & Entertainment"
     }
   ],
   "exceptions": []

--- a/examples/showcases/reskinnable-demo/src/skins/banking/data/store.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/data/store.ts
@@ -29,11 +29,18 @@ import {
 type DB = {
   cards: Card[];
   team: Member[];
-  policies: ExpensePolicy[];
+  /**
+   * Seeded policies carry NO `spent` — it is derived from the ledger on every
+   * read (see `policies()`), so the stored shape omits it rather than holding a
+   * second copy of a number the transactions already determine.
+   */
+  policies: SeededPolicy[];
   transactions: Transaction[];
   exceptions: PolicyException[];
   reports: Report[];
 };
+
+type SeededPolicy = Omit<ExpensePolicy, "spent">;
 
 // Reports are copilot-generated at runtime and never seeded, so the JSON
 // seam cast covers only the seeded collections.
@@ -71,16 +78,53 @@ export const reset = (): void => {
 
 export const cards = (): Card[] => db.cards;
 export const team = (): Member[] => db.team;
-export const policies = (): ExpensePolicy[] => db.policies;
 export const transactions = (): Transaction[] => db.transactions;
 export const exceptions = (): PolicyException[] => db.exceptions;
 export const reports = (): Report[] => db.reports;
 
+/**
+ * Approved spend against one policy, summed from the ledger.
+ *
+ * APPROVED only, deliberately: `isWithinPolicyLimit` asks "would approving this
+ * pending charge breach the limit?", which double-counts if pending spend is
+ * already inside `spent`.
+ */
+const spentFor = (policyId: string): number =>
+  db.transactions
+    .filter((t) => t.status === "approved" && t.policyId === policyId)
+    .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+
+const withSpent = (p: SeededPolicy): ExpensePolicy => ({
+  ...p,
+  spent: spentFor(p.id),
+});
+
+/**
+ * Expense policies, with `spent` DERIVED from the ledger on every read.
+ *
+ * Two bugs this closes, both from `spent` having been static seed data:
+ *
+ *  1. It could disagree with the charts. The report's "Total Q2 spend" KPI sums
+ *     `policy.spent` while its charts read transactions; as separate sources
+ *     they drifted silently — the KPI read $137,000 against a $30,089 ledger.
+ *  2. It never moved. Approving a charge left `spent` untouched, so the budget
+ *     never reflected the approval and `isWithinPolicyLimit` kept gating
+ *     against a stale figure.
+ *
+ * Deriving on read makes both impossible rather than merely fixed, which is why
+ * the seed no longer carries a `spent` value at all.
+ */
+export const policies = (): ExpensePolicy[] => db.policies.map(withSpent);
+
 export const findCard = (id: string): Card | undefined =>
   db.cards.find((c) => c.id === id);
 
-export const findPolicy = (id: string): ExpensePolicy | undefined =>
-  db.policies.find((p) => p.id === id);
+export const findPolicy = (id: string): ExpensePolicy | undefined => {
+  const p = db.policies.find((x) => x.id === id);
+  // Must go through the same derivation as `policies()` — this is what
+  // `isWithinPolicyLimit` reads, so a raw `db` hit would gate on stale spend.
+  return p && withSpent(p);
+};
 
 export const findTransaction = (id: string): Transaction | undefined =>
   db.transactions.find((t) => t.id === id);

--- a/examples/showcases/reskinnable-demo/src/skins/banking/pages/charges-data.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/pages/charges-data.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseSort,
+  parseTop,
+  toChargeRow,
+  SORT_KEYS,
+} from "@/skins/banking/pages/charges-data";
+import type { Transaction } from "@/skins/banking/data/data";
+
+const charge = (over: Partial<Transaction> = {}): Transaction => ({
+  id: "t-1",
+  title: "Amazon Web Services",
+  amount: -91_800,
+  date: "2026-06-01",
+  policyId: "pol-technology",
+  cardId: "card-1",
+  team: "Engineering",
+  category: "Cloud Infrastructure",
+  status: "approved",
+  ...over,
+});
+
+describe("parseSort", () => {
+  it("accepts every real sort key", () => {
+    for (const k of SORT_KEYS) expect(parseSort(k)).toBe(k);
+  });
+
+  // The whole point of returning null rather than a default: the page keys the
+  // Sort control's "active" tint on this result, so an unrecognised value must
+  // read as NOT SET. Returning "amount_desc" here would light the tint and
+  // claim a sort the user never chose.
+  it.each([
+    ["an unknown value", "banana"],
+    ["an empty value", ""],
+    ["a near-miss", "amount_descending"],
+    ["a case mismatch", "AMOUNT_DESC"],
+  ])("treats %s as not set", (_label, raw) => {
+    expect(parseSort(raw)).toBeNull();
+  });
+
+  it("treats an absent param as not set", () => {
+    expect(parseSort(null)).toBeNull();
+  });
+});
+
+describe("parseTop", () => {
+  it("accepts a positive integer", () => {
+    expect(parseTop("10")).toBe(10);
+  });
+
+  // `?top=-5` used to reach rows.slice(0, -5), which drops the LAST five rows —
+  // the opposite of showing a top-5. Zero emptied the table entirely.
+  it.each([
+    ["a negative", "-5"],
+    ["zero", "0"],
+    ["a fraction", "7.5"],
+    ["a non-number", "ten"],
+    ["an empty value", ""],
+  ])("rejects %s", (_label, raw) => {
+    expect(parseTop(raw)).toBeNull();
+  });
+
+  it("treats an absent param as not set", () => {
+    expect(parseTop(null)).toBeNull();
+  });
+});
+
+describe("toChargeRow", () => {
+  it("presents ledger spend as a positive amount", () => {
+    expect(toChargeRow(charge(), false).amount).toBe(91_800);
+  });
+
+  it("renders a derived over-limit status for a pending charge", () => {
+    expect(toChargeRow(charge({ status: "pending" }), true).status).toBe(
+      "over-limit",
+    );
+  });
+
+  // over-limit is only meaningful for a charge awaiting approval; an approved
+  // charge is already inside the policy's spend, so flagging it would double-count
+  // the very condition the badge describes.
+  it("does not mark an approved charge over-limit", () => {
+    expect(toChargeRow(charge({ status: "approved" }), true).status).toBe(
+      "approved",
+    );
+  });
+
+  it("falls back to a dash when a transaction has no team or category", () => {
+    const row = toChargeRow(
+      charge({ team: undefined, category: undefined }),
+      false,
+    );
+    expect(row.team).toBe("—");
+    expect(row.category).toBe("—");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/banking/pages/charges-data.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/pages/charges-data.ts
@@ -1,34 +1,37 @@
-// Standalone dataset for the Charges page. Kept independent of the seeded
-// transaction store (which drives the teach/memory arc) so this richer list can
-// grow without touching those fixtures. ~45 charges across categories, vendors,
-// teams and statuses, with a wide amount spread so "the 10 most expensive"
-// (and the filter/stack-rank flow) is meaningful.
+// Presentation vocabulary for the Charges page.
+//
+// This file used to carry its own 45-row `CHARGES` fixture, kept deliberately
+// "independent of the seeded transaction store". That independence was the bug:
+// the app ended up with three disagreeing answers to "what did we spend" — this
+// fixture ($632,806), the seeded ledger ($30,089, only two months, which made
+// the report's trend chart fall back to hard-coded numbers), and the policy
+// totals ($137,000). Those 45 charges now live in the ledger itself
+// (`data/seed.json`), so every surface reads one source over
+// `/api/banking/v1/transactions`.
+//
+// What remains here is only what the *page* needs that the ledger does not
+// model: the filter vocabularies, and the display status — which includes
+// `over-limit`, a value no transaction stores because it is derived from the
+// charge's amount against its policy's remaining headroom.
 
-export const CHARGE_CATEGORIES = [
-  "Cloud Infrastructure",
-  "Advertising",
-  "SaaS & Software",
-  "Travel",
-  "Payroll & Benefits",
-  "Office & Facilities",
-  "Professional Services",
-  "Marketing Events",
-  "Hardware",
-  "Meals & Entertainment",
-] as const;
-export type ChargeCategory = (typeof CHARGE_CATEGORIES)[number];
+import {
+  CHARGE_CATEGORIES,
+  CHARGE_TEAMS,
+  type ChargeCategory,
+  type ChargeTeam,
+  type Transaction,
+} from "@/skins/banking/data/data";
 
-export const CHARGE_TEAMS = [
-  "Engineering",
-  "Marketing",
-  "Sales",
-  "Executive",
-  "Operations",
-  "Finance",
-  "People",
-] as const;
-export type ChargeTeam = (typeof CHARGE_TEAMS)[number];
+export { CHARGE_CATEGORIES, CHARGE_TEAMS };
+export type { ChargeCategory, ChargeTeam };
 
+/**
+ * The statuses the Charges table can display.
+ *
+ * A superset of `Transaction["status"]`: `over-limit` is derived per row via
+ * `isOverLimit`, and `denied` is omitted because the seeded ledger contains
+ * none (a denied charge is rendered by its stored status if one ever appears).
+ */
 export const CHARGE_STATUSES = [
   "approved",
   "pending",
@@ -37,423 +40,85 @@ export const CHARGE_STATUSES = [
 ] as const;
 export type ChargeStatus = (typeof CHARGE_STATUSES)[number];
 
-export interface Charge {
+/**
+ * One row of the Charges table: a ledger transaction flattened for display,
+ * with spend as a positive number and the over-limit status resolved.
+ */
+export interface ChargeRow {
   id: string;
   merchant: string;
-  category: ChargeCategory;
-  team: ChargeTeam;
-  amount: number; // USD, positive = spend
-  date: string; // ISO yyyy-mm-dd (2026 Q2)
+  /**
+   * Display strings rather than the strict vocabularies: a Transaction's team
+   * and category are optional (a report's synthetic additions have neither), so
+   * a row renders a dash instead of the page having to exclude such rows.
+   */
+  category: string;
+  team: string;
+  /** USD, positive = spend (the ledger stores spend as negative). */
+  amount: number;
+  /** ISO yyyy-mm-dd. */
+  date: string;
   status: ChargeStatus;
 }
 
-export const CHARGES: Charge[] = [
-  // ── Big-ticket (the top of a "most expensive" sort) ──────────────────────
-  {
-    id: "chg-001",
-    merchant: "Amazon Web Services",
-    category: "Cloud Infrastructure",
-    team: "Engineering",
-    amount: 91800,
-    date: "2026-06-01",
-    status: "over-limit",
-  },
-  {
-    id: "chg-002",
-    merchant: "ADP Payroll",
-    category: "Payroll & Benefits",
-    team: "People",
-    amount: 74200,
-    date: "2026-06-15",
-    status: "approved",
-  },
-  {
-    id: "chg-003",
-    merchant: "Wilson Sonsini",
-    category: "Professional Services",
-    team: "Executive",
-    amount: 58400,
-    date: "2026-05-22",
-    status: "flagged",
-  },
-  {
-    id: "chg-004",
-    merchant: "Snowflake",
-    category: "Cloud Infrastructure",
-    team: "Engineering",
-    amount: 43250,
-    date: "2026-05-04",
-    status: "approved",
-  },
-  {
-    id: "chg-005",
-    merchant: "Google Ads",
-    category: "Advertising",
-    team: "Marketing",
-    amount: 38600,
-    date: "2026-06-09",
-    status: "over-limit",
-  },
-  {
-    id: "chg-006",
-    merchant: "Deloitte",
-    category: "Professional Services",
-    team: "Finance",
-    amount: 34900,
-    date: "2026-04-28",
-    status: "approved",
-  },
-  {
-    id: "chg-007",
-    merchant: "Salesforce",
-    category: "SaaS & Software",
-    team: "Sales",
-    amount: 31200,
-    date: "2026-05-18",
-    status: "approved",
-  },
-  {
-    id: "chg-008",
-    merchant: "Meta Ads",
-    category: "Advertising",
-    team: "Marketing",
-    amount: 27450,
-    date: "2026-06-11",
-    status: "pending",
-  },
-  {
-    id: "chg-009",
-    merchant: "Cvent",
-    category: "Marketing Events",
-    team: "Marketing",
-    amount: 24800,
-    date: "2026-05-30",
-    status: "flagged",
-  },
-  {
-    id: "chg-010",
-    merchant: "Microsoft Azure",
-    category: "Cloud Infrastructure",
-    team: "Engineering",
-    amount: 22100,
-    date: "2026-04-12",
-    status: "approved",
-  },
-  // ── Mid-tier ─────────────────────────────────────────────────────────────
-  {
-    id: "chg-011",
-    merchant: "Dell Technologies",
-    category: "Hardware",
-    team: "Operations",
-    amount: 18750,
-    date: "2026-05-07",
-    status: "pending",
-  },
-  {
-    id: "chg-012",
-    merchant: "Google Cloud",
-    category: "Cloud Infrastructure",
-    team: "Engineering",
-    amount: 17300,
-    date: "2026-06-02",
-    status: "approved",
-  },
-  {
-    id: "chg-013",
-    merchant: "HubSpot",
-    category: "SaaS & Software",
-    team: "Marketing",
-    amount: 15900,
-    date: "2026-04-19",
-    status: "approved",
-  },
-  {
-    id: "chg-014",
-    merchant: "WeWork",
-    category: "Office & Facilities",
-    team: "Operations",
-    amount: 14200,
-    date: "2026-06-01",
-    status: "approved",
-  },
-  {
-    id: "chg-015",
-    merchant: "LinkedIn Ads",
-    category: "Advertising",
-    team: "Marketing",
-    amount: 12650,
-    date: "2026-05-14",
-    status: "over-limit",
-  },
-  {
-    id: "chg-016",
-    merchant: "Apple",
-    category: "Hardware",
-    team: "Engineering",
-    amount: 11480,
-    date: "2026-04-25",
-    status: "approved",
-  },
-  {
-    id: "chg-017",
-    merchant: "Marriott",
-    category: "Travel",
-    team: "Sales",
-    amount: 9820,
-    date: "2026-06-06",
-    status: "flagged",
-  },
-  {
-    id: "chg-018",
-    merchant: "Datadog",
-    category: "Cloud Infrastructure",
-    team: "Engineering",
-    amount: 8760,
-    date: "2026-05-11",
-    status: "approved",
-  },
-  {
-    id: "chg-019",
-    merchant: "Gusto",
-    category: "Payroll & Benefits",
-    team: "People",
-    amount: 8100,
-    date: "2026-04-15",
-    status: "approved",
-  },
-  {
-    id: "chg-020",
-    merchant: "Delta Air Lines",
-    category: "Travel",
-    team: "Executive",
-    amount: 7450,
-    date: "2026-05-27",
-    status: "pending",
-  },
-  {
-    id: "chg-021",
-    merchant: "Cloudflare",
-    category: "Cloud Infrastructure",
-    team: "Engineering",
-    amount: 6900,
-    date: "2026-06-03",
-    status: "approved",
-  },
-  {
-    id: "chg-022",
-    merchant: "CDW",
-    category: "Hardware",
-    team: "Operations",
-    amount: 6320,
-    date: "2026-04-30",
-    status: "approved",
-  },
-  {
-    id: "chg-023",
-    merchant: "United Airlines",
-    category: "Travel",
-    team: "Sales",
-    amount: 5980,
-    date: "2026-06-08",
-    status: "flagged",
-  },
-  {
-    id: "chg-024",
-    merchant: "Reddit Ads",
-    category: "Advertising",
-    team: "Marketing",
-    amount: 5400,
-    date: "2026-05-19",
-    status: "approved",
-  },
-  {
-    id: "chg-025",
-    merchant: "Hopin",
-    category: "Marketing Events",
-    team: "Marketing",
-    amount: 4950,
-    date: "2026-04-22",
-    status: "approved",
-  },
-  {
-    id: "chg-026",
-    merchant: "Hilton",
-    category: "Travel",
-    team: "Executive",
-    amount: 4380,
-    date: "2026-05-25",
-    status: "approved",
-  },
-  {
-    id: "chg-027",
-    merchant: "GitHub",
-    category: "SaaS & Software",
-    team: "Engineering",
-    amount: 3900,
-    date: "2026-06-01",
-    status: "approved",
-  },
-  {
-    id: "chg-028",
-    merchant: "TikTok Ads",
-    category: "Advertising",
-    team: "Marketing",
-    amount: 3610,
-    date: "2026-05-16",
-    status: "pending",
-  },
-  {
-    id: "chg-029",
-    merchant: "Vercel",
-    category: "SaaS & Software",
-    team: "Engineering",
-    amount: 3200,
-    date: "2026-04-18",
-    status: "approved",
-  },
-  {
-    id: "chg-030",
-    merchant: "Airbnb",
-    category: "Travel",
-    team: "Sales",
-    amount: 2870,
-    date: "2026-06-05",
-    status: "approved",
-  },
-  // ── Long tail ────────────────────────────────────────────────────────────
-  {
-    id: "chg-031",
-    merchant: "Notion",
-    category: "SaaS & Software",
-    team: "Operations",
-    amount: 2450,
-    date: "2026-05-02",
-    status: "approved",
-  },
-  {
-    id: "chg-032",
-    merchant: "Figma",
-    category: "SaaS & Software",
-    team: "Engineering",
-    amount: 2180,
-    date: "2026-04-11",
-    status: "approved",
-  },
-  {
-    id: "chg-033",
-    merchant: "Eventbrite",
-    category: "Marketing Events",
-    team: "Marketing",
-    amount: 1990,
-    date: "2026-06-07",
-    status: "approved",
-  },
-  {
-    id: "chg-034",
-    merchant: "Slack",
-    category: "SaaS & Software",
-    team: "Operations",
-    amount: 1720,
-    date: "2026-05-09",
-    status: "approved",
-  },
-  {
-    id: "chg-035",
-    merchant: "Staples",
-    category: "Office & Facilities",
-    team: "Operations",
-    amount: 1440,
-    date: "2026-04-16",
-    status: "approved",
-  },
-  {
-    id: "chg-036",
-    merchant: "Linear",
-    category: "SaaS & Software",
-    team: "Engineering",
-    amount: 1180,
-    date: "2026-06-04",
-    status: "approved",
-  },
-  {
-    id: "chg-037",
-    merchant: "Amazon Business",
-    category: "Office & Facilities",
-    team: "Operations",
-    amount: 960,
-    date: "2026-05-13",
-    status: "approved",
-  },
-  {
-    id: "chg-038",
-    merchant: "Uber",
-    category: "Travel",
-    team: "Sales",
-    amount: 740,
-    date: "2026-06-10",
-    status: "approved",
-  },
-  {
-    id: "chg-039",
-    merchant: "DoorDash",
-    category: "Meals & Entertainment",
-    team: "Engineering",
-    amount: 520,
-    date: "2026-05-21",
-    status: "approved",
-  },
-  {
-    id: "chg-040",
-    merchant: "Sweetgreen",
-    category: "Meals & Entertainment",
-    team: "People",
-    amount: 380,
-    date: "2026-04-23",
-    status: "approved",
-  },
-  {
-    id: "chg-041",
-    merchant: "Uber",
-    category: "Travel",
-    team: "Executive",
-    amount: 290,
-    date: "2026-06-12",
-    status: "approved",
-  },
-  {
-    id: "chg-042",
-    merchant: "Blue Bottle Coffee",
-    category: "Meals & Entertainment",
-    team: "Marketing",
-    amount: 148,
-    date: "2026-05-06",
-    status: "approved",
-  },
-  {
-    id: "chg-043",
-    merchant: "DoorDash",
-    category: "Meals & Entertainment",
-    team: "Sales",
-    amount: 96,
-    date: "2026-06-13",
-    status: "approved",
-  },
-  {
-    id: "chg-044",
-    merchant: "Sweetgreen",
-    category: "Meals & Entertainment",
-    team: "Engineering",
-    amount: 64,
-    date: "2026-04-27",
-    status: "approved",
-  },
-  {
-    id: "chg-045",
-    merchant: "Blue Bottle Coffee",
-    category: "Meals & Entertainment",
-    team: "Operations",
-    amount: 28,
-    date: "2026-05-29",
-    status: "approved",
-  },
-];
+/** Shown when a transaction carries no team/category (see `ChargeRow`). */
+const UNATTRIBUTED = "—";
+
+/**
+ * Project a ledger transaction onto a table row.
+ *
+ * `overLimit` is passed in rather than recomputed here so the page derives it
+ * once via `withOverLimit` (the single source of truth for that rule) instead
+ * of this module forming a second opinion about policy headroom.
+ */
+export const toChargeRow = (
+  t: Transaction,
+  overLimit: boolean,
+): ChargeRow => ({
+  id: t.id,
+  merchant: t.title,
+  category: t.category ?? UNATTRIBUTED,
+  team: t.team ?? UNATTRIBUTED,
+  amount: Math.abs(t.amount),
+  date: t.date,
+  status: overLimit && t.status === "pending" ? "over-limit" : toDisplayStatus(t.status),
+});
+
+const toDisplayStatus = (s: Transaction["status"]): ChargeStatus =>
+  // `denied` has no chip of its own; it reads as pending review in the table.
+  s === "denied" ? "pending" : s;
+
+export const SORT_KEYS = [
+  "amount_desc",
+  "amount_asc",
+  "date_desc",
+  "date_asc",
+] as const;
+export type SortKey = (typeof SORT_KEYS)[number];
+
+/**
+ * Narrow a `?sort=` value to a real sort key, or `null` when unrecognised.
+ *
+ * `null` matters as much as the happy path: the page tints the Sort control to
+ * signal "this view is deliberately sorted", and it keys that tint on this
+ * result. The param used to be cast straight to `SortKey`, so `?sort=banana`
+ * lit the tint while no `<option>` matched and the table silently fell back to
+ * amount_desc — the control asserted a filter it was not applying.
+ */
+export const parseSort = (raw: string | null): SortKey | null =>
+  raw !== null && (SORT_KEYS as readonly string[]).includes(raw)
+    ? (raw as SortKey)
+    : null;
+
+/**
+ * Narrow a `?top=` value to a positive row count, or `null`.
+ *
+ * Rejects zero, negatives and fractions. `?top=-5` previously reached
+ * `rows.slice(0, -5)`, which drops the LAST five rows — inverting the meaning
+ * of top-N rather than failing.
+ */
+export const parseTop = (raw: string | null): number | null => {
+  if (raw === null) return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+};

--- a/examples/showcases/reskinnable-demo/src/skins/banking/pages/charges.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/pages/charges.tsx
@@ -2,11 +2,19 @@
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useAgentContext } from "@copilotkit/react-core/v2";
 import { Search, X } from "lucide-react";
-import { CHARGES, CHARGE_CATEGORIES, CHARGE_STATUSES } from "./charges-data";
-import type { Charge, ChargeStatus } from "./charges-data";
+import {
+  CHARGE_CATEGORIES,
+  CHARGE_STATUSES,
+  toChargeRow,
+  parseSort,
+  parseTop,
+} from "./charges-data";
+import type { ChargeRow, ChargeStatus, SortKey } from "./charges-data";
+
+import useCreditCards from "@/skins/banking/actions";
+import { withOverLimit } from "@/skins/banking/data/over-limit";
 import { cn, formatCurrency } from "@/lib/utils";
 
-type SortKey = "amount_desc" | "amount_asc" | "date_desc" | "date_asc";
 const SORT_LABELS: Record<SortKey, string> = {
   amount_desc: "Most expensive",
   amount_asc: "Least expensive",
@@ -26,13 +34,14 @@ export default function ChargesPage() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { transactions, policies } = useCreditCards();
 
   // All filter state lives in the URL so the copilot can deep-link into a
   // pre-filtered, pre-sorted view (e.g. ?sort=amount_desc&top=10) and the
   // on-screen controls reflect exactly what it set.
-  const sort = (searchParams.get("sort") as SortKey) || "amount_desc";
-  const topRaw = searchParams.get("top");
-  const top = topRaw && !Number.isNaN(Number(topRaw)) ? Number(topRaw) : null;
+  const sortParam = parseSort(searchParams.get("sort"));
+  const sort: SortKey = sortParam ?? "amount_desc";
+  const top = parseTop(searchParams.get("top"));
   const categories = (searchParams.get("category") ?? "")
     .split(",")
     .filter(Boolean);
@@ -49,7 +58,11 @@ export default function ChargesPage() {
   // the user can see WHAT changed, not just that the page changed. Manually
   // choosing a non-default keeps the tint, which is the same statement: this
   // view is filtered.
-  const sortIsSet = searchParams.get("sort") !== null;
+  //
+  // Keyed on the PARSED value, not on the param's presence: an unrecognised
+  // `?sort=banana` is not a sort the user chose, so tinting it would claim a
+  // filter the table is not applying.
+  const sortIsSet = sortParam !== null;
   const topIsSet = top !== null;
   const activeSelect =
     "border-brand/50 bg-brand-soft font-semibold text-brand-indigo dark:text-brand-violet";
@@ -81,12 +94,20 @@ export default function ChargesPage() {
     top != null ||
     sort !== "amount_desc";
 
+  // Every charge on this page comes from the same ledger the report and the
+  // agent read, over REST. `withOverLimit` is the single source of truth for the
+  // over-limit rule, so the badge here cannot disagree with the report's
+  // "Needs a decision" rows.
+  const allRows = withOverLimit(transactions, policies).map((t) =>
+    toChargeRow(t, t.overLimit),
+  );
+
   // No manual useMemo: the filter args (categories/statuses) are fresh arrays
   // each render, which the React Compiler's preserve-manual-memoization rule
   // rejects as memo deps. The compiler memoizes this derivation from the URL
   // state on its own, so compute it directly.
-  const visible = ((): Charge[] => {
-    const rows: Charge[] = CHARGES.filter((c) => {
+  const visible = ((): ChargeRow[] => {
+    const rows: ChargeRow[] = allRows.filter((c) => {
       if (categories.length && !categories.includes(c.category)) return false;
       if (statuses.length && !statuses.includes(c.status)) return false;
       if (vendor && !c.merchant.toLowerCase().includes(vendor.toLowerCase()))
@@ -133,7 +154,7 @@ export default function ChargesPage() {
         <div>
           <h2 className="text-xl font-bold tracking-tight text-ink">Charges</h2>
           <p className="mt-1 text-sm text-ink-muted">
-            {visible.length} of {CHARGES.length} charges ·{" "}
+            {visible.length} of {allRows.length} charges ·{" "}
             {formatCurrency(totalVisible)} shown
           </p>
         </div>

--- a/examples/showcases/reskinnable-demo/src/skins/banking/pages/dashboard.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/pages/dashboard.tsx
@@ -3,7 +3,6 @@ import useCreditCards from "@/skins/banking/actions";
 import { useMemo } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { useAgentContext } from "@copilotkit/react-core/v2";
-import type { Transaction } from "@/skins/banking/data/data";
 import { ArrowDownRight, ArrowUpRight, Plus, ArrowRight } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TransactionsList } from "@/skins/banking/components/transactions-list";
@@ -62,7 +61,10 @@ export default function HomePage() {
     status,
   }: {
     id: string;
-    status: Transaction["status"];
+    // The mutation surface, deliberately narrower than Transaction["status"]:
+    // "flagged" is a review state the UI displays but never transitions to, and
+    // over-limit is derived rather than stored.
+    status: "pending" | "approved" | "denied";
   }): Promise<boolean> => {
     const { ok } = await changeTransactionStatus({ id, status });
     return ok;

--- a/examples/showcases/reskinnable-demo/src/skins/banking/sandbox-functions.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/sandbox-functions.test.ts
@@ -5,7 +5,7 @@ import type {
   ExpensePolicy,
   Transaction,
 } from "@/skins/banking/data/data";
-import { CardBrand, ExpenseRole } from "@/skins/banking/data/data";
+import { CardBrand, PolicyType } from "@/skins/banking/data/data";
 
 const fn = (name: string) => {
   const f = sandboxFunctions.find((s) => s.name === name);
@@ -25,7 +25,7 @@ const cards: Card[] = [
   },
 ];
 const policies: ExpensePolicy[] = [
-  { id: "pol-mkt", type: ExpenseRole.Marketing, limit: 5000, spent: 500 },
+  { id: "pol-mkt", type: PolicyType.GoToMarket, limit: 5000, spent: 500 },
 ];
 const transactions: Transaction[] = [
   {
@@ -74,7 +74,7 @@ describe("getPolicies", () => {
       unknown
     >[];
     expect(out).toEqual([
-      { id: "pol-mkt", type: ExpenseRole.Marketing, limit: 5000, spent: 500 },
+      { id: "pol-mkt", type: PolicyType.GoToMarket, limit: 5000, spent: 500 },
     ]);
   });
 });

--- a/examples/showcases/reskinnable-demo/src/skins/banking/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/tools.tsx
@@ -362,8 +362,12 @@ export function BankingTools() {
       // emitter, so the marker is applied here where it is guaranteed — and
       // only when the text actually reads as an alert, so ordinary notes stay
       // plain.
+      // Anchored on BOTH sides, and whole words rather than stems. Left-anchored
+      // alone, `report` matched inside "reporter" and "quarterly report", and
+      // `disput` inside "disputation" — so ordinary notes ("attached to the
+      // quarterly report") were served a fraud marker.
       const alerting =
-        /\b(unrecognized|unrecognised|suspicious|report(ed)?|fraud|disput)/i.test(
+        /\b(unrecognized|unrecognised|suspicious|reported|fraud|fraudulent|dispute[ds]?|disputing)\b/i.test(
           content,
         );
       const text =


### PR DESCRIPTION
Fixes the six defects a 12-agent review found in the banking skin, by fixing the thing that caused most of them: the skin had **three disagreeing answers to "what did we spend"**.

| Source | Total | Drove |
|---|---|---|
| `charges-data.ts` fixture (45 rows, Apr–Jun) | $632,806 | the Charges page |
| `seed.json` ledger (4 rows, **Apr–May only**) | $30,089 | the report's **charts** |
| static `policies[].spent` | $137,000 | the report's **KPI** |

Every one of those numbers appeared in the product, and they were never reconciled.

## The headline defect

`SpendingTrendChart` substituted a hard-coded `[3200, 4100, 3600, 5200, 4800, 6400]` / Jan–Jun series whenever fewer than three distinct months were present. Intended as an empty state — but the ledger spanned exactly **two** months, so the fallback was the **default path**. The report's "Spend over time" showed six invented figures, roughly 20× smaller than the total printed directly above them, under a card whose own docstring reads:

> Every number is computed here from the live ledger … so a report can never quote a figure the app disagrees with.

Reproduced in the running app before fixing (`POST /api/banking/v1/reports`, no agent needed), and there's a nasty interaction worth knowing: attaching an invoice dates a synthetic transaction *today*, supplying a third month, so **attaching an invoice masked the bug**. A test written casually would sit in the masked state and pass.

## The fix: one ledger

The 45 charges now live in `seed.json` as real transactions across **Apr/May/Jun**, and the Charges page reads them over REST like every other surface.

**Team and policy are now different axes.** A charge belongs to one of seven org teams; a policy is one of three budget envelopes (Technology / Go-to-Market / G&A) and several teams share one. They were a single `ExpenseRole` enum — which is exactly why covering every team meant choosing between a seven-slice donut and discarding real charges. `ExpenseRole` still types a member's own team; `PolicyType` types the envelopes, joined by `policyForTeam`.

**`policies[].spent` is derived from approved charges on every read.** It could no longer disagree with the charts — and it also now *moves*: approving a charge previously left `spent` untouched, so the budget never reflected the approval and the over-limit gate kept comparing against a stale figure. Verified live: approving a \$960 charge moved `spent` by exactly \$960.

**Over-limit is derived-only.** A charge no longer *stores* `over-limit`; the Charges badge resolves through `withOverLimit`, the same rule the report uses.

## The six review findings

| | Defect | Fix |
|---|---|---|
| a1 | report charted fabricated spend | charts real months; explicit empty state at zero |
| a2 | donut its own docs said would collapse | real \$533k base — the \$900k invoice that hit **89%** now reaches **73%**; 89% would need ~\$2.8M |
| a3 | `report` matched inside "quarterly report" | anchored both sides, whole words |
| a4 | `as Transaction` laundered a nullable `policyId` | cast removed; compiler checks it |
| a5 | comment claimed additions "have no policyId" | corrected — three lines from the code that sets it |
| a6 | `?sort=banana` lit the "active" tint | params validated; unknown reads as unset |

All six existed **identically in `examples/showcases/banking/`** — they came from the upstream PRs this skin replayed, not from the port. Scoped to the skin per review; banking still carries them.

## The scripted demo is unchanged by construction

- the four demo-load-bearing transactions survive byte-identical
- over-limit is still **exactly 3 charges / \$30,000**
- AWS \$15,000 still derives over-limit for the teach-mode pill
- Delta Airlines is still the only Delta charge (the fixture's near-duplicate "Delta Air Lines" became United Airlines)
- all four status badges still appear (`Amazon Business` is kept pending, under its policy's headroom, so a plain **Pending** chip survives)

The donut goes 44/40/16 → **48/27/24** and is relabelled "Spend by policy", which is what it reads.

## Verification

```
nx build react-core,a2ui-renderer,core,runtime,shared   exit 0
tsc --noEmit                                            0 errors
vitest                                                  239 passed (was 215)
eslint                                                  0 problems
```

Plus live checks against a running server: 49 transactions over 3 months, derived `spent` tracking an approval, over-limit holding at 3/\$30,000.

The 24 new tests are confirmed **red** against the old code — `parseSort("banana")` returned `"banana"`, `parseTop("-5")` returned `-5`, the seed spanned two months, no row carried a team, and `spent` was stored.

## Not in this PR

A "tool replay-guard sweep" (4 items, `navigateToPageAndPerform` and three approval tools missing the resolved-state guard `showCharges` has) and ~13 subject-neutral items are captured as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)