### PR TITLE
fix(react-core): repair useCopilotReadable effect deps, convert args, and dependencies

### DIFF
--- a/packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-copilot-readable.test.tsx
@@ -1,0 +1,259 @@
+import { vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCopilotReadable } from "../use-copilot-readable";
+
+type Availability = "enabled" | "disabled";
+
+interface FakeContextEntry {
+  description: string;
+  value: string;
+}
+
+/**
+ * Mirrors the semantics of `ContextStore` in @copilotkit/core: `addContext`
+ * assigns a fresh id and stores the *already serialized* value, `removeContext`
+ * deletes by id. Using a fake keeps these tests focused on the hook's effect
+ * logic, which is where every one of these regressions lived.
+ */
+function createFakeCopilotKit() {
+  const store: Record<string, FakeContextEntry> = {};
+  let nextId = 0;
+
+  return {
+    get context() {
+      return store;
+    },
+    addContext: vi.fn((entry: FakeContextEntry) => {
+      const id = `ctx-${++nextId}`;
+      store[id] = { ...entry };
+      return id;
+    }),
+    removeContext: vi.fn((id: string) => {
+      delete store[id];
+    }),
+    entries: () => Object.values(store),
+    ids: () => Object.keys(store),
+  };
+}
+
+let fake: ReturnType<typeof createFakeCopilotKit>;
+
+vi.mock("../../v2", () => ({
+  useCopilotKit: () => ({ copilotkit: fake }),
+}));
+
+// Stable across renders so that re-render assertions measure the dependency
+// array, not the identity churn of an inline literal.
+const EMPLOYEES = [{ name: "Jane" }, { name: "Sam" }];
+
+describe("useCopilotReadable", () => {
+  beforeEach(() => {
+    fake = createFakeCopilotKit();
+  });
+
+  it("registers the context on mount", () => {
+    renderHook(() =>
+      useCopilotReadable({ description: "employees", value: EMPLOYEES }),
+    );
+
+    expect(fake.addContext).toHaveBeenCalledTimes(1);
+    expect(fake.entries()).toEqual([
+      { description: "employees", value: JSON.stringify(EMPLOYEES) },
+    ]);
+  });
+
+  it("removes the context on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useCopilotReadable({ description: "employees", value: EMPLOYEES }),
+    );
+    const [id] = fake.ids();
+
+    unmount();
+
+    expect(fake.removeContext).toHaveBeenCalledWith(id);
+    expect(fake.entries()).toEqual([]);
+  });
+
+  describe("available", () => {
+    it("registers nothing when mounted as disabled", () => {
+      renderHook(() =>
+        useCopilotReadable({
+          description: "employees",
+          value: EMPLOYEES,
+          available: "disabled",
+        }),
+      );
+
+      expect(fake.addContext).not.toHaveBeenCalled();
+      expect(fake.entries()).toEqual([]);
+    });
+
+    // Regression: `available` was missing from the effect's dependency array,
+    // so flipping it after mount was a no-op.
+    it("removes the context when flipped to disabled after mount", () => {
+      const { rerender } = renderHook(
+        ({ available }: { available: Availability }) =>
+          useCopilotReadable({
+            description: "employees",
+            value: EMPLOYEES,
+            available,
+          }),
+        { initialProps: { available: "enabled" as Availability } },
+      );
+
+      expect(fake.entries()).toHaveLength(1);
+
+      rerender({ available: "disabled" });
+
+      expect(fake.entries()).toEqual([]);
+    });
+
+    it("re-adds the context when flipped back to enabled", () => {
+      const { rerender } = renderHook(
+        ({ available }: { available: Availability }) =>
+          useCopilotReadable({
+            description: "employees",
+            value: EMPLOYEES,
+            available,
+          }),
+        { initialProps: { available: "disabled" as Availability } },
+      );
+
+      expect(fake.entries()).toEqual([]);
+
+      rerender({ available: "enabled" });
+
+      expect(fake.entries()).toEqual([
+        { description: "employees", value: JSON.stringify(EMPLOYEES) },
+      ]);
+    });
+  });
+
+  describe("convert", () => {
+    // Regression: convert was invoked as `convert(value)`, so a user's function
+    // received the value as `description` and `undefined` as `value`.
+    it("is called with (description, value) in that order", () => {
+      const convert = vi.fn(() => "converted");
+
+      renderHook(() =>
+        useCopilotReadable({
+          description: "employees",
+          value: EMPLOYEES,
+          convert,
+        }),
+      );
+
+      expect(convert).toHaveBeenCalledTimes(1);
+      expect(convert).toHaveBeenCalledWith("employees", EMPLOYEES);
+    });
+
+    it("is used in place of JSON.stringify", () => {
+      const convert = vi.fn(
+        (description: string, value: typeof EMPLOYEES) =>
+          `${description}: ${value.map((e) => e.name).join(", ")}`,
+      );
+
+      renderHook(() =>
+        useCopilotReadable({
+          description: "employees",
+          value: EMPLOYEES,
+          convert,
+        }),
+      );
+
+      expect(fake.entries()).toEqual([
+        { description: "employees", value: "employees: Jane, Sam" },
+      ]);
+    });
+
+    // Guards the fix itself: `JSON.stringify` must never receive the
+    // description as a first argument, because its second parameter is a
+    // replacer. `JSON.stringify("employees", EMPLOYEES)` would yield
+    // `"\"employees\""` rather than the serialized value.
+    it("serializes the value alone when convert is omitted", () => {
+      renderHook(() =>
+        useCopilotReadable({ description: "employees", value: EMPLOYEES }),
+      );
+
+      expect(fake.entries()[0]!.value).toBe(JSON.stringify(EMPLOYEES));
+      expect(fake.entries()[0]!.value).not.toBe(JSON.stringify("employees"));
+    });
+  });
+
+  describe("dependencies", () => {
+    // Regression: the `dependencies` argument was accepted but never reached
+    // the effect's dependency array.
+    it("re-runs the effect when a dependency changes", () => {
+      const { rerender } = renderHook(
+        ({ dep }: { dep: number }) =>
+          useCopilotReadable({ description: "employees", value: EMPLOYEES }, [
+            dep,
+          ]),
+        { initialProps: { dep: 1 } },
+      );
+
+      expect(fake.addContext).toHaveBeenCalledTimes(1);
+      const [firstId] = fake.ids();
+
+      rerender({ dep: 2 });
+
+      expect(fake.addContext).toHaveBeenCalledTimes(2);
+      expect(fake.removeContext).toHaveBeenCalledWith(firstId);
+      // The stale entry is replaced, not accumulated.
+      expect(fake.entries()).toHaveLength(1);
+    });
+
+    it("does not re-run the effect when the dependency is unchanged", () => {
+      const { rerender } = renderHook(
+        ({ dep }: { dep: number }) =>
+          useCopilotReadable({ description: "employees", value: EMPLOYEES }, [
+            dep,
+          ]),
+        { initialProps: { dep: 1 } },
+      );
+
+      rerender({ dep: 1 });
+
+      expect(fake.addContext).toHaveBeenCalledTimes(1);
+      expect(fake.removeContext).not.toHaveBeenCalled();
+    });
+  });
+
+  it("re-registers when the description changes", () => {
+    const { rerender } = renderHook(
+      ({ description }: { description: string }) =>
+        useCopilotReadable({ description, value: EMPLOYEES }),
+      { initialProps: { description: "employees" } },
+    );
+
+    rerender({ description: "staff" });
+
+    expect(fake.entries()).toEqual([
+      { description: "staff", value: JSON.stringify(EMPLOYEES) },
+    ]);
+  });
+
+  // Two components publishing identical readables must each own their entry.
+  // A dedup that reused an existing id would make the first unmount delete the
+  // entry the second component is still relying on.
+  it("keeps separate entries for identical readables in two components", () => {
+    const first = renderHook(() =>
+      useCopilotReadable({ description: "employees", value: EMPLOYEES }),
+    );
+    const second = renderHook(() =>
+      useCopilotReadable({ description: "employees", value: EMPLOYEES }),
+    );
+
+    expect(fake.entries()).toHaveLength(2);
+
+    first.unmount();
+
+    expect(fake.entries()).toEqual([
+      { description: "employees", value: JSON.stringify(EMPLOYEES) },
+    ]);
+
+    second.unmount();
+
+    expect(fake.entries()).toEqual([]);
+  });
+});

