### PR TITLE
fix(showcase): let the Mastra MCP Apps agent self-correct a rejected diagram

### DIFF
--- a/showcase/integrations/mastra/src/mastra/agents/index.ts
+++ b/showcase/integrations/mastra/src/mastra/agents/index.ts
@@ -642,7 +642,12 @@ If a delegation's \`status\` field is \`"failed"\`, treat it as a real error: do
 export const mcpAppsAgent = new Agent({
   id: "mcp-apps-agent",
   name: "MCP Apps Agent",
-  model: openai("gpt-4o-mini"),
+  // `create_view` takes `elements` as a *stringified* JSON array, so the model has
+  // to hand-escape nested JSON. gpt-4o-mini gets this wrong on roughly two thirds
+  // of diagrams (it appends a stray `}` past the closing `]`), the MCP server
+  // rejects the payload, and the cell renders an empty iframe. Keep a model that
+  // emits valid double-encoded JSON.
+  model: openai("gpt-4.1"),
   instructions: `You draw simple diagrams in Excalidraw via the MCP tool.
 
 SPEED MATTERS. Produce a correct-enough diagram fast; do not optimize for polish. Target: one tool call, done in seconds.

--- a/showcase/integrations/mastra/src/mastra/agents/index.ts
+++ b/showcase/integrations/mastra/src/mastra/agents/index.ts
@@ -643,18 +643,22 @@ export const mcpAppsAgent = new Agent({
   id: "mcp-apps-agent",
   name: "MCP Apps Agent",
   // `create_view` takes `elements` as a *stringified* JSON array, so the model has
-  // to hand-escape nested JSON. Weaker models append a stray `}` past the closing
-  // `]`; the MCP server then rejects the payload and the cell renders an empty
-  // iframe. Measured against the real server, gpt-4o-mini failed 5 of 8 diagrams
-  // this way and gpt-5.4 still fails ~3 of 10, so treat an empty diagram as a
-  // model-output problem before suspecting the renderer.
+  // to hand-escape nested JSON and sometimes appends a stray `}` past the closing
+  // `]`. The MCP server rejects that payload, and with no retry the cell just
+  // renders an empty iframe. The server's error names the exact problem, so the
+  // model is told to read it and correct itself rather than relying on one-shot
+  // accuracy: at most 2 corrections (3 `create_view` calls), with the step cap
+  // bounding the loop if it never converges.
   model: openai("gpt-5.4"),
+  defaultOptions: {
+    stopWhen: stepCountIs(6),
+  },
   instructions: `You draw simple diagrams in Excalidraw via the MCP tool.
 
-SPEED MATTERS. Produce a correct-enough diagram fast; do not optimize for polish. Target: one tool call, done in seconds.
+SPEED MATTERS. Produce a correct-enough diagram fast; do not optimize for polish. Target: one successful tool call, done in seconds.
 
 When the user asks for a diagram:
