### PR TITLE
fix(channels): retry WebSocket errors without close

### DIFF
--- a/packages/channels-intelligence/src/realtime-gateway-error-only-reconnect.test.ts
+++ b/packages/channels-intelligence/src/realtime-gateway-error-only-reconnect.test.ts
@@ -1,0 +1,117 @@
+import { expect, test, vi } from "vitest";
+import { connectRealtimeGateway } from "./realtime-gateway.js";
+
+interface ErrorOnlyReconnectSetup {
+  disconnect(): void;
+  dropInitialConnection(): void;
+  isOnline(): boolean;
+  socketCount(): number;
+}
+
+/** Make the first reconnect emit only `error`, then let the next one recover. */
+async function setupErrorOnlyReconnect(): Promise<ErrorOnlyReconnectSetup> {
+  const sockets: ErrorOnlyWebSocket[] = [];
+
+  class ErrorOnlyWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSING = 2;
+    static readonly CLOSED = 3;
+    readyState = ErrorOnlyWebSocket.CONNECTING;
+    bufferedAmount = 0;
+    binaryType = "arraybuffer";
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onerror: ((error: Error) => void) | null = null;
+    onclose: ((event: { code: number }) => void) | null = null;
+
+    constructor() {
+      sockets.push(this);
+      const shouldOpen = sockets.length === 1 || sockets.length >= 3;
+      queueMicrotask(() => {
+        if (shouldOpen) {
+          this.readyState = ErrorOnlyWebSocket.OPEN;
+          this.onopen?.();
+          return;
+        }
+        this.readyState = ErrorOnlyWebSocket.CLOSED;
+        this.onerror?.(new Error("upgrade refused"));
+      });
+    }
+
+    send(data: string): void {
+      const frame = JSON.parse(data) as [string, string, string, string];
+      const [joinRef, ref, topic, event] = frame;
+      if (event !== "phx_join") return;
+      queueMicrotask(() =>
+        this.onmessage?.({
+          data: JSON.stringify([
+            joinRef,
+            ref,
+            topic,
+            "phx_reply",
+            { status: "ok", response: {} },
+          ]),
+        }),
+      );
+    }
+
+    drop(code: number): void {
+      this.readyState = ErrorOnlyWebSocket.CLOSED;
+      this.onclose?.({ code });
+    }
+
+    close(): void {
+      this.readyState = ErrorOnlyWebSocket.CLOSED;
+    }
+  }
+
+  const session = await connectRealtimeGateway({
+    wsUrl: "wss://gateway.example/channels",
+    apiKey: "cpk-test",
+    projectId: 7,
+    join: {
+      protocol: "channel_delivery_v1",
+      runtimeInstanceId: "rti_1",
+      channels: [{ channelName: "opentag", adapter: "slack" }],
+    },
+    diagnosticFetch: vi.fn(async () => new Response(null, { status: 503 })),
+    webSocket: ErrorOnlyWebSocket,
+  });
+  let isOnline = false;
+  session.onStateChange((state) => {
+    isOnline = state === "online";
+  });
+
+  return {
+    disconnect: () => session.disconnect(),
+    dropInitialConnection: () => sockets[0]!.drop(1006),
+    isOnline: () => isOnline,
+    socketCount: () => sockets.length,
+  };
+}
+
+/** Wait for a condition while Phoenix drives its real reconnect timers. */
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+test("keeps reconnecting when Node WebSocket emits error without close", async () => {
+  const setup = await setupErrorOnlyReconnect();
+
+  try {
+    setup.dropInitialConnection();
+    await waitUntil(() => setup.socketCount() >= 3 && setup.isOnline(), 2_000);
+
+    expect(setup.socketCount()).toBeGreaterThanOrEqual(3);
+    expect(setup.isOnline()).toBe(true);
+  } finally {
+    setup.disconnect();
+  }
+});

