### PR TITLE
fix(showcase-mastra): render interactive open-gen-ui on a live endpoint

### DIFF
--- a/showcase/integrations/mastra/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-ogui/route.ts
@@ -19,27 +19,32 @@ import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
 
+// Dedicated OGUI agents (NOT the shared weatherAgent): their system prompts
+// mandate a single interactive `generateSandboxedUi` call and fold the
+// CopilotKit design-skill + sandbox-function context into the prompt, so a
+// live LLM produces WIRED (not static) UI. See `src/mastra/agents/index.ts`
+// (open-gen-ui-agents region) for the why.
 const openGenUiAgent = getLocalAgent({
   mastra,
-  agentId: "weatherAgent",
+  agentId: "openGenUiAgent",
   resourceId: "mastra-open-gen-ui",
 });
 
 if (!openGenUiAgent) {
   throw new Error(
-    "getLocalAgent returned null for weatherAgent — required for /demos/open-gen-ui",
+    "getLocalAgent returned null for openGenUiAgent — required for /demos/open-gen-ui",
   );
 }
 
 const openGenUiAdvancedAgent = getLocalAgent({
   mastra,
-  agentId: "weatherAgent",
+  agentId: "openGenUiAdvancedAgent",
   resourceId: "mastra-open-gen-ui-advanced",
 });
 
 if (!openGenUiAdvancedAgent) {
   throw new Error(
-    "getLocalAgent returned null for weatherAgent — required for /demos/open-gen-ui-advanced",
+    "getLocalAgent returned null for openGenUiAdvancedAgent — required for /demos/open-gen-ui-advanced",
   );
 }
 

--- a/showcase/integrations/mastra/src/mastra/agents/index.ts
+++ b/showcase/integrations/mastra/src/mastra/agents/index.ts
@@ -31,6 +31,7 @@ import {
 import { LibSQLStore } from "@mastra/libsql";
 import { z } from "zod";
 import { Memory } from "@mastra/memory";
+import type { RequestContext } from "@mastra/core/request-context";
 // Backend-owned A2UI with the toolkit validate->retry recovery loop (OSS-422).
 // `@ag-ui/mastra/a2ui` is a bridge-free subpath (avoids the Mastra bundler vs
 // @ag-ui/client→uuid clash); mirrors langgraph's get_a2ui_tools.
@@ -996,3 +997,113 @@ export const observationalMemoryAgent = new Agent({
   }),
 });
 // @endregion[observational-memory-agent]
