### PR TITLE
fix: memoize object-content messages in CopilotChat fingerprint (#6327)

### DIFF
--- a/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -612,6 +612,18 @@ export function useCopilotChatInternal({
     threadId: existingConfig?.threadId ?? threadId,
   });
   const allMessages = agent?.messages ?? [];
+  const messagesFingerprint = useMemo(
+    () =>
+      allMessages
+        .map((m) =>
+          typeof m.content === "object" && m.content !== null
+            ? JSON.stringify(m.content)
+            : String(m.content ?? ""),
+        )
+        .join("|"),
+    [allMessages],
+  );
+
   const resolvedMessages = useMemo(() => {
     let processedMessages = allMessages.map((message) => {
       if (message.role !== "assistant") {
@@ -734,6 +746,7 @@ export function useCopilotChatInternal({
     return processedMessages;
   }, [
     agent?.messages,
+    messagesFingerprint,
     lazyToolRendered,
     allMessages,
     renderCustomMessage,

--- a/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
@@ -23,6 +23,13 @@ export function RenderMessage({
     markdownTagRenderers,
   } = props;
 
+  const hasContent =
+    typeof message.content === "string"
+      ? message.content.length > 0
+      : typeof message.content === "object" && message.content !== null
+        ? Object.keys(message.content).length > 0
+        : !!message.content;
+
   switch (message.role) {
     case "user":
       return (
@@ -43,8 +50,8 @@ export function RenderMessage({
           rawData={message}
           message={message}
           messages={messages}
-          isLoading={inProgress && isCurrentMessage && !message.content}
-          isGenerating={inProgress && isCurrentMessage && !!message.content}
+          isLoading={inProgress && isCurrentMessage && !hasContent}
+          isGenerating={inProgress && isCurrentMessage && hasContent}
           isCurrentMessage={isCurrentMessage}
           onRegenerate={() => onRegenerate?.(message.id)}
           onCopy={onCopy}


### PR DESCRIPTION
Fixes #6327

### Summary
1. ****: Added  using  for object-content messages (activity/tool messages) to ensure   invalidates when object-content properties update.
2. ****: Updated  logic to handle non-string object/array message content when computing  and  states.