### PR TITLE
docs(reskinnable-demo): teach the reskin skill what the demo must prove

### DIFF
--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
@@ -4,11 +4,11 @@ description: >-
   Author a NEW skin for the reskinnable-demo app. A skin is a self-contained
   domain plugin under src/skins/<id>/ that implements the frozen `Skin` contract
   (src/shell/skin-contract.ts) to swap the app's entire experience — brand,
-  theme, layout, pages, tools, data, and agent. Use when the user says "add a
-  skin", "create a skin", "new skin", "reskin the app", "make a <domain> skin",
-  or wants the app re-themed as a new product. Do NOT use for editing the shell
-  itself (src/shell/**), the shared token vocabulary (src/app/globals.css), or
-  the two shipped skins unless explicitly asked.
+  theme, layout, pages, tools, data, and agent — as a live sales demo. Use when
+  the user says "add a skin", "create a skin", "new skin", "reskin the app",
+  "make a <domain> skin", or wants the app re-themed as a new product. Do NOT
+  use for editing the shell itself (src/shell/**), the shared token vocabulary
+  (src/app/globals.css), or the four shipped skins unless explicitly asked.
 ---
 
 # Authoring a reskinnable-demo skin
@@ -19,17 +19,57 @@ under `src/skins/<id>/`. Its ONLY inbound dependency is the frozen `Skin`
 contract in `src/shell/skin-contract.ts` — that is what lets skins be authored
 in isolation without touching shared code.
 
-To add a skin you (1) implement the `Skin` contract in `src/skins/<id>/`,
-(2) put its **server-only** agent in `src/skins/<id>/agent.ts`, and (3) register
-both — the client skin in `src/shell/registry.ts` and the agent in
-`src/shell/agent-registry.ts`, keyed by the identical `id`.
+To add a skin you (1) map the demo beats it must hit, (2) implement the `Skin`
+contract in `src/skins/<id>/`, (3) put its **server-only** agent in
+`src/skins/<id>/agent.ts`, and (4) register both — the client skin in
+`src/shell/registry.ts` and the agent in `src/shell/agent-registry.ts`, keyed by
+the identical `id`.
 
 > Before writing anything, re-open `src/shell/skin-contract.ts` (the source of
-> truth) and read the two shipped skins as worked references:
-> `src/skins/airline/` (the minimal end — in-memory data, no canvas surface) and
-> `src/skins/banking/` (the maximal end — REST-backed, with `Providers`,
-> `CanvasSurface`, `sandboxFunctions`, `chatHeaderActions`, `onSuggestionSelect`).
-> Those files win on any conflict with this skill.
+> truth) and read the shipped skins as worked references. Four are registered —
+> `banking`, `airline`, `logistics`, `keel` — and they are good at different
+> things; **[demo-beats.md](./demo-beats.md) § "Which skin to copy for what"**
+> is the routing table. The short version: `banking` is the maximal end and the
+> only demo-complete skin, `logistics` is the debugged layout reference,
+> `airline` is the minimal contract surface, `keel` is the only one with
+> parameterized routes. Those files win on any conflict with this skill.
+
+---
+
+## ⚠️ FIRST: a skin is a live sales demo, not a theme
+
+A skin exists to prove CopilotKit and Intelligence top to bottom, in front of a
+Fortune 500 buyer. Wiring the contract correctly is table stakes; a skin that
+compiles, looks sharp and proves nothing is a **failed skin**. The banking demo's
+~10 steps are tuned and land with customers — so copy its **beats**, not its
+steps. Your domain can be 1000% different.
+
+| Beat                  | The audience must conclude                                                           | Minimum mechanism                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| **1** Give it a face  | "Generative UI — right out of the gate."                                             | A `useComponent` visual answers pill #1                                    |
+| **2** Rich thread     | "Reload the browser and the chart is still there. Nobody else stores AG-UI streams." | Durable visuals via `useComponent`; **replay-safe** tools                  |
+| **3a** Drive the app  | "It changed the app — and the secret never reached the assistant."                   | A mutation whose sensitive payload stays in the UI                         |
+| **3b** Sees my screen | "Shared state is real." (ask on two different pages)                                 | A **route readable** + per-page on-screen readables                        |
+| **3c** Levers         | "That was a maneuver, not a link."                                                   | HITL confirm → navigate → sort **+** filter, visibly highlighted           |
+| **3d** Multimodal     | "It takes real documents, and the output belongs to my app."                         | Attachment path + artifact written to the store, surviving thread deletion |
+| **4** Memory          | "It remembers how I like things, and says so."                                       | Seeded topical memory + recall-first prompt + a slot naming the "why"      |
+| **5** Stored skill    | "One sentence and it already knows our procedure."                                   | Seeded operational memory + 3 visible writes + distractors                 |
+| **6** Teach a skill   | "It learned by watching me once, then did it alone."                                 | Symptom-only gate + unlock path + recording context + save/recall          |
+
+**Write the beat map before you write code** — the table template and the full
+per-beat spec are in **[demo-beats.md](./demo-beats.md)**, which also covers the
+presentation requirements (a pill per beat so the presenter never types, a visible
+affordance on every mutation, pretty markdown prose, a Reset control, the
+chat-placement framing) and the quality bar.
+
+**If the user named the beats** — fewer, more, or different — theirs win. Record
+what they asked for in the beat map and build that. Absent instructions, build
+all nine.
+
+⚠️ Beats **2, 4, 5 and 6 are runtime-conditional**: they need all three
+`INTELLIGENCE_*` env vars, and beats 4/5 additionally need a seeded-memory file
+(`src/skins/<id>/intelligence/seed-memories.ts`). Without those they degrade
+**silently** — the agent simply doesn't know you. See demo-beats.md.
 
 ---
 
@@ -210,9 +250,9 @@ process.env.NODE_ENV !== "production"` (mirror
   `src/skins/<id>/components/use-ask-copilot.ts` (copy logistics'); do NOT import
   from `src/skins/banking/**` — a skin's only inbound dependency is the contract.
 
-## Registering tools: the deps array + render signatures
+## Registering tools: deps, render signatures, replay safety, readables
 
-Two rules that the `tools.tsx` template bakes in; miss either and the failure is
+Four rules that the `tools.tsx` template bakes in; miss any and the failure is
 silent.
 
 - **Every `useComponent` / `useFrontendTool` / `useHumanInTheLoop` registration
@@ -235,6 +275,28 @@ silent.
   contrast `useHumanInTheLoop` and `useFrontendTool` renders DO receive `{ args,
 status, respond }`. Airline has no parameterized `useComponent`, so don't learn
   the render shape from it — see the template and logistics' `showShipment`.
+- **Renders must be REPLAY-SAFE: key them off the tool `result`, NOT off
+  `status`.** Reopening a thread (or reloading the browser in Intelligence mode)
+  replays recorded tool calls, so you get the stored **result** and no live status
+  transition. A render keyed on `status` looks perfect during the demo and then
+  renders blank or wrong the moment anyone revisits the thread — which is exactly
+  when beat 2 ("reload and the chart is still there") is being shown. Re-derive
+  display state from the replayed result, and never depend on client state that
+  only existed during the live call. Banking is the only skin written this way:
+  `setCardPin` re-derives its card from the replayed result plus a module map
+  holding only `brand`/`last4` — never the PIN (`tools.tsx:70-89`, `418-451`) —
+  and `showCharges` keys off `result` not `status` (`tools.tsx:553-572`).
+- **Register a ROUTE readable and per-page on-screen readables**, not just global
+  ones. `useAgentContext({ description: "The current page…", value: <segment> })`
+  in your layout tells the agent which page is open; readables registered inside
+  each _page_ component tell it what is visibly on screen (active filters, the
+  rows actually rendered, the figures shown). Without both, "what's on my
+  screen?" (beat 3b) returns the same answer on every page and the beat dies.
+  Banking is the only skin that does this — route readable at
+  `layout.tsx:141-143`, page-scoped readables in `dashboard.tsx:148`,
+  `cards.tsx:376`, `team.tsx:54`, and the richest in `charges.tsx:139`. Pair them
+  with a prompt clause telling the agent its context IS its view of the screen
+  and that it must never claim it cannot see (`agent.ts:61-71`).
 
 ---
 
@@ -296,9 +358,10 @@ src/skins/<id>/
 ├── pages/            # one component per nav segment
 ├── tools.tsx         # <XTools/> — frontend tools/HITL/gen-UI + readables; renders null
 ├── catalog/          # createCatalog(...) → the a2ui catalog (index.tsx)
-├── suggestions.ts    # Suggestion[]
+├── suggestions.ts    # Suggestion[] — ONE PILL PER BEAT, in demo order
 ├── design-skill.ts   # the OGUI design-brief string
 ├── data/             # OPTIONAL: seed data + use-data hook (useXData) → useData
+├── intelligence/     # OPTIONAL: user-id.ts (identifyUser) + seed-memories.ts (beats 4/5)
 └── agent.ts          # SERVER-ONLY: export const <id>Agent = () => new BuiltInAgent(...)
 ```
 
@@ -306,15 +369,27 @@ Optional slots you may omit — airline omits all of these EXCEPT `toolLabels` a
 `useData`: `providers.tsx` (→ `Providers` and/or `RuntimeProviders` +
 `useRuntimeProperties`), `intelligence/user-id.ts` (→ server `identifyUser`),
 `canvas-surface.tsx` (→ `CanvasSurface`), `sandboxFunctions`,
-`chatHeaderActions`, `onSuggestionSelect`. (`useData` / `data/` is where the two
-shipped skins split: airline SETS `useData: useAirlineData`; banking omits it and
-reads REST + auth directly, so its `useSkinData<T>()` returns `undefined`.)
+`chatHeaderActions`, `onSuggestionSelect`.
+
+`useData` / `data/` is where the substrates split, and it is a 2-2 split rather
+than a banking-vs-airline one: **banking and logistics** are REST-backed and OMIT
+`useData` (their components read the ledger directly, so `useSkinData<T>()`
+returns `undefined`); **airline and keel** are in-memory and SET it
+(`useAirlineData`, `useKeelData`).
+
 Airline DOES set `toolLabels` (a 9-entry map) so its tool-activity chips read as
 human phrases ("Pulling up your flight") instead of raw tool names (`showFlight`)
 — treat `toolLabels` as expected for any skin with named frontend tools, not
 optional in practice. `RuntimeProviders`/`useRuntimeProperties`/`identifyUser`
-are only for a skin with its own end-user identity (see the identity section
-above); banking uses all three, airline none.
+are for a skin with its own end-user identity (see the identity section above);
+banking, logistics and keel all three ship them, airline none.
+
+`intelligence/seed-memories.ts` is **not** optional if you are building beats 4
+and 5 — "it already knows me" is a seeded file, not emergent behaviour, and only
+banking has one. It seeds the topical preference (beat 4) and the operational
+procedure (beat 5), and deliberately does NOT seed beat 6's procedure — that is
+the one the agent has to learn on stage. See
+**[demo-beats.md](./demo-beats.md) § "Seeding memories"**.
 
 Templates for each file are in **[templates.md](./templates.md)** — copy them and
 fill in your domain. They are written against this app's real contract.
@@ -323,18 +398,26 @@ fill in your domain. They are written against this app's real contract.
 
 ## Authoring order (slot by slot)
 
-Build in dependency order so each slot compiles before the next depends on it:
+**Step 0 — the beat map, before any code.** Fill in the nine-row table from
+[demo-beats.md](./demo-beats.md): for each beat, this skin's step, its pill, and
+what implements it. This is what stops you from building a technically perfect
+skin that proves nothing — the documented failure mode is an author who wires the
+contract beautifully and silently drops beats 2, 3b, 5 and 6. Decide the demo,
+then build it.
+
+Then build in dependency order so each slot compiles before the next depends on it:
 
 1. **identity** (`identity.ts`) — brand, tagline, logo.
 2. **theme** (`theme.css`) — `.theme-<id>` token values.
-3. **data** (`data/`, OPTIONAL) — seed + `useXData()` hook (feeds pages, tools, and the agent's context). Skip if the skin has no shell-managed data (then omit `useData`).
-4. **layout** (`layout.tsx`) — chrome; side-effect-import `./theme.css` here.
-5. **pages** (`pages/`) — one component per nav segment.
-6. **tools** (`tools.tsx`) — frontend tools / HITL / gen-UI + `useAgentContext` readables.
+3. **data** (`data/`, OPTIONAL) — seed + `useXData()` hook (feeds pages, tools, and the agent's context). Skip if the skin has no shell-managed data (then omit `useData`). Seed **two** of anything beat 6 gates, so the replay lands on a fresh one.
+4. **layout** (`layout.tsx`) — chrome; side-effect-import `./theme.css` here; the route readable (beat 3b) and the meta-utility strip live here.
+5. **pages** (`pages/`) — one component per nav segment, each registering its own on-screen readable (beat 3b).
+6. **tools** (`tools.tsx`) — frontend tools / HITL / gen-UI + `useAgentContext` readables. Replay-safe renders (beat 2), visible affordances on every mutation.
 7. **catalog** (`catalog/`) — a2ui catalog via `createCatalog`.
-8. **agent** (`agent.ts`) — server-only `BuiltInAgent` factory.
-9. **suggestions** (`suggestions.ts`) + **design-skill** (`design-skill.ts`).
-10. **register** — `skin.tsx` assembles the object; then wire both registries.
+8. **agent** (`agent.ts`) — server-only `BuiltInAgent` factory. This is where the beats are _enforced_: screen-awareness, recall-first, procedure separation, "never write a markdown table", pretty bold prose.
+9. **intelligence** (`intelligence/`, for beats 4–6) — `user-id.ts` + `seed-memories.ts`.
+10. **suggestions** (`suggestions.ts`) — one pill per beat, in demo order — plus **design-skill** (`design-skill.ts`).
+11. **register** — `skin.tsx` assembles the object; then wire both registries.
 
 Run `pnpm build` after wiring things up — `next build` type-checks the whole app
 (there is no separate `typecheck` script). `pnpm lint` catches the rest.
@@ -414,3 +497,34 @@ If the skin 404s: check `resolvePage` returns a component for `[]` (the index
 segment). If the theme doesn't apply: confirm `themeClass === "theme-<id>"` and
 that `layout.tsx` side-effect-imports `./theme.css`. If chat errors with an
 unknown agent: confirm the agent is in `agent-registry.ts` under the same `id`.
+
+### Then walk the demo (this is the part that actually gates "done")
+
+A green build proves the wiring. Only walking the beats proves the skin. Click
+**every** pill in order, typing nothing, and check each beat's failure mode — all
+of these compile and lint clean while failing live:
+
+1. **Beat 1** — the first pill renders a visual, not a paragraph.
+2. **Beat 2** — reload the browser, reopen the thread: the visuals are still
+   there and still correct. (Needs Intelligence env vars. A render keyed on
+   `status` fails _only_ here.)
+3. **Beat 3a** — the mutation lands, and the sensitive value appears nowhere in
+   the transcript. Earlier gen-UI is still in the thread.
+4. **Beat 3b** — ask on two different pages; the answers differ and cite real
+   on-screen figures. Identical answers mean no route readable.
+5. **Beat 3c** — a confirm card lists the levers before navigating, and after
+   navigation the applied controls are visibly highlighted.
+6. **Beat 3d** — the artifact appears in the app, then delete the thread: it is
+   still there.
+7. **Beat 4** — the answer names the preference it recalled. If it just answers
+   normally, either the seed file or the recall-first prompt clause is missing.
+8. **Beat 5** — one vague sentence fires all the procedure's steps in order, no
+   confirmation, each visibly. If it offers to record something, beats 5 and 6
+   are bleeding into each other in the prompt.
+9. **Beat 6** — it declines, records, saves; then on a **different** gated record
+   it runs the procedure alone.
+10. **Reset** — restores the data, wipes learned memory, re-seeds beats 4/5, and
+    leaves beat 6 unlearned so the demo can run again.
+
+Any beat you deliberately skipped should say so in the beat map. A beat that is
+merely absent is a bug.

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/demo-beats.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/demo-beats.md
@@ -1,0 +1,421 @@
+# The demo beats — what a skin has to prove
+
+A skin is not a theme. It is a **live sales demo** that proves CopilotKit and
+Intelligence top to bottom, in a domain a Fortune 500 buyer recognizes. The
+banking skin ("Northwind Finance") is the reference: its ~10 steps are tuned and
+they land with customers. **Copy its beats, not its steps.**
+
+> "Your use case can be 1000% different. Totally cool. But you still want to hit
+> those beats of: I can manipulate the app, I know what's on the page, I've got
+> long-term memory, I've got a stored procedure, I can create a stored
+> procedure." — the demo walkthrough that defines this file
+
+Each beat below states **what the audience must conclude**, then what your skin
+has to implement for that conclusion to land, then how banking does it. The
+audience conclusion is the point; the mechanism is negotiable.
+
+---
+
+## The beat map (fill this in BEFORE writing code)
+
+Author this table first, in your plan or as a comment at the top of
+`src/skins/<id>/suggestions.ts`. One row per beat, no rows omitted — write
+`SKIPPED — <reason>` in a cell rather than deleting the row, so a reader can
+tell a deliberate choice from an oversight.
+
+```markdown
+| Beat              | This skin's step | Pill | Implemented by |
+| ----------------- | ---------------- | ---- | -------------- |
+| 1 face            |                  |      |                |
+| 2 rich thread     |                  |      |                |
+| 3a drive the app  |                  |      |                |
+| 3b sees my screen |                  |      |                |
+| 3c levers         |                  |      |                |
+| 3d multimodal     |                  |      |                |
+| 4 memory          |                  |      |                |
+| 5 stored skill    |                  |      |                |
+| 6 teach a skill   |                  |      |                |
+```
+
+**If the user named which beats to hit** — fewer, more, or different ones — theirs
+win outright. Record what they asked for in the map (`"user: BI dashboards only,
+no teach mode"`) and build that. Absent instructions, build all nine rows: that
+is what makes a skin demo-complete, and three of the four shipped skins are
+missing most of them (see "Which skin to copy" at the end).
+
+---
+
+## Beat 1 — Give the agent a face
+
+**Audience concludes:** this agent has a face. Generative UI is the reason people
+come to CopilotKit in the first place, so lead with it — never open with a wall
+of text.
+
+**Your skin needs:** a `useComponent` that renders a real visual (chart, tile
+row, card) from live skin data, as the answer to the very first pill. Pair the
+visual with one or two sentences of prose — a chart with no words reads as a
+glitch, and prose with no chart wastes the beat.
+
+**Banking:** pill `"Show the spending trend"` → `showSpendingTrend`
+(`tools.tsx:797`) renders a hand-rolled SVG chart from the live ledger. Its
+sibling charts (`showBudgetUsage`, `showSpendBreakdown`,
+`showIncomeVsExpenses`) all carry a shared `CHART_ANSWER_RULE`
+(`tools.tsx:694`) instructing the agent to render the chart **and** answer in a
+sentence or two.
+
+---
+
+## Beat 2 — The thread is rich, not text
+
+**Audience concludes:** these threads store AG-UI streams, not text. Click across
+threads, hard-reload the browser, come back — the chart is still there. On any
+other product on the planet that chart is gone and only text remains.
+
+**Your skin needs:** durable visuals registered as `useComponent` (they replay
+from thread history) rather than as a `useFrontendTool` render, **and tools
+written to be replay-safe.** This is the part that silently breaks:
+
+- **Key a render off the tool `result`, not off `status`.** On replay you get the
+  recorded result, not a live status transition. A render keyed on `status`
+  looks perfect during the live run and renders blank or wrong the moment the
+  thread is reopened.
+- **Re-derive display state from the replayed result.** Never depend on client
+  state that only existed during the live call.
+- **Keep secrets out of what you re-derive** (see beat 3a).
+
+**Banking:** `setCardPin` re-derives its resolved card from the replayed tool
+result plus a module-level map holding only `brand`/`last4` — never the PIN
+(`tools.tsx:70-89`, `418-451`); `showCharges` explicitly keys off `result` and
+not `status` (`tools.tsx:553-572`).
+
+**⚠️ Runtime-conditional.** Durable cross-reload thread history exists only in
+**Intelligence mode** — all three of `INTELLIGENCE_API_URL`,
+`INTELLIGENCE_GATEWAY_WS_URL`, `INTELLIGENCE_API_KEY` set. The default OSS path
+uses `InMemoryAgentRunner` and is ephemeral. No skin code persists anything.
+Demo this beat in Intelligence mode or not at all — and write your tools
+replay-safe regardless, because the failure is invisible until you reload.
+
+---
+
+## Beat 3 — Manipulate the app (four sub-beats)
+
+These four are one argument made four ways: **the agent drives your real
+application.** Do not collapse them into one step; each closes a different
+objection.
+
+### 3a — Drive the app, and prove the secret never left the UI
+
+**Audience concludes:** it really changed the app — and the sensitive value was
+never sent to the assistant.
+
+**Your skin needs:** a mutation the agent initiates whose sensitive payload it
+never sees, because the user types it into a component in the chat. Two things to
+get right: the agent must be told **never to ask for the secret and never to ask
+which record first** (it should fire the tool immediately), and the gen-UI from
+beat 1 must **stay** in the transcript — the conversation must not collapse into
+"OK, PIN set."
+
+**Banking:** pill `"Change my card PIN"` → `setCardPin` (`useHumanInTheLoop`,
+`tools.tsx:399`) opens `PinChangeCard` in the chat; the user picks the card and
+types the digits there. `changePin` goes straight to REST and the agent's
+`respond()` gets only `"PIN updated on the {label}."` The prompt is explicit:
+"NEVER ask for PIN digits, never repeat them, and never ask which card first"
+(`agent.ts:144`).
+
+### 3b — "What's on my screen?" — asked twice, on two different pages
+
+**Audience concludes:** shared state is real. Not everyone understands it, so
+show it: ask on one page, navigate, ask again. Different, correct answer both
+times.
+
+**Your skin needs — and this is the beat most often broken by omission:**
+
+1. **A route readable.** `useAgentContext({ description: "The current page…",
+value: <current segment> })` in your layout. Without it the agent has no idea
+   which page is open.
+2. **Per-page readables that describe what is visibly on screen** — active
+   filters, the rows actually rendered, the figures shown. Register these in the
+   _page components_, not only globally.
+3. **A prompt clause** telling the agent that its context **is** its view of the
+   screen: name the page, summarize the key elements, cite the actual figures,
+   and **never** say it cannot see the screen.
+
+Every shipped skin registers readables. Only banking registers a route readable
+and per-page on-screen readables — which is why this beat is impossible in
+airline, logistics and keel today: they answer identically no matter which page
+is open.
+
+**Banking:** route readable at `layout.tsx:141-143`; global page/operation
+readables at `tools.tsx:162-170`; page-scoped on-screen readables in
+`dashboard.tsx:148`, `cards.tsx:376`, `team.tsx:54`, and — the richest —
+`charges.tsx:139`, which emits the page name, the active filters, the visible
+row count and the first 25 visible rows. Prompt clause "SCREEN AWARENESS" at
+`agent.ts:61-71`.
+
+### 3c — Navigate with levers, and make it complicated
+
+**Audience concludes:** it didn't follow a link — it performed a maneuver through
+the app's real controls, and those controls are genuinely wired.
+
+**Your skin needs:** one tool that (i) confirms first via HITL, naming the
+filters it is about to apply, (ii) navigates, (iii) applies a sort **and** a
+filter through the page's real query params, and (iv) leaves the applied levers
+**visibly highlighted** so the audience can see the agent set them. A plain
+`navigateTo` does not earn this beat.
+
+**Banking:** pill `"Show me the 10 most expensive charges"` → `showCharges`
+(`useHumanInTheLoop`, `tools.tsx:513`) renders `NavigateConfirmCard` listing the
+sort + filters _before_ navigating, then pushes
+`/banking/charges?sort=amount_desc&top=10`. The page reads those params
+(`charges.tsx:42-53`) and sorts/slices. The highlight is an `activeSelect` tint
+on the Sort and Top-N controls when set from the URL — `border-brand/50
+bg-brand-soft font-semibold text-brand-indigo` (`charges.tsx:67-68`) — plus a
+rank column when sorted by amount. Note it is the **controls** that light up, not
+the rows.
+
+### 3d — Multimodal in, durable artifact out
+
+**Audience concludes:** it takes real documents, and what it produces belongs to
+the _application_, not to the chat. Delete the whole thread — the artifact is
+still there, because it is part of your product.
+
+**Your skin needs:** an attachment path, plus a tool that writes its output to
+your skin's **store**, plus a surface in the app that lists those artifacts.
+Deleting the thread must not remove it. In-memory skins can fake half of this;
+a server-backed store makes it true.
+
+Two mechanics worth copying verbatim:
+
+- **The framework's suggestion path drops attachments.** So a pill that must
+  carry a file has to intercept via `onSuggestionSelect`, stage the file into the
+  composer's hidden `input[type=file]`, then drive the real composer textarea and
+  send button. Share the message string as a constant between the pill and the
+  handler so the match cannot drift.
+- **Give the presenter a paperclip too** via `chatHeaderActions`, so the file can
+  be staged manually if the pill path misbehaves on stage.
+
+**Banking:** pill `"Prep the Q2 spend report"` → `onSuggestionSelect`
+(`skin.tsx:143-149`) matches the shared `Q2_REPORT_MESSAGE` constant and calls
+`sendQ2WithInvoice()`, which stages the bundled PDF via `stageInvoiceAttachment`
+(`attach-invoice.ts`) and drives the composer. The `createReport` frontend tool
+(`components/wow/report-tool.tsx:20`) POSTs to `/api/banking/v1/reports`; the
+filed report renders in the dashboard's **Reports tab** (`reports-view.tsx`),
+keyed to the app and not the thread. The prompt's UPLOADED DOCUMENTS clause
+(`agent.ts:319-328`) tells it to read the PDF and merge the invoice's line items
+into the report via `createReport`'s `additions` array.
+
+---
+
+## Beat 4 — Long-term memory: it remembers how you like things
+
+**Audience concludes:** it remembers me across sessions, and it will tell me what
+it remembered.
+
+**Your skin needs:**
+
+1. **A seeded topical memory** describing a formatting or workflow preference —
+   see "Seeding memories" below.
+2. **A prompt clause** that forces `recall_memory` _before_ answering the class of
+   question the preference applies to.
+3. **A component with a slot for the "why."** The recalled preference must be
+   surfaced, not just silently obeyed — otherwise the audience sees a normal
+   answer and the beat is invisible.
+4. **A remembering voice** in the prompt: "You like these by team, so…"
+
+**Banking:** pill `"Summarize our spend"` → prompt clause at `agent.ts:166-174`
+forces `recall_memory` first, then `showSpendSummary` (`tools.tsx:704`) receives
+`overLimitFirst` / `rounded` from what was recalled, and its **`note` parameter
+is where the agent names the preference it applied**. The seeded memory
+(`intelligence/seed-memories.ts:33-52`) reads: spend summaries grouped by team,
+anything over its policy limit called out first, figures rounded to whole
+dollars.
+
+**⚠️ Runtime-conditional.** `recall_memory` / `save_memory` are attached only in
+Intelligence mode. Without those env vars this beat silently degrades to a
+generic answer.
+
+---
+
+## Beat 5 — Stored procedure: "handle it"
+
+**Audience concludes:** one vague sentence, and it already knows our procedure —
+several steps, in order, no hand-holding.
+
+**Your skin needs:**
+
+1. **A seeded operational memory holding a literal, ordered procedure** — the
+   numbered steps, plus "run all of them immediately, in order, without asking
+   for confirmation."
+2. **Three-ish `useFrontendTool` writes** that the procedure fires, registered
+   globally (they must be callable from anywhere), each producing a **visible**
+   change.
+3. **Distractor tools** registered alongside them, so "it picked the right three"
+   means something.
+4. **Explicit prompt separation from beat 6's procedure.** These two are the
+   easiest thing in the whole demo for the agent to confuse. Say plainly that
+   this is a _different_ procedure and it must not offer to record anything.
+5. **A prompt clause** that finding the record is not handling it.
+
+**Banking:** pill `"I don't recognize the Delta charge"` → seeded operational
+memory (`seed-memories.ts:61-76`) → `flagForReview` (`tools.tsx:323`) +
+`sendSpendAlert` (`tools.tsx:296`) + `addNoteToTransaction` (`tools.tsx:347`).
+The note tool **force-prepends a 🚨** when the text reads as an alert
+(`tools.tsx:363-374`) so the change is un-skimmable on a projector. Prompt clause
+"SUSPICIOUS / UNRECOGNIZED CHARGES FOLLOW A SAVED PROCEDURE" at
+`agent.ts:176-190`, including "This is a DIFFERENT procedure from clearing an
+over-limit charge — do not confuse the two, do not offer to record anything."
+
+**⚠️ Runtime-conditional** (Intelligence, as beat 4).
+
+---
+
+## Beat 6 — Create a stored procedure: teach it
+
+**Audience concludes:** when it _doesn't_ know, it learns by watching me once —
+and then does it alone, on a different case.
+
+**Your skin needs five parts.** Full spec for the banking implementation is in
+`docs/teach-mode/README.md`; read it before building your own.
+
+1. **A gate that fails with symptoms only.** An action that returns a refusal
+   naming the problem and never the fix. Banking: `PUT
+/api/banking/v1/transactions/[id]` → `422 OVER_POLICY_LIMIT`.
+2. **An unlock path with decoys.** A multi-step way through — and near-miss
+   options that look plausible and don't work, so the demonstration is a real
+   demonstration. Banking: `data/policy-exception-codes.ts` (justifying codes,
+   decoy codes, invalid codes rejected without enumeration) + the `exceptions`
+   and `exceptions/[id]/finalize` routes.
+3. **An agent framed to decline rather than bluff.** The prompt withholds the
+   recipe and carries an ACTION DISCIPLINE clause so it says "I don't know this
+   one — want me to record how you do it?" instead of improvising.
+4. **A recording context with live, visible feedback.** Banking:
+   `components/recording-context.tsx` (ref-counted `beginRecording`/
+   `endRecording`, `logStep`, `getDemonstratedCode`), plus a step feed
+   (`recording-feed.tsx`) and a violet canvas-edge glow (`recording-vignette.tsx`)
+   so the audience can see recording is live.
+5. **Save → recall → replay on a _different_ instance.** The case you taught it
+   on is already resolved by the demonstration, so seed **at least two** gated
+   records. The proof is it handling the second one unaided.
+
+**Banking's HITL chain:** `offerWorkflowRecording` (`tools.tsx:1094`) →
+`awaitDashboardDemonstration` (`1169`, live pulsing "Rec" badge + step feed) →
+`saveLearnedWorkflow` (`1251`, then `save_memory` with scope `project`, kind
+`operational`) → replay via `openPolicyException` (`903`) →
+`finalizePolicyException` (`970`) → `approveTransaction` (`1029`).
+
+**⚠️ Runtime-conditional.** Gate → unlock is provable over pure REST today
+(`docs/teach-mode/verify-teachable-gate.sh`). Durable save → recall → _fresh
+thread_ needs Intelligence. `pnpm test:self-learning` covers it deterministically
+via aimock.
+
+---
+
+## Seeding memories (load-bearing for beats 4, 5 and 6)
+
+Beats 4 and 5 are **seeded, not emergent** — "it already knows me" is a file. Add
+`src/skins/<id>/intelligence/seed-memories.ts` alongside your `user-id.ts` and
+mirror `src/skins/banking/intelligence/seed-memories.ts`. Three rules:
+
+- **Seed the topical preference** (beat 4) and the **operational procedure**
+  (beat 5).
+- **Deliberately do NOT seed beat 6's procedure.** That is the one the agent must
+  learn on stage. Banking's seed file omits it on purpose
+  (`seed-memories.ts:53-60`) — if you seed it, beat 6 has nothing to teach.
+- **Scope them** so beat 5's procedure and beat 6's learned procedure can never
+  be mistaken for each other. Banking scopes the learned one `project` /
+  `operational` and words both prompts to force the distinction.
+
+Reset must re-seed. See the Reset requirement below.
+
+---
+
+## Presentation requirements (not beats, still mandatory)
+
+**A pill for every beat, in demo order.** The presenter should never type — "make
+sure that the bubbles are in there so I never have to type, I could just click."
+This is also a correctness measure: free-typed phrasing routes wrong. Saying
+"show me the spending **report**" instead of "trend" sends banking to the canvas
+report tool rather than the in-chat chart. Pills remove that whole class of
+stage accident. Banking ships 8 pills covering its full flow; airline, logistics
+and keel ship 4–5 with partial coverage.
+
+**Every mutation gets a visible affordance.** "Make sure that you use like a
+light or a bell or whatever so people can see that it changed." If the audience
+can't see the change, it didn't happen. Patterns already in the repo: the forced
+🚨 note prefix, the brand-tinted `activeSelect` filter controls, airline's
+`ring-2 ring-brand-indigo` seat highlight, keel's agent-navigated section
+highlight, the pulsing Rec badge and recording vignette. (Note
+`banking/components/wow/proactive-notice.tsx` is an `animate-ping` bell toast
+that is defined and **mounted nowhere** — it is available, not in use.)
+
+**The prose has to be pretty.** "Ask a text question and make sure the prose
+comes through really pretty — use that markdown for the bold highlighting."
+Put it in the prompt: bold the key figures, keep answers short, and never emit a
+raw markdown table where a gen-UI component exists for that data. Banking's
+prompt says "NEVER WRITE A MARKDOWN TABLE" and routes to `showTable`/`showCharges`
+instead (`agent.ts:74-80`).
+
+**A Reset control.** Presenter-gated, in the layout's meta-utility strip; see
+SKILL.md § "The meta-utility strip". Reset must restore the data store, **wipe
+learned memories**, and **re-seed** the "already knows" ones — while still
+leaving beat 6 unlearned. Banking's `dev/reset` route does exactly that. Only
+banking and logistics ship both the route and the button today.
+
+**Open with the placement framing.** Say up front: this is your application, and
+the assistant can be a docked panel, a bubble, a standalone app, or its own
+window. The chat sitting on the _left_ reads as unusual to people who expect
+in-app agents on the right, so say it rather than letting the audience wonder.
+The shell backs this up — the selector card can swap the assistant's side or hide
+it entirely, and the preference persists shell-global.
+
+**Roughly banking's number of steps.** ~10 beats-worth. Not 4, not 25.
+
+---
+
+## Choosing a domain, and the quality bar
+
+If nobody named a domain, pick one that a Fortune 500 buyer sees themselves in.
+The ask is 8–12 skins spanning that space. Two are called out explicitly:
+
+- **Business intelligence / executive analytics — the highest-stakes skin.**
+  "Take my data and show it real pretty for me, and then manipulate and do stuff
+  with it." This is the one that opens doors at CEO / CFO / COO / VP level, and
+  it has to be **the prettiest thing we ship** — "ultra, ultra pretty, as pretty
+  as we can possibly make it."
+- **Real-time collaborative editing with AI.** Notoriously painful to build
+  yourself, which is exactly why showing it working closes people.
+
+Other domains that fit the same buyer: healthcare operations (shipped as `keel`),
+supply chain / logistics (shipped), insurance claims, field service, HR and
+recruiting, legal contract review, retail merchandising, energy and utilities
+operations, customer-support command centers, manufacturing quality.
+
+**The bar is "holy shit" pretty, not "renders correctly."** Arm sales with
+something beautiful and they close monster deals; ship template output and the
+beats land flat no matter how correct the wiring is. Budget real design effort,
+and use the workspace's frontend-design skill rather than eyeballing it.
+
+---
+
+## Which skin to copy for what
+
+| Need                                  | Copy from                                                |
+| ------------------------------------- | -------------------------------------------------------- |
+| Every beat, end to end                | `banking` — the only skin at 6/6                         |
+| Route + on-screen readables (beat 3b) | `banking` — the only skin with them                      |
+| Teach mode (beat 6)                   | `banking` + `docs/teach-mode/README.md`                  |
+| Attachment staging (beat 3d)          | `banking` — `attach-invoice.ts`, `skin.tsx`              |
+| Debugged layout + meta-utility strip  | `logistics`                                              |
+| Server-emitted a2ui canvas            | `logistics` (`renderBrief`), `banking` (`render_report`) |
+| Per-user identity plumbing            | `banking`, `logistics`, `keel`                           |
+| Parameterized routes in `resolvePage` | `keel` (`knowledge/<docId>`, `runs/<runId>`)             |
+| In-memory `useData` substrate         | `airline`, `keel`                                        |
+| Minimal contract surface              | `airline`                                                |
+
+**Do not use airline, logistics or keel as demo-completeness references.** They
+predate this bar: each hits roughly one beat of nine. Logistics and keel are
+especially misleading — both ship the full per-user identity plumbing
+(`RuntimeProviders`, `useRuntimeProperties`, server `identifyUser`) and then no
+memory prompts, no memory tools and no seed file, so they get zero demo value
+from the hardest part. They are excellent _wiring_ references and incomplete
+_demo_ references.

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
@@ -2,8 +2,14 @@
 
 Copy each block into `src/skins/<id>/<file>` and replace `<id>` / `<Brand>` /
 domain specifics. These are written against this app's frozen `Skin` contract
-(`src/shell/skin-contract.ts`) and mirror the two shipped skins
-(`src/skins/airline/`, `src/skins/banking/`).
+(`src/shell/skin-contract.ts`) and mirror the four shipped skins
+(`src/skins/{banking,airline,logistics,keel}/`) — see
+[demo-beats.md](./demo-beats.md) § "Which skin to copy for what" for which one to
+open for which problem.
+
+These templates are the **wiring floor**, not a finished skin. A skin also has to
+hit the demo beats (SKILL.md § "FIRST: a skin is a live sales demo"); where a
+template slot is load-bearing for a beat, it says so.
 
 Throughout: replace `<id>` with your lowercase skin id (e.g. `support`) and
 `<Id>` with the PascalCase form (e.g. `Support`). The id must equal the route
@@ -143,6 +149,7 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { HelpCircle, RotateCcw } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
 import { useSkin } from "@/shell/skin-provider";
 import { usePresenterReset } from "@/shell/presenter-reset-context";
 import { ThemeToggle } from "@/components/ui/theme-toggle"; // SHARED shell component — importing it is fine
@@ -158,6 +165,22 @@ export function <Id>Layout({ children }: { children: ReactNode }) {
   const resetEnabled = usePresenterReset();
   const askCopilot = useAskCopilot();
   const Logo = skin.identity.logo;
+
+  // BEAT 3b — the ROUTE readable. Without this the agent cannot tell which page
+  // is open, so "what's on my screen?" answers identically everywhere and the
+  // beat dies. Pages register their own readables for what is visibly rendered.
+  //
+  // Derive the segment RELATIVE to the skin base, or you report the skin id
+  // instead of a page — the exact bug banking hit before its cutover, when this
+  // read `pathname.split("/")[1]` and every page answered "banking".
+  const rest = pathname.split("/").slice(2).join("/");
+  const restHead = rest.split("/")[0];
+  useAgentContext({
+    description: "The current page where the user is",
+    // Name the INDEX page something meaningful, not "" — in banking `/banking`
+    // IS the Credit Cards view, so it reports "cards".
+    value: restHead === "" ? "<index page name>" : restHead,
+  });
 
   const handleReset = async () => {
     if (!window.confirm("Reset demo state? This restores the seeded scenario.")) return;
@@ -278,13 +301,37 @@ export type <Id>Data = ReturnType<typeof use<Id>Data>;
 
 One component per nav segment. Read the skin's data via `useSkinData<T>()`.
 
+**Each page registers its own on-screen readable** (beat 3b). The route readable in
+`layout.tsx` says _which_ page is open; this says _what is on it_ — the active
+filters and the rows actually rendered after filtering and sorting, not the whole
+data set. That distinction is the beat: the agent describing what the user can
+literally see. Mirror `src/skins/banking/pages/charges.tsx:139`.
+
 ```tsx
 "use client";
+import { useAgentContext } from "@copilotkit/react-core/v2";
 import { useSkinData } from "@/shell/skin-provider";
 import type { <Id>Data } from "../data/use-data";
 
 export function <Id>HomePage() {
   const data = useSkinData<<Id>Data>();
+  const visible = /* the rows actually rendered, after filter + sort */ [];
+
+  // BEAT 3b — what is VISIBLY on screen right now, not the whole data set.
+  useAgentContext({
+    description:
+      "The <Page> page the user is currently viewing: the active filters/sort " +
+      "and the visible rows, in the order shown.",
+    value: JSON.stringify({
+      page: "<segment>",
+      filters: {
+        /* the live filter/sort state */
+      },
+      visibleCount: visible.length,
+      rows: visible.slice(0, 25), // cap it — this rides on every request
+    }),
+  });
+
   return <div>{/* render domain UI from `data` */}</div>;
 }
 ```
@@ -293,8 +340,9 @@ export function <Id>HomePage() {
 
 Renders `null`. Register frontend tools / HITL / gen-UI components and
 `useAgentContext` readables here (all from `@copilotkit/react-core/v2`). Mirror
-`src/skins/logistics/tools.tsx` — it is the debugged reference for the two things
-this file MUST get right.
+`src/skins/logistics/tools.tsx` for the wiring and
+`src/skins/banking/tools.tsx` for the beats — between them they are the debugged
+reference for the four things this file MUST get right.
 
 **1. Every registration closes with a deps array.** `useComponent`,
 `useFrontendTool`, and `useHumanInTheLoop` each take an **optional deps array as
@@ -315,6 +363,21 @@ the same trap in a code comment (search "closure captures empty arrays" in
 and `render: ComponentType<NoInfer<InferRenderProps<TSchema>>>`. By contrast
 `useHumanInTheLoop` and `useFrontendTool` renders DO receive `{ args, status,
 respond }`. Do not copy the HITL `{ args }` shape into a `useComponent`.
+
+**3. Renders must be REPLAY-SAFE — key them off `result`, not `status`** (beat 2).
+Reopening a thread replays recorded tool calls: you get the stored `result` and no
+live status transition. A render keyed on `status` is perfect live and blank or
+wrong on revisit — precisely when "reload and it's still there" is being demoed.
+Banking is the only skin written this way (`tools.tsx:70-89`, `418-451`,
+`553-572`).
+
+**4. Readables must make the agent PAGE-AWARE** (beat 3b). Global readables
+(who the user is, the whole data set) are not enough: "what's on my screen?"
+returns the same answer everywhere without a **route** readable in `layout.tsx`
+plus **per-page** readables describing what is visibly rendered. Register the
+on-screen ones inside the page components, close to the state they describe —
+banking's richest is in `charges.tsx:139`, emitting the page name, active
+filters, visible row count and the first 25 visible rows.
 
 ```tsx
 "use client";
