### PR TITLE
docs: refresh v2 SDK reference

### DIFF
--- a/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
@@ -36,6 +36,11 @@ Don't have it yet? Go to https://dashboard.operations.copilotkit.ai and get one 
 
 </PropertyReference>
 
+<PropertyReference name="licenseToken" type="string">
+  Signed license token for offline verification of Enterprise Intelligence
+  Platform features.
+</PropertyReference>
+
 <PropertyReference name="guardrails_c" type="{ validTopics?: string[]; invalidTopics?: string[]; }"  >
 Restrict input to specific topics using guardrails.
   @remarks
@@ -57,15 +62,20 @@ This feature is only available when using CopilotKit's hosted cloud service. To 
   The endpoint for the Copilot text to speech service.
 </PropertyReference>
 
-<PropertyReference name="headers" type="Record<string, string>"  >
-Additional headers to be sent with the request.
+<PropertyReference name="headers" type="Record<string, string> | (() => Record<string, string>)"  >
+Additional headers to be sent with runtime requests. Pass an object for static
+headers, or a function when headers need to be refreshed from current auth
+state.
 
 For example:
 
-```json
-{
-  "Authorization": "Bearer X"
-}
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  headers={() => ({ Authorization: `Bearer ${getToken()}` })}
+>
+  {children}
+</CopilotKit>
 ```
 
 </PropertyReference>
@@ -127,6 +137,16 @@ Defaults to `false` for production safety.
 
 </PropertyReference>
 
+<PropertyReference name="selfManagedAgents" type="Record<string, AbstractAgent>">
+  AG-UI agents managed by your app and registered directly with CopilotKit.
+  Use this when you connect to agents without routing through a Copilot Runtime.
+</PropertyReference>
+
+<PropertyReference name="agents__unsafe_dev_only" type="Record<string, AbstractAgent>">
+  Preconfigured local agents for development and tests. Use `selfManagedAgents`
+  for production direct-agent setups.
+</PropertyReference>
+
 <PropertyReference name="a2ui" type="{ theme?: Theme }">
 Configuration for the A2UI (Agent-to-UI) renderer.
 
@@ -140,6 +160,18 @@ needed if you want to override the default theme.
 </CopilotKit>
 ```
 
+</PropertyReference>
+
+<PropertyReference name="openGenerativeUI" type="{ sandboxFunctions?: SandboxFunction[]; designSkill?: string }">
+  Configuration for Open Generative UI. Use `sandboxFunctions` to expose host
+  functions to generated sandboxed iframes, and `designSkill` to override the
+  design guidance injected as agent context for `generateSandboxedUi`.
+</PropertyReference>
+
+<PropertyReference name="defaultThrottleMs" type="number">
+  Default throttle interval, in milliseconds, for `useAgent` re-renders caused
+  by message and state updates. Individual `useAgent` calls and prebuilt chat
+  components can override it with their own `throttleMs`.
 </PropertyReference>
 
 <PropertyReference name="agent" type="string">
@@ -168,8 +200,8 @@ This feature is only available when using CopilotKit's hosted cloud service. To 
 <PropertyReference name="onError" type="CopilotErrorHandler"  >
 Optional error handler for comprehensive debugging and observability.
 
-Requires publicApiKey: Error handling only works when publicApiKey is provided.
-This is an Enterprise Intelligence Platform feature.
+The handler runs for runtime connection failures, agent errors, and tool errors.
+It works with runtime-backed and locally registered agents.
 
 @param errorEvent - Structured error event with rich debugging context
 
@@ -177,7 +209,7 @@ This is an Enterprise Intelligence Platform feature.
 
 ```typescript
 <CopilotKit
-  publicApiKey="ck_pub_your_key"
+  runtimeUrl="/api/copilotkit"
   onError={(errorEvent) => {
     debugDashboard.capture(errorEvent);
   }}
@@ -190,4 +222,13 @@ This is an Enterprise Intelligence Platform feature.
   Enable or disable the CopilotKit Inspector, letting you inspect AG-UI events,
   view agent messages, check agent state, and visualize agent context. Defaults
   to enabled.
+</PropertyReference>
+
+<PropertyReference name="inspectorDefaultAnchor" type="{ horizontal: 'left' | 'right'; vertical: 'top' | 'bottom' }">
+  Default corner for the inspector button and window before the user drags it.
+</PropertyReference>
+
+<PropertyReference name="debug" type="boolean | DebugConfig">
+  Enable client-side debug logging for the AG-UI transport and event pipeline.
+  Pass `true` for full output or a config object for granular control.
 </PropertyReference>

