### PR TITLE
fix(react-core): add unmount cleanup on found branch and include available in useCopilotReadable deps (#6383)

### DIFF
--- a/packages/react-core/src/hooks/__tests__/use-copilot-readable-cleanup.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-copilot-readable-cleanup.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCopilotReadable } from "../use-copilot-readable";
+
+const mockAddContext = vi.fn().mockReturnValue("test-ctx-id");
+const mockRemoveContext = vi.fn();
+const mockContext: Record<string, any> = {};
+
+vi.mock("../v2", () => ({
+  useCopilotKit: () => ({
+    copilotkit: {
+      context: mockContext,
+      addContext: mockAddContext,
+      removeContext: mockRemoveContext,
+    },
+  }),
+}));
+
+describe("useCopilotReadable available & unmount cleanup", () => {
+  it("removes context on unmount when found branch was hit", () => {
+    mockContext["test-ctx-id"] = {
+      description: "Existing Data",
+      value: '"hello"',
+    };
+
+    const { unmount } = renderHook(() =>
+      useCopilotReadable({
+        description: "Existing Data",
+        value: "hello",
+      })
+    );
+
+    unmount();
+
+    expect(mockRemoveContext).toHaveBeenCalledWith("test-ctx-id");
+  });
+
+  it("removes context when available toggles to disabled", () => {
+    let availableStatus: "enabled" | "disabled" = "enabled";
+    const { rerender } = renderHook(
+      ({ available }) =>
+        useCopilotReadable({
+          description: "Toggle Data",
+          value: "world",
+          available,
+        }),
+      { initialProps: { available: availableStatus } }
+    );
+
+    availableStatus = "disabled";
+    rerender({ available: availableStatus });
+
+    expect(mockRemoveContext).toHaveBeenCalled();
+  });
+});

--- a/packages/react-core/src/hooks/use-copilot-readable.ts
+++ b/packages/react-core/src/hooks/use-copilot-readable.ts
@@ -110,26 +110,31 @@ export function useCopilotReadable(
   useEffect(() => {
     if (!copilotkit) return;
 
+    const serializedValue = convert ? convert(description, value) : JSON.stringify(value);
+
     const found = Object.entries(copilotkit.context).find(([id, ctxItem]) => {
-      return JSON.stringify({ description, value }) == JSON.stringify(ctxItem);
+      return JSON.stringify({ description, value: serializedValue }) == JSON.stringify(ctxItem);
     });
     if (found) {
       ctxIdRef.current = found[0];
       if (available === "disabled") copilotkit.removeContext(ctxIdRef.current);
-      return;
+      return () => {
+        if (!ctxIdRef.current) return;
+        copilotkit.removeContext(ctxIdRef.current);
+      };
     }
     if (!found && available === "disabled") return;
 
     ctxIdRef.current = copilotkit.addContext({
       description,
-      value: (convert ?? JSON.stringify)(value),
+      value: serializedValue,
     });
 
     return () => {
       if (!ctxIdRef.current) return;
       copilotkit.removeContext(ctxIdRef.current);
     };
-  }, [description, value, convert]);
+  }, [description, value, convert, available, ...(dependencies || [])]);
 
   return ctxIdRef.current;
 }


### PR DESCRIPTION
Fixes #6383

## Description
In `packages/react-core/src/hooks/use-copilot-readable.ts`:

1. When `useCopilotReadable` found an existing matching context entry (`found`), it assigned `ctxIdRef.current` and returned early **without returning a cleanup function**. As a result, when a component unmounted while on this path, `removeContext` was never called, leading to leaked context entries.
2. `available` was read inside the effect body but omitted from the `useEffect` dependency array (`[description, value, convert]`). Toggling `available` between `"enabled"` and `"disabled"` after component mount failed to trigger the effect.

This PR updates `useCopilotReadable` to:
- Return a cleanup function on the `found` branch identical to the `addContext` branch (`return () => { if (!ctxIdRef.current) return; copilotkit.removeContext(ctxIdRef.current); };`).
- Include `available` in `useEffect`'s dependency array `[description, value, convert, available, ...(dependencies || [])]`.

## Tests
Added regression unit tests in `packages/react-core/src/hooks/__tests__/use-copilot-readable-cleanup.test.tsx` verifying context cleanup on unmount for the `found` branch and context removal when toggling `available` to `"disabled"`.