@@ -360,18 +423,28 @@ export function <Id>Tools() {
     [data],
   );
 
-  // Frontend tool (a write) → render DOES receive { args, status, respond }.
+  // Frontend tool (a write) → render receives { name, toolCallId, args, status,
+  // result } (a discriminated union; `result` is defined only when Complete).
+  //
+  // REPLAY-SAFE: key the finished state off `result`, NOT off `status` (beat 2).
+  // On thread reopen you get the recorded result and no live status transition,
+  // so a status-keyed render goes blank exactly when someone revisits the thread.
   useFrontendTool(
     {
       name: "doThing",
       description: "Do the thing.",
       parameters: z.object({ id: z.string() }),
+      // Return everything the render needs to rebuild itself from history — but
+      // NEVER a secret (beat 3a): whatever you return is stored in the thread.
       handler: async ({ id }) => `Did the thing to ${id}.`,
-      render: ({ status }) => (
-        <div className="text-ink-muted">
-          {status === ToolCallStatus.Complete ? "Done." : "Working…"}
-        </div>
-      ),
+      render: ({ result, args }) =>
+        result ? (
+          // Give the audience something to SEE (beat presentation rule): a badge,
+          // a forced emoji prefix, a highlight ring — not just the word "Done."
+          <div className="text-ink">✅ {result}</div>
+        ) : (
+          <div className="text-ink-muted">Working on {args?.id}…</div>
+        ),
     },
     [data], // ← deps here too
   );
