### PR TITLE
fix(react-ui): let sidebar children fill the viewport height

### DIFF
--- a/packages/react-ui/src/components/chat/Sidebar.tsx
+++ b/packages/react-ui/src/components/chat/Sidebar.tsx
@@ -72,7 +72,27 @@ import React, { useState } from "react";
 import type { CopilotModalProps } from "./Modal";
 import { CopilotModal } from "./Modal";
 
-export function CopilotSidebar(props: CopilotModalProps) {
+export interface CopilotSidebarProps extends CopilotModalProps {
+  /**
+   * Make the sidebar's content wrapper exactly one viewport tall, so children
+   * can use `height: 100%` (or `flex: 1`) to fill the screen.
+   *
+   * Off by default: the wrappers are auto-height, so page content flows
+   * normally and percentage heights on children collapse to content height.
+   *
+   * ```tsx
+   * <CopilotSidebar fullHeightChildren>
+   *   <div style={{ height: "100%" }}>...</div>
+   * </CopilotSidebar>
+   * ```
+   */
+  fullHeightChildren?: boolean;
+}
+
+export function CopilotSidebar({
+  fullHeightChildren = false,
+  ...props
+}: CopilotSidebarProps) {
   props = {
     ...props,
     className: props.className
@@ -88,8 +108,16 @@ export function CopilotSidebar(props: CopilotModalProps) {
     setExpandedClassName(open ? "sidebarExpanded" : "");
   };
 
+  const contentWrapperClassName = [
+    "copilotKitSidebarContentWrapper",
+    expandedClassName,
+    fullHeightChildren ? "copilotKitSidebarFullHeightChildren" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div className={`copilotKitSidebarContentWrapper ${expandedClassName}`}>
+    <div className={contentWrapperClassName}>
       <CopilotModal {...props} {...{ onSetOpen }}>
         {props.children}
       </CopilotModal>

--- a/packages/react-ui/src/components/chat/index.tsx
+++ b/packages/react-ui/src/components/chat/index.tsx
@@ -1,6 +1,7 @@
 export * from "./props";
 export { CopilotPopup } from "./Popup";
 export { CopilotSidebar } from "./Sidebar";
+export type { CopilotSidebarProps } from "./Sidebar";
 export { CopilotChat } from "./Chat";
 export { CopilotModal } from "./Modal";
 export type { CopilotModalProps } from "./Modal";

--- a/packages/react-ui/src/css/sidebar-full-height.test.ts
+++ b/packages/react-ui/src/css/sidebar-full-height.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const sidebarCss = fs.readFileSync(
+  path.resolve(__dirname, "sidebar.css"),
+  "utf-8",
+);
+const sidebarTsx = fs.readFileSync(
+  path.resolve(__dirname, "../components/chat/Sidebar.tsx"),
+  "utf-8",
+);
+
+/**
+ * Regression guard for #261: children of `CopilotSidebar` could not use
+ * `height: 100%`, because both wrappers around them are auto-height blocks.
+ * The fix is opt-in, so the guard has two halves — the escape hatch works,
+ * and it stays off for everyone who didn't ask for it.
+ */
+describe("sidebar full-height children opt-in", () => {
+  const fullHeightRule =
+    /\.copilotKitSidebarContentWrapper\.copilotKitSidebarFullHeightChildren\s*\{([^}]*)\}/;
+  const childrenWrapperRule =
+    /\.copilotKitSidebarContentWrapper\.copilotKitSidebarFullHeightChildren\s*>\s*\.copilotKitModalChildrenWrapper\s*\{([^}]*)\}/;
+
+  it("gives the content wrapper a definite height children can resolve against", () => {
+    const [, body] = sidebarCss.match(fullHeightRule) ?? [];
+    expect(body).toBeDefined();
+    expect(body).toContain("display: flex");
+    expect(body).toContain("flex-direction: column");
+    // A viewport unit, not `100%` — `100%` would silently no-op in any app
+    // that doesn't declare a height on html/body/#root.
+    expect(body).toContain("height: 100dvh");
+    expect(body).toContain("height: 100vh");
+    expect(body).not.toMatch(/height:\s*100%/);
+  });
+
+  it("lets the children wrapper fill that height without a flex min-height floor", () => {
+    const [, body] = sidebarCss.match(childrenWrapperRule) ?? [];
+    expect(body).toBeDefined();
+    expect(body).toContain("flex: 1 1 auto");
+    expect(body).toContain("min-height: 0");
+  });
+
+  it("leaves the default content wrapper auto-height", () => {
+    const [, base] =
+      sidebarCss.match(/\.copilotKitSidebarContentWrapper\s*\{([^}]*)\}/) ?? [];
+    expect(base).toBeDefined();
+    expect(base).not.toContain("height");
+    expect(base).not.toContain("display");
+  });
+
+  it("applies the modifier class only when fullHeightChildren is set", () => {
+    expect(sidebarTsx).toContain("fullHeightChildren = false");
+    expect(sidebarTsx).toMatch(
+      /fullHeightChildren\s*\?\s*"copilotKitSidebarFullHeightChildren"\s*:\s*""/,
+    );
+  });
+});

--- a/packages/react-ui/src/css/sidebar.css
+++ b/packages/react-ui/src/css/sidebar.css
@@ -44,3 +44,30 @@
     margin-right: 28rem;
   }
 }
