### PR TITLE
fix(react-core): pass description and value to convert in useCopilotReadable and spread dependencies (#6243)

### DIFF
--- a/packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCopilotReadable } from "../use-copilot-readable";
+
+const mockAddContext = vi.fn().mockReturnValue("test-ctx-id");
+const mockRemoveContext = vi.fn();
+const mockContext: Record<string, any> = {};
+
+vi.mock("../v2", () => ({
+  useCopilotKit: () => ({
+    copilotkit: {
+      context: mockContext,
+      addContext: mockAddContext,
+      removeContext: mockRemoveContext,
+    },
+  }),
+}));
+
+describe("useCopilotReadable", () => {
+  it("invokes custom convert function with description and value parameters", () => {
+    const convertSpy = vi.fn().mockImplementation((desc: string, val: any) => `${desc}: ${JSON.stringify(val)}`);
+
+    renderHook(() =>
+      useCopilotReadable({
+        description: "The list of employees",
+        value: { employees: ["Alice", "Bob"] },
+        convert: convertSpy,
+      })
+    );
+
+    expect(convertSpy).toHaveBeenCalledWith("The list of employees", { employees: ["Alice", "Bob"] });
+    expect(mockAddContext).toHaveBeenCalledWith({
+      description: "The list of employees",
+      value: 'The list of employees: {"employees":["Alice","Bob"]}',
+    });
+  });
+
+  it("re-triggers effect when custom dependencies change", () => {
+    let dep = 1;
+    const { rerender } = renderHook(
+      ({ deps }) =>
+        useCopilotReadable(
+          {
+            description: "Dynamic State",
+            value: { count: dep },
+          },
+          deps
+        ),
+      { initialProps: { deps: [dep] } }
+    );
+
+    expect(mockAddContext).toHaveBeenCalledTimes(1);
+
+    dep = 2;
+    rerender({ deps: [dep] });
+
+    expect(mockAddContext).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-core/src/hooks/use-copilot-readable.ts
+++ b/packages/react-core/src/hooks/use-copilot-readable.ts
@@ -110,8 +110,10 @@ export function useCopilotReadable(
   useEffect(() => {
     if (!copilotkit) return;
 
+    const serializedValue = convert ? convert(description, value) : JSON.stringify(value);
+
     const found = Object.entries(copilotkit.context).find(([id, ctxItem]) => {
-      return JSON.stringify({ description, value }) == JSON.stringify(ctxItem);
+      return JSON.stringify({ description, value: serializedValue }) == JSON.stringify(ctxItem);
     });
     if (found) {
       ctxIdRef.current = found[0];
@@ -122,14 +124,14 @@ export function useCopilotReadable(
 
     ctxIdRef.current = copilotkit.addContext({
       description,
-      value: (convert ?? JSON.stringify)(value),
+      value: serializedValue,
     });
 
     return () => {
       if (!ctxIdRef.current) return;
       copilotkit.removeContext(ctxIdRef.current);
     };
-  }, [description, value, convert]);
+  }, [description, value, convert, available, ...(dependencies || [])]);
 
   return ctxIdRef.current;
 }


### PR DESCRIPTION
Fixes #6243

## Description
In `packages/react-core/src/hooks/use-copilot-readable.ts`:

1. `useCopilotReadable` declared `convert` as `(description: string, value: any) => string`, but called it as `(convert ?? JSON.stringify)(value)`. When a custom `convert` function was provided, it received `value` as its 1st parameter (`description`) and `undefined` as its 2nd parameter (`value`), resulting in formatted strings like `"[object Object]: undefined"`.
2. The optional `dependencies?: any[]` parameter was accepted by the hook signature but never spread into `useEffect`'s dependency array, preventing context updates when passing stable object references (e.g. `useForm` references).

This PR updates `useCopilotReadable` to:
- Invoke `convert` as `convert ? convert(description, value) : JSON.stringify(value)`.
- Pass `serializedValue` to context lookup and `addContext`.
- Spread `dependencies` into `useEffect`'s dependency array `[description, value, convert, available, ...(dependencies || [])]`.

## Tests
Added regression unit tests in `packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx` verifying custom `convert(description, value)` argument passing and custom `dependencies` propagation.