### PR TITLE
fix(ci): repair telemetry install and Inspector test flake

### DIFF
--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -94,8 +94,12 @@ jobs:
         if: steps.token.outputs.token != ''
         working-directory: p2p
         run: |
-          pnpm install --frozen-lockfile
-          pnpm reconcile
+          pnpm install --frozen-lockfile --ignore-workspace
+          if [ ! -x node_modules/.bin/ts-node ]; then
+            echo "::error::Registry dependencies were not installed in p2p/node_modules."
+            exit 1
+          fi
+          pnpm --ignore-workspace reconcile
 
       - name: Open fragment PR
         if: steps.token.outputs.token != ''

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -95,8 +95,12 @@ jobs:
         if: steps.token.outputs.token != ''
         working-directory: p2p
         run: |
-          pnpm install --frozen-lockfile
-          pnpm reconcile
+          pnpm install --frozen-lockfile --ignore-workspace
+          if [ ! -x node_modules/.bin/ts-node ]; then
+            echo "::error::Registry dependencies were not installed in p2p/node_modules."
+            exit 1
+          fi
+          pnpm --ignore-workspace reconcile
 
       - name: Open fragment PR
         if: steps.token.outputs.token != ''

--- a/packages/web-inspector/src/__tests__/threads-usage-footer.spec.ts
+++ b/packages/web-inspector/src/__tests__/threads-usage-footer.spec.ts
@@ -267,7 +267,7 @@ test.each(usageDisplayCases)("$name", async (case_) => {
       );
     }
     if (case_.usage.used === 241) {
-      expect(footer.outerHTML).not.toContain("241");
+      expect(footer.textContent).not.toContain("241");
       expect(context.core.inspectorMetadata?.usage?.used).toBe(241);
     }
   } finally {


### PR DESCRIPTION
## What does this PR do?

- Install and run the telemetry registry as a standalone pnpm project in both fragment workflows.
- Stop at the install step with a clear error if the registry's local `ts-node` binary is missing.
- Check the Inspector's visible overage text instead of Lit's random internal HTML marker.

## Why?

PR #6275 merged successfully, then two `push` workflows failed on its merge commit:

- `telemetry / docs fragment`: the nested `p2p` install joined CopilotKit's parent workspace and did not create `p2p/node_modules`.
- Unit tests: `outerHTML` sometimes contained `241` inside Lit's random marker even though the visible count was `200+ / 200 Threads`.

The runtime fragment workflow had the same nested-workspace bug, so this fixes it before its first affected run.

## Related PRs and issues

- https://github.com/CopilotKit/CopilotKit/pull/6275
- https://github.com/CopilotKit/CopilotKit/actions/runs/31218832777/job/92998527566
- https://github.com/CopilotKit/CopilotKit/actions/runs/31218832813/job/92998528116

## Validation

- [x] `pnpm nx run @copilotkit/web-inspector:test --skip-nx-cache` (373 tests)
- [x] `pnpm nx run-many -t check-types,build --projects=@copilotkit/web-inspector --skip-nx-cache`
- [x] `actionlint` and `zizmor` on both edited workflows
- [x] Registry install, local binary guard, reconcile, and zero-diff check in a nested checkout
- [x] Formatter and lint checks

## Checklist

- [x] I have read the Contribution Guide
- [x] Documentation is not needed; this only repairs CI behavior and a test assertion
- [x] No changeset is needed; no package behavior or release output changes
