### PR TITLE
fix(react-core): collapse duplicate tool-call ids in the message view

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -321,6 +321,42 @@ const MemoizedCustomMessage = React.memo(
  *
  * @internal Exported for unit testing only — not part of the public API.
  */
+/**
+ * Collapse tool calls that share an id, keeping first-seen order.
+ *
+ * AG-UI's TOOL_CALL_START handler appends to the parent message's `toolCalls`
+ * without checking whether that id is already present. So whenever a start
+ * event is applied twice — which the human-in-the-loop flow triggers when the
+ * run syncs after `respond()` — the message ends up carrying the same call
+ * twice. The second copy has EMPTY `arguments`, because a start event carries
+ * none; the args arrive later as TOOL_CALL_ARGS deltas addressed to the first
+ * copy.
+ *
+ * Left alone that renders the same tool call twice: once populated and once
+ * blank (an approval card with no transaction id, offering live buttons for an
+ * action already taken), and React warns "Encountered two children with the
+ * same key" because the call id is the render key.
+ *
+ * The empty copy is the redundant one, so prefer whichever entry actually
+ * carries arguments rather than blindly taking the first.
+ */
+function dedupeToolCalls(
+  toolCalls: NonNullable<AssistantMessage["toolCalls"]>,
+): NonNullable<AssistantMessage["toolCalls"]> {
+  const byId = new Map<string, (typeof toolCalls)[number]>();
+  for (const toolCall of toolCalls) {
+    const existing = byId.get(toolCall.id);
+    if (!existing) {
+      byId.set(toolCall.id, toolCall);
+      continue;
+    }
+    if (!existing.function?.arguments && toolCall.function?.arguments) {
+      byId.set(toolCall.id, toolCall);
+    }
+  }
+  return byId.size === toolCalls.length ? toolCalls : [...byId.values()];
+}
+
 export function deduplicateMessages(messages: Message[]): Message[] {
   const acc = new Map<string, Message>();
   for (const message of messages) {
@@ -341,7 +377,14 @@ export function deduplicateMessages(messages: Message[]): Message[] {
         ...existing,
         ...message,
         content,
-        toolCalls,
+        toolCalls: toolCalls ? dedupeToolCalls(toolCalls) : toolCalls,
+      } as AssistantMessage);
+    } else if (message.role === "assistant" && message.toolCalls) {
+      // Duplicate call ids also arrive on a message that was never itself
+      // duplicated, so this cannot live in the merge branch above.
+      acc.set(message.id, {
+        ...message,
+        toolCalls: dedupeToolCalls(message.toolCalls),
       } as AssistantMessage);
     } else {
       acc.set(message.id, message);

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx
@@ -277,3 +277,85 @@ describe("deduplicateMessages", () => {
     expect((result[0] as UserMessage).content).toBe("Hello (updated)");
   });
 });
