### PR TITLE
fix(reskinnable-demo): resolve thread-list identity from the query-string agentId

### DIFF
--- a/examples/showcases/reskinnable-demo/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -92,11 +92,30 @@ const intelligenceEnabled = Boolean(
  */
 function agentIdFromUrl(url: string): string | undefined {
   try {
-    const segments = new URL(url).pathname.split("/").filter(Boolean);
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
     const i = segments.lastIndexOf("agent");
     if (i >= 0 && i + 1 < segments.length) {
       return decodeURIComponent(segments[i + 1]!);
     }
+    // THREAD ROUTES CARRY THE AGENT IN THE QUERY STRING, NOT THE PATH.
+    //
+    // Run/suggest/connect are `/agent/:agentId/...`, but the thread list is
+    // `/threads?agentId=<id>`. Reading only the path meant every thread-list
+    // request looked agentId-LESS and fell through to `defaultSkinId`'s
+    // resolver — i.e. banking's — so a non-default skin listed threads under
+    // banking's end-user id and got an empty array back. Its runs, which DO go
+    // through `/agent/:id/run`, resolved correctly, so threads were created
+    // under one identity and listed under another.
+    //
+    // The symptom is nasty precisely because nothing errors: the thread rail
+    // just says "No conversations yet" forever and a browser reload never
+    // restores the conversation, which reads as "this product doesn't persist
+    // threads" — the exact opposite of what the demo is trying to prove.
+    // Banking was immune only because it IS `defaultSkinId`; airline,
+    // logistics, keel and people were all affected.
+    const fromQuery = parsed.searchParams.get("agentId");
+    if (fromQuery) return fromQuery;
   } catch {
     // Malformed URL — treat as "no agentId" and fall back.
   }


### PR DESCRIPTION
## The bug

`agentIdFromUrl` in `src/app/api/copilotkit/[[...slug]]/route.ts` only read the target agent from the URL **path** (`/agent/:agentId/run`). Thread routes carry it in the **query string** instead (`/threads?agentId=<id>`), so every thread-list request looked agentId-less and fell through to `defaultSkinId`'s `identifyUser` — banking's.

That split identity for every non-default skin:

| path | resolves via | result |
| --- | --- | --- |
| `POST /agent/people/run` | `people`'s resolver ✅ | thread created under `rowan-demo-user` |
| `GET /threads?agentId=people` | **banking's** resolver ❌ | asks for `northwind-demo-user`, gets `[]` |

## Why it was hard to see

Nothing errors. The thread rail just reads *"No conversations yet"* forever and reopening a conversation after a reload is impossible — which reads to a viewer as "this product doesn't persist threads", the exact opposite of what the demo exists to prove. **Banking was immune only because it IS `defaultSkinId`.**

## The fix

Fall back to `?agentId=` from the query string when the path carries no `/agent/<id>` segment.

## Verification

Against a local Intelligence stack, thread counts from `GET /api/copilotkit/threads?agentId=<id>`:

| skin | before | after |
| --- | --- | --- |
| people | 0 | 11 |
| airline | 0 | 1 |
| logistics | 0 | 3 |
| banking | 7 | 7 (unchanged) |

Confirmed the backend held those threads all along — they were being listed under the wrong end-user id.

Skins with no `identifyUser` (airline) still fall through to `genericIdentity()` via the existing `if (!resolve)` guard, so this widens correct resolution without adding a failure mode.

`pnpm build`, `pnpm lint`, `pnpm test:unit` (335/335) green.

## Skill-staleness check

Per the app's standing rule: **checked, no skill impact.** This is shell-internal identity plumbing; `.claude/skills/reskin/` documents the `identifyUser` contract, which is unchanged — a skin still contributes the same resolver in the same place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)