### PR TITLE
fix(react-core): ship a single v2 context instance

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build:css": "tailwindcss -i ./src/v2/styles/globals.css -o ./dist/v2/index.css -m && node scripts/scope-preflight.mjs ./dist/v2/index.css",
-    "build": "tsdown && pnpm run build:css",
+    "build": "tsdown && pnpm run build:css && node scripts/context-singleton-preflight.mjs",
     "size": "size-limit",
     "size:headline": "node scripts/measure-copilotchat.mjs",
     "compat-check": "es-check es2022 --module 'dist/**/!(*.umd).{mjs,cjs,js}' && es-check es2020 'dist/**/*.umd.js'",

--- a/packages/react-core/scripts/context-singleton-preflight.mjs
+++ b/packages/react-core/scripts/context-singleton-preflight.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Fails the build if `src/v2/context.ts` is inlined into any bundle other than
+ * its own `dist/v2/context.*` entry (the self-contained UMD builds excepted).
+ *
+ * Why this needs a dedicated guard: a duplicated context module is invisible to
+ * every other gate. `tsc`, vitest (which imports source, where there is only one
+ * module), publint and attw all pass while the shipped package contains two
+ * `createContext()` results. The only symptom is at runtime in a consumer app —
+ * `CopilotKitProvider` publishes to the copy inlined in its own chunk, while
+ * anything importing from `@copilotkit/react-core/v2/context` reads a second,
+ * orphaned copy that nothing ever provides and so returns the defaults forever
+ * (e.g. `useLicenseContext().status` pinned to `null` on a valid license).
+ *
+ * tsdown emits a `//#region <src path>` banner for each inlined module, so the
+ * banner appearing outside the allow-list means the module got bundled twice.
+ */
+import fs from "fs";
+import path from "path";
+
+const MARKER = "//#region src/v2/context.ts";
+
+// Bundles that are allowed to contain the module:
+//   dist/v2/context.*  — the standalone entry itself
+//   *.umd.js           — UMD is intentionally self-contained (single-file drop-in)
+const ALLOWED = [/^v2\/context\.(mjs|cjs)$/, /\.umd\.js$/];
+
+const distDir = path.resolve(process.argv[2] ?? "dist");
+
+const jsFiles = [];
+const walk = (current) => {
+  for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+    const full = path.join(current, entry.name);
+    if (entry.isDirectory()) walk(full);
+    else if (/\.(mjs|cjs|js)$/.test(entry.name)) jsFiles.push(full);
+  }
+};
+
+if (!fs.existsSync(distDir)) {
+  console.error(`context-singleton-preflight: ${distDir} does not exist`);
+  process.exit(1);
+}
+walk(distDir);
+
+const carriers = jsFiles.filter((f) =>
+  fs.readFileSync(f, "utf8").includes(MARKER),
+);
+const rel = (f) => path.relative(distDir, f).split(path.sep).join("/");
+
+// Self-check: if the marker convention ever changes, this guard would silently
+// pass on everything. Require the standalone entry to carry it.
+if (!carriers.some((f) => /^v2\/context\.(mjs|cjs)$/.test(rel(f)))) {
+  console.error(
+    `context-singleton-preflight: marker ${MARKER} not found in dist/v2/context.*\n` +
+      `The guard can no longer detect duplication — update MARKER to match the ` +
+      `current bundler output before shipping.`,
+  );
+  process.exit(1);
+}
+
+const offenders = carriers
+  .map(rel)
+  .filter((f) => !ALLOWED.some((allowed) => allowed.test(f)));
+
+if (offenders.length > 0) {
+  console.error(
+    `context-singleton-preflight: src/v2/context.ts is bundled into ${offenders.length} ` +
+      `unexpected file(s):\n` +
+      offenders.map((f) => `  - ${f}`).join("\n") +
+      `\n\nThese ship a duplicate React context: whatever CopilotKitProvider ends up ` +
+      `in will publish to a different instance than @copilotkit/react-core/v2/context ` +
+      `exposes, so consumers of that subpath silently read stale defaults.\n` +
+      `Fix: apply the \`externalizeContext\` plugin to that build in tsdown.config.ts.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `context-singleton-preflight: OK — src/v2/context.ts bundled only into ${carriers.length} allowed target(s).`,
+);

--- a/packages/react-core/src/v2/__tests__/dist-context-singleton.test.tsx
+++ b/packages/react-core/src/v2/__tests__/dist-context-singleton.test.tsx
@@ -1,0 +1,111 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import fs from "fs";
+import path from "path";
+
+/**
+ * End-to-end reproduction of the duplicated-context bug, against the BUILT dist
+ * across the two public entry points — exactly how a consumer app wires it:
+ *
+ *   provider <- @copilotkit/react-core/v2         (shared chunk)
+ *   hook     <- @copilotkit/react-core/v2/context (standalone entry)
+ *
+ * When `src/v2/context.ts` is bundled into both, `createContext()` runs twice:
+ * the provider publishes to its inlined copy while the subpath serves an
+ * orphaned one, so this test sees `null` instead of the server-reported status.
+ *
+ * The hard gate for that regression is `scripts/context-singleton-preflight.mjs`,
+ * which runs as part of `build`. This test is extra confidence and is skipped
+ * when dist is absent, because `test` does not depend on this package's own
+ * `build` (nx `test.dependsOn` is `^build` — upstream only).
+ */
+const pkgRoot = path.resolve(__dirname, "../../..");
+const distEntry = path.join(pkgRoot, "dist/v2/index.mjs");
+const distContext = path.join(pkgRoot, "dist/v2/context.mjs");
+// dist/v2/index.mjs has a side-effect `import "./index.css"`, emitted by
+// `build:css`. Without it the import fails for a reason unrelated to this test.
+const distCss = path.join(pkgRoot, "dist/v2/index.css");
+
+const distReady =
+  fs.existsSync(distEntry) &&
+  fs.existsSync(distContext) &&
+  fs.existsSync(distCss);
+
+if (!distReady) {
+  console.warn(
+    "[dist-context-singleton] SKIPPED — no built dist found. " +
+      "Run `pnpm build` in packages/react-core to exercise this test. " +
+      "The build-time guard (scripts/context-singleton-preflight.mjs) still covers this regression.",
+  );
+}
+
+function mockInfo(licenseStatus?: string) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      version: "1.0.0",
+      agents: {},
+      audioFileTranscriptionEnabled: false,
+      mode: "intelligence",
+      licenseStatus,
+    }),
+  });
+}
+
+describe.skipIf(!distReady)(
+  "dist: /v2 provider -> /v2/context consumer",
+  () => {
+    let CopilotKitProvider: React.ComponentType<any>;
+    let LicenseProbe: React.ComponentType;
+
+    beforeAll(async () => {
+      // Paths are computed, and @vite-ignore'd, so a missing dist cannot break
+      // transform-time analysis for the skipped case.
+      const entryMod = await import(
+        /* @vite-ignore */ new URL(`file://${distEntry}`).href
+      );
+      const contextMod = await import(
+        /* @vite-ignore */ new URL(`file://${distContext}`).href
+      );
+      CopilotKitProvider = entryMod.CopilotKitProvider;
+      const useLicenseContext = contextMod.useLicenseContext;
+      LicenseProbe = () => {
+        const { status } = useLicenseContext();
+        return <div data-testid="status">{String(status)}</div>;
+      };
+    });
+
+    let originalFetch: typeof globalThis.fetch;
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+    });
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it.each(["valid", "expired"])(
+      "useLicenseContext sees server-reported '%s', not the default",
+      async (status) => {
+        globalThis.fetch = mockInfo(status) as any;
+        render(
+          <CopilotKitProvider runtimeUrl="/api">
+            <LicenseProbe />
+          </CopilotKitProvider>,
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("status").textContent).toBe(status);
+        });
+      },
+    );
+  },
+);