--- a/packages/react-core/src/hooks/use-copilot-readable.ts
+++ b/packages/react-core/src/hooks/use-copilot-readable.ts
@@ -1,7 +1,6 @@
 /**
  * `useCopilotReadable` is a React hook that provides app-state and other information
- * to the Copilot. Optionally, the hook can also handle hierarchical state within your
- * application, passing these parent-child relationships to the Copilot.
+ * to the Copilot.
  *
  * ## Usage
  *
@@ -24,41 +23,47 @@
  * }
  * ```
  *
- * ### Nested Components
+ * ### Custom Serialization
  *
- * Optionally, you can maintain the hierarchical structure of information by passing
- * `parentId`. This allows you to use `useCopilotReadable` in nested components:
+ * By default the value is serialized with `JSON.stringify`. Pass `convert` to
+ * control the string the Copilot sees. It is called with the description and the
+ * value, in that order:
  *
- * ```tsx /employeeContextId/1 {17,23}
- * import { useCopilotReadable } from "@copilotkit/react-core";
+ * ```tsx
+ * useCopilotReadable({
+ *   description: "The current user",
+ *   value: user,
+ *   convert: (description, value) => `${description}: ${value.firstName} ${value.lastName}`,
+ * });
+ * ```
  *
- * function Employee(props: EmployeeProps) {
- *   const { employeeName, workProfile, metadata } = props;
+ * ### Conditional Usage
  *
- *   // propagate any information to copilot
- *   const employeeContextId = useCopilotReadable({
- *     description: "Employee name",
- *     value: employeeName
- *   });
+ * Toggle `available` to add or remove the context as your app state changes.
+ * Switching to `"disabled"` removes the entry from the Copilot context; switching
+ * back to `"enabled"` re-adds it.
  *
- *   // Pass a parentID to maintain a hierarchical structure.
- *   // Especially useful with child React components, list elements, etc.
- *   useCopilotReadable({
- *     description: "Work profile",
- *     value: workProfile.description(),
- *     parentId: employeeContextId
- *   });
+ * ```tsx
+ * useCopilotReadable({
+ *   description: "The list of employees",
+ *   value: employees,
+ *   available: showEmployees ? "enabled" : "disabled",
+ * });
+ * ```
  *
- *   useCopilotReadable({
- *     description: "Employee metadata",
- *     value: metadata.description(),
- *     parentId: employeeContextId
- *   });
+ * ### Re-running on Custom Dependencies
  *
- *   return (
- *     // Render as usual...
- *   );
- * }
+ * The context is refreshed whenever `description`, `value`, `convert` or
+ * `available` change. Pass a second argument to add your own dependencies:
+ *
+ * ```tsx
+ * useCopilotReadable(
+ *   {
+ *     description: "The selected employee",
+ *     value: employee,
+ *   },
+ *   [departmentId],
+ * );
  * ```
  */
 import { useCopilotKit } from "../v2";