+
+describe("deduplicateMessages duplicate tool-call ids", () => {
+  // AG-UI's TOOL_CALL_START handler appends to `toolCalls` without checking for
+  // an existing entry with that id, so re-applying a start event (which the HITL
+  // flow does when the run syncs after respond()) leaves a second copy carrying
+  // EMPTY arguments. Rendering both showed a phantom blank approval card and
+  // triggered React's "two children with the same key" warning.
+  it("collapses a duplicated tool-call id on a message that was never itself duplicated", () => {
+    const messages: Message[] = [
+      assistantMsg("a-1", "", [
+        toolCall("call_1", "openPolicyException", '{"transactionId":"t-2"}'),
+        toolCall("call_1", "openPolicyException", ""),
+      ]),
+    ];
+
+    const result = deduplicateMessages(messages);
+
+    expect(result).toHaveLength(1);
+    const toolCalls = (result[0] as AssistantMessage).toolCalls!;
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]!.id).toBe("call_1");
+    // The populated copy must win — the empty one is the redundant re-announce.
+    expect(toolCalls[0]!.function.arguments).toBe('{"transactionId":"t-2"}');
+  });
+
+  it("prefers the populated copy regardless of which order it arrives in", () => {
+    const messages: Message[] = [
+      assistantMsg("a-1", "", [
+        toolCall("call_1", "approveTransaction", ""),
+        toolCall("call_1", "approveTransaction", '{"transactionId":"t-2"}'),
+      ]),
+    ];
+
+    const toolCalls = (deduplicateMessages(messages)[0] as AssistantMessage)
+      .toolCalls!;
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]!.function.arguments).toBe('{"transactionId":"t-2"}');
+  });
+
+  it("keeps distinct tool calls and their order", () => {
+    const messages: Message[] = [
+      assistantMsg("a-1", "", [
+        toolCall("call_1", "first", '{"a":1}'),
+        toolCall("call_2", "second", '{"b":2}'),
+      ]),
+    ];
+
+    const toolCalls = (deduplicateMessages(messages)[0] as AssistantMessage)
+      .toolCalls!;
+
+    expect(toolCalls.map((t) => t.id)).toEqual(["call_1", "call_2"]);
+  });
+
+  it("collapses duplicate tool-call ids when the message is ALSO duplicated", () => {
+    const messages: Message[] = [
+      assistantMsg("a-1", "Working", [
+        toolCall("call_1", "openPolicyException", '{"transactionId":"t-2"}'),
+      ]),
+      assistantMsg("a-1", "", [
+        toolCall("call_1", "openPolicyException", '{"transactionId":"t-2"}'),
+        toolCall("call_1", "openPolicyException", ""),
+      ]),
+    ];
+
+    const result = deduplicateMessages(messages);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as AssistantMessage).toolCalls).toHaveLength(1);
+    expect((result[0] as AssistantMessage).content).toBe("Working");
+  });
+
+  it("returns the original toolCalls array when there is nothing to collapse", () => {
+    const original = [toolCall("call_1", "only", "{}")];
+    const messages: Message[] = [assistantMsg("a-1", "", original)];
+
+    // Reference equality keeps memoized consumers from re-rendering needlessly.
+    expect(
+      (deduplicateMessages(messages)[0] as AssistantMessage).toolCalls,
+    ).toBe(original);
+  });
+});


### PR DESCRIPTION
Follow-up to #6404. That PR stopped the *duplicate write* from a resurrected approval card; this one removes the duplicate card itself.

## Symptom

Approving a HITL card in the banking skin left a **second, blank copy** of the same card in the transcript — "Open policy exception" with no transaction id and no code — plus a React warning:

```
Encountered two children with the same key, call_QHa801k5PL32WtPKsPItO1pI
```

## Root cause

`@ag-ui/client`'s `TOOL_CALL_START` handler appends to the parent assistant message's `toolCalls` with no check for an existing entry with that id:

```js
message.toolCalls ??= [];
message.toolCalls.push({ id, type: "function", function: { name, arguments: "" } });
```

So when a start event is applied twice — which the HITL flow triggers when the run syncs after `respond()` — the message carries the same call twice. The second copy has **empty `arguments`**, because a start event carries none; the args arrive afterwards as `TOOL_CALL_ARGS` deltas addressed to the first copy. That empty copy is what rendered as the blank card, and `CopilotChatToolCallsView` uses the call id as its render key, hence the warning.

Evidence gathered while diagnosing:

- Instrumented the message view: the offending assistant message ends up with `toolCalls: ["call_X","call_X"]`, and the React warning fires on the same id in the same tick.
- Queried a local Intelligence stack: the server emits **exactly one** `TOOL_CALL_START` for that id (one `START`, one `END`, one `RESULT`). So this is client-side state, not a stream defect.
- React StrictMode is **not** involved — the demo sets `reactStrictMode: false`.

## Fix

Extends the existing `deduplicateMessages()` — which already collapses duplicate *message* ids arriving from streaming re-delivery — to also collapse duplicate *call* ids within a message, preferring whichever copy actually carries arguments.

Applied outside the merge branch too, because the duplicate also lands on a message that was never itself duplicated (observed `rawMsgs=5 dedupMsgs=5` with the duplicate still present). Returns the original array untouched when there is nothing to collapse, so memoized consumers don't re-render needlessly.

## Scope / known limitation

This fixes what renders. The underlying agent state still holds the duplicate entry, so a fully correct fix also wants an idempotency guard in the AG-UI start handler (upstream). Filed separately — flagging here so the remaining gap is explicit rather than implied-fixed.

The precise reason a single start event gets applied twice is also still open; the fix is deliberately robust to re-application whatever the trigger.

## Verification

- 5 regression tests added, **verified red before green** (neutered the fix → 3 failed with "Expected 1, Received 2"; restored → pass).
- Full `@copilotkit/react-core` suite: **1480 passed / 123 files**.
- `test`, `publint`, `attw` green for react-core and its dependents.
- In-browser against a live Intelligence stack: before, approving left a blank second card + 3 key warnings; after, **one card and zero warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)