### PR TITLE
fix(core): stop HITL continuations reusing the originating run id on the wire

### DIFF
--- a/packages/core/src/__tests__/core-follow-up.test.ts
+++ b/packages/core/src/__tests__/core-follow-up.test.ts
@@ -75,7 +75,6 @@ describe("CopilotKitCore.runAgent - Follow-up Logic", () => {
           "__copilotkit_follow_up",
         );
       }
-      expect(input.runId).toBe("logical-hitl-run");
     };
 
     await copilotKitCore.runAgent({
@@ -84,10 +83,20 @@ describe("CopilotKitCore.runAgent - Follow-up Logic", () => {
     });
 
     expect(agent.runAgentCalls).toHaveLength(2);
-    expect(agent.runAgentCalls.map((input) => input.runId)).toEqual([
-      "logical-hitl-run",
-      "logical-hitl-run",
-    ]);
+    // The originating run is pinned on the first invocation. The follow-up
+    // deliberately does NOT pin it again: reusing the id on the wire made the
+    // transport treat the follow-up as a resumption of a run it had already
+    // finished, so it re-delivered that run's applied half (duplicating its
+    // tool calls, each duplicate carrying empty arguments) and the follow-up's
+    // own tool call never reached client state.
+    //
+    // Logical identity is preserved a layer up instead: the continuation is
+    // registered against the originating id and the state manager re-stamps its
+    // events onto it, so state/message association and external tracing still
+    // see ONE run. StateManager's "re-stamps a continuation onto the run it
+    // continues" test covers that end.
+    expect(agent.runAgentCalls[0]!.runId).toBe("logical-hitl-run");
+    expect(agent.runAgentCalls[1]!.runId).toBeUndefined();
   });
 
   it("should not trigger recursive call when tool.followUp is false", async () => {

--- a/packages/core/src/__tests__/state-manager.test.ts
+++ b/packages/core/src/__tests__/state-manager.test.ts
@@ -485,6 +485,44 @@ describe("StateManager - Multiple Runs", () => {
     handoff.cancel();
   });
 
+  it("re-stamps a continuation onto the run it continues when the wire id differs", async () => {
+    // The follow-up no longer pins the originating id on the wire — doing that
+    // made the transport treat it as a resumption of an already-finished run.
+    // Logical identity is preserved here instead: the continuation is
+    // registered against the originating id, so the thread must still know
+    // exactly one run afterwards even though the transport assigned its own.
+    const originating = "logical-run-restamped";
+    await copilotKitCore.runAgent({ agent: agent as any, runId: originating });
+
+    const handoff = (
+      copilotKitCore as unknown as {
+        stateManager: {
+          markNextRunAsContinuation: (
+            agent: EventEmittingMockAgent,
+            expectedRunId?: string,
+          ) => { cancel(): void; bind(input: object): void };
+        };
+      }
+    ).stateManager.markNextRunAsContinuation(agent, originating);
+
+    // No runId passed → the agent mints its own for this invocation.
+    await (
+      copilotKitCore as unknown as {
+        runHandler: {
+          runAgent(
+            params: { agent: EventEmittingMockAgent },
+            handoff: { cancel(): void; bind(input: object): void },
+          ): Promise<unknown>;
+        };
+      }
+    ).runHandler.runAgent({ agent }, handoff);
+
+    expect(copilotKitCore.getRunIdsForThread("agent1", "thread1")).toEqual([
+      originating,
+    ]);
+    handoff.cancel();
+  });
+
   it("does not consume an unbound handoff during detach", async () => {
     const runId = "detach-interleaving-run";
     await copilotKitCore.runAgent({ agent: agent as any, runId });

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -505,16 +505,34 @@ export class RunHandler {
       };
       agentSubscriber.onRunStartedEvent = async (params) => {
         started = true;
-        logicalRunId = params.input.runId;
+        // A continuation keeps reporting under the run it continues; only an
+        // ordinary run adopts the id the transport assigned it.
+        if (!continuationHandoff) {
+          logicalRunId = params.input.runId;
+        }
         return onRunStartedEvent?.(params);
       };
+      // An internal continuation (a human-in-the-loop tool resolved and this is
+      // the recursive follow-up) deliberately does NOT pin the originating run
+      // id on the wire. Pinning it made the transport treat the follow-up as a
+      // resumption of a run it had already completed: it re-delivered that
+      // run's applied half — duplicating every tool call already on the
+      // message, each duplicate carrying empty arguments — and the follow-up's
+      // own tool call never reached client state, so its card never rendered.
+      //
+      // One logical run is still what everything downstream sees: the state
+      // manager re-stamps the continuation's events onto `runId` (passed to
+      // markNextRunAsContinuation), and `logicalRunId` below keeps the result
+      // reported under it. So external tracing still gets a single run without
+      // the wire having to lie about which invocation this is.
+      const pinRunIdOnWire = runId !== undefined && !continuationHandoff;
       const agentRunInput = {
         forwardedProps: {
           ...this._internal.properties,
           ...forwardedProps,
         },
         ...(resume !== undefined ? { resume } : {}),
-        ...(runId !== undefined ? { runId } : {}),
+        ...(pinRunIdOnWire ? { runId } : {}),
         tools: this.buildFrontendTools(agent.agentId),
         context: this._internal.getContextForAgent(agent.agentId),
       };

--- a/packages/core/src/core/state-manager.ts
+++ b/packages/core/src/core/state-manager.ts
@@ -25,6 +25,13 @@ export interface CopilotKitCoreContinuationHandoff {
 interface PendingContinuation extends CopilotKitCoreContinuationHandoff {
   expectedInput?: object;
   active: boolean;
+  /**
+   * The logical run id this continuation belongs to. Events arriving on the
+   * continuation are re-stamped with it, so the run reads as ONE run to
+   * everything downstream (state/message association, external tracing) even
+   * though the transport minted a fresh id for the follow-up invocation.
+   */
+  expectedRunId?: string;
 }
 
 /**
@@ -63,7 +70,7 @@ export class StateManager {
 
   markNextRunAsContinuation(
     agent: AbstractAgent,
-    _expectedRunId?: string,
+    expectedRunId?: string,
   ): CopilotKitCoreContinuationHandoff {
     let pendingForAgent = this.pendingContinuations.get(agent);
     if (!pendingForAgent) {
@@ -73,6 +80,7 @@ export class StateManager {
 
     const pending: PendingContinuation = {
       active: true,
+      expectedRunId,
       bind: (input) => {
         if (pending.active) pending.expectedInput = input;
       },
@@ -152,7 +160,12 @@ export class StateManager {
           // runId so the new run's state doesn't collide with the old one.
           subRunId = randomUUID();
         } else {
-          subRunId = input.runId;
+          // An internal continuation re-stamps onto the run id it continues, so
+          // the follow-up does not have to REUSE that id on the wire to look
+          // like one run. Reusing it on the wire made the transport treat the
+          // follow-up as the same run and re-deliver the already-applied half,
+          // which duplicated its tool calls and lost the continuation's own.
+          subRunId = internalContinuation?.expectedRunId ?? input.runId;
         }
         runFinished = false;
         this.handleRunStarted(agent, effectiveInput(input), state);

--- a/packages/react-core/src/hooks/__tests__/use-copilot-action.e2e.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-copilot-action.e2e.test.tsx
@@ -133,9 +133,18 @@ describe("useCopilotAction legacy HITL follow-up", () => {
     await waitFor(() => {
       expect(agent.runInputs).toHaveLength(2);
     });
-    expect(agent.runInputs.map((input) => input.runId)).toEqual([
-      agent.runInputs[0].runId,
-      agent.runInputs[0].runId,
-    ]);
+    // The first invocation carries the run id. The follow-up deliberately does
+    // NOT repeat it on the wire: pinning it there made the transport treat the
+    // follow-up as a resumption of a run it had already finished, re-delivering
+    // that run's applied half (duplicating its tool calls) and losing the
+    // continuation's own tool call.
+    //
+    // Logical identity is preserved a layer up — the continuation is registered
+    // against the originating id and the state manager re-stamps its events onto
+    // it — so this asserts the follow-up happened and left the id to the
+    // transport, not that the wire repeats it. StateManager's "re-stamps a
+    // continuation onto the run it continues" test covers the identity end.
+    expect(agent.runInputs[0].runId).toBeDefined();
+    expect(agent.runInputs[1].runId).not.toBe(agent.runInputs[0].runId);
   });
 });


### PR DESCRIPTION
Linear: [CPK-7786](https://linear.app/copilotkit/issue/CPK-7786/hitl-continuation-reuses-the-originating-run-id-on-the-wire-breaking)

Regression fix. **Nothing from #6296 is reverted** — its goal is kept and moved one layer up.

## What broke

#6296 (@rodboev) preserved the logical run id across a HITL resolve by pinning the originating id on the follow-up's agent invocation, correctly fixing #3456 (external tracing saw one logical run split into two halves).

Pinning it **on the wire**, though, made the transport treat the follow-up as a resumption of a run it had already finished:

- it re-delivered that run's already-applied half, duplicating every tool call on the message — each duplicate carrying **empty arguments**, because a start event has none and the `TOOL_CALL_ARGS` deltas that follow are addressed to the first copy; and
- the follow-up's own tool call never reached client state, so its card never rendered.

In `reskinnable-demo`'s banking skin that killed teach mode: the agent called `awaitDashboardDemonstration`, the server emitted `TOOL_CALL_START` for it, and the live "Recording your workflow" card never appeared — no REC indicator, no step feed, no "I'm done", so a demonstration could not be finished or saved.

## Evidence

- Intelligence event log shows **two `RUN_STARTED`/`RUN_FINISHED` cycles under one run id**, with `TOOL_CALL_START [awaitDashboardDemonstration]` in the second — the server does emit it.
- Instrumented `useRenderToolCall`: **never invoked** for that tool, despite its renderer being registered.
- Client message state after the click: `assistant tc:["recall_memory","recall_memory"]`, `assistant tc:["offerWorkflowRecording","offerWorkflowRecording"]` — prior cycle re-applied, new call absent.
- Bisect: reverting #6296's four source files makes the card appear; restoring them breaks it again. No later commit touches those files.
- Ruled out: React StrictMode (disabled in that app), model/prompt/tool-availability differences (byte-identical between the working and broken apps), and the view-layer dedupe from #6407.

## The fix

`markNextRunAsContinuation` already accepted an `expectedRunId` that was never used. It now records it, and the state manager re-stamps the continuation's events onto that id. So:

- **logical identity is preserved** — state/message association and external tracing still see one run, which is #6296's whole point;
- **the wire identifies the invocation honestly** — the follow-up no longer claims to be a run that already finished, so nothing is re-delivered and the continuation's own tool call lands.

## Test changes — please review this part closely

`core-follow-up`'s run-id test asserted the *mechanism* (both invocations carry the same wire id), which this deliberately changes. It now asserts the *goal*: the originating id is pinned on the first invocation, and the follow-up leaves the id to the transport. Its sibling assertion — the thread still knows exactly one run — was already there and passes untouched.

A new `StateManager` test covers the re-stamp directly, verified **red before green** by dropping the `expectedRunId` lookup (it fails, along with one of #6296's own tests).

@rodboev — flagging you directly since this touches your change from today. If the wire-level pinning was load-bearing for something I have not seen, say so and I will rework it.

## Verification

- `@copilotkit/core` 58 files and `@copilotkit/react-core` 123 files pass.
- In-browser against a live Intelligence stack: before, the recording card never rendered; after, it renders with its REC indicator and I'm done / Cancel controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)