### PR TITLE
fix(react-core): add missing available dep and cleanup to useCopilotReadable

### DIFF
--- a/packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from "react";
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../v2", () => ({
+  useCopilotKit: vi.fn(),
+}));
+
+import { useCopilotKit } from "../../v2";
+import { useCopilotReadable } from "../use-copilot-readable";
+
+const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
+
+function createMockCopilotKit() {
+  let nextId = 1;
+  const entries = new Map<string, { description: string; value: string }>();
+
+  return {
+    get context() {
+      return Object.fromEntries(entries);
+    },
+    addContext: vi.fn((item: { description: string; value: string }) => {
+      const id = `ctx-${nextId++}`;
+      entries.set(id, item);
+      return id;
+    }),
+    removeContext: vi.fn((id: string) => {
+      entries.delete(id);
+    }),
+  };
+}
+
+describe("useCopilotReadable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds context on mount and removes on unmount", () => {
+    const mock = createMockCopilotKit();
+    mockUseCopilotKit.mockReturnValue({ copilotkit: mock });
+
+    const Harness: React.FC = () => {
+      useCopilotReadable({ description: "test", value: "hello" });
+      return null;
+    };
+
+    const { unmount } = render(<Harness />);
+    expect(mock.addContext).toHaveBeenCalledWith({
+      description: "test",
+      value: '"hello"',
+    });
+
+    unmount();
+    expect(mock.removeContext).toHaveBeenCalledWith("ctx-1");
+  });
+
+  it("removes context when available changes to disabled", () => {
+    const mock = createMockCopilotKit();
+    mockUseCopilotKit.mockReturnValue({ copilotkit: mock });
+
+    let setAvailable: (v: "enabled" | "disabled") => void;
+
+    const Harness: React.FC = () => {
+      const [available, _setAvailable] = useState<"enabled" | "disabled">(
+        "enabled",
+      );
+      setAvailable = _setAvailable;
+      useCopilotReadable({ description: "test", value: "hello", available });
+      return null;
+    };
+
+    render(<Harness />);
+    expect(mock.addContext).toHaveBeenCalledTimes(1);
+
+    act(() => setAvailable("disabled"));
+
+    expect(mock.removeContext).toHaveBeenCalled();
+  });
+
+  it("cleans up on unmount when context was found (not freshly added)", () => {
+    const mock = createMockCopilotKit();
+    mock.addContext({ description: "test", value: '"world"' });
+    mock.addContext.mockClear();
+
+    mockUseCopilotKit.mockReturnValue({ copilotkit: mock });
+
+    const Harness: React.FC = () => {
+      useCopilotReadable({ description: "test", value: "world" });
+      return null;
+    };
+
+    const { unmount } = render(<Harness />);
+    expect(mock.addContext).not.toHaveBeenCalled();
+
+    unmount();
+    expect(mock.removeContext).toHaveBeenCalledWith("ctx-1");
+  });
+
+  it("does not add context when available is disabled", () => {
+    const mock = createMockCopilotKit();
+    mockUseCopilotKit.mockReturnValue({ copilotkit: mock });
+
+    const Harness: React.FC = () => {
+      useCopilotReadable({
+        description: "test",
+        value: "hello",
+        available: "disabled",
+      });
+      return null;
+    };
+
+    render(<Harness />);
+    expect(mock.addContext).not.toHaveBeenCalled();
+  });
+
+  it("uses custom convert function", () => {
+    const mock = createMockCopilotKit();
+    mockUseCopilotKit.mockReturnValue({ copilotkit: mock });
+
+    const convert = (_desc: string, val: any) => `custom:${val}`;
+
+    const Harness: React.FC = () => {
+      useCopilotReadable({
+        description: "test",
+        value: 42,
+        convert,
+      });
+      return null;
+    };
+
+    render(<Harness />);
+    expect(mock.addContext).toHaveBeenCalledWith({
+      description: "test",
+      value: "custom:42",
+    });
+  });
+});

--- a/packages/react-core/src/hooks/use-copilot-readable.ts
+++ b/packages/react-core/src/hooks/use-copilot-readable.ts
@@ -116,7 +116,10 @@ export function useCopilotReadable(
     if (found) {
       ctxIdRef.current = found[0];
       if (available === "disabled") copilotkit.removeContext(ctxIdRef.current);
-      return;
+      return () => {
+        if (!ctxIdRef.current) return;
+        copilotkit.removeContext(ctxIdRef.current);
+      };
     }
     if (!found && available === "disabled") return;
 
@@ -129,7 +132,7 @@ export function useCopilotReadable(
       if (!ctxIdRef.current) return;
       copilotkit.removeContext(ctxIdRef.current);
     };
-  }, [description, value, convert]);
+  }, [description, value, convert, available]);
 
   return ctxIdRef.current;
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `useCopilotReadable` (`packages/react-core/src/hooks/use-copilot-readable.ts`):

- **Missing `available` in useEffect deps**: toggling `available` between `"enabled"` and `"disabled"` after mount had no effect because React never re-ran the effect.
- **Missing cleanup on `found` path**: when the hook matched an existing context entry, it returned early without a cleanup function — context leaked on unmount.

## Changes

- Added `available` to the `useEffect` dependency array (line 135)
- Added a cleanup function on the `found` early-return path (lines 119-122), mirroring the existing cleanup on the `addContext` path
- Added 5 regression tests covering both bugs plus normal lifecycle

## Test plan

- [x] New test: context removed when `available` toggles to `"disabled"`
- [x] New test: unmount cleans up context on the `found` path
- [x] New test: normal add/remove lifecycle
- [x] New test: `available: "disabled"` from start skips `addContext`
- [x] New test: custom `convert` function is applied

Closes #6383