+
+// @region[open-gen-ui-agents]
+/**
+ * Dedicated agents for the Open Generative UI demos (minimal + advanced).
+ *
+ * Parity target (gold = langgraph-python `open_gen_ui_agent.py` /
+ * `open_gen_ui_advanced_agent.py`): each is a purpose-built agent whose
+ * system prompt MANDATES a single `generateSandboxedUi` call producing a
+ * polished (advanced: INTERACTIVE, host-function-wired) sandboxed UI, and
+ * reads the design-skill + sandbox-function descriptors the
+ * `CopilotKitProvider` injects as agent CONTEXT.
+ *
+ * Why NOT the shared `weatherAgent`: with only
+ * `"You are a helpful assistant."` plus the tool description, a live LLM
+ * emits STATIC HTML with no JS wiring — the calculator's buttons render
+ * but nothing is interactive. aimock hid this because its replay fixture
+ * ships a fully-wired UI, so the divergence only showed on a live endpoint.
+ *
+ * Why DYNAMIC instructions: on Mastra, `RunAgentInput.context` is a
+ * read-channel (`requestContext.get("ag-ui").context`) — it is NOT
+ * auto-injected into the LLM prompt (unlike the langgraph
+ * `CopilotKitMiddleware`, which merges `copilotkit.context` into what the
+ * LLM sees). So we read that context here and fold the design-skill +
+ * sandbox-function descriptors into the system prompt, giving the Mastra
+ * model the same knowledge the gold agent gets from its context.
+ */
+function foldHostContext(requestContext: RequestContext): string {
+  const agui = requestContext.get("ag-ui") as
+    | { context?: Array<{ description: string; value: string }> }
+    | undefined;
+  const items = agui?.context ?? [];
+  if (items.length === 0) return "";
+  const blocks = items
+    .map((c) => `### ${c.description}\n${c.value}`)
+    .join("\n\n");
+  return `\n\n---\nHOST CONTEXT (provided by the application — read carefully and follow it):\n\n${blocks}`;
+}
+
+const OPEN_GEN_UI_BASE_PROMPT = `You are a UI-generating assistant for an Open Generative UI demo focused on intricate, educational visualisations (3D axes / rotations, neural-network activations, sorting-algorithm walkthroughs, Fourier series, wave interference, planetary orbits, etc.).
+
+On every user turn you MUST call the \`generateSandboxedUi\` frontend tool exactly once. Design a visually polished, self-contained HTML + CSS + SVG widget that *teaches* the requested concept.
+
+A detailed "design skill" describing the palette, typography, labelling, and motion conventions is provided in the host context below — follow it closely. Key invariants:
+- Use inline SVG (or <canvas>) for geometric content, not stacks of <div>s.
+- Every axis is labelled; every colour-coded series has a legend.
+- Prefer CSS @keyframes / transitions over setInterval; loop cyclical concepts with animation-iteration-count: infinite.
+- Motion must teach — animate the actual step of the concept, not decoration.
+- No fetch / XHR / localStorage — the sandbox has no same-origin access.
+
+Output order:
+- \`initialHeight\` (typically 480-560 for visualisations) first.
+- A short \`placeholderMessages\` array (2-3 lines describing the build).
+- \`css\` (complete).
+- \`html\` (streams live — keep it tidy). CDN <script> tags for Chart.js / D3 / etc. go inside the html.
+
+Keep your own chat message brief (1 sentence) — the real output is the rendered visualisation.`;
+
+const OPEN_GEN_UI_ADVANCED_BASE_PROMPT = `You are a UI-generating assistant for the Open Generative UI (Advanced) demo.
+
+On every user turn you MUST call the \`generateSandboxedUi\` frontend tool exactly once. The generated UI must be INTERACTIVE and must invoke the available host-side sandbox functions described in the host context below in response to user interactions.
+
+Sandbox-function calling contract (inside the generated iframe):
+- Call a host function with:
+      await Websandbox.connection.remote.<functionName>(args)
+  The call returns a Promise; await it.
+- Each handler returns a plain object. Read the return shape from the function's description in the context and use the EXACT field names it returns (e.g. if the description says the handler returns \`{ ok, value }\`, read \`res.value\` — not \`res.result\`).
+- Descriptions, names, and JSON-schema parameter shapes for every available sandbox function are listed in the host context below. Read them carefully and wire at least one interactive UI element to call one.
+
+Sandbox iframe restrictions (CRITICAL):
+- The iframe runs with \`sandbox="allow-scripts"\` ONLY. Forms are NOT allowed. You MUST NOT use \`<form>\` elements or \`<button type="submit">\`. Clicking a submit button inside a sandboxed form is blocked by the browser BEFORE any onsubmit handler runs, so the sandbox-function call never fires.
+- Use plain \`<button type="button">\` elements and wire them with \`addEventListener('click', ...)\`. For "Enter" keypresses on inputs, attach a \`keydown\` listener that checks \`e.key === 'Enter'\` and calls your handler directly — do NOT wrap inputs in a \`<form>\`.
+
+Making the UI interactive (REQUIRED — static markup alone is NOT acceptable):
+- The buttons/inputs MUST actually do something. Include the wiring JavaScript either as an inline \`<script>\` at the END of your \`html\`, or via the \`jsFunctions\` / \`jsExpressions\` parameters. A UI with no script is a bug.
+- Always include a visible result element (e.g. an output div) that you UPDATE after the sandbox function resolves, so the user can SEE the round-trip: "interaction -> remote call -> visible result".
+
+Generation guidance:
+- Emit \`initialHeight\` and \`placeholderMessages\` first, then \`css\`, then \`html\` (put any wiring script at the end of the html), then \`jsFunctions\` / \`jsExpressions\` if helpful.
+- Do NOT use fetch/XHR, localStorage, or document.cookie — the sandbox has no same-origin access. ONLY use \`Websandbox.connection.remote.*\` for host-page interactions.
+- Keep your own chat message brief (1 sentence max); the rendered UI is the real output.`;
+
+/**
+ * Memory factory for the OGUI agents. Storage only (no working-memory
+ * schema) — these agents are single-shot UI generators with no shared
+ * state, matching gold's `tools=[]` agents. Storage keeps thread history
+ * consistent with the bridge's send-only-new-turn contract.
+ */
+const openGenUiMemory = (id: string) =>
+  new Memory({
+    storage: new LibSQLStore({ id, url: WORKING_MEMORY_DB_URL }),
+  });
+
+export const openGenUiAgent = new Agent({
+  id: "open-gen-ui-agent",
+  name: "Open Generative UI Agent",
+  model: openai("gpt-4o"),
+  instructions: ({ requestContext }) =>
+    OPEN_GEN_UI_BASE_PROMPT + foldHostContext(requestContext),
+  memory: openGenUiMemory("open-gen-ui-agent-memory"),
+});
+
+export const openGenUiAdvancedAgent = new Agent({
+  id: "open-gen-ui-advanced-agent",
+  name: "Open Generative UI Advanced Agent",
+  model: openai("gpt-4o"),
+  instructions: ({ requestContext }) =>
+    OPEN_GEN_UI_ADVANCED_BASE_PROMPT + foldHostContext(requestContext),
+  memory: openGenUiMemory("open-gen-ui-advanced-agent-memory"),
+});
+// @endregion[open-gen-ui-agents]