--- a/packages/react-core/src/v2/providers/__tests__/providers-exports.test.ts
+++ b/packages/react-core/src/v2/providers/__tests__/providers-exports.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import * as providers from "../index";
+
+// `src/v2/providers/index.ts` enumerates its exports by name rather than
+// re-exporting `*`, so a hook can exist, be re-exported by CopilotKitProvider.tsx,
+// and still never reach `@copilotkit/react-core/v2`. That is how
+// `useLicenseContext` went missing from the public entry: the only path that
+// exposed it was `@copilotkit/react-core/v2/context`, which (before the build
+// was fixed to externalize the context module) served an orphaned copy that no
+// provider ever populated.
+//
+// Typing the list as `(keyof typeof providers)[]` also fails `tsc` if one of
+// these is removed, so the surface is guarded at build time too.
+describe("@copilotkit/react-core/v2 provider entry exports", () => {
+  it("exports the provider hooks as runtime functions", () => {
+    const hooks: (keyof typeof providers)[] = [
+      "useCopilotKit",
+      "useLicenseContext",
+      "useCopilotChatConfiguration",
+      "useSandboxFunctions",
+    ];
+    for (const name of hooks) {
+      expect(
+        typeof providers[name],
+        `${name} should be exported as a runtime function`,
+      ).toBe("function");
+    }
+  });
+
+  it("exports the providers themselves", () => {
+    const values: (keyof typeof providers)[] = [
+      "CopilotKitProvider",
+      "CopilotChatConfigurationProvider",
+      "SandboxFunctionsContext",
+    ];
+    for (const name of values) {
+      expect(providers[name], `${name} should be exported`).toBeDefined();
+    }
+  });
+});