@@ -379,6 +452,10 @@ export function <Id>Tools() {
   return null;
 }
 ```
+
+`ToolCallStatus` is still the right import when you genuinely need the in-flight
+distinction (`InProgress` vs `Executing`); just don't make the **completed** state
+depend on it.
 
 ## `catalog/index.tsx`
 
@@ -396,13 +473,58 @@ export const <id>Catalog = createCatalog(
 );
 ```
 
-## `suggestions.ts`
+## `suggestions.ts` — ONE PILL PER BEAT, IN DEMO ORDER
+
+The pills ARE the demo script. The presenter must never have to type: "make sure
+that the bubbles are in there so I never have to type, I could just click." This
+is also a correctness measure — free-typed phrasing routes to the wrong tool
+(saying "spending **report**" instead of "trend" sends banking to the canvas
+report tool instead of the in-chat chart). Keep the beat map from
+[demo-beats.md](./demo-beats.md) in a comment at the top so the mapping can't rot.
+
+Banking ships 8 pills covering its whole flow; airline/logistics/keel ship 4–5
+and cover it partially — copy banking's coverage, not their count.
 
 ```ts
 import type { Suggestion } from "@/shell/skin-contract";
 
+// Shared with `onSuggestionSelect` in skin.tsx so the match can never drift
+// (beat 3d — the framework's suggestion path drops attachments, so the pill that
+// carries a file has to be intercepted by exact message match).
+export const <ID>_ATTACHMENT_MESSAGE =
+  "<the prompt that must ride along with the staged file>";
+
+// Beat map — keep in sync with the demo:
+//   1  face          → pill 1
+//   2  rich thread   → no pill (reload + reopen a thread)
+//   3a drive the app → pill 2
+//   3b sees screen   → pill 3 (click it on TWO different pages)
+//   3c levers        → pill 4
+//   3d multimodal    → pill 5 (intercepted, stages the file)
+//   4  memory        → pill 6
+//   5  stored skill  → pill 7
+//   6  teach a skill → pill 8
 export const <id>Suggestions: Suggestion[] = [
-  { title: "<pill title>", message: "<prompt sent when clicked>" },
+  // 1 — lead with generative UI, never a wall of text.
+  { title: "<show the headline visual>", message: "<...>" },
+  // 3a — a mutation whose secret never reaches the assistant.
+  { title: "<change the sensitive thing>", message: "<...>" },
+  // 3b — ask it on one page, navigate, ask it again.
+  {
+    title: "What's on my screen?",
+    message:
+      "Look at the page I'm on right now and tell me what's on screen — the key elements and the figures shown.",
+  },
+  // 3c — HITL confirm, then navigate + sort + filter, visibly highlighted.
+  { title: "<the complicated maneuver>", message: "<...>" },
+  // 3d — intercepted in skin.tsx; stages the bundled file.
+  { title: "<produce the artifact>", message: <ID>_ATTACHMENT_MESSAGE },
+  // 4 — recalls a seeded preference AND names it.
+  { title: "<the format-sensitive question>", message: "<...>" },
+  // 5 — one vague sentence replays a seeded procedure.
+  { title: "<I don't recognize this — handle it>", message: "<...>" },
+  // 6 — the gated action it does NOT know how to do yet.
+  { title: "<the gated action>", message: "<...>" },
 ];
 ```
 