@@ -78,11 +83,18 @@ export interface UseCopilotReadableOptions {
   value: any;
   /**
    * The ID of the parent context, if any.
+   *
+   * @deprecated This option is currently ignored. The context store backing this
+   * hook is flat and has no parent/child relationships, so no hierarchy is applied.
+   * Accepted for source compatibility only.
    */
   parentId?: string;
   /**
    * An array of categories to control which context are visible where. Particularly useful
    * with CopilotTextarea (see `useMakeAutosuggestionFunction`)
+   *
+   * @deprecated This option is currently ignored. The context store backing this
+   * hook does not filter by category. Accepted for source compatibility only.
    */
   categories?: string[];
 
@@ -102,34 +114,43 @@ export interface UseCopilotReadableOptions {
  * Adds the given information to the Copilot context to make it readable by Copilot.
  */
 export function useCopilotReadable(
-  { description, value, convert, available }: UseCopilotReadableOptions,
+  {
+    description,
+    value,
+    convert,
+    available = "enabled",
+  }: UseCopilotReadableOptions,
   dependencies?: any[],
 ): string | undefined {
   const { copilotkit } = useCopilotKit();
   const ctxIdRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
     if (!copilotkit) return;
+    if (available === "disabled") return;
 
-    const found = Object.entries(copilotkit.context).find(([id, ctxItem]) => {
-      return JSON.stringify({ description, value }) == JSON.stringify(ctxItem);
-    });
-    if (found) {
-      ctxIdRef.current = found[0];
-      if (available === "disabled") copilotkit.removeContext(ctxIdRef.current);
-      return;
-    }
-    if (!found && available === "disabled") return;
-
-    ctxIdRef.current = copilotkit.addContext({
+    // `convert` takes (description, value). `JSON.stringify` must be called with
+    // the value alone — its second parameter is a replacer, not a value.
+    const id = copilotkit.addContext({
       description,
-      value: (convert ?? JSON.stringify)(value),
+      value: convert ? convert(description, value) : JSON.stringify(value),
     });
+    ctxIdRef.current = id;
 
     return () => {
-      if (!ctxIdRef.current) return;
-      copilotkit.removeContext(ctxIdRef.current);
+      copilotkit.removeContext(id);
+      if (ctxIdRef.current === id) {
+        ctxIdRef.current = undefined;
+      }
     };
-  }, [description, value, convert]);
+  }, [
+    copilotkit,
+    description,
+    value,
+    convert,
+    available,
+    ...(dependencies || []),
+  ]);
 
   return ctxIdRef.current;
 }


### PR DESCRIPTION
Fixes #6383. Fixes #6243.

Both issues land in the same 35 lines of `useCopilotReadable`, so they are fixed together. This PR also covers a third defect neither issue reports.

