### PR TITLE
ci(showcase): retry the Angular pnpm setup and diagnose an absent aggregator input

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -438,8 +438,33 @@ jobs:
         with:
           persist-credentials: false
 
+      # `pnpm/action-setup` shells out to npm for its self-installer, so a
+      # transient registry blip fails the step outright. This job is the
+      # WIDEST blast radius for that failure in the whole workflow: every
+      # `showcase/integrations/**` service sets `needs_angular=true` (see
+      # the `needs_angular` line in detect-changes), and `build` hard-depends
+      # on this job — so one ECONNRESET here skips the ENTIRE fleet build
+      # and the staging redeploy behind it, leaving `:latest` un-advanced
+      # with nothing to reconcile against.
+      #
+      # Measured: run 31187982717 (2026-08-07) lost the ms-agent-dotnet
+      # image + redeploy to exactly this, and stayed undeployed for 2h+
+      # because no later push re-selects an unchanged service.
+      #
+      # `continue-on-error` + a conditional second attempt is the
+      # dependency-free retry: the action exposes no retry input, and a
+      # retry-wrapper action can only wrap `run:` commands, not a `uses:`
+      # step. The retry is deliberately scoped to THIS job rather than all
+      # ~36 pnpm setups in the repo — elsewhere a failure costs one job and
+      # a re-run, not the fleet.
       - name: Setup pnpm
+        id: setup-pnpm
         if: needs.detect-changes.outputs.needs_angular == 'true'
+        continue-on-error: true
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup pnpm (retry after transient installer failure)
+        if: ${{ needs.detect-changes.outputs.needs_angular == 'true' && steps.setup-pnpm.outcome == 'failure' }}
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
@@ -447,6 +472,20 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
+
+      # Guards the `continue-on-error` above: if BOTH attempts failed, pnpm
+      # is absent and the next step would fail with a bare "pnpm: command
+      # not found" that reads like a runner-image problem. Fail here with
+      # the real reason instead. Without this the job could also go GREEN if
+      # a future edit made the following steps tolerant of a missing pnpm.
+      - name: Verify pnpm is available
+        if: needs.detect-changes.outputs.needs_angular == 'true'
+        run: |
+          if ! command -v pnpm >/dev/null 2>&1; then
+            echo "::error::pnpm/action-setup failed on both attempts — see the two 'Setup pnpm' steps above (usually a transient npm registry error; re-run the job)"
+            exit 1
+          fi
+          pnpm --version
 
       - name: Install
         if: needs.detect-changes.outputs.needs_angular == 'true'

--- a/showcase/scripts/__tests__/aggregate-build-results.test.ts
+++ b/showcase/scripts/__tests__/aggregate-build-results.test.ts
@@ -5,7 +5,9 @@
  * The script's `run({inputDir, outputDir, githubOutput})` entrypoint is
  * exercised directly with temp dirs (so we never touch tracked files or
  * spawn subprocesses). We verify:
- *   1. empty INPUT_DIR → results.json = `[]`, any_success=false, no throw
+ *   1. empty INPUT_DIR → fails loud (a zero-slot download is a defect, not
+ *      an empty build set), and an ABSENT INPUT_DIR lands on that same
+ *      fail-loud rather than escaping as a raw ENOENT from readdirSync
  *   2. build-result-<x> dir missing result.json → throws naming the slot
  *   3. non-`build-result-*` dirs are ignored
  *   4. mixed success/failure → correct merged array + any_success=true
