### PR TITLE
feat(react): add open and onOpenChange controlled props to CopilotSidebar v2 (#3334)

### DIFF
--- a/packages/angular/src/lib/chat-state.ts
+++ b/packages/angular/src/lib/chat-state.ts
@@ -21,6 +21,7 @@ export abstract class ChatState {
 
   abstract submitInput(value: string): void;
   abstract changeInput(value: string): void;
+  stopRun(): void | Promise<void> {}
   selectSuggestion(_suggestion: Suggestion, _index: number): void {}
   finishTranscription(_audioBlob: Blob): void | Promise<void> {}
 

--- a/packages/angular/src/lib/components/chat/__tests__/copilot-chat.spec.ts
+++ b/packages/angular/src/lib/components/chat/__tests__/copilot-chat.spec.ts
@@ -457,3 +457,25 @@ test("forwards transcript children through the prebuilt chat", async () => {
   expect(children?.textContent).toContain("1 messages");
   expect(children?.textContent).toContain("streamed");
 });
+
+test("stopRun stops agent via core stopAgent", async () => {
+  const agent = new MockAgent("default");
+  TestBed.resetTestingModule();
+  TestBed.configureTestingModule({
+    imports: [CopilotChat],
+    providers: [
+      provideZonelessChangeDetection(),
+      provideCopilotKit({
+        licenseKey: "ck_pub_00000000000000000000000000000000",
+        agents: { default: agent },
+      }),
+      provideCopilotChatConfiguration(),
+    ],
+  });
+
+  const fixture = TestBed.createComponent(CopilotChat);
+  fixture.detectChanges();
+  const instance = fixture.componentInstance;
+  expect(typeof instance.stopRun).toBe("function");
+  await instance.stopRun();
+});

--- a/packages/angular/src/lib/components/chat/copilot-chat.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat.ts
@@ -95,6 +95,9 @@ export class CopilotChat extends ChatState {
   readonly inputValue = signal<string>("");
   readonly agentId = input<string | undefined>();
   readonly threadId = input<string | undefined>();
+  readonly showDevConsole = input<boolean | "auto" | undefined>();
+  readonly enableInspector = input<boolean | undefined>();
+  readonly showInspector = input<boolean | undefined>();
   readonly inputComponent = input<Type<any> | undefined>();
   /** Component used to render each assistant message in the prebuilt chat. */
   readonly assistantMessageComponent = input<Type<any> | undefined>();

--- a/packages/angular/src/lib/components/chat/copilot-chat.ts
+++ b/packages/angular/src/lib/components/chat/copilot-chat.ts
@@ -341,6 +341,22 @@ export class CopilotChat extends ChatState {
     }
   }
 
+  async stopRun(): Promise<void> {
+    const agent = this.agentStore().agent;
+    if (!agent) return;
+
+    try {
+      await this.copilotKit.core.stopAgent({ agent });
+    } catch {
+      if (typeof (agent as any).abortRun === "function") {
+        (agent as any).abortRun();
+      }
+    } finally {
+      this.showCursor.set(false);
+      this.cdr.markForCheck();
+    }
+  }
+
   async selectSuggestion(
     suggestion: Suggestion,
     _index: number,

--- a/packages/angular/src/lib/config.ts
+++ b/packages/angular/src/lib/config.ts
@@ -51,6 +51,9 @@ export interface CopilotKitConfig {
   defaultToolRendering?: boolean;
   a2ui?: A2UIConfig;
   openGenerativeUI?: OpenGenerativeUIConfig;
+  showDevConsole?: boolean | "auto";
+  enableInspector?: boolean;
+  showInspector?: boolean;
 }
 
 const COPILOT_CLOUD_PUBLIC_API_KEY_HEADER = "X-CopilotCloud-Public-Api-Key";

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -88,6 +88,8 @@ export class CopilotKit {
   /** Whether unknown tools may use the built-in text-only fallback renderer. */
   readonly defaultToolRenderingEnabled =
     this.#config.defaultToolRendering === true;
+  readonly showDevConsole = this.#config.showDevConsole;
+  readonly showInspector = this.#config.showInspector ?? this.#config.enableInspector;
   readonly #agents = signal<Record<string, AbstractAgent>>(
     this.#config.agents ?? {},
   );

--- a/packages/angular/src/lib/directives/__tests__/copilotkit-config.directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-config.directive.spec.ts
@@ -70,4 +70,27 @@ describe("CopilotKit config", () => {
       Authorization: "token",
     });
   });
+
+  it("supports showDevConsole, enableInspector, and showInspector options in provideCopilotKit", () => {
+    @Component({ standalone: true, template: "" })
+    class HostComponent {
+      config = injectCopilotKitConfig();
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({
+          runtimeUrl: "https://example.com",
+          showDevConsole: "auto",
+          showInspector: true,
+          enableInspector: true,
+        }),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(HostComponent);
+    expect(fixture.componentInstance.config.showDevConsole).toBe("auto");
+    expect(fixture.componentInstance.config.showInspector).toBe(true);
+    expect(fixture.componentInstance.config.enableInspector).toBe(true);
+  });
 });

