### PR TITLE
feat(reskinnable-demo): add the `people` skin (Rowan), a demo-complete People Ops desk

### DIFF
--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   the user says "add a skin", "create a skin", "new skin", "reskin the app",
   "make a <domain> skin", or wants the app re-themed as a new product. Do NOT
   use for editing the shell itself (src/shell/**), the shared token vocabulary
-  (src/app/globals.css), or the four shipped skins unless explicitly asked.
+  (src/app/globals.css), or the five shipped skins unless explicitly asked.
 ---
 
 # Authoring a reskinnable-demo skin
@@ -26,13 +26,15 @@ contract in `src/skins/<id>/`, (3) put its **server-only** agent in
 the identical `id`.
 
 > Before writing anything, re-open `src/shell/skin-contract.ts` (the source of
-> truth) and read the shipped skins as worked references. Four are registered —
-> `banking`, `airline`, `logistics`, `keel` — and they are good at different
-> things; **[demo-beats.md](./demo-beats.md) § "Which skin to copy for what"**
-> is the routing table. The short version: `banking` is the maximal end and the
-> only demo-complete skin, `logistics` is the debugged layout reference,
-> `airline` is the minimal contract surface, `keel` is the only one with
-> parameterized routes. Those files win on any conflict with this skill.
+> truth) and read the shipped skins as worked references. Five are registered —
+> `banking`, `airline`, `logistics`, `keel`, `people` — and they are good at
+> different things; **[demo-beats.md](./demo-beats.md) § "Which skin to copy for
+> what"** is the routing table. The short version: `banking` and `people` are the
+> two demo-complete skins (`banking` is the original reference; `people` is the
+> newer one, and the only one whose beat map is written out in its
+> `suggestions.ts`), `logistics` is the debugged layout reference, `airline` is
+> the minimal contract surface, `keel` is the only one with parameterized routes.
+> Those files win on any conflict with this skill.
 
 ---
 
@@ -331,7 +333,8 @@ status, respond }`. Airline has no parameterized `useComponent`, so don't learn
   renders blank or wrong the moment anyone revisits the thread — which is exactly
   when beat 2 ("reload and the chart is still there") is being shown. Re-derive
   display state from the replayed result, and never depend on client state that
-  only existed during the live call. Banking is the only skin written this way:
+  only existed during the live call. Banking and people are the only skins
+  written this way; banking's is the canonical example:
   `setCardPin` re-derives its card from the replayed result plus a module map
   holding only `brand`/`last4` — never the PIN (`tools.tsx:70-89`, `418-451`) —
   and `showCharges` keys off `result` not `status` (`tools.tsx:553-572`).
@@ -341,11 +344,14 @@ status, respond }`. Airline has no parameterized `useComponent`, so don't learn
   each _page_ component tell it what is visibly on screen (active filters, the
   rows actually rendered, the figures shown). Without both, "what's on my
   screen?" (beat 3b) returns the same answer on every page and the beat dies.
-  Banking is the only skin that does this — route readable at
+  Banking and people are the only skins that do this. Banking: route readable at
   `layout.tsx:141-143`, page-scoped readables in `dashboard.tsx:148`,
-  `cards.tsx:376`, `team.tsx:54`, and the richest in `charges.tsx:139`. Pair them
-  with a prompt clause telling the agent its context IS its view of the screen
-  and that it must never claim it cannot see (`agent.ts:61-71`).
+  `cards.tsx:376`, `team.tsx:54`, and the richest in `charges.tsx:139`. People
+  does the same across all four of its pages, and is the tighter read if you want
+  one worked example — the route readable maps the index segment to a real page
+  NAME (`layout.tsx`'s `ROUTE_READABLE_NAME`) rather than reporting `""`. Pair
+  them either way with a prompt clause telling the agent its context IS its view
+  of the screen and that it must never claim it cannot see (`agent.ts:61-71`).
 
 ---
 
@@ -431,11 +437,11 @@ human phrases ("Pulling up your flight") instead of raw tool names (`showFlight`
 — treat `toolLabels` as expected for any skin with named frontend tools, not
 optional in practice. `RuntimeProviders`/`useRuntimeProperties`/`identifyUser`
 are for a skin with its own end-user identity (see the identity section above);
-banking, logistics and keel all three ship them, airline none.
+banking, logistics, keel and people all four ship them, airline none.
 
 `intelligence/seed-memories.ts` is **not** optional if you are building beats 4
 and 5 — "it already knows me" is a seeded file, not emergent behaviour, and only
-banking has one. It seeds the topical preference (beat 4) and the operational
+banking and people have one. It seeds the topical preference (beat 4) and the operational
 procedure (beat 5), and deliberately does NOT seed beat 6's procedure — that is
 the one the agent has to learn on stage. See
 **[demo-beats.md](./demo-beats.md) § "Seeding memories"**.

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/demo-beats.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/demo-beats.md
@@ -40,7 +40,7 @@ tell a deliberate choice from an oversight.
 **If the user named which beats to hit** — fewer, more, or different ones — theirs
 win outright. Record what they asked for in the map (`"user: BI dashboards only,
 no teach mode"`) and build that. Absent instructions, build all nine rows: that
-is what makes a skin demo-complete, and three of the four shipped skins are
+is what makes a skin demo-complete, and three of the five shipped skins are
 missing most of them (see "Which skin to copy" at the end).
 
 ---
@@ -140,10 +140,10 @@ value: <current segment> })` in your layout. Without it the agent has no idea
    screen: name the page, summarize the key elements, cite the actual figures,
    and **never** say it cannot see the screen.
 
-Every shipped skin registers readables. Only banking registers a route readable
-and per-page on-screen readables — which is why this beat is impossible in
-airline, logistics and keel today: they answer identically no matter which page
-is open.
+Every shipped skin registers readables. Only banking and people register a route
+readable AND per-page on-screen readables — which is why this beat is impossible
+in airline, logistics and keel today: they answer identically no matter which
+page is open.
 
 **Banking:** route readable at `layout.tsx:141-143`; global page/operation
 readables at `tools.tsx:162-170`; page-scoped on-screen readables in
@@ -386,9 +386,10 @@ The ask is 8–12 skins spanning that space. Two are called out explicitly:
   yourself, which is exactly why showing it working closes people.
 
 Other domains that fit the same buyer: healthcare operations (shipped as `keel`),
-supply chain / logistics (shipped), insurance claims, field service, HR and
-recruiting, legal contract review, retail merchandising, energy and utilities
-operations, customer-support command centers, manufacturing quality.
+supply chain / logistics (shipped), HR and people operations (shipped as
+`people`), insurance claims, field service, recruiting, legal contract review,
+retail merchandising, energy and utilities operations, customer-support command
+centers, manufacturing quality.
 
 **The bar is "holy shit" pretty, not "renders correctly."** Arm sales with
 something beautiful and they close monster deals; ship template output and the
@@ -399,18 +400,20 @@ and use the workspace's frontend-design skill rather than eyeballing it.
 
 ## Which skin to copy for what
 
-| Need                                  | Copy from                                                |
-| ------------------------------------- | -------------------------------------------------------- |
-| Every beat, end to end                | `banking` — the only skin at 6/6                         |
-| Route + on-screen readables (beat 3b) | `banking` — the only skin with them                      |
-| Teach mode (beat 6)                   | `banking` + `docs/teach-mode/README.md`                  |
-| Attachment staging (beat 3d)          | `banking` — `attach-invoice.ts`, `skin.tsx`              |
-| Debugged layout + meta-utility strip  | `logistics`                                              |
-| Server-emitted a2ui canvas            | `logistics` (`renderBrief`), `banking` (`render_report`) |
-| Per-user identity plumbing            | `banking`, `logistics`, `keel`                           |
-| Parameterized routes in `resolvePage` | `keel` (`knowledge/<docId>`, `runs/<runId>`)             |
-| In-memory `useData` substrate         | `airline`, `keel`                                        |
-| Minimal contract surface              | `airline`                                                |
+| Need                                  | Copy from                                                         |
+| ------------------------------------- | ----------------------------------------------------------------- |
+| Every beat, end to end                | `banking` or `people` — the two skins at 6/6                      |
+| A written-out beat map                | `people` — the table at the top of its `suggestions.ts`           |
+| Route + on-screen readables (beat 3b) | `banking`, `people`                                               |
+| Teach mode (beat 6)                   | `banking` + `docs/teach-mode/README.md`; `people` for a 2nd take  |
+| Attachment staging (beat 3d)          | `banking` (`attach-invoice.ts`), `people` (`attach-offer-letter`) |
+| Seeded memories (beats 4, 5)          | `banking`, `people` — the only two with a seed file               |
+| Debugged layout + meta-utility strip  | `logistics`, `people`                                             |
+| Server-emitted a2ui canvas            | `logistics` (`renderBrief`), `banking` (`render_report`)          |
+| Per-user identity plumbing            | `banking`, `logistics`, `keel`, `people`                          |
+| Parameterized routes in `resolvePage` | `keel` (`knowledge/<docId>`, `runs/<runId>`)                      |
+| In-memory `useData` substrate         | `airline`, `keel`                                                 |
+| Minimal contract surface              | `airline`                                                         |
 
 **Do not use airline, logistics or keel as demo-completeness references.** They
 predate this bar: each hits roughly one beat of nine. Logistics and keel are

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
@@ -2,8 +2,8 @@
 
 Copy each block into `src/skins/<id>/<file>` and replace `<id>` / `<Brand>` /
 domain specifics. These are written against this app's frozen `Skin` contract
-(`src/shell/skin-contract.ts`) and mirror the four shipped skins
-(`src/skins/{banking,airline,logistics,keel}/`) — see
+(`src/shell/skin-contract.ts`) and mirror the five shipped skins
+(`src/skins/{banking,airline,logistics,keel,people}/`) — see
 [demo-beats.md](./demo-beats.md) § "Which skin to copy for what" for which one to
 open for which problem.
 
@@ -378,8 +378,11 @@ respond }`. Do not copy the HITL `{ args }` shape into a `useComponent`.
 Reopening a thread replays recorded tool calls: you get the stored `result` and no
 live status transition. A render keyed on `status` is perfect live and blank or
 wrong on revisit — precisely when "reload and it's still there" is being demoed.
-Banking is the only skin written this way (`tools.tsx:70-89`, `418-451`,
-`553-572`).
+Banking and people are the only skins written this way — banking at
+`tools.tsx:70-89`, `418-451`, `553-572`; people's `setBaseSalary` render at
+`tools.tsx` recovers from an `answeredSalaryChanges` module map that holds the
+person's NAME and nothing else, so a replayed card can rebuild itself without
+the salary ever having been stored.
 
 **4. Readables must make the agent PAGE-AWARE** (beat 3b). Global readables
 (who the user is, the whole data set) are not enough: "what's on my screen?"
@@ -604,8 +607,9 @@ export const <id>IdentifyUser: IdentifyRunUser = (properties) => {
 ## `intelligence/seed-memories.ts` — REQUIRED for beats 4 and 5
 
 "It already knows me" is a **file**, not emergent behaviour. Mirror
-`src/skins/banking/intelligence/seed-memories.ts` — the only implementation in
-the repo, and its comments are worth reading in full. Server-safe plain `.ts`.
+`src/skins/banking/intelligence/seed-memories.ts` or
+`src/skins/people/intelligence/seed-memories.ts` — the only two in the repo, and
+both sets of comments are worth reading in full. Server-safe plain `.ts`.
 Called by your `dev/reset` route immediately after wiping memories, so the demo
 is re-armed before the presenter says a word.
 

--- a/examples/showcases/reskinnable-demo/CLAUDE.md
+++ b/examples/showcases/reskinnable-demo/CLAUDE.md
@@ -2,24 +2,24 @@
 
 One Next.js app whose **entire** experience — brand, theme, layout, pages,
 tools, and agent — is reskinnable at runtime. A skin-agnostic **shell** hosts
-one **skin** per route segment `/[skin]/...`. It ships four skins — `banking`,
-`airline`, `logistics` and `keel` — switchable from a dropdown at the top of the
+one **skin** per route segment `/[skin]/...`. It ships five skins — `banking`,
+`airline`, `logistics`, `keel` and `people` — switchable from a dropdown at the top of the
 assistant column, plus a repo-local **reskin skill**
 (`.claude/skills/reskin/`) for authoring new ones.
 
 The point of the app is the `Skin` contract: a single interface that swaps a
 whole product without the shell knowing anything domain-specific. The skins
-deliberately sit on **two different data substrates** — banking and logistics are
-REST-backed, airline and keel are in-memory — to prove the contract is
-substrate-agnostic.
+deliberately sit on **two different data substrates** — banking, logistics and
+people are REST-backed, airline and keel are in-memory — to prove the contract
+is substrate-agnostic.
 
 **Each skin is also a live sales demo.** It exists to prove CopilotKit and
 Intelligence top to bottom to an enterprise buyer, through a fixed set of demo
 **beats**: lead with generative UI, show that threads store AG-UI streams rather
 than text, manipulate the app four ways (drive it, read the screen, navigate via
 real levers, ingest a document into a durable artifact), recall long-term memory,
-replay a stored procedure, and learn a new one on stage. `banking` is the
-reference implementation and the only skin that currently hits every beat. The
+replay a stored procedure, and learn a new one on stage. `banking` is the original
+reference implementation; `people` is the second skin built to hit every beat. The
 beats, and what each one must prove, are specified in
 [`.claude/skills/reskin/demo-beats.md`](.claude/skills/reskin/demo-beats.md) —
 read it before adding or changing a skin's tools, prompt or suggestion pills,
@@ -183,11 +183,14 @@ export type IdentifyRunUser = (
 - **Banking** contributes `bankingIdentifyUser`
   (`src/skins/banking/intelligence/user-id.ts`), which maps the client-forwarded
   `properties` ({ userRole, userId }) onto its per-member/role memory scope.
-  **Logistics** and **keel** contribute one too (`logisticsIdentifyUser`,
-  `keelIdentifyUser`) for thread scoping — though neither yet uses it for durable
-  memory. **Airline** is the only skin that omits it (no auth, no memory).
-- Banking additionally ships `intelligence/seed-memories.ts` and
-  `intelligence/forget-memories.ts`, which its `dev/reset` route uses to wipe
+  **People** contributes `peopleIdentifyUser` and, like banking, actually uses it
+  for durable memory — its seeded preference belongs to one operator, so
+  switching operator lands in a different bucket. **Logistics** and **keel**
+  contribute one too (`logisticsIdentifyUser`, `keelIdentifyUser`) for thread
+  scoping — though neither yet uses it for durable memory. **Airline** is the
+  only skin that omits it (no auth, no memory).
+- Banking and people each additionally ship `intelligence/seed-memories.ts` and
+  `intelligence/forget-memories.ts`, which their `dev/reset` route uses to wipe
   learned memories and re-seed the ones the demo must start out already knowing.
   That file is what makes the long-term-memory and stored-procedure beats work;
   it is not emergent behaviour.
@@ -362,7 +365,7 @@ Gen-UI components registered via `useComponent` (airline's flight card, banking'
 charts and queues) render in the chat transcript, not on the canvas — that is a
 separate path from the full-region canvas surfaces above.
 
-## The four skins (why they differ)
+## The five skins (why they differ)
 
 Two substrates behind one contract is the architectural demonstration. Demo
 completeness is a **separate axis**, and the two do not correlate — see the beat
@@ -408,24 +411,40 @@ matrix at the end of this section.
   `resolvePage` is Map-based and resolves `knowledge/<docId>` → `DocumentPage` and
   `runs/<runId>` → `RunDetailPage` alongside its static segments.
 
+- **`people`** ("Rowan") — **REST-backed**, a People Ops command center, and the
+  second skin built demo-complete against the full beat list. Pages `roster`
+  (index), `compensation`, `requests`, `onboarding`, over `/api/people/v1/*`
+  (one `ledger` snapshot read plus the write paths, a generated `offer-letter`
+  PDF, and a gated `dev/reset`). Like banking and logistics it **omits
+  `useData`**, reading the ledger through its own `usePeopleLedger()` context —
+  mounted in `RuntimeProviders` rather than `Providers`, so the single fetch also
+  feeds `useRuntimeProperties`. Sets `Providers` (teach-mode recording),
+  `CanvasSurface` (server tool `render_people_brief`), `sandboxFunctions`,
+  `toolLabels`, `chatHeaderActions`, `onSuggestionSelect` and a server
+  `identifyUser`. Its teachable gate is approving an **out-of-band** compensation
+  request (422 `OUT_OF_BAND`), unlocked by a band exception filed under a
+  justifying code; two out-of-band requests are seeded so the case taught on
+  stage and the unaided replay are different people. Its beat map is written out
+  at the top of `src/skins/people/suggestions.ts`.
+
 ### Demo-beat coverage (the other axis)
 
-| Beat                             | banking                   | airline | logistics     | keel          |
-| -------------------------------- | ------------------------- | ------- | ------------- | ------------- |
-| Gen-UI in transcript             | ✅ 8                      | ✅ 6    | ✅ 5          | ✅ 5          |
-| Rich thread survives reload      | ✅ replay-safe tools      | ❌      | ❌            | ❌            |
-| Drive the app, secret withheld   | ✅                        | ❌      | ❌            | ❌            |
-| "What's on my screen?"           | ✅ route + page readables | ❌      | ❌            | ❌            |
-| Navigate via levers + filters    | ✅                        | ❌      | ❌            | nav only      |
-| Multimodal → durable artifact    | ✅                        | ❌      | ❌            | ❌            |
-| Long-term memory recall          | ✅                        | ❌      | plumbing only | plumbing only |
-| Stored-procedure replay          | ✅                        | ❌      | ❌            | ❌            |
-| Teach a new procedure            | ✅                        | ❌      | ❌            | ❌            |
-| Presenter reset (route + button) | ✅                        | ❌      | ✅            | ❌            |
+| Beat                             | banking                   | people                    | airline | logistics     | keel          |
+| -------------------------------- | ------------------------- | ------------------------- | ------- | ------------- | ------------- |
+| Gen-UI in transcript             | ✅ 8                      | ✅ 4                      | ✅ 6    | ✅ 5          | ✅ 5          |
+| Rich thread survives reload      | ✅ replay-safe tools      | ✅ replay-safe tools      | ❌      | ❌            | ❌            |
+| Drive the app, secret withheld   | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| "What's on my screen?"           | ✅ route + page readables | ✅ route + page readables | ❌      | ❌            | ❌            |
+| Navigate via levers + filters    | ✅                        | ✅                        | ❌      | ❌            | nav only      |
+| Multimodal → durable artifact    | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| Long-term memory recall          | ✅                        | ✅                        | ❌      | plumbing only | plumbing only |
+| Stored-procedure replay          | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| Teach a new procedure            | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| Presenter reset (route + button) | ✅                        | ✅                        | ❌      | ✅            | ❌            |
 
-`banking` hits every row; the others predate this bar and hit about one each
-(nine beats plus the presenter-reset requirement are listed above). Note that
-logistics and keel ship the **full per-user identity plumbing** —
+`banking` and `people` hit every row; airline, logistics and keel predate this
+bar and hit about one each (nine beats plus the presenter-reset requirement are
+listed above). Note that logistics and keel ship the **full per-user identity plumbing** —
 `RuntimeProviders`, `useRuntimeProperties`, server `identifyUser` — and then no
 memory prompts, no memory tools and no seed file, so they get no demo value from
 the hardest part of it. Treat all three as excellent **wiring** references and
@@ -484,10 +503,10 @@ Run tasks through Nx per the repo convention where applicable.
 ## Reference
 
 - `src/shell/skin-contract.ts` — the contract (source of truth).
-- `src/skins/{banking,logistics,airline,keel}/skin.tsx` — four implementations.
-  Open `banking` for demo completeness, `logistics` for layout chrome and the
-  server-emitted a2ui canvas, `airline` for the minimal contract surface, `keel`
-  for parameterized routes.
+- `src/skins/{banking,logistics,airline,keel,people}/skin.tsx` — five
+  implementations. Open `banking` or `people` for demo completeness, `logistics`
+  for layout chrome and the server-emitted a2ui canvas, `airline` for the
+  minimal contract surface, `keel` for parameterized routes.
 - `.claude/skills/reskin/` — the authoring skill: `SKILL.md` (contract + wiring
   traps), `demo-beats.md` (what the demo must prove, and the quality bar),
   `templates.md` (per-file starting points).

--- a/examples/showcases/reskinnable-demo/README.md
+++ b/examples/showcases/reskinnable-demo/README.md
@@ -90,8 +90,8 @@ contract, and the shared canvas / OGUI model.
 
 ## The banking skin's demo capabilities
 
-The banking skin is the richest of the four and doubles as a CopilotKit feature
-tour. Notable beats:
+The banking skin is the original reference demo and doubles as a CopilotKit
+feature tour (`people` is the other demo-complete skin). Notable beats:
 
 - **Components, never walls of text** — transactions, the approvals queue,
   charts, and spend summaries render as real components in the chat rather than
@@ -127,7 +127,7 @@ The images under `assets/` (`aurora-dashboard.png`, `copilot-chat.png`,
 skin** specifically — its dashboard, chat panel, and learning-mode recording
 vignette. They predate the current shell chrome entirely: there is now an inset
 frame of resizable cards with a skin-selector dropdown at the top of the assistant
-column, and the app ships four skins rather than two. Treat them as historical
+column, and the app ships five skins rather than two. Treat them as historical
 banking-skin illustrations rather than a picture of the app as it looks today.
 
 ## Testing

--- a/examples/showcases/reskinnable-demo/docs/teach-mode/README.md
+++ b/examples/showcases/reskinnable-demo/docs/teach-mode/README.md
@@ -3,7 +3,11 @@
 > Scope: this documents a feature of the **`banking` skin**
 > (`src/skins/banking/`), not the whole app. The app is a reskinnable shell that
 > hosts one skin per `/[skin]` route; see the top-level `CLAUDE.md`. Teach-mode
-> is banking-specific — the airline skin does not implement it.
+> is per-skin, not a shell feature: `banking` (documented here) and `people`
+> (out-of-band compensation approvals, gated by 422 `OUT_OF_BAND`) implement it;
+> `airline`, `logistics` and `keel` do not. The 5-role contract below is stated
+> demo-agnostically and `people` follows it role for role, so read this file
+> before building a third.
 
 "Teach mode" is the loop where the agent **fails a task it was never told how to
 do**, a human **demonstrates** the workaround in the UI, that demonstration is

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/band-exceptions/[id]/finalize/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/band-exceptions/[id]/finalize/route.ts
@@ -1,0 +1,24 @@
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/**
+ * BEAT 6, unlock step 2 — finalize a draft exception to `approved` and link it
+ * to its comp request.
+ *
+ * Note that finalizing a DECOY succeeds too. The linkage is real; only
+ * `store.hasApprovedJustifyingException` decides whether the gate lifts. Making
+ * this step succeed for every valid code is what keeps the discrimination in
+ * one place (the catalogue) instead of scattering "is this the right code?"
+ * across three endpoints where it could drift.
+ */
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    return Response.json(store.finalizeBandException(id), { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST band-exceptions/[id]/finalize");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/band-exceptions/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/band-exceptions/route.ts
@@ -1,0 +1,28 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/**
+ * BEAT 6, unlock step 1 — file a band exception against a comp request.
+ *
+ * Any code from the catalogue files successfully, including the DECOYS. That is
+ * deliberate: a decoy is a real exception, genuinely recorded in the history,
+ * that simply does not satisfy comp policy. So a successful POST here proves
+ * nothing about whether the gate will lift, and an agent that guessed a
+ * plausible-sounding code still fails at the approve step.
+ *
+ * An unrecognized code is refused WITHOUT listing the valid ones.
+ */
+export const POST = async (req: NextRequest) => {
+  try {
+    const body = await req.json();
+    const exception = store.openBandException(
+      String(body?.compRequestId ?? ""),
+      String(body?.code ?? ""),
+      String(body?.justification ?? "").trim(),
+    );
+    return Response.json(exception, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST band-exceptions");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/comp-requests/[id]/approve/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/comp-requests/[id]/approve/route.ts
@@ -1,0 +1,34 @@
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/**
+ * BEAT 6 — THE GATE.
+ *
+ * Approving a comp request writes the requested salary and level onto the
+ * employee. When the requested figure sits outside the band for the proposed
+ * level and no APPROVED, JUSTIFYING band exception is on file, `store` throws
+ * `OUT_OF_BAND` and this returns 422.
+ *
+ * The refusal is SYMPTOM-ONLY — see the note on `OUT_OF_BAND` in
+ * `src/skins/people/data/http.ts`. It says the band was exceeded; it never says
+ * anything about band exceptions, which codes justify, or that a path around
+ * the gate exists at all. That silence is what forces the agent to stop and ask
+ * to be shown, which is the beat.
+ *
+ * The gate is LIFTABLE, and both ways matter for the demo:
+ *   - `cmp-rhea` is in band, so this returns 201 with no exception at all —
+ *     proving the endpoint works and the 422 is a policy, not a bug.
+ *   - `cmp-marcus` / `cmp-naomi` are out of band, so they need the unlock.
+ */
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const { request, employee } = store.approveCompRequest(id);
+    return Response.json({ request, employee }, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST comp-requests/[id]/approve");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/comp-requests/[id]/decline/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/comp-requests/[id]/decline/route.ts
@@ -1,0 +1,15 @@
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/** Decline a comp request. Ungated — turning someone down never needs a band. */
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    return Response.json(store.declineCompRequest(id), { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST comp-requests/[id]/decline");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/dev/reset/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/dev/reset/route.ts
@@ -1,0 +1,106 @@
+import * as store from "@/skins/people/data/store";
+import { presenterResetEnabled } from "@/lib/presenter";
+import { forgetAllMemories } from "@/skins/people/intelligence/forget-memories";
+import { seedMemories } from "@/skins/people/intelligence/seed-memories";
+import {
+  DEMO_DEFAULT_USER_ID,
+  SEED_TARGET_USER_IDS,
+  SEEDED_USER_IDS,
+} from "@/skins/people/intelligence/user-id";
+
+/**
+ * Presenter/booth reset — put Rowan back to the state the demo starts from.
+ *
+ * Four things have to be true afterwards, and all four are easy to get wrong:
+ *   1. The ledger is re-seeded — both out-of-band comp requests pending again,
+ *      Dana with no buddy and no checklist, request aging re-freshened.
+ *   2. LEARNED memory is wiped, including the default bucket where memory
+ *      taught mid-demo actually lands. Skip that bucket and beat 6 starts out
+ *      already knowing the answer, which is the single most demo-destroying
+ *      form this bug takes: everything still works, it just proves nothing.
+ *   3. The beats 4/5 memories are put BACK, so "it already knows me" works on a
+ *      cold reset with no warm-up run.
+ *   4. Beat 6's procedure is still NOT known. That falls out of (2) + (3)
+ *      because `SEED_MEMORIES` deliberately omits it — see seed-memories.ts.
+ *
+ * Allowed when a booth deployment set PRESENTER_RESET_ENABLED, OR in any
+ * non-production environment. Keeping this in agreement with the sidebar button
+ * matters: gate it more tightly than the button and a production booth shows a
+ * Reset control that 403s.
+ */
+export const POST = async () => {
+  if (!presenterResetEnabled() && process.env.NODE_ENV === "production") {
+    return Response.json(
+      { error: "FORBIDDEN", message: "Not available in production." },
+      { status: 403 },
+    );
+  }
+
+  store.reset();
+
+  const apiUrl = process.env.INTELLIGENCE_API_URL;
+  const apiKey = process.env.INTELLIGENCE_API_KEY;
+  if (!apiUrl || !apiKey) {
+    // OSS path: there is no durable memory to clear, and beats 2/4/5/6 degrade
+    // by design. Report exactly what was reset rather than implying more.
+    return Response.json({ ok: true, reset: ["store"] });
+  }
+
+  // Declared outside the try so the catch can report PARTIAL progress: a
+  // mid-loop failure can leave the store reset and some identities already
+  // forgotten, and an error body that reads "memory untouched" would send a
+  // presenter looking in the wrong place.
+  let forgot = 0;
+  let seeded = 0;
+  // Project-scoped rows the forget helper deliberately left alone — they belong
+  // to sibling demos sharing this backend, not to Rowan. Reported rather than
+  // hidden: a non-zero count after a Rowan-only session means something saved
+  // project-scoped despite the prompt, which is the one way beat 6 could start
+  // out already taught. See intelligence/forget-memories.ts.
+  let skippedProjectScoped = 0;
+
+  const userIds = [...SEEDED_USER_IDS, DEMO_DEFAULT_USER_ID];
+  // Name the backend and the exact ids BEFORE mutating. Several demos in this
+  // repo vendor the same Intelligence stack, so if this process ever resolved a
+  // neighbour's apiUrl, this line is where a human sees the reset was about to
+  // reach across into someone else's memory.
+  console.warn(
+    `[people] presenter reset: forgetting memories at ${apiUrl} for ${userIds.join(", ")}`,
+  );
+
+  try {
+    for (const userId of userIds) {
+      const result = await forgetAllMemories({ apiUrl, apiKey, userId });
+      forgot += result.forgot;
+      skippedProjectScoped = Math.max(
+        skippedProjectScoped,
+        result.skippedProjectScoped,
+      );
+    }
+    // Seed EVERY target bucket — see SEED_TARGET_USER_IDS. Runs currently
+    // resolve to the default identity, so seeding only the mapped operator
+    // leaves recall looking at an empty bucket and beats 4/5 fail silently.
+    for (const userId of SEED_TARGET_USER_IDS) {
+      seeded += await seedMemories({ apiUrl, apiKey, userId });
+    }
+    return Response.json({
+      ok: true,
+      reset: ["store", "memory"],
+      apiUrl,
+      forgot,
+      seeded,
+      skippedProjectScoped,
+    });
+  } catch (err) {
+    return Response.json(
+      {
+        ok: false,
+        reset: forgot > 0 ? ["store", "memory"] : ["store"],
+        apiUrl,
+        forgot,
+        memoryError: err instanceof Error ? err.message : String(err),
+      },
+      { status: 502 },
+    );
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/buddy/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/buddy/route.ts
@@ -1,0 +1,18 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/** BEAT 5, step 2 — assign an onboarding buddy. */
+export const POST = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const updated = store.assignBuddy(id, String(body?.buddyId ?? ""));
+    return Response.json(updated, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST employees/[id]/buddy");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/compensation/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/compensation/route.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/**
+ * BEAT 3a — a merit increase.
+ *
+ * The figure arrives here from the chat card the USER typed it into, over a
+ * plain fetch from the browser. It was never a tool argument the model authored
+ * and it is never written back into the transcript: the frontend tool's
+ * `respond()` returns only a label ("Base salary updated for Priya Raman"). The
+ * response body below is read by the CLIENT to refresh the roster, not by the
+ * agent.
+ *
+ * The in-band check here is the same rule beat 6's gate enforces on comp
+ * requests. That is intentional — one policy, two entry points — but note the
+ * difference in framing: this path is for adjustments a People Ops lead makes
+ * inside the band, so a rejection is a plain validation error, not the
+ * teachable gate.
+ */
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const salary = Number(body?.baseSalary);
+    const updated = store.setBaseSalary(id, salary);
+    return Response.json(updated, { status: 200 });
+  } catch (error) {
+    return errorResponse(error, "PATCH employees/[id]/compensation");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/notes/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/notes/route.ts
@@ -1,0 +1,25 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/** BEAT 5, step 3 — the welcome note. The 🎉 prefix is forced by the tool. */
+export const POST = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const text = String(body?.text ?? "").trim();
+    if (!text) {
+      return Response.json(
+        { error: "BAD_REQUEST", message: "A note needs some text." },
+        { status: 400 },
+      );
+    }
+    const updated = store.addNote(id, text, String(body?.author ?? "Rowan"));
+    return Response.json(updated, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST employees/[id]/notes");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/onboarding-tasks/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/employees/[id]/onboarding-tasks/route.ts
@@ -1,0 +1,69 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/**
+ * BEAT 5, step 1 — build the new-hire checklist.
+ *
+ * The default list lives here rather than in the agent's prompt so the stored
+ * procedure the agent recalls can stay short ("create the onboarding tasks")
+ * instead of enumerating seven task labels it would then paraphrase differently
+ * every run. A demo that renders a slightly different checklist each time reads
+ * as improvisation.
+ */
+const DEFAULT_CHECKLIST = [
+  {
+    label: "Laptop, badge, and building access",
+    owner: "IT",
+    dueOffsetDays: -2,
+  },
+  {
+    label: "Payroll, benefits, and equity paperwork",
+    owner: "People Ops",
+    dueOffsetDays: 1,
+  },
+  {
+    label: "Repo access and development environment",
+    owner: "Engineering",
+    dueOffsetDays: 2,
+  },
+  {
+    label: "Safety certification for the robot cell",
+    owner: "Facilities",
+    dueOffsetDays: 5,
+  },
+  { label: "First-week pairing sessions", owner: "Buddy", dueOffsetDays: 5 },
+  {
+    label: "30-day check-in with the manager",
+    owner: "Manager",
+    dueOffsetDays: 30,
+  },
+];
+
+export const POST = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const body = await req.json().catch(() => ({}));
+    const supplied = Array.isArray(body?.tasks) ? body.tasks : null;
+    const tasks = supplied?.length
+      ? supplied.map(
+          (t: {
+            label?: unknown;
+            owner?: unknown;
+            dueOffsetDays?: unknown;
+          }) => ({
+            label: String(t?.label ?? "Task"),
+            owner: String(t?.owner ?? "People Ops"),
+            dueOffsetDays: Number(t?.dueOffsetDays ?? 0),
+          }),
+        )
+      : DEFAULT_CHECKLIST;
+    const created = store.createOnboardingTasks(id, tasks);
+    return Response.json(created, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST employees/[id]/onboarding-tasks");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/ledger/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/ledger/route.ts
@@ -1,0 +1,15 @@
+import * as store from "@/skins/people/data/store";
+
+/**
+ * The whole ledger in one read.
+ *
+ * Banking exposes a granular endpoint per collection; Rowan deliberately does
+ * not. Almost every surface here is cross-cutting — the ladder needs employees
+ * AND bands, the roster needs employees AND requests AND tasks, and the agent's
+ * readables need all of it — so N endpoints would mean N fetches, N loading
+ * states, and N chances for two panels on the same screen to disagree about
+ * what the data is. One snapshot keeps the page self-consistent, which matters
+ * more than usual here because beat 3b asks the agent to describe exactly what
+ * the user can see.
+ */
+export const GET = async () => Response.json(store.snapshot());

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/offer-letter/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/offer-letter/route.ts
@@ -1,0 +1,53 @@
+import * as store from "@/skins/people/data/store";
+import { buildOfferLetterPdf } from "@/skins/people/data/offer-letter-pdf";
+
+/**
+ * BEAT 3d — serves the offer letter the demo attaches.
+ *
+ * Generated per request from the live employee record, so the start date in the
+ * document always agrees with the seeded hire (whose dates are materialized
+ * relative to now). See `offer-letter-pdf.ts` for why this is not a static file
+ * in `public/`.
+ *
+ * Defaults to whoever is currently onboarding, so the letter follows the seed
+ * rather than hard-coding a name that a future reseed could rename.
+ */
+export const GET = async (req: Request) => {
+  const requested = new URL(req.url).searchParams.get("employeeId");
+  const employee =
+    (requested ? store.employee(requested) : undefined) ??
+    store.employees().find((e) => e.status === "onboarding");
+
+  if (!employee) {
+    return Response.json(
+      { error: "NOT_FOUND", message: "Nobody is onboarding right now." },
+      { status: 404 },
+    );
+  }
+
+  const manager = employee.managerId
+    ? store.employee(employee.managerId)
+    : undefined;
+  const pdf = buildOfferLetterPdf({
+    name: employee.name,
+    title: employee.title,
+    level: employee.level,
+    team: employee.team,
+    managerName: manager?.name ?? "the hiring manager",
+    location: employee.location,
+    startDate: employee.startDate,
+  });
+
+  return new Response(pdf as BodyInit, {
+    status: 200,
+    headers: {
+      "content-type": "application/pdf",
+      "content-disposition": `inline; filename="offer-letter-${employee.name
+        .toLowerCase()
+        .replace(/\s+/g, "-")}.pdf"`,
+      // Never cache: the start date is computed from `now`, and a cached copy
+      // would quietly go stale in exactly the way a static file would.
+      "cache-control": "no-store",
+    },
+  });
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/onboarding-tasks/[id]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/onboarding-tasks/[id]/route.ts
@@ -1,0 +1,18 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/** Tick a checklist item off — used by the Onboarding page's own checkboxes. */
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const updated = store.setTaskDone(id, Boolean(body?.done));
+    return Response.json(updated, { status: 200 });
+  } catch (error) {
+    return errorResponse(error, "PATCH onboarding-tasks/[id]");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/packets/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/packets/route.ts
@@ -1,0 +1,59 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/**
+ * BEAT 3d — the durable artifact.
+ *
+ * An onboarding packet is written to the STORE, so it belongs to the
+ * application and not to the conversation that produced it. That is the whole
+ * point of the beat: delete the thread, reload the browser, and the packet is
+ * still sitting on the Onboarding page. Nothing here references a thread id.
+ */
+export const GET = async () => Response.json(store.packets());
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const body = await req.json();
+    const employeeId = String(body?.employeeId ?? "");
+    const summary = String(body?.summary ?? "").trim();
+    if (!employeeId || !summary) {
+      return Response.json(
+        {
+          error: "BAD_REQUEST",
+          message: "A packet needs an employeeId and a summary.",
+        },
+        { status: 400 },
+      );
+    }
+    // Sanitize the model-authored arrays rather than trusting their shape: the
+    // agent fills these from an uploaded PDF, so a malformed row is a normal
+    // outcome, not an exceptional one.
+    const highlights = Array.isArray(body?.highlights)
+      ? body.highlights
+          .map((h: unknown) => String(h))
+          .filter(Boolean)
+          .slice(0, 3)
+      : [];
+    const schedule = Array.isArray(body?.schedule)
+      ? body.schedule
+          .map((s: { day?: unknown; item?: unknown }) => ({
+            day: String(s?.day ?? "").trim(),
+            item: String(s?.item ?? "").trim(),
+          }))
+          .filter((s: { day: string; item: string }) => s.day && s.item)
+          .slice(0, 8)
+      : [];
+
+    const packet = store.filePacket({
+      employeeId,
+      summary,
+      highlights,
+      schedule,
+      filedBy: String(body?.filedBy ?? "Rowan"),
+    });
+    return Response.json(packet, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST packets");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/people/v1/requests/[id]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/people/v1/requests/[id]/route.ts
@@ -1,0 +1,28 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/people/data/store";
+import { errorResponse } from "@/skins/people/data/http";
+
+/** Approve or decline a queue request (time off, equipment, training, …). */
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const status = body?.status;
+    if (status !== "approved" && status !== "declined") {
+      return Response.json(
+        {
+          error: "BAD_REQUEST",
+          message: 'status must be "approved" or "declined".',
+        },
+        { status: 400 },
+      );
+    }
+    const updated = store.decideRequest(id, status);
+    return Response.json(updated, { status: 200 });
+  } catch (error) {
+    return errorResponse(error, "PATCH requests/[id]");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/shell/agent-registry.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/agent-registry.ts
@@ -6,6 +6,8 @@ import { bankingIdentifyUser } from "@/skins/banking/intelligence/user-id";
 import { keelIdentifyUser } from "@/skins/keel/intelligence/user-id";
 import { logisticsAgent } from "@/skins/logistics/agent";
 import { logisticsIdentifyUser } from "@/skins/logistics/intelligence/user-id";
+import { peopleAgent } from "@/skins/people/agent";
+import { peopleIdentifyUser } from "@/skins/people/intelligence/user-id";
 
 /**
  * Server-safe map of skin id → its server-side registration (agent factory +
@@ -52,6 +54,10 @@ export const agentRegistry: Record<string, AgentRegistration> = {
   // Keel scopes Intelligence per persona (privacy/clinical staff), so it
   // contributes its own resolver alongside the agent factory.
   keel: { createAgent: keelAgent, identifyUser: keelIdentifyUser },
+  // Rowan scopes Intelligence per operator: the seeded beat-4 preference and
+  // beat-5 procedure belong to Maya, and switching to Clara must land in a
+  // different memory bucket so a colleague visibly has NOT taught it anything.
+  people: { createAgent: peopleAgent, identifyUser: peopleIdentifyUser },
 };
 
 export const agentIds = Object.keys(agentRegistry);

--- a/examples/showcases/reskinnable-demo/src/shell/registry.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/registry.ts
@@ -3,6 +3,7 @@ import banking from "@/skins/banking/skin";
 import airline from "@/skins/airline/skin";
 import logistics from "@/skins/logistics/skin";
 import keel from "@/skins/keel/skin";
+import people from "@/skins/people/skin";
 
 export { defaultSkinId } from "./skins-config";
 
@@ -13,6 +14,7 @@ export const SkinRegistry: Record<string, Skin> = {
   [airline.id]: airline,
   [logistics.id]: logistics,
   [keel.id]: keel,
+  [people.id]: people,
 };
 
 export function getSkin(id: string | undefined): Skin | null {

--- a/examples/showcases/reskinnable-demo/src/shell/skins-config.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/skins-config.ts
@@ -7,7 +7,13 @@ export const defaultSkinId = "banking";
 // must stay import-free for the server contexts above, and `registry.ts` pulls in
 // four client skin modules. `skins-config.test.ts` asserts the two stay in sync,
 // so the duplication cannot drift silently. Keep in registry order.
-export const skinIds = ["banking", "airline", "logistics", "keel"] as const;
+export const skinIds = [
+  "banking",
+  "airline",
+  "logistics",
+  "keel",
+  "people",
+] as const;
 
 // Skin id → { brand, tagline }, duplicated from each skin's `identity.brand`
 // and `identity.tagline` for the same reason as `skinIds`: the root layout's
@@ -35,5 +41,9 @@ export const skinIdentities: Record<
   keel: {
     brand: "Keel",
     tagline: "Harbor Point Health — knowledge and operations desk",
+  },
+  people: {
+    brand: "Rowan",
+    tagline: "The people operations desk.",
   },
 };

--- a/examples/showcases/reskinnable-demo/src/skins/people/agent.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/agent.ts
@@ -1,0 +1,228 @@
+import { BuiltInAgent, defineTool } from "@copilotkit/runtime/v2";
+import {
+  A2UI_OPERATIONS_KEY,
+  buildBriefOps,
+  renderBriefParams,
+  SURFACE_ID,
+} from "./build-brief-ops";
+
+/**
+ * Rowan's agent. SERVER-ONLY — no "use client", no JSX, no React. The client
+ * skin (`skin.tsx`) never imports this file; the only link between them is the
+ * shared id `"people"`. It is reached exclusively through the server-side
+ * `src/shell/agent-registry.ts`, which keeps `@copilotkit/runtime` out of the
+ * browser bundle.
+ *
+ * Most demo beats fail in the PROMPT, not in the wiring: the tools exist, the
+ * agent simply doesn't use them the way the demo needs. So the prompt below is
+ * a set of named clauses, each carrying a specific beat, and the comments say
+ * which.
+ */
+
+/**
+ * The a2ui report canvas. This MUST be a server tool. The a2ui middleware only
+ * converts an `{ [A2UI_OPERATIONS_KEY]: ops }` payload into an `a2ui-surface`
+ * activity when it observes it in an in-stream TOOL_CALL_RESULT event, which a
+ * client frontend-tool result never produces — emit these client-side and the
+ * canvas stays permanently blank with no error anywhere.
+ *
+ * A fresh surfaceId per render, so dismissing one brief never suppresses the
+ * next.
+ */
+const renderPeopleBriefTool = defineTool({
+  name: "render_people_brief",
+  description:
+    "Render the People Review brief on the CANVAS — the full-page artifact a " +
+    "People Ops lead takes into a leadership review. Supply SELECTIONS and " +
+    "LABEL-ONLY text; never numbers. Every figure is bound to live app data by " +
+    "the renderer, so anything you typed would be ignored anyway. Use this only " +
+    "when the user asks for a review, a brief, or a report — for an in-chat " +
+    "answer use showCompBands or showCompSummary instead.",
+  parameters: renderBriefParams,
+  execute: async (spec) => ({
+    [A2UI_OPERATIONS_KEY]: buildBriefOps(
+      spec,
+      `${SURFACE_ID}-${Date.now().toString(36)}`,
+    ),
+  }),
+});
+
+const PEOPLE_PROMPT = `
+You are Rowan, the assistant inside the Rowan People Ops application. You work
+alongside a People Operations lead. You can read the page they are looking at,
+render components into the conversation, and drive the real application through
+your tools. You act on their behalf inside their own product — you are not a
+chatbot bolted onto the side of it.
+
+COMPONENT ANSWER RULE.
+When a component exists for what was asked, render the component AND answer in
+one or two sentences. Never one without the other. A chart with no words reads
+as a glitch; words with no chart waste the component. Keep the sentences short
+and specific — name the one or two figures that matter, not all of them.
+
+NEVER WRITE A MARKDOWN TABLE.
+There is a component for every tabular shape in this app, and a raw table is
+always the wrong answer:
+- band positions, who is over or under band, how pay is distributed → showCompBands
+- one person → showPerson
+- more than one queue request → showRequestList
+- "where does compensation stand" → showCompSummary
+- a full review artifact for a meeting → render_people_brief (canvas)
+If you find yourself about to emit a pipe character in a row of data, stop and
+call the component instead.
+
+SCREEN AWARENESS.
+The context you are given IS your view of what the user is looking at. It names
+the current page and describes what is visibly rendered on it — the active
+filters, the rows actually shown, the figures displayed. When you are asked
+what is on screen:
+- name the page they are on,
+- summarize the key elements actually rendered,
+- cite the real figures from the context, not approximations,
+- and mention the active filters or sort if any are set.
+NEVER say you cannot see the screen, cannot inspect the page, or only know
+things "from context". You can see it. Different pages must get different
+answers; if your answer would be the same on every page, you have not read the
+page context.
+
+FORMAT PROSE THE SAME WAY EVERY TIME.
+Short answers. Bold the figures and names that matter — **Priya Raman**,
+**31 days**, **$272,000** — and nothing else; bolding everything is the same as
+bolding nothing. Use a short bulleted list when there are three or more parallel
+facts, prose otherwise. No headings in chat. No preamble: never open with "Sure!"
+or "Here's what I found".
+
+ACT, DON'T ANNOUNCE.
+Do not say you are about to call a tool. Call it, then describe what happened.
+Never ask which record the user means when the context makes it obvious — pick
+the best match and act, and say who you picked.
+
+SENSITIVE FIGURES.
+setBaseSalary opens a card in the chat where the USER types the new salary. You
+must NEVER ask for the figure, never guess it, never repeat it back, and never
+ask which person first. Call setBaseSalary immediately with your best match on
+the name. When it returns, confirm only that the salary was updated and for
+whom. The number is not yours to know and it will never appear in your results.
+
+COMPENSATION SUMMARIES USE THE SAVED FORMAT.
+Before answering any question about where compensation stands, how pay is
+distributed, or how the bands look overall, call recall_memory FIRST and look
+for the user's saved formatting preference. Then pass what you recalled into
+showCompSummary through byLevel / outOfBandFirst / asPercentile, and put the
+preference you applied into the \`note\` parameter in your own words — "You read
+these by level, with anyone out of band first" — so they can see you remembered.
+Speak like a person who remembers, not like a system reporting a cache hit.
+Call recall_memory at most once FOR A FORMATTING PREFERENCE per user message.
+This throttle is about not re-checking the same preference repeatedly; it does
+NOT forbid the separate recall a refused write requires (see OUT-OF-BAND
+COMPENSATION REQUESTS below) — that one is mandatory even if you already
+recalled a preference earlier in the same message.
+
+A NEW HIRE STARTING FOLLOWS A SAVED PROCEDURE.
+When the user says someone is starting, joining, or "starts Monday" — however
+vaguely they put it — recall the saved procedure and EXECUTE it, step by step,
+immediately, without asking for confirmation between steps. Resolve the person's
+name to an id from the ledger context. This is a DIFFERENT procedure from
+approving an out-of-band compensation request; do not confuse the two, and do
+NOT offer to record anything here — you already know this one. When every step
+is done, confirm what you did in one short sentence.
+
+FINDING IS NOT DOING.
+Locating the person, the request, or the record is not handling it. If the user
+asked you to handle something, carry the procedure all the way through before
+you reply.
+
+ACTION DISCIPLINE.
+Only write when you were asked to. And when a write is refused and you have no
+saved procedure for that refusal, STOP. Do not improvise a workaround, do not
+try a plausible-looking tool to see whether it helps, and do not tell the user
+what you think might work. Say plainly that you do not know this one, and call
+offerWorkflowRecording. Guessing here is worse than failing.
+
+OUT-OF-BAND COMPENSATION REQUESTS.
+approveCompRequest sometimes comes back refused because the requested salary is
+outside the band for the proposed level. You MIGHT have been taught how to
+handle that and you MIGHT NOT — you do not know until you check. So when a
+refusal comes back, the FIRST thing you do is call recall_memory and look for a
+saved procedure covering a refused compensation approval.
+
+IF YOU FIND ONE:
+1. Follow it exactly, including the specific exception code it names. Do not
+   substitute a different code because it sounds more appropriate — the saved
+   code is the one that is known to work, and the others are known not to.
+2. Run the whole thing without asking permission: open the band exception on
+   that compensation request, finalize it, then re-run the approval.
+3. Do NOT call offerWorkflowRecording, and do NOT say you don't know how. You
+   do know. Say briefly that you have done this before, and get on with it.
+
+IF YOU FIND NOTHING:
+1. Tell the user, in one sentence, that the approval was refused and repeat the
+   reason the system gave.
+2. Say plainly that you have no saved procedure for this.
+3. Call offerWorkflowRecording.
+4. If they agree, call awaitDemonstration and WAIT. Do not narrate steps, do not
+   suggest what they should click, do not call any other tool while waiting —
+   you genuinely do not know what they are about to do, and pretending otherwise
+   is the one thing that ruins this.
+5. When they finish, summarize exactly what you observed as a numbered procedure
+   — naming the specific code that worked — and call saveLearnedProcedure.
+6. After they confirm, persist it with save_memory (scope "user", kind
+   "operational"). Save it AT MOST ONCE. Use "user" scope, not "project" — a
+   project-scoped memory in this deployment is visible to every other product
+   sharing the backend, and this procedure is specific to Rowan.
+
+The recall step in this clause is the whole point of the feature. An earlier
+version of this prompt asserted "you do not have a saved way to get past that"
+as a flat fact, which meant the agent declined and offered to record even after
+it had been taught — the demonstration worked, the memory saved correctly, and
+the payoff never came, because the prompt was overriding what it knew.
+
+GENERAL MEMORY.
+1. Recall before you answer anything that a standing preference could change.
+2. Save durable facts and procedures the user teaches you; do not save
+   one-off details or anything they could not have meant to be permanent.
+3. Saving is not recalling — calling one does not do the other.
+4. Classify what you save: kind "topical" for preferences, "operational" for
+   procedures. Always use scope "user" — this deployment shares one memory
+   backend with other products, and a project-scoped row leaks into all of them.
+5. Never save a salary figure, a bank detail, or anything from a document the
+   user attached. Preferences and procedures only.
+6. Save a given fact once. If you are updating something you already saved,
+   supersede it rather than adding a near-duplicate.
+7. Do not stop mid-procedure to save something; finish the procedure first.
+
+UPLOADED DOCUMENTS.
+When the user attaches a document, read it and use its REAL contents. For an
+offer letter that means the start date, the title and level, the manager, and
+any week-one schedule it describes — carry those into createOnboardingPacket's
+summary, highlights and schedule rather than inventing plausible ones. If the
+document contradicts the app's data, say so in one sentence instead of silently
+picking one.
+
+THE CANVAS BRIEF.
+render_people_brief takes over the whole page, so use it only when the user asks
+for a brief, a review, or a report to bring to a meeting. Pick exactly one
+report path per request — never render the canvas brief and an in-chat summary
+for the same question. Supply selections and labels only; the renderer binds
+every number to live data.
+
+OPEN GENERATIVE UI.
+generateSandboxedUi is for genuinely novel UI this app has no component for. Do
+not reach for it when showCompBands, showPerson, showRequestList or
+showCompSummary would do. When you do use it, obtain every figure through the
+exposed sandbox functions rather than typing numbers into the generated markup.
+`.trim();
+
+export const peopleAgent = () =>
+  new BuiltInAgent({
+    model: "openai/gpt-5.4",
+    prompt: PEOPLE_PROMPT,
+    tools: [renderPeopleBriefTool],
+    // NO `temperature`. Banking pins it to 0 for determinism, but gpt-5.4 is a
+    // reasoning model that REJECTS the parameter — the dev server logs
+    // 'The feature "temperature" is not supported' on literally every run, and
+    // the value is discarded. Carrying a silently-ignored option alongside a
+    // comment claiming run-to-run determinism is worse than not setting it:
+    // it tells the next reader the demo is pinned when it is not. Determinism
+    // here comes from the prompt's explicit routing rules instead.
+  });

--- a/examples/showcases/reskinnable-demo/src/skins/people/attach-offer-letter.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/attach-offer-letter.ts
@@ -1,0 +1,43 @@
+/**
+ * BEAT 3d — stage the offer letter into the chat composer's built-in hidden
+ * file input, so CopilotKit's standard attachment flow picks it up: the letter
+ * appears as a real attachment chip and rides the next message to the model.
+ *
+ * Shared by the chat header's paperclip AND the suggestion pill, so both take
+ * the identical blessed path (the one that correctly consumes attachments on
+ * submit). The pill needs it because the framework's suggestion path DROPS
+ * attachments — a pill that must carry a file has to be intercepted in
+ * `onSuggestionSelect` and driven through the real composer instead.
+ *
+ * The paperclip exists as a manual fallback: if the pill path misbehaves on
+ * stage, the presenter can still attach the file by hand and carry on.
+ */
+
+export const OFFER_LETTER_URL = "/api/people/v1/offer-letter";
+export const OFFER_LETTER_FILENAME = "offer-letter-dana-whitfield.pdf";
+
+export async function stageOfferLetterAttachment(): Promise<boolean> {
+  try {
+    const res = await fetch(OFFER_LETTER_URL);
+    if (!res.ok) return false;
+    const blob = await res.blob();
+    const file = new File([blob], OFFER_LETTER_FILENAME, {
+      type: "application/pdf",
+    });
+    const input = document.querySelector<HTMLInputElement>(
+      'input[type="file"][accept*="pdf"]',
+    );
+    if (!input) return false;
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    input.files = dt.files;
+    // A native, BUBBLING change event, so CopilotChat's own onChange handler
+    // runs and enqueues the attachment exactly as a manual pick would. A
+    // React-synthetic dispatch would not reach it.
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    return true;
+  } catch (err) {
+    console.error("Could not attach the offer letter", err);
+    return false;
+  }
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/build-brief-ops.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/build-brief-ops.ts
@@ -1,0 +1,172 @@
+import { z } from "zod";
+import { CATALOG_ID } from "./catalog/definitions";
+
+/**
+ * Deterministic A2UI op-builder for Rowan's People Review brief canvas.
+ *
+ * SERVER-SAFE by construction: plain Zod + string constants, no React, no
+ * `.tsx` imports. The skin's `agent.ts` (a server-only module) imports this to
+ * define its render tool, so anything client-flavoured here would drag React
+ * into the runtime bundle.
+ *
+ * The division of labour: the agent picks WHAT to show (the small `renderBrief`
+ * selection below); this module expands that into the verbose A2UI v0.9
+ * operations. Keeping the expansion deterministic — rather than having the model
+ * author the full component JSON inline — is what keeps generation fast and
+ * reliable; the model only emits the tiny selection.
+ *
+ * Data is NEVER carried in the ops. StatCard/LevelBreakdown/PeopleList bind live
+ * client data via `useReportData()` in the catalog renderers. The agent supplies
+ * only metric/list selections + label-only text, so it CANNOT fabricate a figure
+ * — every number on the canvas is read from the ledger the page already shows.
+ */
+
+/** Must match the A2UI middleware's key so tryParseA2UIOperations detects it. */
+export const A2UI_OPERATIONS_KEY = "a2ui_operations";
+
+export const SURFACE_ID = "people-review";
+
+export const BRIEF_METRICS = [
+  "headcount",
+  "outOfBandCount",
+  "openRequests",
+  "medianBandPosition",
+] as const;
+export type BriefMetric = (typeof BRIEF_METRICS)[number];
+
+export const BRIEF_LISTS = ["outOfBand", "openRequests"] as const;
+export type BriefList = (typeof BRIEF_LISTS)[number];
+
+/** Human captions per KPI — assigned here so the agent needn't supply them. */
+const METRIC_LABELS: Record<BriefMetric, string> = {
+  headcount: "Headcount",
+  outOfBandCount: "Out of band",
+  openRequests: "Open requests",
+  medianBandPosition: "Median band position",
+};
+
+/** Parameters for the render tool (kept intentionally small — SELECTIONS + labels). */
+export const renderBriefParams = z.object({
+  title: z
+    .string()
+    .describe(
+      "Short brief title, e.g. 'People Review — Q3'. LABEL ONLY — no figures, counts, salaries, percentages, or trend claims.",
+    ),
+  kpis: z
+    .array(z.enum(BRIEF_METRICS))
+    .describe(
+      "Which KPI stat cards to show, in order: 'headcount', 'outOfBandCount', 'openRequests', 'medianBandPosition'. Pick those relevant to the question.",
+    ),
+  levelBreakdown: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include the compensation band-ladder level breakdown (the whole live roster plotted within band). Omit or false to leave it out.",
+    ),
+  lists: z
+    .array(z.enum(BRIEF_LISTS))
+    .optional()
+    .describe(
+      "Which detail lists to append, in order: 'outOfBand' (people outside their band) and/or 'openRequests' (pending queue items). Omit to leave them out.",
+    ),
+  summary: z
+    .string()
+    .optional()
+    .describe(
+      "Optional one-line NEUTRAL caption under the title. Label-only — no figures, counts, salaries, or trends.",
+    ),
+});
+export type RenderBriefSpec = z.infer<typeof renderBriefParams>;
+
+export type A2UIOp = Record<string, unknown> & { version?: string };
+type Component = { id: string; component: string } & Record<string, unknown>;
+
+/**
+ * Expand a brief selection into A2UI v0.9 operations: createSurface +
+ * updateComponents (a FLAT component list, rooted at id "root"). Children are
+ * referenced by id, never embedded — that flat shape is what the A2UI runtime
+ * expects and what the renderers resolve against.
+ */
+export function buildBriefOps(
+  spec: RenderBriefSpec,
+  surfaceId: string = SURFACE_ID,
+): A2UIOp[] {
+  const components: Component[] = [];
+  const rootChildren: string[] = [];
+
+  components.push({ id: "heading", component: "Heading", text: spec.title });
+  rootChildren.push("heading");
+
+  if (spec.summary) {
+    components.push({
+      id: "summary",
+      component: "Text",
+      text: spec.summary,
+      tone: "muted",
+    });
+    rootChildren.push("summary");
+  }
+
+  if (spec.kpis.length) {
+    const kpiIds = spec.kpis.map((metric) => {
+      const id = `kpi-${metric}`;
+      // Only the label travels in the op; the VALUE is computed live in the
+      // StatCard renderer from useReportData(). That is the "ops carry no data"
+      // rule in one line.
+      components.push({
+        id,
+        component: "StatCard",
+        metric,
+        label: METRIC_LABELS[metric],
+      });
+      return id;
+    });
+    components.push({
+      id: "kpi-grid",
+      component: "Grid",
+      columns: Math.min(spec.kpis.length, 4),
+      children: kpiIds,
+    });
+    rootChildren.push("kpi-grid");
+  }
+
+  if (spec.levelBreakdown) {
+    // No props: LevelBreakdown renders the whole live roster on the ladder.
+    components.push({ id: "level-breakdown", component: "LevelBreakdown" });
+    rootChildren.push("level-breakdown");
+  }
+
+  if (spec.lists?.length) {
+    for (const kind of spec.lists) {
+      const id = `list-${kind}`;
+      components.push({ id, component: "PeopleList", kind });
+      rootChildren.push(id);
+    }
+  }
+
+  // Root goes in FIRST (index 0). The A2UI runtime resolves the tree from the
+  // component whose id is "root", so it must be present; unshift keeps the rest
+  // of the list in authored order for readability.
+  components.unshift({
+    id: "root",
+    component: "Stack",
+    gap: "lg",
+    children: rootChildren,
+  });
+
+  return [
+    { version: "v0.9", createSurface: { surfaceId, catalogId: CATALOG_ID } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
+  ];
+}
+
+/** Read the surfaceId out of an A2UI operation list (any op kind). */
+export function extractSurfaceId(ops: A2UIOp[]): string | null {
+  for (const op of ops) {
+    const target = (op.createSurface ??
+      op.updateComponents ??
+      op.updateDataModel) as { surfaceId?: string } | undefined;
+    if (target?.surfaceId) return target.surfaceId;
+  }
+  return null;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/canvas-surface.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/canvas-surface.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  A2UIProvider,
+  A2UIRenderer,
+  useA2UIActions,
+} from "@copilotkit/a2ui-renderer";
+import { useAgent } from "@copilotkit/react-core/v2";
+import { catalog } from "./catalog";
+import { usePeopleLedger } from "./data/ledger-context";
+import { ReportDataProvider } from "./report-data";
+import { A2UI_OPERATIONS_KEY, extractSurfaceId } from "./build-brief-ops";
+import type { A2UIOp } from "./build-brief-ops";
+
+/**
+ * Rowan's People Review brief canvas — `skin.CanvasSurface`. The shell owns the
+ * canvas region, OGUI rendering and surface-kind detection; this component
+ * renders only this skin's OWN a2ui surface. It binds live people data (via
+ * usePeopleLedger → ReportDataProvider) into the catalog renderers and feeds the
+ * agent's brief ops into the A2UI provider.
+ */
+
+/** Minimal shape of an A2UI activity message in the agent's message list. */
+type MaybeActivityMessage = {
+  role?: string;
+  activityType?: string;
+  content?: Record<string, unknown>;
+};
+
+/**
+ * The latest A2UI brief surface in the agent's message stream. The A2UI
+ * middleware turns the render tool result into an `a2ui-surface` activity
+ * message carrying `a2ui_operations`; we read it straight from `agent.messages`,
+ * the pattern the framework's own renderer uses.
+ */
+function useBriefSurface(): { operations: A2UIOp[]; surfaceId: string | null } {
+  const { agent } = useAgent();
+  const messages = agent?.messages as MaybeActivityMessage[] | undefined;
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (
+        message?.role === "activity" &&
+        message?.activityType === "a2ui-surface"
+      ) {
+        const operations =
+          (message.content?.[A2UI_OPERATIONS_KEY] as A2UIOp[]) ?? [];
+        return {
+          operations,
+          surfaceId: operations.length ? extractSurfaceId(operations) : null,
+        };
+      }
+    }
+  }
+  return { operations: [], surfaceId: null };
+}
+
+export function PeopleCanvasSurface() {
+  // The ledger context is mounted ABOVE this in the skin runtime subtree, so
+  // the canvas reads the SAME snapshot as the pages — the brief and the roster
+  // are never one fetch apart.
+  const { data } = usePeopleLedger();
+  return (
+    <ReportDataProvider
+      value={{
+        employees: data.employees,
+        bands: data.bands,
+        requests: data.requests,
+      }}
+    >
+      <A2UIProvider catalog={catalog}>
+        <CanvasInner />
+      </A2UIProvider>
+    </ReportDataProvider>
+  );
+}
+
+function CanvasInner() {
+  const { operations, surfaceId } = useBriefSurface();
+  const hasContent = operations.length > 0 && !!surfaceId;
+
+  return (
+    <>
+      {surfaceId ? (
+        <SurfaceMessageProcessor
+          operations={operations}
+          surfaceId={surfaceId}
+        />
+      ) : null}
+      {hasContent ? (
+        <div className="h-full overflow-y-auto">
+          <div className="a2ui-surface p-6 md:p-8" data-testid="a2ui-surface">
+            <A2UIRenderer surfaceId={surfaceId} />
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Feeds the surface's operations into the A2UI provider. The activity content
+ * carries the FULL operation list on each snapshot, so we strip a duplicate
+ * createSurface once the surface exists (the MessageProcessor throws if asked to
+ * create a surface that already exists) and skip re-processing identical op
+ * lists via a hash. Mirrors the framework's built-in SurfaceMessageProcessor.
+ */
+function SurfaceMessageProcessor({
+  operations,
+  surfaceId,
+}: {
+  operations: A2UIOp[];
+  surfaceId: string;
+}) {
+  const { processMessages, getSurface } = useA2UIActions();
+  const lastHashRef = useRef("");
+
+  useEffect(() => {
+    if (!operations.length) return;
+    const hash = JSON.stringify(operations);
+    if (hash === lastHashRef.current) return;
+    lastHashRef.current = hash;
+
+    const isExisting = !!getSurface(surfaceId);
+    const ops = isExisting
+      ? operations.filter((op) => !("createSurface" in op))
+      : operations;
+    if (!ops.length) return;
+    try {
+      processMessages(ops as Array<Record<string, unknown>>);
+    } catch (err) {
+      console.warn("[people-canvas] processMessages threw:", err);
+    }
+  }, [operations, processMessages, getSurface, surfaceId]);
+
+  return null;
+}
+
+export default PeopleCanvasSurface;

--- a/examples/showcases/reskinnable-demo/src/skins/people/catalog/definitions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/catalog/definitions.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+/**
+ * Rowan's a2ui catalog — the component vocabulary the People Review brief is
+ * assembled from. It is the CONTRACT between the agent's tiny selection and the
+ * deterministic op-builder (`build-brief-ops.ts`) that expands it.
+ *
+ * The cardinal rule lives in these descriptions: layout + label components may
+ * carry text, but every FIGURE (headcount, out-of-band counts, salaries, band
+ * positions) is bound to live client data inside the renderers via
+ * `useReportData()`. The agent never passes a number, so it can never fabricate
+ * one — see the description prose on Heading/Text/StatCard/LevelBreakdown/PeopleList.
+ */
+
+export const CATALOG_ID = "https://cpk-a2ui.local/catalogs/people/v1";
+
+// A single child id / a list of child ids. Layout components reference their
+// children BY ID (the components list is flat, rooted at "root"); they never
+// embed the child objects. `stringOrPath` is a2ui's "literal string OR a
+// data-bound { path }" union — text props accept either, though Rowan's builder
+// only ever emits literals (all data binding happens in the renderers).
+const childRef = z.string();
+const childrenRef = z.array(z.string());
+const stringOrPath = z.union([z.string(), z.object({ path: z.string() })]);
+
+export const definitions = {
+  Stack: {
+    description:
+      "Vertical layout. Children stack top→bottom. The default brief/section container.",
+    props: z.object({
+      children: childrenRef,
+      gap: z.enum(["sm", "md", "lg", "xl"]).optional(),
+    }),
+  },
+  Row: {
+    description:
+      "Horizontal layout; wraps on small screens. Use for metric rows or chip groups.",
+    props: z.object({
+      children: childrenRef,
+      gap: z.enum(["sm", "md", "lg"]).optional(),
+    }),
+  },
+  Grid: {
+    description:
+      "Responsive grid. Use for a row of StatCards (the KPI band across the top of the brief).",
+    props: z.object({
+      children: childrenRef,
+      columns: z.number().int().min(1).max(4).optional(),
+    }),
+  },
+  Section: {
+    description:
+      "Titled section grouping a region of the brief (e.g. 'Compensation health').",
+    props: z.object({ title: z.string(), child: childRef }),
+  },
+  Heading: {
+    description:
+      "The brief title — a LABEL ONLY. Use once at the top. Do NOT embed figures, " +
+      "counts, salaries, percentages, or trend claims (e.g. NOT 'Headcount up 12%') — " +
+      "all quantitative content comes from StatCard/LevelBreakdown/PeopleList.",
+    props: z.object({ text: stringOrPath }),
+  },
+  Text: {
+    description:
+      "A short NEUTRAL caption or section label (e.g. 'Ahead of the leadership review'). " +
+      "Label-only: do NOT state figures, counts, salaries, percentages, deltas, or trend " +
+      "claims — every quantitative claim must come from StatCard/LevelBreakdown/PeopleList, " +
+      "which bind live client data. Use tone='muted' for secondary captions.",
+    props: z.object({
+      text: stringOrPath,
+      tone: z.enum(["default", "muted"]).optional(),
+    }),
+  },
+  StatCard: {
+    description:
+      "A single KPI computed live on the client. `metric` selects which: 'headcount' " +
+      "(people on the roster), 'outOfBandCount' (people whose salary sits outside their " +
+      "level's band), 'openRequests' (pending items in the requests queue), " +
+      "'medianBandPosition' (the roster's median position within band, 0%=band min, " +
+      "100%=band max). Provide `label` for the caption. Do NOT pass the value.",
+    props: z.object({
+      metric: z.enum([
+        "headcount",
+        "outOfBandCount",
+        "openRequests",
+        "medianBandPosition",
+      ]),
+      label: stringOrPath,
+    }),
+  },
+  LevelBreakdown: {
+    description:
+      "The signature compensation band-ladder: one rail per level (L3–L7), every person " +
+      "plotted at their position within their own band, with anyone outside their band " +
+      "drawn in red outside the rail. Takes NO props — it renders the whole live roster " +
+      "bound on the client. Include it once when the brief is about comp or levelling.",
+    props: z.object({}),
+  },
+  PeopleList: {
+    description:
+      "A live detail list. `kind` selects which: 'outOfBand' (each person whose salary " +
+      "falls outside their band, with the side and figure) or 'openRequests' (each pending " +
+      "item in the requests queue, with requester, kind, and value). Rows are bound on the " +
+      "client — do NOT pass names, figures, or rows.",
+    props: z.object({
+      kind: z.enum(["outOfBand", "openRequests"]),
+    }),
+  },
+};
+
+export type Definitions = typeof definitions;

--- a/examples/showcases/reskinnable-demo/src/skins/people/catalog/index.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/catalog/index.ts
@@ -1,0 +1,12 @@
+import { createCatalog, extractSchema } from "@copilotkit/a2ui-renderer";
+import { CATALOG_ID, definitions } from "./definitions";
+import { renderers } from "./renderers";
+
+export const catalog = createCatalog(definitions, renderers, {
+  catalogId: CATALOG_ID,
+  includeBasicCatalog: false,
+});
+
+export const catalogSchema = extractSchema(definitions);
+
+export { CATALOG_ID, definitions };

--- a/examples/showcases/reskinnable-demo/src/skins/people/catalog/renderers.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/catalog/renderers.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import type { RendererProps } from "@copilotkit/a2ui-renderer";
+import { cn } from "@/lib/utils";
+import { BandLadder } from "../components/band-ladder";
+import { Monogram } from "../components/monogram";
+import {
+  EmptyState,
+  Metric,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+import {
+  REQUEST_KIND_LABEL,
+  ageInDays,
+  bandPosition,
+  formatPercent,
+  formatSalary,
+  isOutOfBand,
+  requestValueLabel,
+} from "../data/derive";
+import { useReportData } from "../report-data";
+
+const GAP = { sm: "gap-2", md: "gap-4", lg: "gap-6", xl: "gap-10" } as const;
+
+// Text props in the catalog are `string | { path }` (a data-bound ref). The
+// A2UI runtime resolves refs before render, but the Zod-inferred type still
+// carries the union, so coerce to a display string here.
+type TextRef = string | { path: string };
+const asText = (value: TextRef): string =>
+  typeof value === "string" ? value : "";
+
+function Slot({ render }: { render: React.ReactNode }) {
+  return <>{render}</>;
+}
+
+// --- Layout primitives (mirror banking/logistics exactly) -------------------
+
+const Stack = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; gap?: keyof typeof GAP }>) => (
+  <div className={cn("flex flex-col", GAP[props.gap ?? "md"])}>
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Row = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; gap?: "sm" | "md" | "lg" }>) => (
+  <div className={cn("flex flex-wrap", GAP[props.gap ?? "md"])}>
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Grid = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; columns?: number }>) => (
+  <div
+    className="grid gap-4"
+    style={{
+      gridTemplateColumns: `repeat(${props.columns ?? 3}, minmax(0, 1fr))`,
+    }}
+  >
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Section = ({
+  props,
+  children,
+}: RendererProps<{ title: string; child: string }>) => (
+  <section className="space-y-3">
+    <h2 className="text-lg font-semibold text-ink">{props.title}</h2>
+    <Slot render={children(props.child)} />
+  </section>
+);
+
+const Heading = ({ props }: RendererProps<{ text: TextRef }>) => (
+  <h1 className="text-2xl font-semibold tracking-tight text-ink">
+    {asText(props.text)}
+  </h1>
+);
+
+const Text = ({
+  props,
+}: RendererProps<{ text: TextRef; tone?: "default" | "muted" }>) => (
+  <p
+    className={cn(
+      "text-sm",
+      props.tone === "muted" ? "text-ink-muted" : "text-ink",
+    )}
+  >
+    {asText(props.text)}
+  </p>
+);
+
+// --- Live, data-bound widgets ----------------------------------------------
+// Every figure below is computed HERE from useReportData(), never read from a
+// prop. The catalog op only ever named the metric/kind; the numbers are the
+// ledger's, so the agent can select but never fabricate.
+
+const StatCard = ({
+  props,
+}: RendererProps<{
+  metric:
+    | "headcount"
+    | "outOfBandCount"
+    | "openRequests"
+    | "medianBandPosition";
+  label: TextRef;
+}>) => {
+  const { employees, bands, requests } = useReportData();
+
+  let value = "—";
+  let tone: "neutral" | "brand" | "positive" | "negative" = "neutral";
+
+  switch (props.metric) {
+    case "headcount":
+      value = String(employees.length);
+      break;
+    case "outOfBandCount": {
+      const n = employees.filter((e) => isOutOfBand(bands, e)).length;
+      value = String(n);
+      // Out-of-band is the exception the whole skin is about — flag it red when
+      // there is anything to act on, quiet green when the roster is clean.
+      tone = n > 0 ? "negative" : "positive";
+      break;
+    }
+    case "openRequests":
+      value = String(requests.filter((r) => r.status === "pending").length);
+      tone = "brand";
+      break;
+    case "medianBandPosition": {
+      const ratios = employees
+        .map((e) => bandPosition(bands, e.baseSalary, e.level)?.ratio)
+        .filter((r): r is number => typeof r === "number")
+        .sort((a, b) => a - b);
+      if (ratios.length) {
+        const mid = Math.floor(ratios.length / 2);
+        const median =
+          ratios.length % 2 === 0
+            ? (ratios[mid - 1] + ratios[mid]) / 2
+            : ratios[mid];
+        value = formatPercent(median);
+      }
+      break;
+    }
+  }
+
+  return <Metric label={asText(props.label)} value={value} tone={tone} />;
+};
+
+const LevelBreakdown = () => {
+  const { employees, bands } = useReportData();
+  if (!employees.length || !bands.length) {
+    return (
+      <Panel>
+        <EmptyState
+          title="No roster to plot"
+          hint="Once the ledger loads, every person appears on the band ladder at their position within their level."
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Level breakdown</SectionLabel>
+      <BandLadder bands={bands} employees={employees} />
+    </Panel>
+  );
+};
+
+function OutOfBandList() {
+  const { employees, bands } = useReportData();
+  const rows = employees.filter((e) => isOutOfBand(bands, e));
+  if (!rows.length) {
+    return (
+      <Panel>
+        <SectionLabel>Out of band</SectionLabel>
+        <EmptyState
+          title="Everyone is inside their band"
+          hint="No salary sits outside its level's range — there is nothing to escalate at the review."
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Out of band</SectionLabel>
+      <ul className="divide-y divide-hairline">
+        {rows.map((e) => {
+          const pos = bandPosition(bands, e.baseSalary, e.level);
+          return (
+            <li
+              key={e.id}
+              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+            >
+              <Monogram name={e.name} size="sm" ring="negative" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-ink">
+                  {e.name}
+                </div>
+                <div className="truncate text-[0.72rem] text-ink-muted">
+                  {e.title} · {e.level}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="rowan-num text-sm font-semibold text-ink">
+                  {formatSalary(e.baseSalary)}
+                </span>
+                <Pill tone="negative">{pos?.side ?? "out of"} band</Pill>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </Panel>
+  );
+}
+
+function OpenRequestsList() {
+  const { employees, requests } = useReportData();
+  const rows = requests.filter((r) => r.status === "pending");
+  if (!rows.length) {
+    return (
+      <Panel>
+        <SectionLabel>Open requests</SectionLabel>
+        <EmptyState
+          title="The queue is clear"
+          hint="No requests are waiting on a decision — the review can skip the queue."
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Open requests</SectionLabel>
+      <ul className="divide-y divide-hairline">
+        {rows.map((r) => {
+          const person = employees.find((e) => e.id === r.employeeId);
+          const age = ageInDays(r.submittedAt);
+          return (
+            <li
+              key={r.id}
+              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+            >
+              <Monogram name={person?.name ?? "Unknown"} size="sm" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium text-ink">
+                    {person?.name ?? "Unknown"}
+                  </span>
+                  <Pill tone="brand">{REQUEST_KIND_LABEL[r.kind]}</Pill>
+                </div>
+                <div className="truncate text-[0.72rem] text-ink-muted">
+                  {r.summary}
+                </div>
+              </div>
+              <div className="flex shrink-0 flex-col items-end">
+                <span className="rowan-num text-sm font-semibold text-ink">
+                  {requestValueLabel(r)}
+                </span>
+                <span className="text-[0.68rem] text-ink-muted">
+                  {age === 0 ? "today" : `${age}d ago`}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </Panel>
+  );
+}
+
+const PeopleList = ({
+  props,
+}: RendererProps<{ kind: "outOfBand" | "openRequests" }>) =>
+  props.kind === "outOfBand" ? <OutOfBandList /> : <OpenRequestsList />;
+
+export const renderers = {
+  Stack,
+  Row,
+  Grid,
+  Section,
+  Heading,
+  Text,
+  StatCard,
+  LevelBreakdown,
+  PeopleList,
+};

--- a/examples/showcases/reskinnable-demo/src/skins/people/components/band-ladder.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/components/band-ladder.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  bandPosition,
+  formatCompact,
+  formatPercent,
+  formatSalary,
+} from "../data/derive";
+import type { Band, Employee, Level } from "../data/types";
+import { Monogram } from "./monogram";
+
+/**
+ * THE BAND LADDER — Rowan's signature element.
+ *
+ * One vertical rail per level, each normalized to its OWN band: the bottom of a
+ * rail is that band's minimum and the top is its maximum, regardless of the
+ * dollar figures involved. That normalization is the whole idea. A conventional
+ * comp chart plots salary on a shared money axis, which makes L7 tower over L3
+ * and tells you nothing you didn't already know. Normalizing per band puts
+ * every person on the same 0–100% scale, so "Priya is halfway up her band" and
+ * "Arun is halfway up his" line up at the same height and become comparable at
+ * a glance — which is exactly the question a People Ops lead is actually
+ * asking, and exactly the shape of the preference beat 4 recalls.
+ *
+ * Anyone outside their band is drawn OUTSIDE the rail, in the negative colour,
+ * with their name always visible. They are the actionable rows, so they are the
+ * only ones that get a label without being hovered.
+ */
+
+export interface LadderPerson {
+  id: string;
+  name: string;
+  level: Level;
+  baseSalary: number;
+  title: string;
+  team: string;
+}
+
+interface PlacedDot {
+  person: LadderPerson;
+  /** Pixels above the rail's base. */
+  y: number;
+  /** Horizontal nudge, px, applied when dots would overlap. */
+  x: number;
+  ratio: number;
+  outOfBand: boolean;
+  side: "below" | "above" | null;
+}
+
+const COLLISION_PX = 19;
+/** Cycled when dots collide, so a cluster fans out instead of stacking. */
+const FAN = [0, 15, -15, 30, -30, 45, -45];
+
+function place(
+  people: LadderPerson[],
+  bands: Band[],
+  railHeight: number,
+): PlacedDot[] {
+  const dots = people
+    .map((person) => {
+      const pos = bandPosition(bands, person.baseSalary, person.level);
+      if (!pos) return null;
+      // The clamped ratio positions the dot; the raw `outOfBand` flag decides
+      // whether it is pushed past the rail's end. Keeping those separate is
+      // what stops clamping from quietly hiding a violation.
+      //
+      // 13px, not more: a below-band dot hangs into the gutter above the level
+      // labels, and a larger offset drops it straight through the "L5 / Senior"
+      // caption. The label block below reserves the matching space.
+      const offset = pos.side === "above" ? 13 : pos.side === "below" ? -13 : 0;
+      return {
+        person,
+        y: pos.ratio * railHeight + offset,
+        x: 0,
+        ratio: pos.ratio,
+        outOfBand: pos.outOfBand,
+        side: pos.side,
+      } satisfies PlacedDot;
+    })
+    .filter((d): d is PlacedDot => d !== null)
+    .sort((a, b) => a.y - b.y);
+
+  // Fan out anything that would land on top of its neighbour.
+  let runStart = 0;
+  for (let i = 1; i <= dots.length; i += 1) {
+    const breaks =
+      i === dots.length || dots[i].y - dots[i - 1].y >= COLLISION_PX;
+    if (!breaks) continue;
+    const run = dots.slice(runStart, i);
+    if (run.length > 1) {
+      run.forEach((dot, idx) => {
+        dot.x = FAN[idx % FAN.length];
+      });
+    }
+    runStart = i;
+  }
+  return dots;
+}
+
+export function BandLadder({
+  bands,
+  employees,
+  compact = false,
+  highlightIds,
+  className,
+}: {
+  bands: Band[];
+  employees: Employee[];
+  /** Narrow variant for the chat transcript. */
+  compact?: boolean;
+  /** Draw a brand ring on these people — the ones a tool just touched. */
+  highlightIds?: string[];
+  className?: string;
+}) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const railHeight = compact ? 160 : 232;
+  const highlighted = useMemo(
+    () => new Set(highlightIds ?? []),
+    [highlightIds],
+  );
+
+  const columns = useMemo(
+    () =>
+      bands.map((band) => ({
+        band,
+        dots: place(
+          employees
+            .filter((e) => e.level === band.level)
+            .map((e) => ({
+              id: e.id,
+              name: e.name,
+              level: e.level,
+              baseSalary: e.baseSalary,
+              title: e.title,
+              team: e.team,
+            })),
+          bands,
+          railHeight,
+        ),
+      })),
+    [bands, employees, railHeight],
+  );
+
+  const outOfBandCount = columns.reduce(
+    (sum, c) => sum + c.dots.filter((d) => d.outOfBand).length,
+    0,
+  );
+
+  return (
+    <figure className={cn("w-full", className)}>
+      <div
+        className="flex items-end gap-1"
+        // Rail + the mt-5 gutter a below-band dot hangs into + the caption
+        // block (two lines compact, three with the band range).
+        style={{ height: railHeight + (compact ? 58 : 78) }}
+      >
+        {columns.map(({ band, dots }) => (
+          <div
+            key={band.level}
+            className="flex min-w-0 flex-1 flex-col items-center"
+          >
+            <div className="relative w-full" style={{ height: railHeight }}>
+              {/* The rail. `.rowan-rail` carries the band gradient so it tracks
+                  the live theme tokens rather than a hard-coded colour. */}
+              <div
+                className="rowan-rail absolute left-1/2 top-0 h-full w-2.5 -translate-x-1/2 rounded-full"
+                aria-hidden
+              />
+              {/* The ceiling cap — the one place a rail earns colour. */}
+              <div
+                className="rowan-rail-cap absolute left-1/2 top-0 h-1 w-2.5 -translate-x-1/2 rounded-full"
+                aria-hidden
+              />
+              {/* Midpoint tick — the band target. */}
+              <div
+                className="absolute left-1/2 w-7 -translate-x-1/2 border-t border-dashed border-ink-muted/40"
+                style={{
+                  bottom:
+                    ((band.mid - band.min) / (band.max - band.min)) *
+                    railHeight,
+                }}
+                aria-hidden
+              />
+              {dots.map((dot) => {
+                const isHovered = hovered === dot.person.id;
+                return (
+                  <button
+                    key={dot.person.id}
+                    type="button"
+                    onMouseEnter={() => setHovered(dot.person.id)}
+                    onMouseLeave={() => setHovered(null)}
+                    onFocus={() => setHovered(dot.person.id)}
+                    onBlur={() => setHovered(null)}
+                    aria-label={`${dot.person.name}, ${dot.person.level}, ${formatSalary(
+                      dot.person.baseSalary,
+                    )}${dot.outOfBand ? `, ${dot.side} band` : ""}`}
+                    className="absolute left-1/2 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                    style={{
+                      bottom: dot.y,
+                      // Both axes in ONE inline transform: a Tailwind
+                      // `-translate-x-1/2` would be overwritten by this style
+                      // rather than composed with it, which silently shifts
+                      // every dot half its width off the rail.
+                      transform: `translate(calc(-50% + ${dot.x}px), 50%)`,
+                      zIndex: isHovered ? 30 : dot.outOfBand ? 20 : 10,
+                    }}
+                  >
+                    <span
+                      className={cn(
+                        "block rounded-full border-2 transition-transform",
+                        compact ? "h-2.5 w-2.5" : "h-3 w-3",
+                        // Full-strength plum with a surface-coloured border: at
+                        // 70% opacity these disappeared into their own rail,
+                        // which is the one thing a dot on a rail must not do.
+                        dot.outOfBand
+                          ? "rowan-flag border-surface bg-negative"
+                          : highlighted.has(dot.person.id)
+                            ? "border-brand-violet bg-brand"
+                            : "border-surface bg-brand",
+                        isHovered && "scale-150",
+                      )}
+                    />
+                  </button>
+                );
+              })}
+
+              {/* Out-of-band names are always visible: they are the rows anyone
+                  is actually here to act on. Everyone else labels on hover. */}
+              {!compact &&
+                dots
+                  .filter((d) => d.outOfBand)
+                  .map((dot) => (
+                    <span
+                      key={`${dot.person.id}-label`}
+                      className="rowan-num pointer-events-none absolute left-1/2 translate-x-4 whitespace-nowrap text-[0.65rem] font-semibold text-negative"
+                      style={{ bottom: dot.y - 6 }}
+                    >
+                      {dot.person.name.split(" ")[0]}
+                    </span>
+                  ))}
+            </div>
+
+            {/* mt-5 reserves the gutter a below-band dot hangs into. */}
+            <div className="mt-5 text-center">
+              <div className="text-[0.72rem] font-semibold text-ink">
+                {band.level}
+              </div>
+              <div className="text-[0.62rem] text-ink-muted">{band.label}</div>
+              {!compact ? (
+                <div className="rowan-num mt-0.5 text-[0.6rem] text-ink-muted">
+                  {formatCompact(band.min)}–{formatCompact(band.max)}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Hover detail. A fixed slot rather than a floating tooltip, so the
+          ladder never reflows and never clips inside the chat column. */}
+      <div className="mt-3 flex min-h-[2.25rem] items-center justify-between gap-3 rounded-md border border-hairline bg-surface-muted px-3 py-1.5">
+        {hovered ? (
+          (() => {
+            const dot = columns
+              .flatMap((c) => c.dots)
+              .find((d) => d.person.id === hovered);
+            if (!dot) return null;
+            return (
+              <>
+                <span className="flex min-w-0 items-center gap-2">
+                  <Monogram name={dot.person.name} size="xs" />
+                  <span className="truncate text-[0.75rem] font-medium text-ink">
+                    {dot.person.name}
+                  </span>
+                  <span className="hidden truncate text-[0.7rem] text-ink-muted sm:inline">
+                    {dot.person.title}
+                  </span>
+                </span>
+                <span className="rowan-num shrink-0 text-[0.72rem] font-semibold text-ink">
+                  {formatSalary(dot.person.baseSalary)}
+                  <span
+                    className={cn(
+                      "ml-2 font-medium",
+                      dot.outOfBand ? "text-negative" : "text-ink-muted",
+                    )}
+                  >
+                    {dot.outOfBand
+                      ? `${dot.side} band`
+                      : `${formatPercent(dot.ratio)} of band`}
+                  </span>
+                </span>
+              </>
+            );
+          })()
+        ) : (
+          <span className="text-[0.72rem] text-ink-muted">
+            {outOfBandCount === 0
+              ? "Everyone is inside their band."
+              : `${outOfBandCount} ${outOfBandCount === 1 ? "person is" : "people are"} outside their band — shown in red, outside the rail.`}
+          </span>
+        )}
+      </div>
+      <figcaption className="sr-only">
+        Compensation band ladder. Each level is a rail from its band minimum to
+        its band maximum; each dot is one person at their position in that band.
+      </figcaption>
+    </figure>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/components/monogram.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/components/monogram.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { initials, monogramHue } from "../data/derive";
+
+/**
+ * A person's monogram tile.
+ *
+ * Rowan uses no photographs — a demo roster of stock headshots reads as fake
+ * the moment anyone looks twice, and a real one is not ours to ship. Instead
+ * every person gets a tile in a colour deterministically derived from their
+ * name (see `monogramHue`), so they keep the same colour on the roster, on the
+ * ladder, in the queue, and inside chat gen-UI. That consistency is what turns
+ * a list of rows into a set of recognisable faces.
+ *
+ * The hue is applied at low saturation and high lightness on purpose. The
+ * chrome is plum; if seventeen monograms were fully saturated they would win
+ * every screen they appear on.
+ */
+export function Monogram({
+  name,
+  size = "md",
+  className,
+  ring,
+}: {
+  name: string;
+  size?: "xs" | "sm" | "md" | "lg";
+  className?: string;
+  /** Draw an emphasis ring — used for the person a tool just acted on. */
+  ring?: "brand" | "negative" | null;
+}) {
+  const hue = monogramHue(name);
+  const dimensions = {
+    xs: "h-6 w-6 text-[0.6rem]",
+    sm: "h-8 w-8 text-[0.7rem]",
+    md: "h-10 w-10 text-xs",
+    lg: "h-14 w-14 text-base",
+  }[size];
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "inline-flex shrink-0 select-none items-center justify-center rounded-full font-semibold tracking-wide",
+        dimensions,
+        ring === "brand" &&
+          "ring-2 ring-brand ring-offset-2 ring-offset-surface",
+        ring === "negative" &&
+          "ring-2 ring-negative ring-offset-2 ring-offset-surface",
+        className,
+      )}
+      style={{
+        backgroundColor: `hsl(${hue} 44% 92%)`,
+        color: `hsl(${hue} 52% 28%)`,
+      }}
+    >
+      {initials(name)}
+    </span>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/components/primitives.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/components/primitives.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Rowan's small shared vocabulary. Everything here styles itself with the
+ * shell's semantic utilities (`bg-surface`, `text-ink`, `border-hairline`, …)
+ * so the whole skin reskins from `theme.css` with no component edits.
+ */
+
+/** The standard panel. One radius, one hairline, one soft shadow, everywhere. */
+export function Panel({
+  children,
+  className,
+  padded = true,
+}: {
+  children: ReactNode;
+  className?: string;
+  padded?: boolean;
+}) {
+  return (
+    <section
+      className={cn(
+        "rounded-lg border border-hairline bg-surface shadow-soft",
+        padded && "p-5",
+        className,
+      )}
+    >
+      {children}
+    </section>
+  );
+}
+
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <header className="mb-5 flex items-end justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          {title}
+        </h1>
+        {subtitle ? (
+          <p className="mt-1 text-sm text-ink-muted">{subtitle}</p>
+        ) : null}
+      </div>
+      {actions ? (
+        <div className="flex items-center gap-2">{actions}</div>
+      ) : null}
+    </header>
+  );
+}
+
+/** An eyebrow above a group. Uppercase, tracked, quiet — it labels, nothing more. */
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="mb-3 text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-ink-muted">
+      {children}
+    </h2>
+  );
+}
+
+type Tone = "neutral" | "brand" | "positive" | "negative" | "gold";
+
+const TONE_CLASS: Record<Tone, string> = {
+  neutral: "bg-surface-muted text-ink-muted border-hairline",
+  brand: "bg-brand-soft text-brand border-brand/30",
+  positive: "bg-positive-soft text-positive border-positive/25",
+  negative: "bg-negative-soft text-negative border-negative/25",
+  // `--brand-violet` is Rowan's gold milestone accent (see theme.css).
+  gold: "bg-brand-violet/12 text-brand-violet border-brand-violet/30",
+};
+
+export function Pill({
+  children,
+  tone = "neutral",
+  className,
+}: {
+  children: ReactNode;
+  tone?: Tone;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[0.68rem] font-medium leading-4",
+        TONE_CLASS[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** A headline figure with its label underneath. Tabular so digits don't jitter. */
+export function Metric({
+  label,
+  value,
+  hint,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: Tone;
+}) {
+  return (
+    <div className="rounded-md border border-hairline bg-surface-muted px-4 py-3">
+      <div
+        className={cn(
+          "rowan-num text-xl font-semibold tracking-tight",
+          tone === "negative" && "text-negative",
+          tone === "positive" && "text-positive",
+          tone === "brand" && "text-brand",
+          tone === "neutral" && "text-ink",
+          tone === "gold" && "text-brand-violet",
+        )}
+      >
+        {value}
+      </div>
+      <div className="mt-0.5 text-[0.72rem] font-medium text-ink-muted">
+        {label}
+      </div>
+      {hint ? (
+        <div className="mt-0.5 text-[0.68rem] text-ink-muted">{hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * An empty state that tells you what to do next. Never a shrug — the frontend
+ * brief is explicit that emptiness is an invitation to act, and in a demo an
+ * unexplained blank panel reads as a bug.
+ */
+export function EmptyState({
+  title,
+  hint,
+  icon,
+}: {
+  title: string;
+  hint: string;
+  icon?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-hairline px-6 py-10 text-center">
+      {icon ? <div className="mb-2 text-ink-muted">{icon}</div> : null}
+      <p className="text-sm font-medium text-ink">{title}</p>
+      <p className="mt-1 max-w-sm text-[0.78rem] text-ink-muted">{hint}</p>
+    </div>
+  );
+}
+
+/**
+ * A control that the AGENT set, rather than the user.
+ *
+ * Beat 3c turns on the audience being able to SEE that a filter and a sort were
+ * applied by the assistant — "it performed a maneuver, not a link". So an
+ * agent-set control gets the brand tint plus a weight change; a user-set one
+ * stays quiet. Banking uses the same treatment on its Sort and Top-N controls.
+ */
+export function activeSelectClass(active: boolean): string {
+  return cn(
+    "rounded-md border px-2.5 py-1.5 text-[0.78rem] transition-colors",
+    active
+      ? "border-brand/50 bg-brand-soft font-semibold text-brand"
+      : "border-hairline bg-surface text-ink-muted hover:text-ink",
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/components/recording-context.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/components/recording-context.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+
+/**
+ * BEAT 6, role #3 — RECORDING.
+ *
+ * While the human demonstrates the out-of-band unlock on the Compensation page,
+ * the agent holds the chat with a waiting card and this context narrates each
+ * real action as it happens. Two things about the design are deliberate:
+ *
+ *  - It records what the human ACTUALLY DID, not what the UI offered. The code
+ *    that lifts the gate is captured from the exception the human actually
+ *    filed (`getDemonstratedCode`), so the saved procedure names the real code
+ *    rather than a guess. If the human files a DECOY, the recording faithfully
+ *    captures the decoy — and the approve still fails, which is the honest
+ *    outcome and a far better demo than a recorder that quietly corrects them.
+ *
+ *  - `beginRecording` / `endRecording` are REF-COUNTED. The waiting card can
+ *    re-render, remount on a thread switch, or briefly double-mount in React
+ *    strict mode; a boolean flag would be switched off by the first unmount and
+ *    the feed would go dead mid-demonstration while everything still looked
+ *    fine. A counter survives all three.
+ */
+
+export interface RecordedStep {
+  id: string;
+  label: string;
+  at: number;
+  /** Set when the step is the one that filed a band exception. */
+  code?: string;
+}
+
+interface RecordingValue {
+  isRecording: boolean;
+  steps: RecordedStep[];
+  beginRecording: () => void;
+  endRecording: () => void;
+  logStep: (label: string, code?: string) => void;
+  /** The exception code the human actually filed during this demonstration. */
+  getDemonstratedCode: () => string | null;
+  reset: () => void;
+}
+
+const RecordingContext = createContext<RecordingValue | null>(null);
+
+export function RecordingProvider({ children }: { children: ReactNode }) {
+  const [depth, setDepth] = useState(0);
+  const [steps, setSteps] = useState<RecordedStep[]>([]);
+  // A ref as well as state: `logStep` is called from event handlers that may
+  // have closed over a stale `depth`, and dropping a step because the closure
+  // was one render behind is invisible until the feed is missing a line.
+  const depthRef = useRef(0);
+
+  const beginRecording = useCallback(() => {
+    depthRef.current += 1;
+    setDepth(depthRef.current);
+  }, []);
+
+  const endRecording = useCallback(() => {
+    depthRef.current = Math.max(0, depthRef.current - 1);
+    setDepth(depthRef.current);
+  }, []);
+
+  const logStep = useCallback((label: string, code?: string) => {
+    if (depthRef.current === 0) return;
+    setSteps((prev) => [
+      ...prev,
+      { id: `${Date.now()}-${prev.length}`, label, at: Date.now(), code },
+    ]);
+  }, []);
+
+  const value = useMemo<RecordingValue>(
+    () => ({
+      isRecording: depth > 0,
+      steps,
+      beginRecording,
+      endRecording,
+      logStep,
+      getDemonstratedCode: () =>
+        [...steps].toReversed().find((s) => s.code)?.code ?? null,
+      reset: () => setSteps([]),
+    }),
+    [depth, steps, beginRecording, endRecording, logStep],
+  );
+
+  return (
+    <RecordingContext.Provider value={value}>
+      {children}
+    </RecordingContext.Provider>
+  );
+}
+
+/**
+ * Safe to call from anywhere, including pages that mount outside the provider
+ * during a route transition. Returns inert no-ops rather than throwing: a page
+ * that logs a step is doing optional narration, and crashing the roster because
+ * the recorder was not mounted would be a much worse failure than a missing
+ * line in a feed.
+ */
+export function useRecording(): RecordingValue {
+  return (
+    useContext(RecordingContext) ?? {
+      isRecording: false,
+      steps: [],
+      beginRecording: () => {},
+      endRecording: () => {},
+      logStep: () => {},
+      getDemonstratedCode: () => null,
+      reset: () => {},
+    }
+  );
+}
+
+/**
+ * The edge glow that tells a room recording is live. Mounted once, below the
+ * CopilotKit provider, and pointer-events-none so it never intercepts the very
+ * clicks it exists to watch.
+ */
+export function RecordingVignette() {
+  const { isRecording } = useRecording();
+  if (!isRecording) return null;
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-[1300] rounded-none"
+      style={{
+        boxShadow: "inset 0 0 0 3px hsl(var(--brand) / 0.55)",
+        animation: "rowan-record-breathe 2.4s ease-in-out infinite",
+      }}
+    />
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/components/use-ask-copilot.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/components/use-ask-copilot.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  useAgent,
+  useCopilotChatConfiguration,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+
+/**
+ * Send a message to Rowan on the user's behalf: open the docked panel, append
+ * the message, and start a run — the same addMessage + runAgent path a
+ * suggestion pill takes, so the conversation reads exactly as if the operator
+ * had typed it. Used by the sidebar Help control.
+ *
+ * PORTED, not imported. A skin's only inbound dependency is the shell's `Skin`
+ * contract, so `src/skins/people/**` must never reach into another skin's
+ * folder — even for a hook this small.
+ */
+export function useAskCopilot() {
+  // No explicit agentId: inherit the surrounding CopilotChatConfiguration's
+  // agentId (the active skin's id, "people"), so this drives the SAME
+  // agent/thread the docked chat panel uses.
+  const { agent } = useAgent();
+  const { copilotkit } = useCopilotKit();
+  const configuration = useCopilotChatConfiguration();
+  const setModalOpen = configuration?.setModalOpen;
+
+  return useCallback(
+    async (message: string) => {
+      setModalOpen?.(true);
+      agent.addMessage({
+        id: crypto.randomUUID(),
+        role: "user",
+        content: message,
+      });
+      try {
+        await copilotkit.runAgent({ agent });
+      } catch (error) {
+        console.error("askCopilot: runAgent failed", error);
+      }
+    },
+    [agent, copilotkit, setModalOpen],
+  );
+}
+
+export default useAskCopilot;

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/band-exception-codes.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/band-exception-codes.ts
@@ -1,0 +1,90 @@
+/**
+ * BEAT 6 — the unlock catalogue.
+ *
+ * Approving an out-of-band comp request is gated (422 OUT_OF_BAND). The unlock
+ * is: file a band exception under a code → finalize it → approve. What makes
+ * that a real DEMONSTRATION rather than a scripted workflow is this catalogue's
+ * shape, and all three properties are load-bearing:
+ *
+ *   1. Only JUSTIFYING codes lift the gate.
+ *   2. DECOY codes are VALID — they file, they finalize, they are recorded in
+ *      the exception history — and they do NOT justify. So "the agent filed an
+ *      exception" is not the same as "the agent cleared the gate", and an agent
+ *      that guessed cannot fake its way through.
+ *   3. Unknown codes are rejected WITHOUT enumerating the catalogue. If the
+ *      error listed the valid codes, an agent could brute-force the recipe in
+ *      one round-trip and the demonstration would prove nothing.
+ *
+ * The agent is never told which codes justify. It learns that by watching a
+ * human file one — mirroring `src/skins/banking/data/policy-exception-codes.ts`.
+ */
+
+export interface BandExceptionCode {
+  code: string;
+  label: string;
+  /** Shown in the filing UI. Never says whether the code justifies. */
+  blurb: string;
+}
+
+/**
+ * Everything the filing UI offers. Deliberately mixed — the justifying and the
+ * decoy codes read equally plausible to someone (or something) guessing.
+ */
+export const BAND_EXCEPTION_CODES: readonly BandExceptionCode[] = [
+  {
+    code: "MKT-ADJ",
+    label: "Market adjustment",
+    blurb: "Benchmarked against a current external salary survey.",
+  },
+  {
+    code: "RETENTION",
+    label: "Documented retention case",
+    blurb: "A competing written offer is on file with People Ops.",
+  },
+  {
+    code: "PROMO-BAND",
+    label: "Promotion ahead of band refresh",
+    blurb: "Scope already at the next level; band review is queued.",
+  },
+  {
+    code: "MGR-DISC",
+    label: "Manager discretion",
+    blurb: "The hiring manager is asking for it on judgement alone.",
+  },
+  {
+    code: "TENURE",
+    label: "Long tenure",
+    blurb: "Recognition of years of service.",
+  },
+  {
+    code: "COST-LIV",
+    label: "Cost-of-living pressure",
+    blurb: "Local cost pressure raised by the employee.",
+  },
+];
+
+/**
+ * The subset that actually lifts the gate. The common thread is EVIDENCE that
+ * exists outside the conversation — a benchmark, a written offer, a queued band
+ * review. The decoys are all judgement calls with nothing on file, which is why
+ * comp policy doesn't accept them.
+ */
+export const JUSTIFYING_EXCEPTION_CODES: readonly string[] = [
+  "MKT-ADJ",
+  "RETENTION",
+  "PROMO-BAND",
+];
+
+export function isValidExceptionCode(code: string): boolean {
+  return BAND_EXCEPTION_CODES.some((entry) => entry.code === code);
+}
+
+export function isJustifying(code: string): boolean {
+  return JUSTIFYING_EXCEPTION_CODES.includes(code);
+}
+
+export function exceptionCodeLabel(code: string): string {
+  return (
+    BAND_EXCEPTION_CODES.find((entry) => entry.code === code)?.label ?? code
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/derive.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/derive.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure derivations shared by the pages, the gen-UI components, the agent's
+ * readables and the sandbox functions.
+ *
+ * These deliberately DO NOT import `store.ts`. The store is the server's
+ * in-memory ledger; importing it from a client component would bundle the whole
+ * seed into the browser and create a second, silently divergent copy of the
+ * data — so everything here takes the bands it needs as an argument, sourced
+ * from the one snapshot the ledger context fetched.
+ */
+
+import type {
+  Band,
+  BandPosition,
+  Employee,
+  Level,
+  PeopleRequest,
+} from "./types";
+
+const DAY_MS = 86_400_000;
+
+export const formatSalary = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+/** "$163k" — for axis labels and dense chips where the full figure won't fit. */
+export const formatCompact = (n: number) =>
+  `$${Math.round(n / 1000).toLocaleString("en-US")}k`;
+
+export const formatPercent = (ratio: number) => `${Math.round(ratio * 100)}%`;
+
+export function bandFor(bands: Band[], level: Level): Band | undefined {
+  return bands.find((b) => b.level === level);
+}
+
+/**
+ * Where a salary sits inside its band. Mirrors `store.bandPosition` exactly —
+ * including the split between the CLAMPED `ratio` (which positions the dot on
+ * the rail) and the RAW `outOfBand` test (which decides whether it is flagged).
+ * Clamping the ratio must never be allowed to hide a violation.
+ */
+export function bandPosition(
+  bands: Band[],
+  salary: number,
+  level: Level,
+): BandPosition | null {
+  const band = bandFor(bands, level);
+  if (!band) return null;
+  const span = band.max - band.min;
+  const raw = span === 0 ? 0.5 : (salary - band.min) / span;
+  return {
+    level: band.level,
+    min: band.min,
+    mid: band.mid,
+    max: band.max,
+    ratio: Math.min(1, Math.max(0, raw)),
+    outOfBand: salary < band.min || salary > band.max,
+    side: salary < band.min ? "below" : salary > band.max ? "above" : null,
+  };
+}
+
+export function isOutOfBand(bands: Band[], employee: Employee): boolean {
+  return (
+    bandPosition(bands, employee.baseSalary, employee.level)?.outOfBand ?? false
+  );
+}
+
+/** Whole days since an ISO timestamp. Never negative. */
+export function ageInDays(iso: string): number {
+  return Math.max(
+    0,
+    Math.floor((Date.now() - new Date(iso).getTime()) / DAY_MS),
+  );
+}
+
+/** Signed days until a date — negative once it is in the past. */
+export function daysUntil(isoDate: string): number {
+  return Math.round((new Date(isoDate).getTime() - Date.now()) / DAY_MS);
+}
+
+/** "2 yr 5 mo", "7 mo", "18 days", or "starts in 4 days" for a future joiner. */
+export function tenureLabel(startDate: string): string {
+  const until = daysUntil(startDate);
+  if (until > 0)
+    return until === 1 ? "starts tomorrow" : `starts in ${until} days`;
+  const days = -until;
+  // Below a month, count days. Flooring straight to months rendered a
+  // three-week-old hire as "0 mo", which reads as missing data rather than as
+  // someone who just joined — and the newest people are the ones this page
+  // exists for.
+  if (days === 0) return "starts today";
+  if (days < 31) return days === 1 ? "1 day" : `${days} days`;
+  const months = Math.floor(days / 30.44);
+  if (months < 12) return `${months} mo`;
+  const years = Math.floor(months / 12);
+  const rest = months % 12;
+  return rest === 0 ? `${years} yr` : `${years} yr ${rest} mo`;
+}
+
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] ?? "";
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? "") : "";
+  return (first + last).toUpperCase();
+}
+
+/**
+ * A stable hue per person, derived from their name.
+ *
+ * Rowan puts a monogram tile on nearly every row, and random colours would make
+ * the roster read as confetti while identical colours would make it read as a
+ * spreadsheet. A deterministic hash gives each person a colour they KEEP —
+ * across pages, across reloads, and inside chat gen-UI — so a face becomes
+ * recognisable at a glance. The range is deliberately narrow and desaturated in
+ * use (see Monogram) so the plum chrome stays the loudest thing on screen.
+ */
+export function monogramHue(name: string): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    hash = (hash * 31 + name.charCodeAt(i)) % 360;
+  }
+  return hash;
+}
+
+export const REQUEST_KIND_LABEL: Record<PeopleRequest["kind"], string> = {
+  "time-off": "Time off",
+  equipment: "Equipment",
+  "role-change": "Role change",
+  "referral-bonus": "Referral bonus",
+  training: "Training",
+};
+
+/** The amount-or-days summary a request row shows on its right edge. */
+export function requestValueLabel(request: PeopleRequest): string {
+  if (request.days !== undefined) {
+    return request.days === 1 ? "1 day" : `${request.days} days`;
+  }
+  if (request.amount !== undefined) return formatSalary(request.amount);
+  return "—";
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/http.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/http.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared error mapping for the `/api/people/v1/*` routes.
+ *
+ * The store throws Errors whose message is a stable CODE; this turns a code
+ * into an HTTP status and a human message in one place. Centralising it is not
+ * just tidiness — it is how the beat-6 gate stays honest. `OUT_OF_BAND` has
+ * exactly ONE message string in the whole app, and it is written here where the
+ * "symptom only, never the fix" rule is visible to anyone editing it.
+ */
+
+/** Codes the routes may surface, mapped to status + a symptom-only message. */
+const CODES: Record<string, { status: number; message: string }> = {
+  NOT_FOUND: { status: 404, message: "That record does not exist." },
+  BUDDY_NOT_FOUND: { status: 404, message: "That buddy does not exist." },
+  SELF_BUDDY: { status: 422, message: "Someone cannot be their own buddy." },
+  ALREADY_DECIDED: {
+    status: 409,
+    message: "That request was already decided.",
+  },
+  ALREADY_FINALIZED: {
+    status: 400,
+    message: "That exception has already been finalized.",
+  },
+  INVALID_SALARY: {
+    status: 422,
+    message: "That is not a usable salary figure.",
+  },
+
+  // ── BEAT 6: the gate ──────────────────────────────────────────────────────
+  // SYMPTOM ONLY. This names the problem — the figure sits outside the band —
+  // and must NEVER mention band exceptions, justifying codes, or any part of
+  // the unlock. An agent that can read the recipe out of the error derives it
+  // in one round-trip, and the demonstration stops proving that it learned
+  // anything. If you are tempted to make this message "more helpful", don't.
+  OUT_OF_BAND: {
+    status: 422,
+    message: "Compensation band exceeded for the proposed level.",
+  },
+
+  // Rejected WITHOUT enumerating the catalogue, for the same reason.
+  INVALID_EXCEPTION_CODE: {
+    status: 422,
+    message: "That is not a recognized band exception code.",
+  },
+  UNKNOWN_LEVEL: { status: 500, message: "No band is defined for that level." },
+};
+
+/** Map a thrown store error onto a Response. Unknown errors become a 400. */
+export function errorResponse(error: unknown, context: string): Response {
+  const code = error instanceof Error ? error.message : "";
+  const known = CODES[code];
+  if (known) {
+    return Response.json(
+      { error: code, message: known.message },
+      { status: known.status },
+    );
+  }
+  console.error(`[people/api] ${context}`, error);
+  return Response.json(
+    { error: "BAD_REQUEST", message: "Bad request." },
+    { status: 400 },
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/ledger-context.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/ledger-context.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import type { Operator, PeopleStoreState } from "./types";
+
+/**
+ * Rowan's single client-side source of truth.
+ *
+ * Mounted in the skin's `RuntimeProviders` — i.e. ABOVE `CopilotKitProvider` —
+ * for one specific reason: `useRuntimeProperties` reads the signed-in operator
+ * out of this context, and `properties` is a PROP of `CopilotKitProvider`, so
+ * its source has to exist before that provider's first commit. A child racing
+ * an imperative `setProperties` after mount is the exact bug the contract's
+ * `RuntimeProviders` slot exists to prevent.
+ *
+ * Because it sits above the provider it is also visible to everything below —
+ * `Tools`, the layout, and every page — so the roster, the ladder, the queue
+ * and the agent's readables all read the SAME snapshot. That consistency is
+ * load-bearing for beat 3b: the agent is asked to describe what is literally on
+ * screen, and it cannot do that if a panel and a readable are one fetch apart.
+ */
+
+interface LedgerContextValue {
+  data: PeopleStoreState;
+  /** Re-fetch after a mutation. Every write path calls this. */
+  refresh: () => Promise<void>;
+  operator: Operator;
+  setOperatorId: (id: string) => void;
+}
+
+const LedgerContext = createContext<LedgerContextValue | null>(null);
+
+const EMPTY: PeopleStoreState = {
+  employees: [],
+  bands: [],
+  requests: [],
+  compRequests: [],
+  bandExceptions: [],
+  onboardingTasks: [],
+  packets: [],
+  operators: [],
+};
+
+export function PeopleLedgerProvider({ children }: { children: ReactNode }) {
+  const [data, setData] = useState<PeopleStoreState>(EMPTY);
+  const [loaded, setLoaded] = useState(false);
+  const [operatorId, setOperatorId] = useState<string>("op-maya");
+
+  // Note the `await` comes FIRST: nothing here sets state synchronously, which
+  // is what keeps the mount effect below off React's cascading-render path
+  // (`react-hooks/set-state-in-effect`). An in-flight flag set before the fetch
+  // would put it straight back on it, and no consumer wanted one.
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/people/v1/ledger", { cache: "no-store" });
+      if (!res.ok) throw new Error(`ledger fetch failed: ${res.status}`);
+      setData((await res.json()) as PeopleStoreState);
+    } catch (error) {
+      // Surfacing this as a thrown error would blank the whole app mid-demo for
+      // what is almost always a dev-server restart. Log it, keep the last good
+      // snapshot on screen, and let the next mutation's refresh recover.
+      console.error("[people] ledger refresh failed", error);
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  // The FIRST load is inlined as a promise chain rather than a call to
+  // `refresh`, mirroring `logistics/components/planner-auth-context.tsx`.
+  // `react-hooks/set-state-in-effect` traces through the callback boundary, so
+  // invoking any setState-calling function synchronously in an effect body
+  // trips it — setting state inside a `.then` does not. The `cancelled` guard
+  // is the second reason to prefer this shape: it stops a slow first fetch from
+  // setting state after the provider has already unmounted.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/people/v1/ledger", { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`ledger fetch failed: ${res.status}`);
+        return res.json() as Promise<PeopleStoreState>;
+      })
+      .then((snapshot) => {
+        if (cancelled) return;
+        setData(snapshot);
+        setLoaded(true);
+      })
+      .catch((error) => {
+        console.error("[people] initial ledger fetch failed", error);
+        // Still mark loaded: children must mount even on a failed first fetch,
+        // or a dev-server hiccup leaves the whole skin rendering nothing with
+        // no indication of why.
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const operator = useMemo(
+    () =>
+      data.operators.find((o) => o.id === operatorId) ??
+      data.operators[0] ?? {
+        id: "op-maya",
+        name: "Maya Lindqvist",
+        role: "people-ops-lead" as const,
+        team: "People Ops" as const,
+      },
+    [data.operators, operatorId],
+  );
+
+  const value = useMemo<LedgerContextValue>(
+    () => ({ data, refresh, operator, setOperatorId }),
+    [data, refresh, operator],
+  );
+
+  // Render nothing until the first load resolves. This looks heavy-handed for a
+  // provider, but it is what makes the runtime identity correct on the FIRST
+  // run of a session: `useRuntimeProperties` reads `operator` from here, so
+  // mounting children early would hand CopilotKitProvider a placeholder
+  // operator and scope the opening messages of a demo to the wrong memory
+  // bucket — which then looks like "memory didn't work".
+  if (!loaded) return null;
+
+  return (
+    <LedgerContext.Provider value={value}>{children}</LedgerContext.Provider>
+  );
+}
+
+/**
+ * Read the ledger. Throws when used outside the provider rather than returning
+ * an empty snapshot: a silently-empty roster renders as "no employees", which
+ * is indistinguishable from a real empty state and would send someone hunting
+ * through the seed file instead of the provider tree.
+ */
+export function usePeopleLedger(): LedgerContextValue {
+  const ctx = useContext(LedgerContext);
+  if (!ctx) {
+    throw new Error(
+      "usePeopleLedger must be used inside <PeopleLedgerProvider>",
+    );
+  }
+  return ctx;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/offer-letter-pdf.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/offer-letter-pdf.ts
@@ -1,0 +1,172 @@
+/**
+ * BEAT 3d — the uploaded document, generated rather than checked in.
+ *
+ * Banking ships a static `public/sample-invoice-q2.pdf`. Rowan generates its
+ * offer letter instead, for one reason: the letter's START DATE has to agree
+ * with the seeded hire, and the seed materializes dates relative to `now` so a
+ * demo given next year still shows a queue with sensible aging. A committed PDF
+ * would say "starts 12 August 2026" forever, and the very first thing the agent
+ * does with the document is read the start date out of it — so the one detail
+ * that would visibly disagree is the one detail the beat turns on.
+ *
+ * The PDF is written by hand rather than with a library. It is a single page of
+ * Helvetica text with no images, no compression and no embedded fonts, which
+ * makes it about eighty lines of string building and saves a dependency whose
+ * only job would be this file. Anything more elaborate should use a real
+ * library instead of growing this.
+ *
+ * Server-safe: plain TS, no React, no "use client".
+ */
+
+/** Escape the three characters that are special inside a PDF literal string. */
+function pdfEscape(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+}
+
+interface Line {
+  text: string;
+  /** Point size. */
+  size?: number;
+  bold?: boolean;
+  /** Extra leading before this line, in points. */
+  gap?: number;
+}
+
+const PAGE_HEIGHT = 792;
+const MARGIN = 64;
+
+function contentStream(lines: Line[]): string {
+  let y = PAGE_HEIGHT - MARGIN;
+  const parts: string[] = ["BT"];
+  for (const line of lines) {
+    y -= (line.gap ?? 0) + (line.size ?? 11) + 4;
+    // The font name is built as a whole token rather than interpolated after a
+    // literal slash. A PDF resource name genuinely starts with "/", but the
+    // repo's LOCK_SKIN lint guard reads `/${…}` in a template as a hardcoded
+    // skin route prefix — a false positive here, and this phrasing sidesteps it
+    // without weakening the rule for the links it exists to catch.
+    const font = line.bold ? "/F2" : "/F1";
+    parts.push(
+      `${font} ${line.size ?? 11} Tf`,
+      `1 0 0 1 ${MARGIN} ${y} Tm`,
+      `(${pdfEscape(line.text)}) Tj`,
+    );
+  }
+  parts.push("ET");
+  return parts.join("\n");
+}
+
+/** Assemble a minimal, valid one-page PDF with a correct xref table. */
+function buildPdf(lines: Line[]): Uint8Array {
+  const stream = contentStream(lines);
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+      "/Resources << /Font << /F1 5 0 R /F2 6 0 R >> >> /Contents 4 0 R >>",
+    `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>",
+  ];
+
+  let body = "%PDF-1.4\n";
+  // Byte offsets have to be recorded as the body is assembled — the xref table
+  // is the one part of a PDF a reader genuinely refuses to guess at.
+  const offsets: number[] = [];
+  objects.forEach((object, index) => {
+    offsets.push(body.length);
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefOffset = body.length;
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    xref += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  const trailer =
+    `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n` +
+    `startxref\n${xrefOffset}\n%%EOF\n`;
+
+  return new TextEncoder().encode(body + xref + trailer);
+}
+
+const LONG_DATE = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+
+export interface OfferLetterInput {
+  name: string;
+  title: string;
+  level: string;
+  team: string;
+  managerName: string;
+  location: string;
+  /** ISO date (YYYY-MM-DD) — read straight off the seeded employee record. */
+  startDate: string;
+}
+
+/**
+ * The letter the agent reads. Its contents are deliberately RICHER than the
+ * app's own record: the week-one schedule, the equity grant and the safety
+ * certification exist only here, so a packet built from the document is
+ * visibly different from one the agent could have assembled from the roster
+ * alone. That difference is how the room knows the file was actually read.
+ */
+export function buildOfferLetterPdf(input: OfferLetterInput): Uint8Array {
+  const start = LONG_DATE.format(new Date(input.startDate));
+  return buildPdf([
+    { text: "ROWAN ROBOTICS", size: 16, bold: true },
+    { text: "Offer of employment", size: 10, gap: 2 },
+    { text: `Prepared for ${input.name}`, size: 10 },
+
+    { text: `Dear ${input.name.split(" ")[0]},`, gap: 20 },
+    {
+      text: `We are delighted to confirm your appointment as ${input.title}`,
+      gap: 8,
+    },
+    {
+      text: `(${input.level}) on the ${input.team} team, reporting to ${input.managerName},`,
+    },
+    { text: `based in ${input.location}.` },
+
+    { text: "Start date", size: 12, bold: true, gap: 18 },
+    { text: `Your first day will be ${start}.`, gap: 6 },
+
+    { text: "Equity", size: 12, bold: true, gap: 16 },
+    {
+      text: "12,000 restricted stock units, vesting over four years with a",
+      gap: 6,
+    },
+    {
+      text: "one-year cliff, subject to board approval at the next grant date.",
+    },
+
+    { text: "Before you start", size: 12, bold: true, gap: 16 },
+    {
+      text: "Robot-cell safety certification must be completed before you can",
+      gap: 6,
+    },
+    {
+      text: "access the lab floor. Facilities will schedule this in week one.",
+    },
+
+    { text: "Your first week", size: 12, bold: true, gap: 16 },
+    { text: "Day 1  Laptop, badge, building access, and the lab tour", gap: 6 },
+    { text: "Day 2  Payroll, benefits and equity paperwork with People Ops" },
+    { text: "Day 3  Toolchain setup and repo access with your buddy" },
+    { text: "Day 4  Robot-cell safety certification" },
+    { text: "Day 5  First paired ticket on the actuation stack" },
+
+    {
+      text: "Please countersign and return this letter before your start date.",
+      gap: 22,
+    },
+    { text: "Maya Lindqvist", gap: 16, bold: true },
+    { text: "Head of People Ops, Rowan Robotics", size: 10 },
+  ]);
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/seed.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/seed.ts
@@ -1,0 +1,665 @@
+/**
+ * Rowan's seeded scenario. Server-safe.
+ *
+ * Dates are stored as RELATIVE OFFSETS and materialized against `now` in
+ * `store.ts`, not written as absolute ISO strings. That is deliberate: request
+ * aging drives beat 3c ("show me the oldest pending requests") and tenure
+ * drives the roster, so a seed with hard-coded 2026 dates would read as a
+ * two-year-old queue the first time this demo is given in 2028. It also means a
+ * presenter Reset genuinely re-freshens the queue rather than restoring stale
+ * timestamps.
+ *
+ * ── Rows that are load-bearing for a demo beat ──────────────────────────────
+ *   emp-priya   BEAT 3a  mid-band, 14 months since her last raise → the merit
+ *                        increase the agent files while the FIGURE is typed by
+ *                        the user into the chat card and never reaches the LLM.
+ *   emp-tobias  BEAT 1/4 sits ABOVE his L4 band today → the ladder has a flag
+ *                        on first paint and "out of band first" has content.
+ *   emp-june    BEAT 1/4 sits BELOW her L5 band → the ladder flags both edges.
+ *   emp-dana    BEAT 5   starts in four days with NO buddy and NO checklist →
+ *               BEAT 3d  the stored procedure has visible work to do, and her
+ *                        offer letter is the uploaded document.
+ *   cmp-marcus  BEAT 6   requested salary is ABOVE the L6 ceiling → 422
+ *                        OUT_OF_BAND. This is the one taught on stage.
+ *   cmp-naomi   BEAT 6   a SECOND out-of-band request. The teaching consumes
+ *                        Marcus's, so the proof of learning is Naomi's being
+ *                        handled unaided. Never remove this row.
+ *   cmp-rhea    BEAT 6   an IN-BAND control. Without it, a presenter can't show
+ *                        that approve works normally and the 422 reads as a
+ *                        broken endpoint rather than as a policy.
+ */
+
+import type {
+  Band,
+  EmployeeStatus,
+  Level,
+  Operator,
+  RequestKind,
+  RequestStatus,
+  Team,
+} from "./types";
+
+export interface EmployeeSeed {
+  id: string;
+  name: string;
+  title: string;
+  level: Level;
+  team: Team;
+  email: string;
+  location: string;
+  managerId: string | null;
+  startedMonthsAgo: number;
+  status: EmployeeStatus;
+  baseSalary: number;
+  lastRaiseMonthsAgo: number | null;
+  buddyId: string | null;
+}
+
+export interface RequestSeed {
+  id: string;
+  employeeId: string;
+  kind: RequestKind;
+  summary: string;
+  detail: string;
+  submittedDaysAgo: number;
+  status: RequestStatus;
+  days?: number;
+  amount?: number;
+}
+
+export interface CompRequestSeed {
+  id: string;
+  employeeId: string;
+  reason: string;
+  currentSalary: number;
+  requestedSalary: number;
+  proposedLevel: Level;
+  submittedBy: string;
+  submittedDaysAgo: number;
+  status: RequestStatus;
+}
+
+export interface OnboardingTaskSeed {
+  id: string;
+  employeeId: string;
+  label: string;
+  owner: string;
+  dueOffsetDays: number;
+  done: boolean;
+}
+
+export interface PacketSeed {
+  id: string;
+  employeeId: string;
+  employeeName: string;
+  role: string;
+  startedMonthsAgo: number;
+  summary: string;
+  highlights: string[];
+  schedule: { day: string; item: string }[];
+  filedDaysAgo: number;
+  filedBy: string;
+}
+
+/**
+ * The band table. The gate in `store.canApproveCompRequest` is enforced against
+ * `min`/`max`; `mid` is the target the ladder ticks. Bands deliberately OVERLAP
+ * at the edges (L4 max 154k, L5 min 152k) the way real ladders do, so "above
+ * your band" is never the same statement as "paid more than the next level".
+ */
+export const SEED_BANDS: readonly Band[] = [
+  { level: "L3", label: "Associate", min: 92_000, mid: 105_000, max: 118_000 },
+  { level: "L4", label: "Engineer", min: 118_000, mid: 136_000, max: 154_000 },
+  { level: "L5", label: "Senior", min: 152_000, mid: 176_000, max: 200_000 },
+  { level: "L6", label: "Staff", min: 196_000, mid: 226_000, max: 256_000 },
+  { level: "L7", label: "Principal", min: 250_000, mid: 288_000, max: 326_000 },
+];
+
+export const SEED_EMPLOYEES: readonly EmployeeSeed[] = [
+  {
+    id: "emp-maya",
+    name: "Maya Lindqvist",
+    title: "Head of People Ops",
+    level: "L6",
+    team: "People Ops",
+    email: "maya@rowan.example",
+    location: "Stockholm",
+    managerId: null,
+    startedMonthsAgo: 52,
+    status: "active",
+    baseSalary: 214_000,
+    lastRaiseMonthsAgo: 8,
+    buddyId: null,
+  },
+  {
+    id: "emp-clara",
+    name: "Clara Mendes",
+    title: "Engineering Manager",
+    level: "L6",
+    team: "Engineering",
+    email: "clara@rowan.example",
+    location: "Lisbon",
+    managerId: null,
+    startedMonthsAgo: 41,
+    status: "active",
+    baseSalary: 232_000,
+    lastRaiseMonthsAgo: 6,
+    buddyId: null,
+  },
+  {
+    id: "emp-arun",
+    name: "Arun Sethi",
+    title: "Principal Engineer",
+    level: "L7",
+    team: "Engineering",
+    email: "arun@rowan.example",
+    location: "Bengaluru",
+    managerId: "emp-clara",
+    startedMonthsAgo: 63,
+    status: "active",
+    baseSalary: 291_000,
+    lastRaiseMonthsAgo: 5,
+    buddyId: null,
+  },
+  {
+    // BEAT 3a — mid-band with real headroom, and overdue for a review, so a
+    // merit increase is the obvious next action a presenter would take.
+    id: "emp-priya",
+    name: "Priya Raman",
+    title: "Senior Robotics Engineer",
+    level: "L5",
+    team: "Engineering",
+    email: "priya@rowan.example",
+    location: "Toronto",
+    managerId: "emp-clara",
+    startedMonthsAgo: 29,
+    status: "active",
+    baseSalary: 163_000,
+    lastRaiseMonthsAgo: 14,
+    buddyId: null,
+  },
+  {
+    // BEAT 6 (#1) — the subject of the out-of-band promotion taught on stage.
+    id: "emp-marcus",
+    name: "Marcus Bell",
+    title: "Senior Controls Engineer",
+    level: "L5",
+    team: "Engineering",
+    email: "marcus@rowan.example",
+    location: "Detroit",
+    managerId: "emp-clara",
+    startedMonthsAgo: 34,
+    status: "active",
+    baseSalary: 194_000,
+    lastRaiseMonthsAgo: 11,
+    buddyId: null,
+  },
+  {
+    // BEAT 1/4 — ABOVE his L4 ceiling (154k) today. The ladder flags him on
+    // first paint, before any tool has run.
+    id: "emp-tobias",
+    name: "Tobias Renn",
+    title: "Firmware Engineer",
+    level: "L4",
+    team: "Engineering",
+    email: "tobias@rowan.example",
+    location: "Berlin",
+    managerId: "emp-clara",
+    startedMonthsAgo: 38,
+    status: "active",
+    baseSalary: 161_000,
+    lastRaiseMonthsAgo: 4,
+    buddyId: null,
+  },
+  {
+    // BEAT 1/4 — BELOW her L5 floor (152k). The other edge of the flag.
+    id: "emp-june",
+    name: "June Castellanos",
+    title: "Senior Data Engineer",
+    level: "L5",
+    team: "Engineering",
+    email: "june@rowan.example",
+    location: "Austin",
+    managerId: "emp-clara",
+    startedMonthsAgo: 19,
+    status: "active",
+    baseSalary: 147_000,
+    lastRaiseMonthsAgo: 16,
+    buddyId: null,
+  },
+  {
+    // BEAT 5 + 3d — starts in four days. No buddy, no checklist, no packet: the
+    // stored procedure and the offer-letter upload both have visible work.
+    id: "emp-dana",
+    name: "Dana Whitfield",
+    title: "Robotics Engineer",
+    level: "L4",
+    team: "Engineering",
+    email: "dana@rowan.example",
+    location: "Toronto",
+    managerId: "emp-clara",
+    startedMonthsAgo: -0.13,
+    status: "onboarding",
+    baseSalary: 138_000,
+    lastRaiseMonthsAgo: null,
+    buddyId: null,
+  },
+  {
+    // Started three weeks ago with a part-finished checklist — gives the
+    // Onboarding page content on load and a contrast for Dana's empty state.
+    id: "emp-yusuf",
+    name: "Yusuf Demir",
+    title: "Associate Engineer",
+    level: "L3",
+    team: "Engineering",
+    email: "yusuf@rowan.example",
+    location: "Istanbul",
+    managerId: "emp-clara",
+    startedMonthsAgo: 0.7,
+    status: "active",
+    baseSalary: 104_000,
+    lastRaiseMonthsAgo: null,
+    buddyId: "emp-tobias",
+  },
+  {
+    id: "emp-holt",
+    name: "Holt Nakamura",
+    title: "Design Lead",
+    level: "L6",
+    team: "Design",
+    email: "holt@rowan.example",
+    location: "Osaka",
+    managerId: null,
+    startedMonthsAgo: 47,
+    status: "on-leave",
+    baseSalary: 219_000,
+    lastRaiseMonthsAgo: 9,
+    buddyId: null,
+  },
+  {
+    // BEAT 6 (#2) — the SECOND out-of-band case, handled unaided after learning.
+    id: "emp-naomi",
+    name: "Naomi Okafor",
+    title: "Senior Product Designer",
+    level: "L5",
+    team: "Design",
+    email: "naomi@rowan.example",
+    location: "Lagos",
+    managerId: "emp-holt",
+    startedMonthsAgo: 26,
+    status: "active",
+    baseSalary: 171_000,
+    lastRaiseMonthsAgo: 12,
+    buddyId: null,
+  },
+  {
+    id: "emp-ines",
+    name: "Inés Vidal",
+    title: "Product Designer",
+    level: "L4",
+    team: "Design",
+    email: "ines@rowan.example",
+    location: "Barcelona",
+    managerId: "emp-holt",
+    startedMonthsAgo: 15,
+    status: "active",
+    baseSalary: 131_000,
+    lastRaiseMonthsAgo: 7,
+    buddyId: null,
+  },
+  {
+    id: "emp-devon",
+    name: "Devon Achebe",
+    title: "Head of Revenue",
+    level: "L6",
+    team: "Go-to-Market",
+    email: "devon@rowan.example",
+    location: "Chicago",
+    managerId: null,
+    startedMonthsAgo: 33,
+    status: "active",
+    baseSalary: 241_000,
+    lastRaiseMonthsAgo: 6,
+    buddyId: null,
+  },
+  {
+    id: "emp-rhea",
+    name: "Rhea Kapoor",
+    title: "Solutions Engineer",
+    level: "L5",
+    team: "Go-to-Market",
+    email: "rhea@rowan.example",
+    location: "London",
+    managerId: "emp-devon",
+    startedMonthsAgo: 22,
+    status: "active",
+    baseSalary: 168_000,
+    lastRaiseMonthsAgo: 10,
+    buddyId: null,
+  },
+  {
+    id: "emp-sasha",
+    name: "Sasha Bergström",
+    title: "Account Executive",
+    level: "L4",
+    team: "Go-to-Market",
+    email: "sasha@rowan.example",
+    location: "Copenhagen",
+    managerId: "emp-devon",
+    startedMonthsAgo: 11,
+    status: "active",
+    baseSalary: 128_000,
+    lastRaiseMonthsAgo: null,
+    buddyId: null,
+  },
+  {
+    id: "emp-oskar",
+    name: "Oskar Lindgren",
+    title: "Controller",
+    level: "L5",
+    team: "Finance",
+    email: "oskar@rowan.example",
+    location: "Stockholm",
+    managerId: null,
+    startedMonthsAgo: 44,
+    status: "active",
+    baseSalary: 175_000,
+    lastRaiseMonthsAgo: 8,
+    buddyId: null,
+  },
+  {
+    id: "emp-bea",
+    name: "Bea Toussaint",
+    title: "People Ops Partner",
+    level: "L4",
+    team: "People Ops",
+    email: "bea@rowan.example",
+    location: "Montréal",
+    managerId: "emp-maya",
+    startedMonthsAgo: 17,
+    status: "active",
+    baseSalary: 134_000,
+    lastRaiseMonthsAgo: 9,
+    buddyId: null,
+  },
+];
+
+/**
+ * The queue. Eleven PENDING rows with a wide aging spread, so beat 3c's
+ * `top=10` genuinely truncates (a top-N that shows everything proves nothing)
+ * and "oldest pending" has an unambiguous winner in Tobias's desk request.
+ */
+export const SEED_REQUESTS: readonly RequestSeed[] = [
+  {
+    id: "req-desk-tobias",
+    employeeId: "emp-tobias",
+    kind: "equipment",
+    summary: "Standing desk and monitor arm",
+    detail: "Occupational health signed off after a back injury in March.",
+    submittedDaysAgo: 31,
+    status: "pending",
+    amount: 940,
+  },
+  {
+    id: "req-kinematics-arun",
+    employeeId: "emp-arun",
+    kind: "training",
+    summary: "Advanced kinematics workshop",
+    detail: "Three-day intensive; Arun would bring the material back in-house.",
+    submittedDaysAgo: 28,
+    status: "pending",
+    amount: 1_900,
+  },
+  {
+    id: "req-october-sasha",
+    employeeId: "emp-sasha",
+    kind: "time-off",
+    summary: "Two weeks in October",
+    detail: "Booked around a wedding; coverage arranged with Rhea.",
+    submittedDaysAgo: 26,
+    status: "pending",
+    days: 10,
+  },
+  {
+    id: "req-rust-yusuf",
+    employeeId: "emp-yusuf",
+    kind: "training",
+    summary: "Embedded Rust certification",
+    detail: "Part of the associate ramp plan agreed at his offer stage.",
+    submittedDaysAgo: 22,
+    status: "pending",
+    amount: 1_450,
+  },
+  {
+    id: "req-family-rhea",
+    employeeId: "emp-rhea",
+    kind: "time-off",
+    summary: "Family leave, three days",
+    detail: "Short-notice caregiving.",
+    submittedDaysAgo: 17,
+    status: "pending",
+    days: 3,
+  },
+  {
+    id: "req-chair-holt",
+    employeeId: "emp-holt",
+    kind: "equipment",
+    summary: "Ergonomic chair",
+    detail: "To be delivered before Holt returns from leave.",
+    submittedDaysAgo: 14,
+    status: "pending",
+    amount: 620,
+  },
+  {
+    id: "req-display-ines",
+    employeeId: "emp-ines",
+    kind: "equipment",
+    summary: "Colour-calibrated display",
+    detail: "Needed for the operator-console contrast audit.",
+    submittedDaysAgo: 12,
+    status: "pending",
+    amount: 1_290,
+  },
+  {
+    id: "req-move-june",
+    employeeId: "emp-june",
+    kind: "role-change",
+    summary: "Move to the Perception team",
+    detail: "Clara and the Perception lead have both agreed in principle.",
+    submittedDaysAgo: 9,
+    status: "pending",
+  },
+  {
+    id: "req-referral-bea",
+    employeeId: "emp-bea",
+    kind: "referral-bonus",
+    summary: "Referral payout for D. Whitfield",
+    detail: "Standard engineering referral, payable on the start date.",
+    submittedDaysAgo: 6,
+    status: "pending",
+    amount: 3_000,
+  },
+  {
+    id: "req-weekend-oskar",
+    employeeId: "emp-oskar",
+    kind: "time-off",
+    summary: "Long weekend",
+    detail: "Two days either side of the quarter close.",
+    submittedDaysAgo: 4,
+    status: "pending",
+    days: 2,
+  },
+  {
+    id: "req-laptop-devon",
+    employeeId: "emp-devon",
+    kind: "equipment",
+    summary: "Laptop refresh",
+    detail: "Four years old; battery no longer holds a customer demo.",
+    submittedDaysAgo: 2,
+    status: "pending",
+    amount: 2_400,
+  },
+  {
+    id: "req-summit-priya",
+    employeeId: "emp-priya",
+    kind: "training",
+    summary: "Robotics summit, Montréal",
+    detail: "Speaking on the actuation stack.",
+    submittedDaysAgo: 41,
+    status: "approved",
+    amount: 2_200,
+  },
+  {
+    id: "req-offsite-clara",
+    employeeId: "emp-clara",
+    kind: "equipment",
+    summary: "Team offsite kit",
+    detail: "Whiteboards and travel adapters for the Lisbon week.",
+    submittedDaysAgo: 35,
+    status: "approved",
+    amount: 780,
+  },
+  {
+    id: "req-sabbatical-naomi",
+    employeeId: "emp-naomi",
+    kind: "time-off",
+    summary: "Sabbatical scoping, four weeks",
+    detail: "Deferred to next year; revisit after the promotion decision.",
+    submittedDaysAgo: 19,
+    status: "declined",
+    days: 20,
+  },
+];
+
+/**
+ * BEAT 6. Two out-of-band requests and one in-band control — see the header
+ * note. Do not collapse these to one: the teaching consumes the first, so the
+ * proof of learning depends on a second, untouched, out-of-band case.
+ */
+export const SEED_COMP_REQUESTS: readonly CompRequestSeed[] = [
+  {
+    id: "cmp-marcus",
+    employeeId: "emp-marcus",
+    reason: "Promotion to Staff — owns the actuation stack end to end",
+    currentSalary: 194_000,
+    requestedSalary: 272_000,
+    proposedLevel: "L6",
+    submittedBy: "Clara Mendes",
+    submittedDaysAgo: 9,
+    status: "pending",
+  },
+  {
+    id: "cmp-naomi",
+    employeeId: "emp-naomi",
+    reason: "Promotion to Staff — owns the operator console end to end",
+    currentSalary: 171_000,
+    requestedSalary: 268_000,
+    proposedLevel: "L6",
+    submittedBy: "Holt Nakamura",
+    submittedDaysAgo: 5,
+    status: "pending",
+  },
+  {
+    id: "cmp-rhea",
+    employeeId: "emp-rhea",
+    reason: "Market adjustment for solutions engineering",
+    currentSalary: 168_000,
+    requestedSalary: 186_000,
+    proposedLevel: "L5",
+    submittedBy: "Devon Achebe",
+    submittedDaysAgo: 3,
+    status: "pending",
+  },
+];
+
+/** Yusuf's part-finished ramp. Dana deliberately has none — beat 5 creates hers. */
+export const SEED_ONBOARDING_TASKS: readonly OnboardingTaskSeed[] = [
+  {
+    id: "task-yusuf-1",
+    employeeId: "emp-yusuf",
+    label: "Laptop and badge issued",
+    owner: "IT",
+    dueOffsetDays: -2,
+    done: true,
+  },
+  {
+    id: "task-yusuf-2",
+    employeeId: "emp-yusuf",
+    label: "Payroll and benefits enrolment",
+    owner: "People Ops",
+    dueOffsetDays: 1,
+    done: true,
+  },
+  {
+    id: "task-yusuf-3",
+    employeeId: "emp-yusuf",
+    label: "Repo access and on-call shadowing",
+    owner: "Engineering",
+    dueOffsetDays: 3,
+    done: true,
+  },
+  {
+    id: "task-yusuf-4",
+    employeeId: "emp-yusuf",
+    label: "30-day check-in with Clara",
+    owner: "Clara Mendes",
+    dueOffsetDays: 30,
+    done: false,
+  },
+  {
+    id: "task-yusuf-5",
+    employeeId: "emp-yusuf",
+    label: "Safety certification for the robot cell",
+    owner: "Facilities",
+    dueOffsetDays: 14,
+    done: false,
+  },
+];
+
+/** One filed packet so the Packets tab is never empty; beat 3d adds Dana's. */
+export const SEED_PACKETS: readonly PacketSeed[] = [
+  {
+    id: "pkt-yusuf",
+    employeeId: "emp-yusuf",
+    employeeName: "Yusuf Demir",
+    role: "Associate Engineer, L3 · Engineering",
+    startedMonthsAgo: 0.7,
+    summary:
+      "Associate engineer joining the firmware group under Clara Mendes, ramping through the embedded toolchain before taking on-call.",
+    highlights: [
+      "Buddy: Tobias Renn (firmware)",
+      "Safety certification required before robot-cell access",
+      "Embedded Rust certification approved at offer stage",
+    ],
+    schedule: [
+      { day: "Day 1", item: "Laptop, badge, and the office tour" },
+      { day: "Day 2", item: "Payroll, benefits, and equity paperwork" },
+      { day: "Day 3", item: "Toolchain setup with Tobias" },
+      { day: "Week 2", item: "First firmware ticket, paired" },
+    ],
+    filedDaysAgo: 24,
+    filedBy: "Maya Lindqvist",
+  },
+];
+
+/**
+ * Who can be signed in. Rowan scopes durable memory by operator id, so the
+ * seeded beat-4 preference belongs to Maya — switching to Clara deliberately
+ * shows a colleague who has NOT taught Rowan anything yet.
+ */
+export const SEED_OPERATORS: readonly Operator[] = [
+  {
+    id: "op-maya",
+    name: "Maya Lindqvist",
+    role: "people-ops-lead",
+    team: "People Ops",
+  },
+  {
+    id: "op-clara",
+    name: "Clara Mendes",
+    role: "manager",
+    team: "Engineering",
+  },
+];
+
+export const DEFAULT_OPERATOR_ID = "op-maya";

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/store.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/store.ts
@@ -1,0 +1,420 @@
+/**
+ * Rowan's server-side ledger.
+ *
+ * An in-memory module, exactly like `src/skins/banking/data/store.ts`: state
+ * lives for the life of the Node process and `reset()` re-materializes it from
+ * the seed. Every `/api/people/v1/*` route reads and writes through here, which
+ * is what makes beat 3d true — a filed onboarding packet belongs to the
+ * APPLICATION, so deleting the chat thread cannot take it away.
+ *
+ * Mutations that can legitimately be refused throw an Error whose `message` is
+ * a stable CODE (`NOT_FOUND`, `OUT_OF_BAND`, `INVALID_EXCEPTION_CODE`, …). The
+ * routes map those codes onto HTTP statuses; nothing parses prose.
+ */
+
+import { isJustifying, isValidExceptionCode } from "./band-exception-codes";
+import {
+  DEFAULT_OPERATOR_ID,
+  SEED_BANDS,
+  SEED_COMP_REQUESTS,
+  SEED_EMPLOYEES,
+  SEED_ONBOARDING_TASKS,
+  SEED_OPERATORS,
+  SEED_PACKETS,
+  SEED_REQUESTS,
+} from "./seed";
+import type {
+  Band,
+  BandException,
+  BandPosition,
+  CompRequest,
+  Employee,
+  Level,
+  OnboardingPacket,
+  OnboardingTask,
+  Operator,
+  PeopleRequest,
+  PeopleStoreState,
+  RequestStatus,
+} from "./types";
+
+export { DEFAULT_OPERATOR_ID };
+
+const DAY_MS = 86_400_000;
+const AVG_MONTH_DAYS = 30.44;
+
+/** `YYYY-MM-DD`, n months before now. Negative n is in the future. */
+function monthsAgoDate(months: number): string {
+  const d = new Date(Date.now() - months * AVG_MONTH_DAYS * DAY_MS);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Full ISO timestamp, n days before now. */
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * DAY_MS).toISOString();
+}
+
+/** Whole days between an ISO timestamp and now. Never negative. */
+export function ageInDays(iso: string): number {
+  return Math.max(
+    0,
+    Math.floor((Date.now() - new Date(iso).getTime()) / DAY_MS),
+  );
+}
+
+/**
+ * Turn the relative-offset seed into dated records. Called at module init and
+ * again on every `reset()`, so a presenter Reset re-freshens request aging
+ * rather than restoring timestamps that were already stale.
+ */
+function materialize(): PeopleStoreState {
+  return {
+    bands: SEED_BANDS.map((b) => ({ ...b })),
+    employees: SEED_EMPLOYEES.map((e) => ({
+      id: e.id,
+      name: e.name,
+      title: e.title,
+      level: e.level,
+      team: e.team,
+      email: e.email,
+      location: e.location,
+      managerId: e.managerId,
+      startDate: monthsAgoDate(e.startedMonthsAgo),
+      status: e.status,
+      baseSalary: e.baseSalary,
+      lastRaiseDate:
+        e.lastRaiseMonthsAgo === null
+          ? null
+          : monthsAgoDate(e.lastRaiseMonthsAgo),
+      buddyId: e.buddyId,
+      notes: [],
+    })),
+    requests: SEED_REQUESTS.map((r) => ({
+      id: r.id,
+      employeeId: r.employeeId,
+      kind: r.kind,
+      summary: r.summary,
+      detail: r.detail,
+      submittedAt: daysAgoIso(r.submittedDaysAgo),
+      status: r.status,
+      ...(r.days === undefined ? {} : { days: r.days }),
+      ...(r.amount === undefined ? {} : { amount: r.amount }),
+    })),
+    compRequests: SEED_COMP_REQUESTS.map((c) => ({
+      id: c.id,
+      employeeId: c.employeeId,
+      reason: c.reason,
+      currentSalary: c.currentSalary,
+      requestedSalary: c.requestedSalary,
+      proposedLevel: c.proposedLevel,
+      submittedBy: c.submittedBy,
+      submittedAt: daysAgoIso(c.submittedDaysAgo),
+      status: c.status,
+      bandExceptionId: null,
+    })),
+    bandExceptions: [],
+    onboardingTasks: SEED_ONBOARDING_TASKS.map((t) => ({ ...t })),
+    packets: SEED_PACKETS.map((p) => ({
+      id: p.id,
+      employeeId: p.employeeId,
+      employeeName: p.employeeName,
+      role: p.role,
+      startDate: monthsAgoDate(p.startedMonthsAgo),
+      summary: p.summary,
+      highlights: [...p.highlights],
+      schedule: p.schedule.map((s) => ({ ...s })),
+      filedAt: daysAgoIso(p.filedDaysAgo),
+      filedBy: p.filedBy,
+    })),
+    operators: SEED_OPERATORS.map((o) => ({ ...o })),
+  };
+}
+
+let state: PeopleStoreState = materialize();
+
+/** Monotonic suffix so generated ids are readable and stable within a run. */
+let counter = 0;
+function nextId(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${Date.now().toString(36)}${counter.toString(36)}`;
+}
+
+export function reset(): void {
+  state = materialize();
+  counter = 0;
+}
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+export const employees = (): Employee[] => state.employees;
+export const bands = (): Band[] => state.bands;
+export const requests = (): PeopleRequest[] => state.requests;
+export const compRequests = (): CompRequest[] => state.compRequests;
+export const bandExceptions = (): BandException[] => state.bandExceptions;
+export const onboardingTasks = (): OnboardingTask[] => state.onboardingTasks;
+export const packets = (): OnboardingPacket[] => state.packets;
+export const operators = (): Operator[] => state.operators;
+
+export function employee(id: string): Employee | undefined {
+  return state.employees.find((e) => e.id === id);
+}
+
+export function bandFor(level: Level): Band {
+  const found = state.bands.find((b) => b.level === level);
+  // Every employee and comp request carries a Level from the union, and the
+  // seed defines a band for all five, so this is unreachable — but throwing a
+  // coded error beats returning a zeroed band that would silently make every
+  // salary look "in band".
+  if (!found) throw new Error("UNKNOWN_LEVEL");
+  return found;
+}
+
+// ── Derived ─────────────────────────────────────────────────────────────────
+
+/**
+ * Where a salary sits in a band. `ratio` is clamped to [0, 1] because it drives
+ * the ladder's dot position; `outOfBand` is computed from the RAW comparison,
+ * so clamping never hides a violation. Keeping those two separate is what lets
+ * an out-of-band person render pinned to the rail's edge AND flagged.
+ */
+export function bandPosition(salary: number, level: Level): BandPosition {
+  const band = bandFor(level);
+  const span = band.max - band.min;
+  const raw = span === 0 ? 0.5 : (salary - band.min) / span;
+  return {
+    level,
+    min: band.min,
+    mid: band.mid,
+    max: band.max,
+    ratio: Math.min(1, Math.max(0, raw)),
+    outOfBand: salary < band.min || salary > band.max,
+    side: salary < band.min ? "below" : salary > band.max ? "above" : null,
+  };
+}
+
+export function isWithinBand(salary: number, level: Level): boolean {
+  const band = bandFor(level);
+  return salary >= band.min && salary <= band.max;
+}
+
+/**
+ * BEAT 6, the discriminating half. An exception only counts when it is filed
+ * against THIS request, has been finalized to `approved`, AND carries a
+ * justifying code. A decoy code satisfies the first two and fails the third —
+ * which is exactly why "the agent filed an exception" is not the same as "the
+ * agent cleared the gate".
+ */
+export function hasApprovedJustifyingException(compRequestId: string): boolean {
+  return state.bandExceptions.some(
+    (x) =>
+      x.compRequestId === compRequestId &&
+      x.status === "approved" &&
+      isJustifying(x.code),
+  );
+}
+
+export function exceptionsFor(compRequestId: string): BandException[] {
+  return state.bandExceptions.filter((x) => x.compRequestId === compRequestId);
+}
+
+/** The gate, as a pure predicate. `null` = allowed; a string = the refusal code. */
+export function compApprovalBlocker(request: CompRequest): string | null {
+  if (request.status !== "pending") return "ALREADY_DECIDED";
+  if (isWithinBand(request.requestedSalary, request.proposedLevel)) return null;
+  if (hasApprovedJustifyingException(request.id)) return null;
+  return "OUT_OF_BAND";
+}
+
+// ── Mutations ───────────────────────────────────────────────────────────────
+
+/**
+ * BEAT 3a. The figure arrives here straight from the chat card the user typed
+ * it into; it is never in a prompt, a tool argument the model authored, or a
+ * transcript. The caller gets back the employee record WITHOUT the new salary
+ * echoed into any agent-visible string — see the route.
+ */
+export function setBaseSalary(employeeId: string, salary: number): Employee {
+  const target = employee(employeeId);
+  if (!target) throw new Error("NOT_FOUND");
+  if (!Number.isFinite(salary) || salary <= 0)
+    throw new Error("INVALID_SALARY");
+  if (!isWithinBand(salary, target.level)) throw new Error("OUT_OF_BAND");
+  target.baseSalary = Math.round(salary);
+  target.lastRaiseDate = new Date().toISOString().slice(0, 10);
+  return target;
+}
+
+export function decideRequest(
+  id: string,
+  status: RequestStatus,
+): PeopleRequest {
+  const target = state.requests.find((r) => r.id === id);
+  if (!target) throw new Error("NOT_FOUND");
+  target.status = status;
+  return target;
+}
+
+/** BEAT 5, step 3. The 🎉 prefix is forced by the tool, not by this layer. */
+export function addNote(
+  employeeId: string,
+  text: string,
+  author: string,
+): Employee {
+  const target = employee(employeeId);
+  if (!target) throw new Error("NOT_FOUND");
+  target.notes.unshift({
+    id: nextId("note"),
+    text,
+    author,
+    createdAt: new Date().toISOString(),
+  });
+  return target;
+}
+
+/** BEAT 5, step 2. */
+export function assignBuddy(employeeId: string, buddyId: string): Employee {
+  const target = employee(employeeId);
+  if (!target) throw new Error("NOT_FOUND");
+  if (!employee(buddyId)) throw new Error("BUDDY_NOT_FOUND");
+  if (buddyId === employeeId) throw new Error("SELF_BUDDY");
+  target.buddyId = buddyId;
+  return target;
+}
+
+/**
+ * BEAT 5, step 1. Idempotent by design: re-running the stored procedure on
+ * someone who already has a checklist replaces it rather than doubling it, so a
+ * presenter who fires the pill twice does not end up with sixteen tasks on
+ * stage.
+ */
+export function createOnboardingTasks(
+  employeeId: string,
+  labels: { label: string; owner: string; dueOffsetDays: number }[],
+): OnboardingTask[] {
+  const target = employee(employeeId);
+  if (!target) throw new Error("NOT_FOUND");
+  state.onboardingTasks = state.onboardingTasks.filter(
+    (t) => t.employeeId !== employeeId,
+  );
+  const created = labels.map((l) => ({
+    id: nextId("task"),
+    employeeId,
+    label: l.label,
+    owner: l.owner,
+    dueOffsetDays: l.dueOffsetDays,
+    done: false,
+  }));
+  state.onboardingTasks.push(...created);
+  return created;
+}
+
+export function setTaskDone(id: string, done: boolean): OnboardingTask {
+  const target = state.onboardingTasks.find((t) => t.id === id);
+  if (!target) throw new Error("NOT_FOUND");
+  target.done = done;
+  return target;
+}
+
+/** BEAT 3d. The durable artifact. */
+export function filePacket(input: {
+  employeeId: string;
+  summary: string;
+  highlights: string[];
+  schedule: { day: string; item: string }[];
+  filedBy: string;
+}): OnboardingPacket {
+  const target = employee(input.employeeId);
+  if (!target) throw new Error("NOT_FOUND");
+  const packet: OnboardingPacket = {
+    id: nextId("pkt"),
+    employeeId: target.id,
+    employeeName: target.name,
+    role: `${target.title}, ${target.level} · ${target.team}`,
+    startDate: target.startDate,
+    summary: input.summary,
+    highlights: input.highlights.slice(0, 3),
+    schedule: input.schedule.slice(0, 8),
+    filedAt: new Date().toISOString(),
+    filedBy: input.filedBy,
+  };
+  state.packets.unshift(packet);
+  return packet;
+}
+
+// ── BEAT 6: the unlock ──────────────────────────────────────────────────────
+
+export function openBandException(
+  compRequestId: string,
+  code: string,
+  justification: string,
+): BandException {
+  const request = state.compRequests.find((c) => c.id === compRequestId);
+  if (!request) throw new Error("NOT_FOUND");
+  // Rejected WITHOUT enumerating the catalogue — listing the valid codes here
+  // would hand the agent the recipe in one round-trip and beat 6 would stop
+  // proving that it learned anything.
+  if (!isValidExceptionCode(code)) throw new Error("INVALID_EXCEPTION_CODE");
+  const exception: BandException = {
+    id: nextId("bex"),
+    compRequestId,
+    code,
+    justification,
+    status: "draft",
+    openedAt: new Date().toISOString(),
+    finalizedAt: null,
+  };
+  state.bandExceptions.push(exception);
+  return exception;
+}
+
+export function finalizeBandException(id: string): BandException {
+  const exception = state.bandExceptions.find((x) => x.id === id);
+  if (!exception) throw new Error("NOT_FOUND");
+  if (exception.status === "approved") throw new Error("ALREADY_FINALIZED");
+  exception.status = "approved";
+  exception.finalizedAt = new Date().toISOString();
+  // Link it for display. Note this happens for DECOY codes too — the exception
+  // is genuinely on file either way; only `hasApprovedJustifyingException`
+  // decides whether it lifts the gate.
+  const request = state.compRequests.find(
+    (c) => c.id === exception.compRequestId,
+  );
+  if (request) request.bandExceptionId = exception.id;
+  return exception;
+}
+
+/**
+ * BEAT 6, the gate itself. Throws `OUT_OF_BAND` — a SYMPTOM-ONLY code. Neither
+ * this nor the route's message may ever mention band exceptions; naming the fix
+ * in the error is the single easiest way to destroy this beat.
+ */
+export function approveCompRequest(id: string): {
+  request: CompRequest;
+  employee: Employee;
+} {
+  const request = state.compRequests.find((c) => c.id === id);
+  if (!request) throw new Error("NOT_FOUND");
+  const blocker = compApprovalBlocker(request);
+  if (blocker) throw new Error(blocker);
+
+  const target = employee(request.employeeId);
+  if (!target) throw new Error("NOT_FOUND");
+  request.status = "approved";
+  target.baseSalary = request.requestedSalary;
+  target.level = request.proposedLevel;
+  target.lastRaiseDate = new Date().toISOString().slice(0, 10);
+  return { request, employee: target };
+}
+
+export function declineCompRequest(id: string): CompRequest {
+  const request = state.compRequests.find((c) => c.id === id);
+  if (!request) throw new Error("NOT_FOUND");
+  if (request.status !== "pending") throw new Error("ALREADY_DECIDED");
+  request.status = "declined";
+  return request;
+}
+
+/** The whole ledger, for the client's single-fetch hook. */
+export function snapshot(): PeopleStoreState {
+  return state;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/data/types.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/data/types.ts
@@ -1,0 +1,189 @@
+/**
+ * Rowan's domain model. Server-safe (plain types + string unions, no React) so
+ * `store.ts`, the REST routes and the agent-side modules can all import it.
+ */
+
+export type Level = "L3" | "L4" | "L5" | "L6" | "L7";
+
+export const LEVELS: readonly Level[] = ["L3", "L4", "L5", "L6", "L7"];
+
+export type Team =
+  | "Engineering"
+  | "Design"
+  | "Go-to-Market"
+  | "Finance"
+  | "People Ops";
+
+export type EmployeeStatus = "active" | "onboarding" | "on-leave";
+
+/**
+ * A compensation band. `min`/`max` are the hard edges the OUT_OF_BAND gate is
+ * enforced against (see store.canApproveCompRequest); `mid` is the target and
+ * is what the ladder renders its midpoint tick at.
+ */
+export interface Band {
+  level: Level;
+  /** The band's canonical title, e.g. "Senior". Not an employee's job title. */
+  label: string;
+  min: number;
+  mid: number;
+  max: number;
+}
+
+export interface EmployeeNote {
+  id: string;
+  text: string;
+  author: string;
+  createdAt: string;
+}
+
+export interface Employee {
+  id: string;
+  name: string;
+  title: string;
+  level: Level;
+  team: Team;
+  email: string;
+  location: string;
+  managerId: string | null;
+  /** ISO date, materialized from the seed's relative offset at store init. */
+  startDate: string;
+  status: EmployeeStatus;
+  baseSalary: number;
+  /** ISO date or null — drives the "due for review" signal on the roster. */
+  lastRaiseDate: string | null;
+  /** Beat 5, step 2: the onboarding buddy the stored procedure assigns. */
+  buddyId: string | null;
+  notes: EmployeeNote[];
+}
+
+export type RequestKind =
+  | "time-off"
+  | "equipment"
+  | "role-change"
+  | "referral-bonus"
+  | "training";
+
+export type RequestStatus = "pending" | "approved" | "declined";
+
+/**
+ * The Requests queue — beat 3c's lever surface. `submittedAt` is materialized
+ * relative to now at store init, so "oldest pending" stays a sensible number of
+ * days no matter how long after authoring the demo is run.
+ */
+export interface PeopleRequest {
+  id: string;
+  employeeId: string;
+  kind: RequestKind;
+  summary: string;
+  detail: string;
+  submittedAt: string;
+  status: RequestStatus;
+  /** Present for time-off. */
+  days?: number;
+  /** Present for equipment / referral-bonus / training. */
+  amount?: number;
+}
+
+/**
+ * BEAT 6 — the gated object. Approving one of these writes the requested salary
+ * onto the employee, and the write is refused with 422 OUT_OF_BAND when
+ * `requestedSalary` sits outside the band for `proposedLevel` and no APPROVED,
+ * JUSTIFYING band exception is linked.
+ */
+export interface CompRequest {
+  id: string;
+  employeeId: string;
+  reason: string;
+  currentSalary: number;
+  requestedSalary: number;
+  proposedLevel: Level;
+  submittedBy: string;
+  submittedAt: string;
+  status: RequestStatus;
+  /** Set by linking a finalized exception; null until the unlock is performed. */
+  bandExceptionId: string | null;
+}
+
+export type BandExceptionStatus = "draft" | "approved";
+
+/**
+ * BEAT 6 — the unlock artifact. Filed under a code from the catalogue in
+ * `band-exception-codes.ts`; only a JUSTIFYING code lifts the gate once the
+ * exception is finalized.
+ */
+export interface BandException {
+  id: string;
+  compRequestId: string;
+  code: string;
+  justification: string;
+  status: BandExceptionStatus;
+  openedAt: string;
+  finalizedAt: string | null;
+}
+
+/**
+ * BEAT 5 — one of the three visible writes the stored procedure fires.
+ */
+export interface OnboardingTask {
+  id: string;
+  employeeId: string;
+  label: string;
+  owner: string;
+  /** Days relative to the employee's start date. Negative = before day one. */
+  dueOffsetDays: number;
+  done: boolean;
+}
+
+/**
+ * BEAT 3d — the durable artifact. Written to the STORE, not to the thread, so
+ * deleting the conversation leaves it standing on the Onboarding page.
+ */
+export interface OnboardingPacket {
+  id: string;
+  employeeId: string;
+  employeeName: string;
+  role: string;
+  startDate: string;
+  summary: string;
+  /** At most three; the tool truncates. */
+  highlights: string[];
+  /** Week-one schedule, typically lifted from an uploaded offer letter. */
+  schedule: { day: string; item: string }[];
+  filedAt: string;
+  filedBy: string;
+}
+
+/** The signed-in operator. Rowan scopes durable memory per person id. */
+export interface Operator {
+  id: string;
+  name: string;
+  role: "people-ops-lead" | "recruiter" | "manager";
+  team: Team;
+}
+
+/** Everything the store holds. Cloned wholesale on reset. */
+export interface PeopleStoreState {
+  employees: Employee[];
+  bands: Band[];
+  requests: PeopleRequest[];
+  compRequests: CompRequest[];
+  bandExceptions: BandException[];
+  onboardingTasks: OnboardingTask[];
+  packets: OnboardingPacket[];
+  operators: Operator[];
+}
+
+/** Where a salary sits inside its band — the ladder's core derived value. */
+export interface BandPosition {
+  level: Level;
+  min: number;
+  mid: number;
+  max: number;
+  /** 0 at band min, 1 at band max. Clamped for rendering, NOT for the gate. */
+  ratio: number;
+  /** True when the salary is genuinely outside [min, max]. */
+  outOfBand: boolean;
+  /** "below" | "above" | null — which edge it fell outside. */
+  side: "below" | "above" | null;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/design-skill.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/design-skill.ts
@@ -1,0 +1,40 @@
+/**
+ * The OGUI design brief, injected as agent context so anything
+ * `generateSandboxedUi` produces looks like it belongs to Rowan rather than to
+ * a generic dashboard template.
+ *
+ * Written as instructions about RESTRAINT as much as about style: generated UI
+ * defaults to gradient hero numbers and rainbow chart palettes, and either
+ * would clash badly with an app whose entire visual argument is a quiet plum
+ * chrome carrying colourful per-person monograms.
+ */
+export const ROWAN_DESIGN_SKILL = `
+Rowan is a People Ops product. Generated UI must look like part of it.
+
+Palette. Deep plum is the only brand colour: hsl(315 38% 36%) for accents and
+fills, hsl(322 44% 26%) for the darker end of any gradient, and a very pale
+hsl(316 46% 95%) for soft backgrounds. Warm gold, hsl(38 88% 50%), marks
+milestones and nothing else. Positive is hsl(158 56% 34%); anything wrong or out
+of policy is hsl(352 70% 48%). Surfaces are white on a hsl(318 16% 95%) canvas,
+text is hsl(318 24% 12%) with hsl(316 9% 44%) for secondary.
+
+Shape and space. 0.875rem corners on cards, 1px hairline borders in
+hsl(318 18% 89%), one soft shadow, generous padding. No heavy borders, no
+double-outlined cards, no drop shadows on text.
+
+Type. System sans throughout. One weight step between a label and its value, no
+more. Every figure — salary, band position, day count, headcount — uses tabular
+numerals so columns line up and a changed digit reads as a change.
+
+People. Anyone shown gets a round monogram tile with their initials, in a
+desaturated colour derived from their name (roughly hsl(H 44% 92%) background
+with hsl(H 52% 28%) text). Never invent avatars or photographs.
+
+Restraint. One accent per view. Do not build gradient hero numbers, multi-colour
+chart palettes, or decorative icons. Bands and positions are the interesting
+part; let them carry the view. Empty states say what to do next, never just
+"no data".
+
+Figures. Never type a number into generated markup. Every value comes from the
+exposed sandbox functions, so the UI stays bound to the real ledger.
+`.trim();

--- a/examples/showcases/reskinnable-demo/src/skins/people/identity.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/identity.ts
@@ -1,0 +1,59 @@
+import { createElement } from "react";
+
+/**
+ * The Rowan mark — a rowan sprig: a stem carrying three pairs of leaflets under
+ * a single berry. Chosen over the usual "three abstract humans" people-ops glyph
+ * because the whole skin's visual thesis is growth over time (tenure, bands,
+ * progression), and a sprig says that in one shape.
+ *
+ * Everything is drawn in `currentColor` so the mark inherits whatever color it
+ * mounts into — brand plum in the nav rail, ink in the skin selector, and the
+ * chat header's own foreground.
+ */
+function RowanLogo({ className }: { className?: string }) {
+  const leaflet = (cx: number, cy: number, tilt: number, key: string) =>
+    createElement("ellipse", {
+      key,
+      cx,
+      cy,
+      rx: 3.3,
+      ry: 1.45,
+      fill: "currentColor",
+      opacity: 0.9,
+      transform: `rotate(${tilt} ${cx} ${cy})`,
+    });
+
+  return createElement(
+    "svg",
+    {
+      className,
+      viewBox: "0 0 24 24",
+      fill: "none",
+      xmlns: "http://www.w3.org/2000/svg",
+      "aria-hidden": true,
+    },
+    createElement("path", {
+      d: "M12 21.5V6.4",
+      stroke: "currentColor",
+      strokeWidth: 1.5,
+      strokeLinecap: "round",
+    }),
+    createElement("circle", { cx: 12, cy: 3.6, r: 2.3, fill: "currentColor" }),
+    leaflet(7.6, 9.4, -24, "l1"),
+    leaflet(16.4, 9.4, 24, "r1"),
+    leaflet(7.6, 13.6, -24, "l2"),
+    leaflet(16.4, 13.6, 24, "r2"),
+    leaflet(7.6, 17.8, -24, "l3"),
+    leaflet(16.4, 17.8, 24, "r3"),
+  );
+}
+
+export const peopleIdentity = {
+  brand: "Rowan",
+  tagline: "The people operations desk.",
+  logo: RowanLogo,
+  favicon: "🌿",
+  assistantName: "Rowan",
+  greeting:
+    "I'm Rowan. I can read whatever page you're on, move people through comp and onboarding, and act on the queue. Pick a suggestion below to start.",
+} as const;

--- a/examples/showcases/reskinnable-demo/src/skins/people/intelligence/forget-memories.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/intelligence/forget-memories.ts
@@ -1,0 +1,105 @@
+/**
+ * Scope-complete clear of durable memory via the Intelligence REST endpoints.
+ * Server-safe plain .ts. Mirrors `src/skins/banking/intelligence/forget-memories.ts`
+ * — including the reason for its shape, which is worth restating because it is
+ * counter-intuitive:
+ *
+ * A single BARE `GET /api/memories` (no query string). The backend rejects ANY
+ * query string on that path with 400 MEMORY_VALIDATION_ERROR, and the bare GET
+ * already enumerates every scope (user + project) in one response — so one list
+ * is inherently scope-complete and no scope can be silently missed. Scope
+ * filtering only exists on `POST /api/memories/recall`, which is top-k semantic
+ * search rather than enumeration and is therefore unfit for a guaranteed clear.
+ *
+ * The booth failure this guards against: a reset that misses a scope, returns
+ * `forgot: 0`, reads as success — and leaves beat 6 already taught, so the
+ * agent "learns" a procedure it demonstrably already knew.
+ */
+export interface ForgetMemoriesParams {
+  apiUrl: string;
+  apiKey: string;
+  userId: string;
+}
+
+interface MemoriesListResponse {
+  memories: Array<{ id: string; scope?: string }>;
+}
+
+export interface ForgetResult {
+  forgot: number;
+  /**
+   * Project-scoped rows this deliberately left alone. Surfaced in the reset
+   * response so a presenter can SEE that something project-scoped is present —
+   * see the `skipProjectScope` note below for why that matters.
+   */
+  skippedProjectScoped: number;
+}
+
+export async function forgetAllMemories(
+  params: ForgetMemoriesParams,
+): Promise<ForgetResult> {
+  const { apiUrl, apiKey, userId } = params;
+  const base = apiUrl.replace(/\/$/, "");
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "x-cpki-user-id": userId,
+  };
+
+  const listRes = await fetch(`${base}/api/memories`, { headers });
+  if (!listRes.ok) {
+    throw new Error(
+      `list memories failed: ${listRes.status} ${await listRes.text()}`,
+    );
+  }
+  const { memories } = (await listRes.json()) as MemoriesListResponse;
+
+  /**
+   * PROJECT-SCOPED ROWS ARE DELIBERATELY LEFT ALONE, and this is the one place
+   * Rowan departs from banking's otherwise-identical helper.
+   *
+   * Verified against the running Intelligence stack: the bare list returns
+   * every `scope: "project"` row for ANY user id, because project scope is
+   * global to the backend instance rather than partitioned per product. All the
+   * skins in this app share one instance locally. So a scope-complete delete
+   * here would silently destroy banking's seeded procedure every time a
+   * presenter resets Rowan — deleting data this skin does not own, to solve a
+   * problem it does not have.
+   *
+   * Rowan owns nothing at project scope BY CONSTRUCTION: its seed file writes
+   * user scope, and its prompt and teach-mode tools all instruct `save_memory`
+   * to use user scope. So skipping project rows still leaves beat 6 unlearned
+   * after a reset, which is the invariant that matters.
+   *
+   * The residual risk is a model that ignores the scope instruction and saves
+   * project-scoped anyway — reset would then miss it and beat 6 would start out
+   * already taught. That is why the count is RETURNED rather than swallowed:
+   * `dev/reset` reports it, so a non-zero number after a Rowan-only session is
+   * the signal to go look.
+   */
+  const deletable = memories.filter((m) => m.scope !== "project");
+  const skippedProjectScoped = memories.length - deletable.length;
+
+  // Dedup defensively — the API should not repeat ids, but a clear has to be
+  // idempotent per id regardless.
+  const ids = new Set<string>();
+  for (const { id } of deletable) ids.add(id);
+
+  let forgot = 0;
+  for (const id of ids) {
+    const delRes = await fetch(
+      `${base}/api/memories/${encodeURIComponent(id)}`,
+      {
+        method: "DELETE",
+        headers,
+      },
+    );
+    // 204 No Content on success; `ok` covers it.
+    if (!delRes.ok) {
+      throw new Error(
+        `delete memory ${id} failed: ${delRes.status} ${await delRes.text()}`,
+      );
+    }
+    forgot += 1;
+  }
+  return { forgot, skippedProjectScoped };
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/intelligence/seed-memories.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/intelligence/seed-memories.ts
@@ -1,0 +1,130 @@
+/**
+ * BEATS 4 AND 5 — the memory Rowan is supposed to start out already having.
+ * Server-safe plain .ts. Called by `dev/reset` immediately after wiping learned
+ * memory, so the demo is re-armed before the presenter says a word.
+ *
+ * "It already knows me" is a FILE, not emergent behaviour. Three rules govern
+ * what belongs here, each of them learned the hard way in the banking skin:
+ *
+ *  1. Seed a standing PREFERENCE, not a fact. "Maya's favourite team" proves
+ *     storage. "Review comp by level, out-of-band first, as band position
+ *     rather than raw salary" proves APPLIED learning, because recall visibly
+ *     changes the answer to a question the user never re-explained.
+ *
+ *  2. The procedure must run FULLY AUTOMATICALLY. Banking's equivalent once
+ *     opened a confirmation card mid-procedure; when a presenter moved on
+ *     without answering it, that tool call sat unresolved and the NEXT message
+ *     failed the whole thread with "Tool result is missing for tool call ...".
+ *     A procedure with no half-finished state has nothing to leave behind, so
+ *     "run all of them immediately, in order, without asking for confirmation"
+ *     is written into the memory text itself, not just the prompt.
+ *
+ *  3. NEVER seed beat 6's procedure. The out-of-band approval is the one Rowan
+ *     has to be taught on stage. Seed it and the agent already knows the
+ *     answer, never offers to record, and the entire teach arc disappears —
+ *     which is exactly the kind of failure that still compiles and still looks
+ *     fine right up until the demo. The beat-5 memory below says so explicitly
+ *     so the two procedures can never be confused for one another.
+ */
+
+export interface SeedMemoriesParams {
+  apiUrl: string;
+  apiKey: string;
+  userId: string;
+}
+
+interface SeedMemory {
+  kind: "topical" | "episodic" | "operational";
+  scope: "user" | "project";
+  content: string;
+}
+
+export const SEED_MEMORIES: readonly SeedMemory[] = [
+  {
+    // ── BEAT 4 ──────────────────────────────────────────────────────────────
+    // A standing preference about SHAPE, so recall changes the answer rather
+    // than adding a fact. Note it names three separate, checkable behaviours
+    // (group by level / out-of-band first / percentages not dollars) — a
+    // single-clause preference is too easy for the audience to read as a
+    // coincidence.
+    kind: "topical",
+    scope: "user",
+    content:
+      "Maya Lindqvist reviews compensation by LEVEL, never by team. She wants " +
+      "anyone sitting outside their band called out FIRST, ahead of everything " +
+      "else, and she reads a person's pay as their POSITION IN BAND as a " +
+      "percentage rather than as a raw salary figure. Apply this to every " +
+      "compensation summary without being asked, and say which preference you " +
+      "applied.",
+  },
+  {
+    // ── BEAT 5 ──────────────────────────────────────────────────────────────
+    // A PROCEDURE, so recall produces visible ACTION — three tool calls in a
+    // row, each changing something on screen — rather than a reformatted
+    // answer. The parenthetical disjointness clause is load-bearing: without
+    // it the agent conflates this with beat 6 and starts offering to record a
+    // procedure it already has.
+    kind: "operational",
+    // `user`, NOT `project` — banking scopes its equivalent procedure to
+    // `project`, and that turned out to be the wrong model here. Verified
+    // against the running Intelligence stack: a project-scoped memory is
+    // returned for EVERY user id in the instance, not just the ones in some
+    // project. Since all five skins in this app point at one instance, a
+    // project-scoped procedure is effectively global — Rowan's onboarding
+    // procedure would surface inside banking's demo and vice versa, each
+    // looking like the memory system had confused two products. User scope is
+    // partitioned correctly, and Rowan's memories belong to one operator
+    // anyway (see intelligence/user-id.ts).
+    scope: "user",
+    content:
+      "Procedure for when a new hire is about to start (this is NOT the " +
+      "procedure for an out-of-band compensation request — they are different " +
+      "situations, do not confuse them, and do not offer to record anything " +
+      "here): (1) call createOnboardingTasks for that person to build their " +
+      "checklist, (2) call assignBuddy to pair them with an experienced " +
+      "teammate on their own team who is not their manager, (3) call " +
+      "postWelcomeNote with a short welcome naming their team and their buddy. " +
+      "Run all three immediately, in order, without asking for confirmation, " +
+      "then confirm what was done in one short sentence.",
+  },
+  // DO NOT seed the out-of-band approval procedure. That is beat 6, and it is
+  // taught live. See rule 3 in the header.
+];
+
+/**
+ * Write the seed memories for one identity; returns how many were stored.
+ *
+ * Never throws. A booth reset must still report success for the DATA store even
+ * when the memory backend is unhappy — a presenter needs the roster restored
+ * far more urgently than they need a stack trace — so failures are counted and
+ * logged, not propagated.
+ */
+export async function seedMemories(
+  params: SeedMemoriesParams,
+): Promise<number> {
+  const { apiUrl, apiKey, userId } = params;
+  const base = apiUrl.replace(/\/$/, "");
+  let stored = 0;
+
+  for (const memory of SEED_MEMORIES) {
+    try {
+      const res = await fetch(`${base}/api/memories`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "X-Cpki-User-Id": userId,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(memory),
+      });
+      if (res.ok) stored += 1;
+      else
+        console.error(`[people/seed-memories] ${userId}: HTTP ${res.status}`);
+    } catch (err) {
+      console.error(`[people/seed-memories] ${userId}: ${String(err)}`);
+    }
+  }
+
+  return stored;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/intelligence/user-id.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/intelligence/user-id.ts
@@ -1,0 +1,122 @@
+/**
+ * Resolve a stable end-user identity for Rowan's Intelligence requests (thread
+ * + durable-memory scoping). SERVER-SAFE: plain .ts, no "use client", no JSX —
+ * it is reached through the server-only `src/shell/agent-registry.ts`.
+ *
+ * Precedence: pinned env > mapped operator id > role-derived > demo default.
+ * The pinned env wins so CI (Playwright/aimock) stays deterministic on one
+ * seeded identity.
+ *
+ * The ids are namespaced `rowan-*` rather than reusing another skin's, which
+ * matters more here than it looks: the seeded beat-4 preference is "review comp
+ * by level, out-of-band first". If Rowan shared a memory scope with banking,
+ * that preference would surface inside banking's spend answers and banking's
+ * spend preference would surface inside Rowan's — and both demos would look
+ * like the memory system had confused two products.
+ *
+ * ⚠ Namespacing the id only isolates `scope: "user"` memories. Verified against
+ * the running Intelligence stack: a `scope: "project"` row comes back for EVERY
+ * user id in the instance, so project scope is NOT a per-skin boundary when
+ * several skins share one backend — which they do locally. That is why Rowan
+ * seeds and saves everything at user scope; see intelligence/seed-memories.ts.
+ */
+
+/** Operator id (data/seed.ts) → memory scope. 1:1, so two on-screen people
+ *  never share one scope. Maya is the seeded persona the demo runs as; Clara is
+ *  deliberately a colleague Rowan has NOT learned anything from yet. */
+const OPERATOR_IDENTITY: Record<string, { userId: string; userName: string }> =
+  {
+    "op-maya": { userId: "rowan-maya-lindqvist", userName: "Maya Lindqvist" },
+    "op-clara": { userId: "rowan-clara-mendes", userName: "Clara Mendes" },
+  };
+
+export const SEEDED_USER_IDS: readonly string[] = Object.values(
+  OPERATOR_IDENTITY,
+).map((o) => o.userId);
+
+/**
+ * Where memory lands when no operator is mapped and no role is set. Memory
+ * taught during a live demo often ends up here, so a presenter reset MUST clear
+ * it too — otherwise a previous run's learned procedure survives and beat 6
+ * silently starts out already knowing the answer.
+ */
+export const DEMO_DEFAULT_USER_ID = "rowan-demo-user";
+
+/**
+ * The identities beat 4's and beat 5's memories are seeded against — BOTH of
+ * them, on purpose.
+ *
+ * This started as just the mapped operator id, and beat 4 failed live: the
+ * agent answered "I didn't have a saved format from you yet" while the memories
+ * sat perfectly well stored under `rowan-maya-lindqvist`. Observed in the dev
+ * log, runs actually resolve to `rowan-demo-user` — the no-properties fallback
+ * — because the client's `properties` are not reaching `identifyUser` on the
+ * run path. Banking hit the same thing and settled on seeding its DEFAULT
+ * bucket (`northwind-demo-user`), which is what its `dev/reset` does and why
+ * its comment says "a lot of demo memory lands here".
+ *
+ * So: seed the default bucket, because that is where recall actually looks, AND
+ * the mapped operator, so the per-operator story is already correct the day the
+ * properties path is fixed. Two extra POSTs on reset is a cheap price for a
+ * beat that otherwise fails silently and looks like the memory system is broken.
+ *
+ * ⚠ Until properties forwarding is fixed, switching operator in the sidebar does
+ * NOT re-scope memory — Maya and Clara both resolve to `rowan-demo-user` on a
+ * run. The "Clara has taught it nothing" contrast is not demoable yet.
+ */
+export const SEED_TARGET_USER_IDS: readonly string[] = [
+  DEMO_DEFAULT_USER_ID,
+  OPERATOR_IDENTITY["op-maya"].userId,
+];
+
+export type IdentityInput = { operatorId?: string; role?: string };
+
+function roleSlug(role?: string): string {
+  if (!role) return DEMO_DEFAULT_USER_ID;
+  const slug = role
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  return slug ? `rowan-${slug}` : DEMO_DEFAULT_USER_ID;
+}
+
+export function resolveUserId({
+  operatorId,
+  role,
+}: IdentityInput = {}): string {
+  const pinned = process.env.INTELLIGENCE_USER_ID;
+  if (pinned) return pinned;
+  if (operatorId && OPERATOR_IDENTITY[operatorId])
+    return OPERATOR_IDENTITY[operatorId].userId;
+  return roleSlug(role);
+}
+
+export function resolveUserName({
+  operatorId,
+  role,
+}: IdentityInput = {}): string {
+  if (process.env.INTELLIGENCE_USER_ID) {
+    return (
+      process.env.INTELLIGENCE_USER_NAME ?? process.env.INTELLIGENCE_USER_ID
+    );
+  }
+  if (operatorId && OPERATOR_IDENTITY[operatorId])
+    return OPERATOR_IDENTITY[operatorId].userName;
+  return role ? `Rowan ${role}` : "Rowan Demo User";
+}
+
+/**
+ * Rowan's `IdentifyRunUser`, registered in `agent-registry.ts`. The client
+ * forwards the active operator through CopilotKit `properties`
+ * ({ userRole, userId }); this maps them onto a stable per-operator scope
+ * WITHOUT the shared API route importing anything skin-specific.
+ */
+export function peopleIdentifyUser(
+  properties: { userRole?: string; userId?: string } | undefined,
+): { id: string; name: string } {
+  const input: IdentityInput = {
+    operatorId: properties?.userId,
+    role: properties?.userRole,
+  };
+  return { id: resolveUserId(input), name: resolveUserName(input) };
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/layout.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/layout.tsx
@@ -1,0 +1,235 @@
+"use client";
+import "./theme.css"; // side-effect import registers the .theme-people block
+
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { HelpCircle, RotateCcw } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { useSkin } from "@/shell/skin-provider";
+import { useSkinHref, useSkinSegments } from "@/shell/skin-path";
+import { usePresenterReset } from "@/shell/presenter-reset-context";
+import { useCanvas } from "@/shell/canvas/canvas-context";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { usePeopleLedger } from "./data/ledger-context";
+import { useAskCopilot } from "./components/use-ask-copilot";
+import { Monogram } from "./components/monogram";
+
+const SIDEBAR_WIDTH_PX = 240;
+
+/**
+ * The page each nav segment reports itself as to the agent. The index route is
+ * `/people`, which IS the roster — reporting `""` there would tell the agent
+ * "the current page is empty string", so it gets a real name.
+ */
+const ROUTE_READABLE_NAME: Record<string, string> = {
+  "": "roster",
+  compensation: "compensation",
+  requests: "requests",
+  onboarding: "onboarding",
+};
+
+export function PeopleLayout({ children }: { children: ReactNode }) {
+  const skin = useSkin();
+  // EVERY in-skin link goes through skinHref — never a hardcoded `/${skin.id}/…`.
+  // Under LOCK_SKIN the deploy is served AT `/` with the skin segment absent
+  // from the URL space, and a hardcoded prefix would put it straight back into
+  // the address bar on the first nav click. `pnpm lint` enforces this.
+  const skinHref = useSkinHref(skin.id);
+  // useSkinSegments strips a LEADING skin id if present, so this is correct
+  // whether or not the pathname carries the prefix. Do NOT hand-roll it as
+  // `pathname.split("/").slice(2)` — that eats the first real segment on a
+  // locked deploy, where there is no prefix to skip.
+  const restHead = useSkinSegments(skin.id)[0] ?? "";
+  const resetEnabled = usePresenterReset();
+  const askCopilot = useAskCopilot();
+  const { operator, data, setOperatorId } = usePeopleLedger();
+  const { clear } = useCanvas();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const Logo = skin.identity.logo;
+
+  // ── BEAT 3b: THE ROUTE READABLE ──────────────────────────────────────────
+  // Without this the agent has no idea which page is open, so "what's on my
+  // screen?" answers identically everywhere and the beat dies silently — the
+  // answers are plausible, just not page-specific. Each PAGE registers its own
+  // readable for what is visibly rendered; this one only says WHERE the user is.
+  useAgentContext({
+    description:
+      "The page the user is currently looking at in the Rowan People Ops app.",
+    value: ROUTE_READABLE_NAME[restHead] ?? restHead,
+  });
+
+  // Who is signed in — Rowan scopes durable memory per operator, so the agent
+  // should speak to the right person by name.
+  useAgentContext({
+    description: "The signed-in Rowan operator.",
+    value: JSON.stringify({
+      id: operator.id,
+      name: operator.name,
+      role: operator.role,
+      team: operator.team,
+    }),
+  });
+
+  // Dismiss a canvas surface when the user navigates away, including a
+  // query-string-only change (beat 3c pushes `?status=…&sort=…`, which is a nav
+  // as far as the user is concerned but would otherwise leave a stale brief
+  // covering the page they just asked to see).
+  useEffect(() => {
+    clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, searchParams?.toString()]);
+
+  const handleReset = async () => {
+    if (!window.confirm("Reset the demo? This restores the seeded scenario.")) {
+      return;
+    }
+    try {
+      const res = await fetch("/api/people/v1/dev/reset", { method: "POST" });
+      if (res.ok) {
+        // Hard navigate to the skin root for a pristine slate — fresh store,
+        // cleared canvas, new thread on the next message — and the clean
+        // starting URL, which is `/` itself on a locked single-tenant deploy.
+        window.location.assign(skinHref());
+      } else {
+        window.alert(`Reset failed (HTTP ${res.status}). See the server logs.`);
+      }
+    } catch (err) {
+      window.alert(`Reset failed: ${err instanceof Error ? err.message : err}`);
+    }
+  };
+
+  return (
+    // h-full + overflow-hidden — NOT h-screen, NOT min-h-screen. This chrome
+    // fills the shell's app CARD, which the frame has already inset by its own
+    // padding, so a viewport-height root overflows the card by exactly that
+    // much. It must still be BOUNDED: an unbounded container scrolls the whole
+    // document, taking the pinned nav with it and rendering <main>'s own
+    // overflow-y-auto inert.
+    <div className="flex h-full overflow-hidden bg-canvas text-ink">
+      <aside
+        className="hidden h-full shrink-0 flex-col border-r border-hairline bg-surface px-3 py-5 md:flex"
+        style={{ width: SIDEBAR_WIDTH_PX }}
+      >
+        <div className="mb-6 flex items-center gap-2.5 px-2">
+          <Logo className="h-7 w-7 text-brand" />
+          <div className="min-w-0">
+            <div className="truncate text-base font-semibold tracking-tight text-ink">
+              {skin.identity.brand}
+            </div>
+            <div className="truncate text-[0.68rem] text-ink-muted">
+              People Ops
+            </div>
+          </div>
+        </div>
+
+        <nav className="flex flex-col gap-0.5">
+          {skin.nav.map((route) => {
+            const href = skinHref(route.segment);
+            // Compare SEGMENTS, not whole pathnames: under a lock the href is
+            // prefix-free while the matched route is not, so `pathname === href`
+            // is not reliably true for the active entry.
+            const active = restHead === route.segment;
+            const Icon = route.icon;
+            return (
+              <Link
+                key={route.segment || "index"}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-brand-soft text-brand"
+                    : "text-ink-muted hover:bg-surface-muted hover:text-ink",
+                )}
+              >
+                {Icon ? <Icon className="h-4 w-4" /> : null}
+                {route.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Meta-utility strip — skin-authored chrome, pinned to the bottom. A
+            new skin gets none of these for free; the shell provides no Reset,
+            no theme toggle and no Help. */}
+        <div className="mt-auto">
+          <TooltipProvider delayDuration={200}>
+            <div className="flex items-center gap-1 border-t border-hairline px-1 pt-3">
+              {resetEnabled ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => void handleReset()}
+                      aria-label="Reset demo state"
+                      className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand"
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Reset demo state</TooltipContent>
+                </Tooltip>
+              ) : null}
+              {/* A real control here, not a dead one: theme.css sets
+                  `--nw-dark-capable: 1` and ships a `.dark .theme-people` block. */}
+              <ThemeToggle />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Ask Rowan for help"
+                    onClick={() =>
+                      void askCopilot(
+                        "What can you help me with in Rowan? Give me a short list.",
+                      )
+                    }
+                    className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand"
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Ask Rowan for help</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+
+          {/* Who is signed in. Switching operator re-scopes Intelligence memory
+              through `useRuntimeProperties`, which is the point: Maya has taught
+              Rowan how she likes comp reviews, Clara has taught it nothing. */}
+          <div className="mt-3 flex items-center gap-2 rounded-md border border-hairline bg-surface-muted px-2 py-2">
+            <Monogram name={operator.name} size="sm" />
+            <label className="min-w-0 flex-1">
+              <span className="sr-only">Signed in as</span>
+              <select
+                value={operator.id}
+                onChange={(event) => setOperatorId(event.target.value)}
+                className="w-full cursor-pointer truncate bg-transparent text-[0.75rem] font-medium text-ink outline-none"
+              >
+                {data.operators.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.name}
+                  </option>
+                ))}
+              </select>
+              <span className="block truncate text-[0.65rem] text-ink-muted">
+                {operator.team}
+              </span>
+            </label>
+          </div>
+        </div>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto px-6 py-6">{children}</main>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/pages/compensation.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/pages/compensation.tsx
@@ -1,0 +1,470 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, Check, FileWarning, Loader2 } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { usePeopleLedger } from "../data/ledger-context";
+import {
+  bandPosition,
+  formatPercent,
+  formatSalary,
+  isOutOfBand,
+} from "../data/derive";
+import {
+  BAND_EXCEPTION_CODES,
+  exceptionCodeLabel,
+} from "../data/band-exception-codes";
+import type { CompRequest } from "../data/types";
+import { BandLadder } from "../components/band-ladder";
+import { Monogram } from "../components/monogram";
+import {
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+import { useRecording } from "../components/recording-context";
+
+/**
+ * BEAT 6 — the human demonstration surface.
+ *
+ * This card is where a person shows Rowan how to get an out-of-band promotion
+ * approved: try Approve (refused, symptom only) → file a band exception under
+ * some code → finalize it → Approve again. Every one of those is a real REST
+ * call against the real gate; nothing here is staged.
+ *
+ * The refusal text is rendered VERBATIM from the server. Do not "improve" it
+ * with a hint about band exceptions — the whole beat rests on the fix not being
+ * discoverable from the error, and a helpful message here would leak it to the
+ * audience even if the agent never saw it.
+ */
+function CompRequestCard({ request }: { request: CompRequest }) {
+  const { data, refresh } = usePeopleLedger();
+  const { logStep } = useRecording();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [filing, setFiling] = useState(false);
+  const [code, setCode] = useState(BAND_EXCEPTION_CODES[0].code);
+  const [justification, setJustification] = useState("");
+
+  const employee = data.employees.find((e) => e.id === request.employeeId);
+  const band = data.bands.find((b) => b.level === request.proposedLevel);
+  const exceptions = data.bandExceptions.filter(
+    (x) => x.compRequestId === request.id,
+  );
+  const overBy =
+    band && request.requestedSalary > band.max
+      ? request.requestedSalary - band.max
+      : 0;
+
+  const approve = async () => {
+    setBusy("approve");
+    setRefusal(null);
+    try {
+      const res = await fetch(
+        `/api/people/v1/comp-requests/${request.id}/approve`,
+        { method: "POST" },
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setRefusal(body?.message ?? `Refused (HTTP ${res.status})`);
+        logStep(`Approve refused for ${employee?.name ?? request.employeeId}`);
+        return;
+      }
+      logStep(
+        `Approved the promotion for ${employee?.name ?? request.employeeId}`,
+      );
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const fileException = async () => {
+    setBusy("file");
+    try {
+      const res = await fetch("/api/people/v1/band-exceptions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          compRequestId: request.id,
+          code,
+          justification:
+            justification.trim() || "Filed from the compensation desk.",
+        }),
+      });
+      if (!res.ok) return;
+      // Record the code the human ACTUALLY chose. If they picked a decoy, the
+      // recording says so and the approve below still fails — which is the
+      // honest demonstration, and a better one than a recorder that silently
+      // corrects the person it is supposed to be learning from.
+      logStep(`Filed a band exception under ${code}`, code);
+      setFiling(false);
+      setJustification("");
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const finalize = async (exceptionId: string, exceptionCode: string) => {
+    setBusy(exceptionId);
+    try {
+      const res = await fetch(
+        `/api/people/v1/band-exceptions/${exceptionId}/finalize`,
+        { method: "POST" },
+      );
+      if (!res.ok) return;
+      logStep(`Finalized the ${exceptionCode} exception`, exceptionCode);
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const decline = async () => {
+    setBusy("decline");
+    try {
+      await fetch(`/api/people/v1/comp-requests/${request.id}/decline`, {
+        method: "POST",
+      });
+      logStep(
+        `Declined the request for ${employee?.name ?? request.employeeId}`,
+      );
+      await refresh();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (!employee) return null;
+  const settled = request.status !== "pending";
+
+  return (
+    <article
+      className={cn(
+        "rounded-lg border bg-surface p-4",
+        overBy ? "border-negative/30" : "border-hairline",
+      )}
+    >
+      <div className="flex flex-wrap items-start gap-3">
+        <Monogram name={employee.name} size="md" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-semibold text-ink">{employee.name}</h3>
+            <Pill tone="brand">
+              {employee.level} → {request.proposedLevel}
+            </Pill>
+            {overBy ? (
+              <Pill tone="negative">
+                <AlertTriangle className="h-3 w-3" />
+                {formatSalary(overBy)} over band
+              </Pill>
+            ) : (
+              <Pill tone="positive">In band</Pill>
+            )}
+            {request.status === "approved" ? (
+              <Pill tone="positive">Approved</Pill>
+            ) : null}
+            {request.status === "declined" ? <Pill>Declined</Pill> : null}
+          </div>
+          <p className="mt-1 text-[0.78rem] text-ink-muted">{request.reason}</p>
+          <p className="rowan-num mt-1 text-[0.75rem] text-ink">
+            {formatSalary(request.currentSalary)}{" "}
+            <span className="text-ink-muted">→</span>{" "}
+            <span className="font-semibold">
+              {formatSalary(request.requestedSalary)}
+            </span>
+            {band ? (
+              <span className="ml-2 text-[0.7rem] text-ink-muted">
+                {request.proposedLevel} band {formatSalary(band.min)}–
+                {formatSalary(band.max)}
+              </span>
+            ) : null}
+          </p>
+          <p className="mt-1 text-[0.68rem] text-ink-muted">
+            Submitted by {request.submittedBy}
+          </p>
+        </div>
+      </div>
+
+      {exceptions.length > 0 ? (
+        <ul className="mt-3 space-y-1.5">
+          {exceptions.map((exception) => (
+            <li
+              key={exception.id}
+              className="flex flex-wrap items-center gap-2 rounded-md border border-hairline bg-surface-muted px-2.5 py-1.5 text-[0.72rem]"
+            >
+              <FileWarning className="h-3.5 w-3.5 text-ink-muted" />
+              <span className="font-medium text-ink">
+                {exceptionCodeLabel(exception.code)}
+              </span>
+              <span className="rowan-num text-ink-muted">{exception.code}</span>
+              {exception.status === "approved" ? (
+                <Pill tone="positive">
+                  <Check className="h-3 w-3" />
+                  Finalized
+                </Pill>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void finalize(exception.id, exception.code)}
+                  disabled={busy === exception.id}
+                  className="ml-auto rounded-md border border-brand/40 bg-brand-soft px-2 py-0.5 font-semibold text-brand disabled:opacity-50"
+                >
+                  {busy === exception.id ? "Finalizing…" : "Finalize"}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {refusal ? (
+        <p
+          role="status"
+          className="mt-3 flex items-start gap-2 rounded-md border border-negative/30 bg-negative-soft px-3 py-2 text-[0.75rem] text-negative"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{refusal}</span>
+        </p>
+      ) : null}
+
+      {filing ? (
+        <div className="mt-3 space-y-2 rounded-md border border-hairline bg-surface-muted p-3">
+          <label className="block">
+            <span className="mb-1 block text-[0.7rem] font-medium text-ink-muted">
+              Exception code
+            </span>
+            <select
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+              className="w-full rounded-md border border-hairline bg-surface px-2 py-1.5 text-[0.78rem] text-ink outline-none focus:border-brand/50"
+            >
+              {BAND_EXCEPTION_CODES.map((entry) => (
+                <option key={entry.code} value={entry.code}>
+                  {entry.code} — {entry.label}
+                </option>
+              ))}
+            </select>
+            <span className="mt-1 block text-[0.68rem] text-ink-muted">
+              {BAND_EXCEPTION_CODES.find((e) => e.code === code)?.blurb}
+            </span>
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-[0.7rem] font-medium text-ink-muted">
+              Justification
+            </span>
+            <textarea
+              value={justification}
+              onChange={(event) => setJustification(event.target.value)}
+              rows={2}
+              placeholder="What is on file to support this?"
+              className="w-full resize-none rounded-md border border-hairline bg-surface px-2 py-1.5 text-[0.78rem] text-ink outline-none placeholder:text-ink-muted focus:border-brand/50"
+            />
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void fileException()}
+              disabled={busy === "file"}
+              className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground disabled:opacity-50"
+            >
+              {busy === "file" ? "Filing…" : "File exception"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFiling(false)}
+              className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {!settled ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => void approve()}
+            disabled={busy === "approve"}
+            className="inline-flex items-center gap-1.5 rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground disabled:opacity-50"
+          >
+            {busy === "approve" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : null}
+            Approve
+          </button>
+          {!filing ? (
+            <button
+              type="button"
+              onClick={() => setFiling(true)}
+              className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] font-medium text-ink hover:bg-surface-muted"
+            >
+              File band exception
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => void decline()}
+            disabled={busy === "decline"}
+            className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink disabled:opacity-50"
+          >
+            Decline
+          </button>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export function CompensationPage() {
+  const { data } = usePeopleLedger();
+  const [level, setLevel] = useState<string>("All");
+
+  const outOfBand = useMemo(
+    () => data.employees.filter((e) => isOutOfBand(data.bands, e)),
+    [data.employees, data.bands],
+  );
+
+  const ladderPeople = useMemo(
+    () =>
+      level === "All"
+        ? data.employees
+        : data.employees.filter((e) => e.level === level),
+    [data.employees, level],
+  );
+
+  const pendingComp = data.compRequests.filter((c) => c.status === "pending");
+
+  const medianPosition = useMemo(() => {
+    const ratios = data.employees
+      .map((e) => bandPosition(data.bands, e.baseSalary, e.level)?.ratio)
+      .filter((r): r is number => r !== undefined)
+      .sort((a, b) => a - b);
+    if (ratios.length === 0) return 0;
+    return ratios[Math.floor(ratios.length / 2)];
+  }, [data.employees, data.bands]);
+
+  // ── BEAT 3b ──────────────────────────────────────────────────────────────
+  // The Compensation page's own on-screen readable. Note it reports positions
+  // as PERCENTAGES of band, which is also the shape beat 4's seeded preference
+  // asks for — so when the agent recalls that preference, the numbers it needs
+  // are already in the form it was told to use.
+  useAgentContext({
+    description:
+      "The Compensation page the user is currently viewing: the band ladder, " +
+      "the active level filter, everyone's position in band, who is outside " +
+      "their band, and the pending compensation requests.",
+    value: JSON.stringify({
+      page: "compensation",
+      filters: { level },
+      bands: data.bands,
+      outOfBand: outOfBand.map((e) => {
+        const pos = bandPosition(data.bands, e.baseSalary, e.level);
+        return {
+          name: e.name,
+          level: e.level,
+          baseSalary: e.baseSalary,
+          side: pos?.side,
+        };
+      }),
+      visiblePeople: ladderPeople.slice(0, 25).map((e) => {
+        const pos = bandPosition(data.bands, e.baseSalary, e.level);
+        return {
+          name: e.name,
+          level: e.level,
+          team: e.team,
+          positionInBand: pos
+            ? pos.outOfBand
+              ? `${pos.side} band`
+              : formatPercent(pos.ratio)
+            : null,
+        };
+      }),
+      pendingCompRequests: pendingComp.map((c) => ({
+        id: c.id,
+        employee: data.employees.find((e) => e.id === c.employeeId)?.name,
+        reason: c.reason,
+        currentSalary: c.currentSalary,
+        requestedSalary: c.requestedSalary,
+        proposedLevel: c.proposedLevel,
+        withinBand: (() => {
+          const band = data.bands.find((b) => b.level === c.proposedLevel);
+          return band
+            ? c.requestedSalary >= band.min && c.requestedSalary <= band.max
+            : null;
+        })(),
+      })),
+    }),
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <PageHeader
+        title="Compensation"
+        subtitle="Every person placed inside their own band, so levels compare like for like."
+      />
+
+      <div className="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <Metric label="People banded" value={String(data.employees.length)} />
+        <Metric
+          label="Outside their band"
+          value={String(outOfBand.length)}
+          tone={outOfBand.length ? "negative" : "positive"}
+        />
+        <Metric
+          label="Median position in band"
+          value={formatPercent(medianPosition)}
+        />
+        <Metric
+          label="Pending comp requests"
+          value={String(pendingComp.length)}
+          tone={pendingComp.length ? "gold" : "neutral"}
+        />
+      </div>
+
+      <Panel className="mb-5">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <SectionLabel>Band ladder</SectionLabel>
+          <div className="flex gap-1">
+            {["All", ...data.bands.map((b) => b.level)].map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() => setLevel(candidate)}
+                className={cn(
+                  "rounded-full border px-2.5 py-1 text-[0.7rem] transition-colors",
+                  level === candidate
+                    ? "border-brand/50 bg-brand-soft font-semibold text-brand"
+                    : "border-hairline bg-surface text-ink-muted hover:text-ink",
+                )}
+              >
+                {candidate}
+              </button>
+            ))}
+          </div>
+        </div>
+        <BandLadder bands={data.bands} employees={ladderPeople} />
+      </Panel>
+
+      <SectionLabel>Compensation requests</SectionLabel>
+      {data.compRequests.length === 0 ? (
+        <EmptyState
+          title="No compensation requests"
+          hint="Managers submit promotions and adjustments here; they land in this list for review."
+        />
+      ) : (
+        <div className="space-y-3">
+          {data.compRequests.map((request) => (
+            <CompRequestCard key={request.id} request={request} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/pages/onboarding.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/pages/onboarding.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CalendarDays, FileText, Sprout } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { usePeopleLedger } from "../data/ledger-context";
+import { daysUntil, tenureLabel } from "../data/derive";
+import type { Employee } from "../data/types";
+import { Monogram } from "../components/monogram";
+import {
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+/**
+ * The Onboarding page carries two beats.
+ *
+ * BEAT 5 — the stored procedure's three writes all show up here: the checklist
+ * it builds, the buddy it assigns, and the 🎉 welcome note it posts. If none of
+ * those were visible the procedure would fire correctly and prove nothing.
+ *
+ * BEAT 3d — the Packets tab is the DURABLE ARTIFACT surface. A packet is stored
+ * in the app's ledger, not in the conversation, so the presenter can delete the
+ * whole thread and the packet is still sitting right here. That is the entire
+ * argument of the beat, and it is why this tab reads from the ledger and has no
+ * notion of a thread id.
+ */
+
+function ChecklistCard({ employee }: { employee: Employee }) {
+  const { data, refresh } = usePeopleLedger();
+  const tasks = data.onboardingTasks.filter(
+    (t) => t.employeeId === employee.id,
+  );
+  const done = tasks.filter((t) => t.done).length;
+  const buddy = data.employees.find((e) => e.id === employee.buddyId);
+  const until = daysUntil(employee.startDate);
+
+  const toggle = async (id: string, next: boolean) => {
+    await fetch(`/api/people/v1/onboarding-tasks/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ done: next }),
+    });
+    await refresh();
+  };
+
+  return (
+    <Panel>
+      <div className="flex flex-wrap items-start gap-3">
+        <Monogram name={employee.name} size="lg" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-ink">{employee.name}</h3>
+          <p className="text-[0.75rem] text-ink-muted">
+            {employee.title} · {employee.level} · {employee.team}
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <Pill tone={until > 0 ? "gold" : "positive"}>
+              <CalendarDays className="h-3 w-3" />
+              {tenureLabel(employee.startDate)}
+            </Pill>
+            {buddy ? (
+              <Pill tone="brand">Buddy · {buddy.name}</Pill>
+            ) : (
+              <Pill tone="neutral">No buddy yet</Pill>
+            )}
+          </div>
+        </div>
+        <div className="rowan-num text-right">
+          <div className="text-lg font-semibold text-ink">
+            {done}/{tasks.length || 0}
+          </div>
+          <div className="text-[0.65rem] text-ink-muted">complete</div>
+        </div>
+      </div>
+
+      {employee.notes.length > 0 ? (
+        <p className="mt-3 rounded-md border border-brand/20 bg-brand-soft px-3 py-2 text-[0.75rem] text-ink">
+          {employee.notes[0].text}
+        </p>
+      ) : null}
+
+      <div className="mt-4">
+        {tasks.length === 0 ? (
+          <EmptyState
+            icon={<Sprout className="h-5 w-5" />}
+            title="No checklist yet"
+            hint={`Nothing has been set up for ${employee.name.split(" ")[0]} — ask Rowan to handle the start and it will build the checklist, assign a buddy, and post a welcome.`}
+          />
+        ) : (
+          <ul className="space-y-1.5">
+            {tasks.map((task) => (
+              <li key={task.id} className="flex items-center gap-2.5">
+                <input
+                  id={task.id}
+                  type="checkbox"
+                  checked={task.done}
+                  onChange={(event) =>
+                    void toggle(task.id, event.target.checked)
+                  }
+                  className="h-3.5 w-3.5 shrink-0 accent-[hsl(var(--brand))]"
+                />
+                <label
+                  htmlFor={task.id}
+                  className={cn(
+                    "min-w-0 flex-1 cursor-pointer truncate text-[0.78rem]",
+                    task.done ? "text-ink-muted line-through" : "text-ink",
+                  )}
+                >
+                  {task.label}
+                </label>
+                <span className="shrink-0 text-[0.68rem] text-ink-muted">
+                  {task.owner}
+                </span>
+                <span className="rowan-num w-12 shrink-0 text-right text-[0.68rem] text-ink-muted">
+                  {task.dueOffsetDays >= 0
+                    ? `day ${task.dueOffsetDays}`
+                    : `${-task.dueOffsetDays}d before`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+export function OnboardingPage() {
+  const { data } = usePeopleLedger();
+  const [tab, setTab] = useState<"checklists" | "packets">("checklists");
+
+  // Anyone still onboarding, plus anyone who joined in the last ~90 days and
+  // still has an open item — a checklist does not stop mattering the moment
+  // someone's status flips to active.
+  const rampingUp = useMemo(() => {
+    const ids = new Set(
+      data.onboardingTasks.filter((t) => !t.done).map((t) => t.employeeId),
+    );
+    return data.employees.filter(
+      (e) => e.status === "onboarding" || ids.has(e.id),
+    );
+  }, [data.employees, data.onboardingTasks]);
+
+  const openTasks = data.onboardingTasks.filter((t) => !t.done).length;
+
+  useAgentContext({
+    description:
+      "The Onboarding page the user is currently viewing: which tab is open, " +
+      "the new hires ramping up with their checklist progress and buddy, and " +
+      "the onboarding packets filed in the app.",
+    value: JSON.stringify({
+      page: "onboarding",
+      tab,
+      newHires: rampingUp.map((e) => {
+        const tasks = data.onboardingTasks.filter((t) => t.employeeId === e.id);
+        return {
+          id: e.id,
+          name: e.name,
+          title: e.title,
+          team: e.team,
+          startDate: e.startDate,
+          startsIn: tenureLabel(e.startDate),
+          buddy: data.employees.find((b) => b.id === e.buddyId)?.name ?? null,
+          checklist: {
+            total: tasks.length,
+            done: tasks.filter((t) => t.done).length,
+          },
+          latestNote: e.notes[0]?.text ?? null,
+        };
+      }),
+      packets: data.packets.map((p) => ({
+        id: p.id,
+        employeeName: p.employeeName,
+        role: p.role,
+        startDate: p.startDate,
+        summary: p.summary,
+        highlights: p.highlights,
+      })),
+    }),
+  });
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <PageHeader
+        title="Onboarding"
+        subtitle="Everyone in their first ninety days, and the packets filed for them."
+      />
+
+      <div className="mb-5 grid grid-cols-3 gap-3">
+        <Metric
+          label="Ramping up"
+          value={String(rampingUp.length)}
+          tone="gold"
+        />
+        <Metric label="Open checklist items" value={String(openTasks)} />
+        <Metric label="Packets on file" value={String(data.packets.length)} />
+      </div>
+
+      <div className="mb-4 flex gap-1 border-b border-hairline">
+        {(["checklists", "packets"] as const).map((candidate) => (
+          <button
+            key={candidate}
+            type="button"
+            onClick={() => setTab(candidate)}
+            aria-current={tab === candidate ? "page" : undefined}
+            className={cn(
+              "-mb-px border-b-2 px-3 py-2 text-[0.8rem] font-medium capitalize transition-colors",
+              tab === candidate
+                ? "border-brand text-brand"
+                : "border-transparent text-ink-muted hover:text-ink",
+            )}
+          >
+            {candidate}
+          </button>
+        ))}
+      </div>
+
+      {tab === "checklists" ? (
+        rampingUp.length === 0 ? (
+          <EmptyState
+            title="Nobody is onboarding right now"
+            hint="New hires appear here from their offer acceptance until their checklist is complete."
+          />
+        ) : (
+          <div className="space-y-4">
+            {rampingUp.map((employee) => (
+              <ChecklistCard key={employee.id} employee={employee} />
+            ))}
+          </div>
+        )
+      ) : (
+        <>
+          <SectionLabel>
+            Filed packets — these belong to the app, not to any conversation
+          </SectionLabel>
+          {data.packets.length === 0 ? (
+            <EmptyState
+              icon={<FileText className="h-5 w-5" />}
+              title="No packets yet"
+              hint="Send Rowan an offer letter and ask for a packet; it reads the document and files the result here."
+            />
+          ) : (
+            <div className="space-y-3">
+              {data.packets.map((packet) => (
+                <Panel key={packet.id}>
+                  <div className="flex flex-wrap items-start gap-3">
+                    <Monogram name={packet.employeeName} size="md" />
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-sm font-semibold text-ink">
+                        {packet.employeeName}
+                      </h3>
+                      <p className="text-[0.72rem] text-ink-muted">
+                        {packet.role}
+                      </p>
+                    </div>
+                    <span className="rowan-num shrink-0 text-[0.68rem] text-ink-muted">
+                      Filed by {packet.filedBy}
+                    </span>
+                  </div>
+
+                  <p className="mt-3 text-[0.8rem] leading-relaxed text-ink">
+                    {packet.summary}
+                  </p>
+
+                  {packet.highlights.length > 0 ? (
+                    <ul className="mt-3 flex flex-wrap gap-1.5">
+                      {packet.highlights.map((highlight) => (
+                        <li key={highlight}>
+                          <Pill tone="brand">{highlight}</Pill>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+
+                  {packet.schedule.length > 0 ? (
+                    <ol className="mt-3 space-y-1 border-t border-hairline pt-3">
+                      {packet.schedule.map((entry) => (
+                        <li
+                          key={`${entry.day}-${entry.item}`}
+                          className="flex gap-3 text-[0.76rem]"
+                        >
+                          <span className="w-16 shrink-0 font-semibold text-brand">
+                            {entry.day}
+                          </span>
+                          <span className="text-ink">{entry.item}</span>
+                        </li>
+                      ))}
+                    </ol>
+                  ) : null}
+                </Panel>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/pages/requests.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/pages/requests.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Check, Clock, X } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { useSkin } from "@/shell/skin-provider";
+import { useSkinHref } from "@/shell/skin-path";
+import { usePeopleLedger } from "../data/ledger-context";
+import {
+  ageInDays,
+  REQUEST_KIND_LABEL,
+  requestValueLabel,
+} from "../data/derive";
+import type { PeopleRequest, RequestStatus } from "../data/types";
+import { Monogram } from "../components/monogram";
+import {
+  activeSelectClass,
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+/**
+ * BEAT 3c — the lever surface.
+ *
+ * Status, sort and top-N are all read from the QUERY STRING, which is what lets
+ * the agent perform a maneuver instead of following a link: it confirms the
+ * levers it is about to pull, navigates to
+ * `?status=pending&sort=aging_desc&top=10`, and this page reads them.
+ *
+ * The controls it set are then VISIBLY highlighted (`activeSelectClass`), which
+ * is the half of the beat that is easy to skip and impossible to recover: if
+ * the page merely shows the right rows, the audience sees a filtered list and
+ * has to take on faith that the assistant did it. Tinting the controls shows
+ * them the assistant reaching into the app's real UI. Note it is the CONTROLS
+ * that light up, not the rows.
+ */
+
+const SORTS = {
+  aging_desc: {
+    label: "Oldest first",
+    compare: (a: PeopleRequest, b: PeopleRequest) =>
+      a.submittedAt.localeCompare(b.submittedAt),
+  },
+  aging_asc: {
+    label: "Newest first",
+    compare: (a: PeopleRequest, b: PeopleRequest) =>
+      b.submittedAt.localeCompare(a.submittedAt),
+  },
+  amount_desc: {
+    label: "Largest value",
+    compare: (a: PeopleRequest, b: PeopleRequest) =>
+      (b.amount ?? 0) - (a.amount ?? 0),
+  },
+} as const;
+
+type SortKey = keyof typeof SORTS;
+
+const STATUSES: (RequestStatus | "all")[] = [
+  "all",
+  "pending",
+  "approved",
+  "declined",
+];
+
+function statusTone(status: RequestStatus) {
+  if (status === "approved") return "positive" as const;
+  if (status === "declined") return "neutral" as const;
+  return "gold" as const;
+}
+
+function RequestRow({
+  request,
+  rank,
+  employeeName,
+  onDecide,
+}: {
+  request: PeopleRequest;
+  rank: number | null;
+  employeeName: string;
+  onDecide: (id: string, status: RequestStatus) => void;
+}) {
+  const age = ageInDays(request.submittedAt);
+  return (
+    <li className="flex flex-wrap items-center gap-3 border-b border-hairline px-4 py-3 last:border-b-0">
+      {rank !== null ? (
+        <span className="rowan-num w-5 shrink-0 text-right text-[0.7rem] font-semibold text-ink-muted">
+          {rank}
+        </span>
+      ) : null}
+      <Monogram name={employeeName} size="sm" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[0.8rem] font-medium text-ink">
+          {request.summary}
+        </p>
+        <p className="truncate text-[0.7rem] text-ink-muted">
+          {employeeName} · {REQUEST_KIND_LABEL[request.kind]}
+        </p>
+      </div>
+      <span
+        className={cn(
+          "rowan-num inline-flex items-center gap-1 text-[0.72rem]",
+          age >= 21 ? "font-semibold text-negative" : "text-ink-muted",
+        )}
+        title={`Submitted ${age} days ago`}
+      >
+        <Clock className="h-3 w-3" />
+        {age}d
+      </span>
+      <span className="rowan-num w-20 shrink-0 text-right text-[0.75rem] font-medium text-ink">
+        {requestValueLabel(request)}
+      </span>
+      <Pill tone={statusTone(request.status)}>{request.status}</Pill>
+      {request.status === "pending" ? (
+        <span className="flex gap-1">
+          <button
+            type="button"
+            aria-label={`Approve ${request.summary}`}
+            onClick={() => onDecide(request.id, "approved")}
+            className="flex h-7 w-7 items-center justify-center rounded-md border border-hairline text-positive hover:bg-positive-soft"
+          >
+            <Check className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label={`Decline ${request.summary}`}
+            onClick={() => onDecide(request.id, "declined")}
+            className="flex h-7 w-7 items-center justify-center rounded-md border border-hairline text-ink-muted hover:bg-surface-muted"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+export function RequestsPage() {
+  const { data, refresh } = usePeopleLedger();
+  const router = useRouter();
+  const skin = useSkin();
+  const skinHref = useSkinHref(skin.id);
+  const params = useSearchParams();
+  const [kind, setKind] = useState<string>("all");
+
+  // Levers that can arrive from the URL. `fromUrl` is what drives the highlight
+  // — a control the USER clicked should not pretend the assistant set it, so
+  // this tracks provenance rather than just the current value.
+  const statusParam = params?.get("status") ?? null;
+  const sortParam = (params?.get("sort") ?? null) as SortKey | null;
+  const topParam = params?.get("top") ?? null;
+
+  const status: RequestStatus | "all" =
+    statusParam && STATUSES.includes(statusParam as RequestStatus)
+      ? (statusParam as RequestStatus)
+      : "all";
+  const sort: SortKey =
+    sortParam && sortParam in SORTS ? sortParam : "aging_desc";
+  const top = topParam ? Math.max(1, Number(topParam) || 0) : null;
+
+  const setLever = (key: string, value: string | null) => {
+    const next = new URLSearchParams(params?.toString() ?? "");
+    if (value === null) next.delete(key);
+    else next.set(key, value);
+    const query = next.toString();
+    // Through skinHref, never a hardcoded `/people/requests` — under LOCK_SKIN
+    // the deploy is served at `/` and a literal prefix reappears in the address
+    // bar on the first click.
+    router.push(`${skinHref("requests")}${query ? `?${query}` : ""}`);
+  };
+
+  const nameOf = (id: string) =>
+    data.employees.find((e) => e.id === id)?.name ?? "Unknown";
+
+  const visible = useMemo(() => {
+    let rows = data.requests.filter((r) => {
+      if (status !== "all" && r.status !== status) return false;
+      if (kind !== "all" && r.kind !== kind) return false;
+      return true;
+    });
+    rows = [...rows].sort(SORTS[sort].compare);
+    if (top) rows = rows.slice(0, top);
+    return rows;
+  }, [data.requests, status, kind, sort, top]);
+
+  const decide = async (id: string, next: RequestStatus) => {
+    await fetch(`/api/people/v1/requests/${id}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ status: next }),
+    });
+    await refresh();
+  };
+
+  const pending = data.requests.filter((r) => r.status === "pending");
+  const oldest = pending.length
+    ? Math.max(...pending.map((r) => ageInDays(r.submittedAt)))
+    : 0;
+
+  // ── BEAT 3b ──────────────────────────────────────────────────────────────
+  // The active levers AND the rows actually rendered after filtering, sorting
+  // and slicing — in the order shown. Asked "what's on my screen?" here, the
+  // agent must be able to say "the oldest ten pending requests, Tobias's desk
+  // at the top, 31 days old" and be right about all of it.
+  useAgentContext({
+    description:
+      "The Requests page the user is currently viewing: the active status " +
+      "filter, sort order and top-N limit, and the request rows actually " +
+      "visible on screen, in the order shown.",
+    value: JSON.stringify({
+      page: "requests",
+      filters: { status, kind, sort, top },
+      pendingTotal: pending.length,
+      visibleCount: visible.length,
+      rows: visible.slice(0, 25).map((r) => ({
+        id: r.id,
+        employee: nameOf(r.employeeId),
+        kind: REQUEST_KIND_LABEL[r.kind],
+        summary: r.summary,
+        status: r.status,
+        ageDays: ageInDays(r.submittedAt),
+        value: requestValueLabel(r),
+      })),
+    }),
+  });
+
+  const showRank = sort === "aging_desc" || sort === "amount_desc";
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <PageHeader
+        title="Requests"
+        subtitle="Time off, equipment, training and role changes, oldest pressure first."
+      />
+
+      <div className="mb-5 grid grid-cols-3 gap-3">
+        <Metric label="Pending" value={String(pending.length)} tone="gold" />
+        <Metric
+          label="Oldest pending"
+          value={`${oldest}d`}
+          tone={oldest >= 21 ? "negative" : "neutral"}
+        />
+        <Metric
+          label="Total this quarter"
+          value={String(data.requests.length)}
+        />
+      </div>
+
+      <Panel className="mb-4" padded={false}>
+        <div className="flex flex-wrap items-center gap-4 px-4 py-3">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Status
+            </span>
+            {STATUSES.map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() =>
+                  setLever("status", candidate === "all" ? null : candidate)
+                }
+                className={activeSelectClass(status === candidate)}
+              >
+                {candidate}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Sort
+            </span>
+            {(Object.keys(SORTS) as SortKey[]).map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() => setLever("sort", candidate)}
+                className={activeSelectClass(sort === candidate)}
+              >
+                {SORTS[candidate].label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Show
+            </span>
+            {[null, 5, 10].map((candidate) => (
+              <button
+                key={String(candidate)}
+                type="button"
+                onClick={() =>
+                  setLever("top", candidate === null ? null : String(candidate))
+                }
+                className={activeSelectClass(top === candidate)}
+              >
+                {candidate === null ? "All" : `Top ${candidate}`}
+              </button>
+            ))}
+          </div>
+
+          <label className="ml-auto flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Type
+            </span>
+            <select
+              value={kind}
+              onChange={(event) => setKind(event.target.value)}
+              className="rounded-md border border-hairline bg-surface px-2 py-1.5 text-[0.78rem] text-ink outline-none focus:border-brand/50"
+            >
+              <option value="all">All types</option>
+              {Object.entries(REQUEST_KIND_LABEL).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </Panel>
+
+      <SectionLabel>
+        {top
+          ? `Top ${Math.min(top, visible.length)} of ${data.requests.filter((r) => status === "all" || r.status === status).length}`
+          : `${visible.length} requests`}
+      </SectionLabel>
+
+      <Panel padded={false}>
+        {visible.length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              title="Nothing in this view"
+              hint="Widen the status filter or clear the top-N limit to see the rest of the queue."
+            />
+          </div>
+        ) : (
+          <ul>
+            {visible.map((request, index) => (
+              <RequestRow
+                key={request.id}
+                request={request}
+                rank={showRank ? index + 1 : null}
+                employeeName={nameOf(request.employeeId)}
+                onDecide={(id, next) => void decide(id, next)}
+              />
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/pages/roster.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/pages/roster.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { usePeopleLedger } from "../data/ledger-context";
+import {
+  bandPosition,
+  formatPercent,
+  formatSalary,
+  isOutOfBand,
+  tenureLabel,
+} from "../data/derive";
+import type { Employee, Team } from "../data/types";
+import { Monogram } from "../components/monogram";
+import {
+  EmptyState,
+  Metric,
+  Panel,
+  PageHeader,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+const TEAMS: (Team | "All")[] = [
+  "All",
+  "Engineering",
+  "Design",
+  "Go-to-Market",
+  "Finance",
+  "People Ops",
+];
+
+/** A thin in-band position track. Reads at a glance; never claims precision. */
+function BandTrack({
+  ratio,
+  outOfBand,
+}: {
+  ratio: number;
+  outOfBand: boolean;
+}) {
+  return (
+    <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface-muted">
+      <div
+        className={cn(
+          "h-full rounded-full",
+          outOfBand ? "bg-negative" : "bg-brand/60",
+        )}
+        style={{ width: `${Math.max(3, ratio * 100)}%` }}
+      />
+    </div>
+  );
+}
+
+function PersonCard({
+  employee,
+  bands,
+  buddyName,
+}: {
+  employee: Employee;
+  bands: ReturnType<typeof usePeopleLedger>["data"]["bands"];
+  buddyName: string | null;
+}) {
+  const pos = bandPosition(bands, employee.baseSalary, employee.level);
+  const latestNote = employee.notes[0];
+
+  return (
+    <article className="flex flex-col gap-3 rounded-lg border border-hairline bg-surface p-4 shadow-soft transition-shadow hover:shadow-lift">
+      <div className="flex items-start gap-3">
+        <Monogram
+          name={employee.name}
+          size="lg"
+          ring={pos?.outOfBand ? "negative" : null}
+        />
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-sm font-semibold text-ink">
+            {employee.name}
+          </h3>
+          <p className="truncate text-[0.75rem] text-ink-muted">
+            {employee.title}
+          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1">
+            <Pill tone="brand">{employee.level}</Pill>
+            <Pill>{employee.team}</Pill>
+            {employee.status === "onboarding" ? (
+              <Pill tone="gold">Onboarding</Pill>
+            ) : null}
+            {employee.status === "on-leave" ? <Pill>On leave</Pill> : null}
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-1 flex items-baseline justify-between text-[0.7rem]">
+          <span className="text-ink-muted">Position in band</span>
+          <span
+            className={cn(
+              "rowan-num font-semibold",
+              pos?.outOfBand ? "text-negative" : "text-ink",
+            )}
+          >
+            {pos
+              ? pos.outOfBand
+                ? `${pos.side} band`
+                : formatPercent(pos.ratio)
+              : "—"}
+          </span>
+        </div>
+        <BandTrack
+          ratio={pos?.ratio ?? 0}
+          outOfBand={pos?.outOfBand ?? false}
+        />
+        <div className="rowan-num mt-1 flex items-baseline justify-between text-[0.68rem] text-ink-muted">
+          <span>{formatSalary(employee.baseSalary)}</span>
+          <span>{tenureLabel(employee.startDate)}</span>
+        </div>
+      </div>
+
+      {/* BEAT 5's visible affordances land here: the buddy chip and the forced
+          🎉 welcome note both appear on the person's card, so a room can see
+          the stored procedure actually changed something. */}
+      {buddyName ? (
+        <div className="flex items-center gap-1.5 text-[0.7rem] text-ink-muted">
+          <span>Buddy</span>
+          <Monogram name={buddyName} size="xs" />
+          <span className="truncate font-medium text-ink">{buddyName}</span>
+        </div>
+      ) : null}
+
+      {latestNote ? (
+        <p className="rounded-md border border-brand/20 bg-brand-soft px-2.5 py-1.5 text-[0.72rem] text-ink">
+          {latestNote.text}
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+export function RosterPage() {
+  const { data } = usePeopleLedger();
+  const [team, setTeam] = useState<Team | "All">("All");
+  const [query, setQuery] = useState("");
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return data.employees.filter((e) => {
+      if (team !== "All" && e.team !== team) return false;
+      if (!q) return true;
+      return (
+        e.name.toLowerCase().includes(q) ||
+        e.title.toLowerCase().includes(q) ||
+        e.level.toLowerCase() === q
+      );
+    });
+  }, [data.employees, team, query]);
+
+  const nameOf = (id: string | null) =>
+    id ? (data.employees.find((e) => e.id === id)?.name ?? null) : null;
+
+  const outOfBand = data.employees.filter((e) => isOutOfBand(data.bands, e));
+  const openRequests = data.requests.filter((r) => r.status === "pending");
+  const startingSoon = data.employees.filter((e) => e.status === "onboarding");
+
+  // ── BEAT 3b: WHAT IS VISIBLY ON SCREEN ───────────────────────────────────
+  // Not the whole roster — the rows actually rendered after the team filter and
+  // the search box, in the order shown, plus the live filter state. That
+  // distinction IS the beat: the agent describing what the user can literally
+  // see, and giving a different answer once they filter or navigate.
+  useAgentContext({
+    description:
+      "The Roster page the user is currently viewing: the active team filter " +
+      "and search text, and the employee cards actually visible on screen, in " +
+      "the order shown.",
+    value: JSON.stringify({
+      page: "roster",
+      filters: { team, search: query || null },
+      visibleCount: visible.length,
+      totalHeadcount: data.employees.length,
+      rows: visible.slice(0, 25).map((e) => ({
+        name: e.name,
+        title: e.title,
+        level: e.level,
+        team: e.team,
+        status: e.status,
+        baseSalary: e.baseSalary,
+        positionInBand: (() => {
+          const pos = bandPosition(data.bands, e.baseSalary, e.level);
+          if (!pos) return null;
+          return pos.outOfBand ? `${pos.side} band` : formatPercent(pos.ratio);
+        })(),
+        tenure: tenureLabel(e.startDate),
+        buddy: nameOf(e.buddyId),
+      })),
+    }),
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <PageHeader
+        title="Roster"
+        subtitle={`${data.employees.length} people across ${new Set(data.employees.map((e) => e.team)).size} teams`}
+      />
+
+      <div className="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <Metric label="Headcount" value={String(data.employees.length)} />
+        <Metric
+          label="Outside their band"
+          value={String(outOfBand.length)}
+          tone={outOfBand.length ? "negative" : "positive"}
+          hint={outOfBand.map((e) => e.name.split(" ")[0]).join(", ") || "None"}
+        />
+        <Metric label="Open requests" value={String(openRequests.length)} />
+        <Metric
+          label="Starting soon"
+          value={String(startingSoon.length)}
+          tone={startingSoon.length ? "gold" : "neutral"}
+          hint={
+            startingSoon.map((e) => e.name.split(" ")[0]).join(", ") || "None"
+          }
+        />
+      </div>
+
+      <Panel className="mb-4" padded={false}>
+        <div className="flex flex-wrap items-center gap-2 px-4 py-3">
+          <div className="relative min-w-[12rem] flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-ink-muted" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search by name, title, or level"
+              aria-label="Search the roster"
+              className="w-full rounded-md border border-hairline bg-surface py-1.5 pl-8 pr-3 text-[0.8rem] text-ink outline-none placeholder:text-ink-muted focus:border-brand/50"
+            />
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {TEAMS.map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() => setTeam(candidate)}
+                className={cn(
+                  "rounded-full border px-2.5 py-1 text-[0.72rem] transition-colors",
+                  team === candidate
+                    ? "border-brand/50 bg-brand-soft font-semibold text-brand"
+                    : "border-hairline bg-surface text-ink-muted hover:text-ink",
+                )}
+              >
+                {candidate}
+              </button>
+            ))}
+          </div>
+        </div>
+      </Panel>
+
+      <SectionLabel>
+        {visible.length === data.employees.length
+          ? "Everyone"
+          : `${visible.length} of ${data.employees.length} people`}
+      </SectionLabel>
+
+      {visible.length === 0 ? (
+        <EmptyState
+          title="No one matches that"
+          hint="Clear the search box or pick a different team to see the rest of the roster."
+        />
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {visible.map((employee) => (
+            <PersonCard
+              key={employee.id}
+              employee={employee}
+              bands={data.bands}
+              buddyName={nameOf(employee.buddyId)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/providers.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/providers.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import type { ReactNode } from "react";
+import { PeopleLedgerProvider, usePeopleLedger } from "./data/ledger-context";
+import {
+  RecordingProvider,
+  RecordingVignette,
+} from "./components/recording-context";
+import { setSandboxSnapshot } from "./sandbox-functions";
+
+/**
+ * Rowan uses BOTH provider slots the contract offers, and the split matters.
+ *
+ * `RuntimeProviders` mounts ABOVE `CopilotKitProvider`. The ledger lives here
+ * because `useRuntimeProperties` reads the signed-in operator out of it, and
+ * `properties` is a PROP of `CopilotKitProvider` — so its source has to exist
+ * before that provider's first commit. A child racing an imperative
+ * `setProperties` after mount is precisely the bug this slot exists to prevent.
+ * Mounting above also means everything below (Tools, layout, pages) shares the
+ * one ledger fetch.
+ *
+ * `Providers` mounts BELOW it, for anything that consumes CopilotKit context —
+ * here, the teach-mode recording context and its canvas-edge vignette.
+ */
+
+/** Above CopilotKitProvider. */
+export function PeopleRuntimeProviders({ children }: { children: ReactNode }) {
+  return <PeopleLedgerProvider>{children}</PeopleLedgerProvider>;
+}
+
+/**
+ * Threaded into `CopilotKitProvider`'s `properties` prop by the shell, and
+ * forwarded to the server as the run body's forwardedProps, where
+ * `peopleIdentifyUser` maps it onto a durable-memory scope.
+ *
+ * Memoized on the two primitive fields rather than the operator object: the
+ * ledger re-creates that object on every refresh, and an unstable `properties`
+ * identity would re-scope the run on every mutation.
+ *
+ * Deliberately does NOT set `a2uiCatalogAvailable` — the shell adds that itself
+ * when a catalog is present.
+ */
+export function usePeopleRuntimeProperties():
+  | Record<string, unknown>
+  | undefined {
+  const { operator } = usePeopleLedger();
+  return useMemo(
+    () => ({ userId: operator.id, userRole: operator.role }),
+    [operator.id, operator.role],
+  );
+}
+
+/**
+ * Keeps the module-scope snapshot the OGUI sandbox functions read in sync with
+ * the live ledger. Renders nothing. Without it those functions answer from an
+ * empty ledger and generated UI comes back convincingly blank.
+ */
+function SandboxDataSync() {
+  const { data } = usePeopleLedger();
+  useEffect(() => {
+    setSandboxSnapshot(data);
+  }, [data]);
+  return null;
+}
+
+/** Below CopilotKitProvider. */
+export function PeopleProviders({ children }: { children: ReactNode }) {
+  return (
+    <RecordingProvider>
+      <SandboxDataSync />
+      {children}
+      <RecordingVignette />
+    </RecordingProvider>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/report-data.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/report-data.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type { Band, Employee, PeopleRequest } from "./data/types";
+
+/**
+ * Binds Rowan's live ledger into the a2ui catalog renderers.
+ *
+ * This context is the reason the agent cannot fabricate a figure on the brief:
+ * data NEVER travels inside the A2UI operations. The agent selects WHAT to show
+ * and the renderers (StatCard/LevelBreakdown/PeopleList) read the real
+ * employees / bands / requests from here — the same snapshot the pages render —
+ * so every number on the canvas is client-computed, not model-authored.
+ */
+export interface ReportData {
+  employees: Employee[];
+  bands: Band[];
+  requests: PeopleRequest[];
+}
+
+const ReportDataContext = createContext<ReportData | null>(null);
+
+export function ReportDataProvider({
+  value,
+  children,
+}: {
+  value: ReportData;
+  children: ReactNode;
+}) {
+  return (
+    <ReportDataContext.Provider value={value}>
+      {children}
+    </ReportDataContext.Provider>
+  );
+}
+
+/**
+ * Live people data for the a2ui brief renderers. Returns empty arrays if a
+ * renderer somehow mounts outside the provider (shouldn't happen on the canvas)
+ * so a renderer degrades to its own empty state rather than throwing.
+ */
+export function useReportData(): ReportData {
+  return (
+    useContext(ReportDataContext) ?? { employees: [], bands: [], requests: [] }
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/sandbox-functions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/sandbox-functions.ts
@@ -1,0 +1,137 @@
+import { z } from "zod";
+import type { SandboxFunction } from "@copilotkit/react-core/v2";
+import type { PeopleStoreState } from "./data/types";
+import {
+  ageInDays,
+  bandPosition,
+  isOutOfBand,
+  REQUEST_KIND_LABEL,
+  requestValueLabel,
+} from "./data/derive";
+
+/**
+ * Functions exposed INSIDE the OGUI sandboxed iframe, so generated UI can bind
+ * to Rowan's real ledger instead of the model typing numbers into markup.
+ *
+ * Two things this file is careful about:
+ *
+ *  1. It projects onto explicit DTOs rather than passing records through. The
+ *     sandbox is a different trust boundary, and a spread of the raw employee
+ *     object would carry email addresses and manager chains across it for no
+ *     reason. Only what a generated view could legitimately draw goes over.
+ *
+ *  2. It reads a module-scope snapshot rather than a hook, because these are
+ *     plain functions invoked from an iframe with no React context. The
+ *     snapshot is kept current by `<SandboxDataSync />`, mounted in the skin's
+ *     Providers — without that component these return an empty ledger, which
+ *     renders as a plausible-looking but entirely blank generated UI.
+ */
+
+let snapshot: PeopleStoreState | null = null;
+
+export function setSandboxSnapshot(next: PeopleStoreState) {
+  snapshot = next;
+}
+
+const empty: PeopleStoreState = {
+  employees: [],
+  bands: [],
+  requests: [],
+  compRequests: [],
+  bandExceptions: [],
+  onboardingTasks: [],
+  packets: [],
+  operators: [],
+};
+
+const read = () => snapshot ?? empty;
+
+export const sandboxFunctions: SandboxFunction[] = [
+  {
+    name: "getPeople",
+    description:
+      "Everyone on the roster with their level, team, tenure, salary and " +
+      "position in their compensation band.",
+    parameters: z.object({
+      team: z.string().optional().describe("Restrict to one team."),
+      level: z
+        .string()
+        .optional()
+        .describe('Restrict to one level, e.g. "L5".'),
+    }),
+    handler: async ({ team, level }: { team?: string; level?: string }) => {
+      const { employees, bands } = read();
+      return employees
+        .filter(
+          (e) => (!team || e.team === team) && (!level || e.level === level),
+        )
+        .map((e) => {
+          const pos = bandPosition(bands, e.baseSalary, e.level);
+          return {
+            id: e.id,
+            name: e.name,
+            title: e.title,
+            level: e.level,
+            team: e.team,
+            status: e.status,
+            baseSalary: e.baseSalary,
+            bandRatio: pos?.ratio ?? null,
+            outOfBand: pos?.outOfBand ?? false,
+            side: pos?.side ?? null,
+          };
+        });
+    },
+  },
+  {
+    name: "getBands",
+    description: "The compensation band table: level, label, min, mid and max.",
+    parameters: z.object({}),
+    handler: async () => read().bands,
+  },
+  {
+    name: "getRequests",
+    description:
+      "The request queue — time off, equipment, training, role changes — with " +
+      "how many days each has been waiting.",
+    parameters: z.object({
+      status: z
+        .enum(["all", "pending", "approved", "declined"])
+        .optional()
+        .describe("Defaults to pending."),
+    }),
+    handler: async ({ status = "pending" }: { status?: string }) => {
+      const { requests, employees } = read();
+      return requests
+        .filter((r) => status === "all" || r.status === status)
+        .map((r) => ({
+          id: r.id,
+          employee:
+            employees.find((e) => e.id === r.employeeId)?.name ?? "Unknown",
+          kind: REQUEST_KIND_LABEL[r.kind],
+          summary: r.summary,
+          status: r.status,
+          ageDays: ageInDays(r.submittedAt),
+          value: requestValueLabel(r),
+        }));
+    },
+  },
+  {
+    name: "getPeopleKpis",
+    description:
+      "Headline People Ops figures: headcount, how many sit outside their " +
+      "band, open requests, pending compensation requests, and people onboarding.",
+    parameters: z.object({}),
+    handler: async () => {
+      const { employees, bands, requests, compRequests } = read();
+      return {
+        headcount: employees.length,
+        outOfBand: employees.filter((e) => isOutOfBand(bands, e)).length,
+        openRequests: requests.filter((r) => r.status === "pending").length,
+        pendingCompRequests: compRequests.filter((c) => c.status === "pending")
+          .length,
+        onboarding: employees.filter((e) => e.status === "onboarding").length,
+        teams: [...new Set(employees.map((e) => e.team))],
+      };
+    },
+  },
+];

--- a/examples/showcases/reskinnable-demo/src/skins/people/skin.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/skin.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { Inbox, Paperclip, Scale, Sprout, Users } from "lucide-react";
+import type { NavRoute, Skin, Suggestion } from "@/shell/skin-contract";
+import { peopleIdentity } from "./identity";
+import { PeopleLayout } from "./layout";
+import { PeopleTools } from "./tools";
+import { RosterPage } from "./pages/roster";
+import { CompensationPage } from "./pages/compensation";
+import { RequestsPage } from "./pages/requests";
+import { OnboardingPage } from "./pages/onboarding";
+import { catalog } from "./catalog";
+import { PeopleCanvasSurface } from "./canvas-surface";
+import { peopleSuggestions, PACKET_MESSAGE } from "./suggestions";
+import { ROWAN_DESIGN_SKILL } from "./design-skill";
+import { sandboxFunctions } from "./sandbox-functions";
+import {
+  PeopleProviders,
+  PeopleRuntimeProviders,
+  usePeopleRuntimeProperties,
+} from "./providers";
+import { stageOfferLetterAttachment } from "./attach-offer-letter";
+
+const nav: NavRoute[] = [
+  { segment: "", label: "Roster", icon: Users },
+  { segment: "compensation", label: "Compensation", icon: Scale },
+  { segment: "requests", label: "Requests", icon: Inbox },
+  { segment: "onboarding", label: "Onboarding", icon: Sprout },
+];
+
+/**
+ * `resolvePage` — not `nav` — is the single source of truth for which segments
+ * are valid. It accepts `roster` as an alias for the index that the nav never
+ * lists, so a deep link or a typed URL lands somewhere sensible instead of 404.
+ */
+const PAGES: Record<string, ComponentType> = {
+  "": RosterPage,
+  roster: RosterPage,
+  compensation: CompensationPage,
+  requests: RequestsPage,
+  onboarding: OnboardingPage,
+};
+
+function resolvePage(segments: string[]): ComponentType | null {
+  const key = segments.length === 0 ? "" : segments.join("/");
+  return PAGES[key] ?? null;
+}
+
+/**
+ * Human labels for the tool-activity chips, so the transcript reads as phrases
+ * rather than as function names. "Optional" in the contract and mandatory in
+ * practice: `showCompBands` on a projector says "this is a demo of an API".
+ */
+const TOOL_LABELS: Record<string, string> = {
+  showCompBands: "Pulling up the band ladder",
+  showPerson: "Looking someone up",
+  showRequestList: "Gathering the requests",
+  showCompSummary: "Summarizing compensation",
+  setBaseSalary: "Opening the merit increase",
+  showRequestQueue: "Setting up the queue view",
+  createOnboardingTasks: "Building the onboarding checklist",
+  assignBuddy: "Assigning an onboarding buddy",
+  postWelcomeNote: "Posting a welcome note",
+  createOnboardingPacket: "Filing the onboarding packet",
+  approveCompRequest: "Approving the compensation request",
+  openBandException: "Filing a band exception",
+  finalizeBandException: "Finalizing the band exception",
+  offerWorkflowRecording: "Asking to learn this one",
+  awaitDemonstration: "Watching you do it",
+  saveLearnedProcedure: "Writing down what it learned",
+  requestBackgroundCheck: "Ordering a background check",
+  scheduleExitInterview: "Scheduling an exit interview",
+  sendPolicyReminder: "Sending a policy reminder",
+  openHeadcountRequisition: "Opening a requisition",
+  render_people_brief: "Building the people review",
+};
+
+// ── BEAT 3d: driving the real composer ──────────────────────────────────────
+// The framework's suggestion path DROPS attachments, so the pill that must
+// carry the offer letter cannot take it. Instead it is intercepted below and
+// pushed through the actual composer — stage the file into the hidden input,
+// set the textarea, click send — which is the path that correctly consumes an
+// attachment on submit.
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Set a React-controlled textarea's value so its onChange actually fires. */
+function setTextareaValue(el: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function sendPacketRequestWithOfferLetter() {
+  const staged = await stageOfferLetterAttachment();
+  // Give the built-in attachment handler time to finish base64-encoding the
+  // file; sending while an attachment is still "uploading" is silently dropped.
+  if (staged) await wait(500);
+
+  const textarea = document.querySelector<HTMLTextAreaElement>(
+    'textarea[data-testid="copilot-chat-textarea"]',
+  );
+  if (!textarea) return;
+  setTextareaValue(textarea, PACKET_MESSAGE);
+  await wait(60);
+
+  document
+    .querySelector<HTMLButtonElement>(
+      'button[data-testid="copilot-send-button"]',
+    )
+    ?.click();
+}
+
+// NOTE: no `agent` field, and this module must NEVER import ./agent.ts. Agents
+// pull in @copilotkit/runtime, which must not reach the browser bundle; the
+// agent registers separately in src/shell/agent-registry.ts under this same id.
+const people: Skin = {
+  id: "people",
+  identity: peopleIdentity,
+  themeClass: "theme-people",
+  Layout: PeopleLayout,
+  nav,
+  resolvePage,
+  Tools: PeopleTools,
+  catalog,
+  suggestions: peopleSuggestions,
+  designSkill: ROWAN_DESIGN_SKILL,
+
+  // Above CopilotKitProvider — holds the ledger, which `useRuntimeProperties`
+  // reads for the signed-in operator.
+  RuntimeProviders: PeopleRuntimeProviders,
+  useRuntimeProperties: usePeopleRuntimeProperties,
+  // Below it — the teach-mode recording context and the sandbox data sync.
+  Providers: PeopleProviders,
+
+  CanvasSurface: PeopleCanvasSurface,
+  sandboxFunctions,
+  toolLabels: TOOL_LABELS,
+
+  // REST-backed like banking and logistics: components read the ledger through
+  // `usePeopleLedger()` directly, so nothing flows through `useSkinData` and
+  // `useData` is deliberately omitted.
+
+  chatHeaderActions: [
+    {
+      icon: Paperclip,
+      label: "Attach the offer letter",
+      // A manual fallback for the presenter if the pill path misbehaves live.
+      onClick: () => void stageOfferLetterAttachment(),
+    },
+  ],
+
+  onSuggestionSelect: (suggestion: Suggestion) => {
+    if (suggestion.message === PACKET_MESSAGE) {
+      void sendPacketRequestWithOfferLetter();
+      return true; // fully handled — the shell does nothing further
+    }
+    return false; // every other pill takes the default "send the message" path
+  },
+};
+
+export default people;

--- a/examples/showcases/reskinnable-demo/src/skins/people/suggestions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/people/suggestions.ts
@@ -1,0 +1,87 @@
+import type { Suggestion } from "@/shell/skin-contract";
+
+/**
+ * THE PILLS ARE THE DEMO SCRIPT.
+ *
+ * The presenter should never have to type. That is partly stagecraft and partly
+ * correctness: free-typed phrasing routes to the wrong tool. Asking for the
+ * comp "report" instead of the comp "bands" sends Rowan to the canvas brief
+ * rather than the in-chat ladder, and the audience sees a hesitation that was
+ * never about the product.
+ *
+ * ── BEAT MAP ────────────────────────────────────────────────────────────────
+ * | Beat              | Rowan's step                          | Pill | Implemented by                                              |
+ * | ----------------- | ------------------------------------- | ---- | ----------------------------------------------------------- |
+ * | 1 face            | The compensation band ladder          | 1    | `showCompBands` useComponent → `components/band-ladder.tsx`  |
+ * | 2 rich thread     | Reload; ladder + receipts still there | —    | every render keyed off `result`; `answeredSalaryChanges` map |
+ * | 3a drive the app  | Merit increase, figure typed in chat  | 2    | `setBaseSalary` HITL → PATCH …/compensation                  |
+ * | 3b sees my screen | Ask on Roster, then on Requests       | 3    | route readable (layout) + per-page readables (all 4 pages)   |
+ * | 3c levers         | Oldest pending requests, top 10       | 4    | `showRequestQueue` HITL → ?status&sort&top, controls tinted  |
+ * | 3d multimodal     | Offer letter → durable packet         | 5    | `onSuggestionSelect` + `attach-offer-letter` → POST /packets |
+ * | 4 memory          | Comp summary in Maya's saved format   | 6    | seeded topical memory + `showCompSummary({ note })`          |
+ * | 5 stored skill    | "Dana starts Monday — handle it"      | 7    | seeded operational memory → 3 writes amid 4 distractors      |
+ * | 6 teach a skill   | Out-of-band raise approval            | 8    | 422 OUT_OF_BAND → offer → watch → save → replay on Naomi     |
+ * | (canvas)          | The People Review brief               | 9    | server `render_people_brief` → a2ui `PeopleCanvasSurface`    |
+ *
+ * Beat 2 has no pill on purpose — it is demonstrated by reloading the browser
+ * and reopening the thread, not by asking for anything.
+ */
+
+/**
+ * Shared with `onSuggestionSelect` in skin.tsx by string equality, so the match
+ * can never drift out of sync with the pill. This is the pill that must carry a
+ * file, and the framework's suggestion path drops attachments — see
+ * `attach-offer-letter.ts`.
+ */
+export const PACKET_MESSAGE =
+  "Here's Dana Whitfield's signed offer letter. Read it and file her onboarding packet.";
+
+export const peopleSuggestions: Suggestion[] = [
+  // 1 — lead with generative UI. The ladder is the signature visual, and it is
+  // also the setup for beats 4 and 6.
+  {
+    title: "Show me the comp bands",
+    message:
+      "Show me the compensation band ladder and tell me who's sitting outside their band.",
+  },
+  // 3a — a mutation whose sensitive value never reaches the assistant.
+  {
+    title: "Priya's merit increase",
+    message: "Priya Raman is overdue for a review. Record her merit increase.",
+  },
+  // 3b — click this on TWO different pages. The answers must differ.
+  {
+    title: "What's on my screen?",
+    message:
+      "Look at the page I'm on right now and tell me what's on screen — the key elements and the figures shown.",
+  },
+  // 3c — HITL confirm, then navigate + filter + sort, controls visibly tinted.
+  {
+    title: "Oldest pending requests",
+    message: "Show me the ten oldest requests still waiting on me.",
+  },
+  // 3d — intercepted in skin.tsx; stages the generated offer letter.
+  { title: "File Dana's packet", message: PACKET_MESSAGE },
+  // 4 — recalls the seeded preference AND names it in the note slot.
+  {
+    title: "Where does comp stand?",
+    message: "Give me a summary of where compensation stands right now.",
+  },
+  // 5 — one vague sentence replays a seeded three-step procedure.
+  {
+    title: "Dana starts Monday",
+    message: "Dana Whitfield starts Monday — handle it.",
+  },
+  // 6 — the gated action Rowan does NOT know how to do yet. It must decline.
+  {
+    title: "Approve Marcus's raise",
+    message:
+      "Clara put Marcus Bell up for Staff. Approve the compensation request.",
+  },
+  // The canvas artifact — a good closer, and the only pill that leaves chat.
+  {
+    title: "Prep the people review",
+    message:
+      "Put together the people review brief for the leadership meeting on the canvas.",
+  },
+];

--- a/examples/showcases/reskinnable-demo/src/skins/people/theme.css
+++ b/examples/showcases/reskinnable-demo/src/skins/people/theme.css
@@ -1,0 +1,163 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   Rowan — People Ops. Skin-scoped VALUES for the shell's shared token
+   vocabulary (names declared in src/app/globals.css; never invent new ones).
+
+   PALETTE RATIONALE. The four shipped skins already own violet (banking 252),
+   cyan (airline 190), amber (logistics 32) and teal (keel 170), so plum is the
+   one warm, human hue still unclaimed — and it is literally the rowan in
+   autumn. It is deliberately DARK and LOW-SATURATION (315 38% 36%) rather than
+   a bright accent, because this app puts a per-person monogram tile on almost
+   every row: the chrome has to stay quiet or the roster turns into confetti.
+
+   `--brand-violet` is repurposed as Rowan's warm GOLD milestone accent (tenure
+   anniversaries, band-ceiling markers, "on track" ribbons) — the same move keel
+   makes with its amber. The shell only cares that the token resolves; what it
+   MEANS is the skin's business.
+
+   `--negative` is pulled to a cool crimson (352) and kept far from the plum
+   brand in lightness, so an out-of-band salary flag never reads as decoration.
+   ────────────────────────────────────────────────────────────────────────── */
+.theme-people {
+  /* Between logistics' utilitarian 0.5rem and banking's pillowy 1.375rem. A
+     people directory wants softened, card-like corners without looking like a
+     consumer app. */
+  --radius: 0.875rem;
+
+  /* Dark-mode OPT-IN. src/hooks/use-theme.ts forces any skin WITHOUT this flag
+     to light and ignores the stored preference, which would make the layout's
+     ThemeToggle a dead control. The `.dark .theme-people` block below is only
+     live because this is set. */
+  --nw-dark-capable: 1;
+
+  --brand: 315 38% 36%;
+  --brand-indigo: 322 44% 26%;
+  --brand-violet: 38 88% 50%;
+  --brand-foreground: 0 0% 100%;
+  --brand-soft: 316 46% 95%;
+
+  --background: 320 24% 99%;
+  --foreground: 318 24% 12%;
+  --canvas: 318 16% 95%;
+  --surface: 0 0% 100%;
+  --surface-muted: 318 22% 97%;
+  --ink: 318 24% 12%;
+  --ink-muted: 316 9% 44%;
+  --hairline: 318 18% 89%;
+
+  --positive: 158 56% 34%;
+  --positive-soft: 158 48% 94%;
+  --negative: 352 70% 48%;
+  --negative-soft: 352 82% 96%;
+}
+
+/* DARK. `.dark` lands on <html>, an ancestor of the `.theme-people` root, so
+   this re-values only what differs — surfaces, ink, hairline and the semantic
+   pairs — and lets the brand ramp and `--radius` inherit from the light block.
+   The plum brand is lightened here only via `--brand-soft`: on a dark surface
+   the 36%-light plum still carries enough contrast as a fill. */
+.dark .theme-people {
+  color-scheme: dark;
+
+  --background: 318 18% 8%;
+  --foreground: 316 20% 94%;
+  --canvas: 318 18% 8%;
+  --surface: 318 15% 12%;
+  --surface-muted: 318 13% 15%;
+  --ink: 316 20% 94%;
+  --ink-muted: 316 8% 60%;
+  --hairline: 318 11% 22%;
+
+  --brand: 315 46% 58%;
+  --brand-indigo: 322 44% 48%;
+  --brand-soft: 316 30% 20%;
+
+  --positive: 158 48% 48%;
+  --positive-soft: 158 32% 15%;
+  --negative: 352 70% 62%;
+  --negative-soft: 352 38% 18%;
+}
+
+/* ── Signature: the band ladder ──────────────────────────────────────────────
+   The one element this skin is meant to be remembered by. Each level is a
+   vertical rail whose fill runs band-min (bottom) → band-max (top); every
+   employee is a dot placed at their real position in that range. Kept in CSS
+   rather than Tailwind because the gradient direction and the out-of-band
+   pulse both need to follow the live tokens. */
+.rowan-rail {
+  /* Plum only, deepening upward. An earlier version faded into the gold
+     milestone accent at the ceiling, which read as unrelated warmth — the rails
+     looked like candles rather than ranges. The ceiling is now marked by a
+     discrete cap element instead, which says "this is the top of the band"
+     without recolouring the whole rail. */
+  background-image: linear-gradient(
+    to top,
+    hsl(var(--brand) / 0.08) 0%,
+    hsl(var(--brand) / 0.3) 100%
+  );
+}
+
+/* The band ceiling. A short solid cap in the gold milestone accent — the one
+   place a rail earns colour, because crossing it is what makes someone
+   actionable. */
+.rowan-rail-cap {
+  background-color: hsl(var(--brand-violet) / 0.75);
+}
+
+/* An employee sitting outside their band gets a ring that breathes once on
+   mount — a visible affordance the audience can catch from the back of a room
+   without it animating forever. */
+@keyframes rowan-flag-in {
+  0% {
+    box-shadow: 0 0 0 0 hsl(var(--negative) / 0.55);
+  }
+
+  70% {
+    box-shadow: 0 0 0 7px hsl(var(--negative) / 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 hsl(var(--negative) / 0);
+  }
+}
+
+.rowan-flag {
+  animation: rowan-flag-in 1.4s ease-out 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rowan-flag {
+    animation: none;
+    outline: 2px solid hsl(var(--negative));
+    outline-offset: 2px;
+  }
+}
+
+/* BEAT 6 — the recording vignette. A slow breathe on the canvas edge so a room
+   can see that Rowan is watching the demonstration, without a spinner or a
+   modal stealing focus from the thing being demonstrated. */
+@keyframes rowan-record-breathe {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Keep the border — it carries the "recording" signal — drop the pulse. */
+  [style*="rowan-record-breathe"] {
+    animation: none !important;
+    opacity: 0.85 !important;
+  }
+}
+
+/* Tabular figures everywhere a salary, a band or a day-count is shown, so
+   columns of numbers line up and a changed digit is visible as a change rather
+   than as a reflow. */
+.rowan-num {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/people/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/people/tools.tsx
@@ -1,0 +1,1357 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import {
+  useAgentContext,
+  useComponent,
+  useFrontendTool,
+  useHumanInTheLoop,
+} from "@copilotkit/react-core/v2";
+import { CheckCircle2, CircleAlert, Radio, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useSkin } from "@/shell/skin-provider";
+import { useSkinHref } from "@/shell/skin-path";
+import { usePeopleLedger } from "./data/ledger-context";
+import {
+  ageInDays,
+  bandPosition,
+  formatPercent,
+  formatSalary,
+  isOutOfBand,
+  REQUEST_KIND_LABEL,
+  requestValueLabel,
+  tenureLabel,
+} from "./data/derive";
+import type { Employee, PeopleStoreState } from "./data/types";
+import { BandLadder } from "./components/band-ladder";
+import { Monogram } from "./components/monogram";
+import { Pill } from "./components/primitives";
+import { useRecording } from "./components/recording-context";
+
+/**
+ * Every frontend tool, HITL card, gen-UI component and global readable Rowan
+ * ships. Renders null. Registered at the SKIN level rather than per page, so
+ * the teach-mode chain survives the navigation it is recording.
+ *
+ * Four rules run through this whole file; each fails SILENTLY if broken.
+ *
+ *  1. EVERY registration closes with a deps array. Omit it and the closure
+ *     captures whatever the data was at registration time — for a REST-backed
+ *     skin, the EMPTY ledger from before the first fetch — forever. It
+ *     compiles, it lints, it passes tests, and the agent narrates confidently
+ *     over a component rendering its "not found" branch.
+ *
+ *  2. A parameterized `useComponent` render receives the schema output
+ *     DIRECTLY (`render: ({ level }) => …`). Only `useFrontendTool` and
+ *     `useHumanInTheLoop` renders get `{ args, status, result, respond }`.
+ *
+ *  3. Renders are REPLAY-SAFE: keyed off `result`, never off `status`. Reopen a
+ *     thread and you get the recorded result with no live status transition, so
+ *     a status-keyed render is perfect during the demo and blank the moment
+ *     anyone revisits — which is exactly when beat 2 is being shown.
+ *
+ *  4. Nothing sensitive goes into a tool result. Whatever a handler returns is
+ *     stored in the thread forever (beat 3a).
+ */
+
+/**
+ * BEAT 2 + 3a — replay memory for the salary card.
+ *
+ * On thread reopen a HITL call replays as in-progress with no live state, so
+ * the card needs somewhere to recover what happened. This map holds ONLY the
+ * person's name and the label shown — never the figure the user typed. That
+ * omission is the beat: the number exists in the REST call and the ledger, and
+ * nowhere the assistant or the transcript can reach.
+ */
+const answeredSalaryChanges = new Map<string, { name: string }>();
+
+/** Same idea for the navigate-confirm card. */
+const answeredNavigations = new Map<string, { confirmed: boolean }>();
+
+function ToolCard({
+  tone = "brand",
+  children,
+}: {
+  tone?: "brand" | "positive" | "negative";
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "my-1 rounded-lg border bg-surface p-3 text-ink shadow-soft",
+        tone === "brand" && "border-brand/25",
+        tone === "positive" && "border-positive/30",
+        tone === "negative" && "border-negative/30",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** A one-line "this happened" receipt. Every mutation gets one. */
+function Receipt({
+  tone = "positive",
+  icon,
+  children,
+}: {
+  tone?: "positive" | "negative";
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "my-1 flex items-start gap-2 rounded-lg border px-3 py-2 text-[0.8rem]",
+        tone === "positive"
+          ? "border-positive/30 bg-positive-soft text-ink"
+          : "border-negative/30 bg-negative-soft text-ink",
+      )}
+    >
+      <span className={tone === "positive" ? "text-positive" : "text-negative"}>
+        {icon ?? <CheckCircle2 className="mt-0.5 h-4 w-4" />}
+      </span>
+      <span className="min-w-0 flex-1">{children}</span>
+    </div>
+  );
+}
+
+export function PeopleTools() {
+  const { data, refresh, operator } = usePeopleLedger();
+  const router = useRouter();
+  const skin = useSkin();
+  const skinHref = useSkinHref(skin.id);
+  const recording = useRecording();
+
+  /**
+   * Handlers read the ledger through a ref, not through the closure.
+   *
+   * `useFrontendTool` / `useHumanInTheLoop` TEAR DOWN and re-register whenever
+   * their deps change. A `[data]` dep on a tool that itself mutates the ledger
+   * therefore unregisters the tool in the middle of its own call — the write
+   * lands, the tool disappears, and the agent gets no result. Banking hit this
+   * exact bug with its PIN tool. So: `[]` deps on write tools plus this ref,
+   * and real deps on the read-only display components below.
+   */
+  const ledgerRef = useRef<PeopleStoreState>(data);
+  useEffect(() => {
+    ledgerRef.current = data;
+  }, [data]);
+  const operatorRef = useRef(operator);
+  useEffect(() => {
+    operatorRef.current = operator;
+  }, [operator]);
+
+  const findPerson = (needle: string): Employee | undefined => {
+    const rows = ledgerRef.current.employees;
+    const key = needle.trim().toLowerCase();
+    return (
+      rows.find((e) => e.id === needle) ??
+      rows.find((e) => e.name.toLowerCase() === key) ??
+      rows.find((e) => e.name.toLowerCase().startsWith(key)) ??
+      rows.find((e) => e.name.toLowerCase().includes(key))
+    );
+  };
+
+  // ── Global readables ──────────────────────────────────────────────────────
+  // The page-scoped readables (in each page component) say what is ON SCREEN.
+  // This one says what EXISTS, so tools callable from anywhere — assign a
+  // buddy, approve a comp request — can resolve a name to an id without the
+  // user having to be on the right page first.
+  useAgentContext({
+    description:
+      "The Rowan people ledger: everyone employed, the compensation bands, " +
+      "each person's position in their band, the open requests, the pending " +
+      "compensation requests, and the onboarding packets on file. Use this to " +
+      "resolve a person's name to an id before calling any tool.",
+    value: JSON.stringify({
+      bands: data.bands,
+      employees: data.employees.map((e) => {
+        const pos = bandPosition(data.bands, e.baseSalary, e.level);
+        return {
+          id: e.id,
+          name: e.name,
+          title: e.title,
+          level: e.level,
+          team: e.team,
+          status: e.status,
+          startDate: e.startDate,
+          tenure: tenureLabel(e.startDate),
+          baseSalary: e.baseSalary,
+          positionInBand: pos
+            ? pos.outOfBand
+              ? `${pos.side} band`
+              : formatPercent(pos.ratio)
+            : null,
+          outOfBand: pos?.outOfBand ?? false,
+          managerId: e.managerId,
+          buddyId: e.buddyId,
+        };
+      }),
+      openRequests: data.requests
+        .filter((r) => r.status === "pending")
+        .map((r) => ({
+          id: r.id,
+          employee: data.employees.find((e) => e.id === r.employeeId)?.name,
+          kind: REQUEST_KIND_LABEL[r.kind],
+          summary: r.summary,
+          ageDays: ageInDays(r.submittedAt),
+          value: requestValueLabel(r),
+        })),
+      pendingCompRequests: data.compRequests
+        .filter((c) => c.status === "pending")
+        .map((c) => ({
+          id: c.id,
+          employee: data.employees.find((e) => e.id === c.employeeId)?.name,
+          reason: c.reason,
+          currentSalary: c.currentSalary,
+          requestedSalary: c.requestedSalary,
+          proposedLevel: c.proposedLevel,
+        })),
+      packets: data.packets.map((p) => ({
+        id: p.id,
+        employeeName: p.employeeName,
+        role: p.role,
+      })),
+    }),
+  });
+
+  // ══ BEAT 1 — GIVE THE AGENT A FACE ═══════════════════════════════════════
+  // Lead with generative UI, never a wall of text. The ladder is Rowan's
+  // signature visual and its first answer.
+
+  useComponent(
+    {
+      name: "showCompBands",
+      description:
+        "Display the compensation band ladder: every person placed at their " +
+        "position inside their own band, with anyone outside their band " +
+        "flagged. Use this for any question about bands, band position, who is " +
+        "out of band, or how compensation is distributed. Render the ladder " +
+        "AND answer in one or two sentences — never one without the other.",
+      parameters: z.object({
+        level: z
+          .string()
+          .optional()
+          .describe('Restrict to one level, e.g. "L5". Omit for every level.'),
+      }),
+      // Parameterized `useComponent` → the render receives the schema output
+      // DIRECTLY. This is NOT the `{ args }` shape a HITL render gets.
+      render: ({ level }) => {
+        const people = level
+          ? data.employees.filter((e) => e.level === level)
+          : data.employees;
+        return (
+          <ToolCard>
+            <BandLadder bands={data.bands} employees={people} compact />
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  useComponent(
+    {
+      name: "showPerson",
+      description:
+        "Display one person's card: level, team, tenure, position in band, " +
+        "buddy and latest note. Use when the user asks about a specific person.",
+      parameters: z.object({
+        employee: z.string().describe("The person's name or id."),
+      }),
+      render: ({ employee }) => {
+        const person =
+          data.employees.find((e) => e.id === employee) ??
+          data.employees.find(
+            (e) => e.name.toLowerCase() === employee.trim().toLowerCase(),
+          ) ??
+          data.employees.find((e) =>
+            e.name.toLowerCase().includes(employee.trim().toLowerCase()),
+          );
+        if (!person) {
+          return (
+            <ToolCard tone="negative">
+              <p className="text-[0.8rem] text-ink-muted">
+                No one on the roster matches “{employee}”.
+              </p>
+            </ToolCard>
+          );
+        }
+        const pos = bandPosition(data.bands, person.baseSalary, person.level);
+        const buddy = data.employees.find((e) => e.id === person.buddyId);
+        return (
+          <ToolCard>
+            <div className="flex items-start gap-3">
+              <Monogram
+                name={person.name}
+                size="lg"
+                ring={pos?.outOfBand ? "negative" : "brand"}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold">{person.name}</p>
+                <p className="text-[0.75rem] text-ink-muted">{person.title}</p>
+                <div className="mt-1.5 flex flex-wrap gap-1">
+                  <Pill tone="brand">{person.level}</Pill>
+                  <Pill>{person.team}</Pill>
+                  <Pill>{tenureLabel(person.startDate)}</Pill>
+                  {pos?.outOfBand ? (
+                    <Pill tone="negative">{pos.side} band</Pill>
+                  ) : (
+                    <Pill tone="positive">
+                      {pos ? formatPercent(pos.ratio) : "—"} of band
+                    </Pill>
+                  )}
+                  {buddy ? <Pill tone="gold">Buddy · {buddy.name}</Pill> : null}
+                </div>
+                {person.notes[0] ? (
+                  <p className="mt-2 rounded-md bg-brand-soft px-2 py-1 text-[0.72rem]">
+                    {person.notes[0].text}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  useComponent(
+    {
+      name: "showRequestList",
+      description:
+        "Display a list of queue requests by id. Use this instead of writing " +
+        "a markdown table whenever you are showing more than one request.",
+      parameters: z.object({
+        requestIds: z
+          .array(z.string())
+          .describe("Request ids, in the order to show."),
+        caption: z.string().optional(),
+      }),
+      render: ({ requestIds, caption }) => {
+        const rows = requestIds
+          .map((id) => data.requests.find((r) => r.id === id))
+          .filter((r): r is NonNullable<typeof r> => Boolean(r));
+        if (rows.length === 0) {
+          return (
+            <ToolCard tone="negative">
+              <p className="text-[0.8rem] text-ink-muted">
+                No matching requests.
+              </p>
+            </ToolCard>
+          );
+        }
+        return (
+          <ToolCard>
+            {caption ? (
+              <p className="mb-2 text-[0.75rem] font-medium text-ink-muted">
+                {caption}
+              </p>
+            ) : null}
+            <ul className="divide-y divide-hairline">
+              {rows.map((request) => {
+                const who =
+                  data.employees.find((e) => e.id === request.employeeId)
+                    ?.name ?? "Unknown";
+                return (
+                  <li
+                    key={request.id}
+                    className="flex items-center gap-2 py-1.5"
+                  >
+                    <Monogram name={who} size="xs" />
+                    <span className="min-w-0 flex-1 truncate text-[0.78rem]">
+                      {request.summary}
+                    </span>
+                    <span className="rowan-num shrink-0 text-[0.7rem] text-ink-muted">
+                      {ageInDays(request.submittedAt)}d
+                    </span>
+                    <span className="rowan-num shrink-0 text-[0.72rem] font-medium">
+                      {requestValueLabel(request)}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  // ══ BEAT 4 — LONG-TERM MEMORY ════════════════════════════════════════════
+  // `note` is the slot where the agent NAMES the preference it recalled. Without
+  // a visible "why", recall looks like a normal answer and the beat is
+  // invisible to the room even when it worked perfectly.
+  useComponent(
+    {
+      name: "showCompSummary",
+      description:
+        "Summarize where compensation stands. Before calling this, recall the " +
+        "user's saved formatting preference and pass it through the flags. " +
+        "ALWAYS fill `note` with the preference you applied, in your own " +
+        "words — that is how the user knows you remembered.",
+      parameters: z.object({
+        byLevel: z.boolean().describe("Group by level rather than by team."),
+        outOfBandFirst: z
+          .boolean()
+          .describe("Put anyone outside their band at the top."),
+        asPercentile: z
+          .boolean()
+          .describe(
+            "Show position in band as a percentage instead of a salary.",
+          ),
+        note: z
+          .string()
+          .describe(
+            "Name the saved preference you applied, e.g. 'You read these by level, out-of-band first.'",
+          ),
+      }),
+      render: ({ byLevel, outOfBandFirst, asPercentile, note }) => {
+        const rows = [...data.employees].sort((a, b) => {
+          if (outOfBandFirst) {
+            const aOut = isOutOfBand(data.bands, a) ? 0 : 1;
+            const bOut = isOutOfBand(data.bands, b) ? 0 : 1;
+            if (aOut !== bOut) return aOut - bOut;
+          }
+          if (byLevel && a.level !== b.level)
+            return a.level.localeCompare(b.level);
+          return a.name.localeCompare(b.name);
+        });
+
+        return (
+          <ToolCard>
+            {/* The "why" slot. Gold, because in Rowan gold marks a milestone —
+                and remembering is one. */}
+            <p className="mb-2 flex items-start gap-1.5 rounded-md border border-brand-violet/30 bg-brand-violet/10 px-2.5 py-1.5 text-[0.74rem] text-ink">
+              <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-brand-violet" />
+              <span>{note}</span>
+            </p>
+            <ul className="divide-y divide-hairline">
+              {rows.slice(0, 12).map((person) => {
+                const pos = bandPosition(
+                  data.bands,
+                  person.baseSalary,
+                  person.level,
+                );
+                return (
+                  <li
+                    key={person.id}
+                    className="flex items-center gap-2 py-1.5"
+                  >
+                    <Monogram name={person.name} size="xs" />
+                    <span className="min-w-0 flex-1 truncate text-[0.78rem]">
+                      {person.name}
+                    </span>
+                    {byLevel ? (
+                      <Pill tone="brand">{person.level}</Pill>
+                    ) : (
+                      <Pill>{person.team}</Pill>
+                    )}
+                    <span
+                      className={cn(
+                        "rowan-num w-24 shrink-0 text-right text-[0.74rem] font-medium",
+                        pos?.outOfBand && "text-negative",
+                      )}
+                    >
+                      {pos?.outOfBand
+                        ? `${pos.side} band`
+                        : asPercentile
+                          ? `${pos ? formatPercent(pos.ratio) : "—"} of band`
+                          : formatSalary(person.baseSalary)}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  // ══ BEAT 3a — DRIVE THE APP, SECRET WITHHELD ═════════════════════════════
+  useHumanInTheLoop(
+    {
+      name: "setBaseSalary",
+      description:
+        "Open the merit-increase card for one person so the user can enter the " +
+        "new base salary themselves. NEVER ask for the figure and never ask " +
+        "which person first — call this immediately with your best match.",
+      parameters: z.object({
+        employee: z.string().describe("The person's name or id."),
+      }),
+      render: ({ args, respond, result, toolCallId }) => {
+        // REPLAY-SAFE. Consult the answered map first (a thread reopened in the
+        // same session), then the recorded `result` (a reload). Only fall
+        // through to the live editor when neither exists. Nothing here reads
+        // `status`, which does not replay.
+        //
+        // The result must be CLASSIFIED, not merely detected. An earlier version
+        // branched on "is there a result at all" and rendered the success
+        // receipt for every settled call — so a CANCELLED change replayed as
+        // "Base salary updated for that person", claiming a mutation that never
+        // happened and printing the fallback name because the success regex had
+        // nothing to match. A replayed card asserting a write that did not occur
+        // is worse than a blank one, and only shows up when someone reopens the
+        // thread — which is exactly when beat 2 is being demonstrated.
+        const remembered = toolCallId
+          ? answeredSalaryChanges.get(toolCallId)
+          : undefined;
+        const settled = typeof result === "string" ? result : null;
+        const updatedName =
+          remembered?.name ??
+          (settled
+            ? /^Base salary updated for (.+?)\.$/.exec(settled)?.[1]
+            : undefined);
+
+        if (updatedName) {
+          return (
+            <Receipt>
+              Base salary updated for <strong>{updatedName}</strong>. The figure
+              stayed in this card — it was never sent to the assistant.
+            </Receipt>
+          );
+        }
+        if (settled) {
+          // Cancelled, or the REST call was refused. Say which, plainly.
+          const cancelled = /cancelled/i.test(settled);
+          return (
+            <Receipt
+              tone="negative"
+              icon={<CircleAlert className="mt-0.5 h-4 w-4" />}
+            >
+              {cancelled
+                ? "The salary change was cancelled — nothing was updated."
+                : settled}
+            </Receipt>
+          );
+        }
+        return (
+          <SalaryCard
+            employeeQuery={args?.employee ?? ""}
+            find={findPerson}
+            bands={ledgerRef.current.bands}
+            onDone={async (person, salary) => {
+              const res = await fetch(
+                `/api/people/v1/employees/${person.id}/compensation`,
+                {
+                  method: "PATCH",
+                  headers: { "content-type": "application/json" },
+                  body: JSON.stringify({ baseSalary: salary }),
+                },
+              );
+              if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                respond?.(
+                  `Could not update ${person.name}: ${body?.message ?? res.status}`,
+                );
+                return;
+              }
+              if (toolCallId) {
+                answeredSalaryChanges.set(toolCallId, { name: person.name });
+              }
+              await refresh();
+              // The ONLY thing the assistant ever learns. No figure, by design.
+              respond?.(`Base salary updated for ${person.name}.`);
+            }}
+            onCancel={() => respond?.("The user cancelled the salary change.")}
+          />
+        );
+      },
+    },
+    // `[]` + ledgerRef: this tool writes, and a data dep would tear it down
+    // mid-write. See the note on ledgerRef above.
+    [],
+  );
+
+  // ══ BEAT 3c — NAVIGATE WITH LEVERS ═══════════════════════════════════════
+  useHumanInTheLoop(
+    {
+      name: "showRequestQueue",
+      description:
+        "Take the user to the Requests page with a specific status filter, " +
+        "sort order and top-N limit applied. Confirm the levers with them " +
+        "first. Use for any 'show me the oldest / biggest / pending requests' " +
+        "question.",
+      parameters: z.object({
+        status: z.enum(["all", "pending", "approved", "declined"]),
+        sort: z.enum(["aging_desc", "aging_asc", "amount_desc"]),
+        top: z.number().optional().describe("Limit to the first N rows."),
+        reason: z.string().describe("One short line on why this view."),
+      }),
+      render: ({ args, respond, result, toolCallId }) => {
+        const remembered = toolCallId
+          ? answeredNavigations.get(toolCallId)
+          : undefined;
+        const settled = remembered !== undefined || typeof result === "string";
+        const confirmed =
+          remembered?.confirmed ?? String(result ?? "").startsWith("Opened");
+
+        const levers = [
+          `Status · ${args?.status ?? "pending"}`,
+          `Sort · ${
+            args?.sort === "aging_asc"
+              ? "newest first"
+              : args?.sort === "amount_desc"
+                ? "largest value"
+                : "oldest first"
+          }`,
+          args?.top ? `Show · top ${args.top}` : "Show · all",
+        ];
+
+        return (
+          <ToolCard tone={settled && !confirmed ? "negative" : "brand"}>
+            <p className="text-[0.8rem] font-medium">
+              {settled
+                ? confirmed
+                  ? "Opened the Requests page with these controls set:"
+                  : "Stayed on this page."
+                : "I can open the Requests page with these controls set:"}
+            </p>
+            <ul className="mt-2 flex flex-wrap gap-1.5">
+              {levers.map((lever) => (
+                <li key={lever}>
+                  <Pill tone="brand">{lever}</Pill>
+                </li>
+              ))}
+            </ul>
+            {args?.reason ? (
+              <p className="mt-2 text-[0.74rem] text-ink-muted">
+                {args.reason}
+              </p>
+            ) : null}
+            {!settled ? (
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const params = new URLSearchParams();
+                    if (args?.status && args.status !== "all") {
+                      params.set("status", args.status);
+                    }
+                    if (args?.sort) params.set("sort", args.sort);
+                    if (args?.top) params.set("top", String(args.top));
+                    const query = params.toString();
+                    router.push(
+                      `${skinHref("requests")}${query ? `?${query}` : ""}`,
+                    );
+                    if (toolCallId) {
+                      answeredNavigations.set(toolCallId, { confirmed: true });
+                    }
+                    respond?.(
+                      "Opened the Requests page with the filters and sort applied. The controls are highlighted on screen.",
+                    );
+                  }}
+                  className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+                >
+                  Open it
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (toolCallId) {
+                      answeredNavigations.set(toolCallId, { confirmed: false });
+                    }
+                    respond?.("The user chose to stay on the current page.");
+                  }}
+                  className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+                >
+                  Stay here
+                </button>
+              </div>
+            ) : null}
+          </ToolCard>
+        );
+      },
+    },
+    [],
+  );
+
+  // ══ BEAT 5 — THE STORED PROCEDURE'S THREE WRITES ═════════════════════════
+  // Registered globally so the procedure can run from any page. Each produces a
+  // change the audience can SEE on the roster and the onboarding page.
+
+  useFrontendTool(
+    {
+      name: "createOnboardingTasks",
+      description:
+        "Build the standard onboarding checklist for one person. Idempotent — " +
+        "re-running replaces the checklist rather than duplicating it.",
+      parameters: z.object({ employee: z.string() }),
+      handler: async ({ employee }) => {
+        const person = findPerson(employee);
+        if (!person) return `No one on the roster matches "${employee}".`;
+        const res = await fetch(
+          `/api/people/v1/employees/${person.id}/onboarding-tasks`,
+          { method: "POST" },
+        );
+        if (!res.ok)
+          return `Could not build the checklist (HTTP ${res.status}).`;
+        const created = (await res.json()) as unknown[];
+        await refresh();
+        recording.logStep(`Built the onboarding checklist for ${person.name}`);
+        return `Built a ${created.length}-step onboarding checklist for ${person.name}.`;
+      },
+      render: ({ result, args }) =>
+        result ? (
+          <Receipt>{String(result)}</Receipt>
+        ) : (
+          <ToolCard>
+            <p className="text-[0.78rem] text-ink-muted">
+              Building the checklist for {args?.employee}…
+            </p>
+          </ToolCard>
+        ),
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "assignBuddy",
+      description:
+        "Pair a new hire with an onboarding buddy. Choose an experienced " +
+        "teammate on the same team who is not their manager.",
+      parameters: z.object({
+        employee: z.string().describe("The new hire's name or id."),
+        buddy: z.string().describe("The buddy's name or id."),
+      }),
+      handler: async ({ employee, buddy }) => {
+        const person = findPerson(employee);
+        const mate = findPerson(buddy);
+        if (!person) return `No one on the roster matches "${employee}".`;
+        if (!mate) return `No one on the roster matches "${buddy}".`;
+        const res = await fetch(`/api/people/v1/employees/${person.id}/buddy`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ buddyId: mate.id }),
+        });
+        if (!res.ok) return `Could not assign the buddy (HTTP ${res.status}).`;
+        await refresh();
+        recording.logStep(`Assigned ${mate.name} as ${person.name}'s buddy`);
+        return `${mate.name} is now ${person.name}'s onboarding buddy.`;
+      },
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "postWelcomeNote",
+      description:
+        "Post a short welcome note on a new hire's record. Name their team and " +
+        "their buddy. Keep it to one sentence.",
+      parameters: z.object({
+        employee: z.string(),
+        text: z.string().describe("The welcome, one sentence."),
+      }),
+      handler: async ({ employee, text }) => {
+        const person = findPerson(employee);
+        if (!person) return `No one on the roster matches "${employee}".`;
+        // Force the marker. "Use a light or a bell or whatever so people can
+        // see that it changed" — a note that reads like every other note is
+        // invisible from the back of a room, so the emoji is prepended here
+        // rather than left to the model's discretion.
+        const marked = text.trim().startsWith("🎉")
+          ? text.trim()
+          : `🎉 ${text.trim()}`;
+        const res = await fetch(`/api/people/v1/employees/${person.id}/notes`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            text: marked,
+            author: operatorRef.current.name,
+          }),
+        });
+        if (!res.ok) return `Could not post the note (HTTP ${res.status}).`;
+        await refresh();
+        recording.logStep(`Posted a welcome note for ${person.name}`);
+        return `Posted the welcome note on ${person.name}'s record.`;
+      },
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  // ── Distractors ──────────────────────────────────────────────────────────
+  // Plausible, real, and useless for both the stored procedure and the gate.
+  // They are what make "it picked the right three" and "it cleared the gate"
+  // mean something rather than being the only options available.
+  useFrontendTool(
+    {
+      name: "requestBackgroundCheck",
+      description: "Order a background check for a new hire.",
+      parameters: z.object({ employee: z.string() }),
+      handler: async ({ employee }) =>
+        `Background check ordered for ${findPerson(employee)?.name ?? employee}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "scheduleExitInterview",
+      description: "Schedule an exit interview for someone who is leaving.",
+      parameters: z.object({ employee: z.string() }),
+      handler: async ({ employee }) =>
+        `Exit interview scheduled for ${findPerson(employee)?.name ?? employee}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "sendPolicyReminder",
+      description: "Send someone a reminder about a People Ops policy.",
+      parameters: z.object({ employee: z.string(), topic: z.string() }),
+      handler: async ({ employee, topic }) =>
+        `Reminder about ${topic} sent to ${findPerson(employee)?.name ?? employee}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "openHeadcountRequisition",
+      description: "Open a new headcount requisition for a team.",
+      parameters: z.object({ team: z.string(), title: z.string() }),
+      handler: async ({ team, title }) =>
+        `Requisition opened: ${title} on ${team}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  // ══ BEAT 3d — MULTIMODAL IN, DURABLE ARTIFACT OUT ════════════════════════
+  useFrontendTool(
+    {
+      name: "createOnboardingPacket",
+      description:
+        "File an onboarding packet for a new hire into the app. When the user " +
+        "has attached an offer letter, read it and carry its real details — " +
+        "start date, level, manager, week-one schedule — into this call.",
+      parameters: z.object({
+        employee: z.string(),
+        summary: z
+          .string()
+          .describe("Two sentences on who they are and what they will do."),
+        highlights: z
+          .array(z.string())
+          .max(3)
+          .describe("At most three short facts worth surfacing."),
+        schedule: z
+          .array(z.object({ day: z.string(), item: z.string() }))
+          .describe(
+            'Week-one schedule, e.g. [{ day: "Day 1", item: "Laptop and badge" }].',
+          ),
+      }),
+      handler: async ({ employee, summary, highlights, schedule }) => {
+        const person = findPerson(employee);
+        if (!person) return `No one on the roster matches "${employee}".`;
+        const res = await fetch("/api/people/v1/packets", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            employeeId: person.id,
+            summary,
+            highlights,
+            schedule,
+            filedBy: operatorRef.current.name,
+          }),
+        });
+        if (!res.ok) return `Could not file the packet (HTTP ${res.status}).`;
+        await refresh();
+        return `Filed the onboarding packet for ${person.name}. It is on the Onboarding page under Packets.`;
+      },
+      render: ({ result, args }) =>
+        result ? (
+          <Receipt>
+            {String(result)}{" "}
+            <span className="text-ink-muted">
+              It belongs to the app, so deleting this conversation will not
+              remove it.
+            </span>
+          </Receipt>
+        ) : (
+          <ToolCard>
+            <p className="text-[0.78rem] text-ink-muted">
+              Filing the packet for {args?.employee}…
+            </p>
+          </ToolCard>
+        ),
+    },
+    [],
+  );
+
+  // ══ BEAT 6 — THE GATE, THE UNLOCK, AND THE TEACH CHAIN ═══════════════════
+
+  useFrontendTool(
+    {
+      name: "approveCompRequest",
+      description:
+        "Approve a pending compensation request, writing the new salary and " +
+        "level onto the person.",
+      parameters: z.object({
+        compRequestId: z
+          .string()
+          .describe("The comp request id, e.g. cmp-marcus."),
+      }),
+      handler: async ({ compRequestId }) => {
+        const res = await fetch(
+          `/api/people/v1/comp-requests/${compRequestId}/approve`,
+          { method: "POST" },
+        );
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          recording.logStep("Approve refused");
+          // The refusal is passed through VERBATIM and is symptom-only. Do not
+          // append a hint here — the agent must not be able to derive the
+          // unlock from the error, or beat 6 stops proving that it learned.
+          return `REFUSED (${body?.error ?? res.status}): ${body?.message ?? "Approval refused."}`;
+        }
+        await refresh();
+        const name = body?.employee?.name ?? "the employee";
+        recording.logStep(`Approved the compensation request for ${name}`);
+        return `Approved. ${name} is now ${body?.employee?.level ?? ""} at the requested salary.`;
+      },
+      render: ({ result, args }) => {
+        if (!result) {
+          return (
+            <ToolCard>
+              <p className="text-[0.78rem] text-ink-muted">
+                Approving {args?.compRequestId}…
+              </p>
+            </ToolCard>
+          );
+        }
+        const refused = String(result).startsWith("REFUSED");
+        return (
+          <Receipt
+            tone={refused ? "negative" : "positive"}
+            icon={
+              refused ? <CircleAlert className="mt-0.5 h-4 w-4" /> : undefined
+            }
+          >
+            {String(result).replace(/^REFUSED \([^)]+\): /, "")}
+          </Receipt>
+        );
+      },
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "openBandException",
+      description:
+        "File a band exception against a compensation request under a given code.",
+      parameters: z.object({
+        compRequestId: z.string(),
+        code: z.string().describe("The exception code to file under."),
+        justification: z.string(),
+      }),
+      handler: async ({ compRequestId, code, justification }) => {
+        const res = await fetch("/api/people/v1/band-exceptions", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ compRequestId, code, justification }),
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) return `REFUSED: ${body?.message ?? res.status}`;
+        await refresh();
+        return `Filed a band exception (${code}). Exception id ${body?.id}. It still needs finalizing.`;
+      },
+      render: ({ result }) =>
+        result ? (
+          <Receipt
+            tone={
+              String(result).startsWith("REFUSED") ? "negative" : "positive"
+            }
+          >
+            {String(result).replace(/^REFUSED: /, "")}
+          </Receipt>
+        ) : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "finalizeBandException",
+      description: "Finalize a draft band exception so it takes effect.",
+      parameters: z.object({ exceptionId: z.string() }),
+      handler: async ({ exceptionId }) => {
+        const res = await fetch(
+          `/api/people/v1/band-exceptions/${exceptionId}/finalize`,
+          { method: "POST" },
+        );
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) return `REFUSED: ${body?.message ?? res.status}`;
+        await refresh();
+        return `Finalized the ${body?.code ?? ""} band exception.`;
+      },
+      render: ({ result }) =>
+        result ? (
+          <Receipt
+            tone={
+              String(result).startsWith("REFUSED") ? "negative" : "positive"
+            }
+          >
+            {String(result).replace(/^REFUSED: /, "")}
+          </Receipt>
+        ) : null,
+    },
+    [],
+  );
+
+  // ── The teach chain: offer → watch → save ────────────────────────────────
+  useHumanInTheLoop(
+    {
+      followUp: true,
+      name: "offerWorkflowRecording",
+      description:
+        "Call this when you have hit a refusal you have no saved procedure " +
+        "for. Say plainly that you do not know this one and offer to watch the " +
+        "user do it. Never guess a workaround instead of calling this.",
+      parameters: z.object({
+        situation: z
+          .string()
+          .describe("What you were blocked on, in one line."),
+      }),
+      render: ({ args, respond, result }) => {
+        // Settled. Render a HUMAN line, never `result` — that string is an
+        // internal directive addressed to the agent ("Call awaitDemonstration
+        // now and wait…") and printing it verbatim puts the demo's own wiring
+        // on screen in front of the audience.
+        if (typeof result === "string") {
+          const agreed = /agreed to demonstrate/i.test(result);
+          return (
+            <ToolCard>
+              <p className="text-[0.78rem] text-ink-muted">
+                {agreed
+                  ? "Watching you do it once."
+                  : "Left it for now — nothing was recorded."}
+              </p>
+            </ToolCard>
+          );
+        }
+        return (
+          <ToolCard>
+            <p className="text-[0.8rem]">
+              I don&rsquo;t have a saved way to do this yet
+              {args?.situation
+                ? ` — ${args.situation.replace(/\.+$/, "")}`
+                : ""}
+              . Want to show me once, and I&rsquo;ll remember it?
+            </p>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  respond?.(
+                    "The user agreed to demonstrate. Call awaitDemonstration now and wait — do not guess any steps.",
+                  )
+                }
+                className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+              >
+                Show me
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  respond?.("The user declined to demonstrate. Stop here.")
+                }
+                className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+              >
+                Not now
+              </button>
+            </div>
+          </ToolCard>
+        );
+      },
+    },
+    [],
+  );
+
+  useHumanInTheLoop(
+    {
+      followUp: true,
+      name: "awaitDemonstration",
+      description:
+        "Hold the conversation while the user demonstrates. Do NOT list steps " +
+        "or suggest what they should do — you do not know yet. That is the point.",
+      parameters: z.object({}),
+      render: ({ respond, result }) => {
+        // Same rule as above: `result` is the raw observed-steps directive
+        // written for the agent. Summarize it for the human instead.
+        if (typeof result === "string") {
+          const count = (result.match(/\d+\.\s/g) ?? []).length;
+          return (
+            <ToolCard tone="positive">
+              <p className="text-[0.78rem]">
+                Recorded {count > 0 ? `${count} steps` : "the demonstration"}.
+              </p>
+            </ToolCard>
+          );
+        }
+        return <DemonstrationCard onDone={(summary) => respond?.(summary)} />;
+      },
+    },
+    [],
+  );
+
+  useHumanInTheLoop(
+    {
+      followUp: true,
+      name: "saveLearnedProcedure",
+      description:
+        "Summarize what you just watched as a numbered procedure and show it " +
+        "for confirmation. After the user confirms, persist it with save_memory " +
+        "(scope 'user', kind 'operational'). Save it AT MOST ONCE.",
+      parameters: z.object({
+        procedure: z
+          .string()
+          .describe(
+            "The numbered procedure, naming the exact code that worked.",
+          ),
+      }),
+      render: ({ args, respond, result }) => {
+        if (typeof result === "string") {
+          return (
+            <Receipt>
+              Saved. I&rsquo;ll use this next time without being asked.
+            </Receipt>
+          );
+        }
+        return (
+          <ToolCard>
+            <p className="text-[0.78rem] font-medium">
+              Here&rsquo;s what I picked up — shall I remember it?
+            </p>
+            <pre className="mt-2 whitespace-pre-wrap rounded-md bg-surface-muted p-2.5 text-[0.73rem] leading-relaxed text-ink">
+              {args?.procedure}
+            </pre>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  respond?.(
+                    "The user confirmed. Persist this with save_memory now (scope 'user', kind 'operational'), then say in one sentence that you have it.",
+                  )
+                }
+                className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+              >
+                Remember it
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  respond?.(
+                    "The user declined to save it. Do not call save_memory.",
+                  )
+                }
+                className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+              >
+                Don&rsquo;t save
+              </button>
+            </div>
+          </ToolCard>
+        );
+      },
+    },
+    [],
+  );
+
+  return null;
+}
+
+/**
+ * BEAT 3a's card. The figure lives in local state and goes straight to REST;
+ * it is never lifted into a tool argument, a respond() string, or the
+ * transcript. The band range is shown so the user can see they are inside it —
+ * the same policy beat 6's gate enforces, surfaced rather than hidden.
+ */
+function SalaryCard({
+  employeeQuery,
+  find,
+  bands,
+  onDone,
+  onCancel,
+}: {
+  employeeQuery: string;
+  find: (needle: string) => Employee | undefined;
+  bands: PeopleStoreState["bands"];
+  onDone: (person: Employee, salary: number) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const person = find(employeeQuery);
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  if (!person) {
+    return (
+      <ToolCard tone="negative">
+        <p className="text-[0.8rem] text-ink-muted">
+          I couldn&rsquo;t find anyone matching “{employeeQuery}”.
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="mt-2 rounded-md border border-hairline px-3 py-1.5 text-[0.75rem]"
+        >
+          Close
+        </button>
+      </ToolCard>
+    );
+  }
+
+  const band = bands.find((b) => b.level === person.level);
+  const parsed = Number(value.replace(/[^0-9.]/g, ""));
+  const valid =
+    Number.isFinite(parsed) &&
+    parsed > 0 &&
+    (!band || (parsed >= band.min && parsed <= band.max));
+
+  return (
+    <ToolCard>
+      <div className="flex items-center gap-2.5">
+        <Monogram name={person.name} size="md" />
+        <div className="min-w-0">
+          <p className="text-[0.82rem] font-semibold">{person.name}</p>
+          <p className="text-[0.72rem] text-ink-muted">
+            {person.title} · {person.level}
+          </p>
+        </div>
+      </div>
+
+      <label className="mt-3 block">
+        <span className="mb-1 block text-[0.7rem] font-medium text-ink-muted">
+          New base salary
+        </span>
+        <input
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          inputMode="numeric"
+          autoComplete="off"
+          placeholder={band ? `${band.min}–${band.max}` : "Amount"}
+          className="rowan-num w-full rounded-md border border-hairline bg-surface px-2.5 py-1.5 text-[0.85rem] text-ink outline-none focus:border-brand/50"
+        />
+        {band ? (
+          <span className="rowan-num mt-1 block text-[0.68rem] text-ink-muted">
+            {person.level} band {formatSalary(band.min)}–
+            {formatSalary(band.max)} · currently{" "}
+            {formatSalary(person.baseSalary)}
+          </span>
+        ) : null}
+      </label>
+
+      <p className="mt-2 text-[0.68rem] text-ink-muted">
+        This figure goes straight to the payroll record. The assistant never
+        sees it.
+      </p>
+
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          disabled={!valid || saving}
+          onClick={async () => {
+            setSaving(true);
+            await onDone(person, parsed);
+          }}
+          className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground disabled:opacity-40"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+        >
+          Cancel
+        </button>
+      </div>
+    </ToolCard>
+  );
+}
+
+/**
+ * BEAT 6's waiting card. Deliberately NON-DIRECTIONAL: it never lists steps or
+ * hints at what to do, because the whole premise is that the agent does not
+ * know them. It shows a live "Rec" badge and narrates the steps it observes, so
+ * the room can see that watching is really happening.
+ */
+function DemonstrationCard({ onDone }: { onDone: (summary: string) => void }) {
+  const { beginRecording, endRecording, steps, getDemonstratedCode, reset } =
+    useRecording();
+
+  useEffect(() => {
+    reset();
+    beginRecording();
+    return () => endRecording();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ToolCard>
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-negative-soft px-2 py-0.5 text-[0.68rem] font-semibold text-negative">
+          <Radio className="h-3 w-3 animate-pulse" />
+          Rec
+        </span>
+        <p className="text-[0.8rem]">Watching — go ahead and show me.</p>
+      </div>
+
+      {steps.length > 0 ? (
+        <ol className="mt-2.5 space-y-1 border-l-2 border-brand/30 pl-3">
+          {steps.map((step, index) => (
+            <li key={step.id} className="text-[0.74rem] text-ink">
+              <span className="rowan-num mr-1.5 text-ink-muted">
+                {index + 1}.
+              </span>
+              {step.label}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="mt-2 text-[0.72rem] text-ink-muted">
+          Nothing captured yet.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => {
+          const code = getDemonstratedCode();
+          const observed = steps
+            .map((s, i) => `${i + 1}. ${s.label}`)
+            .join("\n");
+          onDone(
+            `The user finished. Observed steps:\n${observed || "(nothing captured)"}\n` +
+              (code
+                ? `The exception code they used was ${code}.`
+                : "No exception code was captured."),
+          );
+        }}
+        className="mt-3 rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+      >
+        I&rsquo;m done
+      </button>
+    </ToolCard>
+  );
+}


### PR DESCRIPTION
Rowan is a People Operations command center and the **second skin built against the full nine-beat bar** in `.claude/skills/reskin/demo-beats.md` (banking was the first). Pages: Roster (index), Compensation, Requests, Onboarding.

REST-backed like banking and logistics. `/api/people/v1/*` serves one `ledger` snapshot read plus the write paths, a generated `offer-letter` PDF, and a presenter-gated `dev/reset`. Components read the ledger through the skin's own `usePeopleLedger()` context, so `useData` is omitted — and that context mounts in `RuntimeProviders` rather than `Providers`, which lets the single fetch also feed `useRuntimeProperties`.

## The signature element

The **band ladder**: one rail per level, each normalized to its *own* band, so "halfway up L3" and "halfway up L7" line up at the same height and become comparable. A conventional comp chart plots a shared money axis, which makes L7 tower over L3 and tells you nothing you didn't know. Anyone outside their band is drawn *outside* the rail, in the negative colour, always labelled — they're the actionable rows.

## Beats — all walked in a browser against a live Intelligence stack

| Beat | How it lands |
| --- | --- |
| 1 face | `showCompBands` renders the ladder **and** answers in two sentences |
| 2 rich thread | gen-UI replays intact on reopen after a hard reload |
| 3a drive the app | `setBaseSalary` — the figure is typed into a chat card, goes straight to REST, and appears **nowhere** in the transcript |
| 3b sees my screen | route readable + per-page on-screen readables on all four pages; Roster and Requests give different, correct answers |
| 3c levers | HITL confirm naming the levers → `?status=pending&sort=aging_desc&top=10`, Status/Sort/Show controls visibly tinted, "TOP 10 OF 11" |
| 3d multimodal | an offer-letter PDF rides the pill; the filed packet survives deleting the thread and reloading |
| 4 memory | seeded preference recalled **and named** in the component's `note` slot |
| 5 stored skill | one vague sentence fires three visible writes in order, no confirmations, amid four distractors |
| 6 teach a skill | 422 `OUT_OF_BAND` (symptom only) → decline → record → save → apply **unaided to a different person in a fresh thread** |

## Notes for reviewers

- **The beat-6 gate is discriminating on purpose.** Decoy exception codes file and finalize successfully and still don't lift it; an unknown code is refused without enumerating the catalogue. So "the agent filed an exception" ≠ "the agent cleared the gate". Two out-of-band comp requests are seeded so the case taught on stage and the unaided replay are different people.
- **Seed dates are relative offsets** materialized at store init, not absolute ISO strings — request aging and the generated offer letter stay coherent years from now, and Reset genuinely re-freshens the queue rather than restoring stale timestamps.
- **Memories use `user` scope, not `project`.** Verified against the running stack: a project-scoped row is returned for *every* user id in the instance, so with several skins sharing one backend it isn't a per-skin boundary. For the same reason this skin's `forgetAllMemories` **skips** project-scoped rows rather than deleting data it doesn't own, and `dev/reset` reports the skipped count.
- **`temperature` is not set.** gpt-5.4 rejects it and the value is discarded, so carrying it next to a comment claiming determinism would be misleading. (banking still has it; out of scope here.)
- **Beat 2 additionally needs #6431** (thread-list identity). This merges and runs fine without it — it just can't demo thread reopen.

## Known gaps

- Switching operator in the sidebar does **not** re-scope memory: `properties` aren't forwarded on the run path, so Maya and Clara both resolve to the fallback id. Documented in `intelligence/user-id.ts`; needs a shell change.
- Unknown routes under a REST-backed skin return HTTP 200 with the 404 page rendered (`/banking/nope` and `/logistics/nope` do too — the response commits before `notFound()` throws because their `RuntimeProviders` render `null` pending a fetch). Pre-existing, not addressed here.
- No "file it" path for the canvas review brief. The brief is a *view* — `buildBriefOps` carries selections only and binds figures at render time — so a filed review would need to snapshot its own numbers. Deliberate follow-up.

## Skill-staleness check

Per the app's standing rule: **yes, the skill went stale, and it's updated here.** `CLAUDE.md` (skin list, substrate split, beat matrix, new `people` entry), `README.md`, `docs/teach-mode/README.md` (teach-mode is now per-skin, not banking-only), and `.claude/skills/reskin/{SKILL,demo-beats,templates}.md` — including six "only banking does this" claims that are no longer true.

Verified: `pnpm build`, `pnpm lint`, `pnpm test:unit` (335/335).

🤖 Generated with [Claude Code](https://claude.com/claude-code)