All of it traces to a single commit: 80dffec4e7 ("feat: Reimplement CopilotKit on top of refreshed internals (v1.50.0)", #2638), which repointed the hook from the v1 context tree onto the v2 flat context store. The pre-1.50 implementation was correct on every count below.

## Fixes

**`available` was missing from the effect deps** (#6383)
The effect body read `available` but the deps were `[description, value, convert]`, so toggling between `"enabled"` and `"disabled"` after mount did nothing. It is back in the deps, along with the `available = "enabled"` default the port dropped.

**`convert` was called with one argument** (#6243)
`(convert ?? JSON.stringify)(value)` invoked a user's `(description, value) => string` as `convert(value)`, so it received the value as `description` and `undefined` as `value`. The branches are now split rather than passing two arguments to the combined expression — `JSON.stringify(description, value)` would treat the second argument as a *replacer*, not a value.

**`dependencies` was accepted and ignored** (#6243)
The second positional argument was destructured but never reached the deps array. Now spread, matching `useCopilotAdditionalInstructions`.

**The `found` dedup branch was dead code** (unreported)
It compared `JSON.stringify({ description, value })` against a stored entry whose `value` had already been serialized by `addContext` (`packages/core/src/core/context-store.ts:36`). That never matches — for objects or strings — so the branch and its cleanup-skipping early return were unreachable. Deleted rather than repaired: making the comparison work would newly let component A's unmount remove a context entry component B is still relying on. The test `keeps separate entries for identical readables in two components` locks that in, and it passes against the pre-fix hook, which is what confirms the branch never fired.

## `parentId` / `categories`

Both are still in `UseCopilotReadableOptions` and were still documented — the top-of-file JSDoc example was a `parentId` tutorial — but the same v1.50 commit dropped them from the hook body. They have been no-ops since.

This PR does not implement them. Real support needs parent/child modelling in the v2 context store, which is flat by design (`getContextForAgent` emits `{ description, value }` only). Instead both are marked `@deprecated` and the JSDoc example is rewritten to document behavior that exists. Tracked in #6408.

## Not addressed

Two pre-existing behaviors left alone to keep this a bugfix:

- `value` is in the deps raw, so an inline object literal re-registers the entry on every render. Pre-1.50 depended on the serialized string instead.
- The hook returns `undefined` on first render, since the ref is assigned inside the effect.

## Testing

`useCopilotReadable` had no test file. This adds one — 12 tests, using a fake that mirrors `ContextStore` semantics (`addContext` assigns an id and stores the already-serialized value).

Full project suite — `nx run @copilotkit/react-core:test`:

```
 Test Files  124 passed (124)
      Tests  1487 passed (1487)
 NX   Successfully ran target test for project @copilotkit/react-core and 17 tasks it depends on
```

Each fix is covered by a test that fails against the pre-fix hook. Reverting only `use-copilot-readable.ts` and re-running the new file:

```
   ✓ registers the context on mount
   ✓ removes the context on unmount
   ✓ available > registers nothing when mounted as disabled
   × available > removes the context when flipped to disabled after mount
     → expected [ { description: 'employees', …(1) } ] to deeply equal []
   × available > re-adds the context when flipped back to enabled
     → expected [] to deeply equal [ { description: 'employees', …(1) } ]
   × convert > is called with (description, value) in that order
     → expected "spy" to be called with arguments: [ 'employees', …(1) ]
   × convert > is used in place of JSON.stringify
     → Cannot read properties of undefined (reading 'map')
   ✓ convert > serializes the value alone when convert is omitted
   × dependencies > re-runs the effect when a dependency changes
     → expected "spy" to be called 2 times, but got 1 times
   ✓ dependencies > does not re-run the effect when the dependency is unchanged
   ✓ re-registers when the description changes
   ✓ keeps separate entries for identical readables in two components

 Test Files  1 failed (1)
      Tests  5 failed | 7 passed (12)
```

The two that still pass pre-fix are deliberate: `serializes the value alone when convert is omitted` guards the `JSON.stringify` replacer trap in the fix itself, and `keeps separate entries…` is the evidence that the `found` branch was dead.

With the fix applied:

```
 ✓ src/hooks/__tests__/use-copilot-readable.test.tsx (12 tests) 15ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Types — `pnpm --filter @copilotkit/react-core check-types`:

```
> @copilotkit/react-core@1.66.2 check-types
> tsc --noEmit
```

(no diagnostics)

Formatting — `oxfmt --check` on both files:

```
Checking formatting...
All matched files use the correct format.
Finished in 16ms on 2 files using 18 threads.
```

`oxlint` reports one warning, on `...(dependencies || [])` in the deps array. The same pattern already warns in `use-copilot-additional-instructions.ts`, `use-frontend-tool.ts` and `use-coagent-state-render.ts`; CI runs `oxlint .` without `--deny-warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The `convert` and `dependencies` fixes were independently found and fixed first by @jwgrsol in #6246, opened a week before this PR. Credited below.

Co-authored-by: jwgrsol <wefhio1985@gmail.com>