--- a/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
@@ -7,7 +7,9 @@ description: "React hook for accessing AG-UI agent instances"
 
 `useAgent` is a React hook that returns an [AG-UI AbstractAgent](https://docs.ag-ui.com/sdk/js/client/abstract-agent) instance. The hook subscribes to agent state changes and triggers re-renders when the agent's state, messages, or execution status changes.
 
-**Throws error** if no agent is configured with the specified `agentId`.
+By default it binds to a shared agent from the CopilotKit registry. It can also register a private proxied agent for one thread, which is useful for custom thread switchers and multi-conversation UIs.
+
+**Throws an error** if no agent is configured with the specified `agentId`, or if only part of the thread-scoped option set is provided.
 
 ## Signature
 
@@ -20,15 +22,31 @@ function useAgent(options?: UseAgentProps): {
 };
 ```
 
+For fully headless UI that does not import the built-in chat rendering stack, import the hook from the headless entry:
+
+```tsx
+import { useAgent } from "@copilotkit/react-core/v2/headless";
+```
+
 ## Parameters
 
 <PropertyReference name="options" type="UseAgentProps">
   Configuration object for the hook.
 
 <PropertyReference name="agentId" type="string" default='"default"'>
-  ID of the agent to retrieve. Must match an agent configured in
-  `CopilotKit`.
+  ID of the agent to retrieve. Resolution order is: explicit `agentId`, the
+  surrounding chat configuration's `agentId`, then `"default"`.
 </PropertyReference>
+
+  <PropertyReference name="threadId" type="string">
+    Thread ID for a private proxied agent. Must be passed together with
+    `agentId` and `runtimeAgentId`.
+  </PropertyReference>
+
+  <PropertyReference name="runtimeAgentId" type="string">
+    Runtime-side agent ID to route requests to when registering a private
+    proxied agent. Must be passed together with `agentId` and `threadId`.
+  </PropertyReference>
 
   <PropertyReference name="updates" type="UseAgentUpdate[]" default="[OnMessagesChanged, OnStateChanged, OnRunStatusChanged]">
     Controls which agent changes trigger component re-renders. Options:
@@ -39,7 +57,20 @@ function useAgent(options?: UseAgentProps): {
     Pass an empty array `[]` to prevent automatic re-renders.
 
   </PropertyReference>
+
+  <PropertyReference name="throttleMs" type="number">
+    Throttle interval, in milliseconds, for re-renders triggered by message and
+    state changes. Run lifecycle updates still fire immediately. If omitted,
+    the hook inherits the provider's `defaultThrottleMs`; if neither value is
+    set, updates are unthrottled. Pass `0` to disable provider throttling for
+    this hook.
+  </PropertyReference>
 </PropertyReference>
+
+There are two valid option shapes:
+
+- `useAgent()` or `useAgent({ agentId })`: bind to a shared agent. The thread comes from chat configuration or the agent itself.
+- `useAgent({ agentId, runtimeAgentId, threadId })`: register a private local agent under `agentId`, route it to the runtime agent named by `runtimeAgentId`, and pin it to `threadId`.
 
 ## Return Value
 
@@ -148,7 +179,7 @@ function useAgent(options?: UseAgentProps): {
 
     `agent` is always a fully-constructed instance, so calling its methods is
     always safe. While `isReady` is `false`, the instance is a placeholder that
-    is swapped for the real agent once the runtime finishes syncing — at which
+    is swapped for the real agent once the runtime finishes syncing. At that
     point `agent` changes reference and dependent effects re-run. Guard on
     `isReady` when you only want to act against the real agent, e.g. subscribing
     to run-lifecycle events you don't want to miss during the provisional
@@ -232,6 +263,25 @@ function MultiAgentView() {
 }
 ```
 
+### Thread-scoped Agent
+
+Use the thread-scoped form when one runtime agent needs multiple independent frontend instances, for example one per open conversation. The local `agentId` must be unique in the current provider.
+
+```tsx
+function ThreadPreview({ threadId }: { threadId: string }) {
+  const { agent, isReady } = useAgent({
+    agentId: `preview-${threadId}`,
+    runtimeAgentId: "support",
+    threadId,
+    throttleMs: 100,
+  });
+
+  if (!isReady) return <div>Loading...</div>;
+
+  return <div>{agent.messages.length} messages</div>;
+}
+```
+
 ### Optimizing Re-renders
 
 ```tsx
@@ -248,8 +298,10 @@ function MessageCount() {
 ## Behavior
 
 - **Automatic Re-renders**: Component re-renders when agent state, messages, or execution status changes (configurable via `updates` parameter)
+- **Optional Throttling**: Message and state update re-renders can be throttled with `throttleMs` or the provider's `defaultThrottleMs`.
 - **Readiness**: While the runtime is connecting, `agent` is a fully-constructed provisional stand-in and `isReady` is `false`; once the runtime syncs, `agent` swaps to the real instance and `isReady` becomes `true`. Guard on `isReady` for work that must target the real agent (e.g. one-time subscriptions)
 - **Error Handling**: Throws error if no agent exists with specified `agentId`
+- **Thread Scoping**: `threadId` and `runtimeAgentId` must be passed together with an explicit local `agentId`; partial combinations throw at runtime and are rejected by the TypeScript type.
 - **State Synchronization**: State updates via `setState()` are immediately available to both app and agent
 - **Event Subscriptions**: Subscribe/unsubscribe pattern for lifecycle and custom events
 

--- a/showcase/shell-docs/src/content/reference/index.mdx
+++ b/showcase/shell-docs/src/content/reference/index.mdx
@@ -117,7 +117,7 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 <PropertyReference name="onError" type="(event: { error: Error; code: CopilotKitCoreErrorCode; context: Record<string, any> }) => void | Promise<void>">
   Error handler called when CopilotKit encounters an error. Fires for all error types: runtime connection failures, agent errors, and tool errors.
 
-Unlike the v1 `onError`, this does **not** require a `publicApiKey` — error handling works with any configuration.
+Unlike the v1 `onError`, this does **not** require a `publicApiKey`; error handling works with any configuration.
 
 ```tsx
 <CopilotKit
@@ -134,6 +134,31 @@ Unlike the v1 `onError`, this does **not** require a `publicApiKey` — error ha
 
 </Accordion>
 </Accordions>
+
+## Import Surfaces
+
+Use the main v2 entry when your app renders CopilotKit's web UI components or A2UI surfaces:
+
+```tsx
+import {
+  CopilotKit,
+  CopilotChat,
+  useAgent,
+} from "@copilotkit/react-core/v2";
+```
+
+Use the headless entry when you build a fully custom chat surface and only need platform-agnostic hooks. This avoids the built-in chat rendering stack and its CSS:
+
+```tsx
+import {
+  useAgent,
+  useCopilotKit,
+  useFrontendTool,
+  useRenderToolCall,
+} from "@copilotkit/react-core/v2/headless";
+```
+
+The headless entry exports the provider context, chat configuration provider, `useAgent`, tool hooks, suggestions, threads, capabilities, and shared types. It does not export `CopilotChat`, `CopilotPopup`, `CopilotSidebar`, `useDefaultRenderTool`, or A2UI render helpers.
 
 ## Styling
 


### PR DESCRIPTION
## Summary

Refresh the v2 SDK reference against current main, preserving the existing three-page scope. Merge main into this branch without rewriting its history.

## Why

The original reference update predates the explicit distinction between the v1 `CopilotKit` compatibility wrapper and v2 `CopilotKitProvider`, newer agent-ID defaults, and Inspector changes.

## How

- Use `CopilotKitProvider` in v2 setup and error-handler examples, while retaining the legacy wrapper's public-key requirement for `onError`.
- Document current provider props, dynamic headers, debug verbosity, and localhost-only Inspector availability; remove the obsolete `inspectorDefaultAnchor` addition.
- Preserve main's thread-scoped `useAgent` documentation, add an example and headless imports, and clarify provider agent-ID fallback and throttle overrides.
- Describe the main and headless import surfaces and their provider limitations.

Validation: all three pages compile as MDX; documented provider prop names were checked against current TypeScript interfaces; `git diff --check` against current main passed. Focused validation ran through Nx. No full docs build was run. The merge-triggered broad package hook failed; its unrelated autoformat/lockfile changes were reverted, and lint/lockfile/package hooks were excluded for this docs-only merge. Binary, plugin-skill, Intelligence naming, and commit-message hooks remain enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated provider setup guidance for `CopilotKitProvider`, including authentication tokens, dynamic headers, agent configuration, generative UI, throttling, debugging, and error handling.
  - Clarified v2 and headless import paths, agent ID resolution, thread-scoped options, and private proxied agent usage.
  - Documented that the legacy `CopilotKit` component serves as a v1 compatibility wrapper.
  - Expanded API reference examples and clarified inspector and throttling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->