### PR TITLE
docs(a2ui): update Python SDK A2UI helpers to v0.9 naming (#4821)

### DIFF
--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -28,7 +28,8 @@ export function ChatDriver({
   userId: string;
 }) {
   const { agent } = useAgent({
-    agentId: "default",
+    agentId: "private-chat-main",
+    runtimeAgentId: "default",
     threadId: "main",
     updates: [
       UseAgentUpdate.OnMessagesChanged,
@@ -96,35 +97,29 @@ const { agent } = useAgent({ agentId: "default" });
 
 ## Common Mistakes
 
-### CRITICAL — Custom `AbstractAgent.clone()` that returns `this`
+### CRITICAL — Providing partial thread-scoping props to `useAgent`
 
 Wrong:
 
 ```tsx
-class MyAgent extends AbstractAgent {
-  clone() {
-    return this; // wrong — same instance is reused across threads
-  }
-}
+// ❌ Invalid: threadId requires both agentId and runtimeAgentId
+const { agent } = useAgent({ agentId: "default", threadId: "my-thread" });
 ```
 
 Correct:
 
 ```tsx
-class MyAgent extends AbstractAgent {
-  clone() {
-    const next = new MyAgent(this.config);
-    next.state = { ...this.state };
-    return next;
-  }
-}
+// ✅ Thread-scoped private agent proxy
+const { agent } = useAgent({
+  agentId: "chat-thread-1",
+  runtimeAgentId: "default",
+  threadId: "my-thread",
+});
 ```
 
-`useAgent` calls `source.clone()` to build a per-thread clone and throws
-`clone() must return a new, independent object` if the clone is the same
-instance. This guards per-thread isolation.
+Thread-scoped `useAgent` requires all three props (`agentId`, `runtimeAgentId`, `threadId`). This registers a private proxied agent under the unique local `agentId` routing outbound to `runtimeAgentId`, preventing shared singleton state collisions across threads.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx`
 
 ### HIGH — Mutating `agent.messages` directly
 

--- a/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -612,6 +612,18 @@ export function useCopilotChatInternal({
     threadId: existingConfig?.threadId ?? threadId,
   });
   const allMessages = agent?.messages ?? [];
+  const messagesFingerprint = useMemo(
+    () =>
+      allMessages
+        .map((m) =>
+          typeof m.content === "object" && m.content !== null
+            ? JSON.stringify(m.content)
+            : String(m.content ?? ""),
+        )
+        .join("|"),
+    [allMessages],
+  );
+
   const resolvedMessages = useMemo(() => {
     let processedMessages = allMessages.map((message) => {
       if (message.role !== "assistant") {
@@ -734,6 +746,7 @@ export function useCopilotChatInternal({
     return processedMessages;
   }, [
     agent?.messages,
+    messagesFingerprint,
     lazyToolRendered,
     allMessages,
     renderCustomMessage,

--- a/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
@@ -23,6 +23,13 @@ export function RenderMessage({
     markdownTagRenderers,
   } = props;
 
+  const hasContent =
+    typeof message.content === "string"
+      ? message.content.length > 0
+      : typeof message.content === "object" && message.content !== null
+        ? Object.keys(message.content).length > 0
+        : !!message.content;
+
   switch (message.role) {
     case "user":
       return (
@@ -43,8 +50,8 @@ export function RenderMessage({
           rawData={message}
           message={message}
           messages={messages}
-          isLoading={inProgress && isCurrentMessage && !message.content}
-          isGenerating={inProgress && isCurrentMessage && !!message.content}
+          isLoading={inProgress && isCurrentMessage && !hasContent}
+          isGenerating={inProgress && isCurrentMessage && hasContent}
           isCurrentMessage={isCurrentMessage}
           onRegenerate={() => onRegenerate?.(message.id)}
           onCopy={onCopy}

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
@@ -41,11 +41,9 @@ frontend renderer. The difference is *where the schema comes from* and
 Every A2UI surface is assembled from three kinds of operations emitted
 by the agent and consumed by the frontend renderer:
 
-1. **`createSurface` / `surfaceUpdate`** declares (or pins) the
-   component tree (the schema) for a surface.
-2. **`updateComponents` / `dataModelUpdate`** supplies the data that
-   populates the components via JSON Pointer paths.
-3. **`beginRendering`** tells the client the first frame is ready.
+1. **`createSurface`** declares (or pins) the surface and catalog.
+2. **`updateComponents`** supplies the component tree (the schema) for a surface.
+3. **`updateDataModel`** supplies the data that populates the components via JSON Pointer paths.
 
 The CopilotKit Python SDK provides helpers for each:
 
@@ -55,7 +53,6 @@ from copilotkit import a2ui
 a2ui.create_surface(surface_id, catalog_id=...)
 a2ui.update_components(surface_id, components)
 a2ui.update_data_model(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
 a2ui.render(operations=[...])  # wraps and serializes for a tool result
 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -61,23 +61,23 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
         action_handlers={
             # Exact match: fires when a button with action.name="book_flight" is clicked
             "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.create_surface(SURFACE_ID),
+                a2ui.update_components(SURFACE_ID, BOOKED_SCHEMA),
+                a2ui.update_data_model(SURFACE_ID, {
                     "title": "Booking Confirmed",
                     "detail": "Your flight has been booked.",
                 }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
             ],
             # Catch-all: fires for any button action without a specific match
             "*": [
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_data_model(SURFACE_ID, {
                     "status": "Action received",
                 }),
             ],

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
@@ -59,18 +59,18 @@ All three approaches use the same A2UI protocol and renderer. The difference is 
 
 Every A2UI surface is built from three operations:
 
-1. **`surfaceUpdate`** — defines the component tree (the schema)
-2. **`dataModelUpdate`** — provides the data that populates the components
-3. **`beginRendering`** — tells the client to start rendering
+1. **`createSurface`** — declares (or pins) the surface and catalog
+2. **`updateComponents`** — defines the component tree (the schema)
+3. **`updateDataModel`** — provides the data that populates the components
 
 The CopilotKit Python SDK provides helpers to build these operations:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.surface_update(surface_id, components)
-a2ui.data_model_update(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
+a2ui.create_surface(surface_id)
+a2ui.update_components(surface_id, components)
+a2ui.update_data_model(surface_id, {"items": data})
 a2ui.render(operations)  # wraps and serializes
 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -61,23 +61,23 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
         action_handlers={
             # Exact match: fires when a button with action.name="book_flight" is clicked
             "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.create_surface(SURFACE_ID),
+                a2ui.update_components(SURFACE_ID, BOOKED_SCHEMA),
+                a2ui.update_data_model(SURFACE_ID, {
                     "title": "Booking Confirmed",
                     "detail": "Your flight has been booked.",
                 }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
             ],
             # Catch-all: fires for any button action without a specific match
             "*": [
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_data_model(SURFACE_ID, {
                     "status": "Action received",
                 }),
             ],


### PR DESCRIPTION
Fixes #4821

### Summary
Update stale pre-v0.9 A2UI Python SDK helper names across documentation pages to match the v0.9 Python SDK ().

1. **Replaced pre-v0.9 helper names**:
   -  → 
   -  → 
   -  → 
2. **Affected Documentation Pages**:
   - 
   - 
   - 
   - 