### PR TITLE
docs(channels): clarify the custom channel runner path

### DIFF
--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -4,10 +4,13 @@ The supported platform-neutral foundation behind `@copilotkit/channels`.
 Most applications should use the batteries-included `@copilotkit/channels` package;
 install core directly when building an adapter or intentionally selecting one platform.
 
-**Every Channel requires a CopilotKit Intelligence connection** (an API key — a
-free tier is available). There is no standalone / DIY run path: a Channel is
-started and owned by the `CopilotRuntime` once Intelligence is configured, not
-by calling a method on the Channel itself. See "Running a Channel" below.
+**Channels run through a channel runner.** CopilotKit Intelligence provides the
+managed runner (an API key — a free tier is available): a Channel is started and
+owned by the `CopilotRuntime` once Intelligence is configured, not by calling a
+method on the Channel itself. See "Running a Channel" below. Building and
+operating your own channel runner on the SDK primitives is also a supported
+path; teams choosing it own their state, persistence, concurrency, locking,
+retries, and race-condition handling.
 
 ## Selective install
 
@@ -65,8 +68,8 @@ A `Channel` has no public `start()` / `stop()` — lifecycle is runtime-owned
 
 ## Running a Channel
 
-A Channel only runs when it's declared on an Intelligence-configured
-`CopilotRuntime`; there is no `channel.start()` and no standalone/DIY runner.
+In the managed path, a Channel runs when it's declared on an
+Intelligence-configured `CopilotRuntime`; there is no `channel.start()`.
 Pass the `Channel` in `channels`, then drive activation through the returned
 handler:
 

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -7,10 +7,9 @@ install core directly when building an adapter or intentionally selecting one pl
 **Channels run through a channel runner.** CopilotKit Intelligence provides the
 managed runner, available on a free plan: the `CopilotRuntime` starts and owns
 each Channel once Intelligence is configured — see "Running a Channel" below.
-Building and
-operating your own channel runner on the SDK primitives is also a supported
-path; teams choosing it own their state, persistence, concurrency, locking,
-retries, and race-condition handling.
+Building and operating your own channel runner on the SDK primitives is also a
+supported path; teams choosing it own their state, persistence, concurrency,
+locking, retries, and race-condition handling.
 
 ## Selective install
 
@@ -69,9 +68,8 @@ A `Channel` has no public `start()` / `stop()` — lifecycle is runtime-owned
 ## Running a Channel
 
 In the managed path, a Channel runs when it's declared on an