@@ -469,6 +591,110 @@ export const <id>IdentifyUser: IdentifyRunUser = (properties) => {
 };
 ```
 
+## `intelligence/seed-memories.ts` — REQUIRED for beats 4 and 5
+
+"It already knows me" is a **file**, not emergent behaviour. Mirror
+`src/skins/banking/intelligence/seed-memories.ts` — the only implementation in
+the repo, and its comments are worth reading in full. Server-safe plain `.ts`.
+Called by your `dev/reset` route immediately after wiping memories, so the demo
+is re-armed before the presenter says a word.
+
+Three design rules, each learned the hard way:
+
+- **Seed a standing PREFERENCE, not a fact** (beat 4). "Alex's favourite food"
+  proves storage; "group spend by team, over-limit first, rounded to whole
+  dollars" proves _applied_ learning, because recall visibly changes the answer to
+  a question the user never re-explained.
+- **The procedure must run FULLY AUTOMATICALLY — no confirmation gate** (beat 5).
+  Banking's note step used to open an approval card; if the presenter moved on
+  without answering it, that tool call sat unresolved and the **next message
+  failed the whole thread** with `Tool result is missing for tool call ...`. A
+  procedure with no half-finished state has nothing to leave behind. Put "run all
+  of them immediately, in order, without asking for confirmation" in the memory
+  text itself.
+- **Keep beat 5's procedure and beat 6's DISJOINT, and never seed beat 6's.**
+  Seeding the teachable one means the agent already knows the answer and never
+  offers to record — the entire teach arc vanishes.
+
+```ts
+// server-safe: plain .ts, no "use client", no JSX
+export interface SeedMemoriesParams {
+  apiUrl: string;
+  apiKey: string;
+  userId: string;
+}
+
+interface SeedMemory {
+  kind: "topical" | "episodic" | "operational";
+  scope: "user" | "project";
+  content: string;
+}
+
+export const SEED_MEMORIES: readonly SeedMemory[] = [
+  {
+    // BEAT 4 — a standing preference, so recall CHANGES the answer.
+    kind: "topical",
+    scope: "user",
+    content:
+      "<Name> prefers <the format/ordering/rounding preference>, so answers " +
+      "should apply it without being asked.",
+  },
+  {
+    // BEAT 5 — a PROCEDURE, so recall produces visible ACTION (several tool
+    // calls in a row) rather than a reformatted answer. Disjoint from beat 6's.
+    kind: "operational",
+    scope: "project",
+    content:
+      "Procedure for <the beat-5 situation> (NOT for <the beat-6 situation>): " +
+      "(1) <first tool>, (2) <second tool>, (3) <third tool, with the visible " +
+      "affordance — e.g. prefix the note with 🚨 so it stands out>. Run all " +
+      "three immediately, in order, without asking for confirmation, then " +
+      "confirm what was done in one short sentence.",
+  },
+  // DO NOT seed beat 6's procedure. That one is taught live on stage.
+];
+
+/**
+ * Write the seed memories for one identity; returns how many were stored.
+ * Never throws — a booth reset must still report success for the data store even
+ * if the memory backend is unhappy, so failures are counted, not propagated.
+ */
+export async function seedMemories(
+  params: SeedMemoriesParams,
+): Promise<number> {
+  const { apiUrl, apiKey, userId } = params;
+  const base = apiUrl.replace(/\/$/, "");
+  let stored = 0;
+
+  for (const memory of SEED_MEMORIES) {
+    try {
+      const res = await fetch(`${base}/api/memories`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "X-Cpki-User-Id": userId,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(memory),
+      });
+      if (res.ok) stored += 1;
+      else console.error(`[seed-memories] ${userId}: HTTP ${res.status}`);
+    } catch (err) {
+      console.error(`[seed-memories] ${userId}: ${String(err)}`);
+    }
+  }
+
+  return stored;
+}
+```
+
+Seed the memories against the **same identity your `identifyUser` asserts** for
+the default demo user, or the agent's own `recall_memory` will not find them.
+Banking pairs this with `intelligence/forget-memories.ts` so `dev/reset` can wipe
+learned memories and then re-seed these — see SKILL.md § "The meta-utility strip"
+and demo-beats.md § "Presentation requirements".
+
 ## `agent.ts` — SERVER-ONLY (no "use client", no JSX)
 
 Mirror `src/skins/airline/agent.ts` (minimal) or `src/skins/logistics/agent.ts`
@@ -481,11 +707,37 @@ import { BuiltInAgent } from "@copilotkit/runtime/v2";
 export const <id>Agent = () =>
   new BuiltInAgent({
     model: "openai/gpt-5.4", // the alias used across this repo
-    prompt: "You are the <Brand> agent. ...",
+    prompt: <ID>_PROMPT,
     // tools: [...]       // optional server-side agent tools (defineTool)
-    // temperature: 0,    // optional
+    temperature: 0, // banking pins 0 — a demo has to behave the same every run
   });
 ```
