### PR TITLE
DO NOT MERGE — PNI-188 Showcase baseline probe

### DIFF
--- a/showcase/BASELINE.md
+++ b/showcase/BASELINE.md
@@ -1,0 +1,15 @@
+# Showcase baseline probe — PNI-188
+
+**This file is temporary and must never be merged.**
+
+It exists only so that the comment-triggered Showcase workflows have a pull request to
+attach to. Both `showcase / eval` and `test / e2e / showcase / on-demand` are reachable
+only via `issue_comment` on a PR, or via `workflow_dispatch` that requires a PR number,
+so a baseline run needs a PR even though nothing is being changed.
+
+Dependencies are deliberately untouched. Showcase stays on the published AG-UI packages
+it already pins (`@ag-ui/client|core|encoder@0.0.57`), because PNI-188 measures the
+protocol the way a real consumer consumes it.
+
+The PR carrying this file is closed, not merged, once the runs have been recorded on
+PNI-188.


### PR DESCRIPTION
## Do not merge, do not review

A **throwaway measurement PR** for [PNI-188](https://linear.app/copilotkit/issue/PNI-188/record-the-current-ag-ui-test-baseline). It will be closed, never merged.

## Why it exists

PNI-188 records a one-time snapshot of AG-UI health taken before any 1.0 work starts, so that later failures can be attributed rather than guessed at. Showcase is the clearest single signal, because it exercises the protocol the way a real consumer does.

Both Showcase workflows are reachable only from a PR — `showcase / eval` via `issue_comment` or a dispatch requiring `pr_number`, and `test / e2e / showcase / on-demand` via `/test-aimock` — so the baseline needs a pull request even though nothing is being changed.

## Commits this baseline is taken at

| Repository | Commit |
| --- | --- |
| `CopilotKit/CopilotKit` | `25817605cc6359edf6bc297ff3db01ef94aab777` (`main`) |
| `ag-ui-protocol/ag-ui` | `488d01c2fd9e3c3a773a95d86b519acabdcdda6a` |

A Showcase result is not interpretable without both.

## Deliberately no dependency changes

Showcase stays on the published AG-UI packages it already pins — `@ag-ui/client|core|encoder@0.0.57`. It is tempting to substitute pkg.pr.new builds of the ag-ui baseline commit instead, but that would make the measurement worse:

- **No drift where it would matter.** `git log release/2026-07-31..488d01c2 -- sdks/typescript/packages/` returns **0 commits**; npm latest, the lockfile and the working tree are all `0.0.57`. An override would substitute identical code.
- **pkg.pr.new cannot reach the drift that does exist.** `publish-commit.yml` publishes JavaScript only. The Showcase slugs with the deepest protocol coverage — `langgraph-python`, `crewai-crews`, `hermes`, `ms-agent-python`, `pydantic-ai`, `claude-sdk-python` — install Python agents from PyPI, and the unreleased delta is overwhelmingly Python.
- An override would produce a hybrid — JS at HEAD, Python at published — a state matching no real deployment, and the worst possible anchor for attribution, since a later red release candidate could not be traced to which half moved.

The published-to-baseline delta is recorded on PNI-188 instead of being mixed into the run.

## The ag-ui half is already recorded

51 checks pass, 0 fail at `488d01c2` — TypeScript, Python, .NET, protobuf cross-language TS ↔ C#, all 22 Dojo jobs, and release validation. The only real failures found were in the documentation build, tracked as PNI-265 and PNI-266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)