-Intelligence-configured `CopilotRuntime`; there is no `channel.start()`.
-Pass the `Channel` in `channels`, then drive activation through the returned
-handler:
+Intelligence-configured `CopilotRuntime`. Pass the `Channel` in `channels`,
+then drive activation through the returned handler:
 
 ```ts
 import { createChannel } from "@copilotkit/channels-core";

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -5,7 +5,7 @@ Most applications should use the batteries-included `@copilotkit/channels` packa
 install core directly when building an adapter or intentionally selecting one platform.
 
 **Channels run through a channel runner.** CopilotKit Intelligence provides the
-managed runner (an API key — a free tier is available): a Channel is started and
+managed runner, available on a free plan: a Channel is started and
 owned by the `CopilotRuntime` once Intelligence is configured, not by calling a
 method on the Channel itself. See "Running a Channel" below. Building and
 operating your own channel runner on the SDK primitives is also a supported

--- a/packages/channels-core/README.md
+++ b/packages/channels-core/README.md
@@ -5,9 +5,9 @@ Most applications should use the batteries-included `@copilotkit/channels` packa
 install core directly when building an adapter or intentionally selecting one platform.
 
 **Channels run through a channel runner.** CopilotKit Intelligence provides the
-managed runner, available on a free plan: a Channel is started and
-owned by the `CopilotRuntime` once Intelligence is configured, not by calling a
-method on the Channel itself. See "Running a Channel" below. Building and
+managed runner, available on a free plan: the `CopilotRuntime` starts and owns
+each Channel once Intelligence is configured — see "Running a Channel" below.
+Building and
 operating your own channel runner on the SDK primitives is also a supported
 path; teams choosing it own their state, persistence, concurrency, locking,
 retries, and race-condition handling.

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -8,11 +8,12 @@ streaming, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Discord.
 
-The adapter keeps its own Discord credentials (`botToken` / `appId` / …) — but
-the Channel itself only runs inside a CopilotKit Intelligence-configured
+The adapter keeps its own Discord credentials (`botToken` / `appId` / …) — in
+the managed path the Channel runs inside a CopilotKit Intelligence-configured
 `CopilotRuntime` (an API key; a free tier is available). There is no
-standalone / DIY runner and no `channel.start()`; the runtime starts and owns
-the channel because Intelligence is configured.
+`channel.start()`; the runtime starts and owns the channel. Building and
+operating your own channel runner on the SDK primitives is also a supported path
+— see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -10,10 +10,9 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own Discord credentials (`botToken` / `appId` / …) — in
 the managed path the Channel runs inside a CopilotKit Intelligence-configured
-`CopilotRuntime` (free plan available). There is no `channel.start()`; the
-runtime starts and owns the channel. Building and operating your own channel
-runner on the SDK primitives is also a supported path — see
-`@copilotkit/channels-core`.
+`CopilotRuntime` (free plan available), which starts and owns the channel's
+lifecycle. Building and operating your own channel runner on the SDK primitives
+is also a supported path — see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -12,7 +12,7 @@ The adapter keeps its own Discord credentials (`botToken` / `appId` / …) — i
 the managed path the Channel runs inside a CopilotKit Intelligence-configured
 `CopilotRuntime` (free plan available), which starts and owns the channel's
 lifecycle. Building and operating your own channel runner on the SDK primitives
-is also a supported path — see `@copilotkit/channels-core`.
+is also a supported path.
 
 ## Install
 

--- a/packages/channels-discord/README.md
+++ b/packages/channels-discord/README.md
@@ -10,10 +10,10 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own Discord credentials (`botToken` / `appId` / …) — in
 the managed path the Channel runs inside a CopilotKit Intelligence-configured
-`CopilotRuntime` (an API key; a free tier is available). There is no
-`channel.start()`; the runtime starts and owns the channel. Building and
-operating your own channel runner on the SDK primitives is also a supported path
-— see `@copilotkit/channels-core`.
+`CopilotRuntime` (free plan available). There is no `channel.start()`; the
+runtime starts and owns the channel. Building and operating your own channel
+runner on the SDK primitives is also a supported path — see
+`@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -10,10 +10,9 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own Slack credentials (`botToken` / `appToken`) — in the
 managed path the Channel runs inside a CopilotKit Intelligence-configured
-`CopilotRuntime` (free plan available). There is no `channel.start()`; the
-runtime starts and owns the channel. Building and operating your own channel
-runner on the SDK primitives is also a supported path — see
-`@copilotkit/channels-core`.
+`CopilotRuntime` (free plan available), which starts and owns the channel's
+lifecycle. Building and operating your own channel runner on the SDK primitives
+is also a supported path — see `@copilotkit/channels-core`.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -10,10 +10,10 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own Slack credentials (`botToken` / `appToken`) — in the
 managed path the Channel runs inside a CopilotKit Intelligence-configured
-`CopilotRuntime` (an API key; a free tier is available). There is no
-`channel.start()`; the runtime starts and owns the channel. Building and
-operating your own channel runner on the SDK primitives is also a supported path
-— see `@copilotkit/channels-core`.
+`CopilotRuntime` (free plan available). There is no `channel.start()`; the
+runtime starts and owns the channel. Building and operating your own channel
+runner on the SDK primitives is also a supported path — see
+`@copilotkit/channels-core`.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -12,7 +12,7 @@ The adapter keeps its own Slack credentials (`botToken` / `appToken`) — in the
 managed path the Channel runs inside a CopilotKit Intelligence-configured
 `CopilotRuntime` (free plan available), which starts and owns the channel's
 lifecycle. Building and operating your own channel runner on the SDK primitives