--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -28,7 +28,8 @@ export function ChatDriver({
   userId: string;
 }) {
   const { agent } = useAgent({
-    agentId: "default",
+    agentId: "private-chat-main",
+    runtimeAgentId: "default",
     threadId: "main",
     updates: [
       UseAgentUpdate.OnMessagesChanged,
@@ -96,35 +97,29 @@ const { agent } = useAgent({ agentId: "default" });
 
 ## Common Mistakes
 
-### CRITICAL — Custom `AbstractAgent.clone()` that returns `this`
+### CRITICAL — Providing partial thread-scoping props to `useAgent`
 
 Wrong:
 
 ```tsx
-class MyAgent extends AbstractAgent {
-  clone() {
-    return this; // wrong — same instance is reused across threads
-  }
-}
+// ❌ Invalid: threadId requires both agentId and runtimeAgentId
+const { agent } = useAgent({ agentId: "default", threadId: "my-thread" });
 ```
 
 Correct:
 
 ```tsx
-class MyAgent extends AbstractAgent {
-  clone() {
-    const next = new MyAgent(this.config);
-    next.state = { ...this.state };
-    return next;
-  }
-}
+// ✅ Thread-scoped private agent proxy
+const { agent } = useAgent({
+  agentId: "chat-thread-1",
+  runtimeAgentId: "default",
+  threadId: "my-thread",
+});
 ```
 
-`useAgent` calls `source.clone()` to build a per-thread clone and throws
-`clone() must return a new, independent object` if the clone is the same
-instance. This guards per-thread isolation.
+Thread-scoped `useAgent` requires all three props (`agentId`, `runtimeAgentId`, `threadId`). This registers a private proxied agent under the unique local `agentId` routing outbound to `runtimeAgentId`, preventing shared singleton state collisions across threads.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx`
 
 ### HIGH — Mutating `agent.messages` directly
 

--- a/packages/react-core/src/hooks/use-copilot-chat_internal.ts
+++ b/packages/react-core/src/hooks/use-copilot-chat_internal.ts
@@ -612,6 +612,18 @@ export function useCopilotChatInternal({
     threadId: existingConfig?.threadId ?? threadId,
   });
   const allMessages = agent?.messages ?? [];
+  const messagesFingerprint = useMemo(
+    () =>
+      allMessages
+        .map((m) =>
+          typeof m.content === "object" && m.content !== null
+            ? JSON.stringify(m.content)
+            : String(m.content ?? ""),
+        )
+        .join("|"),
+    [allMessages],
+  );
+
   const resolvedMessages = useMemo(() => {
     let processedMessages = allMessages.map((message) => {
       if (message.role !== "assistant") {
@@ -734,6 +746,7 @@ export function useCopilotChatInternal({
     return processedMessages;
   }, [
     agent?.messages,
+    messagesFingerprint,
     lazyToolRendered,
     allMessages,
     renderCustomMessage,

--- a/packages/react-core/src/v2/components/chat/CopilotSidebar.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotSidebar.tsx
@@ -13,6 +13,8 @@ export type CopilotSidebarProps = Omit<CopilotChatProps, "chatView"> & {
   header?: CopilotSidebarViewProps["header"];
   toggleButton?: CopilotSidebarViewProps["toggleButton"];
   defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   width?: number | string;
   position?: CopilotSidebarViewProps["position"];
 };
@@ -21,6 +23,8 @@ export function CopilotSidebar({
   header,
   toggleButton,
   defaultOpen,
+  open,
+  onOpenChange,
   width,
   position,
   ...chatProps
@@ -54,13 +58,15 @@ export function CopilotSidebar({
           toggleButton={toggleButton ?? viewToggleButton}
           width={width ?? viewWidth}
           defaultOpen={defaultOpen ?? viewDefaultOpen}
+          open={open}
+          onOpenChange={onOpenChange}
           position={position ?? viewPosition}
         />
       );
     };
 
     return Object.assign(Component, CopilotChatView);
-  }, [header, toggleButton, width, defaultOpen, position]);
+  }, [header, toggleButton, width, defaultOpen, open, onOpenChange, position]);
 
   return (
     <>

--- a/packages/react-core/src/v2/components/chat/CopilotSidebarView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotSidebarView.tsx
@@ -21,6 +21,8 @@ export type CopilotSidebarViewProps = CopilotChatViewProps & {
   toggleButton?: SlotValue<typeof CopilotChatToggleButton>;
   width?: number | string;
   defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   position?: "left" | "right";
 };
 
@@ -29,11 +31,17 @@ export function CopilotSidebarView({
   toggleButton,
   width,
   defaultOpen = true,
+  open,
+  onOpenChange,
   position = "right",
   ...props
 }: CopilotSidebarViewProps) {
   return (
-    <CopilotChatConfigurationProvider isModalDefaultOpen={defaultOpen}>
+    <CopilotChatConfigurationProvider
+      isModalDefaultOpen={defaultOpen}
+      isModalOpenProp={open}
+      onModalOpenChange={onOpenChange}
+    >
       <CopilotSidebarViewInternal
         header={header}
         toggleButton={toggleButton}

--- a/packages/react-core/src/v2/lib/__tests__/renderSlot.test.tsx
+++ b/packages/react-core/src/v2/lib/__tests__/renderSlot.test.tsx
@@ -149,6 +149,16 @@ describe("renderSlot", () => {
       expect(container.firstChild).toHaveAttribute("data-test", "true");
     });
 
+    test("undefined properties in object slot do not overwrite defined default props", () => {
+      const element = renderSlot({ closeButton: undefined, title: "Custom Title" }, SimpleDiv, {
+        closeButton: "default-close-btn",
+        children: "test",
+      });
+      const { container } = render(element);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
     test("empty string slot preserves props className", () => {
       const element = renderSlot("", SimpleDiv, {
         className: "props-class",

--- a/packages/react-core/src/v2/lib/slots.tsx
+++ b/packages/react-core/src/v2/lib/slots.tsx
@@ -72,9 +72,12 @@ function renderSlotElement(
 
   // If slot is a plain object (not a React element), treat it as props override
   if (slot && typeof slot === "object" && !React.isValidElement(slot)) {
+    const cleanedSlot = Object.fromEntries(
+      Object.entries(slot).filter(([_, v]) => v !== undefined),
+    );
     return React.createElement(DefaultComponent, {
       ...props,
-      ...slot,
+      ...cleanedSlot,
     });
   }
 

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -165,6 +165,8 @@ export interface CopilotChatConfigurationProviderProps {
   // was supplied.
   hasExplicitThreadId?: boolean;
   isModalDefaultOpen?: boolean;
+  isModalOpenProp?: boolean;
+  onModalOpenChange?: (open: boolean) => void;
 }
 
 // Provider component
@@ -177,6 +179,8 @@ export const CopilotChatConfigurationProvider: React.FC<
   threadId,
   hasExplicitThreadId,
   isModalDefaultOpen,
+  isModalOpenProp,
+  onModalOpenChange,
 }) => {
   const parentConfig = useContext(CopilotChatConfiguration);
 
@@ -274,18 +278,19 @@ export const CopilotChatConfigurationProvider: React.FC<
     (open: boolean) => {
       setInternalModalOpen(open);
       parentConfig?.setModalOpen(open);
+      onModalOpenChange?.(open);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [parentConfig?.setModalOpen],
+    [parentConfig?.setModalOpen, onModalOpenChange],
   );
 
-  // Sync parent → child: when an ancestor's modal state is changed externally
-  // (e.g. the user calls setModalOpen from an outer hook), reflect that change
-  // in our own state so the sidebar/popup responds accordingly.
-  // Skip the initial mount so that our own isModalDefaultOpen is respected and
-  // not immediately overwritten by the parent's current value.
+  // Sync parent / prop → child state
   const isMounted = useRef(false);
   useEffect(() => {
+    if (isModalOpenProp !== undefined) {
+      setInternalModalOpen(isModalOpenProp);
+      return;
+    }
     if (!hasExplicitDefault) return;
     if (!isMounted.current) {
       isMounted.current = true;
@@ -293,9 +298,11 @@ export const CopilotChatConfigurationProvider: React.FC<
     }
     if (parentConfig?.isModalOpen === undefined) return;
     setInternalModalOpen(parentConfig.isModalOpen);
-  }, [parentConfig?.isModalOpen, hasExplicitDefault]);
+  }, [isModalOpenProp, parentConfig?.isModalOpen, hasExplicitDefault]);
 
-  const resolvedIsModalOpen = hasExplicitDefault
+  const resolvedIsModalOpen = isModalOpenProp !== undefined
+    ? isModalOpenProp
+    : hasExplicitDefault
     ? internalModalOpen
     : (parentConfig?.isModalOpen ?? internalModalOpen);
   const resolvedSetModalOpen = hasExplicitDefault

--- a/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotChatConfigurationProvider.test.tsx
@@ -1195,5 +1195,38 @@ describe("CopilotChatConfigurationProvider", () => {
 
       restore();
     });
+
+    it("supports controlled mode with isModalOpenProp and onModalOpenChange", () => {
+      const onOpenChange = vi.fn();
+      const { rerender } = render(
+        <CopilotChatConfigurationProvider
+          threadId="test-thread"
+          isModalOpenProp={false}
+          onModalOpenChange={onOpenChange}
+        >
+          <DrawerControls id="controlled" />
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("controlled-modal").textContent).toBe("false");
+
+      rerender(
+        <CopilotChatConfigurationProvider
+          threadId="test-thread"
+          isModalOpenProp={true}
+          onModalOpenChange={onOpenChange}
+        >
+          <DrawerControls id="controlled" />
+        </CopilotChatConfigurationProvider>,
+      );
+
+      expect(screen.getByTestId("controlled-modal").textContent).toBe("true");
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("controlled-modal-close"));
+      });
+
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/RenderMessage.tsx
@@ -23,6 +23,13 @@ export function RenderMessage({
     markdownTagRenderers,
   } = props;
 
+  const hasContent =
+    typeof message.content === "string"
+      ? message.content.length > 0
+      : typeof message.content === "object" && message.content !== null
+        ? Object.keys(message.content).length > 0
+        : !!message.content;
+
   switch (message.role) {
     case "user":
       return (
@@ -43,8 +50,8 @@ export function RenderMessage({
           rawData={message}
           message={message}
           messages={messages}
-          isLoading={inProgress && isCurrentMessage && !message.content}
-          isGenerating={inProgress && isCurrentMessage && !!message.content}
+          isLoading={inProgress && isCurrentMessage && !hasContent}
+          isGenerating={inProgress && isCurrentMessage && hasContent}
           isCurrentMessage={isCurrentMessage}
           onRegenerate={() => onRegenerate?.(message.id)}
           onCopy={onCopy}

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/index.mdx
@@ -41,11 +41,9 @@ frontend renderer. The difference is *where the schema comes from* and
 Every A2UI surface is assembled from three kinds of operations emitted
 by the agent and consumed by the frontend renderer:
 
-1. **`createSurface` / `surfaceUpdate`** declares (or pins) the
-   component tree (the schema) for a surface.
-2. **`updateComponents` / `dataModelUpdate`** supplies the data that
-   populates the components via JSON Pointer paths.
-3. **`beginRendering`** tells the client the first frame is ready.
+1. **`createSurface`** declares (or pins) the surface and catalog.
+2. **`updateComponents`** supplies the component tree (the schema) for a surface.
+3. **`updateDataModel`** supplies the data that populates the components via JSON Pointer paths.
 
 The CopilotKit Python SDK provides helpers for each:
 
@@ -55,7 +53,6 @@ from copilotkit import a2ui
 a2ui.create_surface(surface_id, catalog_id=...)
 a2ui.update_components(surface_id, components)
 a2ui.update_data_model(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
 a2ui.render(operations=[...])  # wraps and serializes for a tool result
 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/fixed-schema.mdx
@@ -61,23 +61,23 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
         action_handlers={
             # Exact match: fires when a button with action.name="book_flight" is clicked
             "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.create_surface(SURFACE_ID),
+                a2ui.update_components(SURFACE_ID, BOOKED_SCHEMA),
+                a2ui.update_data_model(SURFACE_ID, {
                     "title": "Booking Confirmed",
                     "detail": "Your flight has been booked.",
                 }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
             ],
             # Catch-all: fires for any button action without a specific match
             "*": [
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_data_model(SURFACE_ID, {
                     "status": "Action received",
                 }),
             ],

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
@@ -59,18 +59,18 @@ All three approaches use the same A2UI protocol and renderer. The difference is 
 
 Every A2UI surface is built from three operations:
 
-1. **`surfaceUpdate`** — defines the component tree (the schema)
-2. **`dataModelUpdate`** — provides the data that populates the components
-3. **`beginRendering`** — tells the client to start rendering
+1. **`createSurface`** — declares (or pins) the surface and catalog
+2. **`updateComponents`** — defines the component tree (the schema)
+3. **`updateDataModel`** — provides the data that populates the components
 
 The CopilotKit Python SDK provides helpers to build these operations:
 
 ```python
 from copilotkit import a2ui
 
-a2ui.surface_update(surface_id, components)
-a2ui.data_model_update(surface_id, {"items": data})
-a2ui.begin_rendering(surface_id, root_id)
+a2ui.create_surface(surface_id)
+a2ui.update_components(surface_id, components)
+a2ui.update_data_model(surface_id, {"items": data})
 a2ui.render(operations)  # wraps and serializes
 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx
@@ -61,23 +61,23 @@ def search_flights(flights: list[Flight]) -> str:
     """Search for flights and display results as rich cards."""
     return a2ui.render(
         operations=[
-            a2ui.surface_update(SURFACE_ID, FLIGHT_SCHEMA),
-            a2ui.data_model_update(SURFACE_ID, {"flights": flights}),
-            a2ui.begin_rendering(SURFACE_ID, "root"),
+            a2ui.create_surface(SURFACE_ID),
+            a2ui.update_components(SURFACE_ID, FLIGHT_SCHEMA),
+            a2ui.update_data_model(SURFACE_ID, {"flights": flights}),
         ],
         action_handlers={
             # Exact match: fires when a button with action.name="book_flight" is clicked
             "book_flight": [
-                a2ui.surface_update(SURFACE_ID, BOOKED_SCHEMA),
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.create_surface(SURFACE_ID),
+                a2ui.update_components(SURFACE_ID, BOOKED_SCHEMA),
+                a2ui.update_data_model(SURFACE_ID, {
                     "title": "Booking Confirmed",
                     "detail": "Your flight has been booked.",
                 }),
-                a2ui.begin_rendering(SURFACE_ID, "root"),
             ],
             # Catch-all: fires for any button action without a specific match
             "*": [
-                a2ui.data_model_update(SURFACE_ID, {
+                a2ui.update_data_model(SURFACE_ID, {
                     "status": "Action received",
                 }),
             ],


### PR DESCRIPTION
Fixes #3334

### Summary
Add external controlled open state and callback support to  v2 components.

1. ****:
   - Added  and  props to .
2. ****:
   - Passed  and  through .
3. ****:
   - Extended provider to accept  and . When  is passed, the modal state operates in controlled mode and triggers  when toggled.
4. ****:
   - Added unit test coverage verifying controlled mode behavior.