### PR TITLE
docs: explain managed organization onboarding

### DIFF
--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -14,7 +14,7 @@ For a product-level map of features and hosting options, start with the [Enterpr
   variant="inline"
   title="Start with Cloud-Hosted Enterprise Intelligence"
   body="Create a hosted project, get a project API key, and inspect persistent threads before deciding whether self-hosting is required."
-  ctaLabel="Create a free account"
+  ctaLabel="Start managed onboarding"
   surface="docs_premium_intelligence_architecture_intro"
 />
 

--- a/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
@@ -12,9 +12,9 @@ Cloud-Hosted Enterprise Intelligence is the CopilotKit-operated deployment of th
 
 <OpsPlatformCTA
   variant="inline"
-  title="Create hosted projects and API keys"
-  body="Create a free Enterprise Intelligence account, then use the CLI or dashboard to connect your first app."
-  ctaLabel="Create a free account"
+  title="Start hosted onboarding"
+  body="Sign up or sign in, select an organization and project, then return to the flow that brought you here."
+  ctaLabel="Start managed onboarding"
   surface="docs_premium_managed_intelligence_platform_intro"
 />
 
@@ -26,12 +26,38 @@ The hosted web app is the control surface for developers and administrators. End
 
 Use Cloud-Hosted Enterprise Intelligence when you want the fastest path to production. Use [Self-Hosting Enterprise Intelligence](/premium/self-hosting) when your organization needs the platform inside its own VPC, cluster, or data boundary.
 
-## Login and workspace flow
+## Hosted onboarding
 
-You sign in at [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai). After login, choose or create the organization workspace you want to operate in. The ready page gives you two common paths:
+Start at [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai) or in the CopilotKit CLI.
 
-- `npx copilotkit@latest create` for a new app.
-- `npx copilotkit@latest skills onboard` for adding CopilotKit to an existing app with agent-assisted onboarding.
+<Steps>
+  <Step>
+    ### Sign up or sign in
+
+    New accounts accept the CopilotKit Terms through Clerk during signup. Existing accounts do not re-consent.
+  </Step>
+
+  <Step>
+    ### Select or create an organization
+
+    Select or create an organization in the browser. Organizations created before the rollout cutoff continue without a plan prompt. Only organizations created at or after the rollout cutoff choose Developer or a paid plan. Developer is the no-cost choice, so a paid plan is not required.
+  </Step>
+
+  <Step>
+    ### Select or create a project
+
+    Choose the project that will hold your app's threads, events, runtime connection metadata, and API keys, or create a new one.
+  </Step>
+
+  <Step>
+    ### Continue where you started
+
+    Onboarding resumes the exact CLI or managed flow that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue. In the dashboard, the ready page offers two common paths:
+
+    - `npx copilotkit@latest create` for a new app.
+    - `npx copilotkit@latest skills onboard` for adding CopilotKit to an existing app with agent-assisted onboarding.
+  </Step>
+</Steps>
 
 The [CopilotKit CLI](/cli) uses the same sign-in system. When the CLI needs dashboard access, it opens a browser login flow and then stores a local CLI session so project selection can happen from your terminal.
 
@@ -82,6 +108,10 @@ Some capabilities may appear in the dashboard as early access. Those capabilitie
 
 ## Cloud-hosted vs. self-hosted
 
+<Callout type="info" title="Team Self-hosted is a plan, not a deployment login">
+  A Team Self-hosted purchase uses a Clerk-backed hosted organization, while a customer-run self-hosted deployment uses the customer's identity provider and never uses the Clerk signup or organization plan gate.
+</Callout>
+
 | Choose this | When |
 |---|---|
 | Cloud-Hosted Enterprise Intelligence | You want hosted projects, managed API keys, conversation history, thread inspection, and plan management without running platform infrastructure. |
@@ -90,8 +120,9 @@ Some capabilities may appear in the dashboard as early access. Those capabilitie
 Your application code should stay focused on the CopilotKit frontend SDK and
 runtime. The deployment mode changes which platform endpoint and credentials
 your runtime uses, not how the frontend lists threads or renders chat. Moving
-from cloud-hosted projects to self-hosting is available on the Team self-hosted
-plan or a custom Enterprise plan.
+from cloud-hosted projects to self-hosting requires the Team Self-hosted plan
+or a custom Enterprise plan. That purchase does not replace the identity system
+in a customer-run deployment.
 
 ## Next steps
 

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -8,9 +8,9 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
 
 <OpsPlatformCTA
   variant="inline"
-  title="Start with a hosted Enterprise Intelligence project"
-  body="Create a free account, then copy the create command below to scaffold a connected app."
-  ctaLabel="Create a free account"
+  title="Start managed Intelligence onboarding"
+  body="Sign up or sign in, finish organization onboarding when required, then return to the CLI to connect your app."
+  ctaLabel="Start managed onboarding"
   surface="docs_cli_intro_signup"
 />
 
@@ -19,6 +19,10 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
 - Node.js 20+
 - A CopilotKit account for Cloud-Hosted Enterprise Intelligence
 - An OpenAI API key or another model provider key for the starter app you choose
+
+<Callout type="info" title="Team Self-hosted is a plan, not a deployment login">
+  A Team Self-hosted purchase uses a Clerk-backed hosted organization, while a customer-run self-hosted deployment uses the customer's identity provider and never uses the Clerk signup or organization plan gate.
+</Callout>
 
 ## Start a new app
 
@@ -38,17 +42,25 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
   </Step>
 
   <Step>
-    ### Sign in
+    ### Sign up or sign in
 
-    If you are not already signed in, the CLI opens a browser login flow. Complete login in the browser, then return to the terminal.
+    If you are not already signed in, the CLI opens a browser login flow. New accounts accept the CopilotKit Terms through Clerk during signup. Existing accounts do not re-consent.
 
     If the browser does not open, the CLI prints a login URL and supports a manual paste fallback.
   </Step>
 
   <Step>
-    ### Select a project
+    ### Select or create an organization
+
+    Select or create an organization in the browser. Organizations created before the rollout cutoff continue without a plan prompt. Only organizations created at or after the rollout cutoff choose Developer or a paid plan. Developer is the no-cost choice, so a paid plan is not required.
+  </Step>
+
+  <Step>
+    ### Select or create a project
 
     Choose an existing cloud-hosted project or create a new one. A project is where your app's threads, messages, and platform metadata are stored.
+
+    Onboarding resumes the exact CLI or managed flow that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue.
 
     The CLI writes the selected project to `.copilotkit/project.json`:
 

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -3,15 +3,54 @@ import path from "node:path";
 import { expect, test } from "vitest";
 
 const CONTENT_DIR = path.resolve(import.meta.dirname, "../../content");
+const MANAGED_ONBOARDING_GUIDES = [
+  "docs/premium/managed-intelligence-platform.mdx",
+  "snippets/shared/cli/cli.mdx",
+];
+const MANAGED_CTA_SOURCES = [
+  ...MANAGED_ONBOARDING_GUIDES,
+  "docs/premium/intelligence-platform.mdx",
+];
+
+/** Reads content files used as managed-onboarding contract fixtures. */
+function readSources(
+  relativePaths: readonly string[],
+  normalizeWhitespace = false,
+): string[] {
+  return relativePaths.map((relativePath) => {
+    const source = fs.readFileSync(
+      path.join(CONTENT_DIR, relativePath),
+      "utf8",
+    );
+    return normalizeWhitespace ? source.replace(/\s+/g, " ") : source;
+  });
+}
+
+/** Asserts that a guide presents onboarding requirements in journey order. */
+function expectPatternsInOrder(
+  source: string,
+  patterns: readonly RegExp[],
+): void {
+  let previousIndex = -1;
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(source);
+    if (!match) throw new Error(`Missing onboarding step: ${pattern}`);
+
+    expect(
+      match.index,
+      `Onboarding step is out of order: ${pattern}`,
+    ).toBeGreaterThan(previousIndex);
+    previousIndex = match.index;
+  }
+}
 
 test("names create as the init command alias across managed setup guides", () => {
-  const sources = [
+  const sources = readSources([
     "docs/premium/managed-intelligence-platform.mdx",
     "snippets/shared/cli/cli.mdx",
     "snippets/shared/threads/headless-threads.mdx",
-  ].map((relativePath) =>
-    fs.readFileSync(path.join(CONTENT_DIR, relativePath), "utf8"),
-  );
+  ]);
   const reversedAlias =
     /`create`(?:\s+\(aliased as|\s+(?:and|or)\s+its)\s+`init`/;
   const canonicalAlias =
@@ -24,14 +63,13 @@ test("names create as the init command alias across managed setup guides", () =>
 });
 
 test("documents the managed CLI credential without an offline license token", () => {
-  const sources = [
-    "docs/premium/managed-intelligence-platform.mdx",
-    "snippets/shared/cli/cli.mdx",
-    "snippets/shared/threads/headless-threads.mdx",
-  ].map((relativePath) =>
-    fs
-      .readFileSync(path.join(CONTENT_DIR, relativePath), "utf8")
-      .replace(/\s+/g, " "),
+  const sources = readSources(
+    [
+      "docs/premium/managed-intelligence-platform.mdx",
+      "snippets/shared/cli/cli.mdx",
+      "snippets/shared/threads/headless-threads.mdx",
+    ],
+    true,
   );
 
   for (const source of sources) {
@@ -43,5 +81,39 @@ test("documents the managed CLI credential without an offline license token", ()
       /copy[^.]*`INTELLIGENCE_API_KEY`[^.]*`CPK_INTELLIGENCE_API_KEY`/i,
     );
     expect(source).not.toContain("COPILOTKIT_LICENSE_TOKEN=...");
+  }
+});
+
+test("documents the conditional managed onboarding sequence", () => {
+  const sequence = [
+    /new accounts accept[^.]*(?:Clerk[^.]*Terms|Terms[^.]*Clerk)/i,
+    /select or create an organization/i,
+    /only organizations created at or after[^.]*cutoff[^.]*Developer or a paid plan/i,
+    /select or create a project/i,
+    /resumes? the exact[^.]*CLI[^.]*managed[^.]*flow/i,
+  ];
+
+  for (const source of readSources(MANAGED_ONBOARDING_GUIDES, true)) {
+    expectPatternsInOrder(source, sequence);
+  }
+});
+
+test("documents grandfathering, consent, and customer-run self-hosting boundaries", () => {
+  for (const source of readSources(MANAGED_ONBOARDING_GUIDES, true)) {
+    expect(source).toMatch(
+      /organizations created before[^.]*cutoff[^.]*continue without a plan prompt/i,
+    );
+    expect(source).toMatch(/existing accounts do not re-consent/i);
+    expect(source).toMatch(
+      /Team Self-hosted[^.]*purchase[^.]*customer-run self-hosted deployment[^.]*never uses[^.]*Clerk/i,
+    );
+    expect(source).not.toMatch(/(?:every|all) new organizations?[^.]*paid plan/i);
+  }
+});
+
+test("removes automatic-Free promises from managed onboarding CTAs", () => {
+  for (const source of readSources(MANAGED_CTA_SOURCES)) {
+    expect(source).not.toMatch(/Create a free account/i);
+    expect(source).toContain('ctaLabel="Start managed onboarding"');
   }
 });


### PR DESCRIPTION
## What changed

- replace “Create a free account” with the managed onboarding flow
- document Clerk-native Terms acceptance for new accounts and no re-consent for existing accounts
- explain the cutoff rule: old organizations continue; new organizations choose Developer or a paid plan
- make the CLI return path explicit so the command that opened the browser resumes in place
- separate the Team Self-hosted commercial plan from a customer-run self-hosted deployment

## Why

Managed Intelligence will stop treating Clerk's automatic Free state as a plan choice. These docs set the right expectation without changing starters, runtime packages, or customer-run self-hosted setup.

Implementation plan: https://app.notion.com/p/3b83aa381852818a868acee473e1a07c?pvs=204

## Stack

This draft targets `agent/intelligence-starter-templates` / #6188 because that PR currently owns the same managed onboarding docs. Retarget it to `main` after #6188 merges.

## Validation

- `npm test -- src/lib/__tests__/managed-starter-docs.test.ts` — 5/5 passed
- `npm run typecheck` — passed
- `npm run build` — passed; 222 pages rendered
- `git diff --check` — passed

The build reports the existing Next.js workspace-root and middleware deprecation warnings.