--- a/packages/channels-intelligence/src/realtime-gateway.ts
+++ b/packages/channels-intelligence/src/realtime-gateway.ts
@@ -642,6 +642,41 @@ export async function connectRealtimeGateway(
   // over `lastTransportError` when present, and cleared when the outage ends.
   let lastOutageDiagnosis: string | undefined;
   let connectDeadline: ReturnType<typeof setTimeout> | undefined;
+  let errorOnlyReconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  let errorOnlyReconnectAttempts = 0;
+  const errorOnlyReconnectDelaysMs = [
+    10, 50, 100, 150, 200, 250, 500, 1_000, 2_000,
+  ] as const;
+  /** Cancel a pending fallback when Phoenix receives the matching close/open. */
+  const clearErrorOnlyReconnect = (): void => {
+    if (errorOnlyReconnectTimer !== undefined) {
+      clearTimeout(errorOnlyReconnectTimer);
+      errorOnlyReconnectTimer = undefined;
+    }
+  };
+  /** Retry when a WebSocket transport reports an error without a close event. */
+  const scheduleErrorOnlyReconnect = (): void => {
+    if (closingIntentionally || errorOnlyReconnectTimer !== undefined) return;
+    const delayMs =
+      errorOnlyReconnectDelaysMs[errorOnlyReconnectAttempts] ?? 5_000;
+    errorOnlyReconnectAttempts += 1;
+    errorOnlyReconnectTimer = setTimeout(() => {
+      errorOnlyReconnectTimer = undefined;
+      if (closingIntentionally) return;
+      if (socket.connectionState() === "open") {
+        errorOnlyReconnectAttempts = 0;
+        return;
+      }
+      socket.disconnect(
+        () => {
+          if (!closingIntentionally) socket.connect();
+        },
+        1001,
+        "retrying transport error",
+      );
+    }, delayMs);
+    (errorOnlyReconnectTimer as unknown as { unref?: () => void }).unref?.();
+  };
   // The initial connect settles from several places (the join push's reply
   // hooks, a non-retryable transport error, the connect deadline), so the
   // resolvers are hoisted out of the promise rather than closed over by the
@@ -753,7 +788,10 @@ export async function connectRealtimeGateway(
   socket.onOpen(() => {
     everConnected = true;
     clearConnectDeadline();
+    clearErrorOnlyReconnect();
+    errorOnlyReconnectAttempts = 0;
   });
+  socket.onClose(clearErrorOnlyReconnect);
   socket.onError((error, _transport, establishedConnections) => {
     const detail = describeTransportError(error);
     // A drop after a successful connect belongs to the reconnect path — but it
@@ -767,6 +805,7 @@ export async function connectRealtimeGateway(
       // happened, and the probe would both waste a request and overwrite a
       // better answer — the same trust rule the initial-connect path applies.
       if (detail.code === undefined) probeOutage();
+      scheduleErrorOnlyReconnect();
       return;
     }
     lastTransportRaw = error;
@@ -1124,6 +1163,7 @@ export async function connectRealtimeGateway(
     disconnect: () => {
       closingIntentionally = true;
       clearGiveUpTimer();
+      clearErrorOnlyReconnect();
       socket.disconnect();
     },
   };


### PR DESCRIPTION
## What changed

- Add a backoff-based fallback for established WebSocket errors that do not emit a matching close event.
- Cancel the fallback when Phoenix receives a normal open or close event, so the existing reconnect path stays in charge.
- Add a regression test that models Node's global WebSocket behavior and proves the session reaches `online` on a later retry.

## Why

Phoenix schedules socket retries from `onClose`, not `onError`. Node's global WebSocket can end a refused upgrade with `readyState = CLOSED` and an `error` event but no `close` event. After an established Intelligence session drops, that leaves Phoenix stuck after its first failed reconnect.

## Validation

- RED: the regression test stopped at 2 socket attempts before the fix.
- `pnpm --dir packages/channels-intelligence exec vitest run src/realtime-gateway-error-only-reconnect.test.ts`
- `pnpm nx test @copilotkit/channels-intelligence` — 213 tests passed.
- `pnpm nx check-types @copilotkit/channels-intelligence --skip-nx-cache`
- `pnpm nx build @copilotkit/channels-intelligence --skip-nx-cache`
- `pnpm exec oxfmt --check packages/channels-intelligence/src/realtime-gateway.ts packages/channels-intelligence/src/realtime-gateway-error-only-reconnect.test.ts`
- Pre-commit package test, publint, attw, and lint checks passed.