+
+### The prompt is where the beats are enforced
+
+Most beats fail in the **prompt**, not in the wiring: the tools exist, the agent
+just doesn't use them the way the demo needs. Banking's prompt is one long string
+of named clauses (`src/skins/banking/agent.ts`) — copy the clause set, not the
+banking specifics. The clauses that carry beats:
+
+| Clause                        | Beat            | What it must say                                                                                                                                                                                                                                |
+| ----------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CHART / COMPONENT ANSWER RULE | 1               | Render the visual **and** answer in one or two sentences. Never one without the other.                                                                                                                                                          |
+| NEVER WRITE A MARKDOWN TABLE  | 1, presentation | If a gen-UI component exists for that data, route to it instead of emitting a table.                                                                                                                                                            |
+| SCREEN AWARENESS              | 3b              | "The context you are given IS your view of what the user is looking at." Name the current page, summarize the key elements, cite the actual figures, and **never** say you cannot see/inspect/read the screen.                                  |
+| SECRETS                       | 3a              | Never ask for the sensitive value, never repeat it, and don't ask which record first — fire the tool immediately.                                                                                                                               |
+| UPLOADED DOCUMENTS            | 3d              | Read the attachment, and merge its values into the artifact tool's payload (banking passes them through `createReport`'s `additions` array).                                                                                                    |
+| RECALL FIRST                  | 4               | Before answering this class of question, call `recall_memory`, then pass what you recalled into the component **and name the preference you applied**. Speak like a person who remembers.                                                       |
+| SAVED PROCEDURE               | 5               | Recall, then EXECUTE step by step without asking for confirmation. Resolve the named entity to its id from context. State plainly that this is a DIFFERENT procedure from beat 6's — "do not confuse the two, do not offer to record anything." |
+| FINDING IS NOT DOING          | 5               | Locating the record is not handling it. Carry the procedure through.                                                                                                                                                                            |
+| ACTION DISCIPLINE             | 6               | When there is no saved procedure, decline and offer to record — never improvise or bluff a fix.                                                                                                                                                 |
+| TEACH & RECALL                | 6               | The record → save → replay chain, and "save this procedure AT MOST ONCE".                                                                                                                                                                       |
+| PROSE STYLE                   | presentation    | Short answers, **bold** the key figures, no walls of text.                                                                                                                                                                                      |
+
+Also keep the **tool descriptions** doing routing work: banking puts a shared
+`CHART_ANSWER_RULE` in each chart tool's description and states which question
+shape each tool owns, which is what keeps "show me the trend" off the canvas
+report path.
 
 **If your skin has a `CanvasSurface`, emit its a2ui operations from a SERVER tool
 here — never from a client `useFrontendTool`.** The a2ui middleware only converts
