### PR TITLE
fix(banking): collapse HITL approval buttons on the tool result

### DIFF
--- a/examples/showcases/banking/src/components/approval-buttons.tsx
+++ b/examples/showcases/banking/src/components/approval-buttons.tsx
@@ -2,20 +2,37 @@
 
 import { useState } from "react";
 
+/**
+ * Approve/Deny for a human-in-the-loop card.
+ *
+ * `resolved` is the DURABLE signal that this tool call has already been
+ * answered, and callers should pass it from the tool call itself (a present
+ * `result`, or status "complete"). Local `responded` state alone is not enough:
+ * it dies with the component, and these cards do get remounted — the earliest
+ * card in a multi-step chain has its subtree replaced when the run syncs, which
+ * resurrected live Approve/Deny buttons on an action the user had already
+ * taken. Clicking them a second time would fire a duplicate write against an
+ * already-settled call.
+ *
+ * Local state is still kept, because it collapses the buttons on click without
+ * waiting for the round trip. The two are OR-ed: whichever knows first wins.
+ */
 export function ApprovalButtons({
   onApprove,
   onDeny,
   approveLabel = "Approve",
   denyLabel = "Deny",
+  resolved = false,
 }: {
   onApprove: () => Promise<void> | void;
   onDeny: () => void;
   approveLabel?: string;
   denyLabel?: string;
+  resolved?: boolean;
 }) {
   const [responded, setResponded] = useState(false);
 
-  if (responded) {
+  if (resolved || responded) {
     return <p className="text-sm italic text-ink-muted">Response submitted.</p>;
   }
 

--- a/examples/showcases/banking/src/components/copilot-context.tsx
+++ b/examples/showcases/banking/src/components/copilot-context.tsx
@@ -877,7 +877,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
       transactionId: z.string(),
       code: z.string(),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { transactionId, code } = args;
 
       if (status === "inProgress") {
@@ -903,6 +903,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!transactionId || !code) {
                 respond?.("Missing transaction or exception code");
@@ -940,7 +941,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
     parameters: z.object({
       exceptionId: z.string(),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { exceptionId } = args;
 
       if (status === "inProgress") {
@@ -962,6 +963,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!exceptionId) {
                 respond?.("Missing exception id");
@@ -998,7 +1000,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
     parameters: z.object({
       transactionId: z.string(),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { transactionId } = args;
 
       if (status === "inProgress") {
@@ -1021,6 +1023,7 @@ const CopilotContext = ({ children }: { children: React.ReactNode }) => {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!transactionId) {
                 respond?.("Missing transaction id");


### PR DESCRIPTION
Approve/Deny buttons could reappear on a card the user had **already answered**.

The clearest case is the teach arc: after "Open policy exception" is approved and the chain moves on, that first card comes back showing live buttons, while the two later cards correctly read "Response submitted."

## Root cause

`"Response submitted."` was purely local `useState`. Nothing tied it to the tool call, so any remount lost it — and the earliest card in a multi-step chain has its subtree replaced when the run syncs. That's why card 1 regresses and cards 2 and 3 don't.

The visual glitch is the mild part. The buttons are live: clicking them again fires a duplicate write against an already-settled call.

## Fix

`ApprovalButtons` takes a `resolved` prop carrying the durable signal from the tool call itself, OR-ed with local state:

- local state collapses the buttons instantly on click, without waiting for the round trip
- `resolved` survives remounts and thread reloads

Same result-over-status rule already applied to the PIN and charges cards in #6259.

## Scope

Wires the 3 call sites that had no guard. The 3 that already collapse on `result` are unchanged — there TypeScript correctly rejects `status === "complete"` as unreachable, which is a useful signal that the guard is already in place.

The identical bug existed in `CopilotKit/fde` `reskinnable-demo`, where 10 of 13 call sites were unguarded. Fixed there separately (`58d400b` on that repo's main).

## Verification

`tsc --noEmit` and `oxlint` clean.

Not yet exercised in a browser: reproducing it means running the teach arc through to the AWS climax. The change is mechanical and type-checked, but flagging that the runtime behaviour is reasoned rather than observed, since on this demo green checks have not always meant the surface is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)