-is also a supported path — see `@copilotkit/channels-core`.
+is also a supported path.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-slack/README.md
+++ b/packages/channels-slack/README.md
@@ -8,11 +8,12 @@ streaming, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Slack.
 
-The adapter keeps its own Slack credentials (`botToken` / `appToken`) — but the
-Channel itself only runs inside a CopilotKit Intelligence-configured
+The adapter keeps its own Slack credentials (`botToken` / `appToken`) — in the
+managed path the Channel runs inside a CopilotKit Intelligence-configured
 `CopilotRuntime` (an API key; a free tier is available). There is no
-standalone / DIY runner and no `channel.start()`; the runtime starts and owns
-the channel because Intelligence is configured.
+`channel.start()`; the runtime starts and owns the channel. Building and
+operating your own channel runner on the SDK primitives is also a supported path
+— see `@copilotkit/channels-core`.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -12,10 +12,10 @@ the successor to the Bot Framework SDK.
 The adapter keeps its own Teams/Microsoft 365 credentials (`clientId` /
 `clientSecret` / `tenantId`, or none for anonymous local dev) — in the managed
 path the Channel runs inside a CopilotKit Intelligence-configured
-`CopilotRuntime` (an API key; a free tier is available). There is no
-`channel.start()`; the runtime starts and owns the channel. Building and
-operating your own channel runner on the SDK primitives is also a supported path
-— see `@copilotkit/channels-core`.
+`CopilotRuntime` (free plan available). There is no `channel.start()`; the
+runtime starts and owns the channel. Building and operating your own channel
+runner on the SDK primitives is also a supported path — see
+`@copilotkit/channels-core`.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -12,10 +12,9 @@ the successor to the Bot Framework SDK.
 The adapter keeps its own Teams/Microsoft 365 credentials (`clientId` /
 `clientSecret` / `tenantId`, or none for anonymous local dev) — in the managed
 path the Channel runs inside a CopilotKit Intelligence-configured
-`CopilotRuntime` (free plan available). There is no `channel.start()`; the
-runtime starts and owns the channel. Building and operating your own channel
-runner on the SDK primitives is also a supported path — see
-`@copilotkit/channels-core`.
+`CopilotRuntime` (free plan available), which starts and owns the channel's
+lifecycle. Building and operating your own channel runner on the SDK primitives
+is also a supported path — see `@copilotkit/channels-core`.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -10,11 +10,12 @@ It is built on the **Microsoft 365 Agents SDK** (`@microsoft/agents-hosting`),
 the successor to the Bot Framework SDK.
 
 The adapter keeps its own Teams/Microsoft 365 credentials (`clientId` /
-`clientSecret` / `tenantId`, or none for anonymous local dev) — but the
-Channel itself only runs inside a CopilotKit Intelligence-configured
+`clientSecret` / `tenantId`, or none for anonymous local dev) — in the managed
+path the Channel runs inside a CopilotKit Intelligence-configured
 `CopilotRuntime` (an API key; a free tier is available). There is no
-standalone / DIY runner and no `channel.start()`; the runtime starts and owns
-the channel because Intelligence is configured.
+`channel.start()`; the runtime starts and owns the channel. Building and
+operating your own channel runner on the SDK primitives is also a supported path
+— see `@copilotkit/channels-core`.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-teams/README.md
+++ b/packages/channels-teams/README.md
@@ -14,7 +14,7 @@ The adapter keeps its own Teams/Microsoft 365 credentials (`clientId` /
 path the Channel runs inside a CopilotKit Intelligence-configured
 `CopilotRuntime` (free plan available), which starts and owns the channel's
 lifecycle. Building and operating your own channel runner on the SDK primitives
-is also a supported path — see `@copilotkit/channels-core`.
+is also a supported path.
 
 ## Managed Channels: the alternative to holding your own credentials
 

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -10,9 +10,9 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own Telegram bot token — in the managed path the Channel
 runs inside a CopilotKit Intelligence-configured `CopilotRuntime` (free plan
-available). There is no `channel.start()`; the runtime starts and owns the
-channel. Building and operating your own channel runner on the SDK primitives is
-also a supported path — see `@copilotkit/channels-core`.
+available), which starts and owns the channel's lifecycle. Building and
+operating your own channel runner on the SDK primitives is also a supported path
+— see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -8,11 +8,11 @@ plus streaming via chunked message edits, opaque-id interactions, and HITL.
 You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Telegram.
 