+
+/*
+ * Opt-in (via the `fullHeightChildren` prop on `CopilotSidebar`): let children
+ * of the sidebar use `height: 100%`.
+ *
+ * By default both wrappers CopilotSidebar puts around your app are auto-height
+ * blocks, so a percentage height on a child has no definite containing block to
+ * resolve against and collapses to content height.
+ *
+ * The viewport unit is deliberate: `height: 100%` here would only resolve if
+ * every ancestor (html/body/#root) also declared a height, which react-ui
+ * neither sets nor can guarantee. `min-height: 0` on the children wrapper
+ * overrides the flex-item `min-height: auto` default so tall content scrolls
+ * inside the child instead of stretching the wrapper past the viewport.
+ */
+.copilotKitSidebarContentWrapper.copilotKitSidebarFullHeightChildren {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+}
+
+.copilotKitSidebarContentWrapper.copilotKitSidebarFullHeightChildren
+  > .copilotKitModalChildrenWrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+}

--- a/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotSidebar.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/components/chat/CopilotSidebar.mdx
@@ -277,3 +277,17 @@ A custom Button component to use instead of the default.
 A custom Header component to use instead of the default.
 </PropertyReference>
 
+<PropertyReference name="fullHeightChildren" type="boolean"  > 
+Make the sidebar's content wrapper exactly one viewport tall, so children
+  can use `height: 100%` (or `flex: 1`) to fill the screen.
+ 
+  Off by default: the wrappers are auto-height, so page content flows
+  normally and percentage heights on children collapse to content height.
+ 
+  ```tsx
+  <CopilotSidebar fullHeightChildren>
+    <div style={{ height: "100%" }}>...</div>
+  </CopilotSidebar>
+  ```
+</PropertyReference>
+


### PR DESCRIPTION
Fixes #261 (open since March 2024). Supersedes #4622 — @ashish4143 diagnosed the same wrappers and is credited as co-author on the commit.

## The bug

`CopilotSidebar` wraps consumer content in two divs:

- `.copilotKitSidebarContentWrapper` (`Sidebar.tsx`) — only sets `overflow`, `margin-right`, `transition`
- `.copilotKitModalChildrenWrapper` (`Modal.tsx`) — **has no CSS rule anywhere in the repo**

Both are auto-height blocks, so a child's `height: 100%` has no definite containing block to resolve against and collapses to content height.

## The fix

An opt-in `fullHeightChildren` prop on `CopilotSidebar` that adds a modifier class to the content wrapper. Two deliberate choices, both from the review on #4622:

- **Opt-in, not default.** The content wrapper wraps the *entire* consumer app. Making it a fixed-height flex column for everyone would reflow apps that never asked for it.
- **A viewport unit, not `height: 100%`.** `100%` only resolves if every ancestor (`html`/`body`/`#root`) also declares a height — react-ui neither sets that nor can guarantee it, so `100%` would silently no-op in a stock Next.js app. `min-height: 0` on the children wrapper clears the flex-item `min-height: auto` floor so tall content scrolls inside the child rather than stretching the wrapper past the viewport.

```tsx
<CopilotSidebar fullHeightChildren>
  <div style={{ height: "100%" }}>...</div>
</CopilotSidebar>
```

## Testing

**Unit** — `packages/react-ui/src/css/sidebar-full-height.test.ts` (4 tests), in the repo's existing CSS-contract style. Guards both halves: the escape hatch's rules, and that the default wrapper stays auto-height. Also asserts the height is *not* `100%`, since that's the regression that would make the whole feature a silent no-op.

```
✓ src/css/sidebar-full-height.test.ts (4 tests)
Test Files  9 passed (9)   Tests  58 passed (58)     # full react-ui suite
```
`npx tsc --noEmit` → exit 0. `oxlint` on changed files → 0 warnings, 0 errors.

**Live in Chrome** — the acceptance criterion from the #4622 review: a stock app where **nothing** declares a height on `html`/`body`/`#root`, loading the real built `dist/index.css` (not the source CSS), standards mode, 762px viewport. DOM per `Sidebar.tsx:92` + `Modal.tsx:143`.

| case | child `height:100%` measures |
|---|---|
| default (no opt-in) | **17px** — collapsed, i.e. behavior unchanged for existing consumers |
| `fullHeightChildren` | **762px** — exactly the viewport |
| `fullHeightChildren`, content 3000px tall | **762px**, scrolls inside the child (`min-height: 0` holds) |

Also confirmed on the opt-in path: `.copilotKitSidebar` stays `position: fixed`, and the expanded push-aside `margin-right` is still `448px` (28rem), so the sidebar's own layout is untouched.

**Docs** — `CopilotSidebar.mdx` is auto-generated from `Sidebar.tsx`; regenerated via `scripts/docs/gen.ts` and committed only the new `fullHeightChildren` entry (the generator also surfaces unrelated pre-existing drift in other reference pages, left out of this PR).

## Not covered

The issue mentions a "works in Safari, not Chrome" symptom. I verified in Chromium only — the mechanism above is spec behavior rather than a Chrome quirk, but I haven't measured WebKit.