--- a/packages/react-core/src/v2/providers/index.ts
+++ b/packages/react-core/src/v2/providers/index.ts
@@ -9,6 +9,7 @@ export {
 export {
   CopilotKitProvider,
   useCopilotKit,
+  useLicenseContext,
   type CopilotKitProviderProps,
   type CopilotKitContextValue,
 } from "./CopilotKitProvider";

--- a/packages/react-core/tsdown.config.ts
+++ b/packages/react-core/tsdown.config.ts
@@ -44,6 +44,40 @@ const postProcessDeclarations = (dir: string) => {
   if (fs.existsSync(dir)) walk(dir);
 };
 
+// Redirects any relative `../context` / `./context` import that resolves to
+// src/v2/context.ts onto the external `@copilotkit/react-core/v2/context`
+// package path.
+//
+// src/v2/context.ts is emitted as its own entry (dist/v2/context.*) so React
+// Native can consume it without dragging in the web bundle. Any build that ALSO
+// inlines it ends up running `createContext()` a second time, producing a
+// distinct context instance: `CopilotKitProvider` would publish to its inlined
+// copy while consumers importing from `@copilotkit/react-core/v2/context` read
+// the orphaned one and only ever see the defaults (e.g. `useLicenseContext()`
+// stuck at `status: null`). Externalizing keeps exactly one instance at runtime.
+//
+// The UMD builds deliberately skip this — they must stay self-contained.
+const externalizeContext = {
+  name: "externalize-context",
+  resolveId(source: string, importer?: string) {
+    // When any file imports ../context or ./context, redirect to
+    // the external package path so the context singleton is shared.
+    if (importer && /context(\.ts)?$/.test(source)) {
+      const resolved = path.resolve(path.dirname(importer), source);
+      if (
+        resolved === contextModulePath ||
+        resolved === contextModulePath + ".ts"
+      ) {
+        return {
+          id: "@copilotkit/react-core/v2/context",
+          external: true,
+        };
+      }
+    }
+    return null;
+  },
+};
+
 export default defineConfig([
   {
     entry: ["src/index.tsx", "src/v2/index.ts"],
@@ -55,11 +89,13 @@ export default defineConfig([
     hooks: {
       "build:done": () => postProcessDeclarations(path.resolve("dist")),
     },
+    plugins: [externalizeContext],
     external: [
       "react",
       "react-dom",
       "@copilotkit/core",
       "@copilotkit/shared",
+      "@copilotkit/react-core/v2/context",
       "@copilotkit/web-inspector",
       "@copilotkit/a2ui-renderer",
       // Keep @copilotkit/web-components (the Lit drawer element) + its subpaths
@@ -114,28 +150,7 @@ export default defineConfig([
     sourcemap: true,
     target: "es2022",
     outDir: "dist/v2",
-    plugins: [
-      {
-        name: "externalize-context",
-        resolveId(source, importer) {
-          // When any file imports ../context or ./context, redirect to
-          // the external package path so the context singleton is shared.
-          if (importer && /context(\.ts)?$/.test(source)) {
-            const resolved = path.resolve(path.dirname(importer), source);
-            if (
-              resolved === contextModulePath ||
-              resolved === contextModulePath + ".ts"
-            ) {
-              return {
-                id: "@copilotkit/react-core/v2/context",
-                external: true,
-              };
-            }
-          }
-          return null;
-        },
-      },
-    ],
+    plugins: [externalizeContext],
     external: [
       "react",
       "@ag-ui/client",


### PR DESCRIPTION
## Problem

`@copilotkit/react-core` ships **two independent copies** of the v2 context module, so `useLicenseContext` imported from `@copilotkit/react-core/v2/context` returns the default forever — `status: null` even when `/info` reports `licenseStatus: "valid"`. Reported downstream as a chat-history sidebar that never loads, because `useThreads` is gated on license status.

`src/v2/context.ts` is compiled by two separate tsdown builds:

| Build | Output | Contains |
|---|---|---|
| `entry: ["src/index.tsx", "src/v2/index.ts"]` | `dist/` shared chunk | inlined copy **A** |
| `entry: {context: "src/v2/context.ts"}` | `dist/v2/context.*` | standalone copy **B** |

There is no import edge between them, so `createContext()` runs twice. `CopilotKitProvider` lives in the shared chunk and publishes to **A**; `@copilotkit/react-core/v2/context` exports **B**, which nothing ever provides.

Verified against the published 1.66.4 artifact:

```
$ grep -n "createContext" dist/v2/context.mjs
104:const CopilotKitContext = createContext(null);
124:const LicenseContext = createContext({

$ grep -n "createContext" dist/copilotkit-nRjRp2_5.mjs   # inside //#region src/v2/context.ts
1522:const CopilotKitContext = createContext(null);
1544:const LicenseContext = createContext({

$ grep -E '^import .*from "[^"]*context[^"]*"' dist/copilotkit-nRjRp2_5.mjs
                                                          # (empty — no import edge)
```

`CopilotKitContext` is duplicated identically, so `useCopilotKit` imported from that subpath throws `"useCopilotKit must be used within CopilotKitProvider"`. The subpath was effectively unusable for web consumers; license was just the *silent* failure mode.

**Compounding defect:** `src/v2/providers/index.ts` enumerates its exports by name and omits `useLicenseContext` (even though `CopilotKitProvider.tsx:19` re-exports it). So the live copy had **no public import path at all**, leaving consumers with no correct alternative.

Not a 1.66.x regression — broken since c3c30969e4 (2026-05-06), the commit that introduced the split.

## Fix

1. **`tsdown.config.ts`** — hoist the existing `externalize-context` plugin and apply it to the `dist/` build. The headless build already used it for exactly this reason ("ensuring a shared React context instance at runtime"); it was simply never applied here. One instance now. UMD builds stay self-contained by design.
2. **`src/v2/providers/index.ts`** — export `useLicenseContext`.
3. **`scripts/context-singleton-preflight.mjs`** *(new)* — build-time guard, wired into `build`.
4. **`src/v2/providers/__tests__/providers-exports.test.ts`** *(new)*.

### Why a guard

This bug class is invisible to every gate we have. On the broken build, `tsc`, 1471 vitest tests, `publint` and `attw` were **all green** while the published package shipped two contexts — vitest imports *source*, where only one module exists. The guard keys off the `//#region src/v2/context.ts` banner tsdown emits per inlined module, and self-checks: if that banner convention ever changes it fails loudly rather than silently passing everything.

## Testing

**End-to-end reproduction against the built dist** — provider from `/v2`, hook from `/v2/context`, exactly as a consumer app wires it. This is the test that most directly encodes the reported bug.

Against a **pre-fix** build (rebuilt from the parent commit's `tsdown.config.ts`):

```
× useLicenseContext sees server-reported 'valid', not the default
  → expected 'null' to be 'valid'
× useLicenseContext sees server-reported 'expired', not the default
  → expected 'null' to be 'expired'
```

That `'null'` is precisely the reported symptom — a valid license read as `status: null`, permanently disabling license-gated features.

Against this branch:

```
✓ src/v2/__tests__/dist-context-singleton.test.tsx (2 tests)
```

It also confirms the self-reference resolves under a real bundler (Vite), and it degrades to a loud skip when no dist is present (verified by removing `dist/v2/index.css`): nx `test.dependsOn` is `^build`, so this package's own build is not guaranteed to have run before `test`. The hard gate is therefore the preflight, which runs as part of `build`.

**Both build-level guards proven red→green — not merely green.**

Preflight against the **actual published 1.66.4 dist** (expected fail):

```
$ node scripts/context-singleton-preflight.mjs .../copilotkit-react-core-1.66.4/dist
context-singleton-preflight: src/v2/context.ts is bundled into 2 unexpected file(s):
  - copilotkit-nRjRp2_5.mjs
  - copilotkit-sitn7Oe8.cjs
exit=1
```

Preflight on this branch's build (expected pass):

```
$ node scripts/context-singleton-preflight.mjs
context-singleton-preflight: OK — src/v2/context.ts bundled only into 4 allowed target(s).
exit=0
```

New export test with the fix line removed (expected fail):

```
× exports the provider hooks as runtime functions
  → useLicenseContext should be exported as a runtime function: expected 'undefined' to be 'function'
```

Emitted-bundle verification after the fix:

```
$ grep -c "checkFeature: () => true" dist/copilotkit-*.mjs   # shared chunk no longer defines it
0
$ grep -o 'from "@copilotkit/react-core/v2/context"' dist/copilotkit-*.mjs | head -1
from "@copilotkit/react-core/v2/context"
$ grep -o 'require("@copilotkit/react-core/v2/context")' dist/copilotkit-*.cjs | head -1
require("@copilotkit/react-core/v2/context")
```

UMD must stay self-contained (own copy, no external import) — confirmed unchanged:

```
dist/index.umd.js:    ownCopy=1 externalImport=0
dist/v2/index.umd.js: ownCopy=1 externalImport=0
```

Full gates:

```
$ vitest run
 Test Files  124 passed (124)
      Tests  1475 passed (1475)

$ tsc --noEmit           # exit 0
$ oxlint <changed files> # Found 0 warnings and 0 errors.
$ oxfmt                  # clean
$ publint .              # clean (only pre-existing repository.url suggestion)
$ attw --pack . --profile node16
"@copilotkit/react-core"             node16 CJS/ESM 🟢  bundler 🟢
"@copilotkit/react-core/v2"          node16 CJS/ESM 🟢  bundler 🟢
"@copilotkit/react-core/v2/context"  node16 CJS/ESM 🟢  bundler 🟢
"@copilotkit/react-core/v2/headless" node16 CJS/ESM 🟢  bundler 🟢
```

Bundle-size impact is negligible: `dist/v2/context.mjs` is 4.6 KB, and the `bundle-size` / `copilotchat-import-size` CI checks both pass.

## Reviewer note — one behavioral trade-off

v1 and v2 share the emitted chunk, so `@copilotkit/react-core` (v1) now **transitively depends on package self-reference**. I verified this resolves under both ESM and CJS (above), and it's the same mechanism `/v2/headless` already ships. Every `exports`-map-aware resolver handles it, but a legacy `main`-only resolver (webpack 4) would not. Flagging explicitly rather than assuming, since v1 is fully supported.

Avoiding it entirely would mean splitting v1 and v2 into separate bundles, which duplicates the whole shared chunk — strictly worse. Happy to take that route if we still support webpack-4-era consumers.

## Workaround for consumers on 1.66.4

```tsx
import { useCopilotKit } from "@copilotkit/react-core/v2"; // NOT /v2/context

export function useLicenseStatusCompat() {
  const { copilotkit } = useCopilotKit();
  const [status, setStatus] = useState(copilotkit.licenseStatus);
  useEffect(() => {
    const sync = () => setStatus(copilotkit.licenseStatus);
    const sub = copilotkit.subscribe({ onRuntimeConnectionStatusChanged: sync });
    sync(); // catch-up — /info may resolve before we subscribe
    return () => sub.unsubscribe();
  }, [copilotkit]);
  return status;
}
```

The `sync()` catch-up matters: `useCopilotKit` registers its re-render subscription in an effect with no catch-up read, and a provider-only catch-up (`CopilotKitProvider.tsx:670-696`) won't re-render a `useCopilotKit`-only consumer since `contextValue` doesn't change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