-The adapter keeps its own Telegram bot token — but the Channel itself only runs
-inside a CopilotKit Intelligence-configured `CopilotRuntime` (an API key; a
-free tier is available). There is no standalone / DIY runner and no
-`channel.start()`; the runtime starts and owns the channel because
-Intelligence is configured.
+The adapter keeps its own Telegram bot token — in the managed path the Channel
+runs inside a CopilotKit Intelligence-configured `CopilotRuntime` (an API key; a
+free tier is available). There is no `channel.start()`; the runtime starts and
+owns the channel. Building and operating your own channel runner on the SDK
+primitives is also a supported path — see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -11,8 +11,8 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 The adapter keeps its own Telegram bot token — in the managed path the Channel
 runs inside a CopilotKit Intelligence-configured `CopilotRuntime` (free plan
 available), which starts and owns the channel's lifecycle. Building and
-operating your own channel runner on the SDK primitives is also a supported path
-— see `@copilotkit/channels-core`.
+operating your own channel runner on the SDK primitives is also a supported
+path.
 
 ## Install
 

--- a/packages/channels-telegram/README.md
+++ b/packages/channels-telegram/README.md
@@ -9,10 +9,10 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to Telegram.
 
 The adapter keeps its own Telegram bot token — in the managed path the Channel
-runs inside a CopilotKit Intelligence-configured `CopilotRuntime` (an API key; a
-free tier is available). There is no `channel.start()`; the runtime starts and
-owns the channel. Building and operating your own channel runner on the SDK
-primitives is also a supported path — see `@copilotkit/channels-core`.
+runs inside a CopilotKit Intelligence-configured `CopilotRuntime` (free plan
+available). There is no `channel.start()`; the runtime starts and owns the
+channel. Building and operating your own channel runner on the SDK primitives is
+also a supported path — see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -9,10 +9,11 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 `@copilotkit/channels`; this package is the only one that talks to the WhatsApp Cloud API.
 
 The adapter keeps its own WhatsApp Cloud API credentials (`accessToken` /
-`phoneNumberId` / …) — but the Channel itself only runs inside a CopilotKit
-Intelligence-configured `CopilotRuntime` (an API key; a free tier is
-available). There is no standalone / DIY runner and no `channel.start()`; the
-runtime starts and owns the channel because Intelligence is configured.
+`phoneNumberId` / …) — in the managed path the Channel runs inside a CopilotKit
+Intelligence-configured `CopilotRuntime` (an API key; a free tier is available).
+There is no `channel.start()`; the runtime starts and owns the channel. Building
+and operating your own channel runner on the SDK primitives is also a supported
+path — see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -12,7 +12,7 @@ The adapter keeps its own WhatsApp Cloud API credentials (`accessToken` /
 `phoneNumberId` / …) — in the managed path the Channel runs inside a CopilotKit
 Intelligence-configured `CopilotRuntime` (free plan available), which starts and
 owns the channel's lifecycle. Building and operating your own channel runner on
-the SDK primitives is also a supported path — see `@copilotkit/channels-core`.
+the SDK primitives is also a supported path.
 
 ## Install
 

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -10,10 +10,10 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own WhatsApp Cloud API credentials (`accessToken` /
 `phoneNumberId` / …) — in the managed path the Channel runs inside a CopilotKit
-Intelligence-configured `CopilotRuntime` (an API key; a free tier is available).
-There is no `channel.start()`; the runtime starts and owns the channel. Building
-and operating your own channel runner on the SDK primitives is also a supported
-path — see `@copilotkit/channels-core`.
+Intelligence-configured `CopilotRuntime` (free plan available). There is no
+`channel.start()`; the runtime starts and owns the channel. Building and
+operating your own channel runner on the SDK primitives is also a supported path
+— see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels-whatsapp/README.md
+++ b/packages/channels-whatsapp/README.md
@@ -10,10 +10,9 @@ You write your UI as JSX once (`@copilotkit/channels-ui`) and drive the bot with
 
 The adapter keeps its own WhatsApp Cloud API credentials (`accessToken` /
 `phoneNumberId` / …) — in the managed path the Channel runs inside a CopilotKit