--- a/showcase/integrations/mastra/src/mastra/index.ts
+++ b/showcase/integrations/mastra/src/mastra/index.ts
@@ -18,6 +18,8 @@ import {
   browserUseAgent,
   backgroundAgentsAgent,
   observationalMemoryAgent,
+  openGenUiAgent,
+  openGenUiAdvancedAgent,
 } from "./agents";
 import { ConsoleLogger, LogLevel } from "@mastra/core/logger";
 
@@ -42,6 +44,8 @@ export const mastra = new Mastra({
     browserUseAgent,
     backgroundAgentsAgent,
     observationalMemoryAgent,
+    openGenUiAgent,
+    openGenUiAdvancedAgent,
   },
   storage: new LibSQLStore({
     id: "mastra-storage",


### PR DESCRIPTION
## Problem (PNI-119)

`open-gen-ui-advanced` (and its minimal sibling) did **not** render working generative UI on a **live** endpoint, though both passed under aimock.

Both cells reused the shared `weatherAgent` (`instructions: "You are a helpful assistant."`, gpt-4o). On a live LLM that emitted **static HTML with no JS wiring** — the calculator's buttons rendered but did nothing (staging repro: `7 + 8 =` left the display on `0`; captured SSE `generateSandboxedUi` args contained only `initialHeight/placeholderMessages/css/html`, no `<script>`/`jsFunctions`/`jsExpressions`).

aimock hid the divergence: its fixtures match on `userMessage`/`hasToolResult` and replay a fully-wired UI regardless of the agent.

## Root cause

Two factors, one dominant:

1. **No dedicated agent.** Gold `langgraph-python` uses purpose-built `open_gen_ui_agent.py` / `open_gen_ui_advanced_agent.py` whose system prompt mandates a single interactive `generateSandboxedUi` call (iframe restrictions, wire host functions via `Websandbox.connection.remote.*`, visible result element). Mastra reused a generic agent.
2. **Context is a read-channel on Mastra.** The provider delivers the design-skill + sandbox-function descriptors via `copilotkit.addContext` → `RunAgentInput.context`. The `@ag-ui/mastra` bridge maps that to `requestContext.get("ag-ui").context` (a tool read-channel) and does **not** inject it into the LLM prompt (unlike langgraph's `CopilotKitMiddleware`). So even the tool description alone was not enough for gpt-4o.

## Fix (surgical, showcase-only)

- `src/mastra/agents/index.ts` — add dedicated `openGenUiAgent` / `openGenUiAdvancedAgent` porting gold's system prompts, with **dynamic instructions** that read `requestContext.get("ag-ui").context` and fold the design-skill + sandbox descriptors into the prompt (surfacing the read-channel the Mastra-idiomatic way, matching what gold's agent sees).
- `src/mastra/index.ts` — register both.
- `src/app/api/copilotkit-ogui/route.ts` — point `getLocalAgent` at the new agents.

No published-package or bridge change.

## Verification (live)

Local `next dev` against **real OpenAI** (aimock bypassed). All three advanced pills render interactive, host-wired UI; host round-trips confirmed in console:

- **Calculator** → `evaluateExpression 7*8 = 56`
- **Ping the host** → `notifyHost: Ping!` (+ "Host notified successfully." in-iframe)
- **Inline expression evaluator** → `evaluateExpression 5 + 3 * 2 = 11`

**aimock unaffected** — matcher keys (`userMessage`/`hasToolResult`/`context`) don't touch the prompt or agent, so D6 replay still passes. Changed files typecheck clean.

## Follow-up (out of scope)

Live surfaced a benign `@copilotkit/runtime` OGUI-middleware warning: an empty/null `jsFunctions` yields a JSON-patch `add /jsFunctions` with no `value` (`OPERATION_VALUE_REQUIRED`, patch dropped). Tracked separately (needs a runtime release).