### PR TITLE
fix(next): guard root bodies against extension hydration races

### DIFF
--- a/examples/canvas/gemini/app/layout.tsx
+++ b/examples/canvas/gemini/app/layout.tsx
@@ -24,7 +24,9 @@ export default function RootLayout({
     <html lang="en">
       <LayoutProvider>
         <Wrapper>
-          <body className={inter.className}>{children}</body>
+          <body suppressHydrationWarning className={inter.className}>
+            {children}
+          </body>
         </Wrapper>
       </LayoutProvider>
     </html>

--- a/examples/canvas/langgraph-python/src/app/layout.tsx
+++ b/examples/canvas/langgraph-python/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
-      <body className="subpixel-antialiased">
+      <body suppressHydrationWarning className="subpixel-antialiased">
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"

--- a/examples/canvas/llamaindex-composio/src/app/layout.tsx
+++ b/examples/canvas/llamaindex-composio/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
-      <body className="subpixel-antialiased">
+      <body suppressHydrationWarning className="subpixel-antialiased">
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"

--- a/examples/canvas/llamaindex/src/app/layout.tsx
+++ b/examples/canvas/llamaindex/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
-      <body className="subpixel-antialiased">
+      <body suppressHydrationWarning className="subpixel-antialiased">
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"

--- a/examples/canvas/mastra-pm/src/app/layout.tsx
+++ b/examples/canvas/mastra-pm/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <CopilotKit

--- a/examples/canvas/mastra/src/app/layout.tsx
+++ b/examples/canvas/mastra/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
-      <body className="subpixel-antialiased">
+      <body suppressHydrationWarning className="subpixel-antialiased">
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"

--- a/examples/canvas/pydantic-ai/src/app/layout.tsx
+++ b/examples/canvas/pydantic-ai/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
-      <body className="subpixel-antialiased">
+      <body suppressHydrationWarning className="subpixel-antialiased">
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="sample_agent"

--- a/examples/integrations/a2a-a2ui/app/layout.tsx
+++ b/examples/integrations/a2a-a2ui/app/layout.tsx
@@ -35,7 +35,10 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Google+Symbols:opsz,wght,FILL,GRAD,ROND@20..48,100..700,0..1,-50..200,0..100&display=swap&icon_names=arrow_drop_down,check_circle,close,communication,content_copy,delete,draw,error,info,mobile_layout,pen_size_1,progress_activity,rectangle,send,upload,warning"
         />
       </head>
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body
+        suppressHydrationWarning
+        className={`${geistSans.variable} ${geistMono.variable}`}
+      >
         {children}
       </body>
     </html>

--- a/examples/integrations/a2a-middleware/app/layout.tsx
+++ b/examples/integrations/a2a-middleware/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${plusJakartaSans.variable} ${splineSansMono.variable} antialiased`}
       >
         {children}

--- a/examples/integrations/mcp-apps/app/layout.tsx
+++ b/examples/integrations/mcp-apps/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           showDevConsole={false}

--- a/examples/shadcn/app/layout.tsx
+++ b/examples/shadcn/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={cn("font-sans", inter.variable)}>
-      <body>
+      <body suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/examples/showcases/a2a-travel/app/layout.tsx
+++ b/examples/showcases/a2a-travel/app/layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
+        suppressHydrationWarning
         className={`${plusJakartaSans.variable} ${splineSansMono.variable} antialiased`}
       >
         <ThemeProvider

--- a/examples/showcases/a2ui-pdf-analyst/src/app/layout.tsx
+++ b/examples/showcases/a2ui-pdf-analyst/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       lang="en"
       className={`${plusJakarta.variable} ${splineMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      <body suppressHydrationWarning className="min-h-full flex flex-col">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/examples/showcases/adk-dashboard/src/app/layout.tsx
+++ b/examples/showcases/adk-dashboard/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${manrope.variable} ${GeistMono.variable}`}>
-      <body className={"subpixel-antialiased"}>
+      <body suppressHydrationWarning className={"subpixel-antialiased"}>
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="my_agent"

--- a/examples/showcases/arcade-tools/app/layout.tsx
+++ b/examples/showcases/arcade-tools/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full">
+      <body suppressHydrationWarning className="min-h-full">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/examples/showcases/banking/src/app/layout.tsx
+++ b/examples/showcases/banking/src/app/layout.tsx
@@ -41,6 +41,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="light" suppressHydrationWarning>
       <body
+        suppressHydrationWarning
         className={`${inter.variable} ${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <AuthContextProvider>

--- a/examples/showcases/chatkit-studio/apps/playground/src/app/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/playground/src/app/layout.tsx
@@ -16,7 +16,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>{children}</body>
+      <body suppressHydrationWarning className={"antialiased"}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/showcases/chatkit-studio/apps/playground/src/app/preview/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/playground/src/app/preview/layout.tsx
@@ -2,7 +2,7 @@
 
 import { CopilotKit } from "@copilotkit/react-core";
 import "@copilotkit/react-ui/styles.css";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 /**
  * Preview Layout
@@ -13,7 +13,7 @@ import { ReactNode } from "react";
 export default function PreviewLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <CopilotKit runtimeUrl="/api/copilotkit-preview" agent="sample_agent">
           {children}
         </CopilotKit>

--- a/examples/showcases/chatkit-studio/apps/studio/app/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/studio/app/layout.tsx
@@ -13,7 +13,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">{children}</body>
+      <body suppressHydrationWarning className="antialiased">
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/showcases/chatkit-studio/apps/world/src/app/layout.tsx
+++ b/examples/showcases/chatkit-studio/apps/world/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
 
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <ApiKeyInput />
         <CopilotKit
           runtimeUrl="/api/copilotkit"

--- a/examples/showcases/daytona-runcode/app/layout.tsx
+++ b/examples/showcases/daytona-runcode/app/layout.tsx
@@ -9,7 +9,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body style={{ margin: 0 }}>{children}</body>
+      <body suppressHydrationWarning style={{ margin: 0 }}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/showcases/deep-agents-finance-erp/src/app/layout.tsx
+++ b/examples/showcases/deep-agents-finance-erp/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
         playfairDisplayHeading.variable,
       )}
     >
-      <body className="antialiased">
+      <body suppressHydrationWarning className="antialiased">
         <CopilotKitProvider runtimeUrl="/api/copilotkit">
           <CopilotChatConfigurationProvider agentId="finance_erp_agent">
             <DashboardProvider>{children}</DashboardProvider>

--- a/examples/showcases/deep-agents-job-search/src/app/layout.tsx
+++ b/examples/showcases/deep-agents-job-search/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="job_application_assistant"

--- a/examples/showcases/deep-agents/src/app/layout.tsx
+++ b/examples/showcases/deep-agents/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
+      <body suppressHydrationWarning className="antialiased">
         <CopilotKit runtimeUrl="/api/copilotkit" agent="research_assistant">
           {children}
         </CopilotKit>

--- a/examples/showcases/enterprise-brex/src/app/layout.tsx
+++ b/examples/showcases/enterprise-brex/src/app/layout.tsx
@@ -29,6 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <AuthContextProvider>

--- a/examples/showcases/generative-ui-playground/src/app/layout.tsx
+++ b/examples/showcases/generative-ui-playground/src/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap"
         />
       </head>
-      <body className="antialiased">{children}</body>
+      <body suppressHydrationWarning className="antialiased">
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/showcases/langgraph-js-support-agents/apps/web/src/app/layout.tsx
+++ b/examples/showcases/langgraph-js-support-agents/apps/web/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit runtimeUrl="/api/copilotkit" agent="starterAgent">
           {children}
         </CopilotKit>

--- a/examples/showcases/mcp-apps/src/app/layout.tsx
+++ b/examples/showcases/mcp-apps/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}

--- a/examples/showcases/mcp-demo/src/app/layout.tsx
+++ b/examples/showcases/mcp-demo/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <Providers>{children}</Providers>

--- a/examples/showcases/microsoft-kanban/src/app/layout.tsx
+++ b/examples/showcases/microsoft-kanban/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>

--- a/examples/showcases/multi-agent-canvas/frontend/src/app/layout.tsx
+++ b/examples/showcases/multi-agent-canvas/frontend/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <Providers>{children}</Providers>

--- a/examples/showcases/open-mcp-client/apps/web/app/layout.tsx
+++ b/examples/showcases/open-mcp-client/apps/web/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <DynamicCopilotKitProvider>{children}</DynamicCopilotKitProvider>
       </body>
     </html>

--- a/examples/showcases/oracle-agent-memory/frontend/src/app/layout.tsx
+++ b/examples/showcases/oracle-agent-memory/frontend/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/examples/showcases/orca/frontend/app/layout.tsx
+++ b/examples/showcases/orca/frontend/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body suppressHydrationWarning className={inter.className}>
         <CopilotKit runtimeUrl="/api/copilotkit">
           <ThemeProvider
             attribute="class"

--- a/examples/showcases/presentation/src/app/layout.tsx
+++ b/examples/showcases/presentation/src/app/layout.tsx
@@ -22,7 +22,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body suppressHydrationWarning className={inter.className}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/showcases/pydantic-ai-todos/src/app/layout.tsx
+++ b/examples/showcases/pydantic-ai-todos/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
           {children}
         </CopilotKit>

--- a/examples/showcases/research-canvas/final/frontend/src/app/layout.tsx
+++ b/examples/showcases/research-canvas/final/frontend/src/app/layout.tsx
@@ -31,7 +31,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${lato.variable} ${noto.className} antialiased h-full`}>
+      <body
+        suppressHydrationWarning
+        className={`${lato.variable} ${noto.className} antialiased h-full`}
+      >
         <CopilotKit
           publicApiKey={process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY} // if using copilot cloud
           runtimeUrl={

--- a/examples/showcases/research-canvas/frontend/src/app/layout.tsx
+++ b/examples/showcases/research-canvas/frontend/src/app/layout.tsx
@@ -31,7 +31,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${lato.variable} ${noto.className} antialiased h-full`}>
+      <body
+        suppressHydrationWarning
+        className={`${lato.variable} ${noto.className} antialiased h-full`}
+      >
         <CopilotKit
           publicApiKey={process.env.NEXT_PUBLIC_COPILOT_CLOUD_API_KEY} // if using copilot cloud
           runtimeUrl={

--- a/examples/showcases/research-canvas/start/frontend/src/app/layout.tsx
+++ b/examples/showcases/research-canvas/start/frontend/src/app/layout.tsx
@@ -29,7 +29,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${lato.variable} ${noto.className} antialiased h-full`}>
+      <body
+        suppressHydrationWarning
+        className={`${lato.variable} ${noto.className} antialiased h-full`}
+      >
         <TooltipProvider>
           <ResearchProvider>{children}</ResearchProvider>
         </TooltipProvider>

--- a/examples/showcases/reskinnable-demo/src/app/layout.tsx
+++ b/examples/showcases/reskinnable-demo/src/app/layout.tsx
@@ -39,6 +39,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="light" suppressHydrationWarning>
       <body
+        suppressHydrationWarning
         className={`${inter.variable} ${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {/* Read the presenter-reset deployment gate server-side (non-NEXT_PUBLIC_

--- a/examples/showcases/scene-creator/src/app/layout.tsx
+++ b/examples/showcases/scene-creator/src/app/layout.tsx
@@ -23,6 +23,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${spaceMono.className} antialiased bg-[var(--bg-primary)] text-[var(--fg-primary)]`}
       >
         <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">

--- a/examples/showcases/spreadsheet/src/app/layout.tsx
+++ b/examples/showcases/spreadsheet/src/app/layout.tsx
@@ -18,7 +18,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <ThemeProvider>
-        <body style={{ backgroundColor: "white" }} className={inter.className}>
+        <body
+          suppressHydrationWarning
+          style={{ backgroundColor: "white" }}
+          className={inter.className}
+        >
           {children}
         </body>
       </ThemeProvider>

--- a/examples/showcases/strands-crm/frontend/app/layout.tsx
+++ b/examples/showcases/strands-crm/frontend/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full">
-      <body className="min-h-full">
+      <body suppressHydrationWarning className="min-h-full">
         <CopilotKit
           runtimeUrl="/api/copilotkit"
           agent="strands_agent"

--- a/examples/showcases/strands-file-analyzer/src/app/layout.tsx
+++ b/examples/showcases/strands-file-analyzer/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit runtimeUrl="/api/copilotkit" agent="file_investigator">
           {children}
         </CopilotKit>

--- a/examples/showcases/todo/src/app/layout.tsx
+++ b/examples/showcases/todo/src/app/layout.tsx
@@ -16,7 +16,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body suppressHydrationWarning className={inter.className}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/v1/_legacy/copilot-anthropic-pinecone/src/app/layout.tsx
+++ b/examples/v1/_legacy/copilot-anthropic-pinecone/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <CopilotKit runtimeUrl="/api/copilotkit">
           <MantineProvider>{children}</MantineProvider>
         </CopilotKit>

--- a/examples/v1/_legacy/copilot-fully-custom/app/layout.tsx
+++ b/examples/v1/_legacy/copilot-fully-custom/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <CopilotKit
           publicApiKey={process.env.COPILOT_CLOUD_PUBLIC_API_KEY}
           runtimeUrl={

--- a/examples/v1/_legacy/copilot-openai-mongodb-atlas-vector-search/src/app/layout.tsx
+++ b/examples/v1/_legacy/copilot-openai-mongodb-atlas-vector-search/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <CopilotKit runtimeUrl="/api/copilotkit">
           <MantineProvider>{children}</MantineProvider>
         </CopilotKit>

--- a/examples/v1/_legacy/saas-dynamic-dashboards/frontend/app/layout.tsx
+++ b/examples/v1/_legacy/saas-dynamic-dashboards/frontend/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body suppressHydrationWarning className={inter.className}>
         <CopilotKit runtimeUrl="/api/copilotkit">
           <ThemeProvider
             attribute="class"

--- a/examples/v1/chat-with-your-data/README.md
+++ b/examples/v1/chat-with-your-data/README.md
@@ -103,6 +103,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <CopilotKit runtimeUrl="/api/copilotkit">{children}</CopilotKit>

--- a/examples/v1/chat-with-your-data/app/layout.tsx
+++ b/examples/v1/chat-with-your-data/app/layout.tsx
@@ -28,6 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>

--- a/examples/v1/form-filling/README.md
+++ b/examples/v1/form-filling/README.md
@@ -95,6 +95,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <CopilotKit

--- a/examples/v1/form-filling/app/layout.tsx
+++ b/examples/v1/form-filling/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>

--- a/examples/v1/next-openai/src/app/layout.tsx
+++ b/examples/v1/next-openai/src/app/layout.tsx
@@ -11,7 +11,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="bg-zinc-900">
-      <body>
+      <body suppressHydrationWarning>
         <Suspense fallback={<div>Loading...</div>}>
           {children}
           <ServiceAdapterSelector />

--- a/examples/v1/next-pages-router/pages/_document.tsx
+++ b/examples/v1/next-pages-router/pages/_document.tsx
@@ -4,7 +4,7 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head />
-      <body>
+      <body suppressHydrationWarning>
         <Main />
         <NextScript />
       </body>

--- a/examples/v1/research-canvas/src/app/layout.tsx
+++ b/examples/v1/research-canvas/src/app/layout.tsx
@@ -27,6 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}

--- a/examples/v1/state-machine/src/app/layout.tsx
+++ b/examples/v1/state-machine/src/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <CopilotKit runtimeUrl="/api/copilotkit" showDevConsole={false}>
           <GlobalStateProvider>
             <div className="h-screen w-screen grid grid-cols-[40fr,60fr] p-10 gap-5">

--- a/examples/v1/travel/app/layout.tsx
+++ b/examples/v1/travel/app/layout.tsx
@@ -30,7 +30,9 @@ export default function RootLayout({
           crossOrigin=""
         />
       </head>
-      <body className={inter.className}>{children}</body>
+      <body suppressHydrationWarning className={inter.className}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/examples/v2/interrupts-langgraph/apps/web/src/app/layout.tsx
+++ b/examples/v2/interrupts-langgraph/apps/web/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={"antialiased"}>
+      <body suppressHydrationWarning className={"antialiased"}>
         <CopilotKit runtimeUrl="/api/copilotkit" agent="default">
           {children}
         </CopilotKit>

--- a/examples/v2/next-pages-router/app/layout.tsx
+++ b/examples/v2/next-pages-router/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/examples/v2/react/demo/src/app/layout.tsx
+++ b/examples/v2/react/demo/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
+        suppressHydrationWarning
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}

--- a/packages/react-core/skills/react-core/references/provider-setup.md
+++ b/packages/react-core/skills/react-core/references/provider-setup.md
@@ -58,7 +58,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>
@@ -310,7 +310,7 @@ Wrong:
 
 ```tsx
 <html>
-  <body>
+  <body suppressHydrationWarning>
     <Header>{/* Header uses useFrontendTool internally */}</Header>
     <CopilotKit>{children}</CopilotKit>
   </body>
@@ -321,7 +321,7 @@ Correct:
 
 ```tsx
 <html>
-  <body>
+  <body suppressHydrationWarning>
     <CopilotKit>
       <Header />
       {children}

--- a/showcase/integrations/ag2/src/app/layout.tsx
+++ b/showcase/integrations/ag2/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/agno/src/app/layout.tsx
+++ b/showcase/integrations/agno/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/built-in-agent/src/app/layout.tsx
+++ b/showcase/integrations/built-in-agent/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/claude-sdk-python/src/app/layout.tsx
+++ b/showcase/integrations/claude-sdk-python/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/claude-sdk-typescript/src/app/layout.tsx
+++ b/showcase/integrations/claude-sdk-typescript/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/crewai-crews/src/app/layout.tsx
+++ b/showcase/integrations/crewai-crews/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/google-adk/src/app/layout.tsx
+++ b/showcase/integrations/google-adk/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/langgraph-fastapi/src/app/layout.tsx
+++ b/showcase/integrations/langgraph-fastapi/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   const isProd = process.env.NODE_ENV === "production";
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {isProd && (
           <script
             dangerouslySetInnerHTML={{

--- a/showcase/integrations/langgraph-python/src/app/layout.tsx
+++ b/showcase/integrations/langgraph-python/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   const isProd = process.env.NODE_ENV === "production";
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {isProd && (
           <script
             dangerouslySetInnerHTML={{

--- a/showcase/integrations/langgraph-typescript/src/app/layout.tsx
+++ b/showcase/integrations/langgraph-typescript/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   const isProd = process.env.NODE_ENV === "production";
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {isProd && (
           <script
             dangerouslySetInnerHTML={{

--- a/showcase/integrations/langroid/src/app/layout.tsx
+++ b/showcase/integrations/langroid/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/llamaindex/src/app/layout.tsx
+++ b/showcase/integrations/llamaindex/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/mastra/src/app/layout.tsx
+++ b/showcase/integrations/mastra/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/showcase/integrations/ms-agent-dotnet/src/app/layout.tsx
+++ b/showcase/integrations/ms-agent-dotnet/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   const isProd = process.env.NODE_ENV === "production";
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {isProd && (
           <script
             dangerouslySetInnerHTML={{

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/layout.tsx
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/ms-agent-python/src/app/layout.tsx
+++ b/showcase/integrations/ms-agent-python/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/pydantic-ai/src/app/layout.tsx
+++ b/showcase/integrations/pydantic-ai/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/spring-ai/src/app/layout.tsx
+++ b/showcase/integrations/spring-ai/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/strands-typescript/src/app/layout.tsx
+++ b/showcase/integrations/strands-typescript/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/integrations/strands/src/app/layout.tsx
+++ b/showcase/integrations/strands/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: [

--- a/showcase/scripts/__tests__/next-body-hydration-guard.test.ts
+++ b/showcase/scripts/__tests__/next-body-hydration-guard.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { basename, join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+// Extensions such as Grammarly can add body attributes before React hydrates.
+const BODY_TAG = /^[ \t]*<body\b[^>]*>/gm;
+const IGNORED_DIRECTORIES = new Set([".git", ".next", "dist", "node_modules"]);
+const NEXT_ROOT_FILES = new Set([
+  "_document.js",
+  "_document.jsx",
+  "_document.tsx",
+  "layout.js",
+  "layout.jsx",
+  "layout.tsx",
+]);
+
+function walkFiles(root: string, include: (path: string) => boolean): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRECTORIES.has(entry.name)) {
+        files.push(...walkFiles(path, include));
+      }
+    } else if (entry.isFile() && include(path)) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+function unguardedBodyTags(path: string): string[] {
+  const source = readFileSync(path, "utf8");
+  return [...source.matchAll(BODY_TAG)]
+    .map(([tag]) => tag)
+    .filter((tag) => !tag.includes("suppressHydrationWarning"));
+}
+
+function relativeOffenders(paths: string[]): string[] {
+  return paths
+    .filter((path) => unguardedBodyTags(path).length > 0)
+    .map((path) => relative(REPO_ROOT, path))
+    .sort();
+}
+
+describe("Next.js browser-extension hydration guard", () => {
+  it("guards every first-party Next root body", () => {
+    const rootDocuments = walkFiles(REPO_ROOT, (path) =>
+      NEXT_ROOT_FILES.has(basename(path)),
+    );
+
+    expect(relativeOffenders(rootDocuments)).toEqual([]);
+  });
+
+  it("guards every body shown in Next.js setup documentation", () => {
+    const contentRoot = join(
+      REPO_ROOT,
+      "showcase",
+      "shell-docs",
+      "src",
+      "content",
+    );
+    const documentation = walkFiles(REPO_ROOT, (path) =>
+      /\.(?:md|mdx)$/.test(path),
+    ).filter(
+      (path) =>
+        path.startsWith(contentRoot) ||
+        readFileSync(path, "utf8").includes("RootLayout"),
+    );
+
+    expect(relativeOffenders(documentation)).toEqual([]);
+  });
+});

--- a/showcase/shared/starter-template/app/layout.tsx
+++ b/showcase/shared/starter-template/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <script
           dangerouslySetInnerHTML={{
             __html: `

--- a/showcase/shell-dashboard/src/app/layout.tsx
+++ b/showcase/shell-dashboard/src/app/layout.tsx
@@ -74,7 +74,7 @@ export default function RootLayout({
         />
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>
-      <body>
+      <body suppressHydrationWarning>
         {children}
         <div id="link-preview-root" />
       </body>

--- a/showcase/shell-docs/src/app/layout.tsx
+++ b/showcase/shell-docs/src/app/layout.tsx
@@ -165,7 +165,7 @@ export default function RootLayout({
           />
         ) : null}
       </head>
-      <body>
+      <body suppressHydrationWarning>
         <AnalyticsClient />
         {/* No <Suspense> wrapper around the page tree. Previously this
          * was wrapped in a Suspense with a null fallback, which caused

--- a/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
@@ -354,7 +354,7 @@ hideTOC: true
           export default function RootLayout({ children }: {children: React.ReactNode}) {
             return (
               <html lang="en">
-                <body>
+                <body suppressHydrationWarning>
                   {/* [!code highlight:3] */}
                   <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                     {children}
@@ -506,4 +506,3 @@ Follow per-adapter tutorials: [LangGraph integration](/agent-spec/langgraph) and
 - Agent Spec docs: https://oracle.github.io/agent-spec/development/docs_home.html
 - Agent Spec x AG-UI tutorial: https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html
 - Agent Spec Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
-

--- a/showcase/shell-docs/src/content/docs/deepagents/index.mdx
+++ b/showcase/shell-docs/src/content/docs/deepagents/index.mdx
@@ -269,7 +269,7 @@ Before you begin, you'll need the following:
         export default function RootLayout({ children }: {children: React.ReactNode}) {
             return (
                 <html lang="en">
-                    <body>
+                    <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
                             {children}

--- a/showcase/shell-docs/src/content/docs/deploy/agentcore.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/agentcore.mdx
@@ -297,7 +297,7 @@ Browser → CopilotKit Runtime → AgentCore Runtime → your agent
         export default function RootLayout({ children }: { children: React.ReactNode }) {
           return (
             <html lang="en">
-              <body>
+              <body suppressHydrationWarning>
                 <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                   {children}
                 </CopilotKit>

--- a/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/open-generative-ui.mdx
@@ -117,7 +117,7 @@ Three.js, and any other CDN-hosted library work out of the box.
 <head>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
-<body>
+<body suppressHydrationWarning>
   <canvas id="myChart"></canvas>
 </body>
 ```

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -271,7 +271,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -354,7 +354,7 @@ hideTOC: true
           export default function RootLayout({ children }: {children: React.ReactNode}) {
             return (
               <html lang="en">
-                <body>
+                <body suppressHydrationWarning>
                   {/* [!code highlight:3] */}
                   <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                     {children}
@@ -506,4 +506,3 @@ Follow per-adapter tutorials: [LangGraph integration](/agent-spec/langgraph) and
 - Agent Spec docs: https://oracle.github.io/agent-spec/development/docs_home.html
 - Agent Spec x AG-UI tutorial: https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html
 - Agent Spec Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
-

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -237,7 +237,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -326,7 +326,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="strands_agent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -119,7 +119,7 @@ Before you begin, you'll need the following:
         export default function RootLayout({ children }: {children: React.ReactNode}) {
           return (
             <html lang="en">
-              <body>
+              <body suppressHydrationWarning>
                 {/* [!code highlight:3] */}
                 <CopilotKit runtimeUrl="/api/copilotkit">
                   {children}

--- a/showcase/shell-docs/src/content/docs/integrations/claude-sdk-python/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/claude-sdk-python/quickstart.mdx
@@ -281,7 +281,7 @@ Before you begin, you'll need the following:
           export default function RootLayout({ children }: { children: React.ReactNode }) {
             return (
               <html lang="en">
-                <body>
+                <body suppressHydrationWarning>
                   <CopilotKit runtimeUrl="/api/copilotkit" agent="claude_agent">
                     {children}
                   </CopilotKit>

--- a/showcase/shell-docs/src/content/docs/integrations/claude-sdk-typescript/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/claude-sdk-typescript/quickstart.mdx
@@ -274,7 +274,7 @@ Before you begin, you'll need the following:
           export default function RootLayout({ children }: { children: React.ReactNode }) {
             return (
               <html lang="en">
-                <body>
+                <body suppressHydrationWarning>
                   <CopilotKit runtimeUrl="/api/copilotkit" agent="claude_agent">
                     {children}
                   </CopilotKit>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
@@ -348,7 +348,7 @@ Before you begin, you'll need the following:
         export default function RootLayout({ children }: { children: React.ReactNode }) {
             return (
                 <html lang="en">
-                    <body>
+                    <body suppressHydrationWarning>
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
                             {children}
                         </CopilotKit>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/deep-agents.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/deep-agents.mdx
@@ -272,7 +272,7 @@ Before you begin, you'll need the following:
         export default function RootLayout({ children }: {children: React.ReactNode}) {
             return (
                 <html lang="en">
-                    <body>
+                    <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
                             {children}

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -386,7 +386,7 @@ Before you begin, you'll need the following:
               export default function RootLayout({ children }: {children: React.ReactNode}) {
                 return (
                   <html lang="en">
-                    <body>
+                    <body suppressHydrationWarning>
                       {/* [!code highlight:3] */}
                       <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent">
                         {children}

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/tutorials/agent-native-app/step-3-setup-copilotkit.mdx
@@ -70,7 +70,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${lato.variable} ${noto.className} antialiased h-full`}>
+      <body suppressHydrationWarning className={`${lato.variable} ${noto.className} antialiased h-full`}>
         // [!code ++:4]
         <CopilotKit publicApiKey={process.env.NEXT_PUBLIC_CPK_PUBLIC_API_KEY}>
           <TooltipProvider>

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -279,7 +279,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -247,7 +247,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="myAgent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -371,7 +371,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -241,7 +241,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: {children: React.ReactNode}) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                           {children}

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart/pydantic-ai.mdx
@@ -173,7 +173,7 @@ Before you begin, you'll need the following:
                 export default function RootLayout({ children }: { children: ReactNode }) {
                   return (
                     <html lang="en">
-                      <body>
+                      <body suppressHydrationWarning>
                         {/* This points to the runtime we setup in the previous step */}
                         {/* [!code highlight:3] */}
                         <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">

--- a/showcase/shell-docs/src/content/snippets/cloud/cloud-copilotkit-provider.mdx
+++ b/showcase/shell-docs/src/content/snippets/cloud/cloud-copilotkit-provider.mdx
@@ -6,7 +6,7 @@ import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {/* Use the public api key you got from Copilot Cloud  */}
         {/* [!code highlight:3] */}
         <CopilotKit publicApiKey="<your-copilot-cloud-public-api-key>">

--- a/showcase/shell-docs/src/content/snippets/coagents/cloud-configure-copilotkit-provider.mdx
+++ b/showcase/shell-docs/src/content/snippets/coagents/cloud-configure-copilotkit-provider.mdx
@@ -6,7 +6,7 @@ import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {/* Use the public api key you got from Copilot Cloud  */}
         {/* [!code highlight:6] */}
         <CopilotKit

--- a/showcase/shell-docs/src/content/snippets/coagents/self-host-configure-copilotkit-provider.mdx
+++ b/showcase/shell-docs/src/content/snippets/coagents/self-host-configure-copilotkit-provider.mdx
@@ -6,7 +6,7 @@ import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {/* Use the public api key you got from Copilot Cloud  */}
         {/* [!code highlight:6] */}
         <CopilotKit

--- a/showcase/shell-docs/src/content/snippets/copilot-cloud-configure-copilotkit-provider.mdx
+++ b/showcase/shell-docs/src/content/snippets/copilot-cloud-configure-copilotkit-provider.mdx
@@ -21,7 +21,7 @@ import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {/* Use the public api key you got from Copilot Cloud  */}
         {/* [!code highlight:3] */}
         <CopilotKit publicApiKey="<your-copilot-cloud-public-api-key>">

--- a/showcase/shell-docs/src/content/snippets/integrations/agentcore/index.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/agentcore/index.mdx
@@ -286,7 +286,7 @@ Browser → CopilotKit Runtime → AgentCore Runtime → your agent
         export default function RootLayout({ children }: { children: React.ReactNode }) {
           return (
             <html lang="en">
-              <body>
+              <body suppressHydrationWarning>
                 <CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent">
                   {children}
                 </CopilotKit>

--- a/showcase/shell-docs/src/content/snippets/self-hosting-copilot-runtime-configure-copilotkit-provider.mdx
+++ b/showcase/shell-docs/src/content/snippets/self-hosting-copilot-runtime-configure-copilotkit-provider.mdx
@@ -6,7 +6,7 @@ import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         {/* Make sure to use the URL you configured in the previous step  */}
         {/* [!code highlight:3] */}
         <CopilotKit runtimeUrl="/api/copilotkit">{children}</CopilotKit>

--- a/showcase/shell-docs/src/content/snippets/shared/generative-ui/mcp-apps.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/generative-ui/mcp-apps.mdx
@@ -169,7 +169,7 @@ If you're looking to add an MCP App into an existing application, let's walk thr
     export default function RootLayout({ children }: {children: React.ReactNode}) {
         return (
             <html lang="en">
-                <body>
+                <body suppressHydrationWarning>
                     {/* [!code highlight:3] */}
                     <CopilotKit runtimeUrl="/api/copilotkit">
                         {children}

--- a/showcase/shell-dojo/src/app/layout.tsx
+++ b/showcase/shell-dojo/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body>{children}</body>
+      <body suppressHydrationWarning>{children}</body>
     </html>
   );
 }

--- a/showcase/shell/src/app/layout.tsx
+++ b/showcase/shell/src/app/layout.tsx
@@ -105,7 +105,7 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: injection }}
         />
       </head>
-      <body className="min-h-screen">
+      <body suppressHydrationWarning className="min-h-screen">
         <FrameworkProvider knownFrameworks={knownFrameworks}>
           <BrandNav />
           <main>{children}</main>

--- a/skills/react-core/references/provider-setup.md
+++ b/skills/react-core/references/provider-setup.md
@@ -58,7 +58,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>
@@ -310,7 +310,7 @@ Wrong:
 
 ```tsx
 <html>
-  <body>
+  <body suppressHydrationWarning>
     <Header>{/* Header uses useFrontendTool internally */}</Header>
     <CopilotKit>{children}</CopilotKit>
   </body>
@@ -321,7 +321,7 @@ Correct:
 
 ```tsx
 <html>
-  <body>
+  <body suppressHydrationWarning>
     <CopilotKit>
       <Header />
       {children}


### PR DESCRIPTION
## Summary

- add `suppressHydrationWarning` to every repository-owned Next.js root body, including App Router layouts and the Pages Router document
- update every Next.js setup example in product docs, example READMEs, and React Core skill guidance
- add a repository-wide regression test so new unguarded Next roots or setup snippets fail CI

## Reproduction

Grammarly injects `data-new-gr-c-s-check-loaded` and `data-gr-ext-installed` on `<body>`. Delaying Next.js scripts by five seconds reliably lets the extension mutate the DOM before hydration and reproduces the reported mismatch. With this change, Grammarly still wins that race but React emits zero hydration messages.

## Validation

- `pnpm nx run @copilotkit/showcase-scripts:test` — 2,449 tests passed
- Shell Docs — 374 tests passed, typecheck passed, production build passed
- affected package pre-commit suite — tests, publint, and attw passed
- `pnpm check:plugin-skills`
- real Chrome + current Grammarly delayed-hydration reproduction