@@ -64,6 +66,30 @@ describe("aggregate-build-results.run", () => {
     expect(() => run({ inputDir, outputDir, githubOutput })).toThrow(
       /aggregate-build-results: found 0 build-result-\* slot dirs/,
     );
+  });
+
+  it("ABSENT INPUT_DIR → same fail-loud as an empty one, not a raw ENOENT", () => {
+    // actions/download-artifact creates the path only once its `pattern`
+    // matches >=1 artifact, so a build matrix that never ran (an upstream
+    // job failed, every slot skipped) leaves INPUT_DIR absent rather than
+    // empty. That used to reach readdirSync and surface as
+    // `ENOENT: no such file or directory, scandir '.../build-results-in'`,
+    // which reads as a bug in the aggregator and hides the upstream job
+    // that actually died (measured: run 31187982717, 2026-08-07).
+    // It must land on the deliberate zero-slot fail-loud instead — same
+    // refusal, diagnosable message.
+    const absentDir = join(inputDir, "never-created");
+
+    expect(() => run({ inputDir: absentDir, outputDir, githubOutput })).toThrow(
+      /does not exist \(actions\/download-artifact matched no artifacts\)/,
+    );
+    // Regression guard: the raw filesystem error must NOT be what escapes.
+    expect(() => run({ inputDir: absentDir, outputDir, githubOutput })).toThrow(
+      /^aggregate-build-results:/,
+    );
+    expect(() =>
+      run({ inputDir: absentDir, outputDir, githubOutput }),
+    ).not.toThrow(/ENOENT/);
   });
 
   it("reads a single artifact extracted directly into INPUT_DIR", () => {

--- a/showcase/scripts/aggregate-build-results.ts
+++ b/showcase/scripts/aggregate-build-results.ts
@@ -130,9 +130,21 @@ export function run(opts: RunOptions): void {
 
   mkdirSync(outputDir, { recursive: true });
 
-  const slotDirs = readdirSync(inputDir, { withFileTypes: true })
-    .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
-    .map((d) => d.name);
+  // A MISSING $INPUT_DIR is the SAME condition as an empty one, and must
+  // reach the same fail-loud below. actions/download-artifact creates the
+  // path only once its `pattern` matches at least one artifact, so when the
+  // build matrix never ran at all (e.g. `build-angular` failed and every
+  // slot was skipped) the directory is absent rather than empty. Calling
+  // readdirSync on it threw a raw `ENOENT: ... scandir` that buried the
+  // real story under a filesystem error and sent operators looking at the
+  // aggregator instead of at the upstream job that actually died.
+  // Measured: run 31187982717 (2026-08-07).
+  const inputDirExists = existsSync(inputDir);
+  const slotDirs = inputDirExists
+    ? readdirSync(inputDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && d.name.startsWith("build-result-"))
+        .map((d) => d.name)
+    : [];
   const singleArtifactPath = join(inputDir, "result.json");
 
   // The aggregator job is gated upstream on `has_changes == 'true'`, so the
@@ -144,10 +156,18 @@ export function run(opts: RunOptions): void {
   // would push deploy down the false-green path where it probes the full
   // service set against stale `:latest`. Fail loud instead.
   if (slotDirs.length === 0 && !existsSync(singleArtifactPath)) {
+    // Name which of the two shapes we hit. "absent" almost always means an
+    // upstream job failed so the matrix never produced a slot; "present but
+    // empty" points at the download step itself.
+    const shape = inputDirExists
+      ? `found 0 build-result-* slot dirs in ${inputDir}`
+      : `${inputDir} does not exist (actions/download-artifact matched no artifacts)`;
     throw new Error(
-      `aggregate-build-results: found 0 build-result-* slot dirs in ${inputDir} — ` +
+      `aggregate-build-results: ${shape} — ` +
         `the per-slot artifact download produced nothing; this indicates a broken ` +
-        `download, not an empty build set (the job only runs when >=1 service was scheduled).`,
+        `download or a build matrix that never ran, not an empty build set ` +
+        `(the job only runs when >=1 service was scheduled). Check whether an ` +
+        `upstream job (build-angular / build) failed or was skipped.`,
     );
   }
 


### PR DESCRIPTION
## Why

A transient `npm error code ECONNRESET` inside `pnpm/action-setup`'s self-installer took down the **entire showcase fleet build and the staging redeploy behind it** — [run 31187982717](https://github.com/CopilotKit/CopilotKit/actions/runs/31187982717), 2026-08-07. The `ms-agent-dotnet` image for #6233 went unbuilt and stayed **undeployed for 2h+** until the run was manually re-run.

Nothing was wrong with the merged code. Two independent gaps made one network blip that expensive.

### Gap 1 — `build-angular` is the widest blast radius in the workflow

Every `showcase/integrations/**` service sets `needs_angular=true` (the `needs_angular` line in `detect-changes`), and `build` hard-depends on `build-angular`. So one failed pnpm install:

- skips the **whole** build matrix,
- skips `redeploy-staging`,
- leaves GHCR `:latest` un-advanced — which means the `*/15` **Reconcile staging** self-heal has nothing to detect, since it compares Railway's deployed digest against `:latest`.

And no later push recovers it: `detect-changes` diffs each push against **its own** before-SHA, so an unchanged service is never re-selected. The failure is silent-until-noticed by design of the surrounding machinery.

### Gap 2 — the aggregator then hid the real cause

`Aggregate build results` failed with `ENOENT: no such file or directory, scandir '.../build-results-in'`. That reads as a bug in the aggregator and points away from the job that actually died. `actions/download-artifact` creates the path only once its `pattern` matches ≥1 artifact, so a matrix that never ran leaves the directory **absent**, not empty.

## What changed

**1. `.github/workflows/showcase_build.yml`** — `continue-on-error` + a conditional second attempt on the Angular job's `Setup pnpm`. The action exposes no retry input and a retry-wrapper action can only wrap `run:` steps, not `uses:`, so the two-step form is the dependency-free retry. Added a `Verify pnpm is available` guard so a double failure reports the real reason rather than a bare `pnpm: command not found` — and so the job can't go green if a future edit made a later step tolerant of missing pnpm.

Scoped to **this one job** deliberately, not all ~36 pnpm setups in the repo: elsewhere a pnpm blip costs one job and a re-run, not the fleet. That boundary is stated in the comment.

**2. `showcase/scripts/aggregate-build-results.ts`** — routes the absent-dir case into the **existing** zero-slot fail-loud rather than around it.

Worth being explicit, since my first instinct was wrong: that fail-loud is **load-bearing and intentional** (a silent `results=[]` is indistinguishable from "all builds failed" and pushes deploy down a false-green path against stale `:latest`). Making the aggregator tolerate a missing dir would have broken it. This only makes it *diagnosable* — naming which of the two shapes was hit and pointing at the upstream job.

## Testing

**New test is proven red-before-green.** With the source fix reverted (`git stash push` on the source file only), the new test reproduces the exact CI error:

```
× ABSENT INPUT_DIR → same fail-loud as an empty one, not a raw ENOENT
AssertionError: expected [Function] to throw error matching
  /…/download-artifact matched no artifacts\) but got 'ENOENT: no such file or directory, sc…'
"ENOENT: no such file or directory, scandir '/var/.../agg-build-NcdeNl/in/never-created'"
Tests  1 failed | 11 passed (12)
```

With the fix restored:

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

**Full `showcase/scripts` suite — no regression.** Same command CI uses (`pnpm exec vitest run` in `showcase/scripts`):

| | Test Files | Tests |
|---|---|---|
| baseline (my changes stashed) | 11 failed \| 64 passed (75) | 14 failed \| 1477 passed \| 25 skipped |
| with this PR | 11 failed \| 64 passed (75) | 14 failed \| **1478** passed \| 25 skipped |

Identical failure set; the delta is exactly my one new passing test. Those 14 pre-existing failures are `tsx` path-resolution artifacts of running in a git worktree with symlinked `node_modules` (traces resolve through `../../../CopilotKit/node_modules/.pnpm/tsx@...`), unrelated to this change.

**actionlint — no new findings.** Compared the full finding set against `origin/main`'s version of the file with line numbers stripped:

```
baseline: 10 findings
this PR:  10 findings
diff:     NO NEW FINDINGS
```

All 10 are pre-existing (`SC2086`/`SC2129` in an unrelated `run:` block at :563, unknown `depot-ubuntu-24.04-4` label at :835). The new `run:` block passes shellcheck clean.

**Also run:** `oxfmt --write` on both TS files; `oxlint` → `0 warnings and 0 errors`; `tsc --noEmit` → 21 pre-existing errors repo-wide, **zero** in either touched file.

**Not verifiable locally:** the retry path itself only exercises under a real registry failure. The guard step is what makes a double failure legible if it ever does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)