-Intelligence-configured `CopilotRuntime` (free plan available). There is no
-`channel.start()`; the runtime starts and owns the channel. Building and
-operating your own channel runner on the SDK primitives is also a supported path
-— see `@copilotkit/channels-core`.
+Intelligence-configured `CopilotRuntime` (free plan available), which starts and
+owns the channel's lifecycle. Building and operating your own channel runner on
+the SDK primitives is also a supported path — see `@copilotkit/channels-core`.
 
 ## Install
 

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -4,8 +4,7 @@
 provides the engine, JSX vocabulary, UI primitives, testing API, and every supported adapter.
 
 **Channels run through a channel runner.** CopilotKit Intelligence provides the
-managed runner (an API key — a free tier is available, so this is "connect your
-Intelligence account," not "pay for it"): the `CopilotRuntime` starts and owns
+managed runner, available on a free plan: the `CopilotRuntime` starts and owns
 each Channel's lifecycle once Intelligence is configured. You can also build and
 operate your own channel runner on the lower-level SDK primitives, with no
 Intelligence dependency — a supported path where your team owns state,

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -3,10 +3,13 @@
 `@copilotkit/channels` is the batteries-included CopilotKit Channels package. One install
 provides the engine, JSX vocabulary, UI primitives, testing API, and every supported adapter.
 
-**Channels require a CopilotKit Intelligence connection** (an API key — a free tier
-is available, so this is "connect your Intelligence account," not "pay for it").
-There is no standalone / DIY way to run a Channel: the `CopilotRuntime` starts and
-owns each Channel's lifecycle once Intelligence is configured.
+**Channels run through a channel runner.** CopilotKit Intelligence provides the
+managed runner (an API key — a free tier is available, so this is "connect your
+Intelligence account," not "pay for it"): the `CopilotRuntime` starts and owns
+each Channel's lifecycle once Intelligence is configured. You can also build and
+operate your own channel runner on the lower-level SDK primitives, with no
+Intelligence dependency — a supported path where your team owns state,
+persistence, concurrency, locking, retries, and race-condition handling.
 
 ## Install
 

--- a/showcase/shell-docs/public/images/channels/channels-architecture-light.png
+++ b/showcase/shell-docs/public/images/channels/channels-architecture-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a110f1264f68e2f6d73b78fff150397dae086d642ec364bdbf793181ddb3dbe
-size 132375
+oid sha256:02c8beaeac5a0f2bb866599d9cea82d20a8d0754d9764c3e9e051b9b239401a7
+size 301531

--- a/showcase/shell-docs/public/images/channels/channels-architecture-light.png
+++ b/showcase/shell-docs/public/images/channels/channels-architecture-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b61a769cc8d1a31fc95ef33d4035665438aaf1be1711308ade8f06aacde720d2
-size 283630
+oid sha256:9a110f1264f68e2f6d73b78fff150397dae086d642ec364bdbf793181ddb3dbe
+size 132375

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -21,16 +21,16 @@ between those systems and the path each message takes.
 
 <Image
   src="/images/channels/channels-architecture-light.png"
-  alt="Channels architecture showing agent frameworks connected through AG-UI, CopilotKit Runtime, Enterprise Intelligence, and the Channels SDK to Slack, Microsoft Teams, WhatsApp, and Discord."
-  width={3354}
-  height={2270}
+  alt="Channels architecture showing agent frameworks connected through AG-UI and the CopilotKit Runtime to the Channels SDK, with the channel runner — Enterprise Intelligence's managed runner or your own — connecting to Slack, Microsoft Teams, WhatsApp, Discord, and more."
+  width={2000}
+  height={1304}
   className="block dark:hidden my-8 w-full rounded-xl"
 />
 <Image
-  src="/images/channels/channels-architecture-dark.png"
-  alt="Channels architecture showing agent frameworks connected through AG-UI, CopilotKit Runtime, Enterprise Intelligence, and the Channels SDK to Slack, Microsoft Teams, WhatsApp, and Discord."
-  width={4000}
-  height={2400}
+  src="/images/channels/channels-architecture-light.png"
+  alt="Channels architecture showing agent frameworks connected through AG-UI and the CopilotKit Runtime to the Channels SDK, with the channel runner — Enterprise Intelligence's managed runner or your own — connecting to Slack, Microsoft Teams, WhatsApp, Discord, and more."
+  width={2000}
+  height={1304}
   className="hidden dark:block my-8 w-full rounded-xl"
 />
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -34,6 +34,14 @@ between those systems and the path each message takes.
   className="hidden dark:block my-8 w-full rounded-xl"
 />
 
+Note that you can also build your own channel runner on the open-source
+Channels SDK, with no dependency on CopilotKit Intelligence. This is a
+supported way to use the SDK; teams choosing it are responsible for their own
+state, persistence, concurrency, locking, retries, and race-condition
+handling. CopilotKit Intelligence provides the managed channel runner for
+teams that want those operational concerns handled for them — analytics,
+learning, and governance come in addition.
+
 <OpsPlatformCTA
   variant="inline"
   title="More channels are on the way"
@@ -71,8 +79,10 @@ your agent, tools, or business logic into CopilotKit.
 Production self-hosting keeps your Channels configuration, provider credentials,
 delivery state, and platform operations inside your network, giving your
 organization control over data residency, security, and infrastructure.
-CopilotKit Engineering helps your team deploy Enterprise Intelligence in your
-Kubernetes environment. <DocsTrackedLink href="https://copilotkit.ai/talk-to-an-engineer" surface="docs_channels_self_hosting_contact">Book time with a CopilotKit engineer</DocsTrackedLink> to get started.
+You can fully self-host Enterprise Intelligence. We haven't written the
+onboarding guides for it yet, but if you're comfortable with Docker and
+Kubernetes and can figure it out, go right ahead. We'd be happy to help if
+not — <DocsTrackedLink href="https://copilotkit.ai/talk-to-an-engineer" surface="docs_channels_self_hosting_contact">book time with a CopilotKit engineer</DocsTrackedLink>.
 
 ## Next step
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -22,15 +22,15 @@ between those systems and the path each message takes.
 <Image
   src="/images/channels/channels-architecture-light.png"
   alt="Channels architecture showing agent frameworks connected through AG-UI and the CopilotKit Runtime to the Channels SDK, with the channel runner — Enterprise Intelligence's managed runner or your own — connecting to Slack, Microsoft Teams, WhatsApp, Discord, and more."
-  width={2000}
-  height={1304}
+  width={4000}
+  height={2608}
   className="block dark:hidden my-8 w-full rounded-xl"
 />
 <Image
   src="/images/channels/channels-architecture-light.png"
   alt="Channels architecture showing agent frameworks connected through AG-UI and the CopilotKit Runtime to the Channels SDK, with the channel runner — Enterprise Intelligence's managed runner or your own — connecting to Slack, Microsoft Teams, WhatsApp, Discord, and more."
-  width={2000}
-  height={1304}
+  width={4000}
+  height={2608}
   className="hidden dark:block my-8 w-full rounded-xl"
 />
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -34,14 +34,18 @@ between those systems and the path each message takes.
   className="hidden dark:block my-8 w-full rounded-xl"
 />
 
-Note that you can also build your own channel runner on the open-source
-Channels SDK, with no dependency on CopilotKit Intelligence. This is a
-supported way to use the SDK; teams choosing it are responsible for their own
-state, persistence, concurrency, locking, retries, and race-condition
-handling. CopilotKit Intelligence provides the managed channel runner for
-teams that want those operational concerns handled for them. Channels running
-on the Intelligence runner also get the rest of CopilotKit Intelligence,
-including product analytics, automatic learning, and governance.
+As explained in the [Enterprise Intelligence overview](/premium/overview),
+the dividing line between CopilotKit open source and CopilotKit Intelligence
+is durable data: functionality that runs without it is open source, while
+functionality built on connections to durable data — databases and the state
+kept in them — is part of CopilotKit Intelligence. A channel runner needs
+durable data to run correctly in production: simultaneous participants, race
+conditions, retries, and delivery guarantees all depend on it. CopilotKit
+Intelligence provides the managed channel runner, and channels running on it
+also get the rest of CopilotKit Intelligence, including product analytics,
+automatic learning, and governance. You can absolutely build and operate your
+own channel runner on the open-source Channels SDK — you implement the
+durable-data layer yourself.
 
 <OpsPlatformCTA
   variant="inline"

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -39,8 +39,9 @@ Channels SDK, with no dependency on CopilotKit Intelligence. This is a
 supported way to use the SDK; teams choosing it are responsible for their own
 state, persistence, concurrency, locking, retries, and race-condition
 handling. CopilotKit Intelligence provides the managed channel runner for
-teams that want those operational concerns handled for them — analytics,
-learning, and governance come in addition.
+teams that want those operational concerns handled for them. Channels running
+on the Intelligence runner also get the rest of CopilotKit Intelligence,
+including product analytics, automatic learning, and governance.
 
 <OpsPlatformCTA
   variant="inline"
@@ -79,10 +80,10 @@ your agent, tools, or business logic into CopilotKit.
 Production self-hosting keeps your Channels configuration, provider credentials,
 delivery state, and platform operations inside your network, giving your
 organization control over data residency, security, and infrastructure.
-You can fully self-host Enterprise Intelligence. We haven't written the
-onboarding guides for it yet, but if you're comfortable with Docker and
-Kubernetes and can figure it out, go right ahead. We'd be happy to help if
-not — <DocsTrackedLink href="https://copilotkit.ai/talk-to-an-engineer" surface="docs_channels_self_hosting_contact">book time with a CopilotKit engineer</DocsTrackedLink>.
+You can fully self-host Enterprise Intelligence. Onboarding guides are coming
+soon; in the meantime, if you're comfortable with Docker and Kubernetes, go
+right ahead — and we're happy to help.
+<DocsTrackedLink href="https://copilotkit.ai/talk-to-an-engineer" surface="docs_channels_self_hosting_contact">Book time with a CopilotKit engineer</DocsTrackedLink>.
 
 ## Next step
 

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -80,7 +80,7 @@ your agent, tools, or business logic into CopilotKit.
 Production self-hosting keeps your Channels configuration, provider credentials,
 delivery state, and platform operations inside your network, giving your
 organization control over data residency, security, and infrastructure.
-You can fully self-host Enterprise Intelligence. Onboarding guides are coming
+You can fully self-host the Channels SDK. Onboarding guides are coming
 soon; in the meantime, if you're comfortable with Docker and Kubernetes, go
 right ahead — and we're happy to help.
 <DocsTrackedLink href="https://copilotkit.ai/talk-to-an-engineer" surface="docs_channels_self_hosting_contact">Book time with a CopilotKit engineer</DocsTrackedLink>.


### PR DESCRIPTION
Small docs clarification for the Channels SDK.

- **Channels overview** (`/channels`): adds a short note under the architecture diagram that you can build your own channel runner on the open-source SDK, with no CopilotKit Intelligence dependency — a supported path where the team owns state, persistence, concurrency, locking, retries, and race-condition handling. Intelligence remains the managed runner; analytics, learning, and governance come in addition.
- **Self-hosting section**: Enterprise Intelligence can be fully self-hosted today; onboarding guides are still to come, and we're happy to help in the meantime.
- **Package READMEs** (`channels`, `channels-core`, and the five adapters): removes the "there is no standalone / DIY runner" phrasing, which contradicted the above, in favor of the same managed-vs-custom framing.

Intentionally does **not** add any implementation guidance for custom runners (no state-store interface details, no persistence examples).

Follow-up (not in this PR): swap in the updated architecture diagram assets (light + dark) that show the "Build Your Own Channel Runner" box alongside Enterprise Intelligence.

Refs [FAC-155](https://linear.app/copilotkit/issue/FAC-155/channels-docs-lack-a-clear-supported-path-without-intelligence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)