### PR TITLE
fix(reskinnable-demo): collapse HITL approval buttons on the tool result

### DIFF
--- a/examples/showcases/reskinnable-demo/src/skins/banking/components/approval-buttons.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/components/approval-buttons.tsx
@@ -2,20 +2,37 @@
 
 import { useState } from "react";
 
+/**
+ * Approve/Deny for a human-in-the-loop card.
+ *
+ * `resolved` is the DURABLE signal that this tool call has already been
+ * answered, and callers should pass it from the tool call itself (a present
+ * `result`, or status "complete"). Local `responded` state alone is not enough:
+ * it dies with the component, and these cards do get remounted — the earliest
+ * card in a multi-step chain has its subtree replaced when the run syncs, which
+ * resurrected live Approve/Deny buttons on an action the user had already
+ * taken. Clicking them a second time would fire a duplicate write against an
+ * already-settled call.
+ *
+ * Local state is still kept, because it collapses the buttons on click without
+ * waiting for the round trip. The two are OR-ed: whichever knows first wins.
+ */
 export function ApprovalButtons({
   onApprove,
   onDeny,
   approveLabel = "Approve",
   denyLabel = "Deny",
+  resolved = false,
 }: {
   onApprove: () => Promise<void> | void;
   onDeny: () => void;
   approveLabel?: string;
   denyLabel?: string;
+  resolved?: boolean;
 }) {
   const [responded, setResponded] = useState(false);
 
-  if (responded) {
+  if (resolved || responded) {
     return <p className="text-sm italic text-ink-muted">Response submitted.</p>;
   }
 

--- a/examples/showcases/reskinnable-demo/src/skins/banking/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/tools.tsx
@@ -914,7 +914,7 @@ export function BankingTools() {
       transactionId: z.string(),
       code: z.string(),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { transactionId, code } = args;
 
       if (status === "inProgress") {
@@ -940,6 +940,7 @@ export function BankingTools() {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!transactionId || !code) {
                 respond?.("Missing transaction or exception code");
@@ -977,7 +978,7 @@ export function BankingTools() {
     parameters: z.object({
       exceptionId: z.string(),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { exceptionId } = args;
 
       if (status === "inProgress") {
@@ -999,6 +1000,7 @@ export function BankingTools() {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!exceptionId) {
                 respond?.("Missing exception id");
@@ -1035,7 +1037,7 @@ export function BankingTools() {
     parameters: z.object({
       transactionId: z.string(),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { transactionId } = args;
 
       if (status === "inProgress") {
@@ -1058,6 +1060,7 @@ export function BankingTools() {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!transactionId) {
                 respond?.("Missing transaction id");


### PR DESCRIPTION
Ports the banking demo's #6401 fix, which was never carried over to `reskinnable-demo`. Found while bringing the demo up against a local Intelligence stack.

## The bug

`ApprovalButtons` collapsed only on local `responded` state, which dies with the component. These cards **do** get remounted when the run syncs, which resurrects live Approve/Deny buttons on an action the user already took — a second click fires a duplicate write against an already-settled call.

Reproduced in the banking skin: clicking the "Approve the $15,000 AWS charge" pill and approving the policy exception left a **second card carrying live Approve/Deny buttons** (with empty args).

## The fix

Adds a durable `resolved` prop, OR-ed with the local state so a click still collapses without waiting for the round trip. It is passed from the tool call itself:

```tsx
resolved={status === "complete" || !!result}
```

Applied at the three HITL renders that don't already early-return on `status === "complete"` (`openPolicyException`, `finalizePolicyException`, `approveTransaction`).

The other three (`offerWorkflowRecording`, `awaitDashboardDemonstration`, `saveLearnedWorkflow`) render their own terminal card when complete, so they never reach the buttons — passing `resolved` there is both redundant and a type error, since `status` is narrowed to `ToolCallStatus.Executing`. That is why banking also has exactly three call sites.

## Verification

- Before: second card had live Approve/Deny. After: it reads *"Response submitted."*
- `pnpm lint` → exit 0
- `pnpm build` (the type-check gate) → exit 0

Note: the duplicate card still renders — that comes from a separate pre-existing `Encountered two children with the same key` warning also present in banking, and is out of scope here. This PR removes the *duplicate-write* hazard, which is what #6401 addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)