@@ -551,11 +803,13 @@ const <id>: Skin = {
   suggestions: <id>Suggestions,
   designSkill: <ID>_DESIGN_SKILL,
 
-  // ── Optional slots (omit any you don't need) ──
-  // NOTE: airline omits every optional slot below EXCEPT `toolLabels` + `useData`
-  // — it ships a 9-entry label map so its activity chips read as human phrases,
-  // not raw tool names. If your skin registers named frontend tools, you almost
-  // certainly want `toolLabels` too.
+  // ── Optional slots ──
+  // "Optional" per the CONTRACT; a demo-complete skin sets most of them. Airline
+  // omits every one below EXCEPT `toolLabels` + `useData` — and airline hits one
+  // beat of nine, so do not read its restraint as a model. `toolLabels` in
+  // particular is optional in name only: it is what makes activity chips read as
+  // human phrases ("Pulling up your flight") instead of raw tool names
+  // (`showFlight`). Any skin with named frontend tools wants it.
   useData: use<Id>Data, // () => unknown — OMIT if the skin has no shell-managed
                         //   data (banking omits it, reads REST + auth directly);
                         //   then useSkinData<T>() returns undefined.
@@ -565,10 +819,21 @@ const <id>: Skin = {
   // toolLabels: {        // Record<string, string> — activity-chip labels for your tools
   //   showThing: "Pulling up the thing",
   // },
+  // BEAT 3d — the attachment path. The framework's suggestion path DROPS
+  // attachments, so a pill that must carry a file has to be intercepted here:
+  // stage the file into the composer's hidden input[type=file], then drive the
+  // real composer textarea + send button. Match on the message CONSTANT shared
+  // with suggestions.ts so it can never drift. Ship the paperclip too, so the
+  // presenter can stage the file by hand if the pill path misbehaves on stage.
+  // (Worked implementation: banking's `skin.tsx:87-149` + `attach-invoice.ts`.)
   // chatHeaderActions: [ // ChatHeaderAction[] — buttons in the shared chat header
-  //   { icon: SomeIcon, label: "Do a thing", onClick: () => {} },
+  //   { icon: Paperclip, label: "Attach the <artifact>", onClick: stage<Id>Attachment },
   // ],
-  // onSuggestionSelect: (suggestion, index) => false, // return true if fully handled
+  // onSuggestionSelect: (suggestion) => {
+  //   if (suggestion.message !== <ID>_ATTACHMENT_MESSAGE) return false;
+  //   void send<Id>WithAttachment();
+  //   return true; // fully handled — the shell does nothing further
+  // },
 
   // ── End-user identity (ONLY if your skin scopes Intelligence per user) ──
   // Mount above CopilotKitProvider + contribute its `properties`; pair with a

--- a/examples/showcases/reskinnable-demo/CLAUDE.md
+++ b/examples/showcases/reskinnable-demo/CLAUDE.md
@@ -8,9 +8,23 @@ assistant column, plus a repo-local **reskin skill**
 (`.claude/skills/reskin/`) for authoring new ones.
 
 The point of the app is the `Skin` contract: a single interface that swaps a
-whole product without the shell knowing anything domain-specific. The two
-shipped skins deliberately sit on **different data substrates** (banking is
-REST-backed, airline is in-memory) to prove the contract is substrate-agnostic.
+whole product without the shell knowing anything domain-specific. The skins
+deliberately sit on **two different data substrates** — banking and logistics are
+REST-backed, airline and keel are in-memory — to prove the contract is
+substrate-agnostic.
+
+**Each skin is also a live sales demo.** It exists to prove CopilotKit and
+Intelligence top to bottom to an enterprise buyer, through a fixed set of demo
+**beats**: lead with generative UI, show that threads store AG-UI streams rather
+than text, manipulate the app four ways (drive it, read the screen, navigate via
+real levers, ingest a document into a durable artifact), recall long-term memory,
+replay a stored procedure, and learn a new one on stage. `banking` is the
+reference implementation and the only skin that currently hits every beat. The
+beats, and what each one must prove, are specified in
+[`.claude/skills/reskin/demo-beats.md`](.claude/skills/reskin/demo-beats.md) —
+read it before adding or changing a skin's tools, prompt or suggestion pills,
+because a skin that wires the contract perfectly and hits no beats is a failed
+skin.
 
 ## Shell vs skins
 
@@ -113,7 +127,14 @@ export type IdentifyRunUser = (
 - **Banking** contributes `bankingIdentifyUser`
   (`src/skins/banking/intelligence/user-id.ts`), which maps the client-forwarded
   `properties` ({ userRole, userId }) onto its per-member/role memory scope.
-  **Airline** omits it (no auth, no memory).
+  **Logistics** and **keel** contribute one too (`logisticsIdentifyUser`,
+  `keelIdentifyUser`) for thread scoping — though neither yet uses it for durable
+  memory. **Airline** is the only skin that omits it (no auth, no memory).
+- Banking additionally ships `intelligence/seed-memories.ts` and
+  `intelligence/forget-memories.ts`, which its `dev/reset` route uses to wipe
+  learned memories and re-seed the ones the demo must start out already knowing.
+  That file is what makes the long-term-memory and stored-procedure beats work;
+  it is not emergent behaviour.
 - `identifyUser` is reached through the **server-only** registry, so it MUST be
   server-safe: **no `"use client"`, no JSX, no `.tsx` imports.** Keep it in a
   plain `.ts` module.
@@ -140,14 +161,22 @@ export type IdentifyRunUser = (
   the provider, so `useRuntimeProperties` can read its context) →
   `CopilotKitProvider` (runtimeUrl `/api/copilotkit`, `useSingleEndpoint={false}`,
   `properties={skin.useRuntimeProperties?.()}`, the skin's `catalog`,
-  `sandboxFunctions`, `designSkill`) → `CopilotChatConfigurationProvider
+  `sandboxFunctions`, `designSkill`, and `showDevConsole={true}`) →
+  `CopilotChatConfigurationProvider
 agentId={skin.id}` → `SkinProvider` (runs `skin.useData?.()`) → chat-inbox +
   canvas providers → the skin's optional `Providers` (mounted **below** the
   provider) → `SkinSuggestions` + `Tools` + `LayoutPreferencesProvider` →
   `ShellFrame`, which receives the skin's `Layout` (wrapping `CanvasRegion`) as its
   `app` slot and the shared `ChatPanel` as its `chat` slot.
+- **The inspector is shell-mounted for every skin** via that
+  `showDevConsole={true}`, which surfaces `CopilotKitInspector`. It replaced the
+  old app-specific "glass engine"; a skin contributes nothing to it. Not part of
+  the standard demo flow, but the thing to open when a technical audience wants to
+  see the actual AG-UI event stream, or when debugging one.
 - `src/app/[skin]/[[...rest]]/page.tsx` — renders `skin.resolvePage(rest)`, or a
-  404 when it returns `null`.
+  404 when it returns `null`. `resolvePage` receives **all** remaining segments, so
+  a skin can resolve parameterized routes — `keel` is the worked example
+  (`knowledge/<docId>`, `runs/<runId>`).
 - `src/app/api/copilotkit/[[...slug]]/route.ts` — the Hono runtime handler. It
   builds one `BuiltInAgent` per registered skin from `agentRegistry` (calling
   each registration's `createAgent`), keyed by id, so `agentId={skin.id}`
@@ -179,8 +208,12 @@ Things worth knowing before changing any of it:
   of rail + conversation and produced a cascade of breakpoint and collapse bugs.
 - **`react-resizable-panels` is pinned to 4.x**, whose API is renamed from the 2.x/3.x
   used elsewhere in this repo: `Group`/`orientation`/`Separator`/`useDefaultLayout`.
-  A `Panel`'s `id` also becomes its emitted `data-testid`, overwriting any you pass.
-  See the header comment in `src/components/ui/resizable.tsx`.
+  Bare-number sizes are **pixels** in 4.x (3.x is percentage-only), which is why the
+  pin exists. A `Panel`'s `className` lands on a **nested** div, so panel geometry
+  must come from `minSize`/`defaultSize`/`collapsedSize` and never from classes; the
+  emitted style hooks are `data-group` / `data-panel` / `data-separator`. See the
+  header comment in `src/components/ui/resizable.tsx`, and treat the type
+  declarations in `node_modules` as the authority over any doc site.
 - **Shell controls live in the selector card** — skin switcher, swap sides, hide.
   The chat header holds only conversation actions. Collapsing hides the whole
   column, selector included, and a launcher restores it.
@@ -229,20 +262,36 @@ Gen-UI components registered via `useComponent` (airline's flight card, banking'
 charts and queues) render in the chat transcript, not on the canvas — that is a
 separate path from the full-region canvas surfaces above.
 
-## The two skins (why they differ)
+## The four skins (why they differ)
 
-- **`banking`** ("Northwind Finance") — **REST-backed**. Its pages, tools, and
-  report canvas read a live ledger over `/api/banking/v1/*` (cards, transactions,
-  users, policies, exceptions, reports, and a gated `dev/reset`). It uses the
-  optional `Providers`, `CanvasSurface`, `sandboxFunctions`, `chatHeaderActions`
-  (a paperclip that stages a bundled Q2 invoice PDF), `onSuggestionSelect` (the
-  Q2 pill drives the real composer so the invoice rides as an attachment), and —
-  to scope durable memory per member — `RuntimeProviders` (hoists its
-  `AuthContextProvider` above the provider) + `useRuntimeProperties` (returns
-  `{ userRole, userId }`) on the client plus a server-safe `identifyUser` in the
-  agent registry. It **omits** `useData` — its components read the REST ledger
-  via `useCreditCards` and the current member via `useAuthContext` directly, so
-  nothing flows through `useSkinData`.
+Two substrates behind one contract is the architectural demonstration. Demo
+completeness is a **separate axis**, and the two do not correlate — see the beat
+matrix at the end of this section.
+
+- **`banking`** ("Northwind Finance") — **REST-backed**, and the reference demo.
+  Its pages, tools, and report canvas read a live ledger over
+  `/api/banking/v1/*` (cards, transactions, users, policies, exceptions, reports,
+  and a gated `dev/reset`). It uses the optional `Providers`, `CanvasSurface`,
+  `sandboxFunctions`, `chatHeaderActions` (a paperclip that stages a bundled Q2
+  invoice PDF), `onSuggestionSelect` (the Q2 pill drives the real composer so the
+  invoice rides as an attachment), and — to scope durable memory per member —
+  `RuntimeProviders` (hoists its `AuthContextProvider` above the provider) +
+  `useRuntimeProperties` (returns `{ userRole, userId }`) on the client plus a
+  server-safe `identifyUser` in the agent registry. It **omits** `useData` — its
+  components read the REST ledger via `useCreditCards` and the current member via
+  `useAuthContext` directly, so nothing flows through `useSkinData`. It is also
+  the only skin with a route readable, per-page on-screen readables, seeded
+  memories, and the teach-mode loop (`docs/teach-mode/`).
+- **`logistics`** ("Meridian") — **REST-backed**. A freight control tower for
+  exception triage (expedite / reroute / split / absorb) across pages
+  `control-tower` (index), `lanes`, `inventory`, `decisions`. Like banking it
+  **omits `useData`**, reading its ledger via `useLogistics()` and the planner via
+  `usePlannerAuth()`. Sets `RuntimeProviders`, `useRuntimeProperties`,
+  `Providers`, `CanvasSurface` (fed by the server tool `renderBrief`),
+  `sandboxFunctions`, `toolLabels` and a server `identifyUser`; omits
+  `chatHeaderActions` and `onSuggestionSelect`. **The debugged reference for skin
+  layout chrome** — the `h-full overflow-hidden` root and the meta-utility strip
+  were fixed here first.
 - **`airline`** ("Aeronova") — **in-memory**. Its `useData` (`useAirlineData`) is
   a seed-backed React-state store with no backend; mutations (`selectSeat`,
   `issueBoardingPass`, `chooseRebooking`) update local state. It omits
@@ -250,24 +299,62 @@ separate path from the full-region canvas surfaces above.
   `onSuggestionSelect`, `RuntimeProviders`, `useRuntimeProperties`, and a server
   `identifyUser` — the minimal end of the contract (only `toolLabels` beyond the
   required fields).
+- **`keel`** (Harbor Point Health) — **in-memory**, a healthcare knowledge and
+  operations desk. Sets `useData: useKeelData` (a `useState` store over
+  `seedKeelRuns`), plus `CanvasSurface` (server tool `render_ops_report`),
+  `sandboxFunctions`, `toolLabels`, `RuntimeProviders`, `useRuntimeProperties`
+  and a server `identifyUser`; omits `Providers`, `chatHeaderActions`,
+  `onSuggestionSelect`. **The only skin with parameterized routes** —
+  `resolvePage` is Map-based and resolves `knowledge/<docId>` → `DocumentPage` and
+  `runs/<runId>` → `RunDetailPage` alongside its static segments.
 
-Two substrates behind one contract is the whole demonstration.
+### Demo-beat coverage (the other axis)
+
+| Beat                             | banking                   | airline | logistics     | keel          |
+| -------------------------------- | ------------------------- | ------- | ------------- | ------------- |
+| Gen-UI in transcript             | ✅ 8                      | ✅ 6    | ✅ 5          | ✅ 5          |
+| Rich thread survives reload      | ✅ replay-safe tools      | ❌      | ❌            | ❌            |
+| Drive the app, secret withheld   | ✅                        | ❌      | ❌            | ❌            |
+| "What's on my screen?"           | ✅ route + page readables | ❌      | ❌            | ❌            |
+| Navigate via levers + filters    | ✅                        | ❌      | ❌            | nav only      |
+| Multimodal → durable artifact    | ✅                        | ❌      | ❌            | ❌            |
+| Long-term memory recall          | ✅                        | ❌      | plumbing only | plumbing only |
+| Stored-procedure replay          | ✅                        | ❌      | ❌            | ❌            |
+| Teach a new procedure            | ✅                        | ❌      | ❌            | ❌            |
+| Presenter reset (route + button) | ✅                        | ❌      | ✅            | ❌            |
+
+`banking` hits every row; the others predate this bar and hit about one each
+(nine beats plus the presenter-reset requirement are listed above). Note that
+logistics and keel ship the **full per-user identity plumbing** —
+`RuntimeProviders`, `useRuntimeProperties`, server `identifyUser` — and then no
+memory prompts, no memory tools and no seed file, so they get no demo value from
+the hardest part of it. Treat all three as excellent **wiring** references and
+incomplete **demo** references.
 
 ## How to add a skin
 
 Use the repo-local skill in `.claude/skills/reskin/` — it walks the full
 authoring flow. In short:
 
-1. Scaffold `src/skins/<id>/` and implement each `Skin` contract field.
-2. Write `src/skins/<id>/theme.css` (a `.theme-<id>` block re-valuing shared
+1. **Map the demo beats first**, before any code — the table template is in
+   [`.claude/skills/reskin/demo-beats.md`](.claude/skills/reskin/demo-beats.md).
+   The demo decides the tools, the pages, the prompt and the pills; discovering
+   the beats afterwards means rebuilding them.
+2. Scaffold `src/skins/<id>/` and implement each `Skin` contract field.
+3. Write `src/skins/<id>/theme.css` (a `.theme-<id>` block re-valuing shared
    tokens) and side-effect-import it from the skin's `layout.tsx`.
-3. Add a server-safe `src/skins/<id>/agent.ts` (no `"use client"`, no JSX).
-4. Register in **both** `src/shell/registry.ts` (client skin) and
+4. Add a server-safe `src/skins/<id>/agent.ts` (no `"use client"`, no JSX). The
+   prompt is where most beats are actually enforced.
+5. Register in **both** `src/shell/registry.ts` (client skin) and
    `src/shell/agent-registry.ts` (as `{ createAgent, identifyUser? }`), keyed by
    the identical `id`.
-5. If the skin scopes Intelligence per end-user, add its client
+6. If the skin scopes Intelligence per end-user, add its client
    `RuntimeProviders` + `useRuntimeProperties` and a server-safe `identifyUser`.
-6. Optionally set `defaultSkinId` in `src/shell/skins-config.ts`.
+   If it has memory or stored-procedure beats, add
+   `intelligence/seed-memories.ts` and re-seed from its `dev/reset` route.
+7. Ship one suggestion pill per beat, in demo order — the presenter should never
+   have to type.
+8. Optionally set `defaultSkinId` in `src/shell/skins-config.ts`.
 
 ## Commands
 
@@ -289,6 +376,14 @@ Run tasks through Nx per the repo convention where applicable.
 ## Reference
 
 - `src/shell/skin-contract.ts` — the contract (source of truth).
-- `src/skins/banking/skin.tsx`, `src/skins/airline/skin.tsx` — two implementations.
+- `src/skins/{banking,logistics,airline,keel}/skin.tsx` — four implementations.
+  Open `banking` for demo completeness, `logistics` for layout chrome and the
+  server-emitted a2ui canvas, `airline` for the minimal contract surface, `keel`
+  for parameterized routes.
+- `.claude/skills/reskin/` — the authoring skill: `SKILL.md` (contract + wiring
+  traps), `demo-beats.md` (what the demo must prove, and the quality bar),
+  `templates.md` (per-file starting points).
 - `docs/DESIGN.md` — the banking skin's visual design system ("Aurora").
-- `docs/teach-mode/` — the banking skin's teachable over-limit-approval flow.
+- `docs/teach-mode/` — the banking skin's teachable over-limit-approval flow, plus
+  `verify-teachable-gate.sh` which proves the gate → unlock path over pure REST.
+- `docs/superpowers/` — plans and specs for this app's own development.


### PR DESCRIPTION
## What does this PR do?

Reworks the repo-local `reskin` skill so it teaches **what a skin's demo has to prove**, not just how to wire the `Skin` contract — based on David's walkthrough of the banking demo (the "beats" and the why behind each one), plus the layout facts from #6394.

Docs only. No code changes.

## Why

The skill documented the contract thoroughly and the demo not at all. I tested that gap before writing anything: gave a fresh agent the **old** skill and asked it to plan a new BI skin.

It returned a technically sound plan — correct contract usage, server-emitted a2ui, deps arrays, OGUI sandbox, dark mode — that missed most of the beats, and substituted its own thesis (RBAC governance) for the demo's.

| Beat | Old skill | Reworked skill |
| --- | --- | --- |
| 1. Lead with generative UI | ✅ | ✅ |
| 2. Rich thread survives reload | ❌ absent | ✅ explicit step; renders keyed off `result` |
| 3a. Drive the app, secret withheld | ⚠️ reframed as RBAC | ✅ confidential figure never enters the transcript |
| 3b. "What's on my screen?" | ❌ **zero readables planned** | ✅ route + per-page readables, asked on two pages |
| 3c. Navigate via real levers | ⚠️ plain `navigateTo` | ✅ HITL confirm → query params → highlighted controls |
| 3d. Multimodal → durable artifact | ⚠️ no durability | ✅ artifact outlives thread deletion (demonstrated) |
| 4. Long-term memory recall | ⚠️ one line | ✅ seeded preference + recall-first + names what it recalled |
| 5. Stored-procedure replay | ❌ absent | ✅ seeded procedure, 3 visible writes, distractors |
| 6. Teach a new procedure | ❌ absent | ✅ symptom-only gate, decoys, record → save → replay |
| Presenter Reset | ❌ | ✅ |
| Pills covering the flow | 6, partial | 8, one per beat |

Same prompt, same conditions, only the skill changed. The telling detail is 3b: `useAgentContext` was already in the skill's contract table, so the agent *knew* the field existed — it just had no reason to prioritise it. Contract docs say what is available; only choreography says what is required.

## What changed

**`.claude/skills/reskin/demo-beats.md`** (new) — nine beats, each framed by *what the audience must conclude*, then what the skin needs, then banking's implementation with file:line. Plus seeding rules, the presentation requirements (a pill per beat so the presenter never types, a visible affordance on every mutation, pretty markdown prose, Reset, the chat-placement framing), the vertical shortlist with BI called out as highest-stakes, the quality bar, and a "which skin to copy for what" routing table.

The beats are a **strong default that an explicit instruction overrides**, expressed as a beat map with one row per beat that records deliberate skips. Omission failures respond to a slot you have to fill in, not to exhortation.

**`SKILL.md`** — beat table and override rule up front; step 0 is the beat map, before code. Two new silent-failure rules found by tracing banking:
- Renders must key off the tool `result`, not `status`, or they go blank on thread replay — exactly when beat 2 is being demonstrated. Only banking does this today.
- Beat 3b needs a route readable plus per-page on-screen readables. All four skins register readables; only banking registers those, which is why the beat is impossible in the other three.

Verification now ends with a 10-point demo walkthrough, since a green build proves the wiring and nothing about the demo.

**`templates.md`** — pills-per-beat template; `seed-memories.ts` against the real `POST /api/memories` shape (long-term memory is a seeded file, not emergent — including why beat 6's procedure must never be seeded, and why a seeded procedure must run with no confirmation gate, which previously left an unresolved tool call that failed the next message); a prompt-clause table mapping clauses to beats; replay-safe render; route and per-page readables.

**`CLAUDE.md`** — claimed four skins in the intro and then documented two. Now covers all four across both substrates with a beat-coverage matrix, and corrects three false claims:
- `identifyUser` was attributed to banking alone; logistics and keel contribute one too.
- An unsupported claim that a `Panel`'s `id` becomes its emitted `data-testid` — the cited header comment says no such thing and the installed package has no such behaviour. Replaced with what it actually documents.
- "two implementations" in Reference.

Also notes keel's parameterized routes (the only skin with them) and the shell-mounted inspector that replaced the glass engine.

## Notes for reviewers

- Verified against source rather than assumed: the entire `Skin` contract field table in both docs was already accurate and is unchanged; so were the Commands section, all panel-size/breakpoint/radius numbers, the `.d.cts` filename the skill cites, and `defaultSkinId`. There were no glass-engine references left to remove.
- Two follow-ups surfaced but deliberately not included here: `banking/components/wow/proactive-notice.tsx` is an `animate-ping` bell toast that is mounted nowhere, and logistics/keel already ship the full per-user identity plumbing with no memory prompts, tools or seed file — the cheapest beat-4 upgrades available if we want existing skins pulled up to the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)