-1. Call \`create_view\` ONCE with 3-5 elements total: shapes + arrows + an optional title text.
+1. Call \`create_view\` with 3-5 elements total: shapes + arrows + an optional title text.
 2. Use straightforward shapes (rectangle, ellipse, diamond) with plain \`label\` fields (\`{"text": "...", "fontSize": 18}\`) on them.
 3. Connect with arrows. Endpoints can be element centers or simple coordinates.
 4. Include ONE \`cameraUpdate\` at the END of the elements array that frames the whole diagram (600x450 or 800x600).
@@ -662,7 +666,9 @@ When the user asks for a diagram:
 
 Every element needs a unique string \`id\` (e.g. \`"b1"\`, \`"a1"\`, \`"title"\`). Standard sizes: rectangles 160x70, ellipses/diamonds 120x80, 40-80px gap between shapes.
 
-Do NOT call \`read_me\`, do NOT iterate, do NOT make multiple calls. Ship on the first shot.`,
+Do NOT call \`read_me\`. Get it right on the first call whenever you can.
+
+If \`create_view\` returns an error, the \`elements\` string you sent was not valid JSON. It must contain ONLY a JSON array: start at \`[\`, end at \`]\`, and emit nothing after that final \`]\`. Read the error, fix the string, and call \`create_view\` again. You may correct at most TWICE (3 calls total). If the third call still fails, reply with one short sentence saying you could not render the diagram.`,
   memory: new Memory({
     storage: new LibSQLStore({
       id: "mcp-apps-agent-memory",

--- a/showcase/integrations/mastra/src/mastra/agents/index.ts
+++ b/showcase/integrations/mastra/src/mastra/agents/index.ts
@@ -643,11 +643,12 @@ export const mcpAppsAgent = new Agent({
   id: "mcp-apps-agent",
   name: "MCP Apps Agent",
   // `create_view` takes `elements` as a *stringified* JSON array, so the model has
-  // to hand-escape nested JSON. gpt-4o-mini gets this wrong on roughly two thirds
-  // of diagrams (it appends a stray `}` past the closing `]`), the MCP server
-  // rejects the payload, and the cell renders an empty iframe. Keep a model that
-  // emits valid double-encoded JSON.
-  model: openai("gpt-4.1"),
+  // to hand-escape nested JSON. Weaker models append a stray `}` past the closing
+  // `]`; the MCP server then rejects the payload and the cell renders an empty
+  // iframe. Measured against the real server, gpt-4o-mini failed 5 of 8 diagrams
+  // this way and gpt-5.4 still fails ~3 of 10, so treat an empty diagram as a
+  // model-output problem before suspecting the renderer.
+  model: openai("gpt-5.4"),
   instructions: `You draw simple diagrams in Excalidraw via the MCP tool.
 
 SPEED MATTERS. Produce a correct-enough diagram fast; do not optimize for polish. Target: one tool call, done in seconds.


### PR DESCRIPTION
## Problem

PNI-118: the Mastra **MCP Apps** cell intermittently renders an **empty iframe** (an empty box or a thin band) on a live endpoint, while passing under aimock. Reproduced on `showcase-mastra-staging`.

## Root cause

Not the renderer, not a delivery race, not a version pin.

Excalidraw's `create_view` takes `elements` as a **stringified** JSON array:

```json
{"elements": {"type": "string", "description": "JSON array string of Excalidraw elements. Must be valid JSON ..."}}
```

So the model has to hand-escape nested JSON, and it appends a stray `}` just past the closing `]`:

```
tail:  ...,"width":800,"height":600}]}
                                    ^ stray brace
```

The MCP server rejects the call, returns `isError: true`, and there is no diagram to draw, so the iframe paints empty.

The agent's raw tool-call args arrive over SSE as **valid** JSON, so streaming and arg assembly are healthy. The stray brace sits inside the `elements` string value, written by the model.

## Fix: let the agent self-correct

Swapping models only moved the failure rate around (gpt-4o-mini ~63% of diagrams failed, gpt-5.4 ~30%), so this stops depending on one-shot accuracy.

The server's error already names the exact fault and already comes back as a tool result, and the agent had no step cap, so a retry was mechanically possible all along. **What blocked it was our own prompt:** `"Call create_view ONCE"` and `"do NOT iterate, do NOT make multiple calls. Ship on the first shot."`

Now the prompt tells the model to read the error and try again, capped at **2 corrections (3 calls total)**, with `stopWhen: stepCountIs(6)` bounding the loop if it never converges. This mirrors the validate-then-retry recovery pattern already used for A2UI on the other integrations.

The agent also moves to `gpt-5.4` (owner preference for the 5.x line).

## Validation

Against the **real Excalidraw MCP server**, using the agent's prompt extracted verbatim from this file and the real tool schema, over the Responses API (the path the AI SDK actually uses):

| scenario | result |
| --- | --- |
| normal runs | **12/12 succeeded**, all on the first call |
| attempt 1 force-corrupted with the real-world stray `}` | **10/10 recovered on the second call** (`err > ok` every trial) |

Model comparison that motivated moving away from one-shot (create_view against the real server):

| model | OK | isError |
| --- | --- | --- |
| gpt-4o-mini (before) | 3 | 5 |
| gpt-5.4 (no retry) | 7 | 3 |
| gpt-4.1 | 8 | 0 |
| gpt-5.5 | 10 | 0 |

Prompt hardening alone was measured and does **not** fix it (gpt-4o-mini 8/12 to 7/12 invalid; gpt-5.4 still 2/16).

Also verified in the running app (local dev server, real key): valid JSON, `isError: false`, diagram rendered.

**Not yet verified in-app:** the recovery path itself. No natural failure occurred during the in-app runs, so the retry is proven at the API level rather than through the Mastra agent loop.

## Why aimock never caught this

- aimock replaces the LLM and the fixture hard-codes the `create_view` tool call, so no model-generated JSON is involved. This bug cannot occur under replay.
- The shared d5/d6 probe (`harness/src/probes/scripts/d5-mcp-apps.ts`) asserts only that an iframe element exists (`[data-testid="mcp-app-iframe"] || iframe[sandbox]`) - "the page renders an iframe shell". It never asserts a diagram rendered, and a **rejected payload still mounts an iframe**. So the probe is blind to this class of failure by construction.

The fixture is unaffected by this change: `showcase/aimock/d6/mastra/mcp-apps.json` contains no model or `gpt` reference.

## Follow-ups (not fixed here)

1. **The mcp-apps fixture payload is itself schema-invalid.** Its `elements` is a JSON **array**, but `create_view` requires a **string**. Sent verbatim to the real server it returns `-32602 Invalid arguments for tool create_view: expected "string"`; stringified, the same payload succeeds. No test overrides `MCP_SERVER_URL`, so aimock runs still call the real server.
2. **`MCPAppsActivityRenderer` ignores `isError`** and still renders an empty sandbox iframe, which is why a rejected tool call looks like a silent blank box. Lives in the published `@copilotkit/react-core`, so it would need a release.
3. **The shared probe could assert the diagram actually drew**, not just that an iframe exists. That is one shared probe across every integration (iron rule 1), so it is broader than this ticket.
