### PR TITLE
feat(reskinnable-demo): add the commerce skin (Bellwether)

### DIFF
--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   the user says "add a skin", "create a skin", "new skin", "reskin the app",
   "make a <domain> skin", or wants the app re-themed as a new product. Do NOT
   use for editing the shell itself (src/shell/**), the shared token vocabulary
-  (src/app/globals.css), or the five shipped skins unless explicitly asked.
+  (src/app/globals.css), or the six shipped skins unless explicitly asked.
 ---
 
 # Authoring a reskinnable-demo skin
@@ -26,15 +26,16 @@ contract in `src/skins/<id>/`, (3) put its **server-only** agent in
 the identical `id`.
 
 > Before writing anything, re-open `src/shell/skin-contract.ts` (the source of
-> truth) and read the shipped skins as worked references. Five are registered —
-> `banking`, `airline`, `logistics`, `keel`, `people` — and they are good at
-> different things; **[demo-beats.md](./demo-beats.md) § "Which skin to copy for
-> what"** is the routing table. The short version: `banking` and `people` are the
-> two demo-complete skins (`banking` is the original reference; `people` is the
-> newer one, and the only one whose beat map is written out in its
-> `suggestions.ts`), `logistics` is the debugged layout reference, `airline` is
-> the minimal contract surface, `keel` is the only one with parameterized routes.
-> Those files win on any conflict with this skill.
+> truth) and read the shipped skins as worked references. Six are registered —
+> `banking`, `airline`, `logistics`, `keel`, `people`, `commerce` — and they are
+> good at different things; **[demo-beats.md](./demo-beats.md) § "Which skin to
+> copy for what"** is the routing table. The short version: `banking`, `people`
+> and `commerce` are the three demo-complete skins (`banking` is the original
+> reference; `people` and `commerce` are the newer ones, and the only two whose
+> beat maps are written out in their `suggestions.ts`), `logistics` is the
+> debugged layout reference, `airline` is the minimal contract surface, `keel` is
+> the only one with parameterized routes. Those files win on any conflict with
+> this skill.
 
 ---
 
@@ -67,6 +68,17 @@ chat-placement framing) and the quality bar.
 **If the user named the beats** — fewer, more, or different — theirs win. Record
 what they asked for in the beat map and build that. Absent instructions, build
 all nine.
+
+**Then read [failure-modes.md](./failure-modes.md), before you write tools or
+pages.** It is the cross-cutting half of this skill, and its through-line is the
+one thing to carry into every file: **a skin's characteristic bug is not a crash —
+it is a confident falsehood.** A crash is visible on stage and gets fixed; a
+convincing lie reads as success and proves nothing. An empty chart drawn with
+confidence, a lever chip naming a choice the agent never made, a receipt for a
+write that did not land, a readable reporting an all-clear it never checked — all
+of those compile, lint, pass tests, and land as a successful demo. That file states
+the principles and points at the shipped `commerce` code for each; the per-file
+scaffolds stay in [templates.md](./templates.md).
 
 ⚠️ Beats **2, 4, 5 and 6 are runtime-conditional**: they need all three
 `INTELLIGENCE_*` env vars, and beats 4/5 additionally need a seeded-memory file
@@ -117,6 +129,26 @@ it). A skin does **not** supply an OGUI renderer — it only contributes
 a2ui _report_ surface is different: a skin renders its own via the optional
 `CanvasSurface`.)
 
+**A `sandboxFunction`'s `parameters` schema is DOCUMENTATION, not a gate — and its
+returns are undocumented unless the `description` says so.** Two traps, both of
+which produce a generated panel that renders and is wrong:
+
+- The provider serializes `parameters` into agent context and the renderer then
+  hands your bare `handler` to the iframe (`api[fn.name] = fn.handler`). Nothing
+  validates the arguments, so a loose parameter (`category: z.string()`) filters
+  on a value nothing matches and returns `[]` — a convincingly blank view, with
+  the model never told it guessed wrong. Enumerate every parameter to its real
+  domain (`z.enum(YOUR_CONST_TUPLE)`, so the vocabulary reaches the model too) and
+  parse the args in the handler, throwing a message that names the accepted
+  values. Commerce's `define()` wrapper in `src/skins/commerce/sandbox-functions.ts`
+  is the worked example.
+- The model never sees a sample result — only `name`, `description` and the
+  JSON-schema-ified `parameters`. So a figure whose unit is not in its FIELD NAME
+  must have it in the `description`: an unlabelled ratio (`0.418`) renders as
+  "0.42%" or "41.8%" with equal confidence. Commerce ships ratios as
+  `…Ratio` + a `…Label` string built with the app's own formatter, which also makes
+  the generated panel read identically to the app card beside it.
+
 **An a2ui `CanvasSurface` must be fed by a SERVER tool, never a client one.** If
 your skin ships a `CanvasSurface`, emit its `{ [A2UI_OPERATIONS_KEY]:
 buildOps(spec) }` payload from a **server-side `defineTool` on the `BuiltInAgent`
@@ -162,17 +194,17 @@ against that file; it wins.
 
 **Optional:**
 
-| Field                   | Type                                                 | Purpose                                                                                                                                                                                                                                                                                                    |
-| ----------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Providers?`            | `ComponentType<{ children: ReactNode }>`             | Skin-specific provider stack mounted **below** `CopilotKitProvider` (escape hatch). Omit → shell substitutes a pass-through.                                                                                                                                                                               |
-| `CanvasSurface?`        | `ComponentType`                                      | Renders the skin's own a2ui report surface full-region on the shared canvas. Omit if no a2ui report canvas.                                                                                                                                                                                                |
-| `sandboxFunctions?`     | `SandboxFunction[]`                                  | Functions exposed inside OGUI sandboxed iframes for this skin.                                                                                                                                                                                                                                             |
-| `toolLabels?`           | `Record<string, string>`                             | Human labels for this skin's OWN tool-activity chips, keyed by tool name. Unlisted tools fall back to a prettified raw name.                                                                                                                                                                               |
-| `chatHeaderActions?`    | `ChatHeaderAction[]`                                 | Buttons this skin contributes to the shared chat header (drawn before the shell's own controls).                                                                                                                                                                                                           |
-| `onSuggestionSelect?`   | `(suggestion: Suggestion, index: number) => boolean` | Intercept a suggestion click. Return `true` if fully handled (shell does nothing further); return `false`/omit for the default "send the message" path.                                                                                                                                                    |
-| `RuntimeProviders?`     | `ComponentType<{ children: ReactNode }>`             | Provider stack mounted **above** `CopilotKitProvider` (unlike `Providers`, below). The sanctioned place to establish context your `useRuntimeProperties` must read — it has to sit above the provider so the provider owns `properties` from its first commit. See "Contributing end-user identity" below. |
-| `useRuntimeProperties?` | `() => Record<string, unknown> \| undefined`         | Contributes this skin's runtime `properties`; the shell threads the result into `CopilotKitProvider`'s `properties` prop. How a skin scopes its Intelligence runs / durable memory per end-user. Return a stable/memoized object. Omit if the skin contributes no runtime identity.                        |
-| `useData?`              | `() => unknown`                                      | Seed-backed data hook; the shell runs it in `SkinProvider`, components read via `useSkinData<T>()`. **Optional** — omit when the skin has no shell-managed data (banking omits it and reads REST + auth directly; then `useSkinData<T>()` returns `undefined`). Airline supplies a real one.               |
+| Field                   | Type                                                 | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Providers?`            | `ComponentType<{ children: ReactNode }>`             | Skin-specific provider stack mounted **below** `CopilotKitProvider` (escape hatch). Omit → shell substitutes a pass-through.                                                                                                                                                                                                                                                                                                                                                                                |
+| `CanvasSurface?`        | `ComponentType`                                      | Renders the skin's own a2ui report surface full-region on the shared canvas. Omit if no a2ui report canvas.                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `sandboxFunctions?`     | `SandboxFunction[]`                                  | Functions exposed inside OGUI sandboxed iframes for this skin.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `toolLabels?`           | `Record<string, string>`                             | Human labels for this skin's OWN tool-activity chips, keyed by tool name. Unlisted tools fall back to a prettified raw name.                                                                                                                                                                                                                                                                                                                                                                                |
+| `chatHeaderActions?`    | `ChatHeaderAction[]`                                 | Buttons this skin contributes to the shared chat header (drawn before the shell's own controls).                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `onSuggestionSelect?`   | `(suggestion: Suggestion, index: number) => boolean` | Intercept a suggestion click. Return `true` if fully handled (shell does nothing further); return `false`/omit for the default "send the message" path. `true` is a PROMISE that something happened — the handler it launches must either do the thing or tell the presenter why it could not (see beat 3d in demo-beats.md); `true` plus silence is the bug this contract keeps producing.                                                                                                                 |
+| `RuntimeProviders?`     | `ComponentType<{ children: ReactNode }>`             | Provider stack mounted **above** `CopilotKitProvider` (unlike `Providers`, below). The sanctioned place to establish context your `useRuntimeProperties` must read — it has to sit above the provider so the provider owns `properties` from its first commit. See "Contributing end-user identity" below.                                                                                                                                                                                                  |
+| `useRuntimeProperties?` | `() => Record<string, unknown> \| undefined`         | Contributes this skin's runtime `properties`; the shell threads the result into `CopilotKitProvider`'s `properties` prop. How a skin scopes its Intelligence runs / durable memory per end-user. Return a stable/memoized object. Omit if the skin contributes no runtime identity.                                                                                                                                                                                                                         |
+| `useData?`              | `() => unknown`                                      | Seed-backed data hook; the shell runs it in `SkinProvider`, components read via `useSkinData<T>()`. **The standard mechanism for the two in-memory skins, deliberately unused by the four REST-backed ones** — it splits along the substrate line: `airline` (`useAirlineData`) and `keel` (`useKeelData`) each supply a real one; banking, logistics, people and commerce all omit it and read their REST ledger through their own context/hooks, so in those four `useSkinData<T>()` returns `undefined`. |
 
 Supporting types (also in the contract):
 
@@ -233,9 +265,10 @@ overflow-hidden` on the root, plus `h-full` on the `<aside>`, so only `<main>`
 (`src/shell/skin-path.ts`), and every "which nav entry is active" derivation
 through its companion `useSkinSegments`. Both are in the layout template.
 
-Skins live under `/[skin]` on the normal four-skin demo, but a `LOCK_SKIN` deploy
-is served **at `/`** with the segment gone from the URL space entirely —
-`src/proxy.ts` rewrites the prefix-free space onto the route tree. So:
+Skins live under `/[skin]` on the normal demo (one segment per registered skin),
+but a `LOCK_SKIN` deploy is served **at `/`** with the segment gone from the URL
+space entirely — `src/proxy.ts` rewrites the prefix-free space onto the route
+tree. So:
 
 - `skinHref("cards")` → `/banking/cards` unlocked, `/cards` locked.
 - A hardcoded `` `/${skin.id}/cards` `` still RESOLVES under a lock, which is why
@@ -285,8 +318,21 @@ sidebar). Three controls:
 
 - **Reset** (`RotateCcw`) — render it only when `usePresenterReset()` (from
   `@/shell/presenter-reset-context`) is true; on click, `window.confirm` then
-  `POST /api/<id>/v1/dev/reset` then `window.location.assign(`/${skin.id}`)` for a
-  pristine slate. Keep the button and the endpoint in agreement: your skin's own
+  `POST /api/<id>/v1/dev/reset` then `window.location.assign(skinHref())` for a
+  pristine slate. **Branch on what the route says about the STORE, not on
+  `res.ok`** — the route wipes the store first and can still answer non-2xx, so an
+  ok-only branch leaves the page (and the readables describing it) asserting rows
+  that are gone, and throws away the body's `memoryError` sentence, which is the
+  only warning that beat 6 may start out already taught. See the scaffold in
+  templates.md and `runPresenterReset` in `src/skins/commerce/layout.tsx`.
+  This one deliberately IS a full document load rather than a
+  `router.push` — dropping every module reload-fresh is the point (new store, new
+  thread, cleared canvas) — but the URL it navigates to is still built by
+  `useSkinHref`, exactly as in the layout template. Do **not** hand-roll it as
+  `` `/${skin.id}` ``: that is shape (iii) from the URL contract above, so it fails
+  `pnpm lint`, and on a locked deploy it re-introduces the tenant segment the
+  reset is supposed to leave behind (`skinHref()` returns `/` there). Keep the
+  button and the endpoint in agreement: your skin's own
   `dev/reset` route should allow the reset when `presenterResetEnabled() ||
 process.env.NODE_ENV !== "production"` (mirror
   `src/app/api/logistics/v1/dev/reset/route.ts`), or a production booth shows a
@@ -303,7 +349,7 @@ process.env.NODE_ENV !== "production"` (mirror
 
 ## Registering tools: deps, render signatures, replay safety, readables
 
-Four rules that the `tools.tsx` template bakes in; miss any and the failure is
+Five rules that the `tools.tsx` template bakes in; miss any and the failure is
 silent.
 
 - **Every `useComponent` / `useFrontendTool` / `useHumanInTheLoop` registration
@@ -326,6 +372,53 @@ silent.
   contrast `useHumanInTheLoop` and `useFrontendTool` renders DO receive `{ args,
 status, respond }`. Airline has no parameterized `useComponent`, so don't learn
   the render shape from it — see the template and logistics' `showShipment`.
+- **A gen-UI render's `parameters` schema is NOT enforced either, and a render-only
+  tool has no way to report a bad argument back.** Same trap as a
+  `sandboxFunction`'s schema (above), one degree worse. A `useComponent` render is
+  handed `partialJSONParse(toolCall.function.arguments)` verbatim
+  (`use-render-tool-call.tsx` in `@copilotkit/react-core`); the schema is only
+  serialized into the tool definition the model reads. And because a
+  render-only tool has no `handler`, core posts an EMPTY tool result
+  (`executeSpecificTool` in `run-handler.ts`), so there is no string to correct the
+  model with — the sandbox's "throw a message naming the accepted values" escape
+  hatch does not exist here. So do BOTH: enumerate the parameter to its real
+  domain (`z.enum(YOUR_CONST_TUPLE)`, which is what puts the vocabulary in front of
+  the model), AND resolve it explicitly in the render, drawing a plain "there is no
+  such X, the real ones are …" card instead of the visual. Commerce's
+  `showMarginLadder` + `src/skins/commerce/category-argument.ts` is the worked
+  example: a `z.string()` category meant "Shoes" for "Footwear" drew the signature
+  five-rail ladder with ZERO dots on it — an empty view that renders confidently is
+  the worst outcome available, because it looks like an answer. Note the third
+  state that module carries: arguments STREAM, so a value that is still a PREFIX of
+  a real member is "not arrived yet", not a refusal — refuse it and you flash a red
+  card on every call the demo makes.
+- **EVERY argument is `undefined` mid-render, including the ones your schema
+  declares REQUIRED.** The point above is about a value that arrived and was
+  wrong; this one is about a value that has not arrived at all. A render runs from
+  the first frame of its tool call, and `partialJSONParse` returns `{}` for those
+  frames, so `.optional()` is not what makes a field absent and a required field
+  is not what makes it present. Two different bugs come out of that and one guard
+  fixes only one of them:
+  - it **THROWS**: `orderIds.map(…)` / `list.length` / `id.replace(…)` on an
+    argument that is still `undefined` is a TypeError **inside React render**.
+    Guard the shape — banking's `showTable` is the reference (`columns ?? []`,
+    `rows ?? []`, `src/skins/banking/tools.tsx:793-794`) — and remember the
+    CONTENTS too: a half-streamed `["` parses to `[""]`.
+  - it **LIES**: formatting an absent value into a confident label asserts a
+    choice nobody made. `showOrderQueue`'s Sort chip printed "Sort · oldest first"
+    over an unset lever (see `src/skins/commerce/order-queue-levers.ts`);
+    `showProduct` flashed a red "nothing matches ''" before its needle arrived;
+    `showMarginSummary` drew beat 4's rose "why" band as an empty coloured bar
+    while the note streamed. The fix is never a default — it is to render only
+    what is known.
+
+  And do not over-guard into silence: a card that returns nothing while arguments
+  stream is worse television than a placeholder, because beat 1 leads with
+  generative UI and the room is watching it appear. Commerce's `ArrivingCard` +
+  `arrivedText` in `src/skins/commerce/tools.tsx` are the worked example —
+  one muted card that names only what has arrived, and the confident branch
+  (a miss, a receipt, a label) reserved for arguments that actually landed.
+
 - **Renders must be REPLAY-SAFE: key them off the tool `result`, NOT off
   `status`.** Reopening a thread (or reloading the browser in Intelligence mode)
   replays recorded tool calls, so you get the stored **result** and no live status
@@ -333,7 +426,8 @@ status, respond }`. Airline has no parameterized `useComponent`, so don't learn
   renders blank or wrong the moment anyone revisits the thread — which is exactly
   when beat 2 ("reload and the chart is still there") is being shown. Re-derive
   display state from the replayed result, and never depend on client state that
-  only existed during the live call. Banking and people are the only skins
+  only existed during the live call. Banking, people and commerce are the only
+  skins
   written this way; banking's is the canonical example:
   `setCardPin` re-derives its card from the replayed result plus a module map
   holding only `brand`/`last4` — never the PIN (`tools.tsx:70-89`, `418-451`) —
@@ -344,7 +438,8 @@ status, respond }`. Airline has no parameterized `useComponent`, so don't learn
   each _page_ component tell it what is visibly on screen (active filters, the
   rows actually rendered, the figures shown). Without both, "what's on my
   screen?" (beat 3b) returns the same answer on every page and the beat dies.
-  Banking and people are the only skins that do this. Banking: route readable at
+  Banking, people and commerce are the only skins that do this. Banking: route
+  readable at
   `layout.tsx:141-143`, page-scoped readables in `dashboard.tsx:148`,
   `cards.tsx:376`, `team.tsx:54`, and the richest in `charges.tsx:139`. People
   does the same across all four of its pages, and is the tighter read if you want
@@ -426,22 +521,25 @@ Optional slots you may omit — airline omits all of these EXCEPT `toolLabels` a
 `canvas-surface.tsx` (→ `CanvasSurface`), `sandboxFunctions`,
 `chatHeaderActions`, `onSuggestionSelect`.
 
-`useData` / `data/` is where the substrates split, and it is a 2-2 split rather
-than a banking-vs-airline one: **banking and logistics** are REST-backed and OMIT
-`useData` (their components read the ledger directly, so `useSkinData<T>()`
-returns `undefined`); **airline and keel** are in-memory and SET it
-(`useAirlineData`, `useKeelData`).
+`useData` / `data/` is where the substrates split, and it is a 4-2 split rather
+than a banking-vs-airline one: **banking, logistics, people and commerce** are
+REST-backed and OMIT `useData` (their components read the ledger directly, so
+`useSkinData<T>()` returns `undefined`); **airline and keel** are in-memory and
+SET it (`useAirlineData`, `useKeelData`).
 
 Airline DOES set `toolLabels` (a 9-entry map) so its tool-activity chips read as
 human phrases ("Pulling up your flight") instead of raw tool names (`showFlight`)
 — treat `toolLabels` as expected for any skin with named frontend tools, not
 optional in practice. `RuntimeProviders`/`useRuntimeProperties`/`identifyUser`
 are for a skin with its own end-user identity (see the identity section above);
-banking, logistics, keel and people all four ship them, airline none.
+banking, logistics, keel, people and commerce all five ship them, airline none.
 
 `intelligence/seed-memories.ts` is **not** optional if you are building beats 4
-and 5 — "it already knows me" is a seeded file, not emergent behaviour, and only
-banking and people have one. It seeds the topical preference (beat 4) and the operational
+and 5 — "it already knows me" is a seeded file, not emergent behaviour, so every
+demo-complete skin ships one (`banking`, `commerce` and `people`, each alongside a
+sibling `forget-memories.ts` its `dev/reset` route calls first); a skin claiming
+those beats without one is claiming behaviour it does not have. It seeds the
+topical preference (beat 4) and the operational
 procedure (beat 5), and deliberately does NOT seed beat 6's procedure — that is
 the one the agent has to learn on stage. See
 **[demo-beats.md](./demo-beats.md) § "Seeding memories"**.
@@ -481,7 +579,9 @@ Run `pnpm build` after wiring things up — `next build` type-checks the whole a
 
 ## Registration (the only shared-file touch)
 
-Two appends, both keyed by the identical `id`.
+Five appends. The first two are keyed by the identical `id`; the third teaches the
+lint guard that your id exists; the last two are the hand-copied config in
+`src/shell/skins-config.ts` that server components read. All five are REQUIRED.
 
 **1. Client skin** — `src/shell/registry.ts`:
 
@@ -523,7 +623,77 @@ export const agentRegistry: Record<string, AgentRegistration> = {
 (`AgentRegistration` and the `IdentifyRunUser` type are declared in
 `agent-registry.ts` itself — import the type from there for your resolver.)
 
-**3. (Optional) default skin** — set `defaultSkinId` in
+⚠️ **This is the one append with NO automated guard.** No test imports
+`agent-registry.ts` (`grep -rln agentRegistry src --include='*.test.*'` is empty),
+and its `Record<string, AgentRegistration>` type accepts a missing key, so
+forgetting it builds, lints and renders — the only symptom is Verification step 5:
+sending a chat message errors with an unknown agent. Appends 3–5 below are all
+compared against `registry.ts` by `skins-config.test.ts`; this one is on you.
+
+**3. Lint guard id list** — append your id to `LINTED_SKIN_IDS` in
+`eslint.config.mjs`. This is REQUIRED, not optional: that array is what the
+URL-contract selectors interpolate into their regexes, so until your id is in it
+`pnpm lint` is BLIND to your skin and a hardcoded `"/support/tickets"` href passes
+clean while breaking the address bar under a lock. It is a hand-copy of `skinIds`
+because an ESLint flat config is loaded by Node and cannot import a `.ts` module.
+
+```ts
+export const LINTED_SKIN_IDS = [
+  "banking",
+  "airline",
+  "logistics",
+  "keel",
+  "people",
+  "commerce",
+  "support", // ← add
+];
+```
+
+Forgetting this fails `pnpm test:unit` — `src/shell/skins-config.test.ts` lints a
+synthetic prefixed link for every registered skin through the real selectors, so an
+unguarded id is RED rather than silent. (That test exists because this list DID rot:
+it named four skins for two releases after `people` and `commerce` shipped.)
+
+**4. LOCK_SKIN id list** — append your id to `skinIds` in
+`src/shell/skins-config.ts`, in registry order. That module stays import-free so
+server components can read it, which forces the list to be a hand-copy of the
+registry's keys — and it is the set the `LOCK_SKIN` validator accepts, so until
+your id is in it `LOCK_SKIN=<id>` throws at boot and `/` cannot serve your skin:
+
+```ts
+export const skinIds = [
+  "banking",
+  "airline",
+  "logistics",
+  "keel",
+  "people",
+  "commerce",
+  "support", // ← add
+] as const;
+```
+
+**5. Locked-deploy metadata** — add an entry to `skinIdentities`, in the same
+file, copying your `identity.brand` and `identity.tagline` VERBATIM. The root
+layout's `generateMetadata` (`src/app/layout.tsx`) is a server component and
+reads this map — not your skin module — to give a locked deploy the brand as its
+`<title>` and the tagline as its `<meta name="description">`:
+
+```ts
+export const skinIdentities: Record<
+  (typeof skinIds)[number],
+  { brand: string; tagline: string }
+> = {
+  // …existing skins…
+  support: { brand: "Support Desk", tagline: "Every ticket, answered." }, // ← add
+};
+```
+
+Neither of those two can be forgotten quietly. A missing `skinIdentities` entry is
+a `pnpm build` type error, because the `Record` key type is derived from `skinIds`;
+a WRONG brand or tagline, or an id missing from `skinIds`, is caught by
+`skins-config.test.ts`, which compares both against the registry.
+
+**6. (Optional) default skin** — set `defaultSkinId` in
 `src/shell/skins-config.ts` if the `/` redirect should land on your new skin:
 
 ```ts
@@ -551,8 +721,12 @@ Do NOT touch anything else in the shell.
    `no-restricted-syntax` skin-prefix selectors in `eslint.config.mjs`, which fail
    and NAME YOUR FILE if any link in your skin hardcodes its route prefix or
    hand-concatenates onto a builder result (a leading `//`). It is the cheap check
-   for the contract above; step 8 is the real one. (`pnpm test:unit` should also be
-   green — it just no longer carries this particular guard, which moved to lint.)
+   for the contract above; step 8 is the real one. **This only works if your id is
+   in `LINTED_SKIN_IDS`** (registration step 3) — otherwise lint is green because it
+   is not looking. `pnpm test:unit` must also be green; `skins-config.test.ts` is
+   what catches an id missing from that list, and `skin-roster-docs.test.ts` what
+   catches prose left behind — a skin count or a "valid ids" list in CLAUDE.md,
+   README.md, `.env.example` or this skill that predates your skin.
 8. **Run your skin locked**: stop the dev server, then
    `LOCK_SKIN=<id> pnpm dev`, and open **`/`** (not `/<id>`). Your skin must
    render at the root, every nav href in the DOM must be prefix-free, and

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/demo-beats.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/demo-beats.md
@@ -40,7 +40,7 @@ tell a deliberate choice from an oversight.
 **If the user named which beats to hit** — fewer, more, or different ones — theirs
 win outright. Record what they asked for in the map (`"user: BI dashboards only,
 no teach mode"`) and build that. Absent instructions, build all nine rows: that
-is what makes a skin demo-complete, and three of the five shipped skins are
+is what makes a skin demo-complete, and three of the six shipped skins are
 missing most of them (see "Which skin to copy" at the end).
 
 ---
@@ -115,6 +115,26 @@ which record first** (it should fire the tool immediately), and the gen-UI from
 beat 1 must **stay** in the transcript — the conversation must not collapse into
 "OK, PIN set."
 
+**The card's own guidance must be a figure the card ACCEPTS.** Any ceiling, floor
+or format the component PRINTS has to come out of the same expression its submit
+predicate compares against. Commerce printed `up to ${formatMoney(itemValue)}` —
+rounded to whole dollars — beside a button comparing the typed amount EXACTLY
+against `itemValue`, so a $152.50 return invited "up to $153" and then sat
+disabled with nothing on screen saying why. That is worse than a wrong number:
+the presenter follows the app's own instruction on stage and the app refuses. Have
+one helper return the guidance AND the predicate (`refundGuidance` in
+`skins/commerce/data/derive.ts`), and print each figure from one place.
+
+**And that helper must REFUSE a figure it cannot read, never rewrite it.** The
+same helper parsed the typed string with `Number(typed.replace(/[^0-9.]/g, ""))`,
+which deletes whatever it does not recognise: `-50` became a real $50 refund and
+`1e5` became $15 — finite, positive, under the ceiling, so nothing downstream
+could catch either. On a beat-3a control the typed value IS the write, so validate
+the whole string against one shape (tolerate a leading `$`, spaces, a thousands
+comma; refuse a sign, an exponent, a second dot) and hand the caller a refusal it
+can SAY out loud, plus a separate "nothing typed yet" flag so an untouched field
+is not scolded.
+
 **Banking:** pill `"Change my card PIN"` → `setCardPin` (`useHumanInTheLoop`,
 `tools.tsx:399`) opens `PinChangeCard` in the chat; the user picks the card and
 types the digits there. `changePin` goes straight to REST and the agent's
@@ -135,15 +155,19 @@ value: <current segment> })` in your layout. Without it the agent has no idea
    which page is open.
 2. **Per-page readables that describe what is visibly on screen** — active
    filters, the rows actually rendered, the figures shown. Register these in the
-   _page components_, not only globally.
+   _page components_, not only globally. Each list in the readable must be the
+   SAME expression the panel renders (one `useMemo`, mapped twice), never a second
+   slice of the same source: commerce shipped a readable slicing 5 notifications
+   against a panel showing 6, so the agent described the screen wrongly by one row
+   — silently, which is the only failure mode this beat cannot survive.
 3. **A prompt clause** telling the agent that its context **is** its view of the
    screen: name the page, summarize the key elements, cite the actual figures,
    and **never** say it cannot see the screen.
 
-Every shipped skin registers readables. Only banking and people register a route
-readable AND per-page on-screen readables — which is why this beat is impossible
-in airline, logistics and keel today: they answer identically no matter which
-page is open.
+Every shipped skin registers readables. Only banking, people and commerce
+register a route readable AND per-page on-screen readables — which is why this
+beat is impossible in airline, logistics and keel today: they answer identically
+no matter which page is open.
 
 **Banking:** route readable at `layout.tsx:141-143`; global page/operation
 readables at `tools.tsx:162-170`; page-scoped on-screen readables in
@@ -173,6 +197,40 @@ bg-brand-soft font-semibold text-brand-indigo` (`charges.tsx:67-68`) — plus a
 rank column when sorted by amount. Note it is the **controls** that light up, not
 the rows.
 
+**Two ways the confirm card lies, both of which shipped in `commerce`:**
+
+- **A lever value the view will not honour.** Every value your schema advertises
+  must have a control on the page, must filter, and must leave a view the agent
+  can still DESCRIBE — check your global readable too, not just the page one.
+  Commerce advertised `status: "cancelled"` while its ledger readable filtered
+  cancelled orders out, so the one status only the agent could reach was the one
+  it could not talk about. Derive the schema's enums FROM the page's control
+  vocabularies (`ORDER_STATUS_FILTERS`, `EXCEPTION_FILTERS`, `ORDER_SORTS` in
+  `skins/commerce/data/derive.ts`) instead of hand-copying them, and the mismatch
+  stops being possible. Same rule for a numeric lever: run it through the page's
+  own parser (`parseTopLever`), because a limit the page ignores must not be drawn
+  as a limit.
+- **A chip for a lever nobody set.** Arguments STREAM, so the card renders while
+  `args` is still half-empty. A `?? "all"` or a ternary ending in a bare default
+  therefore asserts a choice the agent never made — and it can then flip. Draw
+  the chips and build the URL from ONE normalized record
+  (`skins/commerce/order-queue-levers.ts`), and give an unset lever no chip at
+  all.
+
+**And one way the PAGE lies: a count that ignores the levers it sits under.** If
+your view prints a "Top 10 of 22"-style caption, the denominator must be the
+FILTERED, pre-truncation count — derived from the same pipeline the rows are, not
+from `data.<collection>.length`. Commerce shipped the unfiltered version, so the
+beat's own lever set read "Top 10 of 22" against 13 matching rows: the single
+number the room is asked to read as proof of the maneuver instead said the filters
+did nothing. Publish two lengths from ONE `useMemo` — `matching` (levers applied)
+and `visible` (`matching` truncated) — and let the caption, the rows and the
+readable all read those (`skins/commerce/pages/orders.tsx`). Any book-wide KPI you
+show on the same page then needs to SAY it is book-wide, on screen and in the
+readable (commerce captions its KPI row "The whole order book" and nests those
+figures under a `book` key), because a page-level total beside filtered rows is
+the same misread one step removed.
+
 ### 3d — Multimodal in, durable artifact out
 
 **Audience concludes:** it takes real documents, and what it produces belongs to
@@ -184,7 +242,7 @@ your skin's **store**, plus a surface in the app that lists those artifacts.
 Deleting the thread must not remove it. In-memory skins can fake half of this;
 a server-backed store makes it true.
 
-Two mechanics worth copying verbatim:
+Three mechanics worth copying verbatim:
 
 - **The framework's suggestion path drops attachments.** So a pill that must
   carry a file has to intercept via `onSuggestionSelect`, stage the file into the
@@ -193,6 +251,42 @@ Two mechanics worth copying verbatim:
   handler so the match cannot drift.
 - **Give the presenter a paperclip too** via `chatHeaderActions`, so the file can
   be staged manually if the pill path misbehaves on stage.
+- **The attachment chain must fail LOUD, and must never send without the file.**
+  This is not defensive polish; it is what makes the beat honest. If any failure
+  still lets the prompt go out, the model INVENTS the document's contents, your
+  tool files the artifact anyway, and it reads plausibly — so the beat proves the
+  opposite of its claim and the room cannot tell.
+
+  **Reporting a failure is the easy half. DETECTING it is the half that gets
+  skipped.** Every step of this chain is a REQUEST made of framework code you do
+  not own, so an unobserved step is an assumption. Nine ways it breaks, and what
+  each one needs:
+
+  | Failure                                                        | Detected by                                                                                                                                                                                  |
+  | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | The document route answers non-2xx                             | `!res.ok`                                                                                                                                                                                    |
+  | The fetch throws                                               | its OWN `try`, not one wrapping the whole chain                                                                                                                                              |
+  | A 2xx body that is empty, or an HTML error page served as 200  | check the BYTES (`%PDF` header), not the URL                                                                                                                                                 |
+  | The composer's hidden `input[type=file]` is gone (an upgrade)  | `querySelector` returns null                                                                                                                                                                 |
+  | Writing the file onto the input throws (`File`/`DataTransfer`) | a `try` around the DOM write, so it is not blamed on the fetch                                                                                                                               |
+  | **The composer silently REJECTS the file**                     | `processFiles` drops anything failing `accept`/`maxSize` and calls an `onUploadFailed` nobody wires — so wait for an attachment CHIP to appear in `[data-testid="copilot-attachment-queue"]` |
+  | **The file is still base64-ENCODING when you click send**      | `consumeAttachments` hands over only `ready` files and `onSubmitInput` refuses to send while anything is `uploading` — wait for the chip to print the filename                               |
+  | **The send button is currently a STOP button**                 | one button plays both roles; mid-run a click CANCELS the run. Require the enabled + send-mark state                                                                                          |
+  | The textarea's React value setter is gone, or the write missed | check `el.value` after writing — do NOT `setter?.call()` the only failure away                                                                                                               |
+
+  Rules: locate the composer before staging; return a machine-readable CAUSE, not
+  a bare boolean, and give each cause its own sentence (a presenter needs to know
+  whether to retry, press send by hand, or restart the dev server); abort the send
+  on any failure; **wait on a CONDITION with a bounded budget, never on a fixed
+  `setTimeout`** — a sleep that races an async encode is the defect, and an expired
+  budget is a failure, not a green light; confirm the CLICK too (the attachment
+  leaving the queue is the only proof `consumeAttachments` ran); report every
+  failure with `console.error` AND `window.alert` (a log nobody opens mid-demo is
+  not a report); never `void` the promise — route both entry points through one
+  launcher that catches. Commerce's `attach-price-sheet.ts` +
+  `attach-price-sheet.test.ts` is the worked reference; note that banking's
+  `attach-invoice.ts` and people's `attach-offer-letter.ts` predate the detection
+  half and still only cover the first rows of that table.
 
 **Banking:** pill `"Prep the Q2 spend report"` → `onSuggestionSelect`
 (`skin.tsx:143-149`) matches the shared `Q2_REPORT_MESSAGE` constant and calls
@@ -336,8 +430,23 @@ sure that the bubbles are in there so I never have to type, I could just click."
 This is also a correctness measure: free-typed phrasing routes wrong. Saying
 "show me the spending **report**" instead of "trend" sends banking to the canvas
 report tool rather than the in-chat chart. Pills remove that whole class of
-stage accident. Banking ships 8 pills covering its full flow; airline, logistics
-and keel ship 4–5 with partial coverage.
+stage accident. **Derive the count from your beat map, never from a target
+number:** one pill per beat, in demo order, skipping only beat 2 (which is
+demonstrated by reloading the browser). That is the base formula, and it lands on
+eight.
+
+Add a ninth pill only when your canvas brief needs an ask of its own — having a
+`CanvasSurface` is not by itself a ninth pill. `people` and `commerce` do give the
+brief its own pill (row `(canvas)` in their beat maps, pill 9). `banking` has a
+`CanvasSurface` too and still ships eight, because its beat-3d pill ("Prep the Q2
+spend report") both ingests the invoice AND files the canvas report, so the brief
+rides along instead of asking twice.
+
+Read the beat-map header at the top of `people`'s or `commerce`'s `suggestions.ts`
+to see the mapping written out, and count what any skin actually ships with
+`grep -c 'title:' src/skins/<id>/suggestions.ts` rather than trusting a number in
+prose. The pre-bar skins (`airline`, `logistics`, `keel`) ship four or five and
+cover the beats only partially; do not calibrate against them.
 
 **Every mutation gets a visible affordance.** "Make sure that you use like a
 light or a bell or whatever so people can see that it changed." If the audience
@@ -358,8 +467,18 @@ instead (`agent.ts:74-80`).
 **A Reset control.** Presenter-gated, in the layout's meta-utility strip; see
 SKILL.md § "The meta-utility strip". Reset must restore the data store, **wipe
 learned memories**, and **re-seed** the "already knows" ones — while still
-leaving beat 6 unlearned. Banking's `dev/reset` route does exactly that. Only
-banking and logistics ship both the route and the button today.
+leaving beat 6 unlearned. Banking's `dev/reset` route does exactly that.
+
+**The route and the button are one feature — ship both or neither counts.** Every
+skin that has one has the other: `ls -d src/app/api/*/v1/dev/reset` and
+`grep -rln usePresenterReset src/skins/` return the same set, which today is
+`banking`, `commerce`, `logistics` and `people`. Run both commands rather than
+trusting this list — a new skin is expected to appear in both. Of those four,
+banking, people and commerce also do the **memory** half (they are the only three
+with `intelligence/seed-memories.ts` + `intelligence/forget-memories.ts`);
+logistics restores its data store only, so it cannot reset beats 4–6. Treat the
+route, the button and the re-seed as required: without them you cannot re-run the
+demo for the second room in the day.
 
 **Open with the placement framing.** Say up front: this is your application, and
 the assistant can be a docked panel, a bubble, a standalone app, or its own
@@ -387,33 +506,110 @@ The ask is 8–12 skins spanning that space. Two are called out explicitly:
 
 Other domains that fit the same buyer: healthcare operations (shipped as `keel`),
 supply chain / logistics (shipped), HR and people operations (shipped as
-`people`), insurance claims, field service, recruiting, legal contract review,
-retail merchandising, energy and utilities operations, customer-support command
-centers, manufacturing quality.
+`people`), retail merchandising and commerce operations (shipped as `commerce`),
+insurance claims, field service, recruiting, legal contract review, energy and
+utilities operations, customer-support command centers, manufacturing quality.
 
 **The bar is "holy shit" pretty, not "renders correctly."** Arm sales with
 something beautiful and they close monster deals; ship template output and the
 beats land flat no matter how correct the wiring is. Budget real design effort,
 and use the workspace's frontend-design skill rather than eyeballing it.
 
+**And "renders correctly" is a weaker floor than it sounds.** A skin's failures
+are almost never crashes — they are **confident falsehoods**: a beat that renders
+beautifully, narrates fluently and proves nothing, which nobody in the room can
+distinguish from the beat working. Each beat above therefore has a lie-shaped
+failure mode as well as a broken one, and the ones this app has actually shipped
+are collected in [failure-modes.md](./failure-modes.md) — read it before writing
+tools or pages, alongside this file.
+
 ---
 
 ## Which skin to copy for what
 
-| Need                                  | Copy from                                                         |
-| ------------------------------------- | ----------------------------------------------------------------- |
-| Every beat, end to end                | `banking` or `people` — the two skins at 6/6                      |
-| A written-out beat map                | `people` — the table at the top of its `suggestions.ts`           |
-| Route + on-screen readables (beat 3b) | `banking`, `people`                                               |
-| Teach mode (beat 6)                   | `banking` + `docs/teach-mode/README.md`; `people` for a 2nd take  |
-| Attachment staging (beat 3d)          | `banking` (`attach-invoice.ts`), `people` (`attach-offer-letter`) |
-| Seeded memories (beats 4, 5)          | `banking`, `people` — the only two with a seed file               |
-| Debugged layout + meta-utility strip  | `logistics`, `people`                                             |
-| Server-emitted a2ui canvas            | `logistics` (`renderBrief`), `banking` (`render_report`)          |
-| Per-user identity plumbing            | `banking`, `logistics`, `keel`, `people`                          |
-| Parameterized routes in `resolvePage` | `keel` (`knowledge/<docId>`, `runs/<runId>`)                      |
-| In-memory `useData` substrate         | `airline`, `keel`                                                 |
-| Minimal contract surface              | `airline`                                                         |
+| Need                                  | Copy from                                                                  |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| Every beat, end to end                | `banking`, `people` or `commerce` — the only three at 9/9 beats            |
+| A written-out beat map                | `people` or `commerce` — the table at the top of their `suggestions.ts`    |
+| Route + on-screen readables (beat 3b) | `banking`, `people`, `commerce`                                            |
+| Teach mode (beat 6)                   | `banking` + `docs/teach-mode/README.md`; `people`/`commerce` for 2nd takes |
+| A four-lever navigation (beat 3c)     | `commerce` — status + exception + sort + top-N, all four tinted            |
+| Attachment staging (beat 3d)          | `banking` (`attach-invoice.ts`), `people`, `commerce`                      |
+| A GENERATED uploaded document         | `people` (`offer-letter-pdf.ts`), `commerce` (`price-sheet-pdf.ts`)        |
+| Seeded memories (beats 4, 5)          | `banking`, `people`, `commerce` — the only three with a seed file          |
+| Debugged layout + meta-utility strip  | `logistics`, `people`, `commerce`                                          |
+| Server-emitted a2ui canvas            | `logistics` (`renderBrief`), `banking` (`render_report`)                   |
+| Per-user identity plumbing            | `banking`, `logistics`, `keel`, `people`, `commerce`                       |
+| Parameterized routes in `resolvePage` | `keel` (`knowledge/<docId>`, `runs/<runId>`)                               |
+| In-memory `useData` substrate         | `airline`, `keel`                                                          |
+| Minimal contract surface              | `airline`                                                                  |
+
+> **Writing a PDF by hand?** Two traps, both of which produce a VALID PDF that is
+> wrong on screen — nothing type-checks a rendered page, and this document is
+> projected at exactly the moment the room is looking.
+>
+> 1. **Encoding.** The page declares base-14 fonts (WinAnsi, one byte per glyph)
+>    while the content stream is written with `TextEncoder` (UTF-8), so a single em
+>    dash goes out as three bytes: the reader shows mojibake AND the `/Length`
+>    computed from JS string length no longer matches the byte count. Fold the text
+>    to ASCII first — `toAscii` in `commerce/data/price-sheet-pdf.ts`.
+>
+>    **Only one of the two shipped builders does that**, so copy commerce's and
+>    not the other one. `people/data/offer-letter-pdf.ts` has no fold at all while
+>    using the identical `/Length ${stream.length}` and `body.length` xref math,
+>    which makes this a live defect rather than a hypothetical: the seed carries
+>    `Inés Vidal`, `Sasha Bergström` and `Montréal`, and
+>    `GET /api/people/v1/offer-letter?employeeId=…` reaches every one of them. It
+>    is named here as the counter-example; fixing it is out of scope for the PR
+>    that wrote this note.
+>
+>    **Then PIN the fold with a test, or your byte-layout assertions are
+>    decorative.** Once the document is ASCII, characters and bytes are the same
+>    thing, so a test that checks `/Length` or an xref offset against a
+>    `TextDecoder().decode()` string passes for the same reason the builder is
+>    correct — and would desync in step with the builder if the fold were ever
+>    relaxed, so it can never fail for the case it exists to catch. Two cheap
+>    habits close it: build a sheet from input carrying an accent, a curly quote and
+>    an em dash and assert every emitted byte is `< 0x80`; and decode with
+>    `new TextDecoder("latin1")` (one byte, one character) wherever an assertion is
+>    about byte offsets rather than glyphs. `price-sheet-pdf.layout.test.ts` § "ASCII
+>    invariant" is the worked version — and the offer letter has neither the fold
+>    nor any test, so there is nothing there to be decorative in the first place.
+>
+> 2. **Alignment.** Any table spaced with `padEnd` is aligned by CHARACTER COUNT,
+>    which is only true in a MONOSPACED font. Drawn in Helvetica, every row starts
+>    its next column somewhere new and the table renders visibly ragged. So either
+>    draw each column at an explicit x-offset (and carry a glyph-width table to
+>    bound overflow), or set the columnar lines in Courier — `price-sheet-pdf.ts`
+>    takes the second route: `mono` on a `Line` selects `/F3` Courier or `/F4`
+>    Courier-Bold, and its 600/1000-em advance turns both alignment and the
+>    page-fit bound into arithmetic on character counts. If you add a face, declare
+>    it in the page's `/Font` dictionary AND emit its font object — a referenced
+>    but undeclared `/Fn` renders blank, which is worse than ragged.
+
+> **Generating a document? Every sentence in it must be DERIVED from its own
+> rows.** The agent lifts facts out of this file and narrates them, so a claim the
+> document's own numbers contradict comes back as something the assistant asserts
+> to the room. Commerce shipped a hardcoded "Driven by merino price" under a rise
+> the route put on two non-merino styles while quoting its only merino SKU flat.
+> Do not name a material, a cause, or a direction of change that you did not
+> compute from the rows — the row set is usually parameterized (commerce's vendor
+> is a query parameter), so today's shape is not tomorrow's. See
+> `costMovementLines` in `commerce/data/price-sheet-pdf.ts` and its test.
+
+> **And every ROW has to belong to the party the document is addressed to.** The
+> same defect one level down from the sentence above, and easier to ship: beat 3d
+> wants one row the app's own data cannot supply (that is what proves the file was
+> read rather than politely acknowledged), and the cheap way to get it is to append
+> a fixed row. Commerce appended one hard-coded "Alder Crewneck" to EVERY vendor's
+> price sheet, so `?vendor=Ardent%20Leather` handed the model a leather-goods
+> supplier quoting a knit crewneck — a supplier relationship that does not exist,
+> asserted by us and narrated by the assistant. Key the invented row by whatever
+> parameterizes the document and check it against the LIVE data before emitting it
+> (`commerce/data/price-sheet-styles.ts`: one entry per vendor, each in a category
+> that vendor actually supplies, re-checked against the vendor's own rows, and
+> DROPPED rather than misattributed when a reseed moves them). Losing the row for
+> one party is recoverable; a false claim about them is not.
 
 **Do not use airline, logistics or keel as demo-completeness references.** They
 predate this bar: each hits roughly one beat of nine. Logistics and keel are

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/failure-modes.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/failure-modes.md
@@ -1,0 +1,501 @@
+# Failure modes — how a skin lies
+
+Read this before you write tools or pages. It is not a bug list; the per-file
+traps live in [templates.md](./templates.md) and this file cross-links to them.
+It is the set of ideas you need up front, because each one changes a decision you
+make while writing, and none of them belongs to a single file.
+
+Everything here came out of one review of the `commerce` skin: two rounds, one of
+them twenty-four independent agents, ~233 findings that resolved into about a
+dozen recurring classes. The classes are what generalise; the individual bugs do
+not.
+
+---
+
+## The through-line
+
+> **A demo skin's characteristic bug is not a crash — it is a confident
+> falsehood. A crash is visible on stage and gets fixed. A convincing lie reads
+> as success and proves nothing.**
+
+CLAUDE.md already says this about beat 3d ("the demo appears to work and proves
+nothing"). It is not a property of beat 3d. It is the shape of nearly every defect
+worth catching in a skin, and it is why the ordinary quality bar is not enough
+here.
+
+Ordinary software fails toward noise: an exception, a red box, a 500. This app
+fails toward **plausibility**, because almost everything it does is _describe
+something_ — a card in the transcript, a readable handed to a model, a receipt
+line, a generated panel, a PDF that gets projected. A description does not throw
+when it is wrong. It renders, in the house style, at the exact moment a Fortune
+500 buyer is looking at it, and the presenter is the last person in the room who
+can tell.
+
+Three consequences to carry through everything below:
+
+1. **"It compiles, lints and passes tests" is not evidence of anything you care
+   about.** Every class in this file did all three.
+2. **The demo is the test suite for the properties nothing else checks.** Which
+   means beats you never walk are properties you never checked — see SKILL.md
+   § "Then walk the demo".
+3. **Prefer visible ignorance to invisible confidence.** A muted "still
+   arriving…" card, a caveat sentence, a `null` — every one of those is a better
+   outcome than a figure you cannot stand behind. This trade shows up in half the
+   sections below and the answer is always the same direction.
+
+---
+
+## The other organising idea: three audiences, three obligations
+
+A skin publishes facts to three audiences, and they have **different** obligations.
+Collapsing them is how several of these classes happened.
+
+| Audience                          | Reads                  | Obligation                                                                                                                                                                                                                     |
+| --------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **The screen** — a human watching | Pixels                 | Unknown must be VISIBLY unknown. Not green, not red, and not a bare figure in neutral ink either — an uncaveated number reads as "checked, fine".                                                                              |
+| **An agent readable** — the model | Your JSON              | `null`, never `false`. The model cannot see what you omitted, so it cannot discount it. It will restate your `false` as an all-clear, in prose, out loud.                                                                      |
+| **A sandbox function / OGUI**     | Rows it did not choose | Send a COMPLETE list whose rows describe themselves. A filtered list is worse than a declared unknown: generated UI can only report what it was handed, and a dropped row is indistinguishable from a row that does not exist. |
+
+Commerce's floor vocabulary is the worked example of all three at once, and
+`src/skins/commerce/floor-unknown.test.tsx` pins them apart deliberately — its
+header names the three obligations as "three different lies". Read that file
+before designing any verdict your skin publishes.
+
+---
+
+## 1. "Unknown" is not `false`, `0`, or an empty list
+
+A category with no margin floor recorded is not a category that passed. A SKU
+whose floor could not be looked up is not a compliant SKU. Publishing `false`
+there does not mean "no data" to anybody downstream — it means **"checked, and
+fine"**, which is the strongest claim your skin makes about that record and the
+one it has the least right to.
+
+And the missing-data state is **reachable, not theoretical**. In a REST-backed
+skin the ledger arrives through an unvalidated cast, the provider mounts children
+on a FAILED first fetch with empty collections, a report hook falls back to empty
+outside its provider, the sandbox snapshot starts empty, and any two hand-written
+constant lists (`CATEGORIES` vs `SEED_FLOORS`) can disagree with no drift guard.
+Every one of those routes to "I have no fact here" while your types still say
+`boolean`.
+
+**The shipped pattern** is a tri-state plus two wire forms, all in
+`src/skins/commerce/data/derive.ts`:
+
+- `FloorStatus` — `"below" | "clear" | "unknown"`, with `productFloorStatus` /
+  `promotionFloorStatus` producing it. The type is what makes forgetting the third
+  case a compile error instead of a rounding decision.
+- `nullableBelowFloor(status)` — the readable/DTO form: `boolean | null`, never
+  `false` for unknown.
+- `tallyFloorStatus` → a `FloorTally` with `below` / `clear` / **`unknown`** as
+  separate counts, so a green `0` cannot mean "we did not look", plus
+  `noFloorCaveat(unknown, noun)` returning the caveat sentence or `null` — the
+  count and its caveat come off ONE derivation, so they can never disagree.
+- `FLOOR_WORKLIST_RANK` — even the SORT order has to place unknown somewhere
+  explicit, or two surfaces will each invent a different place for it.
+
+`src/skins/commerce/sandbox-functions.ts` shows the third-audience decision
+worked out in a comment worth reading: its range filter was renamed
+`belowFloorOnly` → `notClearingFloorOnly` and **includes** the unmeasurable rows
+(already `belowFloor: null`) rather than dropping them, because "a complete list
+whose rows describe themselves is the only shape the model can report truthfully".
+Note the second half of that fix: the schema is `.strict()`, so a call still
+carrying the OLD key is REFUSED rather than silently losing its filter — a rename
+without `.strict()` is the same defect one layer down.
+
+⚠ **The reach of this fix is the whole lesson.** The first pass at it introduced
+the tri-state and updated **16 consumer sites**. Nine more instances survived,
+including a card sort order, a missing on-screen caveat, a book-scope confusion and
+a third private rank table — found only by enumerating all **33** floor-fact
+consumers and recording a verdict for each. Twenty of the 33 were already honest,
+which is the evidence that the vocabulary was right and only its **reach** was
+short. If you introduce a tri-state, grep for every consumer of the old boolean and
+write the list down. See § 10.
+
+---
+
+## 2. Gen-UI renders run mid-stream, with partial arguments
+
+`useComponent`'s `render` is invoked from the FIRST frame of its tool call. It is
+handed `partialJSONParse(toolCall.function.arguments)` verbatim, which is `{}`
+until the first field closes. So **every** argument is `undefined` for some of the
+renders it appears in, including the ones your schema declares REQUIRED —
+`.optional()` is not what makes a field absent, and `.strict()` cannot help you.
+
+There are **two** failure modes here and one guard fixes only one of them:
+
+- **It THROWS.** `orderIds.map(…)`, `list.length`, `id.replace(…)` on an argument
+  that has not arrived is a TypeError **inside React render** — a blank crash on
+  beat 1, the beat the demo opens with. Remember the CONTENTS too: a half-streamed
+  `["` parses to `[""]`, and a value can arrive as a non-string.
+- **It LIES.** Formatting an absent value into a confident label asserts on screen
+  a choice the agent has not made. A Sort chip printed "Sort · oldest first" over
+  an unset lever; a lookup card flashed a red "nothing matches ''" before its
+  needle arrived; a beat-4 "why" band drew as an empty coloured bar while its note
+  streamed. Every one of those renders, in the house style, and then **flips** when
+  the real value lands.
+
+The honest state is neither a default nor an empty return. A default asserts a
+choice nobody made; returning nothing is worse television than a placeholder,
+because beat 1 leads with generative UI and the room is watching it appear. So:
+one muted card that claims **only what has arrived**, with the confident branch (a
+miss, a receipt, a label) reserved for arguments that actually landed.
+
+**The shipped pattern** is two small helpers in `src/skins/commerce/tools.tsx`,
+whose header comment states the rule: `ArrivingCard` (the muted placeholder) and
+`arrivedText(value)` (the trimmed string an argument holds once it has arrived, or
+`null` — covering absent, blank AND not-yet-a-string in one predicate). The
+no-invented-defaults standard for lever chips is
+`src/skins/commerce/order-queue-levers.ts`: `normalizeQueueLevers` produces ONE
+record that both `queueLeverChips` and `queueLeverQuery` read, and an unset lever
+gets **no chip at all**. `src/skins/commerce/streaming-args.test.tsx` red-greens
+each render at absent / partial / complete.
+
+Related, one degree worse, and covered in SKILL.md § "Registering tools": a
+render-only tool has **no handler**, so core posts an empty tool result and there
+is no string with which to correct the model. Enumerate the parameter to its real
+domain AND resolve it in the render —
+`src/skins/commerce/category-argument.ts`'s `resolveCategoryScope` is the worked
+example, including the third state that a streaming argument forces: a value that
+is still a PREFIX of a real member is "not arrived yet", not a refusal.
+
+⚠ The finding that opened this class named **4** sites. Walking all **19** renders
+field by field found **9**, including two failure modes nobody had reported and
+three confident receipt LINES — `goes live at % off`, `Waiver id undefined`, and
+`Finalized the  margin waiver.` (note the double space). Handler strings stream too.
+
+---
+
+## 3. Every write control needs four things, and the fourth is the one people miss
+
+For every control a presenter can click that writes:
+
+1. **Refuse a concurrent second fire** — with a REF, not only `useState`. Two
+   clicks dispatched before React commits `disabled` both read the same
+   `busy === null` out of their closure.
+2. **Disable while in flight**, so the refusal is visible rather than merely
+   correct.
+3. **Restore in a `finally`**, so no rejection can latch the button on
+   "Issuing…" for the rest of the demo with no way back but a reload.
+4. **Distinguish "the write FAILED" from "the write LANDED but the re-read
+   failed."**
+
+That fourth case is the one that keeps shipping — it turned up in **three separate
+files** in this skin, each time only because the sweep was asked to look for it
+rather than assume. Treating a landed write as a failure re-arms the control and
+invites a duplicate write. On the money path that is **a second refund for money
+that already moved**. Report it as "it happened, and the page is behind", and
+**LOCK** the control rather than re-arming it — on a failed re-read the row still
+shows its old status, so the control is still on screen and still inviting.
+
+Why the stakes are different here than in ordinary software: a normal user who
+sees a spurious failure retries, shrugs, or files a ticket. A presenter on stage
+has exactly one recourse — **do it again**. So a false refusal is not a cosmetic
+defect, it is a mechanism for producing the duplicate write.
+
+**The shipped pattern:** `useInFlight` in
+`src/skins/commerce/components/use-in-flight.ts` (ref mutex + visible `busy` +
+`try/catch/finally`, resolving "did this write LAND" and never rejecting);
+`narrateWrite`, `staleNote` and `STALE_VIEW_NOTE` in
+`src/skins/commerce/settle.ts` for the three-outcome receipt; and the
+`RefundOutcome` type in `src/skins/commerce/pages/returns.tsx`, which is what
+splits landed money from a stale view on the surface that matters most. Rule 5 of
+templates.md § "REST-backed instead?" carries the scaffold and the testing notes —
+including that jsdom does **not** dispatch a click to a `disabled` button, so a
+rendered double-click only ever proves the visible half.
+
+**Granularity is a demo requirement, not just a correctness one.** Two rules that
+pull in opposite directions and both have to hold:
+
+- A guard must be **at least as coarse as the MESSAGE CHANNEL** its writes share.
+  Two controls reporting into one error slot must share one guard, or whichever
+  write finishes last speaks for both and a refusal is erased by an unrelated
+  success — the same silent no-op, reached through the report instead of the
+  request.
+- But coarser is **not** automatically safer. A page-wide mutex would be correct
+  and would stop a presenter holding two orders in quick succession — turning a
+  correctness fix into a demo regression. **Split the message slot per record
+  first, then mount the guard to match it.** Commerce ended up with one guard per
+  promotion CARD, one per orders ROW, and one per returns PAGE, each because of
+  its slot; `use-in-flight.ts`'s header explains all three.
+
+---
+
+## 4. If you drive the framework's own DOM, confirm the effect — never assume it
+
+Beat 3d stages a file into the composer and clicks send, because the framework's
+suggestion path drops attachments. That means a chain of REQUESTS made of code you
+do not own, and **an unobserved step is an assumption**. Six independent ways it
+reported success having achieved nothing — and the whole point of the beat is the
+claim "it read a real document", so a silent failure makes the model INVENT the
+document's contents, your tool file the artifact anyway, and the beat prove the
+exact opposite of what it says while reading perfectly.
+
+Three rules, in order of how often they are skipped:
+
+- **Reporting a failure is the easy half; DETECTING it is the half that gets
+  skipped.** Hardening the error path while every failure still resolves `true` is
+  the version of this that ships.
+- **A fixed sleep is not a confirmation.** It races an async encode. The original
+  code waited 500 ms and returned success; the red proof against it was seventeen
+  failures "at 564 ms each — the old sleep completing and claiming success". Wait
+  on a **CONDITION with a bounded budget**, and treat an expired budget as a
+  failure, not a green light.
+- **Read the framework's source for the observable signals**, and be specific:
+  file accepted vs silently rejected (`processFiles` drops anything failing
+  `accept`/`maxSize` and calls an `onUploadFailed` nobody wires), encoding
+  finished, send button in SEND vs STOP vs disabled (one button plays both roles,
+  so mid-run a click CANCELS the run), and the click itself confirmable.
+
+⚠ **If no signal exists for one of them, fail CLOSED and say so in a comment.**
+This is the part to copy. Commerce's `stagePriceSheetAttachment`
+(`src/skins/commerce/attach-price-sheet.ts`) established from source that no
+`ready` status attribute exists AT ALL, so it uses a filename-in-queue proxy,
+documents that it is a proxy, and makes the bounded wait around it fail closed —
+rather than quietly assuming success on the one step it could not observe.
+Everything else it does verify: `%PDF` magic bytes rather than a 2xx, acceptance
+by a chip appearing in the queue, and the send by the attachment LEAVING the
+queue. It classifies fifteen distinct causes, because "a presenter needs to know
+whether to retry, press send by hand, or restart the dev server". The full
+failure table is in demo-beats.md § 3d.
+
+⚠ `banking/attach-invoice.ts` and `people/attach-offer-letter.ts` predate this and
+carry the identical unfixed defect. Copy `commerce` for this beat, not banking.
+
+---
+
+## 5. Redact from an env-derived secret SET, not from one argument
+
+Anything presenter-facing that echoes backend text — a `dev/reset` response body,
+an error surfaced in an alert, a `memoryError` sentence — has to be scrubbed
+against **every** secret the environment holds, derived from the environment
+itself.
+
+A redactor that takes one secret as an argument is a redactor that will miss the
+next one. This one scrubbed the backend URL faithfully and **leaked the API key
+verbatim five times in a single response body** — a presenter-facing body, on a
+control a presenter clicks. The finding named two secrets; the sweep found five.
+
+**The shipped pattern** is `src/lib/redact-secrets.ts`: `envSecretNeedles()`
+derives the needle set from the environment (including the easily-missed portless
+`URL.hostname`), and `redactSecrets` applies it. Two design points worth copying:
+
+- **Per-secret placeholders that preserve diagnosis.** A body reading
+  `HTTP 401 <intelligence-api-key>` still tells a presenter what failed; a blanket
+  `[redacted]` does not, and a message that cannot diagnose gets replaced by
+  someone echoing the raw text again.
+- **An explicit DELIBERATELY-ABSENT list, with reasons**, in the module header —
+  a public signing key, and two values that are not secrets. That is the whole
+  difference between a justified subset and a silent one, and a silent subset is
+  exactly what the one-argument version was.
+
+⚠ Also: route every NEW echo path through it. The same sweep noted that fixing an
+unrelated `failed[].reason` field would reintroduce the class through a new path.
+And `banking` and `people` have this class today, worse (an unredacted
+`memoryError` plus an echoed `apiUrl`) — do not copy their reset routes.
+
+---
+
+## 6. A guard you never tried to fool is not a guard
+
+Two rules, and the second is the sharper one.
+
+**Validate a check against content it must NOT flag, not only content it must.**
+"Zero false positives on today's tree" proves that no CURRENT sentence trips your
+rule — not that no LEGITIMATE sentence does. The doc drift guard shipped in this
+very loop passed exactly that bar and then fired on a truthful sentence ("the
+sixth skin", a real reference) and on a deliberate partial glob. The tree simply
+did not happen to contain the shapes that break it. The fix pinned **must-flag AND
+must-not-flag fixtures** for each discriminator, so neither can be quietly widened
+back — read the header of `src/shell/skin-roster-docs.test.ts`, which documents
+both false positives and why the weaker validation missed them.
+
+**And when a check PASSES, ask where its premise came from.** If the premise came
+out of the artifact under test, the check agrees with the bug. Three instances in
+one review:
+
+- A WCAG contrast assertion measuring the wrong background — the chip renders on a
+  12% tint, the guard measured the card. The card said 4.52:1 (pass); the real
+  ground said 3.75:1 (fail). Worse, the app's own `design-skill.ts` carried the
+  same false justification, so it was instructing GENERATED UIs to use a colour
+  that fails AA. The fix changed **the colour, not the assertion** — the lazy fix
+  here is always to move the goalposts. See `src/skins/commerce/theme.test.ts`,
+  whose pairs now composite an alpha ground before measuring and DERIVE their
+  render sites from grep patterns that fail when a pattern finds nothing.
+- PDF `/Length` and xref byte offsets asserted in **decoded characters**, so the
+  multi-byte desync the file exists to catch can never fail them. Two reviewers
+  disagreed here — one said the mechanism was broken, the other that the outcome
+  was fine because the document is ASCII — and this note used to record the
+  dispute as unresolved. **It is resolved, and both were partly right.** The
+  assertions really do pass for a reason other than the one they name; they also
+  really cannot fail today, because `toAscii` makes characters and bytes the same
+  thing. The gap neither reviewer named is that **`toAscii` was the load-bearing
+  premise and nothing asserted it** — relax the fold and the assertions go on
+  passing while the PDF breaks. It is now pinned by `price-sheet-pdf.layout.test.ts`
+  § "ASCII invariant", which builds from accented input and asserts every emitted
+  byte is `< 0x80`.
+
+  What that taught, and the reason it is worth more than the open question: an
+  argument about whether a passing check is "really" wrong is usually the wrong
+  argument. **Find the premise the pass depends on and assert THAT.** It ends the
+  dispute without either side having to concede, and it is the only version that
+  still holds a year later.
+
+- `npx prettier --check` reporting "All matched files use Prettier code style!" on
+  `templates.md` while two of its `.theme-<id>` placeholders read `.theme-<id >` —
+  prettier's CSS parser re-spaces `<id>` inside a fenced `css` block, so **prettier
+  considered its own mangled output canonical**. The fix is the
+  `<!-- prettier-ignore -->` guard now in templates.md. Do not remove it, and guard
+  any new fenced CSS block with placeholders the same way.
+
+---
+
+## 7. Test traps that produce green for the wrong reason
+
+This review found roughly twenty-two tests that passed while the behaviour they
+name was wrong or never exercised. That number matters because a large green suite
+was what every earlier gate relied on for confidence — the gate was weaker than
+the record said it was.
+
+**The general rule: for every assertion, ask what would have to break for this to
+go red. If you cannot answer, the test is decoration.** The concrete, transferable
+traps:
+
+- **Vitest `it.each` SPREADS array rows.** An `[]` case therefore runs with NO
+  argument — the title prints a literal `%o` — and silently duplicates the
+  `undefined` case. The coercion the docstring specifically called out was never
+  tested.
+- **`expect(...).toBeTruthy()` passes for `[]`**, which is very often the exact
+  failure being guarded (here: the blank generated panel).
+- **Mocking a `Promise<boolean>` contract as `Promise<void>`** resolves
+  `undefined`, which is falsy — so the HAPPY path silently exercises the failure
+  branch. `vi.mock` does not type-check its factory against the real module. This
+  is the natural companion to § 3: the moment `refresh()` became
+  `Promise<boolean>`, every `async () => {}` mock of it started asserting the
+  stale-view branch while looking green.
+- **Asserting a byte layout in decoded characters** can never catch a multi-byte
+  desync (§ 6).
+- **`vi.stubEnv` without `afterEach(vi.unstubAllEnvs)`** leaks into later test
+  FILES, not just later tests. `src/skins/banking/intelligence/user-id.test.ts`
+  cleans up; commerce's sibling does not.
+- **A test that omits the very argument that makes its assertion meaningful**
+  cannot fail for its stated reason — e.g. asserting that a recital does not
+  inherit another record's history while passing no subject at all, so the lookup
+  returns empty regardless.
+- **Two tests pinning contradictory contracts for one vocabulary** (one refuses a
+  lowercase category, another folds it) — the direct consequence of a hand-copied
+  enum with a drift guard on only one copy.
+- **A test that pins the wrong behaviour.** Several here bless a truncation the
+  route refuses, or a caption whose grammar is wrong. When a fix requires changing
+  a test, check whether the test was the bug.
+
+⚠ Honest status: most of these are **parked, not fixed** — they change no shipped
+behaviour, so they lost to the merge gate. Several are still live in commerce's
+test files. Treat this section as a list of shapes to avoid, not as a description
+of an exemplary suite.
+
+---
+
+## 8. Put a shared helper where a second page can import it
+
+`useInFlight` already existed and was already correct — ref mutex, `finally`,
+honest `false`. It just lived **inside a page module**. The second page that
+needed it grew a weaker local copy with no mutex and no `finally` instead, whose
+rejecting fetch wedged a button until the presenter reloaded.
+
+A hook exported from `pages/promotions.tsx` does not READ as importable. That is
+the whole bug. It now lives in `src/skins/commerce/components/use-in-flight.ts`,
+and its header says why in one line worth stealing: "One definition, every
+caller."
+
+Two transferable habits:
+
+- Anything two surfaces will plausibly need goes in `components/` (or `data/`, or
+  a bare module at the skin root) from the start — not in whichever page needed it
+  first. This review found **six** hand-copied-helper defects, most of them with
+  the same origin.
+- ⚠ **When you find two divergent copies of a helper, check where the ORIGINAL
+  lives before assuming the copier was careless.** The copy is usually a symptom of
+  placement, and fixing the copy without moving the original just sets up the third
+  copy. Do the move as its OWN commit, separate from the behaviour change — a
+  semantic change hidden inside a relocation is unreviewable.
+
+---
+
+## 9. State a claim as an invariant plus the command that proves it
+
+Sixteen documentation findings in this review were **all one shape**: prose
+hard-coded a count or a roster, the set grew, and nothing checked it. "ships four
+of them", "these four", a four-value `LOCK_SKIN` list, "all four stay reachable",
+"the unlocked four-skin demo". Every one was true when written.
+
+Prose discipline had already been tried here — CLAUDE.md's standing rule to
+re-read this skill after every change predates those sixteen instances and did not
+prevent them. So the durable fix is not "be careful", it is **to replace the fact
+with its derivation**:
+
+- ❌ "Three skins ship a seed file."
+- ✅ "Every demo-complete skin ships one — `ls src/skins/*/intelligence/seed-memories.ts`
+  shows which."
+
+Prefer "every registered skin", "each demo-complete skin", "the REST-backed ones",
+plus the `ls` / `grep -c` that enumerates them, over any numeral. demo-beats.md
+already does this in several places (counting pills with
+`grep -c 'title:' src/skins/<id>/suggestions.ts`, and pairing
+`ls -d src/app/api/*/v1/dev/reset` with `grep -rln usePresenterReset src/skins/`);
+copy that habit into whatever you write.
+
+**There is now a mechanical guard**, `src/shell/skin-roster-docs.test.ts`, which
+derives its expectations from `skinIds` and fails on a stale count or a stale
+roster in the documents it names. Its boundary, honestly:
+
+- It checks a fixed `DOC_SET`. **This file is not in it** — nor is any other new
+  file you add to the skill — so the discipline above is still yours to keep here.
+- It deliberately does not check subset counts, per-skin counts (gen-UI
+  registrations, pills, beats) or source comments; its header lists two known
+  stale instances outside the set. Read that header before assuming a claim is
+  covered.
+
+---
+
+## 10. If you are REVIEWING or FIXING a skin: fix classes, not instances
+
+The strongest single number this build produced:
+
+> **Ten class sweeps ran. Every one found more instances than the finding that
+> triggered it.** A 2-secret finding was 5 secrets. A 4-site finding was 9 sites.
+> A 5-site finding was 9 sites, out of 33 consumers that had to be enumerated to
+> find them. A finding that named 4 write controls turned out to include two more
+> in a file nobody had scoped.
+
+Fixing the named line and moving on is what produced ~233 second-round findings
+from a tree that had already had ~95 fixes applied to it. There is nothing special
+about this skin; the shape is that a skin is written surface by surface, so a
+mistaken idea about how to describe something gets applied everywhere that idea
+appears.
+
+**The technique that made the sweeps work: require an ENUMERATION with negatives
+recorded.** Not "I checked the rest" — that is unfalsifiable — but a list of every
+consumer, call site, render or write path in the class, each with a verdict.
+Concretely:
+
+- 33 floor-fact consumers listed; 9 defects, 20 confirmed already honest.
+- All 19 gen-UI renders walked field by field; 9 defects.
+- 13 candidate echo paths listed; 3 needed redaction, 10 recorded as fine.
+
+The negatives are what make the enumeration checkable, and they are what caught a
+scoping error the orchestrator had made — one file's write controls were dropped
+while assembling the class, and the sweep's own required whole-skin enumeration
+surfaced it. A prompt saying "fix these five sites" fixes five sites and tells you
+nothing about the sixth.
+
+Two corollaries:
+
+- **A class sweep may legitimately span several commits.** Separate a pure move
+  from a behaviour change (§ 8), and report every hash.
+- **When you remove a pattern from the app, remove it from this skill in the same
+  commit.** Four independent sweeps each found the skill still teaching the pattern
+  they had just deleted, and all four doc edits auto-merged precisely because each
+  was scoped to the change that caused it. That is CLAUDE.md's standing rule doing
+  its job; see the top of this app's CLAUDE.md for why it is a rule rather than a
+  nicety.

--- a/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
+++ b/examples/showcases/reskinnable-demo/.claude/skills/reskin/templates.md
@@ -2,8 +2,8 @@
 
 Copy each block into `src/skins/<id>/<file>` and replace `<id>` / `<Brand>` /
 domain specifics. These are written against this app's frozen `Skin` contract
-(`src/shell/skin-contract.ts`) and mirror the five shipped skins
-(`src/skins/{banking,airline,logistics,keel,people}/`) — see
+(`src/shell/skin-contract.ts`) and mirror the six shipped skins
+(`src/skins/{banking,airline,logistics,keel,people,commerce}/`) — see
 [demo-beats.md](./demo-beats.md) § "Which skin to copy for what" for which one to
 open for which problem.
 
@@ -63,8 +63,16 @@ for a full, working example): `--brand`, `--brand-violet`, `--brand-indigo`,
 `--surface`, `--surface-muted`, `--ink`, `--ink-muted`, `--hairline`,
 `--positive`, `--positive-soft`, `--negative`, `--negative-soft`, `--radius`.
 
+**Do not remove the `prettier-ignore` below.** Prettier formats fenced blocks by
+language, and its CSS parser reads `<id>` as a token to re-space — it rewrites
+`.theme-<id>` into `.theme-<id >`, an INVALID selector that silently applies no
+theme, and then reports that broken form as correctly formatted. (The `ts`/`tsx`
+fences need no guard: they fail to parse as TypeScript, so Prettier skips them
+whole.)
+
+<!-- prettier-ignore -->
 ```css
-.theme-<id > {
+.theme-<id> {
   --radius: 1.125rem;
 
   /* OPT-IN dark mode. `src/hooks/use-theme.ts` forces any skin WITHOUT this flag
@@ -101,7 +109,7 @@ for a full, working example): `--brand`, `--brand-violet`, `--brand-indigo`,
    re-values only the tokens that DIFFER — surfaces, ink, and semantic tokens —
    and lets the brand ramp and `--radius` inherit from the light block.
    (Mirror `src/skins/logistics/theme.css` / `src/skins/banking/theme.css`.) */
-.dark .theme-<id > {
+.dark .theme-<id> {
   color-scheme: dark;
 
   --background: 252 20% 8%;
@@ -121,6 +129,53 @@ for a full, working example): `--brand`, `--brand-violet`, `--brand-indigo`,
   --negative-soft: 349 40% 18%;
 }
 ```
+
+**If your dark block LIFTS `--brand`, it MUST re-value `--brand-foreground` too.**
+The template above leaves both alone in dark on purpose. A dark-anchored brand
+(commerce's `206 72% 30%`, keel's `170 38% 28%`, people's `315 38% 36%`) vanishes
+on a dark surface, so the dark block lifts it — and that FLIPS the polarity of
+every pair the brand anchors while `--brand-foreground: 0 0% 100%` stays behind in
+the light block. Commerce shipped that way and every primary button in its dark
+mode measured **2.60:1**; the labels are small and semibold, so 4.5:1 applies, not
+3:1. Two traps make this invisible:
+
+- **Do not "fix" it by darkening `--brand`.** `--brand` is simultaneously a FILL
+  under `--brand-foreground` and TEXT on `--brand-soft` (nav active state, brand
+  pills, `activeSelectClass`). Darkening it to satisfy white labels collapses the
+  text pair instead. Re-value `--brand-foreground` to a deep ink in the brand's
+  own hue — logistics does this in light mode for its bright amber
+  (`--brand-foreground: 30 50% 10%`), commerce in dark (`206 60% 10%`).
+- **`--brand-violet` on `--brand-soft` is a real pair in DARK ONLY.** The shared
+  chrome pairs brand-soft with `text-brand-indigo` in light and reaches for
+  `dark:text-brand-violet` in dark (`components/ui/dropdown-menu.tsx`,
+  `select.tsx`, `avatar.tsx`, `button.tsx`). If your skin repurposes
+  `--brand-violet` as a domain accent, that pair still has to clear 4.5:1 in dark.
+  **It does NOT do that everywhere**, so do not conclude `--brand-indigo` is
+  exempt in dark: `button.tsx`'s `outline` variant re-inks its hovered LABEL to
+  `--brand-indigo` with no dark counterpart (2.75:1 in banking dark, 1.21:1 in
+  keel), and the theme toggle does the same for its icon. Both are shell-wide
+  follow-ups no skin can fix alone; `theme.test.ts`'s
+  `UN_OVERRIDDEN_BRAND_SOFT_INK` is the live list, and a test there fails if the
+  set grows or shrinks — read it rather than trusting this sentence.
+
+- **A tinted chip's ground is the TINT, not the card under it.** A chip written as
+  `bg-<token>/12 text-<token>` — the shape every skin reaches for to make an accent
+  chip — paints its label against a 12% wash of its own colour over the card, which
+  is darker than the card. Measure the card and you get a number the user never
+  sees: commerce's rose read 4.52:1 on `--surface` and **3.75:1** on the wash it
+  actually renders on, and the guard called that a pass for a release. Composite
+  the tint before measuring (`theme.test.ts`'s `bg.alpha` / `bg.over`).
+
+Nothing else in this app catches a contrast regression — it type-checks, lints and
+renders. Copy `src/skins/commerce/theme.test.ts`: it parses your `theme.css`,
+computes WCAG ratios for your skin's text pairs in BOTH modes and asserts them.
+Copy two habits from it as well, both earned: it locates each rule by an
+**anchored, line-start** selector (an `indexOf(".theme-<id> {")` also matches
+inside `.dark .theme-<id> {`, so reordering the file silently pointed every
+light-mode assertion at the dark block), and it **derives** each pair's render
+sites by grepping for the class pair rather than citing `file:line` — every
+hand-written citation in the first version had rotted, which is how the wrong-ground
+measurement above survived review.
 
 ## `layout.tsx`
 
@@ -156,7 +211,13 @@ import { ThemeToggle } from "@/components/ui/theme-toggle"; // SHARED shell comp
 import { useAskCopilot } from "./components/use-ask-copilot"; // PORT this into your skin (see below)
 import { cn } from "@/lib/utils";
 
-// The sidebar width doubles as the shell's nav inset — keep them the same value.
+// Sidebar width is yours alone — NOTHING in the shell reads it, so pick whatever
+// your chrome needs. The skin switcher is a dropdown in its own card at the top of
+// the assistant column, so it occupies a slot and can never overlap your nav; the
+// `--nw-nav-inset-left` / `--nw-nav-inset-right` variables older skins published
+// for the retired floating selector are gone. Do not add those publishers, and do
+// not couple this constant to anything outside your own layout. (SKILL.md § "The
+// layout contract".)
 const SIDEBAR_WIDTH_PX = 240;
 
 export function <Id>Layout({ children }: { children: ReactNode }) {
@@ -188,17 +249,46 @@ export function <Id>Layout({ children }: { children: ReactNode }) {
     value: restHead === "" ? "<index page name>" : restHead,
   });
 
+  // ⚠ Do NOT branch on `res.ok` ALONE. Your reset route wipes the store as its
+  // FIRST act and nothing rolls that back, so a non-2xx (commerce's route 502s
+  // when the memory wipe/re-seed fell short) still means THE STORE IS GONE. An
+  // ok-only branch then alerts and stays put, leaving the page — and the agent's
+  // readables, which describe that page — asserting rows that no longer exist,
+  // and leaving any module-level client journal (see rule 4 below) reciting
+  // writes the reset took away. Read what the BODY says about the store instead,
+  // navigate on every outcome except a provably untouched one, and put the
+  // route's own explanation in the alert: a bare "HTTP 502" drops the one
+  // sentence saying the memory beats may start out already taught. Commerce's
+  // `runPresenterReset` (src/skins/commerce/layout.tsx) is the worked version.
   const handleReset = async () => {
     if (!window.confirm("Reset demo state? This restores the seeded scenario.")) return;
-    const res = await fetch(`/api/${skin.id}/v1/dev/reset`, { method: "POST" });
-    if (res.ok) {
-      // Hard-navigate to the skin root for a pristine slate (fresh store, cleared
-      // canvas, new thread on the next message) AND the clean starting URL —
-      // which is `/` itself on a locked single-tenant deploy.
+    let res: Response;
+    try {
+      res = await fetch(`/api/${skin.id}/v1/dev/reset`, { method: "POST" });
+    } catch (err) {
+      // No response at all: an in-memory store whose server restarted mid-call
+      // has already reset itself, so reload rather than trust the screen.
+      window.alert(`Reset could not be confirmed: ${String(err)}. Reloading.`);
       window.location.assign(skinHref());
-    } else {
-      window.alert(`Reset failed (HTTP ${res.status}). See the server logs.`);
+      return;
     }
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const reset = Array.isArray(body.reset) ? body.reset : null;
+    // `false` only where the route answered BEFORE it mutated (the 403 gate).
+    if (reset === null && typeof body.error === "string") {
+      window.alert(`The demo was NOT reset (HTTP ${res.status}). Nothing has changed.`);
+      return;
+    }
+    // Alert FIRST (it is modal, so it is read), then hard-navigate to the skin
+    // root for a pristine slate (fresh store, cleared canvas, new thread on the
+    // next message) AND the clean starting URL — `/` itself on a locked deploy.
+    if (!res.ok) {
+      window.alert(
+        `Reset incomplete (HTTP ${res.status}). The demo data WAS reset; ` +
+          `${String(body.memoryError ?? "see the server logs")}.`,
+      );
+    }
+    window.location.assign(skinHref());
   };
 
   return (
@@ -307,6 +397,141 @@ export function use<Id>Data() {
 export type <Id>Data = ReturnType<typeof use<Id>Data>;
 ```
 
+### REST-backed instead? Five rules for your write paths
+
+A REST-backed skin replaces the hook above with a ledger CONTEXT that holds one
+snapshot and exposes a `refresh()` every write path calls after its mutation
+(`src/skins/commerce/data/ledger-context.tsx` is the worked example). Every one of
+these fails **silently** if you skip it, and none is caught by lint, tsc or a
+test you would think to write:
+
+1. **Guard every `setState` behind a provider-lifetime liveness ref.** The shell
+   remounts the entire runtime subtree keyed by skin id, so switching skins in the
+   selector unmounts your provider while a mutation's `refresh()` is still in
+   flight. That is routine operation, not a rare race. One `useRef(true)` cleared
+   by the mount effect's cleanup covers the mount fetch AND `refresh`.
+2. **Type it `Promise<boolean>`, not `Promise<void>`.** A `refresh()` that
+   resolves regardless of whether the re-read succeeded lets every caller print
+   "done" over pre-mutation rows — the one failure mode indistinguishable from a
+   slow network. Resolve `true` only when a snapshot was actually committed, and
+   have callers say so when it is `false`: pages via their inline error slot or a
+   one-line notice, tool handlers by appending it to the string they return (see
+   commerce's `staleNote`). Do NOT reject — the callers `await` it bare, so
+   rejecting turns a dev-server restart into a dozen unhandled rejections and a
+   blank app mid-demo.
+3. **Check `res.ok` BEFORE you call `refresh()`, on every write path.** A
+   `refresh()` after a refused write repaints the identical rows, so a real 409 or
+   422 is indistinguishable from a slow network — and every one of these controls
+   is something a presenter clicks on stage. Surface the route's own `message`
+   (your `errorResponse` map writes them to be read by a human) and fall back to a
+   status-bearing sentence, then `return` without refreshing. Note this is a
+   DIFFERENT report from rule 2's: refused means nothing happened, stale means the
+   write landed and only the view is behind. Four of commerce's page write paths
+   shipped without this check while three others in the same files had it —
+   nothing type-checks the difference, so grep your own pages for
+   `await fetch(` and confirm each hit branches on `res.ok`.
+4. **`res.ok` is only HALF of the failures — catch the REJECTED fetch too.**
+   `fetch` rejects outright when the browser is offline, the connection drops, or
+   the dev server restarts mid-call, and `!res.ok` never runs. In a page handler
+   that is an unhandled rejection and a button that never recovers; in a TOOL
+   handler it is worse — the throw escapes the handler, so the agent receives no
+   result for that step AT ALL and cannot narrate it. Every one of commerce's
+   seven write handlers shipped checking `res.ok` and nothing else, and the same
+   grep as rule 3 passed on all seven.
+
+   Write it ONCE as a wrapper and route every handler through it —
+   `narrateWrite` in `src/skins/commerce/settle.ts` is the worked example, tested
+   in `write-failures.test.tsx`. Seven hand-written try/catches is how the eighth
+   handler ships without one. The wrapper must distinguish three outcomes, not
+   two: the write never landed, the write landed and only the follow-up broke
+   (report the SUCCESS — a failure line over a write that really happened is the
+   mirror-image lie), and the server refused it. And make the receipt's TONE
+   follow the line: a failure sentence under a green tick is the same as showing
+   no error, because from the back of a room the tick is what registers.
+
+   If a beat is a CHAIN of writes against one record — commerce's beat 5 holds
+   the order, posts the note, then notifies the customer — a failure on step two
+   leaves the ledger half-mutated. Say so: "held the order, but could not post
+   the note" is both more useful on stage and more honest than a bare failure.
+   Commerce keys a small module-level journal by record id for exactly this
+   (`landedWritesOn`); it is safe to leave unbounded only because the presenter
+   reset CLEARS IT EXPLICITLY and then hard-navigates (a real document load drops
+   the module too). Both halves, and unconditionally: relying on the navigate
+   alone was a bug, because the reset can wipe the store and answer non-2xx, and
+   the old handler only navigated on `res.ok` — so on exactly those paths the
+   journal outlived the ledger and the next failure recited writes that were
+   reset away.
+
+5. **A control that writes must not be RE-ENTRANT, and must only clear what the
+   user typed on a path that SUCCEEDED.** Two halves of one mistake, and the
+   teach-mode page is where both hurt most, because that is the surface a
+   presenter is clicking live.
+
+   A button with no in-flight guard fires twice on a double-click. Your store
+   almost certainly settles each record once — commerce refuses the repeat with
+   `ALREADY_FINALIZED` / `ALREADY_DECIDED` — so rule 3 dutifully paints that
+   refusal on a card whose action **just succeeded**, and the presenter is told
+   the thing they did failed. Guard it with a ref, not only `useState`: the state
+   is what renders "Finalizing…" and `disabled`, and the ref is what makes the
+   guard a mutex regardless of whether a lever remembered `disabled`. And guard it
+   in a `try/finally`: a rejecting `fetch` that skips the release latches the
+   button on "Issuing…" for the rest of the demo, with no way back but a reload.
+   `useInFlight` in `src/skins/commerce/components/use-in-flight.ts` is the worked
+   example — and it is in `components/`, not in a page, for a reason worth
+   copying: it first lived inside `pages/promotions.tsx`, a hook exported from a
+   PAGE does not read as importable, and the second page that needed one grew a
+   weaker `useState`-only copy with no mutex and no `finally` instead. Put shared
+   guards where a second page can plausibly import them.
+
+   **Mount an instance no finer than the MESSAGE CHANNEL its writes share.** A
+   per-button or per-surface mutex is no help when two controls report into one
+   error slot: whichever write finishes last speaks for both, so a refusal gets
+   erased by an unrelated success and the refused write says nothing at all — the
+   same silent no-op, reached through the report instead of the request. Commerce
+   needed BOTH halves: one instance per promotion card (its four levers write one
+   record) plus a separate message slot per surface (decision vs waiver), and one
+   instance per RETURNS page, because every decision there reports through the
+   page's single notice.
+
+   Note the rule cuts both ways — coarser is not automatically safer, and "one per
+   page" is not the answer, the CHANNEL is. The orders queue's two levers report
+   about a single ROW, so they share that row's guard and that row's slot, and a
+   different row's write may proceed: a page-wide slot there meant one row's
+   success cleared another row's refusal, and a page-wide guard would have blocked
+   a write that could never have spoken for it. Split the slot per record FIRST,
+   then mount the guard to match it.
+
+   The other half: a write helper that reports refusal by RETURNING (rule 3) will
+   also return on the path where the caller then does `setInput("")`. So a refused
+   filing wipes the sentence the user typed and they retype it on stage. Have the
+   helper resolve `Promise<boolean>` — "did this write LAND", which is NOT rule
+   2's "and the view is current" — and clear typed state only inside
+   `if (landed)`. A validation refusal is not exotic: commerce's justification has
+   a server-side minimum length (`INVALID_JUSTIFICATION`, 422) that no input
+   attribute enforces, so the ordinary too-short filing takes that path.
+
+   And the case that is neither: a write that LANDED whose follow-up `refresh()`
+   did not. That is not a refusal, and a control that reads it as one re-arms
+   itself and invites the write a second time — on a money path, a second refund
+   for money that already moved. Report it the way `settle.ts`'s
+   `STALE_VIEW_NOTE` / `staleNote(refreshed)` does, as "it happened, and the page
+   is behind", and LOCK the control rather than re-arming it: on a failed re-read
+   the row still shows its old status, so the control is still on screen.
+
+   Testing it: jsdom does **not** dispatch a click to a `disabled` button, so a
+   rendered double-click only ever proves the visible half. Test the guard hook
+   directly with `renderHook` for the mutex
+   (`src/skins/commerce/components/use-in-flight.test.tsx`), and drive the
+   rendered page with a `fetch` you settle by hand for the rest — see
+   `src/skins/commerce/pages/promotions.test.tsx`,
+   `src/skins/commerce/pages/returns.test.tsx` and
+   `src/skins/commerce/pages/orders.test.tsx`, which cover the double-click, the
+   rejecting fetch, the landed-but-stale write, and erasure both across surfaces
+   and across rows. Watch the ledger mock while you are there: `refresh` is
+   `Promise<boolean>`, `vi.mock` does not type-check the factory against the real
+   module, and a mock returning `Promise<void>` sends every write down the
+   stale-view branch with the happy path still green.
+
 ## `pages/<page>.tsx`
 
 One component per nav segment. Read the skin's data via `useSkinData<T>()`.
@@ -316,6 +541,23 @@ One component per nav segment. Read the skin's data via `useSkinData<T>()`.
 filters and the rows actually rendered after filtering and sorting, not the whole
 data set. That distinction is the beat: the agent describing what the user can
 literally see. Mirror `src/skins/banking/pages/charges.tsx:139`.
+
+**Every list in the readable must be the same expression the panel renders.** Derive
+each visible list ONCE — `const visible = useMemo(…)`, `const visibleNotifications =
+useMemo(() => data.notifications.slice(0, NOTIFICATION_ROWS), …)` — and hand that one
+array to both the JSX and `useAgentContext`. Two independent slices of the same source
+is how commerce's Orders page came to send five notifications while rendering six: the
+agent then confidently describes a screen the presenter is not looking at, off by one
+row, which is the version of wrong that survives a live demo. Mirror
+`src/skins/commerce/pages/orders.tsx` (its `visible` / `visibleNotifications` pair and
+`orders.test.tsx`, which asserts the readable equals the DOM).
+
+**Every COUNT obeys the same rule as every list.** A "Top N of X" caption's
+denominator, and any total you send the agent, must come off that same derivation —
+publish `matching` (levers applied) and `visible` (truncated) from one `useMemo` and
+read both. Whole-collection figures may stay whole-collection, but then label them as
+such on screen and nest them under a scoped key (commerce uses `book: { … }`) so the
+agent cannot report them as the contents of the view. See demo-beats.md § 3c.
 
 ```tsx
 "use client";
@@ -338,7 +580,10 @@ export function <Id>HomePage() {
         /* the live filter/sort state */
       },
       visibleCount: visible.length,
-      rows: visible.slice(0, 25), // cap it — this rides on every request
+      // The SAME expression the panel renders — never a second slice of the same
+      // source. If a list on screen is truncated, truncate it ONCE, above, and
+      // let both the JSX and this readable map that one array.
+      rows: visible,
     }),
   });
 
@@ -352,7 +597,7 @@ Renders `null`. Register frontend tools / HITL / gen-UI components and
 `useAgentContext` readables here (all from `@copilotkit/react-core/v2`). Mirror
 `src/skins/logistics/tools.tsx` for the wiring and
 `src/skins/banking/tools.tsx` for the beats — between them they are the debugged
-reference for the four things this file MUST get right.
+reference for the five things this file MUST get right.
 
 **1. Every registration closes with a deps array.** `useComponent`,
 `useFrontendTool`, and `useHumanInTheLoop` each take an **optional deps array as
@@ -374,23 +619,64 @@ and `render: ComponentType<NoInfer<InferRenderProps<TSchema>>>`. By contrast
 `useHumanInTheLoop` and `useFrontendTool` renders DO receive `{ args, status,
 respond }`. Do not copy the HITL `{ args }` shape into a `useComponent`.
 
+It also receives that output **UNVALIDATED** — the schema is documentation, and a
+render-only tool posts an empty tool result, so there is nothing to correct the
+model with. Enumerate any closed-set parameter (`z.enum(YOUR_CONST_TUPLE)`) AND
+resolve it in the render, saying plainly that the value is unknown rather than
+drawing an empty visual. See SKILL.md's gen-UI enforcement rule and commerce's
+`src/skins/commerce/category-argument.ts`.
+
+And it receives that output **INCOMPLETE**: arguments STREAM, `partialJSONParse`
+returns `{}` for the first frames of every call, so each field — required ones
+included — is `undefined` in some of the renders it appears in. Never dereference
+one bare (`orderIds.map(…)` is a TypeError inside React render; banking guards the
+same shape with `columns ?? []` / `rows ?? []` at `banking/tools.tsx:793-794`) and
+never format an absent one into a confident label. Draw a visible arriving card
+instead — `ArrivingCard` / `arrivedText` in `src/skins/commerce/tools.tsx` — and
+keep the confident branch for values that actually landed. See SKILL.md's
+"EVERY argument is `undefined` mid-render" rule.
+
 **3. Renders must be REPLAY-SAFE — key them off `result`, not `status`** (beat 2).
 Reopening a thread replays recorded tool calls: you get the stored `result` and no
 live status transition. A render keyed on `status` is perfect live and blank or
 wrong on revisit — precisely when "reload and it's still there" is being demoed.
-Banking and people are the only skins written this way — banking at
+Banking, people and commerce are the only skins written this way — banking at
 `tools.tsx:70-89`, `418-451`, `553-572`; people's `setBaseSalary` render at
 `tools.tsx` recovers from an `answeredSalaryChanges` module map that holds the
 person's NAME and nothing else, so a replayed card can rebuild itself without
 the salary ever having been stored.
 
-**4. Readables must make the agent PAGE-AWARE** (beat 3b). Global readables
+**4. Every write handler must END IN A RESULT on all three paths** — success,
+refusal, AND a `fetch` that rejected. A handler that only checks `!res.ok` throws
+straight out when the browser is offline or the dev server restarts mid-call, and
+the agent then gets no result for that step at all: it cannot narrate it, and the
+transcript has no record that it was attempted. On a chained beat that is a
+half-mutated ledger with one visible receipt, one vanished write, and no error
+anywhere. Route every handler through ONE wrapper rather than seven try/catches —
+`narrateWrite` in `src/skins/commerce/settle.ts`, with rule 4 of the REST write-path
+rules above for the full contract, and `write-failures.test.tsx` for the coverage
+your own skin needs.
+
+**5. Readables must make the agent PAGE-AWARE** (beat 3b). Global readables
 (who the user is, the whole data set) are not enough: "what's on my screen?"
 returns the same answer everywhere without a **route** readable in `layout.tsx`
 plus **per-page** readables describing what is visibly rendered. Register the
 on-screen ones inside the page components, close to the state they describe —
 banking's richest is in `charges.tsx:139`, emitting the page name, active
 filters, visible row count and the first 25 visible rows.
+
+**5. A capped gen-UI list must SAY what it withheld.** Capping a chat list is
+right — it keeps the transcript readable. Capping it silently is not: the list
+renders as though it were the whole answer. The trap is worse than a missing row
+whenever the list is GROUPED, because the cap then eats trailing GROUPS whole and
+a group that vanished is indistinguishable from a group with nothing to report.
+Commerce's `showMarginSummary` shipped `rows.slice(0, 12)` over a 14-SKU range
+grouped by category and dropped both Outerwear SKUs, one of them below its margin
+floor — an omission that read as an all-clear. Surface the withheld count, the
+exceptions among them, and any group that disappeared, by name. Mirror
+`src/skins/commerce/margin-summary.ts` (`selectSummaryRows`, pure and tested
+apart from the component) plus `MarginSummaryList` in `src/skins/commerce/tools.tsx`.
+Rank exceptions FIRST so the cap can only ever withhold clean rows.
 
 ```tsx
 "use client";
@@ -431,7 +717,15 @@ export function <Id>Tools() {
       name: "showThingById",
       description: "Display one thing by id.",
       parameters: z.object({ id: z.string().describe("The thing's id.") }),
-      render: ({ id }) => <div className="text-ink">{/* look `id` up in `data` */}</div>,
+      // `id` is `undefined` while the arguments stream — a required field is no
+      // guarantee of a present one. Draw the arriving state, never a miss and
+      // never a bare dereference.
+      render: ({ id }) =>
+        typeof id === "string" && id.trim() ? (
+          <div className="text-ink">{/* look `id` up in `data` */}</div>
+        ) : (
+          <div className="text-ink-muted">Looking that up…</div>
+        ),
     },
     [data],
   );
@@ -456,7 +750,11 @@ export function <Id>Tools() {
           // a forced emoji prefix, a highlight ring — not just the word "Done."
           <div className="text-ink">✅ {result}</div>
         ) : (
-          <div className="text-ink-muted">Working on {args?.id}…</div>
+          // `args.id` streams too, so name it only once it is there — "Working on
+          // …" with the id missing is the same absent-value formatting.
+          <div className="text-ink-muted">
+            {args?.id ? `Working on ${args.id}…` : "Working on it…"}
+          </div>
         ),
     },
     [data], // ← deps here too
@@ -495,8 +793,13 @@ is also a correctness measure — free-typed phrasing routes to the wrong tool
 report tool instead of the in-chat chart). Keep the beat map from
 [demo-beats.md](./demo-beats.md) in a comment at the top so the mapping can't rot.
 
-Banking ships 8 pills covering its whole flow; airline/logistics/keel ship 4–5
-and cover it partially — copy banking's coverage, not their count.
+**Derive the count from the beat map, never from a target number.** The arithmetic
+is in [demo-beats.md](./demo-beats.md) § "Presentation requirements" — that is the
+one authority; do not re-derive it here. It lands on eight in `banking` and nine in
+`people` and `commerce`, whose `suggestions.ts` headers write the mapping out —
+read one of those two before writing yours, and check any skin's real count with
+`grep -c 'title:' src/skins/<id>/suggestions.ts`. Airline, logistics and keel ship
+four or five and cover the beats partially: copy the coverage, never the count.
 
 ```ts
 import type { Suggestion } from "@/shell/skin-contract";
@@ -517,6 +820,9 @@ export const <ID>_ATTACHMENT_MESSAGE =
 //   4  memory        → pill 6
 //   5  stored skill  → pill 7
 //   6  teach a skill → pill 8
+//   (canvas)         → pill 9, ONLY if the brief needs its own ask. banking has
+//                      a CanvasSurface and no such pill — its pill 5 files the
+//                      brief as well. people and commerce do add pill 9.
 export const <id>Suggestions: Suggestion[] = [
   // 1 — lead with generative UI, never a wall of text.
   { title: "<show the headline visual>", message: "<...>" },
@@ -608,7 +914,8 @@ export const <id>IdentifyUser: IdentifyRunUser = (properties) => {
 
 "It already knows me" is a **file**, not emergent behaviour. Mirror
 `src/skins/banking/intelligence/seed-memories.ts` or
-`src/skins/people/intelligence/seed-memories.ts` — the only two in the repo, and
+`src/skins/people/intelligence/seed-memories.ts` — two of the only three in the
+repo (`commerce` has the third), and
 both sets of comments are worth reading in full. Server-safe plain `.ts`.
 Called by your `dev/reset` route immediately after wiping memories, so the demo
 is re-armed before the presenter says a word.
@@ -636,7 +943,11 @@ export interface SeedMemoriesParams {
   apiUrl: string;
   apiKey: string;
   userId: string;
+  /** Per-request timeout. NOT optional in spirit — see the note below. */
+  timeoutMs?: number;
 }
+
+const DEFAULT_TIMEOUT_MS = 10_000;
 
 interface SeedMemory {
   kind: "topical" | "episodic" | "operational";
@@ -669,14 +980,18 @@ export const SEED_MEMORIES: readonly SeedMemory[] = [
 ];
 
 /**
- * Write the seed memories for one identity; returns how many were stored.
- * Never throws — a booth reset must still report success for the data store even
- * if the memory backend is unhappy, so failures are counted, not propagated.
+ * Write the seed memories for one identity; returns how many were STORED.
+ * Never throws — a booth reset must still restore the data store even if the
+ * memory backend is unhappy, so failures are counted, not propagated.
+ *
+ * ⚠ Because it never throws, a `try`/`catch` in your reset route learns NOTHING
+ * from it. The returned count is the only signal, so the CALLER must compare it
+ * against the expected total — see "⚠ Check the seeded count" below.
  */
 export async function seedMemories(
   params: SeedMemoriesParams,
 ): Promise<number> {
-  const { apiUrl, apiKey, userId } = params;
+  const { apiUrl, apiKey, userId, timeoutMs = DEFAULT_TIMEOUT_MS } = params;
   const base = apiUrl.replace(/\/$/, "");
   let stored = 0;
 
@@ -691,6 +1006,10 @@ export async function seedMemories(
           Accept: "application/json",
         },
         body: JSON.stringify(memory),
+        // BOUND EVERY MEMORY FETCH. A reset sweeps and re-seeds several buckets
+        // serially inside ONE request; one wedged POST with no signal leaves the
+        // presenter's Reset button spinning with no way out.
+        signal: AbortSignal.timeout(timeoutMs),
       });
       if (res.ok) stored += 1;
       else console.error(`[seed-memories] ${userId}: HTTP ${res.status}`);
@@ -708,6 +1027,154 @@ the default demo user, or the agent's own `recall_memory` will not find them.
 Banking pairs this with `intelligence/forget-memories.ts` so `dev/reset` can wipe
 learned memories and then re-seed these — see SKILL.md § "The meta-utility strip"
 and demo-beats.md § "Presentation requirements".
+
+### ⚠ Copy `forget-memories.ts` from COMMERCE, not from banking or people
+
+All three skins have one, but only `src/skins/commerce/intelligence/forget-memories.ts`
+stops the clear from reporting success it has not earned. The banking/people copies
+still do all four of these, and every one of them fails SILENTLY behind an
+`ok: true` reset:
+
+- **They throw on the first non-ok DELETE, including a 404.** A 404 only means the
+  row is already gone — the end state you wanted — yet it abandons the current
+  bucket AND every bucket after it.
+- **They treat one bare `GET /api/memories` as exhaustive.** The list envelope has
+  no cursor and the path rejects query strings, so pagination cannot be probed:
+  verify instead — list → delete → **list again**, and only claim success when a
+  pass comes back with nothing deletable.
+- **They cast the envelope (`as MemoriesListResponse`).** When the shape changes,
+  the failure surfaces as `Cannot read properties of undefined (reading 'filter')`
+  — a message that names no layer at all. Validate and throw with your own prefix.
+- **No `AbortSignal` on any memory fetch.** Same reason as the seed template above.
+
+Return enough for the caller to tell COMPLETE from PARTIAL (commerce returns
+`{ forgot, alreadyGone, skippedProjectScoped, failed[], passes, complete,
+incompleteReason? }`) and make your `dev/reset` route report `ok: false` when the
+sweep says `complete: false`. A reset that says it cleared memory and did not is
+the one bug that makes beats 4–6 prove nothing while looking perfect.
+
+### ⚠ Do NOT hardcode the bucket list in your `dev/reset` route
+
+Your reset forgets and re-seeds a SET of user ids. Write that set down anywhere
+other than `user-id.ts` and it will disagree with what `resolveUserId` actually
+returns — and **every way it can disagree is silent**: the reset returns
+`ok: true` with a plausible `forgot` count, recall reads an empty bucket, and a
+procedure taught in beat 6 survives into the next run.
+
+Two ways it drifts, both of which shipped in commerce before being fixed:
+
+- **A pinned `INTELLIGENCE_USER_ID` wins inside `resolveUserId`**, and
+  `playwright.config.ts` pins it (to banking's `jordan-beamson`). So under e2e
+  your runs read and write BANKING's bucket while your reset scrubs your own
+  `<brand>-*` buckets — beats 4/5 recall nothing and beat 6 starts out taught.
+- **An operator in your roster but absent from your identity map** resolves to a
+  `<brand>-<role>` slug that a hand-written list does not contain.
+
+Have the reset ASK your identity module instead. Commerce is the worked example
+(`src/skins/commerce/intelligence/user-id.ts`): `memoryScopeUserIds()` and
+`memorySeedTargetUserIds()` build their sets by calling `resolveUserId` over every
+identity input the runtime can present (derived from the operator roster in
+`data/seed.ts`), so a pin collapses both onto the pinned bucket automatically.
+Both are FUNCTIONS, not module constants — a constant would freeze whatever the
+env was at import time, which is how the pinned case got missed. Guard it with a
+drift test that asserts the reset's set equals what `resolveUserId` can produce
+INCLUDING the pinned case: `src/skins/commerce/intelligence/user-id.test.ts`.
+
+### ⚠ Check the seeded count in your `dev/reset` route
+
+`seedMemories` above **never throws**: it counts stored rows and logs the rest. So
+a reset route that wraps it in `try`/`catch` and then returns
+`{ ok: true, reset: ["store", "memory"] }` reports success **on a backend that
+rejected every single POST** — `seeded: 0` sits in the body, unread, and the
+presenter walks on stage believing beats 4/5 are armed. This shipped in commerce.
+
+The expected count is KNOWABLE, so compare against it rather than reporting
+whatever happened:
+
+```ts
+const expectedSeeds = seedTargets.length * SEED_MEMORIES.length;
+// "seeded" only when every memory landed in every bucket; otherwise
+// "partial" / "failed" — and NOT `reset: ["store", "memory"]`, because a wipe
+// with no re-seed leaves the demo unarmed.
+```
+
+Return a non-2xx (commerce uses **502** — the upstream memory API is the failing
+dependency) for **both** partial and total shortfalls. The degree belongs in the
+body (`memory`, `seeded`, `expectedSeeds`), not the status line, because the only
+caller — your sidebar Reset button — branches solely on `res.ok`, and a partial
+seed must alert exactly as loudly as a total one: a shortfall does not say WHICH
+memory is missing, and beat 4's preference and beat 5's procedure are independent.
+
+**Keep every Intelligence SECRET out of every response body.** Log them — commerce
+`console.warn`s the backend and the exact bucket ids before mutating anything, so
+a human debugging a reset can see which of this repo's several vendored stacks was
+about to be touched — but do NOT echo them back to the caller. Commerce used to
+return the address as `apiUrl` in every response, success and failure alike, and
+this route is gated only by `PRESENTER_RESET_ENABLED` / `NODE_ENV`: a demo
+convenience, not an authorization boundary, so a booth deployment handed its
+internal backend address to anyone who could reach the box. Nothing consumed it —
+the sidebar button branches on `res.ok` alone.
+
+Dropping the field is only half of it: two body fields carry text your route did
+not compose (an `Error.message` in your `catch`, and the wipe's
+`incompleteReason`, which quotes the backend's own response body — and a 401
+payload is exactly the response that echoes the key it rejected). Scrub those on
+the way out with **`redactSecrets` from `src/lib/redact-secrets.ts`**, which
+derives its needle set FROM THE ENVIRONMENT and takes the text alone:
+
+```ts
+import { redactSecrets } from "@/lib/redact-secrets";
+
+memoryError: redactSecrets(detail),
+forgetShortfalls: forgetShortfalls.map((s) => redactSecrets(s)),
+```
+
+Do NOT write your own, and do NOT reintroduce the shape commerce's first attempt
+had — `redactBackend(text, apiUrl)`, a redactor handed the ONE value to scrub. It
+was correct about the address and silent about the API KEY, which was never passed
+to it, so a 401 body echoing the credential travelled to the caller through a
+field that was being sanitized. It also missed `URL.hostname` (the PORTLESS host,
+which `getaddrinfo ENOTFOUND …` names and which is a substring of neither the raw
+URL nor `URL.host`). A secret the redactor was never handed is a secret it cannot
+remove; add yours to `ENV_SECRETS` in that module instead, and every existing
+caller is covered at once.
+
+The presenter still needs to know memory failed and roughly why — `memory`,
+`memoryError`, the counters — never where the backend lives or what opens it. Each
+placeholder names its secret (`<intelligence-backend>`, `<intelligence-api-key>`),
+so a redacted reason still diagnoses.
+
+**Hold the `catch` path to the same standard**, because it is the one path nobody
+exercises until it fires on stage. Keep every accumulator (`forgot`, `seeded`,
+per-bucket loop counters, wipe shortfalls) declared OUTSIDE the `try` and report
+them, rather than inferring memory state from one number: commerce's catch used to
+answer `reset: forgot > 0 ? ["store","memory"] : ["store"]`, which told the "memory
+is armed" lie whenever the wipe ran and the seed loop did not — and, with
+`forgot === 0` (a bucket that was legitimately EMPTY, i.e. the second reset in a
+row), read as "memory untouched". A throw can never earn `"memory"` in `reset`:
+memory counts as reset only when it was wiped AND fully re-seeded. Count the
+buckets each loop got through, since `forgot`/`seeded` are 0 both when a loop never
+ran and when it ran over empty buckets.
+
+Worked example plus its red-green coverage:
+`src/app/api/commerce/v1/dev/reset/route.ts` and `route.test.ts`.
+
+### ⚠ Make your identity map a `Map`, not a plain object
+
+The same prototype-chain hazard as the `PAGES` table above applies to the
+operator→identity map inside `user-id.ts`, and it bites harder here. Its key is
+`properties.userId`, forwarded by the client and therefore untrusted. With a plain
+object, `operatorId && IDENTITY[operatorId]` resolves TRUTHY for `"toString"`,
+`"constructor"`, `"valueOf"`, `"__proto__"`, … — and `.userId` / `.userName` on the
+inherited member is then `undefined`, so `identifyUser` hands Intelligence an
+`undefined` memory bucket. Silently: writes and recall both go somewhere nobody
+intended, and beats 4/5/6 are exactly the beats that depend on that scope being
+right. `Record<string, …>` does not catch it; the annotation is a lie about a plain
+object. Use `new Map(...)` + `.get()` and cover it with a prototype-chain test:
+`src/skins/commerce/intelligence/user-id.ts` and its `user-id.test.ts`.
+
+Banking and people still carry the older hardcoded-list shape; copy commerce's,
+not theirs.
 
 ## `agent.ts` — SERVER-ONLY (no "use client", no JSX)
 
@@ -784,6 +1251,28 @@ export const <id>Agent = () =>
   });
 ```
 
+**De-duplicate every array selection at the top of your op-builder.** zod arrays
+do not deduplicate, and the spec comes from the MODEL: `kpis:["valueAtRisk",
+"valueAtRisk"]` is an ordinary generation, not an edge case. Because op-builders
+derive each component id from its selection value (`` `kpi-${metric}` ``), a
+repeat emits two components with the SAME id — and a2ui's per-surface
+`componentsModel` is a MAP keyed by id, so the second silently overwrites the
+first (one card renders where two were asked for) while the layout renderer's
+`children.map((id) => <Slot key={id} …>)` trips a React duplicate-key warning.
+Dedupe rather than throw: a repeat has an unambiguous intent, and throwing blanks
+the canvas mid-demo. `[...new Set(...)]` keeps first-occurrence order, so the
+builder's deterministic ordering survives. Then derive the grid's `columns` and
+every `children` array from the DE-DUPED list, not from `spec.*`:
+
+```ts
+const kpis = [...new Set(spec.kpis)];
+const lists = [...new Set(spec.lists ?? [])];
+// …then use `kpis` / `lists` everywhere below, including Math.min(kpis.length, 4).
+```
+
+Worked references with tests: `src/skins/commerce/build-brief-ops.ts` +
+`build-brief-ops.test.ts`, and `src/skins/keel/ops-report.ts` + `ops-report.test.ts`.
+
 ## `skin.tsx` — assembles the contract (NEVER imports agent.ts)
 
 ```tsx
@@ -800,10 +1289,20 @@ import { <ID>_DESIGN_SKILL } from "./design-skill";
 import { use<Id>Data } from "./data/use-data"; // NO-DATA skin: delete this import AND the `useData` field below
 // import { <Id>Providers, <Id>RuntimeProviders, use<Id>RuntimeProperties } from "./providers";
 
-const PAGES: Record<string, ComponentType> = {
-  "": <Id>HomePage,
-  // "reports": <Id>ReportsPage,
-};
+// A `Map`, NOT a plain object — load-bearing for security. `segments` is the URL
+// path after `/<id>`, i.e. untrusted caller input. A plain-object lookup
+// (`PAGES[key]`) walks the prototype chain, so "toString", "constructor",
+// "valueOf", "__proto__", … all resolve TRUTHY and slip past the `?? null` 404
+// guard, handing the shell a `Function` where a `ComponentType` is declared —
+// `/<id>/toString` then 500s instead of 404ing. `Map.get` only sees own entries.
+// `Record<string, ComponentType>` cannot catch this; the annotation is a lie
+// about a plain object. See `src/skins/keel/skin.tsx` and
+// `src/skins/commerce/skin.tsx`, and cover it with a prototype-chain test like
+// `src/skins/commerce/skin.test.tsx`.
+const PAGES: Map<string, ComponentType> = new Map([
+  ["", <Id>HomePage],
+  // ["reports", <Id>ReportsPage],
+]);
 
 const <id>: Skin = {
   id: "<id>",
@@ -811,7 +1310,7 @@ const <id>: Skin = {
   themeClass: "theme-<id>",
   Layout: <Id>Layout,
   nav: [{ segment: "", label: "Home" }],
-  resolvePage: (segments) => PAGES[segments.length === 0 ? "" : segments.join("/")] ?? null,
+  resolvePage: (segments) => PAGES.get(segments.length === 0 ? "" : segments.join("/")) ?? null,
   Tools: <Id>Tools,
   catalog: <id>Catalog,
   suggestions: <id>Suggestions,
@@ -839,14 +1338,71 @@ const <id>: Skin = {
   // real composer textarea + send button. Match on the message CONSTANT shared
   // with suggestions.ts so it can never drift. Ship the paperclip too, so the
   // presenter can stage the file by hand if the pill path misbehaves on stage.
-  // (Worked implementation: banking's `skin.tsx:87-149` + `attach-invoice.ts`.)
+  //
+  // ⚠️ FAIL LOUD, OR DO NOT SHIP THIS BEAT. If any failure lets the prompt go out
+  // anyway, the model invents the document's contents, the artifact is still
+  // filed, and it reads plausibly: the beat proves the exact opposite of its claim
+  // and nobody in the room can tell.
+  //
+  // Reporting loudly is the EASY half. The half that gets skipped is DETECTING
+  // the failure: every step here is a request made of framework code you do not
+  // own, so an unobserved step is an assumption. So:
+  //   - Never send the prompt unless the file is VERIFIED attached — which means
+  //     three separate observations, not one dispatched event:
+  //       (a) the composer ACCEPTED it — a chip appeared in
+  //           `[data-testid="copilot-attachment-queue"]`. `processFiles` drops
+  //           anything failing `accept`/`maxSize` and calls an `onUploadFailed`
+  //           this app never wires, so a rejection is otherwise INVISIBLE.
+  //       (b) it finished base64 ENCODING — the chip prints its filename.
+  //           `consumeAttachments` hands over only `ready` files, and
+  //           `onSubmitInput` refuses to send while anything is `uploading`.
+  //       (c) the send button is in SEND state — the SAME button is the STOP
+  //           button mid-run, and a click then CANCELS the run and sends nothing.
+  //   - Wait on a CONDITION with a bounded budget. Never a fixed `setTimeout`: a
+  //     sleep that races an async encode is the defect, not its duration. An
+  //     expired budget is a failure, not a green light.
+  //   - Confirm the CLICK as well — the attachment leaving the queue is the only
+  //     proof that `consumeAttachments` ran and the sheet rode the message out.
+  //   - Check the BYTES of the document (`%PDF`), not just the status: a route
+  //     that throws can answer 200 with an HTML error page, and forcing
+  //     `type: "application/pdf"` onto the File would smuggle it past `accept`.
+  //   - Locate the composer BEFORE staging, so a rename aborts while the beat is
+  //     still a no-op instead of stranding an attachment you cannot submit.
+  //   - Return a machine-readable CAUSE, not a boolean, and give each cause its
+  //     own sentence: "retry the pill", "press send by hand" and "restart the dev
+  //     server" are different instructions.
+  //   - Give each throwing step its OWN `try`. One file-wide catch blames the
+  //     fetch for a `File`/`DataTransfer` failure and sends the presenter to
+  //     check a healthy network.
+  //   - Check that the textarea write LANDED (`el.value` after setting). Do not
+  //     `setter?.call()` the one failure available away and then dispatch an
+  //     `input` event carrying the stale value.
+  //   - Surface every failure where a presenter will actually see it:
+  //     `console.error` for the log AND `window.alert` for the stage (the same
+  //     pattern the reset button uses in `layout.tsx`).
+  //   - Never `void` these promises. A dropped rejection is the silent failure
+  //     again; route both entry points through one launcher that `.catch`es.
+  // (Worked implementation: commerce's `attach-price-sheet.ts` +
+  // `attach-price-sheet.test.ts`, which red-greens every row above. Banking's
+  // `attach-invoice.ts` and people's `attach-offer-letter.ts` predate the
+  // detection half — copy commerce, not those.)
   // chatHeaderActions: [ // ChatHeaderAction[] — buttons in the shared chat header
-  //   { icon: Paperclip, label: "Attach the <artifact>", onClick: stage<Id>Attachment },
+  //   {
+  //     icon: Paperclip,
+  //     label: "Attach the <artifact>",
+  //     // The paperclip is the FALLBACK, so it must be the loudest link: if it
+  //     // fails quietly too, the presenter has nothing left to try.
+  //     onClick: () => launchBeat3d(attach<Id>ByHand),
+  //   },
   // ],
   // onSuggestionSelect: (suggestion) => {
   //   if (suggestion.message !== <ID>_ATTACHMENT_MESSAGE) return false;
-  //   void send<Id>WithAttachment();
-  //   return true; // fully handled — the shell does nothing further
+  //   // `true` means "the shell must NOT run its default send" — unconditionally
+  //   // right here, because that default path drops the attachment. Claiming the
+  //   // click is only honest if the handler guarantees two outcomes: sent WITH
+  //   // the file, or aborted AND the presenter told why. Never `true` + silence.
+  //   launchBeat3d(send<Id>WithAttachment);
+  //   return true;
   // },
 
   // ── End-user identity (ONLY if your skin scopes Intelligence per user) ──
@@ -862,13 +1418,22 @@ export default <id>;
 
 ## Multi-page `nav` + `resolvePage`
 
+Extra segments are extra `Map` entries — the resolver itself does not change. Keep
+it a `Map`, never a plain object indexed by the key, for the reason spelled out on
+the `PAGES` scaffold above (`segments` is untrusted, so `/<id>/toString` 500s
+instead of 404ing).
+
 ```tsx
+const PAGES: Map<string, ComponentType> = new Map([
+  ["", <Id>HomePage],
+  ["reports", <Id>ReportsPage],
+]);
+
+// …then in the Skin object:
 nav: [
   { segment: "", label: "Home" },
   { segment: "reports", label: "Reports" },
 ],
-resolvePage: (segments) => {
-  const key = segments.length === 0 ? "" : segments.join("/");
-  return { "": <Id>HomePage, reports: <Id>ReportsPage }[key] ?? null; // else → 404
-},
+// a miss → null → 404
+resolvePage: (segments) => PAGES.get(segments.length === 0 ? "" : segments.join("/")) ?? null,
 ```

--- a/examples/showcases/reskinnable-demo/.env.example
+++ b/examples/showcases/reskinnable-demo/.env.example
@@ -50,24 +50,37 @@ INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:7253
 # when pointed at one stack.
 INTELLIGENCE_API_KEY=cpk_s2PRVSED_seed0privat0longtoken01
 
-# Leave INTELLIGENCE_USER_ID UNPINNED for the interactive demo so the sidebar
-# user switcher drives memory scope (Alex -> jordan-beamson, Maya -> morgan-fluxx;
-# see src/skins/banking/intelligence/user-id.ts). Pin it only for a single-identity run
-# (CI/e2e already pins it in playwright.config.ts).
+# Leave INTELLIGENCE_USER_ID UNPINNED for the interactive demo, so every run
+# resolves through the active skin's own identifyUser instead of one fixed id
+# (banking's map: Alex -> jordan-beamson, Maya -> morgan-fluxx; see
+# src/skins/banking/intelligence/user-id.ts). Pin it only for a single-identity
+# run (CI/e2e already pins it in playwright.config.ts).
+#
+# CAVEAT: unpinned does NOT mean the sidebar user/operator switcher drives memory
+# scope. The client's `properties` frequently do not reach `identifyUser` on a
+# run, so the on-screen people collapse into the one default bucket and switching
+# re-scopes NOTHING. That is why banking's dev/reset seeds
+# DEMO_DEFAULT_USER_ID ("northwind-demo-user") rather than a mapped member, and
+# why the people and commerce resets seed the default bucket alongside the mapped
+# operator's. Do not present per-user memory isolation on stage; the authorities
+# are each skin's intelligence/user-id.ts and the flagged comments in
+# src/shell/agent-registry.ts.
 #
 # NOTE: banking's copy of this file warns that "non-seeded ids 403 against the
 # Intelligence stack". That is not true of the current stack — measured against a
 # freshly seeded backend, GET/POST /api/memories returns 200/201 for an unseeded
 # id and even for a nonsense one; the scope is created on demand. It matters
-# because DEMO_DEFAULT_USER_ID ("northwind-demo-user") is NOT in seed.sql, so the
-# warning implied the unpinned config recommended right above was broken. It is
-# not. Left as a note rather than deleted because banking still carries the claim.
+# because DEMO_DEFAULT_USER_ID is NOT in seed.sql, so the warning implied the
+# unpinned config recommended right above was broken. It is not. Left as a note
+# rather than deleted because the claim is repeated as fact inside THIS app too —
+# the header docblock of src/skins/banking/intelligence/user-id.ts still asserts
+# both it and the switcher claim above. Fix the two together.
 # INTELLIGENCE_USER_ID=jordan-beamson
 # INTELLIGENCE_USER_NAME=Jordan Beamson
 
 # ── Single-tenant deploy gate ────────────────────────────────────────────────
-# Unset (default) = the normal multi-skin demo: all four skins reachable, the
-# switcher visible in the assistant column. Set to ONE skin id and the UI and
+# Unset (default) = the normal multi-skin demo: every registered skin reachable,
+# the switcher visible in the assistant column. Set to ONE skin id and the UI and
 # routing expose only that skin on this deploy:
 #   - the skin is SERVED AT `/` — the `/<id>` prefix leaves the URL space
 #     entirely, so its pages are `/`, `/dashboard`, `/team` (not `/banking/...`).
@@ -78,25 +91,31 @@ INTELLIGENCE_API_KEY=cpk_s2PRVSED_seed0privat0longtoken01
 #     absent as /nope.
 #   - the switcher collapses to a static brand badge.
 #
-# This is a presentation/deploy gate, NOT a security boundary: all four agents
-# stay registered server-side, so another skin's agent endpoint (e.g. POST
+# This is a presentation/deploy gate, NOT a security boundary: EVERY skin's agent
+# stays registered server-side, so another skin's agent endpoint (e.g. POST
 # /api/copilotkit/agent/banking/run) is still reachable under a lock.
 #
 # For a URL that goes to one prospect, one booth, or one pilot — the deploy then
-# reads as a product rather than as a four-tenant demo harness.
+# reads as a product rather than as a multi-tenant demo harness.
 #
-# Valid ids: banking, airline, logistics, keel. An unrecognised value THROWS at
-# boot rather than silently 404ing every page.
+# Valid ids: ANY registered skin id. `src/lib/locked-skin.ts` validates the value
+# against `skinIds` in `src/shell/skins-config.ts`, so the supported set is exactly
+# the registered set — currently banking, airline, logistics, keel, people,
+# commerce, and automatically any skin added later. An unrecognised value THROWS
+# at boot rather than silently 404ing every page.
 #
 # This does NOT pin dark/light — that is a separate axis (the theme toggle +
 # per-skin `--nw-dark-capable`). It also does NOT hide the inspector; a locked
 # deploy still shows it, which is the intended FDE configuration.
 LOCK_SKIN=
 
-# Presenter/booth reset button (left sidebar). Unset = hidden AND the
-# /api/banking/v1/dev/reset endpoint is disabled (403). Set to "true" for
-# FDE/sales/conference deployments so a presenter can reset demo state
-# (re-seed transactions + forget all durable memories) without curl.
+# Presenter/booth reset button (left sidebar). Unset = hidden AND
+# /api/banking/v1/dev/reset returns 403. The other presenter-ready skins
+# (commerce, logistics, people) each ship their own `v1/dev/reset` and gate it on
+# this var too, but only when NODE_ENV=production. Set to "true" for
+# FDE/sales/conference deployments so a presenter can reset that skin's demo state
+# (re-seed its ledger, and — where the skin seeds memories — forget the durable
+# ones it learned) without curl.
 PRESENTER_RESET_ENABLED=
 
 # Test-only: point the agent LLM at aimock for the deterministic E2E proof.

--- a/examples/showcases/reskinnable-demo/CLAUDE.md
+++ b/examples/showcases/reskinnable-demo/CLAUDE.md
@@ -2,16 +2,16 @@
 
 One Next.js app whose **entire** experience — brand, theme, layout, pages,
 tools, and agent — is reskinnable at runtime. A skin-agnostic **shell** hosts
-one **skin** per route segment `/[skin]/...`. It ships five skins — `banking`,
-`airline`, `logistics`, `keel` and `people` — switchable from a dropdown at the top of the
-assistant column, plus a repo-local **reskin skill**
+one **skin** per route segment `/[skin]/...`. It ships six skins — `banking`,
+`airline`, `logistics`, `keel`, `people` and `commerce` — switchable from a
+dropdown at the top of the assistant column, plus a repo-local **reskin skill**
 (`.claude/skills/reskin/`) for authoring new ones.
 
 The point of the app is the `Skin` contract: a single interface that swaps a
 whole product without the shell knowing anything domain-specific. The skins
-deliberately sit on **two different data substrates** — banking, logistics and
-people are REST-backed, airline and keel are in-memory — to prove the contract
-is substrate-agnostic.
+deliberately sit on **two different data substrates** — banking, logistics,
+people and commerce are REST-backed, airline and keel are in-memory — to prove
+the contract is substrate-agnostic.
 
 **Each skin is also a live sales demo.** It exists to prove CopilotKit and
 Intelligence top to bottom to an enterprise buyer, through a fixed set of demo
@@ -19,7 +19,8 @@ Intelligence top to bottom to an enterprise buyer, through a fixed set of demo
 than text, manipulate the app four ways (drive it, read the screen, navigate via
 real levers, ingest a document into a durable artifact), recall long-term memory,
 replay a stored procedure, and learn a new one on stage. `banking` is the original
-reference implementation; `people` is the second skin built to hit every beat. The
+reference implementation; `people` and `commerce` are the later skins built to hit
+every beat. The
 beats, and what each one must prove, are specified in
 [`.claude/skills/reskin/demo-beats.md`](.claude/skills/reskin/demo-beats.md) —
 read it before adding or changing a skin's tools, prompt or suggestion pills,
@@ -123,17 +124,17 @@ Required:
 
 Optional:
 
-| Field                   | Type                                                 | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| ----------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Providers?`            | `ComponentType<{ children: ReactNode }>`             | Escape hatch: a skin-specific provider stack mounted **below** `CopilotKitProvider` (banking uses it for its recording context). Omitted → the shell substitutes a pass-through.                                                                                                                                                                                                                                                                                 |
-| `CanvasSurface?`        | `ComponentType`                                      | Renders this skin's own a2ui report surface full-region on the shared canvas. Omit if the skin has no a2ui report canvas (airline omits it).                                                                                                                                                                                                                                                                                                                     |
-| `sandboxFunctions?`     | `SandboxFunction[]`                                  | Functions exposed inside OGUI sandboxed iframes for this skin (e.g. banking's spend-data getters).                                                                                                                                                                                                                                                                                                                                                               |
-| `toolLabels?`           | `Record<string, string>`                             | Human labels for this skin's own tool-activity chips, keyed by tool name. Unlisted tools fall back to a prettified raw name.                                                                                                                                                                                                                                                                                                                                     |
-| `chatHeaderActions?`    | `ChatHeaderAction[]`                                 | Buttons this skin contributes to the shared chat header, drawn before the shell's own controls.                                                                                                                                                                                                                                                                                                                                                                  |
-| `onSuggestionSelect?`   | `(suggestion: Suggestion, index: number) => boolean` | Intercepts a suggestion click. Return `true` if the skin fully handled it (the shell does nothing further); return `false`/omit for the default "send the message" path.                                                                                                                                                                                                                                                                                         |
-| `RuntimeProviders?`     | `ComponentType<{ children: ReactNode }>`             | Provider stack mounted **above** `CopilotKitProvider` (unlike `Providers`, which mounts below). The sanctioned place to establish any context `useRuntimeProperties` must read — the identity source must sit above the provider so the provider owns the property bag from its first commit (no child racing `setProperties`). Banking hoists its `AuthContextProvider` here; airline omits it.                                                                 |
-| `useRuntimeProperties?` | `() => Record<string, unknown> \| undefined`         | Contributes this skin's runtime `properties`. The shell calls it inside `RuntimeProviders` (above `CopilotKitProvider`) and threads the result straight into `CopilotKitProvider`'s `properties` prop — this is how a skin scopes its Intelligence runs / durable memory per end-user without the shell reaching into skin internals. Return a stable/memoized object; banking returns `{ userRole, userId }`. Omit if the skin contributes no runtime identity. |
-| `useData?`              | `() => unknown`                                      | Seed-backed data hook; the shell runs it in `SkinProvider`, components read it via `useSkinData<T>()`. Omit when a skin has no shell-managed data — banking omits it (it reads REST via `useCreditCards` and the member via `useAuthContext` directly), so `useSkinData<T>()` returns `undefined`. Airline supplies a real one.                                                                                                                                  |
+| Field                   | Type                                                 | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Providers?`            | `ComponentType<{ children: ReactNode }>`             | Escape hatch: a skin-specific provider stack mounted **below** `CopilotKitProvider`, for anything that must consume CopilotKit context. Set by the four REST-backed skins — banking, people and commerce for their teach-mode recording context (plus their OGUI sandbox data sync), logistics for the sandbox sync alone; omitted by airline and keel → the shell substitutes a pass-through.                                                                                                                                                                                                                                                                                               |
+| `CanvasSurface?`        | `ComponentType`                                      | Renders this skin's own a2ui report surface full-region on the shared canvas. Omit if the skin has no a2ui report canvas (airline omits it).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `sandboxFunctions?`     | `SandboxFunction[]`                                  | Functions exposed inside OGUI sandboxed iframes for this skin (e.g. banking's spend-data getters).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `toolLabels?`           | `Record<string, string>`                             | Human labels for this skin's own tool-activity chips, keyed by tool name. Unlisted tools fall back to a prettified raw name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `chatHeaderActions?`    | `ChatHeaderAction[]`                                 | Buttons this skin contributes to the shared chat header, drawn before the shell's own controls.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `onSuggestionSelect?`   | `(suggestion: Suggestion, index: number) => boolean` | Intercepts a suggestion click. Return `true` if the skin fully handled it (the shell does nothing further); return `false`/omit for the default "send the message" path.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `RuntimeProviders?`     | `ComponentType<{ children: ReactNode }>`             | Provider stack mounted **above** `CopilotKitProvider` (unlike `Providers`, which mounts below). The sanctioned place to establish any context `useRuntimeProperties` must read — the identity source must sit above the provider so the provider owns the property bag from its first commit (no child racing `setProperties`). Banking hoists its `AuthContextProvider` here; airline omits it.                                                                                                                                                                                                                                                                                             |
+| `useRuntimeProperties?` | `() => Record<string, unknown> \| undefined`         | Contributes this skin's runtime `properties`. The shell calls it inside `RuntimeProviders` (above `CopilotKitProvider`) and threads the result straight into `CopilotKitProvider`'s `properties` prop — this is how a skin scopes its Intelligence runs / durable memory per end-user without the shell reaching into skin internals. Return a stable/memoized object; banking returns `{ userRole, userId }`. Omit if the skin contributes no runtime identity.                                                                                                                                                                                                                             |
+| `useData?`              | `() => unknown`                                      | Seed-backed data hook; the shell runs it in `SkinProvider`, components read it via `useSkinData<T>()`. **This is the standard mechanism for the two in-memory skins and is deliberately unused by the four REST-backed ones**, so it splits exactly along the substrate line: `airline` (`useAirlineData`) and `keel` (`useKeelData`) each supply a real one, while banking, logistics, people and commerce all omit it and read their REST ledger through their own context/hooks instead (banking via `useCreditCards` + `useAuthContext`; logistics `useLogistics()`; people `usePeopleLedger()`; commerce `useCommerceLedger()`) — in those four `useSkinData<T>()` returns `undefined`. |
 
 Supporting types (also in the contract file):
 
@@ -159,12 +160,20 @@ browser. So:
   - `src/shell/agent-registry.ts` — the **server** `agentRegistry` map (imports
     only server-safe modules). Kept separate so the API route never pulls
     client-only code server-side.
-- `src/shell/skins-config.ts` holds `defaultSkinId` and `skinIds` as pure config
-  (no skin imports), so the server-component `/` redirect, `src/proxy.ts` and the
+- `src/shell/skins-config.ts` holds `defaultSkinId`, `skinIds` and
+  `skinIdentities` as pure config (no skin imports), so the server-component `/`
+  redirect, the root layout's `generateMetadata`, `src/proxy.ts` and the
   `LOCK_SKIN` validator can read them without dragging client skin modules into
   an RSC (or, for the proxy, into the request hook).
-  `skinIds` duplicates the registry's keys on purpose; `skins-config.test.ts` is
-  the drift guard.
+  `skinIds` duplicates the registry's keys on purpose, and `skinIdentities`
+  duplicates every skin's `identity.brand` + `identity.tagline` — that map is
+  what `generateMetadata` in `src/app/layout.tsx` reads to give a `LOCK_SKIN`
+  deploy the locked brand as its `<title>` and the locked tagline as its
+  `<meta name="description">` (unlocked, both fall back to the generic
+  demo pair). `skins-config.test.ts` is the drift guard for both copies;
+  `skinIdentities` is additionally typed
+  `Record<(typeof skinIds)[number], …>`, so a registered skin with no entry is a
+  `pnpm build` type error rather than a wrong tab title.
 
 ### Per-skin server identity (`agentRegistry`)
 
@@ -184,16 +193,30 @@ export type IdentifyRunUser = (
   (`src/skins/banking/intelligence/user-id.ts`), which maps the client-forwarded
   `properties` ({ userRole, userId }) onto its per-member/role memory scope.
   **People** contributes `peopleIdentifyUser` and, like banking, actually uses it
-  for durable memory — its seeded preference belongs to one operator, so
-  switching operator lands in a different bucket. **Logistics** and **keel**
-  contribute one too (`logisticsIdentifyUser`, `keelIdentifyUser`) for thread
-  scoping — though neither yet uses it for durable memory. **Airline** is the
-  only skin that omits it (no auth, no memory).
-- Banking and people each additionally ship `intelligence/seed-memories.ts` and
-  `intelligence/forget-memories.ts`, which their `dev/reset` route uses to wipe
-  learned memories and re-seed the ones the demo must start out already knowing.
-  That file is what makes the long-term-memory and stored-procedure beats work;
-  it is not emergent behaviour.
+  for durable memory — its `intelligence/seed-memories.ts` seeds the mapped
+  operator's bucket (Maya's) AND the default one, because runs frequently resolve
+  to the default: the client's `properties` often do not reach `identifyUser`, so
+  Maya and Clara both land in `rowan-demo-user` and switching operator re-scopes
+  nothing (read `src/skins/people/intelligence/user-id.ts` before writing
+  anything about per-operator scoping there). **Commerce** contributes
+  `commerceIdentifyUser` and likewise uses it for durable memory — its
+  `intelligence/seed-memories.ts` seeds the mapped operator's bucket AND the
+  default one, because runs frequently resolve to the default (read
+  `src/skins/commerce/intelligence/user-id.ts` before writing anything about
+  per-operator scoping there). **Logistics** and **keel** contribute one too
+  (`logisticsIdentifyUser`, `keelIdentifyUser`) for thread scoping — though
+  neither yet uses it for durable memory. That is five of the six skins;
+  **airline** is the only one that omits it (no auth, no memory).
+- Every skin that claims the memory beats additionally ships
+  `intelligence/seed-memories.ts` and `intelligence/forget-memories.ts`, which its
+  `dev/reset` route uses to wipe learned memories and re-seed the ones the demo
+  must start out already knowing. Today that is the three demo-complete skins —
+  **banking**, **commerce** and **people**. That pair is what makes the
+  long-term-memory, stored-procedure-replay and teach-a-procedure beats work; it
+  is not emergent behaviour. The gated `dev/reset` route is the wider set: four
+  skins have one, those three plus **logistics** — which ships neither memory
+  file, so its reset restores its data store only and cannot restore the memory
+  beats.
 - `identifyUser` is reached through the **server-only** registry, so it MUST be
   server-safe: **no `"use client"`, no JSX, no `.tsx` imports.** Keep it in a
   plain `.ts` module.
@@ -229,6 +252,12 @@ export type IdentifyRunUser = (
   and yields a leading `//`. The `//` guard is nav-scoped on purpose so it never
   false-positives on ordinary date/ratio templates (`` `${m}/${d}` ``); the cost is
   that a URL built into a variable before navigating is not caught by that guard.
+  Those selectors interpolate `LINTED_SKIN_IDS` from the same file — a hand-copy of
+  `skinIds` (an ESLint flat config is loaded by Node and cannot import a `.ts`
+  module), so **a new skin must be appended there or lint is blind to it**.
+  `skins-config.test.ts` guards that copy by linting a synthetic prefixed link for
+  every registered skin through the real selectors; it exists because the list did
+  rot, naming four skins for two releases after `people` and `commerce` shipped.
   `useSkinSegments` is its companion for nav active-state; it strips a LEADING
   skin id rather than slicing a fixed offset, so it is correct whether or not the
   pathname carries the prefix. Keel wraps both in `src/skins/keel/href.ts`.
@@ -365,7 +394,7 @@ Gen-UI components registered via `useComponent` (airline's flight card, banking'
 charts and queues) render in the chat transcript, not on the canvas — that is a
 separate path from the full-region canvas surfaces above.
 
-## The five skins (why they differ)
+## The six skins (why they differ)
 
 Two substrates behind one contract is the architectural demonstration. Demo
 completeness is a **separate axis**, and the two do not correlate — see the beat
@@ -382,9 +411,15 @@ matrix at the end of this section.
   `useRuntimeProperties` (returns `{ userRole, userId }`) on the client plus a
   server-safe `identifyUser` in the agent registry. It **omits** `useData` — its
   components read the REST ledger via `useCreditCards` and the current member via
-  `useAuthContext` directly, so nothing flows through `useSkinData`. It is also
-  the only skin with a route readable, per-page on-screen readables, seeded
-  memories, and the teach-mode loop (`docs/teach-mode/`).
+  `useAuthContext` directly, so nothing flows through `useSkinData`. It was the
+  FIRST skin with a route readable, per-page on-screen readables, seeded memories
+  and the teach-mode loop (`docs/teach-mode/`) — it is no longer the only one:
+  `people` and `commerce` have all four too, as the beat matrix below and
+  `docs/teach-mode/README.md` both say. Which skins have which is derivable, so
+  derive it rather than trusting a sentence:
+  `grep -rln useAgentContext src/skins/*/layout.tsx` (route readable),
+  `ls src/skins/*/intelligence/seed-memories.ts` (seeded memories), and
+  `grep -l offerWorkflowRecording src/skins/*/tools.tsx` (teach mode).
 - **`logistics`** ("Meridian") — **REST-backed**. A freight control tower for
   exception triage (expedite / reroute / split / absorb) across pages
   `control-tower` (index), `lanes`, `inventory`, `decisions`. Like banking it
@@ -427,28 +462,50 @@ matrix at the end of this section.
   stage and the unaided replay are different people. Its beat map is written out
   at the top of `src/skins/people/suggestions.ts`.
 
+- **`commerce`** ("Bellwether") — **REST-backed**, a storefront operations
+  console for a DTC retail brand, and the third skin built demo-complete against
+  the full beat list. Pages `orders` (index), `catalog`, `promotions`, `returns`,
+  over `/api/commerce/v1/*` (one `ledger` snapshot read plus the write paths, a
+  generated `price-sheet` PDF, and a gated `dev/reset`). Like banking, logistics
+  and people it **omits `useData`**, reading the ledger through its own
+  `useCommerceLedger()` context — mounted in `RuntimeProviders` rather than
+  `Providers`, so the single fetch also feeds `useRuntimeProperties`. Sets
+  `Providers` (teach-mode recording), `CanvasSurface` (server tool
+  `render_trade_brief`), `sandboxFunctions`, `toolLabels`, `chatHeaderActions`,
+  `onSuggestionSelect` and a server `identifyUser`. Its signature visual is the
+  **margin ladder** — one rail per category, each anchored to that category's own
+  margin floor, so "how far from the line I may not cross" is comparable across
+  categories at a glance. Its teachable gate is approving a markdown that would
+  trade **below the category margin floor** (422 `BELOW_MARGIN_FLOOR`), unlocked
+  by a margin waiver filed under a justifying code; two below-floor markdowns are
+  seeded so the case taught on stage and the unaided replay are different
+  products. **The reference for a four-lever navigation** (beat 3c): status,
+  exception class, sort and top-N all arrive from the query string and all four
+  controls tint. Its beat map is written out at the top of
+  `src/skins/commerce/suggestions.ts`.
+
 ### Demo-beat coverage (the other axis)
 
-| Beat                             | banking                   | people                    | airline | logistics     | keel          |
-| -------------------------------- | ------------------------- | ------------------------- | ------- | ------------- | ------------- |
-| Gen-UI in transcript             | ✅ 8                      | ✅ 4                      | ✅ 6    | ✅ 5          | ✅ 5          |
-| Rich thread survives reload      | ✅ replay-safe tools      | ✅ replay-safe tools      | ❌      | ❌            | ❌            |
-| Drive the app, secret withheld   | ✅                        | ✅                        | ❌      | ❌            | ❌            |
-| "What's on my screen?"           | ✅ route + page readables | ✅ route + page readables | ❌      | ❌            | ❌            |
-| Navigate via levers + filters    | ✅                        | ✅                        | ❌      | ❌            | nav only      |
-| Multimodal → durable artifact    | ✅                        | ✅                        | ❌      | ❌            | ❌            |
-| Long-term memory recall          | ✅                        | ✅                        | ❌      | plumbing only | plumbing only |
-| Stored-procedure replay          | ✅                        | ✅                        | ❌      | ❌            | ❌            |
-| Teach a new procedure            | ✅                        | ✅                        | ❌      | ❌            | ❌            |
-| Presenter reset (route + button) | ✅                        | ✅                        | ❌      | ✅            | ❌            |
+| Beat                             | banking                   | people                    | commerce                  | airline | logistics     | keel          |
+| -------------------------------- | ------------------------- | ------------------------- | ------------------------- | ------- | ------------- | ------------- |
+| Gen-UI in transcript             | ✅ 9                      | ✅ 4                      | ✅ 4                      | ✅ 6    | ✅ 5          | ✅ 4          |
+| Rich thread survives reload      | ✅ replay-safe tools      | ✅ replay-safe tools      | ✅ replay-safe tools      | ❌      | ❌            | ❌            |
+| Drive the app, secret withheld   | ✅                        | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| "What's on my screen?"           | ✅ route + page readables | ✅ route + page readables | ✅ route + page readables | ❌      | ❌            | ❌            |
+| Navigate via levers + filters    | ✅                        | ✅                        | ✅ four levers            | ❌      | ❌            | nav only      |
+| Multimodal → durable artifact    | ✅                        | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| Long-term memory recall          | ✅                        | ✅                        | ✅                        | ❌      | plumbing only | plumbing only |
+| Stored-procedure replay          | ✅                        | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| Teach a new procedure            | ✅                        | ✅                        | ✅                        | ❌      | ❌            | ❌            |
+| Presenter reset (route + button) | ✅                        | ✅                        | ✅                        | ❌      | ✅            | ❌            |
 
-`banking` and `people` hit every row; airline, logistics and keel predate this
-bar and hit about one each (nine beats plus the presenter-reset requirement are
-listed above). Note that logistics and keel ship the **full per-user identity plumbing** —
-`RuntimeProviders`, `useRuntimeProperties`, server `identifyUser` — and then no
-memory prompts, no memory tools and no seed file, so they get no demo value from
-the hardest part of it. Treat all three as excellent **wiring** references and
-incomplete **demo** references.
+`banking`, `people` and `commerce` hit every row; airline, logistics and keel
+predate this bar and hit about one each (nine beats plus the presenter-reset
+requirement are listed above). Note that logistics and keel ship the **full
+per-user identity plumbing** — `RuntimeProviders`, `useRuntimeProperties`, server
+`identifyUser` — and then no memory prompts, no memory tools and no seed file, so
+they get no demo value from the hardest part of it. Treat all three as excellent
+**wiring** references and incomplete **demo** references.
 
 ## How to add a skin
 
@@ -466,7 +523,26 @@ authoring flow. In short:
    prompt is where most beats are actually enforced.
 5. Register in **both** `src/shell/registry.ts` (client skin) and
    `src/shell/agent-registry.ts` (as `{ createAgent, identifyUser? }`), keyed by
-   the identical `id`.
+   the identical `id` — and append the id to `LINTED_SKIN_IDS` in
+   `eslint.config.mjs`, or the LOCK_SKIN lint guard never looks at your skin.
+   Then append the same id to `skinIds` in `src/shell/skins-config.ts`, or
+   `LOCK_SKIN=<id>` is rejected at boot, plus an entry to `skinIdentities` in
+   that same file carrying your `identity.brand` and `identity.tagline`
+   verbatim — that map, not your skin module, is what a locked deploy's
+   `<title>` and `<meta name="description">` come from. **Only some of those
+   sites are guarded, so read this before trusting a green tree.**
+   `skins-config.test.ts` compares `LINTED_SKIN_IDS`, `skinIds` and
+   `skinIdentities` against `registry.ts` and fails on any of the three (a
+   missing `skinIdentities` entry additionally fails `pnpm build`, because that
+   map is typed `Record<(typeof skinIds)[number], …>`). `registry.ts` is the
+   thing they are all compared TO, so it cannot drift — forget it and your skin
+   simply does not exist (no selector entry, `/<id>` 404s). **`agent-registry.ts`
+   has no drift guard at all**: nothing imports it from a test
+   (`grep -rln agentRegistry src --include='*.test.*'` is empty) and its
+   `Record<string, AgentRegistration>` type accepts a missing key, so a skin
+   wired everywhere else renders fine and only fails when someone sends a chat
+   message. Check that one by hand, or by step 5 of the skill's Verification
+   list.
 6. If the skin scopes Intelligence per end-user, add its client
    `RuntimeProviders` + `useRuntimeProperties` and a server-safe `identifyUser`.
    If it has memory or stored-procedure beats, add
@@ -503,10 +579,10 @@ Run tasks through Nx per the repo convention where applicable.
 ## Reference
 
 - `src/shell/skin-contract.ts` — the contract (source of truth).
-- `src/skins/{banking,logistics,airline,keel,people}/skin.tsx` — five
-  implementations. Open `banking` or `people` for demo completeness, `logistics`
-  for layout chrome and the server-emitted a2ui canvas, `airline` for the
-  minimal contract surface, `keel` for parameterized routes.
+- `src/skins/{banking,logistics,airline,keel,people,commerce}/skin.tsx` — six
+  implementations. Open `banking`, `people` or `commerce` for demo completeness,
+  `logistics` for layout chrome and the server-emitted a2ui canvas, `airline` for
+  the minimal contract surface, `keel` for parameterized routes.
 - `.claude/skills/reskin/` — the authoring skill: `SKILL.md` (contract + wiring
   traps), `demo-beats.md` (what the demo must prove, and the quality bar),
   `templates.md` (per-file starting points).

--- a/examples/showcases/reskinnable-demo/README.md
+++ b/examples/showcases/reskinnable-demo/README.md
@@ -2,7 +2,8 @@
 
 One Next.js app whose **entire** experience — brand, theme, layout, pages,
 tools, and agent — is reskinnable at runtime. A skin-agnostic **shell** hosts
-one **skin** per route segment `/[skin]/...`, and ships four of them:
+one **skin** per route segment `/[skin]/...`. The registered set lives in
+`src/shell/registry.ts` — today six skins:
 
 - **`banking`** — "Northwind Finance", a corporate banking dashboard. **REST-backed**
   (a live ledger at `/api/banking/v1/*`): transactions, cards, expense policies,
@@ -11,16 +12,23 @@ one **skin** per route segment `/[skin]/...`, and ships four of them:
 - **`logistics`** — "Meridian", a freight control tower. **REST-backed** (a live
   ledger of its own): exception triage — expedite, reroute, split, or absorb —
   across lanes, inventory, and decisions.
+- **`people`** — "Rowan", a People Ops command center. **REST-backed**
+  (`/api/people/v1/*`): roster, compensation bands, requests, and onboarding,
+  with a teachable out-of-band compensation approval.
+- **`commerce`** — "Bellwether", a storefront operations console for a DTC retail
+  brand. **REST-backed** (`/api/commerce/v1/*`): orders, catalog, promotions, and
+  returns, with a margin ladder and a teachable below-floor markdown approval.
 - **`airline`** — "Aeronova", a passenger concierge. **In-memory** (a seed-backed
   React store): check-in and seat selection, loyalty, and disruption rebooking.
 - **`keel`** — "Keel", Harbor Point Health's knowledge and operations desk.
   **In-memory** (a seed-backed React store), and the only skin with parameterized
   routes (`knowledge/<docId>`, `runs/<runId>`).
 
-These four run behind the **same** `Skin` contract on purpose: banking and
-logistics are REST-backed, airline and keel are in-memory, which proves the
-contract is substrate-agnostic. Every skin gets the same inset frame, shared chat
-panel, tool-activity lines, suggestion pills, and full-region canvas from the shell.
+All of them run behind the **same** `Skin` contract on purpose: banking,
+logistics, people and commerce are REST-backed, airline and keel are in-memory,
+which proves the contract is substrate-agnostic. Every skin gets the same inset
+frame, shared chat panel, tool-activity lines, suggestion pills, and full-region
+canvas from the shell.
 
 ## What it demonstrates
 
@@ -54,20 +62,25 @@ services. Durable cross-thread memory is env-gated (Intelligence mode); see
 Use the **skin switcher** — a dropdown at the top of the assistant column, in
 the selector card — it lists every registered skin and navigates to `/<id>`
 client-side (instant, no reload). Each skin starts in its own fresh thread. You
-can also go straight to `/banking` or `/airline`.
+can also go straight to any registered id — `/banking`, `/commerce`, `/keel`, …
 
 ### Pinning a deploy to one skin
 
-Set `LOCK_SKIN` to a skin id (`banking`, `airline`, `logistics`, `keel`) and the
-deploy becomes single-tenant: the skin is **served at `/`**, with the `/<id>`
-prefix gone from the URL space altogether — `LOCK_SKIN=banking` puts the credit
-cards view at `/` and the dashboard at `/dashboard`, never `/banking/dashboard`.
-Every other skin's segment 404s, as does the locked skin's own prefix, and the
-switcher collapses to a static brand badge. Unset — the default — all four stay
-reachable under `/<id>` exactly as before.
+Set `LOCK_SKIN` to **any registered skin id** and the deploy becomes
+single-tenant: the skin is **served at `/`**, with the `/<id>` prefix gone from
+the URL space altogether — `LOCK_SKIN=banking` puts the credit cards view at `/`
+and the dashboard at `/dashboard`, never `/banking/dashboard`. Every other skin's
+segment 404s, as does the locked skin's own prefix, and the switcher collapses to
+a static brand badge. Unset — the default — every registered skin stays reachable
+under `/<id>` exactly as before.
+
+`src/lib/locked-skin.ts` validates the value against `skinIds` from
+`src/shell/skins-config.ts`, so the supported set is exactly the registered set —
+currently `banking`, `airline`, `logistics`, `keel`, `people`, `commerce`, and
+automatically any skin added later.
 
 Use it for a URL that goes to one prospect, one booth, or one pilot, so the app
-reads as a product rather than as a four-tenant demo harness. An unrecognised id
+reads as a product rather than as a multi-tenant demo harness. An unrecognised id
 throws at boot rather than silently 404ing every page. See `.env.example`.
 
 ## Adding a skin
@@ -81,17 +94,32 @@ rebuilding them. The shape:
 2. Write `theme.css` (a `.theme-<id>` block re-valuing the shared tokens) and
    side-effect-import it from the skin's `layout.tsx`.
 3. Add a server-safe `agent.ts` (no `"use client"`, no JSX).
-4. Register in **both** `src/shell/registry.ts` (client) and
-   `src/shell/agent-registry.ts` (server), keyed by the identical `id`.
+4. Register in **five** places, all keyed by the identical `id`:
+   `src/shell/registry.ts` (client skin), `src/shell/agent-registry.ts` (server
+   agent), `LINTED_SKIN_IDS` in `eslint.config.mjs` (or the LOCK_SKIN lint guard
+   never looks at your skin), and both `skinIds` (or `LOCK_SKIN=<id>` throws at
+   boot) and `skinIdentities` (the locked deploy's `<title>` and
+   `<meta name="description">`) in `src/shell/skins-config.ts`. `pnpm test:unit`
+   catches a missed append to the last three; the first two it does not — see
+   CLAUDE.md § "How to add a skin" for which failure is silent.
 
 See **[CLAUDE.md](./CLAUDE.md)** for the full architecture: the contract field by
 field, the client/server boundary, routing/provider composition, the theming
 contract, and the shared canvas / OGUI model.
 
-## The banking skin's demo capabilities
+## Demo capabilities
 
-The banking skin is the original reference demo and doubles as a CopilotKit
-feature tour (`people` is the other demo-complete skin). Notable beats:
+Three of the six skins — **`banking`**, **`people`** and **`commerce`** — are
+demo-complete against the full beat list in
+[`.claude/skills/reskin/demo-beats.md`](./.claude/skills/reskin/demo-beats.md).
+`airline`, `logistics` and `keel` predate that bar: treat them as wiring
+references (contract surface, layout chrome, parameterized routes) rather than as
+demo references. The per-beat coverage matrix is in
+[CLAUDE.md](./CLAUDE.md).
+
+### `banking` — the original reference demo
+
+The banking skin doubles as a CopilotKit feature tour. Notable beats:
 
 - **Components, never walls of text** — transactions, the approvals queue,
   charts, and spend summaries render as real components in the chat rather than
@@ -108,6 +136,25 @@ feature tour (`people` is the other demo-complete skin). Notable beats:
   no saved procedure, watches you clear one, and (in Intelligence mode) recalls
   it on a later thread. See `docs/teach-mode/`.
 
+### `people` and `commerce` — the later demo-complete skins
+
+Both were built against the beat list from the start, so each hits every beat
+banking does. Their beat maps are written out at the top of their own
+`src/skins/<id>/suggestions.ts`, one suggestion pill per beat in demo order.
+
+- **`people`** ("Rowan") — a People Ops command center over `/api/people/v1/*`.
+  Its teachable gate is approving an **out-of-band** compensation request (422
+  `OUT_OF_BAND`), unlocked by a band exception filed under a justifying code. Two
+  out-of-band requests are seeded, so the case taught on stage and the unaided
+  replay are different people.
+- **`commerce`** ("Bellwether") — a storefront operations console over
+  `/api/commerce/v1/*`. Its signature visual is the **margin ladder**: one rail
+  per category, each anchored to that category's own margin floor. Its teachable
+  gate is approving a markdown that would trade **below the category margin
+  floor** (422 `BELOW_MARGIN_FLOOR`), unlocked by a margin waiver filed under a
+  justifying code. It is also the reference for a four-lever navigation — status,
+  exception class, sort and top-N all arrive from the query string.
+
 ### Memory & durable self-learning (Intelligence mode)
 
 By default the runtime is pure OSS — the teach-a-workflow loop works within a
@@ -115,8 +162,9 @@ single conversation, but nothing persists across threads or restarts. When
 `INTELLIGENCE_API_URL`, `INTELLIGENCE_GATEWAY_WS_URL`, and `INTELLIGENCE_API_KEY`
 are all set (`src/app/api/copilotkit/[[...slug]]/route.ts`), the runtime builds
 in Intelligence mode: the agent gains durable long-term memory via the
-`recall_memory` / `save_memory` tools, so a demonstrated over-limit procedure
-(and remembered facts/preferences) survive across threads and users. The bundled
+`recall_memory` / `save_memory` tools, so a demonstrated procedure — banking's
+over-limit approval, people's band exception, commerce's margin waiver — and
+remembered facts/preferences survive across threads and users. The bundled
 `docker-compose.yml` and `*-demo.sh` scripts stand up the memory stack; the
 `.env.example` documents the required variables.
 
@@ -127,7 +175,7 @@ The images under `assets/` (`aurora-dashboard.png`, `copilot-chat.png`,
 skin** specifically — its dashboard, chat panel, and learning-mode recording
 vignette. They predate the current shell chrome entirely: there is now an inset
 frame of resizable cards with a skin-selector dropdown at the top of the assistant
-column, and the app ships five skins rather than two. Treat them as historical
+column, and the app ships six skins rather than two. Treat them as historical
 banking-skin illustrations rather than a picture of the app as it looks today.
 
 ## Testing

--- a/examples/showcases/reskinnable-demo/docs/teach-mode/README.md
+++ b/examples/showcases/reskinnable-demo/docs/teach-mode/README.md
@@ -1,13 +1,68 @@
-# teach-mode — the banking skin's teachable over-limit flow
+# teach-mode — the teachable-gate loop, worked on the banking skin
 
-> Scope: this documents a feature of the **`banking` skin**
-> (`src/skins/banking/`), not the whole app. The app is a reskinnable shell that
-> hosts one skin per `/[skin]` route; see the top-level `CLAUDE.md`. Teach-mode
-> is per-skin, not a shell feature: `banking` (documented here) and `people`
-> (out-of-band compensation approvals, gated by 422 `OUT_OF_BAND`) implement it;
-> `airline`, `logistics` and `keel` do not. The 5-role contract below is stated
-> demo-agnostically and `people` follows it role for role, so read this file
-> before building a third.
+> Scope: teach-mode is a **per-skin feature, not a shell feature**. This file
+> documents it demo-agnostically as a 5-role contract and uses the **`banking`
+> skin** (`src/skins/banking/`) as the worked example throughout; the app is a
+> reskinnable shell that hosts one skin per `/[skin]` route, see the top-level
+> `CLAUDE.md`.
+>
+> **Which skins implement it is deliberately not listed here.** A roster written
+> into prose is the defect this repo keeps shipping — it goes stale the moment a
+> skin lands, and nothing catches it (`src/shell/skin-roster-docs.test.ts` exists
+> because that happened sixteen times in one review). The invariant instead: **a
+> skin implements teach mode exactly when its `Tools` registers the recording
+> hand-off**, so the roster is a command, not a sentence:
+>
+> ```bash
+> grep -l offerWorkflowRecording src/skins/*/tools.tsx
+> ```
+>
+> **The grep gives you the roster; it does not certify compliance.** Do not read
+> it as "every skin it names follows all five roles" — an earlier revision of this
+> paragraph said exactly that on the strength of two skins, and the third
+> falsifies it. Verified role by role at the time of writing: **`banking` and
+> `commerce` satisfy all five. `people` satisfies #1, #2, #4 and #5, and of role
+> #3's TWO replay invariants it satisfies one and violates the other** — read both
+> before deciding what to copy from it:
+>
+> - _Survives replay_ — **satisfied.** `people`'s `awaitDemonstration` render
+>   (`src/skins/people/tools.tsx:1103`) counts `\d+\.\s` in `result`, and `result`
+>   is the **tool result** — the observed-steps directive that `DemonstrationCard`
+>   builds and hands to `respond?.()` (`tools.tsx:1337-1341`), numbering included.
+>   It is not parsing its own rendering, and that branch prints no list that could
+>   disagree with the number. The directive is what replays, so the count is
+>   stable. It is still the brittle FORM — it parses a count instead of reading one
+>   the recorder reported, so a numeral inside a step label would inflate it — but
+>   that is a robustness gap, not a replay defect.
+> - _A settle is not an answer_ — **violated.** `saveLearnedProcedure`'s render
+>   (`tools.tsx:1135-1139`) prints "Saved. I'll use this next time" on ANY string
+>   result, and the _Don't save_ button settles with one (`tools.tsx:1164-1167`).
+>   The card asserts a durable write that never happened — live, and identically on
+>   every replay, which is why it survived.
+>
+> **So copy `commerce`.** It is the only one whose replay behaviour is _pinned_:
+> `src/skins/commerce/teach-mode-directives.ts` lifts the two rules out of the
+> render (`readDemonstratedStepCount`, `classifySaveProcedureResult`) so a
+> round-trip test can hold the builder and the reader together. `banking` is
+> correct but hand-rolled and unasserted, so it can rot without failing anything.
+> **Neither grep below is a verdict** — a hit is a place to read, not a defect,
+> and an empty result is not compliance:
+>
+> ```bash
+> # SMELL, not a violation: a teach card deriving a count by PARSING a directive
+> # instead of reading a count the recorder reported. This is people's hit — and
+> # it is NOT people's defect.
+> grep -n 'result\.match' src/skins/*/tools.tsx
+>
+> # WHERE people's actual defect lives: branching on the PRESENCE of a settle.
+> # Legitimate on cards whose buttons cannot disagree, so read every hit; on the
+> # "shall I remember this?" card it prints "Saved" after _Don't save_.
+> grep -n 'typeof result === "string"' src/skins/*/tools.tsx
+> ```
+>
+> Where a compliant skin diverges from banking on a load-bearing detail, the
+> divergence is called out inline as a **Per-skin divergence** note. Read this
+> file, and run both commands, before building the next one.
 
 "Teach mode" is the loop where the agent **fails a task it was never told how to
 do**, a human **demonstrates** the workaround in the UI, that demonstration is
@@ -99,6 +154,25 @@ waiting card and a live recorder feed that narrates each action as it happens
 > steps, because the point is the agent doesn't yet know them. The contrast
 > between the gated state and the unlocked effect is the signal the save distills.
 
+> **Invariant (survives replay).** Everything a teach-chain card prints must
+> travel INSIDE the tool result the card reads back. The recording context is
+> live-session state and is empty when a stored thread is reopened — which is
+> exactly when the "threads store AG-UI streams, not text" beat is on screen. So
+> the recorder REPORTS its step count in the directive and the card prints the
+> reported number. A card that re-derives a fact by parsing its own rendering
+> (counting `N.` matches in the step prose) announces a different number than the
+> list under it as soon as a step label contains a numeral. Worked example, with
+> the round-trip test that pins builder to reader:
+> `src/skins/commerce/teach-mode-directives.ts`.
+
+> **Invariant (a settle is not an answer).** The "shall I remember this?" card
+> settles with a string on BOTH buttons, so `typeof result === "string"` tells you
+> the card was answered and NOTHING about the answer. Classify the directive;
+> never branch on mere presence, and never treat an unrecognized settle as a
+> success. Getting this wrong prints "Saved. I'll use this next time" after the
+> presenter clicked _Don't save_ — a durable write asserted on stage that never
+> happened — and it mis-renders the same way on every later replay of the thread.
+
 ### 4. AGENT FRAMING — withhold the recipe, ship distractors, enforce discipline
 
 The system prompt lists the unlock's tools but **never the procedure**, and ships
@@ -122,6 +196,26 @@ default, `CopilotKitIntelligence` when configured.
 > _without_ it. In OSS mode the loop works within one conversation only; durable
 > cross-thread / cross-user recall requires Intelligence mode (the
 > `recall_memory` / `save_memory` tools attach from the memory-enabled backend).
+
+> **Invariant (recall before declining).** The prompt must make the agent
+> `recall_memory` FIRST on every refusal and branch on what comes back. A prompt
+> that states "you have no saved way past this" as a flat fact makes the agent
+> decline and offer to record even after it has been taught: the demonstration
+> works, the memory saves correctly, and the payoff never arrives — the prompt
+> overrode what the agent knew.
+
+> **Per-skin divergence — memory SCOPE.** `banking` saves the learned procedure at
+> `scope:"project"`. Later skins save at `scope:"user"` and say so in their
+> prompts, because one Intelligence backend is shared by every product in this
+> deployment: a project-scoped procedure is visible to skins that never learned
+> it. Prefer `"user"` for a new skin unless it genuinely owns its own backend.
+
+> **Per-skin divergence — tool names.** The chain's shape is fixed (offer → wait →
+> summarize → confirm → persist); the names are not. `banking` calls the middle
+> two `awaitDashboardDemonstration` / `saveLearnedWorkflow`; later skins call them
+> `awaitDemonstration` / `saveLearnedProcedure`. Match your skin, not this page —
+> and note the grep at the top keys on `offerWorkflowRecording`, which all of them
+> share.
 
 ---
 
@@ -175,7 +269,17 @@ It asserts, in order:
 
 > The store is in-memory and seeded from `src/skins/banking/data/seed.json`. Each
 > scenario uses a different seeded over-limit transaction, so one run needs no
-> reset. To re-run from scratch, restart the dev server to reseed.
+> reset. To re-run from scratch, restart the dev server, or `POST` the skin's
+> gated presenter-reset route (`/api/banking/v1/dev/reset`, enabled by
+> `PRESENTER_RESET_ENABLED=true`; the sidebar Reset button hits the same route).
+>
+> **Prefer the reset route before the learning proof below.** Restarting the dev
+> server re-seeds the in-memory store and nothing else — durable memory lives in
+> the Intelligence backend and survives it. The reset route also forgets and
+> re-seeds that memory, which is the only thing that puts the demo back into a
+> genuinely _un-taught_ state. It reports a `memoryError` when that half fails;
+> that sentence is the only warning that the loop is starting out already taught,
+> so surface it rather than collapsing the response to a status code.
 
 ### Fresh-agent learning proof — roles #3 + #5 (Intelligence mode)
 
@@ -183,13 +287,15 @@ This proves the loop _learned_, not that the REST works. It needs the env-gated
 `CopilotKitIntelligence` runtime configured (`INTELLIGENCE_API_URL`,
 `INTELLIGENCE_GATEWAY_WS_URL`, `INTELLIGENCE_API_KEY`).
 
-1. **Baseline.** In a fresh thread, ask the agent to approve an over-limit
+1. **Baseline.** Reset first (above) — durable memory outlives a dev-server
+   restart, so an un-reset run starts out already taught and the control passes
+   vacuously. Then, in a fresh thread, ask the agent to approve an over-limit
    charge. With role #4 framing intact it declines and offers to record — it does
    not fire a distractor. _This is the control._
 2. **Teach.** The human demonstrates the unlock on the dashboard (justifying code
    → finalize → approve) while the recorder card narrates each step.
-3. **Save.** The agent summarizes and calls `save_memory` (`scope:"project"`,
-   `kind:"operational"`).
+3. **Save.** The agent summarizes and calls `save_memory` (`kind:"operational"`;
+   `scope:"project"` in banking, `"user"` in the later skins — see role #5).
 4. **Fresh agent succeeds.** In a **new** thread (no memory of the human's
    session), ask to approve a _different_ over-limit charge. The agent
    `recall_memory` → files a justifying exception → finalizes → approves —

--- a/examples/showcases/reskinnable-demo/eslint.config.mjs
+++ b/examples/showcases/reskinnable-demo/eslint.config.mjs
@@ -21,8 +21,35 @@ import nextTypescript from "eslint-config-next/typescript";
  * scanner kept producing). It also cannot be fooled by a `$` in a variable name.
  */
 
-// Route id segments. Keep in sync with `src/shell/skins-config.ts` `skinIds`.
-const SKIN_IDS = "banking|airline|logistics|keel";
+/**
+ * Route id segments the selectors below guard.
+ *
+ * WHY A HAND-COPY OF `skinIds` AND NOT AN IMPORT. The source of truth is
+ * `skinIds` in `src/shell/skins-config.ts`, but this file cannot import it: an
+ * ESLint flat config is loaded by Node, `skins-config.ts` is TypeScript, and
+ * teaching ESLint to load a `.ts` config needs `jiti`, which this app does not
+ * depend on. Re-exporting the ids through a plain `.mjs` module instead would
+ * cost `skinIds` its `as const` tuple type — which `skinIdentities` relies on to
+ * stay exhaustive — so the copy is the cheapest correct option.
+ *
+ * WHY IT IS EXPORTED. A hand-copied list rots SILENTLY: this literal read
+ * `banking|airline|logistics|keel` for two skins after `people` and `commerce`
+ * shipped, so a hardcoded `"/commerce/orders"` href passed `pnpm lint` cleanly
+ * while breaking the address bar on a locked deploy. Nothing failed. The export
+ * exists so `src/shell/skins-config.test.ts` can lint a synthetic prefixed link
+ * for EVERY registered skin through these very selectors and fail when one is
+ * unguarded. ESLint reads only the default export; this named one is inert to it.
+ */
+export const LINTED_SKIN_IDS = [
+  "banking",
+  "airline",
+  "logistics",
+  "keel",
+  "people",
+  "commerce",
+];
+
+const SKIN_IDS = LINTED_SKIN_IDS.join("|");
 
 const FIX_HINT =
   "Build the link through useSkinHref(skin.id) — or the skin's own helper, e.g. " +

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/dev/reset/route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/dev/reset/route.test.ts
@@ -1,0 +1,620 @@
+/**
+ * The presenter reset's ONE job is to guarantee a known-good starting state, so
+ * the thing worth testing hardest is not that it works — it is that it REFUSES
+ * to say it worked when it did not.
+ *
+ * The bug these tests pin: `seedMemories` never throws (it counts stored rows and
+ * logs the rest), so the route used to fall out of its try block and answer
+ * `ok: true, reset: ["store", "memory"]` even when the memory backend had
+ * rejected every POST. `seeded: 0` sat in the body, unread, while the presenter
+ * walked on stage believing beats 4/5 were armed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/skins/commerce/data/store", () => ({ reset: vi.fn() }));
+vi.mock("@/skins/commerce/intelligence/forget-memories", () => ({
+  forgetAllMemories: vi.fn(),
+}));
+// Only `seedMemories` is faked. `SEED_MEMORIES` stays REAL so the expected count
+// this suite compares against is derived from the same literal the route reads —
+// adding a seed memory must not silently turn these assertions into no-ops.
+vi.mock(
+  "@/skins/commerce/intelligence/seed-memories",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/skins/commerce/intelligence/seed-memories")
+    >()),
+    seedMemories: vi.fn(),
+  }),
+);
+
+import * as store from "@/skins/commerce/data/store";
+import { forgetAllMemories } from "@/skins/commerce/intelligence/forget-memories";
+import {
+  SEED_MEMORIES,
+  seedMemories,
+} from "@/skins/commerce/intelligence/seed-memories";
+import {
+  memoryScopeUserIds,
+  memorySeedTargetUserIds,
+} from "@/skins/commerce/intelligence/user-id";
+import { POST } from "./route";
+
+beforeEach(() => {
+  // Silence the route's own reset logging without losing a real failure.
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  // Re-established per test rather than in the `vi.mock` factory: the factory
+  // runs once, and `restoreAllMocks` in afterEach strips a factory-set
+  // implementation — after which `forgetAllMemories` resolves `undefined`, the
+  // route throws on `result.forgot`, and EVERY case lands in the catch path
+  // returning a 502 that looks exactly like the failure being asserted.
+  // `complete: true` is the DEFAULT for the same reason the implementation had to
+  // start reporting it: a sweep that returns having stepped over failures is not a
+  // finished sweep, and every case below except the two that assert otherwise is
+  // about a wipe that genuinely emptied its bucket.
+  vi.mocked(forgetAllMemories).mockResolvedValue({
+    forgot: 2,
+    alreadyGone: 0,
+    skippedProjectScoped: 0,
+    failed: [],
+    passes: 1,
+    complete: true,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+/** Intelligence configured, and NOT pinned to a single bucket. */
+function configureIntelligence() {
+  vi.stubEnv("PRESENTER_RESET_ENABLED", "true");
+  vi.stubEnv("INTELLIGENCE_API_URL", "http://localhost:7250");
+  vi.stubEnv("INTELLIGENCE_API_KEY", "cpk_test");
+  vi.stubEnv("INTELLIGENCE_USER_ID", "");
+}
+
+describe("POST /api/commerce/v1/dev/reset", () => {
+  it("403s in production when presenter reset is disabled, touching nothing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PRESENTER_RESET_ENABLED", "");
+    const res = await POST();
+    expect(res.status).toBe(403);
+    expect(store.reset).not.toHaveBeenCalled();
+    expect(forgetAllMemories).not.toHaveBeenCalled();
+    expect(seedMemories).not.toHaveBeenCalled();
+  });
+
+  it("resets the store only, and claims only that, when Intelligence is unconfigured", async () => {
+    vi.stubEnv("PRESENTER_RESET_ENABLED", "true");
+    vi.stubEnv("INTELLIGENCE_API_URL", "");
+    vi.stubEnv("INTELLIGENCE_API_KEY", "");
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, reset: ["store"] });
+    expect(store.reset).toHaveBeenCalledTimes(1);
+    expect(seedMemories).not.toHaveBeenCalled();
+  });
+
+  it("reports success when every expected memory landed in every target bucket", async () => {
+    configureIntelligence();
+    const targets = memorySeedTargetUserIds();
+    vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    expect(seedMemories).toHaveBeenCalledTimes(targets.length);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      reset: ["store", "memory"],
+      memory: "seeded",
+      seeded: targets.length * SEED_MEMORIES.length,
+      expectedSeeds: targets.length * SEED_MEMORIES.length,
+    });
+  });
+
+  it("does NOT report ok/memory-reset when the WIPE could not prove it finished", async () => {
+    // The other half of the same question, and the more dangerous half. A short
+    // SEED leaves a beat unarmed and visibly quiet. A memory the wipe MISSED
+    // leaves the demo already knowing something — so beat 6 can look taught
+    // before anyone taught it, which reads as success and proves nothing.
+    // `forgetAllMemories` no longer aborts on a bad row, so returning normally
+    // stopped implying that it finished; the route has to read `complete`.
+    configureIntelligence();
+    vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+    vi.mocked(forgetAllMemories).mockResolvedValue({
+      forgot: 1,
+      alreadyGone: 0,
+      skippedProjectScoped: 0,
+      failed: [{ id: "mem-7", reason: "HTTP 500" }],
+      passes: 3,
+      complete: false,
+      incompleteReason: "still deletable after 3 passes",
+    });
+
+    const res = await POST();
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: false, reset: ["store"] });
+    // A fully-seeded run must NOT be able to launder an unfinished wipe into a
+    // "seeded" verdict.
+    expect(body.memory).not.toBe("seeded");
+    // Summed ACROSS buckets, not per bucket: the stub answers for every identity
+    // in the scope set, so one failed row per bucket is one failure per bucket.
+    // Asserted as an accumulation rather than a literal, so the number of seeded
+    // operators stays free to change.
+    expect(body.forgetFailures).toBe(body.forgetShortfalls.length);
+    expect(body.forgetFailures).toBeGreaterThan(0);
+    expect(body.memoryError).toMatch(/wipe did not finish/i);
+    // The reason survives to the response, per bucket, or a presenter cannot tell
+    // which identity is dirty.
+    expect(body.forgetShortfalls.join(" ")).toContain(
+      "still deletable after 3 passes",
+    );
+  });
+
+  it("counts an already-absent row as forgotten without inflating `forgot`", async () => {
+    configureIntelligence();
+    vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+    vi.mocked(forgetAllMemories).mockResolvedValue({
+      forgot: 1,
+      alreadyGone: 4,
+      skippedProjectScoped: 0,
+      failed: [],
+      passes: 2,
+      complete: true,
+    });
+
+    const res = await POST();
+
+    // A 404 on delete means the row is gone, which is all the reset needs — so
+    // this is success, and `alreadyGone` is reported separately so `forgot` stays
+    // literally true rather than being padded to look better.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, memory: "seeded" });
+    expect(body.forgot).toBeGreaterThan(0);
+    expect(body.alreadyGone).toBeGreaterThan(0);
+  });
+
+  it("does NOT report ok/memory-reset when every seed POST failed", async () => {
+    configureIntelligence();
+    const expected = memorySeedTargetUserIds().length * SEED_MEMORIES.length;
+    // Exactly the real helper's total-failure shape: it swallows every rejection
+    // and returns 0 stored. Nothing throws, so only the count can catch this.
+    vi.mocked(seedMemories).mockResolvedValue(0);
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.ok).toBe(false);
+    expect(body.memory).toBe("failed");
+    // The load-bearing assertion: "memory" must be absent from `reset`. A wipe
+    // with no re-seed leaves beats 4/5 unarmed.
+    expect(body.reset).toEqual(["store"]);
+    expect(body.seeded).toBe(0);
+    expect(body.expectedSeeds).toBe(expected);
+    expect(body.memoryError).toContain("beats 4/5 are not armed");
+    // The ledger genuinely WAS restored; the body must still say so.
+    expect(store.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinguishes a partial seed from a total failure", async () => {
+    configureIntelligence();
+    const targets = memorySeedTargetUserIds();
+    // Guard the premise: a partial case only exists with >1 bucket or >1 memory.
+    expect(targets.length * SEED_MEMORIES.length).toBeGreaterThan(1);
+    // First bucket fully seeded, the rest rejected — the mid-loop shortfall.
+    vi.mocked(seedMemories)
+      .mockResolvedValueOnce(SEED_MEMORIES.length)
+      .mockResolvedValue(0);
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.ok).toBe(false);
+    expect(body.memory).toBe("partial");
+    expect(body.reset).toEqual(["store"]);
+    expect(body.seeded).toBe(SEED_MEMORIES.length);
+    expect(body.expectedSeeds).toBe(targets.length * SEED_MEMORIES.length);
+  });
+
+  it("scales the expectation to the collapsed bucket set when the user id is pinned", async () => {
+    configureIntelligence();
+    // A pinned id collapses every scope onto one bucket (Playwright pins one), so
+    // the expectation must shrink with it. A hardcoded expected count would fail
+    // a perfectly good reset here.
+    vi.stubEnv("INTELLIGENCE_USER_ID", "pinned-bucket");
+    vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    expect(seedMemories).toHaveBeenCalledTimes(1);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      memory: "seeded",
+      expectedSeeds: SEED_MEMORIES.length,
+    });
+  });
+
+  /**
+   * The catch path — the one nobody exercises until it fires at a booth, and the
+   * moment a presenter most needs the truth. It used to infer memory state from
+   * `forgot` alone (`reset: forgot > 0 ? ["store","memory"] : ["store"]`) and drop
+   * every other counter, so it told BOTH lies available to it: memory reset when
+   * only the wipe had run, and memory untouched when the sweep had run over
+   * legitimately empty buckets.
+   */
+  describe("when the sequence throws part-way through", () => {
+    /** A bucket that genuinely had nothing to forget — a second reset in a row. */
+    const emptyBucket = {
+      forgot: 0,
+      alreadyGone: 0,
+      skippedProjectScoped: 0,
+      failed: [],
+      passes: 1,
+      complete: true,
+    } as const;
+
+    it("does NOT imply memory was untouched when an EMPTY first bucket was swept", async () => {
+      configureIntelligence();
+      const scope = memoryScopeUserIds();
+      // Premise: a mid-loop throw needs a bucket after the first one.
+      expect(scope.length).toBeGreaterThan(1);
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      vi.mocked(forgetAllMemories)
+        .mockResolvedValueOnce({ ...emptyBucket, failed: [] })
+        .mockRejectedValue(
+          new Error(
+            "[commerce/forget-memories] list memories failed: 503 nope",
+          ),
+        );
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.reset).toEqual(["store"]);
+      // The load-bearing pair: `forgot === 0` is TRUE and says nothing, so the
+      // response has to report that a sweep ran anyway. Reading memory state off
+      // `forgot` is what made an empty bucket indistinguishable from no sweep.
+      expect(body.forgot).toBe(0);
+      expect(body.bucketsSwept).toBe(1);
+      expect(body.bucketsToSweep).toBe(scope.length);
+      expect(body.memory).toBe("partial");
+      expect(body.memoryError).toContain("wipe phase");
+      expect(body.memoryError).toContain("503 nope");
+      // The throw aborted before seeding, and the body must say so rather than
+      // omitting the field.
+      expect(body.seeded).toBe(0);
+      expect(body.bucketsSeeded).toBe(0);
+      expect(seedMemories).not.toHaveBeenCalled();
+    });
+
+    it("does NOT claim memory was reset when the wipe finished but seeding threw", async () => {
+      configureIntelligence();
+      const scope = memoryScopeUserIds();
+      const targets = memorySeedTargetUserIds();
+      // The wipe half succeeds everywhere (default stub forgets 2 per bucket) and
+      // the seed half never lands a single row. `forgot > 0` used to be enough to
+      // report `reset: ["store","memory"]` here — memory armed, on stage, empty.
+      vi.mocked(seedMemories).mockRejectedValue(
+        new Error("seed POST exploded"),
+      );
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.reset).toEqual(["store"]);
+      expect(body.reset).not.toContain("memory");
+      expect(body.memory).toBe("partial");
+      expect(body.forgot).toBeGreaterThan(0);
+      expect(body.bucketsSwept).toBe(scope.length);
+      expect(body.seeded).toBe(0);
+      expect(body.bucketsSeeded).toBe(0);
+      expect(body.expectedSeeds).toBe(targets.length * SEED_MEMORIES.length);
+      expect(body.memoryError).toContain("seed phase");
+      expect(body.memoryError).toContain("seed POST exploded");
+    });
+
+    it("reports the counters the loops actually reached when seeding throws mid-loop", async () => {
+      configureIntelligence();
+      const targets = memorySeedTargetUserIds();
+      // Premise: a mid-seed throw needs a target after the first one.
+      expect(targets.length).toBeGreaterThan(1);
+      vi.mocked(forgetAllMemories).mockResolvedValue({
+        forgot: 3,
+        alreadyGone: 1,
+        skippedProjectScoped: 2,
+        failed: [],
+        passes: 2,
+        complete: true,
+      });
+      vi.mocked(seedMemories)
+        .mockResolvedValueOnce(SEED_MEMORIES.length)
+        .mockRejectedValue(new Error("seed POST exploded"));
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      // Every accumulator, as measured: one target seeded, the rest never ran.
+      expect(body.seeded).toBe(SEED_MEMORIES.length);
+      expect(body.bucketsSeeded).toBe(1);
+      expect(body.forgot).toBe(3 * memoryScopeUserIds().length);
+      expect(body.alreadyGone).toBe(1 * memoryScopeUserIds().length);
+      // MAX across buckets, not a sum: the same global project-scoped rows come
+      // back for every user id, so summing would report N× the truth.
+      expect(body.skippedProjectScoped).toBe(2);
+      expect(body.forgetFailures).toBe(0);
+      expect(body.forgetShortfalls).toEqual([]);
+      expect(body.memory).toBe("partial");
+    });
+
+    it("reports `failed` when the very first sweep threw, so nothing landed", async () => {
+      configureIntelligence();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      vi.mocked(forgetAllMemories).mockRejectedValue(
+        new Error(
+          "[commerce/forget-memories] list memories failed: ECONNREFUSED",
+        ),
+      );
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.reset).toEqual(["store"]);
+      expect(body.memory).toBe("failed");
+      expect(body.bucketsSwept).toBe(0);
+      expect(body.forgot).toBe(0);
+      expect(body.seeded).toBe(0);
+      // The ledger genuinely WAS restored before the memory work began.
+      expect(store.reset).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces a swept bucket that could not prove it was emptied", async () => {
+      configureIntelligence();
+      expect(memoryScopeUserIds().length).toBeGreaterThan(1);
+      vi.mocked(forgetAllMemories)
+        .mockResolvedValueOnce({
+          forgot: 1,
+          alreadyGone: 0,
+          skippedProjectScoped: 0,
+          failed: [{ id: "mem-7", reason: "HTTP 500" }],
+          passes: 3,
+          complete: false,
+          incompleteReason: "1 row(s) failed to delete",
+        })
+        .mockRejectedValue(new Error("list memories failed: 503"));
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      // A row the wipe missed can leave beat 6 already taught, so the shortfall
+      // must survive into the error body rather than being dropped with the rest
+      // of the try's progress.
+      expect(body.forgetFailures).toBe(1);
+      expect(body.forgetShortfalls.join(" ")).toContain(
+        "1 row(s) failed to delete",
+      );
+      expect(body.memoryError).toMatch(/could not prove they were emptied/i);
+    });
+  });
+
+  /**
+   * The route's gate (`PRESENTER_RESET_ENABLED`, or any non-production env) is a
+   * demo convenience, NOT an authorization boundary: a booth deployment that
+   * sets it answers this POST for anyone who can reach the box. So no
+   * Intelligence SECRET may travel in the body — the address used to, as
+   * `apiUrl`, in EVERY response, success and failure alike.
+   *
+   * The address was the FIRST secret this body leaked, never the only one. Every
+   * free-text field here is backend-derived (`forgetShortfalls` quotes the
+   * backend's own response body; `memoryError` embeds an arbitrary
+   * `Error.message`), so a 401 payload echoing the API KEY, or a transport error
+   * naming the gateway, lands in the body by the identical route. The first
+   * redactor knew about the URL alone, which is why these cases assert the whole
+   * secret set rather than one value.
+   *
+   * Each case asserts the WHOLE serialized body rather than one field, so adding
+   * a field that happens to carry a secret cannot slip past, and pairs that with
+   * what the presenter must still be told: the log keeps the detail, the body
+   * keeps the diagnosis.
+   */
+  describe("Intelligence secrets", () => {
+    /** Distinctive on purpose: a substring assertion against `localhost` proves little. */
+    const BACKEND = "http://memory.internal.example:7250";
+    /** `URL.host` — WITH the port. */
+    const HOST = "memory.internal.example:7250";
+    /**
+     * `URL.hostname` — WITHOUT the port, and the form the first needle set
+     * missed. It only ever passed before because every fixture quoted the
+     * hostname as part of the full URL, where redacting the URL took it along.
+     */
+    const HOSTNAME = "memory.internal.example";
+    /** Shaped like the real thing (see .env.example) so length ordering is realistic. */
+    const API_KEY = "cpk_s2PRVSED_seed0privat0longtoken01";
+    /** A DIFFERENT host, so covering the gateway is proven independently. */
+    const WS_URL = "ws://gateway.internal.example:7253";
+
+    function configureNamedBackend() {
+      configureIntelligence();
+      vi.stubEnv("INTELLIGENCE_API_URL", BACKEND);
+      vi.stubEnv("INTELLIGENCE_API_KEY", API_KEY);
+      vi.stubEnv("INTELLIGENCE_GATEWAY_WS_URL", WS_URL);
+    }
+
+    /**
+     * Asserted on the serialized body, so a NEW field cannot reintroduce the
+     * leak — and against EVERY secret, so a redactor that covers some of them
+     * cannot pass. The URL half of this list was here from the start; the key
+     * and the gateway are what the first redactor could not have removed,
+     * because it was never handed them.
+     */
+    function expectNoSecrets(body: unknown) {
+      const serialized = JSON.stringify(body);
+      for (const secret of [BACKEND, HOST, HOSTNAME, API_KEY, WS_URL]) {
+        expect(serialized).not.toContain(secret);
+      }
+    }
+
+    const loggedText = (spy: typeof console.warn | typeof console.error) =>
+      vi.mocked(spy).mock.calls.flat().map(String).join("\n");
+
+    it("stays out of a successful reset's body while the log still names the backend", async () => {
+      configureNamedBackend();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toMatchObject({ ok: true, memory: "seeded" });
+      expectNoSecrets(body);
+      // The deliberate pre-mutation warning is the one place it belongs: several
+      // demos in this repo vendor the same stack, so a human needs to see which
+      // backend was about to be touched.
+      expect(loggedText(console.warn)).toContain(BACKEND);
+    });
+
+    it("stays out of a shortfall body, which still names the dirty identity", async () => {
+      configureNamedBackend();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      // The backend quoting its OWN address in an error body is why the reason is
+      // redacted rather than merely omitted from a field of this route's own text.
+      vi.mocked(forgetAllMemories).mockResolvedValue({
+        forgot: 1,
+        alreadyGone: 0,
+        skippedProjectScoped: 0,
+        failed: [{ id: "mem-7", reason: "HTTP 500" }],
+        passes: 3,
+        complete: false,
+        incompleteReason: `HTTP 500 from ${BACKEND}/api/memories`,
+      });
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expectNoSecrets(body);
+      // The presenter is still told enough to act: memory failed, which half,
+      // which bucket, and that a survivor can leave beat 6 already taught.
+      expect(body.memory).not.toBe("seeded");
+      expect(body.memoryError).toMatch(/wipe did not finish/i);
+      expect(body.forgetShortfalls.join(" ")).toContain("HTTP 500");
+      expect(body.forgetShortfalls.join(" ")).toContain(
+        memoryScopeUserIds()[0],
+      );
+      // Redaction leaves a marker rather than a hole, so the reason still reads.
+      expect(body.forgetShortfalls.join(" ")).toContain(
+        "<intelligence-backend>",
+      );
+    });
+
+    it("stays out of the interrupted body even when the CAUSE quotes the address", async () => {
+      configureNamedBackend();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      // Undici's own wording for a malformed backend env names the address
+      // verbatim, and `memoryError` embeds the cause message unchanged.
+      vi.mocked(forgetAllMemories).mockRejectedValue(
+        new Error(`Failed to parse URL from ${BACKEND}/api/memories`),
+      );
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expectNoSecrets(body);
+      // Everything the presenter acts on survives: the phase, the counters, the
+      // cause's wording, and the fact that memory is not armed.
+      expect(body.memory).toBe("failed");
+      expect(body.reset).toEqual(["store"]);
+      expect(body.memoryError).toContain("wipe phase");
+      expect(body.memoryError).toContain("Failed to parse URL");
+      expect(body.memoryError).toContain("<intelligence-backend>");
+      // And the log — what the sidebar button tells the presenter to read — keeps
+      // the address it was redacted out of the response.
+      expect(loggedText(console.error)).toContain(BACKEND);
+    });
+
+    it("removes the host named WITHOUT its port", async () => {
+      configureNamedBackend();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      // A scheme-less env, a proxy error, or a DNS failure names the bare
+      // hostname with no port and no scheme — a form neither the raw URL needle
+      // nor `URL.host` contains, so redacting those two leaves it in the body.
+      vi.mocked(forgetAllMemories).mockRejectedValue(
+        new Error(`getaddrinfo ENOTFOUND ${HOSTNAME}`),
+      );
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expectNoSecrets(body);
+      expect(body.memoryError).toContain("ENOTFOUND");
+      expect(body.memoryError).toContain("<intelligence-backend>");
+    });
+
+    it("removes the API KEY when the backend echoes it back", async () => {
+      configureNamedBackend();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      // `forgetAllMemories` puts the backend's own response text into its
+      // reasons (`HTTP ${status} ${await safeText(res)}`), and an auth failure is
+      // exactly the response that quotes the credential it rejected. The key is
+      // WORSE in a body than the address: the address only says where the stack
+      // is, the key opens it.
+      vi.mocked(forgetAllMemories).mockResolvedValue({
+        forgot: 0,
+        alreadyGone: 0,
+        skippedProjectScoped: 0,
+        failed: [{ id: "mem-7", reason: "HTTP 401" }],
+        passes: 1,
+        complete: false,
+        incompleteReason: `HTTP 401 {"error":"invalid api key ${API_KEY}"}`,
+      });
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expectNoSecrets(body);
+      // Diagnosable without the credential: the status and the marker survive.
+      expect(body.forgetShortfalls.join(" ")).toContain("HTTP 401");
+      expect(body.forgetShortfalls.join(" ")).toContain(
+        "<intelligence-api-key>",
+      );
+    });
+
+    it("removes the gateway WS URL when a cause quotes it", async () => {
+      configureNamedBackend();
+      vi.mocked(seedMemories).mockResolvedValue(SEED_MEMORIES.length);
+      // Reachable the same way every other secret is: this route composes none
+      // of this text. The gateway is a second internal address the same
+      // deployment exposes, so a redactor scoped to the REST URL alone publishes
+      // it the moment any upstream message names it.
+      vi.mocked(forgetAllMemories).mockRejectedValue(
+        new Error(`connect ECONNREFUSED ${WS_URL}`),
+      );
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expectNoSecrets(body);
+      expect(body.memoryError).toContain("ECONNREFUSED");
+      expect(body.memoryError).toContain("<intelligence-gateway>");
+    });
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/dev/reset/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/dev/reset/route.ts
@@ -1,0 +1,391 @@
+import * as store from "@/skins/commerce/data/store";
+import { presenterResetEnabled } from "@/lib/presenter";
+import { redactSecrets } from "@/lib/redact-secrets";
+import { forgetAllMemories } from "@/skins/commerce/intelligence/forget-memories";
+import {
+  SEED_MEMORIES,
+  seedMemories,
+} from "@/skins/commerce/intelligence/seed-memories";
+import {
+  memoryScopeUserIds,
+  memorySeedTargetUserIds,
+} from "@/skins/commerce/intelligence/user-id";
+
+/**
+ * How much of the beats 4/5 memory actually landed. Reported as a word, not
+ * inferred by the caller from two numbers.
+ *
+ *  - `seeded`  — every expected memory is in every target bucket. The ONLY state
+ *                in which this route may claim `reset: ["store", "memory"]`.
+ *  - `partial` — some landed. Beats 4/5 may work, may not: `seedMemories`
+ *                iterates `SEED_MEMORIES` in order and swallows per-row failures,
+ *                so a shortfall says nothing about WHICH memory is missing. The
+ *                beat-4 preference and the beat-5 procedure are independent, so a
+ *                presenter cannot reason "3 of 4 means only the last one is gone".
+ *  - `failed`  — nothing landed. Beats 4 and 5 WILL fail on stage.
+ */
+type MemoryStatus = "seeded" | "partial" | "failed";
+
+/**
+ * Compare against the KNOWABLE expectation instead of reporting whatever
+ * happened. The count is knowable because both factors are: `SEED_MEMORIES` is a
+ * fixed literal and `memorySeedTargetUserIds()` is derived from `resolveUserId`.
+ *
+ * `expected === 0` is deliberately `failed`, never a vacuous "seeded": zero
+ * expected memories means either `SEED_MEMORIES` was emptied or the target-bucket
+ * derivation returned nothing, and in both cases the memory beats are unarmed.
+ * Treating "expected nothing, got nothing" as success is the same lie this whole
+ * classification exists to remove, one level up.
+ */
+function classifySeeding(seeded: number, expected: number): MemoryStatus {
+  if (expected > 0 && seeded >= expected) return "seeded";
+  return seeded > 0 ? "partial" : "failed";
+}
+
+/**
+ * The verdict for a reset that THREW part-way through, from what was actually
+ * measured before the throw.
+ *
+ * `"seeded"` is UNREACHABLE here by construction, and that is the point: the
+ * sequence only earns that word by sweeping every bucket AND re-seeding every
+ * target, and an exception proves at least one of those did not finish. So the
+ * only question left is whether anything landed at all — and that is answered by
+ * counters, not by a proxy:
+ *
+ *  - `bucketsSwept` (not `forgot`) is what says the wipe did something. A bucket
+ *    that was legitimately EMPTY forgets zero rows, which is the normal state of
+ *    a second reset in a row, so `forgot === 0` says nothing about whether the
+ *    sweep ran.
+ *  - `seeded` says the same for the seed half.
+ */
+function classifyInterrupted(progress: {
+  bucketsSwept: number;
+  seeded: number;
+}): Exclude<MemoryStatus, "seeded"> {
+  return progress.bucketsSwept > 0 || progress.seeded > 0
+    ? "partial"
+    : "failed";
+}
+
+/**
+ * WHY EVERY FREE-TEXT FIELD BELOW GOES THROUGH `redactSecrets`.
+ *
+ * Keep the Intelligence SECRETS out of RESPONSE bodies while leaving them in the
+ * SERVER LOGS, which is the only place they belong.
+ *
+ * The route's gate (`PRESENTER_RESET_ENABLED`, or any non-production env) is a
+ * demo convenience, NOT an authorization boundary — a booth deployment that sets
+ * it answers this POST for anyone who can reach the box. So the body must not
+ * name the internal backend or the credential that opens it, while
+ * `console.warn`/`console.error` still do: a human debugging a reset needs to see
+ * WHICH stack was about to be touched (this repo vendors several), and the
+ * sidebar button already tells them to read the logs.
+ *
+ * This exists on top of simply not putting `apiUrl` in the body, because two
+ * body fields carry free text this route did not compose: `memoryError`'s `cause`
+ * (an arbitrary `Error.message` — undici's own "Failed to parse URL from …"
+ * names the address verbatim) and `forgetShortfalls`, whose reasons quote the
+ * backend's own response body (`HTTP ${status} ${await safeText(res)}` — and a
+ * 401 payload is exactly the response that echoes the key it rejected). Both are
+ * redacted on the way OUT rather than at their source, so the log keeps the
+ * unredacted text.
+ *
+ * The redactor takes the TEXT ALONE and derives its needles from the
+ * environment, which is deliberate: its predecessor here took the value to
+ * scrub as an argument, was handed `apiUrl`, and therefore could not remove the
+ * API KEY from a body it was busy sanitizing. See src/lib/redact-secrets.ts.
+ *
+ * Wrapped rather than passed to `.map` directly: `map` supplies (value, index,
+ * array), so `map(redactSecrets)` would hand the INDEX to the optional needle
+ * parameter. `tsc` rejects that particular arity clash (`number` is not
+ * `SecretNeedle[]`), so this wrapper is about intent rather than safety — it
+ * states that production callers pass the text and nothing else.
+ */
+const redactText = (text: string) => redactSecrets(text);
+
+/**
+ * Presenter/booth reset — put Bellwether back to the state the demo starts from.
+ *
+ * Four things have to be true afterwards, and all four are easy to get wrong:
+ *   1. The ledger is re-seeded — both below-floor markdowns pending again,
+ *      order 4471 back on fraud-review with no hold and no notes, Marguerite's
+ *      return un-refunded, order aging re-freshened.
+ *   2. LEARNED memory is wiped in EVERY bucket this process's runtime can reach —
+ *      which is why the id set is asked for (`memoryScopeUserIds()`) rather than
+ *      written down here. Miss a bucket and beat 6 starts out already knowing the
+ *      answer, the single most demo-destroying form this bug takes: everything
+ *      still works, it just proves nothing.
+ *   3. The beats 4/5 memories are put BACK — ALL of them, in EVERY target bucket
+ *      — so "it already knows me" works on a cold reset with no warm-up run.
+ *      This one is CHECKED rather than assumed: see `classifySeeding` below.
+ *   4. Beat 6's procedure is still NOT known. That falls out of (2) + (3)
+ *      because `SEED_MEMORIES` deliberately omits it — see seed-memories.ts.
+ *
+ * Allowed when a booth deployment set PRESENTER_RESET_ENABLED, OR in any
+ * non-production environment. Keeping this in agreement with the sidebar button
+ * matters: gate it more tightly than the button and a production booth shows a
+ * Reset control that 403s.
+ */
+export const POST = async () => {
+  if (!presenterResetEnabled() && process.env.NODE_ENV === "production") {
+    return Response.json(
+      { error: "FORBIDDEN", message: "Not available in production." },
+      { status: 403 },
+    );
+  }
+
+  store.reset();
+
+  const apiUrl = process.env.INTELLIGENCE_API_URL;
+  const apiKey = process.env.INTELLIGENCE_API_KEY;
+  if (!apiUrl || !apiKey) {
+    // OSS path: there is no durable memory to clear, and beats 2/4/5/6 degrade
+    // by design. Report exactly what was reset rather than implying more.
+    return Response.json({ ok: true, reset: ["store"] });
+  }
+
+  // Declared outside the try so the catch can report PARTIAL progress: a
+  // mid-loop failure can leave the store reset and some identities already
+  // forgotten, and an error body that reads "memory untouched" would send a
+  // presenter looking in the wrong place.
+  let forgot = 0;
+  let seeded = 0;
+  /**
+   * How many buckets/targets each loop got THROUGH — the only figures that
+   * distinguish "the sweep never ran" from "the sweep ran and the buckets were
+   * legitimately empty", which `forgot`/`seeded` alone cannot: both are 0 in both
+   * cases. Only the catch path reports them; on every returning path both loops
+   * ran to completion, so there they would be constants.
+   */
+  let bucketsSwept = 0;
+  let bucketsSeeded = 0;
+  /**
+   * Rows that were already absent when the DELETE landed. Success for the
+   * reset's purposes — the row is gone either way — but kept out of `forgot` so
+   * that figure stays literally true.
+   */
+  let alreadyGone = 0;
+  /**
+   * Buckets whose sweep could NOT prove it left nothing deletable behind, with
+   * the reason. `forgetAllMemories` reports this as `complete: false`; it no
+   * longer aborts on one bad row, so a sweep can now finish having stepped over
+   * failures — which is exactly the state that must not be called a reset.
+   *
+   * An unfinished wipe matters as much as a short seed, and for the same reason:
+   * a memory the wipe missed is a memory the demo starts out already knowing, so
+   * beat 6 can appear to have been taught before anyone taught it.
+   */
+  const forgetShortfalls: string[] = [];
+  /** Individual rows that failed to delete, across all buckets. */
+  let forgetFailures = 0;
+  // Project-scoped rows the forget helper deliberately left alone — they belong
+  // to sibling demos sharing this backend, not to Bellwether. Reported rather
+  // than hidden: a non-zero count after a Bellwether-only session means
+  // something saved project-scoped despite the prompt, which is the one way beat
+  // 6 could start out already taught. See intelligence/forget-memories.ts.
+  let skippedProjectScoped = 0;
+
+  // ASKED, never restated. `memoryScopeUserIds()` derives the bucket set from
+  // the same `resolveUserId` the runtime identifies runs with, so the two cannot
+  // drift: a pinned `INTELLIGENCE_USER_ID` (Playwright pins one) collapses the
+  // set onto that single bucket, which is exactly the one the agent will use. A
+  // hardcoded list here missed it entirely — the reset scrubbed `bellwether-*`
+  // buckets nothing was reading while the run wrote a pinned one, so beats 4/5
+  // recalled nothing and beat 6's taught procedure survived the reset.
+  const userIds = memoryScopeUserIds();
+  const seedTargets = memorySeedTargetUserIds();
+  // Name the backend and the exact ids BEFORE mutating. Several demos in this
+  // repo vendor the same Intelligence stack, so if this process ever resolved a
+  // neighbour's apiUrl, this line is where a human sees the reset was about to
+  // reach across into someone else's memory. It also makes the pinned-env
+  // collapse VISIBLE: one id in this line means the deploy is pinned.
+  //
+  // THE LOG IS THE ONLY PLACE THE ADDRESS APPEARS. It used to be echoed as
+  // `apiUrl` in every response body too — success and failure alike — which
+  // handed the internal backend's address to anyone who could reach a booth
+  // deployment that had set PRESENTER_RESET_ENABLED. Do not put it back: the
+  // presenter needs to know memory failed and roughly why (`memory`,
+  // `memoryError`, the counters), never where the backend lives.
+  console.warn(
+    `[commerce] presenter reset: forgetting memories at ${apiUrl} for ${userIds.join(", ")}`,
+  );
+
+  try {
+    for (const userId of userIds) {
+      const result = await forgetAllMemories({ apiUrl, apiKey, userId });
+      forgot += result.forgot;
+      alreadyGone += result.alreadyGone;
+      forgetFailures += result.failed.length;
+      if (!result.complete) {
+        forgetShortfalls.push(
+          `${userId}: ${result.incompleteReason ?? "sweep did not prove it was empty"}`,
+        );
+      }
+      // MAX, not a sum: verified against the running stack, the bare list returns
+      // every `scope: "project"` row for ANY user id (see forget-memories.ts), so
+      // each bucket re-sees the same global rows and summing would report N× the
+      // truth. `forgetAllMemories` returns a count rather than ids, so the largest
+      // per-bucket count is the closest this route can get to the union without
+      // widening that contract; it is exact whenever the buckets saw one set.
+      skippedProjectScoped = Math.max(
+        skippedProjectScoped,
+        result.skippedProjectScoped,
+      );
+      bucketsSwept += 1;
+    }
+    // Seed EVERY target bucket — see `memorySeedTargetUserIds`. Runs currently
+    // resolve to the default identity, so seeding only the mapped operator
+    // leaves recall looking at an empty bucket and beats 4/5 fail silently.
+    for (const userId of seedTargets) {
+      seeded += await seedMemories({ apiUrl, apiKey, userId });
+      bucketsSeeded += 1;
+    }
+
+    // `seedMemories` NEVER throws — it counts stored rows and logs the rest — so
+    // reaching this line proves nothing about whether memory was written. Without
+    // the comparison below the route answered `ok: true, reset: ["store",
+    // "memory"]` on a backend that had rejected every single POST, and the
+    // presenter walked on stage believing beats 4/5 were armed. The expected
+    // count is knowable, so it is compared rather than reported.
+    const expectedSeeds = seedTargets.length * SEED_MEMORIES.length;
+    const seedVerdict = classifySeeding(seeded, expectedSeeds);
+    // The WIPE half of the same question. `forgetAllMemories` sets
+    // `complete: false` when no list pass proved the bucket was empty, and it
+    // deliberately steps over individual delete failures rather than abandoning
+    // the remaining buckets — so "it returned" no longer implies "it finished".
+    // Memory counts as reset only when it was wiped AND fully re-seeded (the
+    // comment on `reset: ["store"]` below has always said so); this is the half
+    // that was unverifiable until the sweep started reporting it.
+    const wipeIncomplete = forgetShortfalls.length > 0;
+    const memory = wipeIncomplete ? "partial" : seedVerdict;
+
+    if (memory !== "seeded") {
+      // 502 for BOTH partial and total, deliberately. Two reasons: (a) the
+      // failing dependency is the upstream memory API in either case, and the
+      // difference is degree, which belongs in the body — `memory`, `seeded`,
+      // `expectedSeeds` — not in the status line; (b) the only caller, the
+      // sidebar Reset button in src/skins/commerce/layout.tsx, branches solely on
+      // `res.ok`, and a partial seed must alert exactly as loudly as a total one,
+      // because a shortfall does not say WHICH memory is missing. A 200 here
+      // would navigate the presenter to a clean-looking app whose memory beats
+      // are quietly broken — the precise failure this route exists to prevent.
+      console.error(
+        `[commerce] presenter reset: seeded ${seeded}/${expectedSeeds} memories (${memory})` +
+          (wipeIncomplete
+            ? `; wipe incomplete — ${forgetShortfalls.join(" | ")}`
+            : ""),
+      );
+      return Response.json(
+        {
+          ok: false,
+          // NOT ["store", "memory"]: memory is only "reset" once it is wiped AND
+          // fully re-seeded. The wipe on its own leaves the demo unarmed, so
+          // listing it here would re-tell the same lie in a different field.
+          reset: ["store"],
+          memory,
+          forgot,
+          alreadyGone,
+          forgetFailures,
+          // Redacted, not dropped: which identity is dirty and why is the whole
+          // point of this field, but a reason quoting the backend's own response
+          // can carry its address OR the credential it rejected. See
+          // `redactSecrets`.
+          forgetShortfalls: forgetShortfalls.map(redactText),
+          seeded,
+          expectedSeeds,
+          skippedProjectScoped,
+          memoryError: wipeIncomplete
+            ? // Named FIRST when both halves fell short: a memory the wipe missed
+              // is worse than a memory the seed missed. A short seed leaves a beat
+              // unarmed and visibly quiet; a surviving row leaves the demo already
+              // knowing something, which reads as success and proves nothing.
+              `memory wipe did not finish (${forgetShortfalls.length} of ${userIds.length} bucket(s), ${forgetFailures} row(s) failed to delete); a surviving memory can leave beat 6 already taught`
+            : `seeded ${seeded} of ${expectedSeeds} expected memories across ${seedTargets.length} bucket(s); beats 4/5 are not armed`,
+        },
+        { status: 502 },
+      );
+    }
+
+    return Response.json({
+      ok: true,
+      reset: ["store", "memory"],
+      memory,
+      forgot,
+      alreadyGone,
+      seeded,
+      expectedSeeds,
+      skippedProjectScoped,
+    });
+  } catch (err) {
+    // ── THE INTERRUPTED PATH ────────────────────────────────────────────────
+    // Reached when a bucket cannot be ENUMERATED (`forgetAllMemories` throws
+    // rather than guess at a list it never got) or anything else in the sequence
+    // throws. Nobody exercises this path until it fires at a booth, so it reports
+    // the same MEASURED figures as the shortfall response above instead of
+    // inferring memory state from one number, which is what it used to do:
+    //
+    //   - `forgot > 0` claimed `reset: ["store", "memory"]` even though the seed
+    //     loop may never have run — the exact "memory is armed" lie the success
+    //     path was fixed to stop telling, restated in the error body;
+    //   - `forgot === 0` claimed `reset: ["store"]`, indistinguishable from a
+    //     sweep that ran over legitimately EMPTY buckets (the normal state of a
+    //     second reset in a row) and read as "memory untouched" — sending a
+    //     presenter to look in the wrong place;
+    //   - and it dropped `seeded`, `alreadyGone`, `forgetShortfalls` and
+    //     `skippedProjectScoped` entirely, so the progress the try HAD made was
+    //     unreadable. Those accumulators live outside the try for this response.
+    //
+    // `reset` is always `["store"]` here: `store.reset()` ran before the try, and
+    // memory only counts as reset once it was wiped AND fully re-seeded, which an
+    // exception rules out.
+    const expectedSeeds = seedTargets.length * SEED_MEMORIES.length;
+    const memory = classifyInterrupted({ bucketsSwept, seeded });
+    const cause = err instanceof Error ? err.message : String(err);
+    // Name the phase from the counters rather than from a flag some future edit
+    // can forget to move: the seed loop cannot start until the sweep loop is done.
+    const phase = bucketsSwept < userIds.length ? "wipe" : "seed";
+    const detail =
+      `interrupted during the ${phase} phase — swept ${bucketsSwept}/${userIds.length} ` +
+      `bucket(s), seeded ${seeded}/${expectedSeeds} memories across ` +
+      `${bucketsSeeded}/${seedTargets.length} bucket(s): ${cause}` +
+      (forgetShortfalls.length > 0
+        ? // Surfaced even though the throw is the headline: a memory a completed
+          // sweep could not prove gone is a memory the demo starts out already
+          // knowing, so beat 6 can look taught before anyone taught it.
+          `; ${forgetShortfalls.length} swept bucket(s) also could not prove they ` +
+          `were emptied, so a surviving memory may leave beat 6 already taught`
+        : "");
+    // The sidebar Reset button says "See the server logs" on a non-ok response,
+    // and this path used to write nothing to them. Logged UNREDACTED — this is
+    // the copy a human debugging the reset reads, and `redactSecrets` exists to
+    // keep the Intelligence secrets out of the RESPONSE, not out of the log. A
+    // secret only reaches this line if an upstream message quoted one back, and
+    // a booth's server log is not reachable by whoever can POST this route.
+    console.error(`[commerce] presenter reset: ${detail}`);
+    return Response.json(
+      {
+        ok: false,
+        reset: ["store"],
+        memory,
+        forgot,
+        alreadyGone,
+        forgetFailures,
+        // See the same call in the shortfall response above.
+        forgetShortfalls: forgetShortfalls.map(redactText),
+        bucketsSwept,
+        bucketsToSweep: userIds.length,
+        seeded,
+        expectedSeeds,
+        bucketsSeeded,
+        skippedProjectScoped,
+        // `detail` embeds an arbitrary `Error.message`, which can quote the
+        // backend address verbatim (undici: "Failed to parse URL from …"), name
+        // the bare hostname (`getaddrinfo ENOTFOUND …`), or carry any other
+        // secret an upstream layer decided to mention. The presenter still gets
+        // the phase, every counter and the cause.
+        memoryError: redactText(detail),
+      },
+      { status: 502 },
+    );
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/ledger/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/ledger/route.ts
@@ -1,0 +1,16 @@
+import * as store from "@/skins/commerce/data/store";
+
+/**
+ * The whole ledger in one read.
+ *
+ * Banking exposes a granular endpoint per collection; Bellwether deliberately
+ * does not. Almost every surface here is cross-cutting — the margin ladder needs
+ * products AND floors, the orders page needs orders AND products, the promotions
+ * table needs promotions AND products AND floors AND waivers, and the agent's
+ * readables need all of it — so N endpoints would mean N fetches, N loading
+ * states, and N chances for two panels on the same screen to disagree about what
+ * the data is. One snapshot keeps the page self-consistent, which matters more
+ * than usual here because beat 3b asks the agent to describe exactly what the
+ * user can see.
+ */
+export const GET = async () => Response.json(store.snapshot());

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/margin-waivers/[id]/finalize/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/margin-waivers/[id]/finalize/route.ts
@@ -1,0 +1,15 @@
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse } from "@/skins/commerce/data/http";
+
+/** BEAT 6, unlock step 2 — finalize a draft waiver so it takes effect. */
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    return Response.json(store.finalizeMarginWaiver(id), { status: 200 });
+  } catch (error) {
+    return errorResponse(error, "POST margin-waivers/[id]/finalize");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/margin-waivers/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/margin-waivers/route.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse } from "@/skins/commerce/data/http";
+
+/**
+ * BEAT 6, unlock step 1 — file a margin waiver against a promotion.
+ *
+ * Any code from the catalogue files successfully, including the DECOYS. That is
+ * deliberate: a decoy is a real waiver, genuinely recorded in the history, that
+ * simply does not satisfy trading policy. So a successful POST here proves
+ * nothing about whether the gate will lift, and an agent that guessed a
+ * plausible-sounding code still fails at the approve step.
+ *
+ * An unrecognized code is refused WITHOUT listing the valid ones.
+ *
+ * What a code alone does NOT buy is the waiver: a filing with no written
+ * justification (or an unbounded one) is refused with `INVALID_JUSTIFICATION`.
+ * That rule lives in the store, next to the catalogue, so it holds for the
+ * merchandiser's filing panel as well as for the agent's tool — see
+ * `normalizeJustification` in `data/waiver-codes.ts`. This route deliberately
+ * does NOT `String()`-coerce the field on the way in: coercion is what would let
+ * a non-string body arrive as text long enough to pass the floor.
+ */
+export const POST = async (req: NextRequest) => {
+  try {
+    const body = await req.json();
+    const waiver = store.openMarginWaiver(
+      String(body?.promotionId ?? ""),
+      String(body?.code ?? ""),
+      body?.justification,
+    );
+    return Response.json(waiver, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, "POST margin-waivers");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/orders/[id]/notes/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/orders/[id]/notes/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse, readJsonBody } from "@/skins/commerce/data/http";
+
+/**
+ * BEAT 5, step 3 — the note. The 🚨 prefix is forced by the tool, not here.
+ *
+ * `text` and `author` are length-bounded by the store (`NOTE_TOO_LONG` /
+ * `ACTOR_NAME_TOO_LONG`, both mapped to 400 in `data/http.ts`) for the same
+ * reason the notify route validates its template: the note is rendered on the
+ * Orders page and its text is handed to the beat-3b readable as `latestNote`,
+ * so an unbounded body is a channel into the next prompt.
+ *
+ * The body is decoded by `readJsonBody` BEFORE the `try` opens — an unreadable
+ * one is a deliberate 400 naming the order, not a `SyntaxError` indistinguishable
+ * from a store defect.
+ */
+export const POST = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const parsed = await readJsonBody(req, "POST orders/[id]/notes", id);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+
+  try {
+    const text = String(body.text ?? "").trim();
+    if (!text) {
+      return Response.json(
+        { error: "BAD_REQUEST", message: "A note needs some text." },
+        { status: 400 },
+      );
+    }
+    const updated = store.addOrderNote(
+      id,
+      text,
+      String(body.author ?? "").trim() || "Bellwether",
+    );
+    return Response.json(updated, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, `POST orders/[id]/notes id=${id}`);
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/orders/[id]/notify/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/orders/[id]/notify/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse, readJsonBody } from "@/skins/commerce/data/http";
+
+/**
+ * BEAT 5, step 2 — notify the customer.
+ *
+ * This writes a real, listed record rather than pretending to send an email.
+ * The Orders page renders the notification log, so the audience sees the second
+ * step of the stored procedure land on screen the same way the hold and the note
+ * do. A step whose only evidence is a sentence in the transcript is a step the
+ * room has to take on trust.
+ *
+ * Both fields are validated by the store rather than waved through as "a
+ * non-empty string": `template` is a closed set of four, and `sentBy` is
+ * length-bounded. What is stored here is rendered on the Orders page AND fed to
+ * the beat-3b on-screen readable, so an unvalidated body would put arbitrary
+ * text in front of the model wearing app state's clothes. `UNKNOWN_TEMPLATE` /
+ * `ACTOR_NAME_TOO_LONG` are mapped to 400 in `data/http.ts`.
+ *
+ * The body is decoded by `readJsonBody` BEFORE the `try` opens, so an unreadable
+ * one is a deliberate 400 naming the order rather than a `SyntaxError` that
+ * `errorResponse` cannot tell apart from a store defect.
+ */
+export const POST = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const parsed = await readJsonBody(req, "POST orders/[id]/notify", id);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+
+  try {
+    const notification = store.notifyCustomer(
+      id,
+      String(body.template ?? "").trim(),
+      String(body.sentBy ?? "").trim() || "Bellwether",
+    );
+    return Response.json(notification, { status: 201 });
+  } catch (error) {
+    return errorResponse(error, `POST orders/[id]/notify id=${id}`);
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/orders/[id]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/orders/[id]/route.ts
@@ -1,0 +1,91 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse, readJsonBody } from "@/skins/commerce/data/http";
+import type { OrderException, OrderStatus } from "@/skins/commerce/data/types";
+
+const STATUSES: OrderStatus[] = ["open", "on-hold", "fulfilled", "cancelled"];
+const EXCEPTIONS: OrderException[] = [
+  "none",
+  "fraud-review",
+  "address-invalid",
+  "oversell",
+  "carrier-delay",
+  "payment-declined",
+];
+
+/**
+ * BEAT 5, step 1 — put an order on hold (and optionally restate why).
+ *
+ * The `id` accepts either the internal id or the human-facing order NUMBER; the
+ * store resolves both. The agent reads "order 4471" out of the page context and
+ * either spelling is a reasonable thing for it to send, so refusing one of them
+ * would be a routing failure dressed up as a 404.
+ *
+ * This route validates the VOCABULARY only — that the strings name a real
+ * status and a real exception. Which status changes are legal, and which
+ * (status, exception) pairs an order may hold, is the state machine in
+ * `store.orderStatusBlocker`, because that invariant belongs to the ledger and
+ * not to one of its two writers. `setOrderStatus` throws a coded refusal and
+ * `errorResponse` maps it (409 / 422); do NOT re-implement any of it here.
+ *
+ * `status` and `exception` are INDEPENDENTLY optional, and that independence is
+ * load-bearing rather than convenience. A PATCH that always had to carry a status
+ * forced the Orders page's "Clear the exception" button to send one, and the one
+ * it sent (`open`) silently RELEASED any hold beat 5 had just placed — undoing
+ * the first of the stored procedure's three writes while claiming only to have
+ * cleared a flag. A request that names only the field it means cannot do that. At
+ * least one of the two must be present: an empty PATCH is a caller bug, and
+ * answering 200 to it would report a write that never happened.
+ *
+ * The body is decoded by `readJsonBody` BEFORE the `try` opens, so an unreadable
+ * one is a deliberate 400 naming the order rather than a `SyntaxError` that
+ * `errorResponse` cannot tell apart from a store defect.
+ */
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const parsed = await readJsonBody(req, "PATCH orders/[id]", id);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+
+  try {
+    // Presence, not truthiness: `exception: ""` is a malformed value, not an
+    // omission, and must reach the vocabulary check below rather than be dropped.
+    const hasStatus = body.status !== undefined && body.status !== null;
+    const hasException =
+      body.exception !== undefined && body.exception !== null;
+    if (!hasStatus && !hasException) {
+      return Response.json(
+        {
+          error: "BAD_REQUEST",
+          message: "Provide a status, an exception, or both.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const status = String(body.status ?? "") as OrderStatus;
+    if (hasStatus && !STATUSES.includes(status)) {
+      return Response.json(
+        { error: "BAD_REQUEST", message: "Unknown order status." },
+        { status: 400 },
+      );
+    }
+    const exception = String(body.exception ?? "") as OrderException;
+    if (hasException && !EXCEPTIONS.includes(exception)) {
+      return Response.json(
+        { error: "BAD_REQUEST", message: "Unknown order exception." },
+        { status: 400 },
+      );
+    }
+
+    const updated = hasStatus
+      ? store.setOrderStatus(id, status, hasException ? exception : undefined)
+      : store.setOrderException(id, exception);
+    return Response.json(updated, { status: 200 });
+  } catch (error) {
+    return errorResponse(error, `PATCH orders/[id] id=${id}`);
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/plans/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/plans/route.ts
@@ -1,0 +1,238 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse } from "@/skins/commerce/data/http";
+
+/**
+ * BEAT 3d — the durable artifact.
+ *
+ * A restock plan is written to the STORE, so it belongs to the application and
+ * not to the conversation that produced it. That is the whole point of the beat:
+ * delete the thread, reload the browser, and the plan is still sitting on the
+ * Catalog page. Nothing here references a thread id.
+ */
+export const GET = async () => Response.json(store.plans());
+
+// ── Row budgets ──────────────────────────────────────────────────────────────
+// These caps are a LAYOUT budget, not a whim: a plan renders as ONE card in a
+// two-column grid (`skins/commerce/pages/catalog.tsx`), and three bullets, eight
+// SKU rows and eight schedule steps is what fits before the card stops being
+// readable. `createRestockPlan`'s own schema already declares `highlights.max(3)`.
+//
+// Over-budget input is REFUSED, never trimmed. The trim this replaced was silent
+// in the one place silence is unaffordable: the tool answered "Filed the plan",
+// the agent narrated the twelve SKUs it had read out of the price sheet, and the
+// artifact on the page held eight rows — a discrepancy nobody in the room can
+// see, in a record that outlives the thread. A refusal names the limit, so the
+// agent re-files a plan that fits instead of storing one that lies.
+const MAX_HIGHLIGHTS = 3;
+const MAX_LINES = 8;
+const MAX_SCHEDULE = 8;
+
+/** Landed cost per unit, in dollars. A restock plan is a PO, not a bond issue. */
+const MAX_LANDED_COST = 1_000_000;
+/** Units on a single line of a single plan. */
+const MAX_UNITS = 10_000_000;
+
+/**
+ * The codes this route can refuse with.
+ *
+ * Deliberately RETURNED rather than thrown. `errorResponse` (`data/http.ts`)
+ * resolves a thrown code through a closed `Map` and answers a logged **500** for
+ * anything it does not recognise — correct for a store invariant, wrong for "the
+ * model sent me a bad row", which is a 4xx the agent can act on. It also needs a
+ * FIELD-SPECIFIC message so the retry is informed, and the shared map only
+ * carries one fixed string per code. The `{ error, message }` envelope is
+ * identical either way, so callers see one shape.
+ */
+type PlanRejection = "BAD_REQUEST" | "INVALID_PLAN_FIELD" | "PLAN_TOO_LARGE";
+
+class PlanInputError extends Error {
+  constructor(
+    readonly code: PlanRejection,
+    readonly detail: string,
+    readonly status: number,
+  ) {
+    super(code);
+    this.name = "PlanInputError";
+  }
+}
+
+const reject = (error: PlanRejection, message: string, status: number) =>
+  Response.json({ error, message }, { status });
+
+/** Refuse one field, naming it, so the agent's retry is informed. */
+function invalid(detail: string): never {
+  throw new PlanInputError("INVALID_PLAN_FIELD", detail, 422);
+}
+
+/**
+ * A trimmed, non-empty string — or a refusal.
+ *
+ * `String(value)` is never used on model-authored input: it renders `null` as
+ * `"null"` and `{}` as `"[object Object]"`, both of which are truthy, survive a
+ * `.filter(Boolean)`, and land in the durable artifact verbatim.
+ */
+function requireText(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    invalid(`${field} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function requireRecord(value: unknown, field: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    invalid(`${field} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * A number the artifact can be reasoned about with.
+ *
+ * `Number(x) || 0` is never used: it mapped `NaN`, `"$52"`, `null` AND a genuine
+ * `0` onto the same stored `0`, so a cost the agent failed to parse was
+ * indistinguishable from a cost that really is zero — in the very figures the
+ * margin narrative is built on. A genuine `0` is accepted here and stored as
+ * `0`; anything unparseable, negative or absurd is refused.
+ */
+function requireNumber(
+  value: unknown,
+  field: string,
+  max: number,
+  { integer = false }: { integer?: boolean } = {},
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    invalid(`${field} must be a finite number.`);
+  }
+  if (integer && !Number.isInteger(value)) {
+    invalid(`${field} must be a whole number.`);
+  }
+  if (value < 0 || value > max) {
+    invalid(`${field} must be between 0 and ${max}.`);
+  }
+  return value;
+}
+
+/**
+ * An absent list is empty; a present one must be a list, and must fit.
+ *
+ * `Array.isArray(x) ? … : []` was the same coerce-and-continue decision as the
+ * trim: a `highlights` the model sent as a single string became an empty section
+ * on the card, with success reported.
+ */
+function requireList(value: unknown, field: string, max: number): unknown[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    invalid(`${field} must be an array.`);
+  }
+  if (value.length > max) {
+    throw new PlanInputError(
+      "PLAN_TOO_LARGE",
+      `A plan holds at most ${max} ${field}; ${value.length} were sent. File a plan that fits rather than one that is silently shorter than the document.`,
+      422,
+    );
+  }
+  return value;
+}
+
+/**
+ * The Catalog card keys its React lists off these very values (`key={highlight}`,
+ * `key={line.sku}`, `` key={`${step.week}-${step.item}`} ``), so a repeated value
+ * is not merely redundant — React renders one row where the plan holds two, and
+ * the card quietly shows less than the record contains.
+ */
+function requireDistinct(keys: string[], field: string): void {
+  if (new Set(keys).size !== keys.length) {
+    invalid(`${field} must not repeat; the page keys its rows off them.`);
+  }
+}
+
+/**
+ * Absent → the documented default. PRESENT → it has to be usable.
+ *
+ * `String(body.season ?? "Unscheduled").trim()` let an explicit `""` through and
+ * stored a blank season: a card with no title, and a receipt reading "Filed the
+ * restock plan for …" with a double space where the season should be. Omitting
+ * the field is a choice we can default; sending an empty one is a mistake we
+ * cannot tell apart from a parse failure.
+ */
+function optionalText(value: unknown, field: string, fallback: string): string {
+  if (value === undefined || value === null) return fallback;
+  return requireText(value, field);
+}
+
+export const POST = async (req: NextRequest) => {
+  try {
+    const body = await req.json();
+
+    // `typeof === "string"`, not `String(...)`: `{ vendor: {} }` used to pass
+    // this check as the literal text "[object Object]".
+    const vendor = typeof body?.vendor === "string" ? body.vendor.trim() : "";
+    const summary =
+      typeof body?.summary === "string" ? body.summary.trim() : "";
+    if (!vendor || !summary) {
+      return reject("BAD_REQUEST", "A plan needs a vendor and a summary.", 400);
+    }
+
+    // Validate the model-authored fields rather than coercing them. The agent
+    // fills these from an uploaded PDF against a zod schema, so a malformed row
+    // does not mean "documents are messy" — it means the model misread the
+    // sheet, which is exactly when a quietly thinner artifact is worst.
+    const highlights = requireList(
+      body?.highlights,
+      "highlights",
+      MAX_HIGHLIGHTS,
+    ).map((h, i) => requireText(h, `highlights[${i}]`));
+    requireDistinct(highlights, "highlights");
+
+    const lines = requireList(body?.lines, "lines", MAX_LINES).map((raw, i) => {
+      const line = requireRecord(raw, `lines[${i}]`);
+      return {
+        sku: requireText(line.sku, `lines[${i}].sku`),
+        name: requireText(line.name, `lines[${i}].name`),
+        landedCost: requireNumber(
+          line.landedCost,
+          `lines[${i}].landedCost`,
+          MAX_LANDED_COST,
+        ),
+        units: requireNumber(line.units, `lines[${i}].units`, MAX_UNITS, {
+          integer: true,
+        }),
+      };
+    });
+    requireDistinct(
+      lines.map((l) => l.sku),
+      "lines[].sku",
+    );
+
+    const schedule = requireList(body?.schedule, "schedule", MAX_SCHEDULE).map(
+      (raw, i) => {
+        const step = requireRecord(raw, `schedule[${i}]`);
+        return {
+          week: requireText(step.week, `schedule[${i}].week`),
+          item: requireText(step.item, `schedule[${i}].item`),
+        };
+      },
+    );
+    requireDistinct(
+      schedule.map((s) => `${s.week}-${s.item}`),
+      "schedule",
+    );
+
+    const plan = store.filePlan({
+      vendor,
+      season: optionalText(body?.season, "season", "Unscheduled"),
+      summary,
+      highlights,
+      lines,
+      schedule,
+      filedBy: optionalText(body?.filedBy, "filedBy", "Bellwether"),
+    });
+    return Response.json(plan, { status: 201 });
+  } catch (error) {
+    if (error instanceof PlanInputError) {
+      return reject(error.code, error.detail, error.status);
+    }
+    return errorResponse(error, "POST plans");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/price-sheet/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/price-sheet/route.ts
@@ -1,0 +1,176 @@
+import * as store from "@/skins/commerce/data/store";
+import { buildPriceSheetPdf } from "@/skins/commerce/data/price-sheet-pdf";
+import type { PriceSheetLine } from "@/skins/commerce/data/price-sheet-pdf";
+import { errorResponse } from "@/skins/commerce/data/http";
+import { freshStyleFor } from "@/skins/commerce/data/price-sheet-styles";
+
+/**
+ * BEAT 3d — serves the vendor price sheet the demo attaches.
+ *
+ * Generated per request from the live catalog, so the SKUs and the current costs
+ * in the document always agree with what the Catalog page shows, and the ship
+ * schedule is always a sensible number of weeks out. See `price-sheet-pdf.ts`
+ * for why this is not a static file in `public/`.
+ *
+ * Defaults to Kestrel Mills, the vendor with the most SKUs in the range, so the
+ * sheet follows the seed rather than hard-coding a name a future reseed could
+ * rename.
+ *
+ * EVERY ROW IS SCOPED TO THE VENDOR REQUESTED. The model lifts facts out of this
+ * document and narrates them, so a row the requested vendor does not supply is
+ * the app asserting a supplier relationship that does not exist. The carried rows
+ * come from that vendor's own catalog entries, and the one row that cannot (the
+ * fresh style beat 3d needs) is per-vendor and category-checked — see
+ * `data/price-sheet-styles.ts`.
+ */
+const DEFAULT_VENDOR = "Kestrel Mills";
+
+/**
+ * Resolves the `vendor` lever, treating an absent value and an unusable one as
+ * the same request.
+ *
+ * `searchParams.get("vendor") ?? DEFAULT_VENDOR` was wrong: `??` only falls back
+ * on `null`/`undefined`, but `?vendor=` — the shape a cleared field or a
+ * `URLSearchParams.set("vendor", "")` produces — yields the EMPTY STRING, which
+ * is not nullish. The default never applied, the catalog filter matched nothing,
+ * and the route 404'd on a vendor nobody had named. That is beat 3d's silent
+ * failure once more: `stagePriceSheetAttachment` maps the non-2xx to
+ * `staged === false` and the prompt is sent with no document attached.
+ *
+ * The fallback (rather than a 400) is the house rule for levers, set by
+ * `parseTopLever` in `skins/commerce/pages/orders.tsx`: trim, then IGNORE a
+ * value that cannot be used instead of failing the request on it. Trimming is
+ * what makes whitespace-only unusable too, and it also lets a stray surrounding
+ * space on a REAL vendor name resolve rather than 404. A vendor the caller
+ * genuinely named but the seed does not stock is still a miss, and still 404s —
+ * this only collapses "said nothing" and "said nothing usable".
+ */
+const requestedVendor = (url: string): string =>
+  new URL(url).searchParams.get("vendor")?.trim() || DEFAULT_VENDOR;
+
+/**
+ * Why the WHOLE body is inside the `try`, not just the `buildPriceSheetPdf` call.
+ *
+ * This route is beat 3d's document source, and a failure here is silent all the
+ * way to the stage. `stagePriceSheetAttachment` treats any non-2xx as
+ * `staged === false` (`attach-price-sheet.ts`), and
+ * `sendRestockRequestWithPriceSheet` then sends the pill's prompt ANYWAY
+ * (`skin.tsx`) — so the model is told "here's the autumn price sheet, read it"
+ * with no file attached, and answers from the catalog it can already see. The
+ * demo appears to work and proves nothing. Without the `catch` below there was
+ * no server-side record either: an uncaught throw is whatever Next decides to
+ * emit, with none of this route's own context in it.
+ *
+ * Three distinct throw sites live in here, which is why the guard is the whole
+ * handler rather than one expression:
+ *   1. `new URL(req.url)` / `store.products()` — before any PDF work.
+ *   2. `buildPriceSheetPdf` — the PDF writer itself.
+ *   3. `new Response(...)` — header validation. `content-disposition` below
+ *      interpolates the caller-supplied `vendor`, and a value outside
+ *      ISO-8859-1 makes the Response constructor throw. Reachable only for a
+ *      vendor that matched a seeded product, but it is a throw site on the
+ *      success path, so it belongs under the same guard.
+ *
+ * `errorResponse` is the same mapper the other eight routes funnel through, so
+ * the failure arrives as this skin's structured `{ error, message }` JSON — a
+ * shape the consumer can tell from a PDF — and lands in the server log with the
+ * `[commerce/api]` prefix.
+ */
+export const GET = async (req: Request) => {
+  // Hoisted out of the `try` only so the `catch` can name the vendor: it is the
+  // one request-varying input this route has, and therefore the only thing that
+  // distinguishes one failing request from another in the log.
+  let vendor = DEFAULT_VENDOR;
+  try {
+    // Still assigned INSIDE the `try`: `new URL(req.url)` is throw site 1 above,
+    // and hoisting the call itself would put that throw outside the guard.
+    vendor = requestedVendor(req.url);
+    // One snapshot, read twice at most: the vendor's rows, and — only on a miss —
+    // the vendor names to name in the log.
+    const all = store.products();
+    const catalog = all.filter((p) => p.vendor === vendor);
+
+    if (catalog.length === 0) {
+      // The miss used to be answered with NOTHING in the server log, which made a
+      // seed vendor rename an invisible way to disable beat 3d: the pill fetches
+      // this route with no `vendor` at all, so `DEFAULT_VENDOR` above stops
+      // matching, the route 404s, and `stagePriceSheetAttachment` maps that to
+      // `staged: false`. The consumer chain does name it to the PRESENTER
+      // (`reportPriceSheetFailure` alerts, and the prompt is not sent), but the
+      // alert only says "HTTP 404 — see the server logs", and there was nothing
+      // in the server logs to see.
+      //
+      // `console.warn`, not `console.error`: this is a deliberate domain answer,
+      // not a fault, and `errorResponse` owns the `console.error` channel for real
+      // faults. Same split as `readJsonBody`'s malformed-body warning in
+      // `data/http.ts`.
+      //
+      // The stocked vendors ride along because the rename is the failure this line
+      // exists to diagnose — "who IS stocked?" is the very next question, and
+      // answering it in the same line saves the reader a trip to the seed. Safe to
+      // be specific: this is a server log, not a response body.
+      const stocked = [...new Set(all.map((p) => p.vendor))].sort();
+      console.warn(
+        `[commerce/api] GET price-sheet?vendor=${vendor} — no SKUs are sourced ` +
+          `from that vendor; stocked vendors: ${stocked.join(", ") || "(none)"}`,
+      );
+      return Response.json(
+        {
+          error: "NOT_FOUND",
+          message: "No SKUs are sourced from that vendor.",
+        },
+        { status: 404 },
+      );
+    }
+
+    // Quote a modest increase on two of the vendor's existing SKUs, then — only
+    // if this vendor can credibly quote it — one style the app has never seen.
+    // The new style is what makes "did it actually read the document?" answerable
+    // at a glance: it cannot come from the catalog. See `price-sheet-styles.ts`
+    // for why it is per-vendor and conditional rather than a fixed row.
+    const carried: PriceSheetLine[] = catalog
+      .slice(0, 3)
+      .map((item, index) => ({
+        sku: item.sku,
+        name: item.name,
+        currentCost: item.unitCost,
+        quotedCost:
+          index < 2 ? Math.round(item.unitCost * 1.08) : item.unitCost,
+        minimumUnits: index === 0 ? 1200 : 600,
+      }));
+
+    const fresh = freshStyleFor(vendor, catalog);
+    const lines: PriceSheetLine[] = fresh
+      ? [
+          ...carried,
+          {
+            sku: fresh.sku,
+            name: fresh.name,
+            // Left UNDEFINED rather than 0: the document must not claim a style
+            // it has never bought "rose from $0", and `costMovementLines` reads
+            // the absence as "quoted for the first time".
+            currentCost: undefined,
+            quotedCost: fresh.quotedCost,
+            minimumUnits: fresh.minimumUnits,
+          },
+        ]
+      : carried;
+
+    const pdf = buildPriceSheetPdf({ vendor, season: "Autumn", lines });
+
+    return new Response(pdf as BodyInit, {
+      status: 200,
+      headers: {
+        "content-type": "application/pdf",
+        "content-disposition": `inline; filename="price-sheet-${vendor
+          .toLowerCase()
+          .replace(/\s+/g, "-")}.pdf"`,
+        // Never cache: the ship schedule is computed from `now`, and a cached copy
+        // would quietly go stale in exactly the way a static file would.
+        "cache-control": "no-store",
+      },
+    });
+  } catch (error) {
+    return errorResponse(error, `GET price-sheet?vendor=${vendor}`);
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/promotions/[id]/approve/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/promotions/[id]/approve/route.ts
@@ -1,0 +1,24 @@
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse } from "@/skins/commerce/data/http";
+
+/**
+ * BEAT 6 — the gate.
+ *
+ * Refuses with 422 BELOW_MARGIN_FLOOR when the discounted margin falls under the
+ * category floor and no approved, JUSTIFYING margin waiver is linked. The
+ * message that reaches the agent is written once, in `data/http.ts`, and names
+ * the SYMPTOM only — never the unlock. Everything about this beat depends on the
+ * agent being unable to read the recipe out of the error.
+ */
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    const { promotion, product } = store.approvePromotion(id);
+    return Response.json({ promotion, product }, { status: 200 });
+  } catch (error) {
+    return errorResponse(error, "POST promotions/[id]/approve");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/promotions/[id]/decline/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/promotions/[id]/decline/route.ts
@@ -1,0 +1,14 @@
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse } from "@/skins/commerce/data/http";
+
+export const POST = async (
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  try {
+    const { id } = await params;
+    return Response.json(store.declinePromotion(id), { status: 200 });
+  } catch (error) {
+    return errorResponse(error, "POST promotions/[id]/decline");
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/returns/[id]/refund/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/returns/[id]/refund/route.ts
@@ -1,0 +1,47 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import {
+  errorResponse,
+  readJsonBody,
+  requireAmount,
+} from "@/skins/commerce/data/http";
+
+/**
+ * BEAT 3a — a goodwill refund.
+ *
+ * The figure arrives here from the chat card the MERCHANT typed it into, over a
+ * plain fetch from the browser. It was never a tool argument the model authored
+ * and it is never written back into the transcript: the HITL tool's `respond()`
+ * returns only a label ("Refund issued on Marguerite Bell's return"). The
+ * response body below is read by the CLIENT to refresh the returns desk, not by
+ * the agent.
+ *
+ * The "cannot exceed what was charged" check lives in the store rather than
+ * here, so the same rule applies however the refund is issued — including from
+ * the Returns page's own control. What DOES belong here is the type of the
+ * figure: this is the only place an untrusted body is decoded, so `requireAmount`
+ * refuses a non-number outright instead of letting `Number()` coerce one into a
+ * refund. It is the single route in the skin that moves money, and settling is
+ * irreversible — see the note on `requireAmount`.
+ *
+ * `readJsonBody` runs BEFORE the `try` for the matching reason: a body we could
+ * not read is a bad request about a named return (a deliberate 400), while
+ * anything the store raises past that point is ours and keeps its logged 500.
+ * On the route that moves money the two must never share one report.
+ */
+export const POST = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const parsed = await readJsonBody(req, "POST returns/[id]/refund", id);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+
+  try {
+    const updated = store.issueRefund(id, requireAmount(body.amount));
+    return Response.json(updated, { status: 200 });
+  } catch (error) {
+    return errorResponse(error, `POST returns/[id]/refund id=${id}`);
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/returns/[id]/route.ts
+++ b/examples/showcases/reskinnable-demo/src/app/api/commerce/v1/returns/[id]/route.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from "next/server";
+import * as store from "@/skins/commerce/data/store";
+import { errorResponse, readJsonBody } from "@/skins/commerce/data/http";
+
+/**
+ * Approve or decline a return request from the Returns desk.
+ *
+ * The body is decoded by `readJsonBody` BEFORE the `try` opens, so an unreadable
+ * one is a deliberate 400 naming the return rather than a `SyntaxError` that
+ * `errorResponse` cannot tell apart from a store defect.
+ */
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const parsed = await readJsonBody(req, "PATCH returns/[id]", id);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+
+  try {
+    const status = String(body.status ?? "");
+    if (status !== "approved" && status !== "declined") {
+      return Response.json(
+        { error: "BAD_REQUEST", message: "Unknown return status." },
+        { status: 400 },
+      );
+    }
+    return Response.json(store.decideReturn(id, status), { status: 200 });
+  } catch (error) {
+    return errorResponse(error, `PATCH returns/[id] id=${id}`);
+  }
+};

--- a/examples/showcases/reskinnable-demo/src/lib/locked-skin.ts
+++ b/examples/showcases/reskinnable-demo/src/lib/locked-skin.ts
@@ -12,7 +12,7 @@ import { skinIds } from "@/shell/skins-config";
  *
  * A per-deploy SERVER env (deliberately non-NEXT_PUBLIC_, like
  * PRESENTER_RESET_ENABLED) so one build serves both a locked single-tenant host
- * and the unlocked four-skin demo. Threaded to client chrome as a prop in
+ * and the unlocked multi-skin demo. Threaded to client chrome as a prop in
  * `src/app/layout.tsx` → `LockedSkinProvider`.
  *
  * NOTE: this does NOT pin dark/light. That is a separate axis (localStorage +

--- a/examples/showcases/reskinnable-demo/src/lib/redact-secrets.test.ts
+++ b/examples/showcases/reskinnable-demo/src/lib/redact-secrets.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The redactor's contract, tested at the level the CALLERS cannot: a route test
+ * proves one body is clean, these prove the needle DERIVATION is, which is where
+ * the class of bug lives. Its predecessor in commerce's `dev/reset` was correct
+ * about the one secret it was handed and silent about the other four.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { envSecretNeedles, redactSecrets } from "./redact-secrets";
+
+/** Distinctive on purpose: asserting against `localhost` proves little. */
+const API_URL = "http://memory.internal.example:7250";
+const WS_URL = "ws://gateway.internal.example:7253";
+const API_KEY = "cpk_s2PRVSED_seed0privat0longtoken01";
+const LICENSE = "eyJhbGciOiJFZERTQSJ9.license-payload.sig";
+const OPENAI_KEY = "sk-proj-abcdef0123456789";
+
+function stubEverySecret() {
+  vi.stubEnv("INTELLIGENCE_API_URL", API_URL);
+  vi.stubEnv("INTELLIGENCE_GATEWAY_WS_URL", WS_URL);
+  vi.stubEnv("INTELLIGENCE_API_KEY", API_KEY);
+  vi.stubEnv("COPILOTKIT_LICENSE_TOKEN", LICENSE);
+  vi.stubEnv("OPENAI_API_KEY", OPENAI_KEY);
+}
+
+/** Every secret unset, so a passthrough case cannot be satisfied by luck. */
+function stubNoSecrets() {
+  for (const key of [
+    "INTELLIGENCE_API_URL",
+    "INTELLIGENCE_GATEWAY_WS_URL",
+    "INTELLIGENCE_API_KEY",
+    "COPILOTKIT_LICENSE_TOKEN",
+    "OPENAI_API_KEY",
+  ]) {
+    vi.stubEnv(key, undefined);
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("redactSecrets", () => {
+  it("removes every configured secret from one message", async () => {
+    stubEverySecret();
+
+    const out = redactSecrets(
+      `POST ${API_URL}/api/memories with key ${API_KEY} (gateway ${WS_URL}, ` +
+        `license ${LICENSE}, llm ${OPENAI_KEY}) failed`,
+    );
+
+    for (const secret of [API_URL, WS_URL, API_KEY, LICENSE, OPENAI_KEY]) {
+      expect(out).not.toContain(secret);
+    }
+    // Each placeholder NAMES its secret, so a redacted message still diagnoses.
+    expect(out).toContain("<intelligence-backend>");
+    expect(out).toContain("<intelligence-api-key>");
+    expect(out).toContain("<intelligence-gateway>");
+    expect(out).toContain("<license-token>");
+    expect(out).toContain("<openai-api-key>");
+    // And the surrounding wording — the part a presenter reads — is untouched.
+    expect(out).toContain("POST");
+    expect(out).toContain("/api/memories");
+    expect(out).toContain("failed");
+  });
+
+  it("removes a URL's host WITH and WITHOUT its port", () => {
+    stubEverySecret();
+
+    // `URL.hostname` (portless) is a substring of neither the raw URL nor
+    // `URL.host`, so a needle set built from those two leaves it behind. Real
+    // messages produce it: `getaddrinfo ENOTFOUND <hostname>`.
+    expect(redactSecrets("getaddrinfo ENOTFOUND memory.internal.example")).toBe(
+      "getaddrinfo ENOTFOUND <intelligence-backend>",
+    );
+    expect(
+      redactSecrets("proxy could not reach memory.internal.example:7250"),
+    ).toBe("proxy could not reach <intelligence-backend>");
+  });
+
+  it("replaces the full URL before its host can shadow it", () => {
+    stubEverySecret();
+
+    // Shortest-first would leave `http://<intelligence-backend>/api/memories`,
+    // which still publishes the scheme and the path shape of the internal API.
+    const out = redactSecrets(
+      `Failed to parse URL from ${API_URL}/api/memories`,
+    );
+
+    expect(out).toBe(
+      "Failed to parse URL from <intelligence-backend>/api/memories",
+    );
+    expect(out).not.toContain("http://<intelligence-backend>");
+  });
+
+  it("removes a trailing-slash URL quoted back without its slash", () => {
+    vi.stubEnv("INTELLIGENCE_API_URL", `${API_URL}/`);
+
+    expect(redactSecrets(`connect ECONNREFUSED ${API_URL}`)).toBe(
+      "connect ECONNREFUSED <intelligence-backend>",
+    );
+  });
+
+  it("still scrubs the raw form of an UNPARSABLE url secret", () => {
+    // A malformed env is exactly the case whose parse error quotes it verbatim,
+    // and `new URL()` throws, so only the raw forms are derivable.
+    vi.stubEnv("INTELLIGENCE_API_URL", "memory.internal.example:not-a-port");
+    vi.stubEnv("INTELLIGENCE_API_KEY", API_KEY);
+
+    expect(
+      redactSecrets(
+        "Failed to parse URL from memory.internal.example:not-a-port",
+      ),
+    ).toBe("Failed to parse URL from <intelligence-backend>");
+  });
+
+  describe("a secret that is absent or empty", () => {
+    /**
+     * The degenerate-needle rule, and the reason it is a TEST rather than a
+     * comment: `"abc".split("")` is every character, so an empty needle joined
+     * on a placeholder rewrites the entire message into placeholders — losing
+     * the diagnosis a presenter needs while reading exactly like a successful
+     * redaction.
+     */
+    it("yields NO needle rather than an empty one", () => {
+      stubNoSecrets();
+
+      expect(envSecretNeedles()).toEqual([]);
+      const message = "interrupted during the wipe phase: 503 nope";
+      expect(redactSecrets(message)).toBe(message);
+    });
+
+    it("treats a set-but-empty env var the same as unset", () => {
+      stubNoSecrets();
+      vi.stubEnv("INTELLIGENCE_API_KEY", "");
+
+      expect(envSecretNeedles()).toEqual([]);
+      expect(redactSecrets("HTTP 401 unauthorized")).toBe(
+        "HTTP 401 unauthorized",
+      );
+    });
+
+    it("covers the secrets that ARE set when others are missing", () => {
+      // The OSS path sets no Intelligence vars at all; a partly-configured env
+      // must still be covered for what it does hold, not skipped wholesale.
+      stubNoSecrets();
+      vi.stubEnv("INTELLIGENCE_API_KEY", API_KEY);
+
+      const out = redactSecrets(`HTTP 401 invalid api key ${API_KEY}`);
+      expect(out).toBe("HTTP 401 invalid api key <intelligence-api-key>");
+    });
+  });
+
+  describe("envSecretNeedles", () => {
+    it("sorts longest first, and emits no empty values", () => {
+      stubEverySecret();
+
+      const needles = envSecretNeedles();
+      const lengths = needles.map((n) => n.value.length);
+      expect(lengths).toEqual([...lengths].sort((a, b) => b - a));
+      expect(needles.every((n) => n.value.length > 0)).toBe(true);
+    });
+
+    it("reads the CURRENT environment on every call", () => {
+      // Derived per call, never cached at module load: the reset route builds a
+      // response after reading env itself, and a needle set frozen at import
+      // time would go stale under any per-request env change (and, more
+      // practically, under `vi.stubEnv`).
+      stubNoSecrets();
+      expect(envSecretNeedles()).toEqual([]);
+      vi.stubEnv("INTELLIGENCE_API_KEY", API_KEY);
+      expect(envSecretNeedles().map((n) => n.value)).toEqual([API_KEY]);
+    });
+
+    it("names a form shared by two secrets once", () => {
+      // Two URLs on ONE host (the local docker-compose shape) share a hostname.
+      // Emitting it twice would replace it, then hunt for it inside its own
+      // placeholder; the first declaration wins and the value appears once.
+      stubNoSecrets();
+      vi.stubEnv("INTELLIGENCE_API_URL", "http://one.host.example:7250");
+      vi.stubEnv("INTELLIGENCE_GATEWAY_WS_URL", "ws://one.host.example:7253");
+
+      const values = envSecretNeedles().map((n) => n.value);
+      expect(values.length).toBe(new Set(values).size);
+      expect(
+        envSecretNeedles().find((n) => n.value === "one.host.example")
+          ?.placeholder,
+      ).toBe("<intelligence-backend>");
+    });
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/lib/redact-secrets.ts
+++ b/examples/showcases/reskinnable-demo/src/lib/redact-secrets.ts
@@ -1,0 +1,182 @@
+/**
+ * Strip environment SECRETS out of text that is about to travel in an HTTP
+ * RESPONSE BODY. Server-safe plain `.ts` (no `"use client"`, no JSX).
+ *
+ * ── WHY A MODULE, RATHER THAN A HELPER PER ROUTE ──────────────────────────────
+ * The demo's presenter-reset routes echo text they did not compose — an
+ * upstream `Error.message`, a backend response body quoted into a shortfall
+ * reason — into a body that any caller who can reach the box gets to read (the
+ * `PRESENTER_RESET_ENABLED` gate is a demo convenience, not an authorization
+ * boundary). Commerce's first redactor took the value to scrub as an ARGUMENT:
+ *
+ *     redactBackend(text, apiUrl)   // knows about ONE secret, the one passed in
+ *
+ * which cannot cover a secret nobody remembered to pass, and the API key was
+ * never passed. That is the defect this module's SHAPE removes: the needle set
+ * is DERIVED FROM THE ENVIRONMENT here, so a call site cannot under-supply it
+ * and adding a secret to {@link ENV_SECRETS} covers every existing caller at
+ * once. Call sites take one argument — the text — on purpose.
+ *
+ * ── WHY ON THE WAY OUT, NOT AT THE SOURCE ────────────────────────────────────
+ * Redacting where the text is COMPOSED would scrub the server logs too, and the
+ * logs are the one place these values belong: a human debugging a reset needs to
+ * see which backend was about to be touched (this repo vendors several stacks
+ * against several ports). So the callers log unredacted and redact only what
+ * they serialize.
+ *
+ * `split`/`join` rather than a RegExp: every needle is arbitrary environment
+ * text that would otherwise need escaping.
+ */
+
+/** A secret worth removing, and how it shows up in text. */
+interface EnvSecret {
+  /** Env var that carries the value. Read at CALL time, never cached. */
+  env: string;
+  /**
+   * What the value reads as once removed. Names WHICH secret went, so a
+   * redacted message still diagnoses: `HTTP 401 <intelligence-api-key>` says
+   * the credential was rejected, where a bare `<redacted>` says nothing.
+   */
+  placeholder: string;
+  /**
+   * `"url"` also derives the host forms (see {@link deriveNeedles}) — a URL
+   * leaks through its host as readily as through its full text.
+   */
+  kind: "url" | "opaque";
+}
+
+/**
+ * Every secret the demo's server env holds that would be damaging in a response
+ * body, in the order needles are derived (which decides the placeholder when two
+ * secrets share a derived form, e.g. two URLs on one host).
+ *
+ * The last three are covered DEFENSIVELY rather than because a known message
+ * quotes them: this module is cheap, over-redaction is safe, and "no current
+ * code path reaches it" is precisely the reasoning that left the API key
+ * uncovered while the address was being fixed.
+ *
+ * DELIBERATELY ABSENT: `BAKED_LICENSE_KEYS_JSON` (a PUBLIC signing key, and a
+ * multi-kilobyte JSON blob), and `INTELLIGENCE_USER_ID` / `INTELLIGENCE_USER_NAME`
+ * — demo identities, not credentials, and the reset's shortfall list names the
+ * dirty bucket ON PURPOSE so a presenter knows which identity to look at.
+ */
+const ENV_SECRETS: readonly EnvSecret[] = [
+  {
+    env: "INTELLIGENCE_API_URL",
+    placeholder: "<intelligence-backend>",
+    kind: "url",
+  },
+  {
+    env: "INTELLIGENCE_GATEWAY_WS_URL",
+    placeholder: "<intelligence-gateway>",
+    kind: "url",
+  },
+  {
+    env: "INTELLIGENCE_API_KEY",
+    placeholder: "<intelligence-api-key>",
+    kind: "opaque",
+  },
+  {
+    env: "COPILOTKIT_LICENSE_TOKEN",
+    placeholder: "<license-token>",
+    kind: "opaque",
+  },
+  { env: "OPENAI_API_KEY", placeholder: "<openai-api-key>", kind: "opaque" },
+];
+
+/** One literal to remove, with what it becomes. */
+export interface SecretNeedle {
+  value: string;
+  placeholder: string;
+}
+
+/**
+ * The literals to remove for one secret value.
+ *
+ * A URL is quoted back in more forms than the env var holds, and each is a
+ * separate literal that a single-form needle misses:
+ *
+ *  - the raw value, and the value without a trailing slash (undici quotes the
+ *    address it was given: "Failed to parse URL from …");
+ *  - `URL.host` — host WITH port;
+ *  - `URL.hostname` — host WITHOUT port. This one is not cosmetic: a DNS or
+ *    proxy failure (`getaddrinfo ENOTFOUND memory.internal.example`) names the
+ *    bare hostname, which is a substring of NEITHER of the two forms above, so
+ *    scrubbing them leaves the internal host in the body.
+ */
+function deriveNeedles(raw: string, kind: EnvSecret["kind"]): string[] {
+  if (kind === "opaque") return [raw];
+  const forms = [raw, raw.replace(/\/$/, "")];
+  try {
+    const url = new URL(raw);
+    forms.push(url.host, url.hostname);
+  } catch {
+    // A malformed env is exactly the case whose parse error quotes it back, so
+    // the raw forms above still have to be scrubbed. Nothing else is derivable.
+  }
+  return forms;
+}
+
+/**
+ * Read the current environment and build the needle set, LONGEST FIRST.
+ *
+ * Ordering is load-bearing: replace the full URL before its host can shadow it,
+ * or `https://host:7250/x` becomes `https://<intelligence-backend>/x` and the
+ * scheme-and-path shell of the address survives.
+ *
+ * ── AN ABSENT OR EMPTY SECRET YIELDS NO NEEDLE ───────────────────────────────
+ * Skipped, explicitly, and covered by a test. Two reasons, and the second is the
+ * one that matters:
+ *
+ *  1. There is nothing to leak. A secret with no value in `process.env` cannot
+ *     appear in text derived from a call that used it, so its absence from this
+ *     set is the absence of a thing to cover, not a hole in coverage.
+ *  2. `""` is a CATASTROPHIC needle, not a harmless one: `"abc".split("")` is
+ *     every character, so joining on a placeholder rewrites the whole message
+ *     into placeholders. That destroys the diagnosis a presenter needs AND reads
+ *     as though redaction had done its job.
+ *
+ * Note the corollary: a redactor is never a proof that redaction happened.
+ * Callers must not infer "safe" from having called it — the guarantee is only
+ * "no needle in this set survived", which is why the reset's tests assert the
+ * SERIALIZED BODY against each secret rather than asserting a call was made.
+ *
+ * No minimum needle length: a 1-character secret would over-redact, and
+ * over-redaction is the safe direction. Under-redaction is the bug.
+ */
+export function envSecretNeedles(): SecretNeedle[] {
+  /** Keyed by value so a form shared by two secrets is replaced once. */
+  const byValue = new Map<string, string>();
+  for (const secret of ENV_SECRETS) {
+    const raw = process.env[secret.env];
+    if (!raw) continue;
+    for (const value of deriveNeedles(raw, secret.kind)) {
+      // Guard again after derivation, and it is load-bearing rather than
+      // paranoia: `new URL("host.example:not-a-port")` PARSES — as scheme
+      // `host.example:` — so `url.host` is "", and an empty needle would rewrite
+      // every character of the message into a placeholder.
+      if (value && !byValue.has(value)) byValue.set(value, secret.placeholder);
+    }
+  }
+  return [...byValue]
+    .map(([value, placeholder]) => ({ value, placeholder }))
+    .sort((a, b) => b.value.length - a.value.length);
+}
+
+/**
+ * Replace every environment secret in `text` with its placeholder.
+ *
+ * Call with the text alone — the needle set defaults to the current
+ * environment's, which is the whole point (see the module header). The parameter
+ * exists so tests can pin a set; production callers should not pass it.
+ */
+export function redactSecrets(
+  text: string,
+  needles: SecretNeedle[] = envSecretNeedles(),
+): string {
+  let out = text;
+  for (const needle of needles) {
+    out = out.split(needle.value).join(needle.placeholder);
+  }
+  return out;
+}

--- a/examples/showcases/reskinnable-demo/src/shell/agent-registry.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/agent-registry.ts
@@ -8,6 +8,8 @@ import { logisticsAgent } from "@/skins/logistics/agent";
 import { logisticsIdentifyUser } from "@/skins/logistics/intelligence/user-id";
 import { peopleAgent } from "@/skins/people/agent";
 import { peopleIdentifyUser } from "@/skins/people/intelligence/user-id";
+import { commerceAgent } from "@/skins/commerce/agent";
+import { commerceIdentifyUser } from "@/skins/commerce/intelligence/user-id";
 
 /**
  * Server-safe map of skin id → its server-side registration (agent factory +
@@ -25,8 +27,9 @@ import { peopleIdentifyUser } from "@/skins/people/intelligence/user-id";
 /**
  * Resolve a stable end-user identity from the client-forwarded run `properties`
  * (`{ userRole, userId }`) for Intelligence thread + durable-memory scoping. A
- * skin supplies this only if it has per-user memory; skins without it (e.g.
- * airline) let the runtime fall back to a generic identity.
+ * skin supplies this whenever it wants its own scoping scheme — that need not
+ * imply per-user memory (logistics and keel scope threads only); skins without
+ * it (e.g. airline) let the runtime fall back to a generic identity.
  */
 export type IdentifyRunUser = (
   properties: { userRole?: string; userId?: string } | undefined,
@@ -45,8 +48,12 @@ export const agentRegistry: Record<string, AgentRegistration> = {
   banking: { createAgent: bankingAgent, identifyUser: bankingIdentifyUser },
   // Airline has no auth and no memory, so it contributes no identity resolver.
   airline: { createAgent: airlineAgent },
-  // Logistics scopes Intelligence per planner (authority + durable memory), so
-  // it contributes its own resolver.
+  // Logistics resolves a per-planner identity — `PLANNER_IDENTITY` maps each
+  // planner 1:1 — so its Intelligence THREADS are scoped per planner. That is
+  // all this resolver buys: logistics ships neither
+  // `intelligence/seed-memories.ts` nor `intelligence/forget-memories.ts`, so
+  // there is nothing seeded to recall and nothing learned to forget. Identity
+  // plumbing only — do NOT read it as a durable-memory demo.
   logistics: {
     createAgent: logisticsAgent,
     identifyUser: logisticsIdentifyUser,
@@ -54,10 +61,33 @@ export const agentRegistry: Record<string, AgentRegistration> = {
   // Keel scopes Intelligence per persona (privacy/clinical staff), so it
   // contributes its own resolver alongside the agent factory.
   keel: { createAgent: keelAgent, identifyUser: keelIdentifyUser },
-  // Rowan scopes Intelligence per operator: the seeded beat-4 preference and
-  // beat-5 procedure belong to Maya, and switching to Clara must land in a
-  // different memory bucket so a colleague visibly has NOT taught it anything.
+  // Rowan resolves a per-operator identity — `OPERATOR_IDENTITY` maps each
+  // operator 1:1 — and its seeded beat-4 preference and beat-5 procedure are
+  // Maya's.
+  //
+  // ⚠ Same caveat as Bellwether below: do NOT present this as per-operator
+  // memory isolation on stage. The client's `properties` frequently do not
+  // reach `identifyUser` on a run, so Maya AND Clara both resolve to the same
+  // `rowan-demo-user` bucket and switching operator in the sidebar re-scopes
+  // NOTHING — the "Clara has taught it nothing" contrast is not demoable until
+  // properties forwarding is fixed. That is also why `dev/reset` seeds BOTH the
+  // default bucket and Maya's mapped id; see `SEED_TARGET_USER_IDS` in
+  // `src/skins/people/intelligence/user-id.ts`, the authority on which inputs
+  // land in which bucket.
   people: { createAgent: peopleAgent, identifyUser: peopleIdentifyUser },
+  // Bellwether resolves a per-operator identity — `OPERATOR_IDENTITY` maps each
+  // operator 1:1 — and its seeded beat-4 preference and beat-5 procedure belong
+  // to Nadia.
+  //
+  // ⚠ Do NOT present that as per-operator memory isolation on stage. The
+  // client's `properties` frequently do not reach `identifyUser` on a run, so
+  // Nadia AND Theo both resolve to the same `bellwether-demo-user` bucket and
+  // switching operator in the sidebar re-scopes NOTHING: the "Theo has taught it
+  // nothing" contrast is not demoable until properties forwarding is fixed.
+  // `src/skins/commerce/intelligence/user-id.ts` is the authority on which
+  // inputs land in which bucket; read its `memorySeedTargetUserIds` note (and
+  // the pinned-`INTELLIGENCE_USER_ID` short-circuit) before changing this.
+  commerce: { createAgent: commerceAgent, identifyUser: commerceIdentifyUser },
 };
 
 export const agentIds = Object.keys(agentRegistry);

--- a/examples/showcases/reskinnable-demo/src/shell/registry.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/registry.ts
@@ -4,6 +4,7 @@ import airline from "@/skins/airline/skin";
 import logistics from "@/skins/logistics/skin";
 import keel from "@/skins/keel/skin";
 import people from "@/skins/people/skin";
+import commerce from "@/skins/commerce/skin";
 
 export { defaultSkinId } from "./skins-config";
 
@@ -15,6 +16,7 @@ export const SkinRegistry: Record<string, Skin> = {
   [logistics.id]: logistics,
   [keel.id]: keel,
   [people.id]: people,
+  [commerce.id]: commerce,
 };
 
 export function getSkin(id: string | undefined): Skin | null {

--- a/examples/showcases/reskinnable-demo/src/shell/skin-roster-docs.test.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/skin-roster-docs.test.ts
@@ -1,0 +1,708 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { skinIds } from "./skins-config";
+
+/**
+ * The prose drift guard.
+ *
+ * `skins-config.test.ts` (its neighbour) stops the three CODE copies of the skin
+ * id list from rotting. This file stops the PROSE copies from rotting, which is
+ * the same defect class and the one that actually keeps shipping: a doc hardcodes
+ * a skin count or a skin roster, the registered set grows, and the sentence turns
+ * false with nothing to catch it. One CR pass over the `commerce` skin found
+ * FOURTEEN live instances of exactly that across six documents — "ships four of
+ * them", "these four", a four-value `LOCK_SKIN` list, "all four stay reachable",
+ * "a four-tenant demo harness", "the unlocked four-skin demo", and so on.
+ *
+ * CLAUDE.md already carries a standing rule telling the next author to re-read
+ * the reskin skill after every change, and it explains why the rot is invisible:
+ * "it goes stale SILENTLY — nothing type-checks it, no test imports it, and a
+ * skin built from a stale template still compiles, lints and renders." That rule
+ * was written BEFORE the fourteen instances, so prose discipline has already been
+ * tried and has already failed. This file is the mechanical replacement.
+ *
+ * The expected values are DERIVED from `skinIds`; the digit 6 and the word "six"
+ * appear nowhere below, or this test would become the fifteenth instance of the
+ * bug it exists to prevent.
+ *
+ * ── Coverage, stated honestly ────────────────────────────────────────────────
+ *
+ * COVERED: the six documents in `DOC_SET` below, for (a) count claims that assert
+ * the size of the shipped set, and (b) inline id enumerations that the doc frames
+ * as the valid/registered set.
+ *
+ * ── TWO FALSE POSITIVES THIS FILE SHIPPED WITH, both fixed ───────────────────
+ *
+ * A drift guard that fails CORRECT prose is worse than none: it trains the next
+ * author to reach for an exemption. This file was originally validated only
+ * against the tree as it stood, which is the weaker test — it proved that no
+ * CURRENT sentence trips a rule, not that no LEGITIMATE sentence does. Two
+ * legitimate sentences did:
+ *
+ *  1. **"the sixth skin"** — a TRUE reference to `commerce` — was flagged as a
+ *     stale count, because the ordinal rule assumed every ordinal names the
+ *     HYPOTHETICAL NEXT skin (`registered + 1`). That holds for the indefinite
+ *     article ("a fifth skin added to the registry…", the phrasing the rule was
+ *     built from) and not for the definite one, which names an EXISTING member.
+ *     The article now decides, and a numeral equal to the registered count is
+ *     never treated as stale under either reading.
+ *  2. **A deliberate partial glob** — `src/skins/{banking,people}/…` — was flagged
+ *     as an incomplete roster, because the brace-glob rule demanded exhaustiveness
+ *     with no totality framing at all, while the id-list rule (correctly) required
+ *     one. Globs now need the same framing, from a cue window on EITHER side: the
+ *     two real globs are framed by "the six shipped skins" BEFORE (templates.md)
+ *     and "six implementations" AFTER (CLAUDE.md).
+ *
+ * Both discriminators are pinned below by must-flag AND must-not-flag fixtures,
+ * so neither can be quietly widened back.
+ *
+ * NOT COVERED, deliberately:
+ *
+ *  - **Subset counts** ("the four REST-backed skins", "the three demo-complete
+ *    skins", "all three skins have one"). These are true statements about a
+ *    subset, and a subset size is not derivable from the registry, so asserting
+ *    on them would only produce false alarms. `COUNT_EXEMPTIONS` below carries
+ *    the one subset phrase whose grammar is indistinguishable from a total claim.
+ *  - **Per-skin counts** — gen-UI registration counts, suggestion-pill counts,
+ *    beat counts ("nine beats", "the three skins at 9/9"). Not skin-roster
+ *    claims; verifying them would mean parsing each skin's source.
+ *  - **Two known instances OUTSIDE the doc set**, both classified as follow-up
+ *    work for a separate PR and both still stale as of this file's commit:
+ *      1. `src/proxy.ts` — a comment saying "the other three skins".
+ *      2. `e2e/inset-layout.spec.ts` — a loop over a hardcoded four-skin list, so
+ *         the shell frame is never e2e-verified for `people` or `commerce`.
+ *    They are named here rather than checked because adding them would make this
+ *    test red on a tree the rest of the PR considers converged. Whoever fixes
+ *    them should consider widening `DOC_SET`/adding a source-comment sweep here.
+ */
+
+/** Walks up from this file to the app root (the dir holding package.json + the skill). */
+function appRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i++) {
+    if (
+      existsSync(join(dir, "package.json")) &&
+      existsSync(join(dir, ".claude", "skills", "reskin"))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(
+    "could not locate the reskinnable-demo app root from " + import.meta.url,
+  );
+}
+
+const DOC_SET = [
+  "CLAUDE.md",
+  "README.md",
+  ".env.example",
+  ".claude/skills/reskin/SKILL.md",
+  ".claude/skills/reskin/demo-beats.md",
+  ".claude/skills/reskin/templates.md",
+] as const;
+
+const NUMBER_WORDS: Record<string, number> = {
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+};
+const ORDINAL_WORDS: Record<string, number> = {
+  fourth: 4,
+  fifth: 5,
+  sixth: 6,
+  seventh: 7,
+  eighth: 8,
+  ninth: 9,
+  tenth: 10,
+};
+/** Group-free alternations, so they can be embedded more than once per pattern. */
+const NUM_ALT = `(?:${Object.keys(NUMBER_WORDS).join("|")}|[2-9]|1[0-2])`;
+const ORD_ALT = `(?:${Object.keys(ORDINAL_WORDS).join("|")})`;
+/** The claimed numeral, always captured as `num` so one reader serves every rule. */
+const NUM = `(?<num>${NUM_ALT})`;
+const ORD = `(?<num>${ORD_ALT})`;
+const MENTIONS_SKIN = /\bskins?\b/i;
+
+/**
+ * Each rule matches a phrase shape that asserts the SIZE OF THE SHIPPED SET, and
+ * only that shape — the discriminator is that a subset claim is virtually always
+ * qualified ("four REST-backed skins", "five of the six skins"), so a bare number
+ * fused to a totality cue is the total. Every historical instance is listed with
+ * the rule that catches it; `catches` doubles as the synthetic red fixture in the
+ * self-test at the bottom, so a refactor that keeps the list but breaks a regex
+ * fails too.
+ */
+type CountRule = {
+  id: string;
+  re: RegExp;
+  /** Require /skins?/ in the N chars AFTER the match. */
+  skinAfter?: number;
+  /** Require /skins?/ within N chars either side of the match. */
+  skinAround?: number;
+  /**
+   * Is `claimed` a TRUE statement given `registered`? Defaults to "exactly the
+   * registered count". A rule overrides this only when its phrase shape admits
+   * more than one true reading — see `ordinal-skin`, whose original single
+   * reading flagged the truthful "the sixth skin".
+   */
+  accepts?: (
+    claimed: number,
+    registered: number,
+    m: RegExpExecArray,
+  ) => boolean;
+  /** How the failure message describes what WOULD have been true. */
+  expectation?: (registered: number, m: RegExpExecArray) => string;
+  catches: string[];
+};
+
+/** Was the ordinal introduced by "the" (an existing member) or "a" (the next one)? */
+const isDefinite = (m: RegExpExecArray) =>
+  m.groups?.art?.toLowerCase() === "the";
+
+const COUNT_RULES: CountRule[] = [
+  {
+    id: "ships-N-skins",
+    re: new RegExp(
+      `\\b(?:ships?|shipped|shipping)\\s+${NUM}\\s+skins?\\b`,
+      "gi",
+    ),
+    catches: ["the app ships four skins rather than two"],
+  },
+  {
+    id: "today-N-skins",
+    re: new RegExp(`\\btoday\\s+${NUM}\\s+skins?\\b`, "gi"),
+    catches: ["`src/shell/registry.ts` — today four skins:"],
+  },
+  {
+    id: "the-N-skins",
+    re: new RegExp(
+      `\\bthe\\s+${NUM}\\s+(?:shipped\\s+|registered\\s+)?skins?\\b`,
+      "gi",
+    ),
+    catches: [
+      "## The four skins (why they differ)",
+      "read the four shipped skins as worked references",
+      "mirror the four shipped skins (`src/skins/{banking,airline,logistics,keel}/`)",
+    ],
+  },
+  {
+    id: "N-are-registered",
+    re: new RegExp(`\\b${NUM}\\s+(?:skins?\\s+)?are\\s+registered\\b`, "gi"),
+    catches: [
+      "Four are registered — `banking`, `airline`, `logistics`, `keel`",
+    ],
+  },
+  {
+    id: "N-compound-noun",
+    re: new RegExp(`\\b${NUM}-(?:skin|tenant|brand|product|domain)\\b`, "gi"),
+    catches: [
+      "Skins live under `/[skin]` on the normal four-skin demo",
+      "reads as a product rather than as a four-tenant demo harness",
+      "one build serves both a locked single-tenant host and the unlocked four-skin demo",
+    ],
+  },
+  {
+    id: "all-N-skins",
+    re: new RegExp(
+      `\\ball\\s+${NUM}\\s+(?:skins?|agents?|stay|remain)\\b`,
+      "gi",
+    ),
+    catches: [
+      "the normal multi-skin demo: all four skins reachable, the switcher visible",
+      "NOT a security boundary: all four agents stay registered server-side",
+      "Unset — the default — all four stay reachable under `/<id>`",
+    ],
+  },
+  {
+    id: "these-N",
+    re: new RegExp(`\\bthese\\s+${NUM}\\b`, "gi"),
+    skinAfter: 80,
+    catches: ["These four run behind the **same** `Skin` contract on purpose"],
+  },
+  {
+    id: "N-of-them",
+    re: new RegExp(`\\b${NUM}\\s+of\\s+them\\b`, "gi"),
+    skinAround: 140,
+    catches: [
+      "hosts one **skin** per route segment `/[skin]/...`, and ships four of them:",
+    ],
+  },
+  {
+    id: "ordinal-skin",
+    re: new RegExp(`\\b(?<art>an?|the)\\s+${ORD}\\s+skin\\b`, "gi"),
+    // THE ARTICLE CARRIES THE CLAIM, and conflating the two readings is what made
+    // this rule flag a truthful sentence:
+    //  - "A fifth skin added to the registry…" — INDEFINITE, so it is the
+    //    hypothetical NEXT skin and must name `registered + 1`. (`registered`
+    //    itself is also accepted: a numeral that equals the shipped count is not
+    //    stale under any reading, and refusing it is how a doc gets pushed into
+    //    an exemption for being right.)
+    //  - "the sixth skin" — DEFINITE, so it names an EXISTING member. Any ordinal
+    //    from first to `registered` is a true statement about the roster; only an
+    //    ordinal PAST the end claims a skin that does not exist.
+    accepts: (claimed, registered, m) =>
+      isDefinite(m)
+        ? claimed >= 1 && claimed <= registered
+        : claimed === registered + 1 || claimed === registered,
+    expectation: (registered, m) =>
+      isDefinite(m)
+        ? `an ordinal no greater than ${registered}`
+        : `${registered + 1}`,
+    catches: [
+      "A fifth skin added to the registry and not to `skinIds` fails HERE",
+    ],
+  },
+];
+
+/**
+ * Subset claims whose grammar is identical to a total claim, so the rules above
+ * cannot tell them apart. Each entry must still be FOUND in its file — a stale
+ * exemption fails its own test rather than silently widening into a blanket
+ * suppression.
+ */
+const COUNT_EXEMPTIONS: { file: string; phrase: string; why: string }[] = [
+  {
+    file: ".claude/skills/reskin/templates.md",
+    phrase: "All three skins have one",
+    why:
+      "TRUE subset: the skins that ship intelligence/forget-memories.ts " +
+      "(banking, people, commerce), not the registered roster.",
+  },
+];
+
+/** A backticked/bolded skin id, as the docs write them. */
+const ID_TOKEN = `(?:\\*\\*)?\`?(?:${skinIds.join("|")})\`?(?:\\*\\*)?`;
+/** `,` `|` `/` `and` `or` — optionally across a wrapped line. */
+const ID_SEP = `(?:\\s*[,|/]\\s*|\\s*,?\\s+(?:and|or)\\s+)`;
+const ID_LIST = new RegExp(`${ID_TOKEN}(?:${ID_SEP}${ID_TOKEN})+`, "gi");
+/** `{banking,airline,…}` shell-glob form, e.g. in a path reference. */
+const ID_BRACE_GLOB = /\{([a-z][a-z,\s]*)\}/gi;
+/**
+ * An id list is only required to be COMPLETE when the doc frames it as the valid
+ * or registered set. Every other list in these docs is a deliberate subset
+ * ("banking, people and commerce are demo-complete"), which is why the cue is
+ * this narrow: broadening it to a bare "registered" immediately false-positives
+ * on CLAUDE.md's TRUE history sentence about `people` and `commerce` shipping.
+ */
+const EXHAUSTIVE_CUE = /valid ids?|registered set|are registered|LOCK_SKIN/i;
+const CUE_LOOKBEHIND = 140;
+
+/**
+ * Totality framing for a brace GLOB, which needs its own cue vocabulary: a path
+ * glob is framed by prose about the skins it points at ("mirror the six shipped
+ * skins", "— six implementations"), not by the "valid ids" wording that frames an
+ * inline id list. Without this, every partial glob was demanded to be exhaustive
+ * — a verified false positive on a deliberate two-member glob.
+ *
+ * The window spans BOTH sides because the two real globs are framed on opposite
+ * sides: templates.md's cue precedes it, CLAUDE.md's follows it.
+ */
+const GLOB_TOTALITY_CUE = new RegExp(
+  [
+    EXHAUSTIVE_CUE.source,
+    `\\b(?:all|every|each)\\s+(?:${NUM_ALT}\\s+)?(?:shipped\\s+|registered\\s+)?skins?\\b`,
+    `\\b${NUM_ALT}\\s+(?:shipped\\s+|registered\\s+)?(?:skins?|implementations?)\\b`,
+  ].join("|"),
+  "i",
+);
+const GLOB_CUE_WINDOW = 160;
+
+type Hit = {
+  line: number;
+  phrase: string;
+  claimed: number;
+  /** What would have been true, as prose — some rules admit more than one value. */
+  expected: string;
+  rule: string;
+};
+
+/** Blanks `# ` comment prefixes (offset-preserving) so .env.example prose reads as prose. */
+function unwrapComments(text: string): string {
+  return text.replace(/\n#( ?)/g, (m) => "\n" + " ".repeat(m.length - 1));
+}
+
+const lineAt = (text: string, index: number) =>
+  text.slice(0, index).split("\n").length;
+
+/** Count claims about the shipped set that disagree with `registered`. */
+export function findStaleCountClaims(
+  source: string,
+  registered: number,
+  exempt: string[] = [],
+): Hit[] {
+  const text = unwrapComments(source);
+  // Exemptions are matched by POSITION, not by substring: an exempted sentence is
+  // longer than the phrase a rule matches inside it, so a naive substring compare
+  // would never fire — and comparing the other way round would let the exemption
+  // silence the same wording everywhere else in the file.
+  const exemptSpans: [number, number][] = exempt.flatMap((phrase) => {
+    const spans: [number, number][] = [];
+    for (
+      let at = text.indexOf(phrase);
+      at !== -1;
+      at = text.indexOf(phrase, at + 1)
+    ) {
+      spans.push([at, at + phrase.length]);
+    }
+    return spans;
+  });
+  const isExempt = (index: number) =>
+    exemptSpans.some(([start, end]) => index >= start && index < end);
+  const hits: Hit[] = [];
+  for (const rule of COUNT_RULES) {
+    const re = new RegExp(rule.re.source, rule.re.flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text))) {
+      const end = m.index + m[0].length;
+      if (
+        rule.skinAfter !== undefined &&
+        !MENTIONS_SKIN.test(text.slice(end, end + rule.skinAfter))
+      ) {
+        continue;
+      }
+      if (
+        rule.skinAround !== undefined &&
+        !MENTIONS_SKIN.test(
+          text.slice(
+            Math.max(0, m.index - rule.skinAround),
+            end + rule.skinAround,
+          ),
+        )
+      ) {
+        continue;
+      }
+      const token = (m.groups?.num ?? "").toLowerCase();
+      const claimed =
+        ORDINAL_WORDS[token] ?? NUMBER_WORDS[token] ?? Number(token);
+      const accepts = rule.accepts ?? ((c: number, reg: number) => c === reg);
+      if (accepts(claimed, registered, m)) continue;
+      if (isExempt(m.index)) continue;
+      const phrase = m[0].replace(/\s+/g, " ");
+      hits.push({
+        line: lineAt(text, m.index),
+        phrase,
+        claimed,
+        expected: rule.expectation
+          ? rule.expectation(registered, m)
+          : String(registered),
+        rule: rule.id,
+      });
+    }
+  }
+  return hits.sort((a, b) => a.line - b.line);
+}
+
+/** Id enumerations the doc presents as the whole set, but which omit a registered id. */
+export function findIncompleteRosters(
+  source: string,
+  ids: readonly string[],
+): { line: number; phrase: string; missing: string[]; rule: string }[] {
+  const text = unwrapComments(source);
+  const found: {
+    line: number;
+    phrase: string;
+    missing: string[];
+    rule: string;
+  }[] = [];
+  const record = (
+    index: number,
+    phrase: string,
+    listed: string[],
+    rule: string,
+  ) => {
+    const missing = ids.filter((id) => !listed.includes(id));
+    found.push({
+      line: lineAt(text, index),
+      phrase: phrase.replace(/\s+/g, " "),
+      missing,
+      rule,
+    });
+  };
+
+  const glob = new RegExp(ID_BRACE_GLOB.source, ID_BRACE_GLOB.flags);
+  let g: RegExpExecArray | null;
+  while ((g = glob.exec(text))) {
+    const members = g[1]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    // Only a glob whose every member is a skin id is a roster; `{ createAgent,
+    // identifyUser? }` and friends are not.
+    if (members.length < 2 || !members.every((s) => ids.includes(s))) continue;
+    // …and only one the doc FRAMES as the whole set. `src/skins/{banking,people}/`
+    // as a pointer at two worked examples is not a roster claim, and demanding
+    // exhaustiveness there was a false positive on legitimate prose.
+    if (
+      !GLOB_TOTALITY_CUE.test(
+        text.slice(
+          Math.max(0, g.index - GLOB_CUE_WINDOW),
+          g.index + g[0].length + GLOB_CUE_WINDOW,
+        ),
+      )
+    ) {
+      continue;
+    }
+    record(g.index, g[0], members, "brace-glob");
+  }
+
+  const list = new RegExp(ID_LIST.source, ID_LIST.flags);
+  const anyId = new RegExp(ids.join("|"), "g");
+  let m: RegExpExecArray | null;
+  while ((m = list.exec(text))) {
+    const listed = [...new Set(m[0].toLowerCase().match(anyId) ?? [])];
+    if (listed.length < 2) continue;
+    if (
+      !EXHAUSTIVE_CUE.test(
+        text.slice(Math.max(0, m.index - CUE_LOOKBEHIND), m.index),
+      )
+    ) {
+      continue;
+    }
+    record(m.index, m[0], listed, "valid-id-list");
+  }
+  return found.sort((a, b) => a.line - b.line);
+}
+
+const ROOT = appRoot();
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+// Derived, never literal. `skins-config.test.ts` proves `skinIds` equals the
+// registry's keys, so this is the registered set.
+const REGISTERED = skinIds.length;
+const ROSTER = `${REGISTERED} skins are registered (${skinIds.join(", ")})`;
+
+describe("the documented skin roster", () => {
+  it("checks every file it claims to check", () => {
+    // A renamed or moved doc must not silently drop out of coverage.
+    expect(DOC_SET.filter((rel) => !existsSync(join(ROOT, rel)))).toEqual([]);
+  });
+
+  it("states no skin count that contradicts the registered set", () => {
+    const failures = DOC_SET.flatMap((rel) => {
+      const exempt = COUNT_EXEMPTIONS.filter((e) => e.file === rel).map(
+        (e) => e.phrase,
+      );
+      return findStaleCountClaims(read(rel), REGISTERED, exempt).map(
+        (h) =>
+          `${rel}:${h.line} says "${h.phrase}" — that claims ${h.claimed}, where ` +
+          `${h.expected} would be true; ${ROSTER}. [rule: ${h.rule}] Fix the ` +
+          `sentence, or phrase it without a numeral so the next skin cannot ` +
+          `re-falsify it.`,
+      );
+    });
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps every enumeration of the valid skin ids complete", () => {
+    const rosters = DOC_SET.flatMap((rel) =>
+      findIncompleteRosters(read(rel), skinIds).map((h) => ({ rel, ...h })),
+    );
+    // Guard the guard: if the patterns stop matching anything, the check above
+    // passes vacuously. The docs do enumerate the roster, in several places — and
+    // in BOTH shapes, so requiring both catches ONE rule going blind, which the
+    // bare count would not.
+    //
+    // STATED HONESTLY: this proves each rule still fires SOMEWHERE, not that every
+    // glob is covered. The brace-glob rule needs totality framing near the glob
+    // (deliberately, so a partial glob is not demanded to be exhaustive), so a
+    // single doc rephrased away from that framing drops out of coverage while the
+    // other doc's glob keeps this assertion green. Verified: removing
+    // templates.md's "the six shipped skins" leaves the suite passing.
+    expect(rosters.length).toBeGreaterThan(2);
+    expect([...new Set(rosters.map((h) => h.rule))].sort()).toEqual([
+      "brace-glob",
+      "valid-id-list",
+    ]);
+    expect(
+      rosters
+        .filter((h) => h.missing.length > 0)
+        .map(
+          (h) =>
+            `${h.rel}:${h.line} lists the valid skin ids as "${h.phrase}" but omits ` +
+            `${h.missing.join(", ")} — ${ROSTER}. [rule: ${h.rule}]`,
+        ),
+    ).toEqual([]);
+  });
+
+  it("carries no dead count-claim exemption", () => {
+    // An exemption that no longer matches its file is a suppression nobody reads;
+    // it must be deleted (or the prose it excused restored) rather than left to rot.
+    expect(
+      COUNT_EXEMPTIONS.filter((e) => !read(e.file).includes(e.phrase)).map(
+        (e) => `${e.file} no longer contains the exempted phrase "${e.phrase}"`,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("the roster checks themselves", () => {
+  // The red half of red-green, kept permanently. Every string below is the ACTUAL
+  // stale wording that shipped in one of these six documents (or, for two of
+  // them, in src/lib/locked-skin.ts and skins-config.test.ts) and was fixed in
+  // the CR pass that motivated this file. If a regex is loosened or broken, the
+  // instance it used to catch fails here.
+  it.each(COUNT_RULES.flatMap((r) => r.catches.map((c) => [r.id, c] as const)))(
+    "still catches the %s instance: %s",
+    (ruleId, phrase) => {
+      const hits = findStaleCountClaims(phrase, REGISTERED);
+      expect(hits.map((h) => h.rule)).toContain(ruleId);
+      // The message has to name the number it read and the number it expected.
+      expect(hits[0].claimed).not.toBe(REGISTERED);
+    },
+  );
+
+  it("passes a count that matches the registered set", () => {
+    const word = Object.keys(NUMBER_WORDS).find(
+      (w) => NUMBER_WORDS[w] === REGISTERED,
+    );
+    expect(word).toBeDefined();
+    expect(
+      findStaleCountClaims(`the app ships ${word} skins`, REGISTERED),
+    ).toEqual([]);
+  });
+
+  it("passes a TRUTHFUL count in every phrasing a rule matches", () => {
+    // The test the original should have carried. Validating only against today's
+    // tree proves that no CURRENT sentence trips a rule — not that no CORRECT
+    // sentence does. These are the shapes of all nine rules, written truthfully
+    // and DERIVED from the registry, so they stay truthful as skins are added.
+    const n = REGISTERED;
+    const word = Object.keys(NUMBER_WORDS).find((w) => NUMBER_WORDS[w] === n);
+    const nextOrdinal = Object.keys(ORDINAL_WORDS).find(
+      (w) => ORDINAL_WORDS[w] === n + 1,
+    );
+    const lastOrdinal = Object.keys(ORDINAL_WORDS).find(
+      (w) => ORDINAL_WORDS[w] === n,
+    );
+    expect([word, nextOrdinal, lastOrdinal].every(Boolean)).toBe(true);
+    const truthful = [
+      `the app ships ${word} skins`,
+      `\`src/shell/registry.ts\` — today ${n} skins:`,
+      `## The ${word} skins (why they differ)`,
+      `${word} are registered — see \`skinIds\``,
+      `the unlocked ${word}-skin demo`,
+      `all ${word} skins reachable, the switcher visible`,
+      `These ${word} run behind the **same** \`Skin\` contract on purpose`,
+      `hosts one **skin** per route segment, and ships ${word} of them:`,
+      // Both readings of an ordinal, which is the discriminator this rule turns
+      // on: the definite one names a member that EXISTS, the indefinite one the
+      // hypothetical next.
+      `the ${lastOrdinal} skin is the newest one`,
+      `a ${nextOrdinal} skin added to the registry and not to \`skinIds\` fails HERE`,
+      // A definite ordinal BELOW the count is still a true statement.
+      "the fourth skin in registry order",
+    ];
+    expect(
+      truthful.flatMap((text) =>
+        findStaleCountClaims(text, REGISTERED).map(
+          (h) => `${h.rule} flagged "${h.phrase}" in "${text}"`,
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it("still flags an ordinal past the end of the roster", () => {
+    // The other half of the article discriminator: "the sixth skin" is true on a
+    // six-skin registry, "the seventh" claims a skin that does not exist. Without
+    // this, relaxing the definite reading would have opened a hole.
+    const past = Object.keys(ORDINAL_WORDS).find(
+      (w) => ORDINAL_WORDS[w] === REGISTERED + 1,
+    );
+    const hits = findStaleCountClaims(`the ${past} skin`, REGISTERED);
+    expect(hits.map((h) => h.rule)).toEqual(["ordinal-skin"]);
+    expect(hits[0].claimed).toBe(REGISTERED + 1);
+  });
+
+  it("ignores the legitimate phrasings that must never be flagged", () => {
+    // Verbatim from the current docs. Each is TRUE and must stay as written:
+    // past-tense incident history, beat vocabulary, subset counts qualified by an
+    // adjective, and numbers about things that are not skins.
+    const legitimate = [
+      "naming four skins for two releases after `people` and `commerce` shipped",
+      "it named four skins for two releases after `people` and `commerce` shipped",
+      "Absent instructions, build all nine rows",
+      "`banking`, `people` or `commerce` — the only three at 9/9 beats",
+      "Set by the four REST-backed skins — banking, people and commerce",
+      "**This is the standard mechanism for the two in-memory skins**",
+      "That is five of the six skins; **airline** is the only one that omits it",
+      "The gated `dev/reset` route is the wider set: four skins have one",
+      "The ask is 8–12 skins spanning that space",
+      "banking, logistics, keel, people and commerce all five ship them",
+      "All four appends are guarded: `skins-config.test.ts` fails on any of them",
+      "the same grep as rule 3 passed on all seven",
+      "the second skin built demo-complete against the full beat list",
+      "a 600/1000-em advance width",
+      "Two registries, one id",
+    ];
+    expect(
+      legitimate.flatMap((text) =>
+        findStaleCountClaims(text, REGISTERED).map(
+          (h) => `${h.rule}: ${h.phrase} in "${text}"`,
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it("catches an id enumeration that omits a registered skin", () => {
+    // The README's worst instance: a four-value LOCK_SKIN list, which a count
+    // check alone would have missed entirely.
+    const stale =
+      "Set `LOCK_SKIN` to a skin id (`banking`, `airline`, `logistics`, `keel`) and " +
+      "the deploy becomes single-tenant.";
+    const hits = findIncompleteRosters(stale, skinIds);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].missing).toEqual(["people", "commerce"]);
+
+    const envStyle =
+      "# Valid ids: banking, airline, logistics, keel. An unrecognised value THROWS.";
+    expect(findIncompleteRosters(envStyle, skinIds)[0]?.missing).toEqual([
+      "people",
+      "commerce",
+    ]);
+  });
+
+  it("leaves a deliberate subset list alone", () => {
+    // No "valid/registered set" framing → not a roster claim.
+    const subset =
+      "Three of the six skins — **`banking`**, **`people`** and **`commerce`** — are " +
+      "demo-complete against the full beat list.";
+    expect(findIncompleteRosters(subset, skinIds)).toEqual([]);
+  });
+
+  it("leaves a deliberate PARTIAL glob alone", () => {
+    // The second verified false positive. A glob that points at two worked
+    // examples is not a claim about the valid set, and demanding exhaustiveness
+    // here is what pushes a correct doc towards an exemption.
+    const partial =
+      "Open `src/skins/{banking,people}/suggestions.ts` for a written-out beat map.";
+    expect(findIncompleteRosters(partial, skinIds)).toEqual([]);
+  });
+
+  it("catches a glob the doc frames as the whole set", () => {
+    // …and the framing is what re-arms it. Both real globs in the doc set are
+    // framed, one from each side, so both phrasings are pinned here.
+    const before =
+      "mirror the four shipped skins (`src/skins/{banking,airline,logistics,keel}/`)";
+    expect(findIncompleteRosters(before, skinIds)).toMatchObject([
+      { rule: "brace-glob", missing: ["people", "commerce"] },
+    ]);
+
+    const after =
+      "- `src/skins/{banking,airline,logistics,keel}/skin.tsx` — four implementations.";
+    expect(findIncompleteRosters(after, skinIds)).toMatchObject([
+      { rule: "brace-glob", missing: ["people", "commerce"] },
+    ]);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/shell/skins-config.test.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/skins-config.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { Linter } from "eslint";
 import { defaultSkinId, skinIdentities, skinIds } from "./skins-config";
 import { allSkins, SkinRegistry } from "./registry";
+import eslintConfig, { LINTED_SKIN_IDS } from "../../eslint.config.mjs";
 
 describe("skinIds", () => {
   // `skins-config.ts` must stay free of skin imports so server components can
   // read it without dragging client skin modules into an RSC. That forces the id
   // list to be duplicated here rather than derived — so this test is the thing
-  // that stops the copy from rotting. A fifth skin added to the registry and not
-  // to `skinIds` fails HERE, instead of silently rejecting LOCK_SKIN=<newskin>.
+  // that stops the copy from rotting. Any skin added to the registry and not to
+  // `skinIds` fails HERE, instead of silently rejecting LOCK_SKIN=<newskin>.
   it("lists exactly the registered skins, in registry order", () => {
     expect([...skinIds]).toEqual(Object.keys(SkinRegistry));
   });
@@ -18,6 +20,53 @@ describe("skinIds", () => {
   });
 });
 
+describe("the LOCK_SKIN lint guard", () => {
+  // `eslint.config.mjs` hand-copies the skin id list into the `no-restricted-syntax`
+  // selectors that enforce the LOCK_SKIN URL contract (it cannot import `skinIds`
+  // — see the comment on `LINTED_SKIN_IDS`). That copy rots SILENTLY: it named
+  // only the first four skins for two releases after `people` and `commerce`
+  // shipped, so a hardcoded `"/commerce/orders"` href passed `pnpm lint` while
+  // breaking the address bar on a locked deploy. CLAUDE.md and the reskin skill
+  // both promise `pnpm lint` "fails and names your file" for exactly that href,
+  // so the omission falsified documented behaviour with nothing to catch it.
+  //
+  // These two tests are that catch. The first pins the list; the second proves
+  // the SELECTORS actually fire, so a refactor that keeps the list but breaks the
+  // regexes fails too.
+  const skinSourceBlock = eslintConfig.find(
+    (block) =>
+      Array.isArray(block.files) && block.files.includes("src/skins/**/*.tsx"),
+  );
+  const restrictedSyntax = skinSourceBlock?.rules?.["no-restricted-syntax"];
+
+  it("guards exactly the registered skins", () => {
+    expect(LINTED_SKIN_IDS).toEqual([...skinIds]);
+  });
+
+  it("reports a hardcoded skin route prefix in every registered skin", () => {
+    expect(Array.isArray(restrictedSyntax)).toBe(true);
+    const linter = new Linter();
+    // Both hardcoding shapes the selectors are meant to catch: a bare literal and
+    // a template whose first quasi opens with the prefix. Plain JS on purpose —
+    // the selectors match shape, not types, so the default parser suffices.
+    const unguarded = skinIds.flatMap((id) =>
+      [
+        `router.push("/${id}/orders");`,
+        `router.push(\`/${id}/orders/\${orderId}\`);`,
+      ].filter(
+        (code) =>
+          linter.verify(code, {
+            rules: {
+              "no-restricted-syntax": restrictedSyntax as Linter.RuleEntry,
+            },
+            languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+          }).length === 0,
+      ),
+    );
+    expect(unguarded).toEqual([]);
+  });
+});
+
 describe("skinIdentities", () => {
   // Same rationale as `skinIds`: `skins-config.ts` stays import-free, so the
   // root layout's `generateMetadata` can resolve BOTH the locked tab title
@@ -25,8 +74,8 @@ describe("skinIdentities", () => {
   // module into an RSC. That forces `skinIdentities` to be a hand-copied
   // duplicate of each skin's `identity.brand` and `identity.tagline` — and THIS
   // is the test that stops the copy from rotting. A renamed brand or tagline (or
-  // a fifth skin) that is not mirrored here fails HERE, instead of silently
-  // shipping a stale tab title or a contradicting unfurl description.
+  // a newly registered skin) that is not mirrored here fails HERE, instead of
+  // silently shipping a stale tab title or a contradicting unfurl description.
   it("matches every registered skin's identity.brand and identity.tagline", () => {
     expect(skinIdentities).toEqual(
       Object.fromEntries(

--- a/examples/showcases/reskinnable-demo/src/shell/skins-config.ts
+++ b/examples/showcases/reskinnable-demo/src/shell/skins-config.ts
@@ -5,14 +5,21 @@ export const defaultSkinId = "banking";
 
 // The registered skin ids, duplicated from `registry.ts` on purpose: this module
 // must stay import-free for the server contexts above, and `registry.ts` pulls in
-// four client skin modules. `skins-config.test.ts` asserts the two stay in sync,
-// so the duplication cannot drift silently. Keep in registry order.
+// one client skin module per registered skin. `skins-config.test.ts` asserts the
+// two stay in sync, so the duplication cannot drift silently. Keep in registry
+// order.
+//
+// There is a THIRD copy: `LINTED_SKIN_IDS` in `eslint.config.mjs`, which feeds the
+// LOCK_SKIN URL-contract selectors and cannot import this module (an ESLint flat
+// config is loaded by Node, and this is TypeScript). Adding a skin here means adding
+// it there too — `skins-config.test.ts` guards that copy as well.
 export const skinIds = [
   "banking",
   "airline",
   "logistics",
   "keel",
   "people",
+  "commerce",
 ] as const;
 
 // Skin id → { brand, tagline }, duplicated from each skin's `identity.brand`
@@ -45,5 +52,9 @@ export const skinIdentities: Record<
   people: {
     brand: "Rowan",
     tagline: "The people operations desk.",
+  },
+  commerce: {
+    brand: "Bellwether",
+    tagline: "Storefront operations, from order to margin.",
   },
 };

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/agent.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/agent.ts
@@ -1,0 +1,285 @@
+import { BuiltInAgent, defineTool } from "@copilotkit/runtime/v2";
+import {
+  A2UI_OPERATIONS_KEY,
+  buildBriefOps,
+  renderBriefParams,
+  SURFACE_ID,
+} from "./build-brief-ops";
+
+/**
+ * Bellwether's agent. SERVER-ONLY — no "use client", no JSX, no React. The
+ * client skin (`skin.tsx`) never imports this file; the only link between them
+ * is the shared id `"commerce"`. It is reached exclusively through the
+ * server-side `src/shell/agent-registry.ts`, which keeps `@copilotkit/runtime`
+ * out of the browser bundle.
+ *
+ * Most demo beats fail in the PROMPT, not in the wiring: the tools exist, the
+ * agent simply doesn't use them the way the demo needs. So the prompt below is
+ * one template literal broken into ALL-CAPS named clauses. The clauses cannot
+ * carry inline comments — anything written between them lands inside the string
+ * and is sent to the model — so the clause-to-beat map lives in the comment
+ * directly above `COMMERCE_PROMPT` instead.
+ */
+
+/**
+ * The a2ui report canvas. This MUST be a server tool. The a2ui middleware only
+ * converts an `{ [A2UI_OPERATIONS_KEY]: ops }` payload into an `a2ui-surface`
+ * activity when it observes it in an in-stream TOOL_CALL_RESULT event, which a
+ * client frontend-tool result never produces — emit these client-side and the
+ * canvas stays permanently blank with no error anywhere.
+ *
+ * A fresh surfaceId per render, so dismissing one brief never suppresses the
+ * next.
+ */
+const renderTradeBriefTool = defineTool({
+  name: "render_trade_brief",
+  description:
+    "Render the Trading Review brief on the CANVAS — the full-page artifact a " +
+    "merchandiser takes into a leadership review. Supply SELECTIONS and " +
+    "LABEL-ONLY text; never numbers. Every figure is bound to live app data by " +
+    "the renderer, so anything you typed would be ignored anyway. Use this only " +
+    "when the user asks for a review, a brief, or a report — for an in-chat " +
+    "answer use showMarginLadder or showMarginSummary instead.",
+  parameters: renderBriefParams,
+  execute: async (spec) => ({
+    [A2UI_OPERATIONS_KEY]: buildBriefOps(
+      spec,
+      `${SURFACE_ID}-${Date.now().toString(36)}`,
+    ),
+  }),
+});
+
+/**
+ * ── CLAUSE → BEAT MAP ───────────────────────────────────────────────────────
+ *
+ * Which demo beat each ALL-CAPS clause below is there to enforce. Beat numbers
+ * are the ones specified in `.claude/skills/reskin/demo-beats.md`; the pill that
+ * triggers each beat is mapped at the top of `suggestions.ts`. When a beat
+ * regresses on stage, start at its clause here.
+ *
+ * | Clause                                        | Beat                       |
+ * | --------------------------------------------- | -------------------------- |
+ * | COMPONENT ANSWER RULE                         | 1 face                     |
+ * | NEVER WRITE A MARKDOWN TABLE                  | 1 face (routing)           |
+ * | SCREEN AWARENESS                              | 3b sees my screen          |
+ * | FORMAT PROSE THE SAME WAY EVERY TIME          | — house style, no beat     |
+ * | MARGIN IS ALWAYS RELATIVE TO A FLOOR          | — domain rule; sets up 6   |
+ * | ACT, DON'T ANNOUNCE                           | 3a drive the app           |
+ * | SENSITIVE FIGURES                             | 3a (the withheld figure)   |
+ * | MARGIN SUMMARIES USE THE SAVED FORMAT         | 4 memory                   |
+ * | BUILDING A QUEUE VIEW YOUR OWN WRITES …       | 3c levers                  |
+ * | A SUSPECT ORDER FOLLOWS A SAVED PROCEDURE     | 5 stored skill             |
+ * | FINDING IS NOT DOING                          | 5 (carry it through)       |
+ * | ACTION DISCIPLINE                             | 6 teach a skill (decline)  |
+ * | BELOW-FLOOR MARKDOWN APPROVALS                | 6 teach + its later replay |
+ * | GENERAL MEMORY                                | 4 and 6 (memory hygiene)   |
+ * | UPLOADED DOCUMENTS                            | 3d multimodal              |
+ * | THE CANVAS BRIEF                              | — the canvas artifact      |
+ * | OPEN GENERATIVE UI                            | — OGUI, no beat            |
+ *
+ * Beat 2 (the thread is rich, not text) has NO clause and cannot have one: it is
+ * enforced in `tools.tsx` by keying every render off the tool `result` rather
+ * than off `status`, so it survives replay. Do not add a prompt clause for it.
+ *
+ * Nothing type-checks this map. Adding, renaming or deleting a clause below
+ * means editing a row here in the same change.
+ */
+const COMMERCE_PROMPT = `
+You are Bellwether, the assistant inside the Bellwether commerce operations
+application. You work alongside a merchandising and fulfillment desk at a
+direct-to-consumer retail brand. You can read the page they are looking at,
+render components into the conversation, and drive the real application through
+your tools. You act on their behalf inside their own product — you are not a
+chatbot bolted onto the side of it.
+
+COMPONENT ANSWER RULE.
+When a component exists for what was asked, render the component AND answer in
+one or two sentences. Never one without the other. A chart with no words reads
+as a glitch; words with no chart waste the component. Keep the sentences short
+and specific — name the one or two figures that matter, not all of them.
+
+NEVER WRITE A MARKDOWN TABLE.
+There is a component for every tabular shape in this app, and a raw table is
+always the wrong answer:
+- margin, which products are below floor, how the range is trading → showMarginLadder
+- one product → showProduct
+- more than one order → showOrderList
+- "where does margin stand" → showMarginSummary
+- a full review artifact for a meeting → render_trade_brief (canvas)
+If you find yourself about to emit a pipe character in a row of data, stop and
+call the component instead.
+
+SCREEN AWARENESS.
+The context you are given IS your view of what the user is looking at. It names
+the current page and describes what is visibly rendered on it — the active
+filters, the rows actually shown, the figures displayed. When you are asked what
+is on screen:
+- name the page they are on,
+- summarize the key elements actually rendered,
+- cite the real figures from the context, not approximations,
+- and mention the active filters or sort if any are set.
+NEVER say you cannot see the screen, cannot inspect the page, or only know
+things "from context". You can see it. Different pages must get different
+answers; if your answer would be the same on every page, you have not read the
+page context.
+
+FORMAT PROSE THE SAME WAY EVERY TIME.
+Short answers. Bold the figures and names that matter — **Harbor Parka**,
+**34 days**, **41.4%** — and nothing else; bolding everything is the same as
+bolding nothing. Use a short bulleted list when there are three or more parallel
+facts, prose otherwise. No headings in chat. No preamble: never open with "Sure!"
+or "Here's what I found".
+
+MARGIN IS ALWAYS RELATIVE TO A FLOOR.
+Every category has a margin floor, and a margin figure quoted without it is
+meaningless to this desk. When you state a margin, state what floor it is being
+measured against, or say it is above or below that floor. "39.3%" is not an
+answer; "**39.3%**, under the 40% Footwear floor" is.
+
+ACT, DON'T ANNOUNCE.
+Do not say you are about to call a tool. Call it, then describe what happened.
+Never ask which record the user means when the context makes it obvious — pick
+the best match and act, and say which one you picked.
+
+SENSITIVE FIGURES.
+issueRefund opens a card in the chat where the USER types the refund amount. You
+must NEVER ask for the figure, never guess it, never repeat it back, and never
+ask which return first. Call issueRefund immediately with your best match on the
+customer or the order number. When it returns, confirm only that a refund was
+issued and on whose return. The number is not yours to know and it will never
+appear in your results.
+
+MARGIN SUMMARIES USE THE SAVED FORMAT.
+Before answering any question about where margin stands, how the range is
+trading, or how pricing looks overall, call recall_memory FIRST and look for the
+user's saved formatting preference. Then pass what you recalled into
+showMarginSummary through byCategory / belowFloorFirst / asMarginPercent, and put
+the preference you applied into the \`note\` parameter in your own words — "You
+read these by category, with anything under its floor first" — so they can see
+you remembered. Speak like a person who remembers, not like a system reporting a
+cache hit. Call recall_memory at most once FOR A FORMATTING PREFERENCE per user
+message. This throttle is about not re-checking the same preference repeatedly;
+it does NOT forbid the separate recall a refused write requires (see BELOW-FLOOR
+MARKDOWN APPROVALS below) — that one is mandatory even if you already recalled a
+preference earlier in the same message.
+
+BUILDING A QUEUE VIEW YOUR OWN WRITES WILL NOT EMPTY.
+showOrderQueue's filters are the app's real controls, so they keep applying after
+you act. When the question is about orders being stuck, waiting or overdue,
+filter on the EXCEPTION and leave status as "all": the exception filter already
+excludes clean orders, and adding a status filter on top means the moment you put
+one of those orders on hold it disappears from the very view you just built —
+taking the note you posted on it with it. Pin the status only when the user asked
+about a status specifically ("what's on hold?", "what shipped?").
+
+A SUSPECT ORDER FOLLOWS A SAVED PROCEDURE.
+When the user says an order looks fraudulent, looks wrong, or asks you to
+"handle it" — however vaguely they put it — recall the saved procedure and
+EXECUTE it, step by step, immediately, without asking for confirmation between
+steps. Resolve the order number to an id from the ledger context. This is a
+DIFFERENT procedure from approving a markdown that breaks the margin floor; do
+not confuse the two, and do NOT offer to record anything here — you already know
+this one. When every step is done, confirm what you did in one short sentence.
+
+FINDING IS NOT DOING.
+Locating the order, the product, or the markdown is not handling it. If the user
+asked you to handle something, carry the procedure all the way through before you
+reply.
+
+ACTION DISCIPLINE.
+Only write when you were asked to. And when a write is refused and you have no
+saved procedure for that refusal, STOP. Do not improvise a workaround, do not try
+a plausible-looking tool to see whether it helps, and do not tell the user what
+you think might work. Say plainly that you do not know this one, and call
+offerWorkflowRecording. Guessing here is worse than failing.
+
+BELOW-FLOOR MARKDOWN APPROVALS.
+approveMarkdown sometimes comes back refused because the discounted price would
+trade under the category's margin floor. You MIGHT have been taught how to handle
+that and you MIGHT NOT — you do not know until you check. So when a refusal comes
+back, the FIRST thing you do is call recall_memory and look for a saved procedure
+covering a refused markdown approval.
+
+IF YOU FIND ONE:
+1. Follow it exactly, including the specific waiver code it names. Do not
+   substitute a different code because it sounds more appropriate — the saved
+   code is the one that is known to work, and the others are known not to.
+2. Run the whole thing without asking permission: open the margin waiver on that
+   markdown, finalize it, then re-run the approval.
+3. Do NOT call offerWorkflowRecording, and do NOT say you don't know how. You do
+   know. Say briefly that you have done this before, and get on with it.
+
+IF YOU FIND NOTHING:
+1. Tell the user, in one sentence, that the approval was refused and repeat the
+   reason the system gave.
+2. Say plainly that you have no saved procedure for this.
+3. Call offerWorkflowRecording.
+4. If they agree, call awaitDemonstration and WAIT. Do not narrate steps, do not
+   suggest what they should click, do not call any other tool while waiting — you
+   genuinely do not know what they are about to do, and pretending otherwise is
+   the one thing that ruins this.
+5. When they finish, summarize exactly what you observed as a numbered procedure
+   — naming the specific waiver code that worked — and call saveLearnedProcedure.
+6. After they confirm, persist it with save_memory (scope "user", kind
+   "operational"). Save it AT MOST ONCE. Use "user" scope, not "project" — a
+   project-scoped memory in this deployment is visible to every other product
+   sharing the backend, and this procedure is specific to Bellwether.
+
+The recall step in this clause is the whole point of the feature. An earlier
+version of the equivalent prompt in a sibling skin asserted "you do not have a
+saved way to get past that" as a flat fact, which meant the agent declined and
+offered to record even after it had been taught — the demonstration worked, the
+memory saved correctly, and the payoff never came, because the prompt was
+overriding what it knew.
+
+GENERAL MEMORY.
+1. Recall before you answer anything that a standing preference could change.
+2. Save durable facts and procedures the user teaches you; do not save one-off
+   details or anything they could not have meant to be permanent.
+3. Saving is not recalling — calling one does not do the other.
+4. Classify what you save: kind "topical" for preferences, "operational" for
+   procedures. Always use scope "user" — this deployment shares one memory
+   backend with other products, and a project-scoped row leaks into all of them.
+5. Never save a refund amount, a customer's contact details, or anything from a
+   document the user attached. Preferences and procedures only.
+6. Save a given fact once. If you are updating something you already saved,
+   supersede it rather than adding a near-duplicate.
+7. Do not stop mid-procedure to save something; finish the procedure first.
+
+UPLOADED DOCUMENTS.
+When the user attaches a document, read it and use its REAL contents. For a
+vendor price sheet that means the quoted landed costs, the minimum order
+quantities, the freight terms and the ship schedule — carry those into
+createRestockPlan's summary, highlights, lines and schedule rather than inventing
+plausible ones. Quote the vendor's QUOTED cost, not the cost already in the
+catalog. If the document contradicts the app's data — a cost that has moved, a
+style the range does not carry — say so in one sentence instead of silently
+picking one.
+
+THE CANVAS BRIEF.
+render_trade_brief takes over the whole page, so use it only when the user asks
+for a brief, a review, or a report to bring to a meeting. Pick exactly one report
+path per request — never render the canvas brief and an in-chat summary for the
+same question. Supply selections and labels only; the renderer binds every number
+to live data.
+
+OPEN GENERATIVE UI.
+generateSandboxedUi is for genuinely novel UI this app has no component for. Do
+not reach for it when showMarginLadder, showProduct, showOrderList or
+showMarginSummary would do. When you do use it, obtain every figure through the
+exposed sandbox functions rather than typing numbers into the generated markup.
+`.trim();
+
+export const commerceAgent = () =>
+  new BuiltInAgent({
+    model: "openai/gpt-5.4",
+    prompt: COMMERCE_PROMPT,
+    tools: [renderTradeBriefTool],
+    // NO `temperature`. Banking pins it to 0 for determinism, but gpt-5.4 is a
+    // reasoning model that REJECTS the parameter — the dev server logs 'The
+    // feature "temperature" is not supported' on literally every run, and the
+    // value is discarded. Carrying a silently-ignored option alongside a comment
+    // claiming run-to-run determinism is worse than not setting it: it tells the
+    // next reader the demo is pinned when it is not. Determinism here comes from
+    // the prompt's explicit routing rules instead.
+  });

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/attach-price-sheet.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/attach-price-sheet.test.ts
@@ -1,0 +1,706 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import commerce from "@/skins/commerce/skin";
+import { RESTOCK_PLAN_MESSAGE } from "@/skins/commerce/suggestions";
+import type { Beat3dTimings } from "@/skins/commerce/attach-price-sheet";
+import {
+  ATTACHMENT_CHIP_SELECTOR,
+  ATTACHMENT_QUEUE_SELECTOR,
+  CHAT_TEXTAREA_SELECTOR,
+  PRICE_SHEET_FILENAME,
+  PRICE_SHEET_FILE_INPUT_SELECTOR,
+  PRICE_SHEET_URL,
+  attachPriceSheetByHand,
+  sendRestockRequestWithPriceSheet,
+  stagePriceSheetAttachment,
+} from "@/skins/commerce/attach-price-sheet";
+
+/**
+ * BEAT 3d's failure contract.
+ *
+ * The beat claims a REAL vendor price sheet was ingested into a durable restock
+ * plan. The catastrophic failure is not "the beat did not run" — it is "the
+ * prompt was sent with NO attachment", because the model then invents a cost
+ * sheet, the plan is still filed, and the artifact reads plausibly. The demo
+ * looks perfect while proving the opposite of its point.
+ *
+ * The defect CLASS these tests exist to make unrepresentable is broader than any
+ * one bug: **an async DOM-driving step that resolves `true` without confirming
+ * its effect.** Fetching, staging, encoding and clicking are all REQUESTS made of
+ * code we do not own; each one has to be observed. So the file asserts:
+ *
+ *   1. the prompt is not sent unless the sheet is queued AND finished encoding —
+ *      for every way each of those can fail;
+ *   2. the send is not claimed unless the click actually consumed the attachment;
+ *   3. every failure surfaces something a presenter can see (`console.error` for
+ *      the log AND `window.alert` for the stage) and names ITSELF, because "retry
+ *      the pill", "press send by hand" and "restart the dev server" are different
+ *      instructions;
+ *   4. a missing composer does not leave `onSuggestionSelect` having returned
+ *      `true` — "handled" — with nothing whatsoever having happened.
+ *
+ * Written against the DOM rather than a render because the whole mechanism IS
+ * DOM manipulation: it reaches for framework-owned elements by test id. What the
+ * fake composer below reproduces is not React, it is the framework's observable
+ * ATTACHMENT STATE MACHINE, which is the thing being verified.
+ */
+
+/**
+ * jsdom implements no drag-and-drop, so it ships no `DataTransfer` — and that is
+ * the only way to build a `FileList`, which is what `input.files` demands. The
+ * stub is the narrowest possible: an `items.add` that collects Files and a
+ * `files` view shaped like a FileList. Without it the happy path throws inside
+ * the production try/catch and reports a failure, which would make the
+ * fail-loud assertions below pass for entirely the wrong reason.
+ */
+class DataTransferStub {
+  private collected: File[] = [];
+  items = {
+    add: (file: File) => {
+      this.collected.push(file);
+    },
+  };
+  get files(): FileList {
+    const list = this.collected;
+    return Object.assign([...list], {
+      item: (i: number) => list[i] ?? null,
+      length: list.length,
+    }) as unknown as FileList;
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("DataTransfer", DataTransferStub);
+});
+
+/**
+ * Fast budgets. Production waits seconds because a real encode can take them;
+ * a test that spent the real budget on each expiry branch would add half a
+ * minute to the suite. `0` forces the expiry branch deterministically —
+ * `waitUntil` still evaluates its predicate, so a condition that is already true
+ * still passes with a `0` budget.
+ */
+const FAST: Beat3dTimings = {
+  acceptMs: 200,
+  readyMs: 200,
+  sendableMs: 200,
+  consumedMs: 200,
+  pollMs: 5,
+};
+const fast = (over: Partial<Beat3dTimings> = {}): Beat3dTimings => ({
+  ...FAST,
+  ...over,
+});
+
+// ── the composer, as CopilotChat actually behaves ───────────────────────────
+
+interface ComposerOptions {
+  fileInput?: boolean;
+  textarea?: boolean;
+  sendButton?: boolean;
+  /**
+   * `processFiles` drops a file that fails `accept`/`maxSize` and calls an
+   * `onUploadFailed` this app does not wire — so a rejection means NO chip ever
+   * appears (use-attachments.tsx:76-99). That silence is the whole point.
+   */
+  rejectFile?: boolean;
+  /**
+   * How long base64 encoding takes before the chip flips `uploading` → `ready`
+   * and the queue starts printing the filename. `"never"` is a stuck encode:
+   * `consumeAttachments` would hand over nothing and `onSubmitInput` would refuse
+   * to send at all.
+   */
+  encodeMs?: number | "never";
+  /**
+   * Which role the ONE send/stop button is playing. `"stop"` mirrors a run in
+   * flight: enabled, carrying the square mark, and a click cancels the run.
+   * `"unrecognized"` mirrors a lucide rename.
+   */
+  sendRole?: "send" | "stop" | "unrecognized";
+  /** Simulates React never registering the typed prompt: `canSend` stays false. */
+  neverEnableSend?: boolean;
+  /**
+   * Whether the click runs `consumeAttachments` — the only thing that removes a
+   * ready chip, and only as part of dispatching the message.
+   */
+  consumeOnSend?: boolean;
+}
+
+const sendClicks = vi.fn();
+
+function mountComposer({
+  fileInput = true,
+  textarea = true,
+  sendButton = true,
+  rejectFile = false,
+  encodeMs = 0,
+  sendRole = "send",
+  neverEnableSend = false,
+  consumeOnSend = true,
+}: ComposerOptions = {}) {
+  document.body.innerHTML = "";
+
+  // The queue is mounted ONLY while non-empty (CopilotChatView.tsx:356), so it
+  // starts absent and is created on the first accepted file.
+  const ensureQueue = () => {
+    let queue = document.querySelector<HTMLElement>(ATTACHMENT_QUEUE_SELECTOR);
+    if (!queue) {
+      queue = document.createElement("div");
+      queue.setAttribute("data-testid", "copilot-attachment-queue");
+      document.body.appendChild(queue);
+    }
+    return queue;
+  };
+  const dropQueueIfEmpty = () => {
+    const queue = document.querySelector<HTMLElement>(
+      ATTACHMENT_QUEUE_SELECTOR,
+    );
+    if (
+      queue &&
+      queue.querySelectorAll(ATTACHMENT_CHIP_SELECTOR).length === 0
+    ) {
+      queue.remove();
+    }
+  };
+
+  if (fileInput) {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.setAttribute("accept", "application/pdf,image/*");
+    // jsdom's `files` setter runs a webidl conversion that only accepts a real
+    // jsdom FileList wrapper, which no stub can produce — it rejects even a
+    // correctly shaped object with a TypeError. Replace the accessor with a plain
+    // data property so the production `input.files = dt.files` is an ordinary
+    // write. (Verified the hard way: without this the assignment throws, the
+    // production catch turns it into a reported failure, and every fail-loud
+    // assertion in this file would pass for the wrong reason.)
+    Object.defineProperty(input, "files", {
+      writable: true,
+      configurable: true,
+      value: null,
+    });
+    input.addEventListener("change", () => {
+      const picked = input.files?.[0];
+      if (!picked || rejectFile) return; // dropped, silently, exactly as the framework does
+
+      // A chip appears on the next tick, as a React re-render would.
+      setTimeout(() => {
+        const chip = document.createElement("div");
+        // The chip renders an EMPTY body while uploading
+        // (CopilotChatAttachmentQueue.tsx:43,75-77) — no filename yet.
+        const remove = document.createElement("button");
+        remove.setAttribute("aria-label", "Remove attachment");
+        chip.appendChild(remove);
+        chip.dataset.ready = "false";
+        ensureQueue().appendChild(chip);
+
+        if (encodeMs === "never") return;
+        setTimeout(() => {
+          // `ready`: DocumentPreview prints the filename
+          // (CopilotChatAttachmentQueue.tsx:357-359).
+          const name = document.createElement("span");
+          name.textContent = picked.name;
+          chip.insertBefore(name, remove);
+          chip.dataset.ready = "true";
+        }, encodeMs);
+      }, 0);
+    });
+    document.body.appendChild(input);
+  }
+
+  let btn: HTMLButtonElement | undefined;
+  if (sendButton) {
+    btn = document.createElement("button");
+    btn.setAttribute("data-testid", "copilot-send-button");
+    const mark = document.createElement("span");
+    // lucide-react stamps `lucide-<kebab-name>`; the production code reads that
+    // mark to tell SEND from STOP (CopilotChatInput.tsx:540-547, 1158).
+    if (sendRole === "stop") mark.className = "lucide-square";
+    else if (sendRole === "send") mark.className = "lucide-arrow-up";
+    btn.appendChild(mark);
+    // disabled = isProcessing ? !canStop : !canSend. A stop button is ENABLED.
+    btn.disabled = sendRole !== "stop";
+    btn.addEventListener("click", () => {
+      sendClicks();
+      if (btn?.disabled) return; // a real disabled button dispatches nothing
+      if (sendRole === "stop") return; // a click here cancels the run; nothing is sent
+      if (!consumeOnSend) return;
+      // consumeAttachments(): every READY chip leaves the queue
+      // (use-attachments.tsx:245-253), as part of building the message.
+      document
+        .querySelectorAll<HTMLElement>(
+          `${ATTACHMENT_QUEUE_SELECTOR} [data-ready="true"]`,
+        )
+        .forEach((chip) => chip.remove());
+      dropQueueIfEmpty();
+    });
+    document.body.appendChild(btn);
+  }
+
+  if (textarea) {
+    const el = document.createElement("textarea");
+    el.setAttribute("data-testid", "copilot-chat-textarea");
+    el.addEventListener("input", () => {
+      if (!btn || sendRole === "stop") return; // isProcessing: canSend is irrelevant
+      // canSend = value.trim().length > 0 (CopilotChatInput.tsx:517)
+      btn.disabled = neverEnableSend || el.value.trim().length === 0;
+    });
+    document.body.appendChild(el);
+  }
+}
+
+function queuedChipCount() {
+  return document.querySelectorAll(
+    `${ATTACHMENT_QUEUE_SELECTOR} ${ATTACHMENT_CHIP_SELECTOR}`,
+  ).length;
+}
+
+/** A real PDF body — checked on the BYTES by the production code. */
+const pdfBytes = () => new TextEncoder().encode("%PDF-1.4\nprice sheet\n%%EOF");
+
+/**
+ * A 200 carrying `body`. Both `arrayBuffer()` and `blob()` are provided because a
+ * real `Response` has both: a stub missing one would make a failure look like
+ * "the route is broken" when it is really "the test lied about the Response
+ * shape", and that contaminates exactly the failure messages this file asserts on.
+ */
+const bodyResponse = (body: Uint8Array) =>
+  ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => body.slice().buffer,
+    blob: async () => new Blob([body.slice()]),
+  }) as unknown as Response;
+
+const okResponse = () => bodyResponse(pdfBytes());
+
+// The two halves of "say something": the log line, and the thing a presenter on
+// stage will actually notice.
+let errorSpy: MockInstance;
+let alertSpy: MockInstance;
+
+beforeEach(() => {
+  sendClicks.mockClear();
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+/** Everything the presenter would see: the log line plus the on-stage alert. */
+function surfacedText() {
+  const calls = [...errorSpy.mock.calls, ...alertSpy.mock.calls];
+  return calls.map((args) => args.map(String).join(" ")).join("\n");
+}
+
+function detailOf(
+  result: Awaited<ReturnType<typeof stagePriceSheetAttachment>>,
+) {
+  return result.staged ? "" : result.detail;
+}
+
+describe("stagePriceSheetAttachment: every failure names itself", () => {
+  it("names the route's status when it answers non-2xx", async () => {
+    mountComposer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 500 }) as unknown as Response),
+    );
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("http-error");
+    expect(detailOf(result)).toContain("HTTP 500");
+    expect(detailOf(result)).toContain(PRICE_SHEET_URL);
+  });
+
+  it("names the thrown error when the fetch itself dies", async () => {
+    mountComposer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("fetch-failed");
+    expect(detailOf(result)).toContain("network down");
+  });
+
+  it("rejects a 200 whose body is not a PDF, rather than smuggling it past the accept filter", async () => {
+    // The File is built with `type:"application/pdf"` so the composer's accept
+    // filter takes it — which means an HTML error page served with 200 would sail
+    // straight through and the model would be told to read costs off a web page.
+    mountComposer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        bodyResponse(
+          new TextEncoder().encode("<!doctype html><h1>500 — route threw</h1>"),
+        ),
+      ),
+    );
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("not-a-pdf");
+    expect(detailOf(result)).toContain("not a PDF");
+    // Nothing was pushed at the composer at all.
+    expect(queuedChipCount()).toBe(0);
+  });
+
+  it("rejects a 200 with an empty body", async () => {
+    mountComposer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => bodyResponse(new Uint8Array())),
+    );
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("empty-body");
+    expect(detailOf(result)).toContain("EMPTY");
+  });
+
+  it("names the missing composer file input — the formerly silent path", async () => {
+    mountComposer({ fileInput: false });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("no-file-input");
+    expect(detailOf(result)).toContain(PRICE_SHEET_FILE_INPUT_SELECTOR);
+  });
+
+  it("does NOT claim staged when the composer silently REJECTED the file", async () => {
+    // `processFiles` drops a file failing accept/maxSize and calls an
+    // `onUploadFailed` this app never wires, so the only trace is a chip that
+    // never appears. Dispatching `change` is a request, not an outcome.
+    mountComposer({ rejectFile: true });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("rejected");
+    expect(detailOf(result)).toContain("rejected");
+  });
+
+  it("does NOT claim staged while the file is still ENCODING", async () => {
+    // `consumeAttachments` hands over only `ready` files and `onSubmitInput`
+    // refuses to send while anything is `uploading`. A chip in the queue is not
+    // a sendable attachment.
+    mountComposer({ encodeMs: "never" });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const result = await stagePriceSheetAttachment(fast({ readyMs: 0 }));
+
+    expect(result.staged).toBe(false);
+    expect(result.staged === false && result.cause).toBe("encode-timeout");
+    // The file WAS accepted — the queue holds it — it just is not ready.
+    expect(queuedChipCount()).toBe(1);
+  });
+
+  it("stages only once the chip is queued AND finished encoding", async () => {
+    mountComposer({ encodeMs: 10 });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+    const changes = vi.fn();
+    document.body.addEventListener("change", changes);
+
+    const result = await stagePriceSheetAttachment(fast());
+
+    expect(result.staged).toBe(true);
+    const input = document.querySelector<HTMLInputElement>(
+      PRICE_SHEET_FILE_INPUT_SELECTOR,
+    );
+    expect(input?.files?.[0]?.name).toBe(PRICE_SHEET_FILENAME);
+    expect(changes).toHaveBeenCalled();
+    expect(
+      document.querySelector(ATTACHMENT_QUEUE_SELECTOR)?.textContent,
+    ).toContain(PRICE_SHEET_FILENAME);
+  });
+});
+
+describe("sendRestockRequestWithPriceSheet: never sends an unattached prompt", () => {
+  it.each([
+    [
+      "the route answers 500",
+      () =>
+        vi.fn(async () => ({ ok: false, status: 500 }) as unknown as Response),
+      {},
+      {},
+      "HTTP 500",
+    ],
+    [
+      "the fetch throws",
+      () =>
+        vi.fn(async () => {
+          throw new Error("network down");
+        }),
+      {},
+      {},
+      "network down",
+    ],
+    [
+      "the body is an HTML error page, not a PDF",
+      () =>
+        vi.fn(async () =>
+          bodyResponse(new TextEncoder().encode("<!doctype html>nope")),
+        ),
+      {},
+      {},
+      "not a PDF",
+    ],
+    [
+      "the composer's file input is gone",
+      () => vi.fn(okResponse),
+      { fileInput: false },
+      {},
+      PRICE_SHEET_FILE_INPUT_SELECTOR,
+    ],
+    [
+      "the composer REJECTED the file",
+      () => vi.fn(okResponse),
+      { rejectFile: true },
+      {},
+      "rejected by the attachment filter",
+    ],
+    [
+      "the file is still encoding",
+      () => vi.fn(okResponse),
+      { encodeMs: "never" as const },
+      { readyMs: 0 },
+      "never finished encoding",
+    ],
+  ])(
+    "aborts, and says so, when %s",
+    async (_label, makeFetch, dom: ComposerOptions, budget, expectedText) => {
+      mountComposer(dom);
+      vi.stubGlobal("fetch", makeFetch());
+
+      const sent = await sendRestockRequestWithPriceSheet(fast(budget));
+
+      expect(sent).toBe(false);
+      // THE assertion. Without the sheet the model invents the costs, so the
+      // prompt must not reach the composer at all.
+      expect(sendClicks).not.toHaveBeenCalled();
+      expect(
+        document.querySelector<HTMLTextAreaElement>(CHAT_TEXTAREA_SELECTOR)
+          ?.value,
+      ).toBe("");
+      // Every failure surfaces, in the log AND on the screen.
+      expect(errorSpy).toHaveBeenCalled();
+      expect(alertSpy).toHaveBeenCalled();
+      expect(surfacedText()).toContain(expectedText);
+    },
+  );
+
+  it("aborts BEFORE staging when the composer cannot be driven", async () => {
+    // A framework test-id rename. This used to return early AFTER staging and
+    // AFTER onSuggestionSelect had claimed the click, making the pill a total
+    // no-op. It must now bail before touching the network, so no attachment is
+    // left stranded in a composer we cannot submit.
+    mountComposer({ textarea: false });
+    const fetchSpy = vi.fn(okResponse);
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const sent = await sendRestockRequestWithPriceSheet(fast());
+
+    expect(sent).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalled();
+    expect(surfacedText()).toContain(CHAT_TEXTAREA_SELECTOR);
+  });
+
+  it("does NOT click a STOP button — that would cancel the run, not send", async () => {
+    // One button plays both roles (CopilotChatInput.tsx:520-530, 540-547). Mid-run
+    // it is a Stop button and a click aborts the run: the beat would then have
+    // killed the presenter's demo AND reported success.
+    mountComposer({ sendRole: "stop" });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const sent = await sendRestockRequestWithPriceSheet(fast());
+
+    expect(sent).toBe(false);
+    expect(sendClicks).not.toHaveBeenCalled();
+    expect(surfacedText()).toContain("STOP button");
+    expect(surfacedText()).toContain("CANCEL");
+  });
+
+  it("does NOT click a DISABLED send button", async () => {
+    // `canSend` never flips — React did not register the prompt. The old code
+    // clicked anyway, which dispatches nothing, and resolved `true`.
+    mountComposer({ neverEnableSend: true });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const sent = await sendRestockRequestWithPriceSheet(
+      fast({ sendableMs: 0 }),
+    );
+
+    expect(sent).toBe(false);
+    expect(sendClicks).not.toHaveBeenCalled();
+    expect(surfacedText()).toContain("stayed disabled");
+  });
+
+  it("does NOT click a button whose role it cannot identify", async () => {
+    // A lucide rename. Failing CLOSED matters: the unknown button might be Stop.
+    mountComposer({ sendRole: "unrecognized" });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const sent = await sendRestockRequestWithPriceSheet(
+      fast({ sendableMs: 0 }),
+    );
+
+    expect(sent).toBe(false);
+    expect(sendClicks).not.toHaveBeenCalled();
+    expect(surfacedText()).toContain("role cannot be identified");
+  });
+
+  it("does NOT claim success when React's textarea value setter is gone", async () => {
+    // The setter used to be invoked as `setter?.call(...)`, optional-chaining away
+    // the only failure available and then dispatching an `input` event carrying
+    // the STALE value.
+    const proto = window.HTMLTextAreaElement.prototype;
+    const original = Object.getOwnPropertyDescriptor(proto, "value");
+    expect(original?.set).toBeTypeOf("function");
+    // `set: undefined` is REQUIRED, not decorative: defineProperty leaves omitted
+    // attributes of an EXISTING property unchanged, so omitting it silently keeps
+    // jsdom's real setter and this test would pass against the broken code.
+    Object.defineProperty(proto, "value", {
+      configurable: true,
+      enumerable: original?.enumerable,
+      get: original?.get,
+      set: undefined,
+    });
+    try {
+      mountComposer();
+      vi.stubGlobal("fetch", vi.fn(okResponse));
+
+      const sent = await sendRestockRequestWithPriceSheet(fast());
+
+      expect(sent).toBe(false);
+      expect(sendClicks).not.toHaveBeenCalled();
+      expect(surfacedText()).toContain(
+        "could not be written into the composer",
+      );
+    } finally {
+      Object.defineProperty(proto, "value", original!);
+    }
+  });
+
+  it("does NOT claim the send when the click never consumed the attachment", async () => {
+    // The click is a request too. If `consumeAttachments` never runs, the sheet is
+    // still sitting in the queue and nothing carrying it went out.
+    mountComposer({ consumeOnSend: false });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const sent = await sendRestockRequestWithPriceSheet(
+      fast({ consumedMs: 0 }),
+    );
+
+    expect(sent).toBe(false);
+    expect(sendClicks).toHaveBeenCalledTimes(1);
+    expect(surfacedText()).toContain("unconfirmed");
+    // The ONE case where "nothing was sent" would be a lie — a message may be in
+    // flight, and telling the presenter otherwise invites a double send.
+    expect(surfacedText()).not.toContain("nothing was sent");
+    expect(surfacedText()).toContain("Could not confirm");
+  });
+
+  it("sends the prompt with the sheet on the happy path", async () => {
+    mountComposer({ encodeMs: 10 });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const sent = await sendRestockRequestWithPriceSheet(fast());
+
+    expect(sent).toBe(true);
+    expect(sendClicks).toHaveBeenCalledTimes(1);
+    expect(
+      document.querySelector<HTMLTextAreaElement>(CHAT_TEXTAREA_SELECTOR)
+        ?.value,
+    ).toBe(RESTOCK_PLAN_MESSAGE);
+    // Consumed: the attachment rode the message out.
+    expect(queuedChipCount()).toBe(0);
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("attachPriceSheetByHand: the paperclip fallback is the loudest link", () => {
+  it("reports rather than resolving quietly when staging fails", async () => {
+    mountComposer({ fileInput: false });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const attached = await attachPriceSheetByHand(fast());
+
+    expect(attached).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalled();
+  });
+
+  it("does not claim the sheet is attached while it is still encoding", async () => {
+    // The paperclip's contract is "the sheet is now attached", and an attachment
+    // stuck in `uploading` is one the composer would refuse to send.
+    mountComposer({ encodeMs: "never" });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    const attached = await attachPriceSheetByHand(fast({ readyMs: 0 }));
+
+    expect(attached).toBe(false);
+    expect(surfacedText()).toContain("never finished encoding");
+    // It never claims a send it did not attempt.
+    expect(surfacedText()).not.toContain("nothing was sent");
+  });
+
+  it("resolves true and stays quiet when it works", async () => {
+    mountComposer({ encodeMs: 10 });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    await expect(attachPriceSheetByHand(fast())).resolves.toBe(true);
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("commerce.onSuggestionSelect", () => {
+  const pill = {
+    title: "File the restock plan",
+    message: RESTOCK_PLAN_MESSAGE,
+  };
+
+  it("passes every other pill through to the shell's default send", () => {
+    mountComposer();
+    expect(
+      commerce.onSuggestionSelect?.(
+        { title: "Show me the margin ladder", message: "Show me the ladder." },
+        0,
+      ),
+    ).toBe(false);
+  });
+
+  it("claims the restock pill, and never claims it silently", () => {
+    // Semantics: `true` means "the shell must NOT run its default send", which
+    // is unconditionally right here — the default path drops attachments. What
+    // must never happen again is `true` plus total silence, so a missing
+    // composer has to have surfaced something by the time this returns. The
+    // report is synchronous (the guard runs before the first await), which is
+    // exactly why the composer lookup moved ahead of staging.
+    mountComposer({ textarea: false, sendButton: false });
+    vi.stubGlobal("fetch", vi.fn(okResponse));
+
+    expect(commerce.onSuggestionSelect?.(pill, 4)).toBe(true);
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/attach-price-sheet.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/attach-price-sheet.ts
@@ -1,0 +1,612 @@
+/**
+ * BEAT 3d — stage the vendor price sheet into the chat composer's built-in
+ * hidden file input, so CopilotKit's standard attachment flow picks it up: the
+ * sheet appears as a real attachment chip and rides the next message to the
+ * model.
+ *
+ * Shared by the chat header's paperclip AND the suggestion pill, so both take
+ * the identical blessed path (the one that correctly consumes attachments on
+ * submit). The pill needs it because the framework's suggestion path DROPS
+ * attachments — a pill that must carry a file has to be intercepted in
+ * `onSuggestionSelect` and driven through the real composer instead.
+ *
+ * The paperclip exists as a manual fallback: if the pill path misbehaves on
+ * stage, the presenter can still attach the file by hand and carry on.
+ *
+ * ── WHY THIS WHOLE CHAIN IS FAIL-LOUD ───────────────────────────────────────
+ * Beat 3d's entire claim is that a REAL document was ingested into a durable
+ * artifact. If the prompt ("read the attached price sheet and file the restock
+ * plan") is sent with no attachment, the model invents the costs and the plan is
+ * still filed — so the demo LOOKS fine while proving the exact opposite of its
+ * point. That is the most damaging failure available here, and it is invisible.
+ *
+ * ── AND WHY IT VERIFIES RATHER THAN ASSUMES ─────────────────────────────────
+ * Reporting a failure loudly is worthless if the failure is never DETECTED. This
+ * module drives someone else's React component through the DOM, so every step is
+ * a request whose effect has to be observed, never assumed:
+ *
+ *   - Dispatching `change` on the hidden input does not mean the file was taken.
+ *     `useAttachments.processFiles` silently DROPS files that fail the `accept`
+ *     filter or the size cap (`use-attachments.tsx:76-99`) and this app wires no
+ *     `onUploadFailed`, so a rejection is otherwise invisible.
+ *   - An accepted file is not a SENDABLE file. It lands as `status:"uploading"`
+ *     and only becomes `"ready"` after base64 encoding resolves
+ *     (`use-attachments.tsx:103-144`). `CopilotChat.onSubmitInput` REFUSES to
+ *     send while anything is uploading (`CopilotChat.tsx:649-657, 677-686`), and
+ *     `consumeAttachments` only ever hands over `ready` files
+ *     (`use-attachments.tsx:245-253`). A fixed sleep races that encode; on a slow
+ *     machine or a bigger sheet it loses.
+ *   - Clicking the send button does not mean a message was sent. The same button
+ *     is the STOP button while a run is in flight, and a click then CANCELS the
+ *     run (`CopilotChatInput.tsx:520-530, 540-547`).
+ *
+ * So every step below obeys four rules:
+ *   1. The prompt is NEVER sent unless the sheet is verifiably staged, accepted
+ *      AND finished encoding.
+ *   2. Waiting is CONDITION-based with a bounded budget, never a fixed sleep. An
+ *      expired budget is a failure, not a green light.
+ *   3. Every failure names ITSELF — a distinct `cause` and a distinct sentence,
+ *      because "retry" and "restart the dev server" are different instructions.
+ *      Reported via `console.error` for the log AND `window.alert` so a presenter
+ *      mid-demo actually sees it (the pattern the skin's reset button uses).
+ *   4. No promise is launched and forgotten, and no path resolves `true` without
+ *      a confirmed attachment AND a confirmed send.
+ */
+
+import { RESTOCK_PLAN_MESSAGE } from "./suggestions";
+
+export const PRICE_SHEET_URL = "/api/commerce/v1/price-sheet";
+export const PRICE_SHEET_FILENAME = "price-sheet-kestrel-mills.pdf";
+
+/**
+ * The composer elements this beat drives. They are framework-owned test ids, so
+ * a CopilotKit upgrade can rename them out from under us — which is precisely
+ * why their absence has to be reported rather than returned as a silent no-op.
+ */
+export const PRICE_SHEET_FILE_INPUT_SELECTOR =
+  'input[type="file"][accept*="pdf"]';
+export const CHAT_TEXTAREA_SELECTOR =
+  'textarea[data-testid="copilot-chat-textarea"]';
+export const CHAT_SEND_BUTTON_SELECTOR =
+  'button[data-testid="copilot-send-button"]';
+
+/**
+ * The attachment QUEUE — the only place the framework's attachment state machine
+ * is observable from outside React. `CopilotChatView` mounts it only when the
+ * queue is non-empty (`CopilotChatView.tsx:356`) and it carries this test id
+ * (`CopilotChatAttachmentQueue.tsx:25`), so:
+ *
+ *   - a new chip appearing  ⇒ `processFiles` ACCEPTED the file (it pushed the
+ *     `uploading` placeholder, `use-attachments.tsx:103-112`);
+ *   - no chip appearing     ⇒ it was rejected by `accept`/`maxSize` and dropped.
+ *
+ * Each chip is the PARENT of a "Remove attachment" button
+ * (`CopilotChatAttachmentQueue.tsx:45-54`), which is the most stable way to count
+ * them — the chip div itself carries only utility classes.
+ */
+export const ATTACHMENT_QUEUE_SELECTOR =
+  '[data-testid="copilot-attachment-queue"]';
+export const ATTACHMENT_CHIP_SELECTOR =
+  'button[aria-label="Remove attachment"]';
+
+/**
+ * The framework exposes NO status attribute on an attachment chip — nothing like
+ * `data-status="ready"`. What it does do is render an EMPTY body while a chip is
+ * `uploading` (`CopilotChatAttachmentQueue.tsx:43,75-77`) and only print the
+ * filename once the chip is `ready` and `DocumentPreview` takes over
+ * (`CopilotChatAttachmentQueue.tsx:336-366, esp. 357-359`).
+ *
+ * So "the queue contains a chip whose text includes our filename" is a DERIVED
+ * proxy for `status === "ready"`. It is the best signal available, and being a
+ * proxy is exactly why the wait around it is bounded and fails CLOSED: if the
+ * framework stops printing filenames, this beat aborts loudly instead of sending
+ * an unattached prompt.
+ */
+function attachmentChips(): HTMLElement[] {
+  const queue = document.querySelector(ATTACHMENT_QUEUE_SELECTOR);
+  if (!queue) return [];
+  return Array.from(
+    queue.querySelectorAll<HTMLElement>(ATTACHMENT_CHIP_SELECTOR),
+  )
+    .map((button) => button.parentElement)
+    .filter((chip): chip is HTMLElement => chip !== null);
+}
+
+/** Chips whose text names our sheet — i.e. that reached `ready`. See above. */
+function readySheetChipCount(): number {
+  return attachmentChips().filter((chip) =>
+    (chip.textContent ?? "").includes(PRICE_SHEET_FILENAME),
+  ).length;
+}
+
+/**
+ * SEND state vs STOP state, derived from the framework rather than guessed.
+ *
+ * `CopilotChatInput` renders ONE button for both roles
+ * (`CopilotChatInput.tsx:540-547`):
+ *
+ *   children: isProcessing && canStop ? <Square/> : undefined
+ *   disabled: isProcessing ? !canStop : !canSend
+ *
+ * and `SendButton` falls back to `<ArrowUp/>` when `children` is undefined
+ * (`CopilotChatInput.tsx:1158`). lucide-react stamps each mark with
+ * `lucide-<kebab-name>` (`lucide-react@0.447.0`, `createLucideIcon`), so the mark
+ * inside the button is a faithful read of that ternary. Enumerating the four
+ * states:
+ *
+ *   | isProcessing | canStop | canSend | mark     | disabled |
+ *   | no           | –       | yes     | arrow-up | no       | ← the only sendable one
+ *   | no           | –       | no      | arrow-up | yes      |
+ *   | yes          | yes     | –       | square   | no       | ← a click CANCELS the run
+ *   | yes          | no      | –       | arrow-up | yes      |
+ *
+ * Hence: an enabled button carrying the arrow-up mark is sendable, and nothing
+ * else is. Requiring the arrow-up mark POSITIVELY (rather than merely checking
+ * the square is absent) is what makes a future icon rename abort the beat instead
+ * of clicking a button whose role we can no longer identify.
+ */
+export const SEND_MARK_SELECTOR = ".lucide-arrow-up";
+export const STOP_MARK_SELECTOR = ".lucide-square";
+
+type SendButtonState = "sendable" | "stop" | "disabled" | "unrecognized";
+
+function sendButtonState(button: HTMLButtonElement): SendButtonState {
+  // Checked FIRST: a stop button is enabled, so a `disabled` test would miss it.
+  if (button.querySelector(STOP_MARK_SELECTOR)) return "stop";
+  if (button.disabled) return "disabled";
+  if (!button.querySelector(SEND_MARK_SELECTOR)) return "unrecognized";
+  return "sendable";
+}
+
+/**
+ * How long each observation is allowed to take. Exposed (and injectable) so the
+ * budgets are readable in one place and so tests can exercise every expiry
+ * branch without spending the real budget on each.
+ */
+export interface Beat3dTimings {
+  /** Composer ACCEPTS the staged file — a chip appears in the queue. */
+  acceptMs: number;
+  /** Base64 encoding finishes — that chip reaches `ready`. */
+  readyMs: number;
+  /** The send button reaches an enabled SEND state after the prompt is typed. */
+  sendableMs: number;
+  /** The click CONSUMES the attachment — the chip leaves the queue. */
+  consumedMs: number;
+  /** Poll interval for all of the above. */
+  pollMs: number;
+}
+
+export const DEFAULT_BEAT_3D_TIMINGS: Beat3dTimings = {
+  acceptMs: 3_000,
+  readyMs: 10_000,
+  sendableMs: 2_000,
+  consumedMs: 10_000,
+  pollMs: 25,
+};
+
+/** Why a beat-3d attempt stopped. One value per distinct presenter instruction. */
+export type PriceSheetFailureCause =
+  /** The fetch itself threw — network layer, dev server down. */
+  | "fetch-failed"
+  /** The route answered non-2xx. */
+  | "http-error"
+  /** 2xx with a zero-length body. */
+  | "empty-body"
+  /** 2xx whose bytes are not a PDF (typically an HTML error page). */
+  | "not-a-pdf"
+  /** The composer's hidden file input is not in the DOM. */
+  | "no-file-input"
+  /** Writing the file onto the input threw (DataTransfer/File unavailable). */
+  | "staging-threw"
+  /** The composer never took the file — `accept`/`maxSize` dropped it. */
+  | "rejected"
+  /** The file was accepted but never finished encoding within budget. */
+  | "encode-timeout"
+  /** The textarea or the send button is not in the DOM. */
+  | "no-composer"
+  /** The React value setter is gone, or the write did not land. */
+  | "stale-value"
+  /** The send button stayed disabled. */
+  | "send-disabled"
+  /** The button is a STOP button — clicking would cancel a run, not send. */
+  | "send-stop-state"
+  /** The button carries neither known mark; its role cannot be identified. */
+  | "send-unrecognized"
+  /** The click did not consume the attachment within budget. */
+  | "send-unconfirmed"
+  /** Anything that escaped a narrower handler. */
+  | "unexpected";
+
+/**
+ * The outcome of a staging attempt.
+ *
+ * WHY NOT A BOOLEAN. A bare `boolean` collapsed every distinct failure into one
+ * indistinguishable `false`, so no caller could tell the presenter what actually
+ * broke. Carrying a machine-readable `cause` AND a human `detail` is what makes
+ * "say something USEFUL on every path" expressible — and what lets the tests
+ * pin each mode without matching on prose.
+ */
+export type PriceSheetStaging =
+  | { staged: true }
+  | { staged: false; cause: PriceSheetFailureCause; detail: string };
+
+function fail(
+  cause: PriceSheetFailureCause,
+  detail: string,
+): { staged: false; cause: PriceSheetFailureCause; detail: string } {
+  return { staged: false, cause, detail };
+}
+
+/**
+ * The single reporting surface for this beat. A `console.error` alone is not
+ * enough: the failure it describes happens while someone is standing in front of
+ * an audience, and nobody opens devtools mid-demo. The alert is the point — it
+ * stops the presenter from narrating a plan built on invented numbers.
+ *
+ * The lede is overridable for the ONE case where "nothing was sent" would be a
+ * lie: a send we clicked but could not confirm. Telling a presenter nothing was
+ * sent when a message may be in flight sends them into a double-send.
+ */
+export const NOTHING_SENT_LEDE =
+  "Could not attach the vendor price sheet — nothing was sent.";
+
+export function reportPriceSheetFailure(
+  detail: string,
+  lede: string = NOTHING_SENT_LEDE,
+): void {
+  const message = `${lede} ${detail}`;
+  console.error(message);
+  if (typeof window !== "undefined") window.alert(message);
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll `predicate` until it holds or the budget expires. Resolves whether it
+ * held — an expiry is a plain `false`, never an assumption that it "probably"
+ * happened by now. This replaces the fixed 500 ms sleep that used to race the
+ * framework's base64 encode: the defect was the racing, not the duration.
+ */
+async function waitUntil(
+  predicate: () => boolean,
+  budgetMs: number,
+  pollMs: number,
+): Promise<boolean> {
+  if (predicate()) return true;
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    await sleep(pollMs);
+    if (predicate()) return true;
+  }
+  return predicate();
+}
+
+/**
+ * A PDF really is a PDF, checked on the BYTES rather than trusted from the URL.
+ *
+ * The route is a Next handler: a thrown error, a stray redirect or a dev-server
+ * error overlay can all answer 200 with HTML. Forcing `type:"application/pdf"`
+ * onto the File (below) would then smuggle that HTML past the composer's accept
+ * filter, and the model would be handed a web page to "read costs" from. The
+ * header is searched rather than required at offset 0 because real-world PDFs
+ * tolerate leading bytes; an HTML page still has no `%PDF` in its first KB.
+ */
+function looksLikePdf(bytes: Uint8Array): boolean {
+  const header = "%PDF";
+  const lead = bytes.subarray(0, 1024);
+  for (let i = 0; i + header.length <= lead.length; i++) {
+    let hit = true;
+    for (let j = 0; j < header.length; j++) {
+      if (lead[i + j] !== header.charCodeAt(j)) {
+        hit = false;
+        break;
+      }
+    }
+    if (hit) return true;
+  }
+  return false;
+}
+
+/** The first bytes as text, for a failure message that identifies the culprit. */
+function describeBody(bytes: Uint8Array): string {
+  const head = Array.from(bytes.subarray(0, 48))
+    .map((byte) =>
+      byte >= 0x20 && byte < 0x7f ? String.fromCharCode(byte) : ".",
+    )
+    .join("");
+  return `${bytes.length} bytes starting "${head}"`;
+}
+
+/**
+ * Fetch the sheet, verify it IS a sheet, hand it to the composer, and confirm
+ * the composer both accepted it and finished encoding it.
+ *
+ * Resolves `{ staged: true }` only when the attachment is present in the queue
+ * AND `ready` — i.e. only when `consumeAttachments` would actually hand it to the
+ * next message. Every other outcome names its own cause.
+ */
+export async function stagePriceSheetAttachment(
+  timings: Beat3dTimings = DEFAULT_BEAT_3D_TIMINGS,
+): Promise<PriceSheetStaging> {
+  // ── 1. the document ───────────────────────────────────────────────────────
+  // Its own try, so a `File`/`DataTransfer` failure downstream can never be
+  // reported as "the fetch threw" — which is what the single file-wide catch
+  // used to do, sending a presenter to check a healthy network.
+  // `<ArrayBuffer>` rather than a bare `Uint8Array`: since TS 5.7 the default
+  // parameter is `ArrayBufferLike`, which includes `SharedArrayBuffer` and is
+  // therefore not a valid `BlobPart` for the `new File([...])` below.
+  let bytes: Uint8Array<ArrayBuffer>;
+  try {
+    const res = await fetch(PRICE_SHEET_URL);
+    // A non-2xx is the SAME failure as a thrown fetch and has to be as loud, or
+    // beat 3d fails invisibly.
+    if (!res.ok) {
+      return fail(
+        "http-error",
+        `${PRICE_SHEET_URL} answered HTTP ${res.status}. See the server logs.`,
+      );
+    }
+    bytes = new Uint8Array(await res.arrayBuffer());
+  } catch (err) {
+    // Logged HERE in addition to the caller's report because only this frame
+    // still holds the Error object, and its stack is what identifies a fetch
+    // that died in the network layer. The string `detail` cannot carry it.
+    console.error("Could not fetch the price sheet", err);
+    return fail(
+      "fetch-failed",
+      `Fetching ${PRICE_SHEET_URL} threw: ${errorText(err)}`,
+    );
+  }
+
+  if (bytes.length === 0) {
+    return fail(
+      "empty-body",
+      `${PRICE_SHEET_URL} answered 200 with an EMPTY body, so there is no sheet to attach.`,
+    );
+  }
+  if (!looksLikePdf(bytes)) {
+    return fail(
+      "not-a-pdf",
+      `${PRICE_SHEET_URL} answered 200 but the body is not a PDF (${describeBody(bytes)}) — probably an error page. Restart the dev server and check the route.`,
+    );
+  }
+
+  // ── 2. hand it to the composer ────────────────────────────────────────────
+  const input = document.querySelector<HTMLInputElement>(
+    PRICE_SHEET_FILE_INPUT_SELECTOR,
+  );
+  // This used to be a bare `return false` — the one failure mode in the chain
+  // with no log at all. It fires when the framework's composer changes its
+  // hidden input, i.e. on a dependency upgrade, which is exactly the class of
+  // breakage that must not be discoverable only by watching the model lie.
+  if (!input) {
+    return fail(
+      "no-file-input",
+      `The composer's hidden file input (${PRICE_SHEET_FILE_INPUT_SELECTOR}) is not in the DOM.`,
+    );
+  }
+
+  const chipsBefore = attachmentChips().length;
+  const readyBefore = readySheetChipCount();
+
+  try {
+    const file = new File([bytes], PRICE_SHEET_FILENAME, {
+      type: "application/pdf",
+    });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    input.files = dt.files;
+    // A native, BUBBLING change event, so CopilotChat's own onChange handler
+    // runs and enqueues the attachment exactly as a manual pick would. A
+    // React-synthetic dispatch would not reach it.
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  } catch (err) {
+    console.error("Could not stage the price sheet into the composer", err);
+    return fail(
+      "staging-threw",
+      `Writing the file onto the composer's hidden input threw: ${errorText(err)}`,
+    );
+  }
+
+  // ── 3. did the composer TAKE it? ──────────────────────────────────────────
+  // Dispatching `change` is a request, not an outcome. `processFiles` drops a
+  // file that fails `accept` or `maxSize` and calls an `onUploadFailed` this app
+  // does not wire, so a rejection leaves NO trace except this chip never
+  // appearing (`use-attachments.tsx:76-99`).
+  const accepted = await waitUntil(
+    () => attachmentChips().length > chipsBefore,
+    timings.acceptMs,
+    timings.pollMs,
+  );
+  if (!accepted) {
+    return fail(
+      "rejected",
+      `The composer never queued the sheet — it was rejected by the attachment filter (accept/maxSize) or the queue is not rendering. No attachment chip appeared within ${timings.acceptMs}ms.`,
+    );
+  }
+
+  // ── 4. has it finished ENCODING? ──────────────────────────────────────────
+  // `consumeAttachments` hands over only `ready` files and `onSubmitInput`
+  // refuses to send while anything is `uploading`, so sending now would either
+  // be blocked outright or strip the sheet and strand it on the next message.
+  const ready = await waitUntil(
+    () => readySheetChipCount() > readyBefore,
+    timings.readyMs,
+    timings.pollMs,
+  );
+  if (!ready) {
+    return fail(
+      "encode-timeout",
+      `The sheet was queued but never finished encoding within ${timings.readyMs}ms, so the composer would refuse to send it. Wait a moment and retry the paperclip.`,
+    );
+  }
+
+  return { staged: true };
+}
+
+/**
+ * Set a React-controlled textarea's value so its onChange actually fires, and
+ * report whether the write LANDED.
+ *
+ * The setter lookup used to be `setter?.call(...)`, which optional-chained away
+ * the only thing that can go wrong here and then dispatched an `input` event
+ * carrying the STALE value — React re-rendered the empty textarea, `canSend`
+ * stayed false, and the caller clicked a disabled button while resolving `true`.
+ */
+function setTextareaValue(el: HTMLTextAreaElement, value: string): boolean {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  if (!setter) return false;
+  setter.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  return el.value === value;
+}
+
+/**
+ * The chat header's paperclip — the presenter's manual fallback.
+ *
+ * Returns whether the sheet is now attached AND ready to ride the next message.
+ * It used to be launched as `void stagePriceSheetAttachment()`, discarding both
+ * the boolean and any rejection, so the fallback for a broken pill could itself
+ * fail with nothing anywhere. Every failure now reports before this resolves
+ * `false`.
+ */
+export async function attachPriceSheetByHand(
+  timings: Beat3dTimings = DEFAULT_BEAT_3D_TIMINGS,
+): Promise<boolean> {
+  try {
+    const result = await stagePriceSheetAttachment(timings);
+    if (result.staged) return true;
+    reportPriceSheetFailure(
+      result.detail,
+      "Could not attach the vendor price sheet.",
+    );
+    return false;
+  } catch (err) {
+    reportPriceSheetFailure(unexpected(err));
+    return false;
+  }
+}
+
+/**
+ * BEAT 3d's pill: stage the file into the composer's hidden input, type the
+ * prompt into the real textarea, click the real send button. That is the only
+ * path that consumes an attachment on submit; the framework's suggestion path
+ * drops it.
+ *
+ * ORDER IS LOAD-BEARING. The composer is located BEFORE anything is staged, so a
+ * renamed test id aborts the beat while it is still a no-op — rather than after
+ * an attachment chip has been pushed into a composer we then discover we cannot
+ * drive, leaving the sheet stranded on the next thing the presenter types.
+ *
+ * Resolves `true` only when the prompt was actually sent WITH the sheet —
+ * confirmed by the attachment leaving the queue, which only `consumeAttachments`
+ * does and only as part of dispatching the message. Every `false` has already
+ * been reported to the presenter.
+ */
+export async function sendRestockRequestWithPriceSheet(
+  timings: Beat3dTimings = DEFAULT_BEAT_3D_TIMINGS,
+): Promise<boolean> {
+  try {
+    const textarea = document.querySelector<HTMLTextAreaElement>(
+      CHAT_TEXTAREA_SELECTOR,
+    );
+    const sendButton = document.querySelector<HTMLButtonElement>(
+      CHAT_SEND_BUTTON_SELECTOR,
+    );
+    if (!textarea || !sendButton) {
+      reportPriceSheetFailure(
+        `The chat composer was not found (${CHAT_TEXTAREA_SELECTOR} / ${CHAT_SEND_BUTTON_SELECTOR}). Attach the sheet with the paperclip and send the prompt by hand.`,
+      );
+      return false;
+    }
+
+    const staging = await stagePriceSheetAttachment(timings);
+    // THE GUARD THIS WHOLE FILE EXISTS FOR. Sending the prompt without the sheet
+    // makes the model invent a cost sheet and file a plausible-looking plan off
+    // it, which is worse than not running the beat at all.
+    if (!staging.staged) {
+      reportPriceSheetFailure(staging.detail);
+      return false;
+    }
+
+    // The prompt has to be in the composer BEFORE the send button can be
+    // sendable at all: `canSend` requires a non-empty trimmed value
+    // (`CopilotChatInput.tsx:517`). That dependency is also what turns the wait
+    // below into a check on this write.
+    if (!setTextareaValue(textarea, RESTOCK_PLAN_MESSAGE)) {
+      reportPriceSheetFailure(
+        "The prompt could not be written into the composer (React's textarea value setter is unavailable, or the write did not stick), so the sheet is attached but nothing was sent. Type the prompt and press send.",
+      );
+      return false;
+    }
+
+    // React has to re-render before `canSend` flips, so this is a wait, not an
+    // assertion. An expiry is classified rather than collapsed: a STOP button, a
+    // disabled button and an unidentifiable button need three different actions
+    // from the presenter.
+    const sendable = await waitUntil(
+      () => sendButtonState(sendButton) === "sendable",
+      timings.sendableMs,
+      timings.pollMs,
+    );
+    if (!sendable) {
+      reportPriceSheetFailure(sendBlockedDetail(sendButtonState(sendButton)));
+      return false;
+    }
+
+    const readyBeforeSend = readySheetChipCount();
+    sendButton.click();
+
+    // Clicking is a request too. `onSubmitInput` calls `consumeAttachments`,
+    // which is the ONLY thing that removes a `ready` chip from the queue
+    // (`use-attachments.tsx:245-253`) and does so as part of building the
+    // outgoing message (`CopilotChat.tsx:688-716`). So the chip leaving IS the
+    // confirmation that the sheet went out attached.
+    const consumed = await waitUntil(
+      () => readySheetChipCount() < readyBeforeSend,
+      timings.consumedMs,
+      timings.pollMs,
+    );
+    if (!consumed) {
+      // The one case where "nothing was sent" would be a LIE — the click landed
+      // and a message may be in flight. Telling the presenter otherwise invites
+      // a double send.
+      reportPriceSheetFailure(
+        `The send button was clicked but the sheet never left the attachment queue within ${timings.consumedMs}ms, so it is unconfirmed whether the prompt went out WITH the document. Check the transcript before retrying.`,
+        "Could not confirm the vendor price sheet was sent.",
+      );
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    reportPriceSheetFailure(unexpected(err));
+    return false;
+  }
+}
+
+function sendBlockedDetail(state: SendButtonState): string {
+  switch (state) {
+    case "stop":
+      return "The composer's send button is currently a STOP button — a run is already in flight, and clicking it would CANCEL that run instead of sending. Wait for the run to finish and retry the pill.";
+    case "disabled":
+      return "The composer's send button stayed disabled — either it never registered the prompt text, or a run is in flight with no stop handler. The sheet is attached; press send by hand.";
+    case "unrecognized":
+      return `The composer's send button carries neither the send (${SEND_MARK_SELECTOR}) nor the stop (${STOP_MARK_SELECTOR}) mark, so its role cannot be identified and clicking it is unsafe. The framework's icons changed — the sheet is attached; press send by hand.`;
+    case "sendable":
+      // Only reachable if the button became sendable between the expiry and this
+      // re-read. Naming it beats pretending the wait told us nothing.
+      return "The composer's send button only became sendable after the wait expired, so the prompt was not clicked. The sheet is attached; press send by hand.";
+  }
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function unexpected(err: unknown): string {
+  return `Unexpected error: ${errorText(err)}`;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/build-brief-ops.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/build-brief-ops.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildBriefOps,
+  extractSurfaceId,
+  BRIEF_LISTS,
+  BRIEF_METRICS,
+  SURFACE_ID,
+  renderBriefParams,
+} from "./build-brief-ops";
+import type { A2UIOp } from "./build-brief-ops";
+
+type Component = { id: string; component: string } & Record<string, unknown>;
+type ComponentsOp = {
+  updateComponents: { surfaceId: string; components: Component[] };
+};
+
+function componentsOf(ops: A2UIOp[]): Component[] {
+  const uc = ops.find((op) => "updateComponents" in op) as
+    | ComponentsOp
+    | undefined;
+  return uc?.updateComponents.components ?? [];
+}
+
+function byId(comps: Component[], id: string): Component | undefined {
+  return comps.find((c) => c.id === id);
+}
+
+/**
+ * a2ui's per-surface componentsModel is a MAP keyed by component id, and the
+ * layout renderers use the id as `key={id}`. So id uniqueness across the whole
+ * emitted tree is a contract, not a nicety: a collision silently overwrites a
+ * card and trips a React duplicate-key warning.
+ */
+function expectUniqueIds(comps: Component[]): void {
+  const ids = comps.map((c) => c.id);
+  expect(new Set(ids).size).toBe(ids.length);
+}
+
+describe("buildBriefOps", () => {
+  it("emits createSurface then updateComponents with a root Stack", () => {
+    const ops = buildBriefOps({ title: "Trading Review — Week 40", kpis: [] });
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toMatchObject({
+      version: "v0.9",
+      createSurface: { surfaceId: SURFACE_ID },
+    });
+    const comps = componentsOf(ops);
+    expect(comps[0]).toMatchObject({ id: "root", component: "Stack" });
+    expect(byId(comps, "heading")).toMatchObject({
+      component: "Heading",
+      text: "Trading Review — Week 40",
+    });
+    expectUniqueIds(comps);
+  });
+
+  it("expands a normal selection unchanged, in order", () => {
+    const comps = componentsOf(
+      buildBriefOps({
+        title: "T",
+        kpis: ["valueAtRisk", "medianMargin"],
+        categoryBreakdown: true,
+        lists: ["belowFloor", "pendingMarkdowns"],
+        summary: "Ahead of Monday's review",
+      }),
+    );
+
+    expect(byId(comps, "kpi-valueAtRisk")).toMatchObject({
+      component: "StatCard",
+      metric: "valueAtRisk",
+      label: "Value at risk",
+    });
+    expect(byId(comps, "kpi-grid")).toMatchObject({
+      component: "Grid",
+      columns: 2,
+      children: ["kpi-valueAtRisk", "kpi-medianMargin"],
+    });
+    expect(byId(comps, "category-breakdown")).toMatchObject({
+      component: "CategoryBreakdown",
+    });
+    expect(byId(comps, "summary")).toMatchObject({
+      component: "Text",
+      tone: "muted",
+    });
+    expect(
+      comps.filter((c) => c.component === "TradingList").map((c) => c.id),
+    ).toEqual(["list-belowFloor", "list-pendingMarkdowns"]);
+    expect(byId(comps, "root")?.children).toEqual([
+      "heading",
+      "summary",
+      "kpi-grid",
+      "category-breakdown",
+      "list-belowFloor",
+      "list-pendingMarkdowns",
+    ]);
+    expectUniqueIds(comps);
+  });
+
+  it("collapses a duplicated KPI selection into exactly one unique card", () => {
+    const comps = componentsOf(
+      buildBriefOps({ title: "T", kpis: ["valueAtRisk", "valueAtRisk"] }),
+    );
+
+    const cards = comps.filter((c) => c.component === "StatCard");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.id).toBe("kpi-valueAtRisk");
+
+    // The grid must reference the single card once, and its column count must
+    // match the de-duplicated child count.
+    expect(byId(comps, "kpi-grid")).toMatchObject({
+      columns: 1,
+      children: ["kpi-valueAtRisk"],
+    });
+    expectUniqueIds(comps);
+  });
+
+  it("collapses a duplicated list selection into exactly one unique list", () => {
+    const comps = componentsOf(
+      buildBriefOps({
+        title: "T",
+        kpis: [],
+        lists: ["belowFloor", "belowFloor"],
+      }),
+    );
+
+    const lists = comps.filter((c) => c.component === "TradingList");
+    expect(lists).toHaveLength(1);
+    expect(lists[0]).toMatchObject({
+      id: "list-belowFloor",
+      kind: "belowFloor",
+    });
+    expect(byId(comps, "root")?.children).toEqual([
+      "heading",
+      "list-belowFloor",
+    ]);
+    expectUniqueIds(comps);
+  });
+
+  it("preserves the order of the distinct selections after de-duplication", () => {
+    const comps = componentsOf(
+      buildBriefOps({
+        title: "T",
+        // Interleaved duplicates: distinct order is belowFloorSkus, valueAtRisk.
+        kpis: [
+          "belowFloorSkus",
+          "valueAtRisk",
+          "belowFloorSkus",
+          "valueAtRisk",
+        ],
+        lists: ["pendingMarkdowns", "belowFloor", "pendingMarkdowns"],
+      }),
+    );
+
+    expect(byId(comps, "kpi-grid")?.children).toEqual([
+      "kpi-belowFloorSkus",
+      "kpi-valueAtRisk",
+    ]);
+    expect(
+      comps.filter((c) => c.component === "TradingList").map((c) => c.id),
+    ).toEqual(["list-pendingMarkdowns", "list-belowFloor"]);
+    expectUniqueIds(comps);
+  });
+
+  it("keeps ids unique across the whole tree for the maximal selection", () => {
+    // Every value-derived id family at once. `pendingMarkdowns` is BOTH a metric
+    // and a list kind, so this is the case the "kpi-"/"list-" prefixes exist for.
+    const comps = componentsOf(
+      buildBriefOps({
+        title: "T",
+        kpis: [...BRIEF_METRICS],
+        categoryBreakdown: true,
+        lists: [...BRIEF_LISTS],
+        summary: "S",
+      }),
+    );
+    expectUniqueIds(comps);
+    expect(comps).toHaveLength(
+      // root + heading + summary + kpi cards + kpi-grid + breakdown + lists
+      1 + 1 + 1 + BRIEF_METRICS.length + 1 + 1 + BRIEF_LISTS.length,
+    );
+  });
+
+  it("carries NO data in the ops — only selections and labels", () => {
+    // This assertion used to be `not.toMatch(/\d{3,}/)`, whose premise was that a
+    // leaked figure runs to three digits. Most do not: a price ("$48.20"), a
+    // margin ("42%"), a day count or a small SKU count all pass a three-digit
+    // check, so the guard was green on precisely the leaks it was written for.
+    //
+    // The premise that DOES hold: given a digit-free title and summary, the
+    // expansion may introduce no digit of its own — every figure on the canvas is
+    // read live by the renderers. So strip the three structural literals that
+    // legitimately carry digits, and nothing numeric may remain.
+    const ops = buildBriefOps({
+      title: "Trading review",
+      kpis: [...BRIEF_METRICS],
+      categoryBreakdown: true,
+      lists: [...BRIEF_LISTS],
+      summary: "Ahead of the review",
+    });
+    const residue = JSON.stringify(ops)
+      // The A2UI protocol version, the catalog URL's version segment, and the
+      // grid's column count. Nothing else in a data-free expansion has a digit.
+      .replaceAll('"version":"v0.9"', "")
+      .replace(/"catalogId":"[^"]*"/g, "")
+      .replace(/"columns":\d+/g, "");
+    expect(
+      residue,
+      "a digit survived a digit-free spec, so the expansion introduced a figure",
+    ).not.toMatch(/\d/);
+  });
+
+  it("extracts the surface id from any op kind", () => {
+    expect(extractSurfaceId(buildBriefOps({ title: "T", kpis: [] }))).toBe(
+      SURFACE_ID,
+    );
+    expect(extractSurfaceId([])).toBeNull();
+  });
+
+  it("rejects an uncatalogued metric or list kind at the schema boundary", () => {
+    expect(
+      renderBriefParams.safeParse({ title: "T", kpis: ["madeUp"] }).success,
+    ).toBe(false);
+    expect(
+      renderBriefParams.safeParse({ title: "T", kpis: [], lists: ["madeUp"] })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/build-brief-ops.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/build-brief-ops.ts
@@ -1,0 +1,206 @@
+import { z } from "zod";
+import { CATALOG_ID } from "./catalog/definitions";
+
+/**
+ * Deterministic A2UI op-builder for Bellwether's Trading Review brief canvas.
+ *
+ * SERVER-SAFE by construction: plain Zod + string constants, no React, no `.tsx`
+ * imports. The skin's `agent.ts` (a server-only module) imports this to define
+ * its render tool, so anything client-flavoured here would drag React into the
+ * runtime bundle.
+ *
+ * The division of labour: the agent picks WHAT to show (the small `renderBrief`
+ * selection below); this module expands that into the verbose A2UI v0.9
+ * operations. Keeping the expansion deterministic — rather than having the model
+ * author the full component JSON inline — is what keeps generation fast and
+ * reliable; the model only emits the tiny selection.
+ *
+ * Data is NEVER carried in the ops. StatCard/CategoryBreakdown/TradingList bind
+ * live client data via `useReportData()` in the catalog renderers. The agent
+ * supplies only metric/list selections + label-only text, so it CANNOT fabricate
+ * a figure — every number on the canvas is read from the ledger the page already
+ * shows.
+ */
+
+/** Must match the A2UI middleware's key so tryParseA2UIOperations detects it. */
+export const A2UI_OPERATIONS_KEY = "a2ui_operations";
+
+export const SURFACE_ID = "trading-review";
+
+export const BRIEF_METRICS = [
+  "ordersOnException",
+  "valueAtRisk",
+  "belowFloorSkus",
+  "medianMargin",
+  "pendingMarkdowns",
+] as const;
+export type BriefMetric = (typeof BRIEF_METRICS)[number];
+
+export const BRIEF_LISTS = [
+  "belowFloor",
+  "exceptionOrders",
+  "pendingMarkdowns",
+] as const;
+export type BriefList = (typeof BRIEF_LISTS)[number];
+
+/** Human captions per KPI — assigned here so the agent needn't supply them. */
+const METRIC_LABELS: Record<BriefMetric, string> = {
+  ordersOnException: "Orders on exception",
+  valueAtRisk: "Value at risk",
+  belowFloorSkus: "SKUs below floor",
+  medianMargin: "Median margin",
+  pendingMarkdowns: "Markdowns pending",
+};
+
+/** Parameters for the render tool (kept intentionally small — SELECTIONS + labels). */
+export const renderBriefParams = z.object({
+  title: z
+    .string()
+    .describe(
+      "Short brief title, e.g. 'Trading Review — Week 40'. LABEL ONLY — no figures, counts, prices, percentages, or trend claims.",
+    ),
+  kpis: z
+    .array(z.enum(BRIEF_METRICS))
+    .describe(
+      "Which KPI stat cards to show, in order: 'ordersOnException', 'valueAtRisk', 'belowFloorSkus', 'medianMargin', 'pendingMarkdowns'. Pick those relevant to the question.",
+    ),
+  categoryBreakdown: z
+    .boolean()
+    .optional()
+    .describe(
+      "Include the margin-ladder category breakdown (the whole live range plotted against each category floor). Omit or false to leave it out.",
+    ),
+  lists: z
+    .array(z.enum(BRIEF_LISTS))
+    .optional()
+    .describe(
+      "Which detail lists to append, in order: 'belowFloor' (products under their category floor), 'exceptionOrders' (orders still stuck) and/or 'pendingMarkdowns' (markdowns awaiting a decision). Omit to leave them out.",
+    ),
+  summary: z
+    .string()
+    .optional()
+    .describe(
+      "Optional one-line NEUTRAL caption under the title. Label-only — no figures, counts, prices, or trends.",
+    ),
+});
+export type RenderBriefSpec = z.infer<typeof renderBriefParams>;
+
+export type A2UIOp = Record<string, unknown> & { version?: string };
+type Component = { id: string; component: string } & Record<string, unknown>;
+
+/**
+ * Expand a brief selection into A2UI v0.9 operations: createSurface +
+ * updateComponents (a FLAT component list, rooted at id "root"). Children are
+ * referenced by id, never embedded — that flat shape is what the A2UI runtime
+ * expects and what the renderers resolve against.
+ */
+export function buildBriefOps(
+  spec: RenderBriefSpec,
+  surfaceId: string = SURFACE_ID,
+): A2UIOp[] {
+  // De-duplicate the selections BEFORE expanding them. zod arrays do not
+  // deduplicate, and this tool is driven by an LLM: a plausible generation like
+  // kpis:["valueAtRisk","valueAtRisk"] would otherwise expand into duplicate
+  // component ids ("kpi-valueAtRisk"), because every id below is derived from the
+  // selection value. A duplicate id is not cosmetic — a2ui's componentsModel is a
+  // MAP keyed by id, so the second entry silently overwrites the first (one card
+  // renders where two were asked for) while the Grid renderer's
+  // `children.map((id) => <Slot key={id} …>)` emits a React duplicate-key warning.
+  // `[...new Set(...)]` keeps first-occurrence order, so this module's
+  // deterministic ordering guarantee is preserved (dedupe never reorders).
+  //
+  // De-duplicating rather than REJECTING is deliberate: this builder feeds the
+  // demo's canvas brief, and a repeated entry is an ordinary model slip with an
+  // unambiguous intent ("show this card"). Throwing would blank the canvas
+  // mid-presentation over a spec we can honour exactly. The schema still rejects
+  // anything uncatalogued, so dedupe never silences a real disagreement.
+  //
+  // The remaining ids are fixed constants ("heading", "summary", "kpi-grid",
+  // "category-breakdown", "root"), and the two value-derived families are
+  // namespaced by disjoint prefixes ("kpi-" vs "list-"), so post-dedupe the whole
+  // emitted tree has unique ids — locked by build-brief-ops.test.ts.
+  const kpis = [...new Set(spec.kpis)];
+  const lists = [...new Set(spec.lists ?? [])];
+
+  const components: Component[] = [];
+  const rootChildren: string[] = [];
+
+  components.push({ id: "heading", component: "Heading", text: spec.title });
+  rootChildren.push("heading");
+
+  if (spec.summary) {
+    components.push({
+      id: "summary",
+      component: "Text",
+      text: spec.summary,
+      tone: "muted",
+    });
+    rootChildren.push("summary");
+  }
+
+  if (kpis.length) {
+    const kpiIds = kpis.map((metric) => {
+      const id = `kpi-${metric}`;
+      // Only the label travels in the op; the VALUE is computed live in the
+      // StatCard renderer from useReportData(). That is the "ops carry no data"
+      // rule in one line.
+      components.push({
+        id,
+        component: "StatCard",
+        metric,
+        label: METRIC_LABELS[metric],
+      });
+      return id;
+    });
+    components.push({
+      id: "kpi-grid",
+      component: "Grid",
+      columns: Math.min(kpis.length, 4),
+      children: kpiIds,
+    });
+    rootChildren.push("kpi-grid");
+  }
+
+  if (spec.categoryBreakdown) {
+    // No props: CategoryBreakdown renders the whole live range on the ladder.
+    components.push({
+      id: "category-breakdown",
+      component: "CategoryBreakdown",
+    });
+    rootChildren.push("category-breakdown");
+  }
+
+  if (lists.length) {
+    for (const kind of lists) {
+      const id = `list-${kind}`;
+      components.push({ id, component: "TradingList", kind });
+      rootChildren.push(id);
+    }
+  }
+
+  // Root goes in FIRST (index 0). The A2UI runtime resolves the tree from the
+  // component whose id is "root", so it must be present; unshift keeps the rest
+  // of the list in authored order for readability.
+  components.unshift({
+    id: "root",
+    component: "Stack",
+    gap: "lg",
+    children: rootChildren,
+  });
+
+  return [
+    { version: "v0.9", createSurface: { surfaceId, catalogId: CATALOG_ID } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
+  ];
+}
+
+/** Read the surfaceId out of an A2UI operation list (any op kind). */
+export function extractSurfaceId(ops: A2UIOp[]): string | null {
+  for (const op of ops) {
+    const target = (op.createSurface ??
+      op.updateComponents ??
+      op.updateDataModel) as { surfaceId?: string } | undefined;
+    if (target?.surfaceId) return target.surfaceId;
+  }
+  return null;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/canvas-surface.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/canvas-surface.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  A2UIProvider,
+  A2UIRenderer,
+  useA2UIActions,
+} from "@copilotkit/a2ui-renderer";
+import { useAgent } from "@copilotkit/react-core/v2";
+import { catalog } from "./catalog";
+import { useCommerceLedger } from "./data/ledger-context";
+import { ReportDataProvider } from "./report-data";
+import { A2UI_OPERATIONS_KEY, extractSurfaceId } from "./build-brief-ops";
+import type { A2UIOp } from "./build-brief-ops";
+
+/**
+ * Bellwether's Trading Review brief canvas — `skin.CanvasSurface`. The shell
+ * owns the canvas region, OGUI rendering and surface-kind detection; this
+ * component renders only this skin's OWN a2ui surface. It binds live commerce
+ * data (via useCommerceLedger → ReportDataProvider) into the catalog renderers
+ * and feeds the agent's brief ops into the A2UI provider.
+ */
+
+/** Minimal shape of an A2UI activity message in the agent's message list. */
+type MaybeActivityMessage = {
+  role?: string;
+  activityType?: string;
+  content?: Record<string, unknown>;
+};
+
+/**
+ * The latest A2UI brief surface in the agent's message stream. The A2UI
+ * middleware turns the render tool result into an `a2ui-surface` activity
+ * message carrying `a2ui_operations`; we read it straight from `agent.messages`,
+ * the pattern the framework's own renderer uses.
+ */
+function useBriefSurface(): { operations: A2UIOp[]; surfaceId: string | null } {
+  const { agent } = useAgent();
+  const messages = agent?.messages as MaybeActivityMessage[] | undefined;
+  if (messages) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i];
+      if (
+        message?.role === "activity" &&
+        message?.activityType === "a2ui-surface"
+      ) {
+        const operations =
+          (message.content?.[A2UI_OPERATIONS_KEY] as A2UIOp[]) ?? [];
+        return {
+          operations,
+          surfaceId: operations.length ? extractSurfaceId(operations) : null,
+        };
+      }
+    }
+  }
+  return { operations: [], surfaceId: null };
+}
+
+export function CommerceCanvasSurface() {
+  // The ledger context is mounted ABOVE this in the skin runtime subtree, so the
+  // canvas reads the SAME snapshot as the pages — the brief and the order book
+  // are never one fetch apart.
+  const { data } = useCommerceLedger();
+  return (
+    <ReportDataProvider
+      value={{
+        products: data.products,
+        floors: data.floors,
+        orders: data.orders,
+        promotions: data.promotions,
+      }}
+    >
+      <A2UIProvider catalog={catalog}>
+        <CanvasInner />
+      </A2UIProvider>
+    </ReportDataProvider>
+  );
+}
+
+function CanvasInner() {
+  const { operations, surfaceId } = useBriefSurface();
+  const hasContent = operations.length > 0 && !!surfaceId;
+
+  return (
+    <>
+      {surfaceId ? (
+        <SurfaceMessageProcessor
+          operations={operations}
+          surfaceId={surfaceId}
+        />
+      ) : null}
+      {hasContent ? (
+        <div className="h-full overflow-y-auto">
+          <div className="a2ui-surface p-6 md:p-8" data-testid="a2ui-surface">
+            <A2UIRenderer surfaceId={surfaceId} />
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Feeds the surface's operations into the A2UI provider. The activity content
+ * carries the FULL operation list on each snapshot, so we strip a duplicate
+ * createSurface once the surface exists (the MessageProcessor throws if asked to
+ * create a surface that already exists) and skip re-processing identical op
+ * lists via a hash. Mirrors the framework's built-in SurfaceMessageProcessor.
+ */
+function SurfaceMessageProcessor({
+  operations,
+  surfaceId,
+}: {
+  operations: A2UIOp[];
+  surfaceId: string;
+}) {
+  const { processMessages, getSurface } = useA2UIActions();
+  const lastHashRef = useRef("");
+
+  useEffect(() => {
+    if (!operations.length) return;
+    const hash = JSON.stringify(operations);
+    if (hash === lastHashRef.current) return;
+    lastHashRef.current = hash;
+
+    const isExisting = !!getSurface(surfaceId);
+    const ops = isExisting
+      ? operations.filter((op) => !("createSurface" in op))
+      : operations;
+    if (!ops.length) return;
+    try {
+      processMessages(ops as Array<Record<string, unknown>>);
+    } catch (err) {
+      console.warn("[commerce-canvas] processMessages threw:", err);
+    }
+  }, [operations, processMessages, getSurface, surfaceId]);
+
+  return null;
+}
+
+export default CommerceCanvasSurface;

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/catalog/definitions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/catalog/definitions.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+/**
+ * Bellwether's a2ui catalog — the component vocabulary the Trading Review brief
+ * is assembled from. It is the CONTRACT between the agent's tiny selection and
+ * the deterministic op-builder (`build-brief-ops.ts`) that expands it.
+ *
+ * The cardinal rule lives in these descriptions: layout + label components may
+ * carry text, but every FIGURE (order counts, value at risk, margins, prices) is
+ * bound to live client data inside the renderers via `useReportData()`. The
+ * agent never passes a number, so it can never fabricate one — see the
+ * description prose on Heading/Text/StatCard/CategoryBreakdown/TradingList.
+ */
+
+export const CATALOG_ID = "https://cpk-a2ui.local/catalogs/commerce/v1";
+
+// A single child id / a list of child ids. Layout components reference their
+// children BY ID (the components list is flat, rooted at "root"); they never
+// embed the child objects. `stringOrPath` is a2ui's "literal string OR a
+// data-bound { path }" union — text props accept either, though Bellwether's
+// builder only ever emits literals (all data binding happens in the renderers).
+const childRef = z.string();
+const childrenRef = z.array(z.string());
+const stringOrPath = z.union([z.string(), z.object({ path: z.string() })]);
+
+export const definitions = {
+  Stack: {
+    description:
+      "Vertical layout. Children stack top→bottom. The default brief/section container.",
+    props: z.object({
+      children: childrenRef,
+      gap: z.enum(["sm", "md", "lg", "xl"]).optional(),
+    }),
+  },
+  Row: {
+    description:
+      "Horizontal layout; wraps on small screens. Use for metric rows or chip groups.",
+    props: z.object({
+      children: childrenRef,
+      gap: z.enum(["sm", "md", "lg"]).optional(),
+    }),
+  },
+  Grid: {
+    description:
+      "Responsive grid. Use for a row of StatCards (the KPI band across the top of the brief).",
+    props: z.object({
+      children: childrenRef,
+      columns: z.number().int().min(1).max(4).optional(),
+    }),
+  },
+  Section: {
+    description:
+      "Titled section grouping a region of the brief (e.g. 'Margin health').",
+    props: z.object({ title: z.string(), child: childRef }),
+  },
+  Heading: {
+    description:
+      "The brief title — a LABEL ONLY. Use once at the top. Do NOT embed figures, " +
+      "counts, prices, percentages, or trend claims (e.g. NOT 'Margin down 3pts') — " +
+      "all quantitative content comes from StatCard/CategoryBreakdown/TradingList.",
+    props: z.object({ text: stringOrPath }),
+  },
+  Text: {
+    description:
+      "A short NEUTRAL caption or section label (e.g. 'Ahead of Monday's trading review'). " +
+      "Label-only: do NOT state figures, counts, prices, percentages, deltas, or trend " +
+      "claims — every quantitative claim must come from StatCard/CategoryBreakdown/" +
+      "TradingList, which bind live client data. Use tone='muted' for secondary captions.",
+    props: z.object({
+      text: stringOrPath,
+      tone: z.enum(["default", "muted"]).optional(),
+    }),
+  },
+  StatCard: {
+    description:
+      "A single KPI computed live on the client. `metric` selects which: 'ordersOnException' " +
+      "(orders still stuck in the queue), 'valueAtRisk' (the total value of those orders), " +
+      "'belowFloorSkus' (products whose margin sits under their category floor), " +
+      "'medianMargin' (the range's median gross margin), 'pendingMarkdowns' (markdowns " +
+      "waiting on a decision). Provide `label` for the caption. Do NOT pass the value.",
+    props: z.object({
+      metric: z.enum([
+        "ordersOnException",
+        "valueAtRisk",
+        "belowFloorSkus",
+        "medianMargin",
+        "pendingMarkdowns",
+      ]),
+      label: stringOrPath,
+    }),
+  },
+  CategoryBreakdown: {
+    description:
+      "The signature margin ladder: one rail per category, every product plotted at its " +
+      "gross margin against that category's own floor, with anything under its floor drawn " +
+      "in red beneath the line. Takes NO props — it renders the whole live range bound on " +
+      "the client. Include it once when the brief is about margin, pricing or the range.",
+    props: z.object({}),
+  },
+  TradingList: {
+    description:
+      "A live detail list. `kind` selects which: 'belowFloor' (each product trading under " +
+      "its category floor, with the gap in margin points), 'exceptionOrders' (each order " +
+      "still carrying an exception, with the customer, the exception and the value) or " +
+      "'pendingMarkdowns' (each markdown awaiting a decision, with the margin it would " +
+      "trade at). Rows are bound on the client — do NOT pass names, figures, or rows.",
+    props: z.object({
+      kind: z.enum(["belowFloor", "exceptionOrders", "pendingMarkdowns"]),
+    }),
+  },
+};
+
+export type Definitions = typeof definitions;

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/catalog/index.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/catalog/index.ts
@@ -1,0 +1,12 @@
+import { createCatalog, extractSchema } from "@copilotkit/a2ui-renderer";
+import { CATALOG_ID, definitions } from "./definitions";
+import { renderers } from "./renderers";
+
+export const catalog = createCatalog(definitions, renderers, {
+  catalogId: CATALOG_ID,
+  includeBasicCatalog: false,
+});
+
+export const catalogSchema = extractSchema(definitions);
+
+export { CATALOG_ID, definitions };

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/catalog/renderers.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/catalog/renderers.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import type { RendererProps } from "@copilotkit/a2ui-renderer";
+import { cn } from "@/lib/utils";
+import { MarginLadder } from "../components/margin-ladder";
+import { SkuTile } from "../components/sku-tile";
+import {
+  EmptyState,
+  Metric,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+import {
+  ORDER_EXCEPTION_LABEL,
+  ageInDays,
+  belowFloorCount,
+  formatMargin,
+  formatMoney,
+  noFloorCaveat,
+  ordersOnException,
+  productMargin,
+  productPosition,
+  promotionFloorStatus,
+  promotionMargin,
+  tallyFloorStatus,
+  valueAtRisk,
+} from "../data/derive";
+import type { MarginPosition, Product } from "../data/types";
+import { useReportData } from "../report-data";
+
+const GAP = { sm: "gap-2", md: "gap-4", lg: "gap-6", xl: "gap-10" } as const;
+
+// Text props in the catalog are `string | { path }` (a data-bound ref). The A2UI
+// runtime resolves refs before render, but the Zod-inferred type still carries
+// the union, so coerce to a display string here.
+type TextRef = string | { path: string };
+const asText = (value: TextRef): string =>
+  typeof value === "string" ? value : "";
+
+function Slot({ render }: { render: React.ReactNode }) {
+  return <>{render}</>;
+}
+
+// --- Layout primitives (mirror banking/logistics/people exactly) ------------
+
+const Stack = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; gap?: keyof typeof GAP }>) => (
+  <div className={cn("flex flex-col", GAP[props.gap ?? "md"])}>
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Row = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; gap?: "sm" | "md" | "lg" }>) => (
+  <div className={cn("flex flex-wrap", GAP[props.gap ?? "md"])}>
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Grid = ({
+  props,
+  children,
+}: RendererProps<{ children: string[]; columns?: number }>) => (
+  <div
+    className="grid gap-4"
+    style={{
+      gridTemplateColumns: `repeat(${props.columns ?? 3}, minmax(0, 1fr))`,
+    }}
+  >
+    {props.children?.map((id) => (
+      <Slot key={id} render={children(id)} />
+    ))}
+  </div>
+);
+
+const Section = ({
+  props,
+  children,
+}: RendererProps<{ title: string; child: string }>) => (
+  <section className="space-y-3">
+    <h2 className="text-lg font-semibold text-ink">{props.title}</h2>
+    <Slot render={children(props.child)} />
+  </section>
+);
+
+const Heading = ({ props }: RendererProps<{ text: TextRef }>) => (
+  <h1 className="text-2xl font-semibold tracking-tight text-ink">
+    {asText(props.text)}
+  </h1>
+);
+
+const Text = ({
+  props,
+}: RendererProps<{ text: TextRef; tone?: "default" | "muted" }>) => (
+  <p
+    className={cn(
+      "text-sm",
+      props.tone === "muted" ? "text-ink-muted" : "text-ink",
+    )}
+  >
+    {asText(props.text)}
+  </p>
+);
+
+// --- Live, data-bound widgets ----------------------------------------------
+// Every figure below is computed HERE from useReportData(), never read from a
+// prop. The catalog op only ever named the metric/kind; the numbers are the
+// ledger's, so the agent can select but never fabricate.
+
+const StatCard = ({
+  props,
+}: RendererProps<{
+  metric:
+    | "ordersOnException"
+    | "valueAtRisk"
+    | "belowFloorSkus"
+    | "medianMargin"
+    | "pendingMarkdowns";
+  label: TextRef;
+}>) => {
+  const { products, floors, orders, promotions } = useReportData();
+
+  let value = "—";
+  let hint: string | null = null;
+  let tone: "neutral" | "brand" | "positive" | "negative" | "markdown" =
+    "neutral";
+
+  switch (props.metric) {
+    case "ordersOnException": {
+      const n = ordersOnException(orders).length;
+      value = String(n);
+      tone = n > 0 ? "negative" : "positive";
+      break;
+    }
+    case "valueAtRisk":
+      value = formatMoney(valueAtRisk(orders));
+      break;
+    case "belowFloorSkus": {
+      const n = belowFloorCount(floors, products);
+      // Below-floor is the exception the whole skin is about — flag it red when
+      // there is anything to act on, quiet green when the range is clean, and an
+      // em dash when a missing category floor means it CANNOT be called clean.
+      // A green `0` here would be a fabricated all-clear on the canvas.
+      value = n === null ? "—" : String(n);
+      tone = n === null || n > 0 ? "negative" : "positive";
+      hint = noFloorCaveat(tallyFloorStatus(floors, products).unknown);
+      break;
+    }
+    case "medianMargin": {
+      const margins = products.map(productMargin).sort((a, b) => a - b);
+      if (margins.length) {
+        const mid = Math.floor(margins.length / 2);
+        const median =
+          margins.length % 2 === 0
+            ? (margins[mid - 1] + margins[mid]) / 2
+            : margins[mid];
+        value = formatMargin(median);
+      }
+      tone = "brand";
+      break;
+    }
+    case "pendingMarkdowns":
+      value = String(promotions.filter((p) => p.status === "pending").length);
+      tone = "markdown";
+      break;
+  }
+
+  return (
+    <Metric
+      label={asText(props.label)}
+      value={value}
+      hint={hint ?? undefined}
+      tone={tone}
+    />
+  );
+};
+
+const CategoryBreakdown = () => {
+  const { products, floors } = useReportData();
+  if (!products.length || !floors.length) {
+    return (
+      <Panel>
+        <EmptyState
+          title="No range to plot"
+          hint="Once the ledger loads, every product appears on the margin ladder against its own category floor."
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Category breakdown</SectionLabel>
+      <MarginLadder floors={floors} products={products} />
+    </Panel>
+  );
+};
+
+function BelowFloorList() {
+  const { products, floors } = useReportData();
+  // Carry each row's POSITION rather than re-finding its floor below: a row is
+  // only in this list because it has a floor, so the floor comes back non-null
+  // and there is no lookup left to default. (It used to end `?? 0`, which would
+  // have printed a nonsense "−45pt under" out of a missing floor.)
+  const rows = products
+    .map((item) => ({ item, position: productPosition(floors, item) }))
+    .filter(
+      (row): row is { item: Product; position: MarginPosition } =>
+        row.position !== null && row.position.belowFloor,
+    );
+  const caveat = noFloorCaveat(tallyFloorStatus(floors, products).unknown);
+  if (!rows.length) {
+    return (
+      <Panel>
+        <SectionLabel>Below floor</SectionLabel>
+        {/* Only ever an all-clear when the whole range was actually checked. */}
+        <EmptyState
+          title={
+            caveat
+              ? "The range could not be fully checked"
+              : "Every product is above its floor"
+          }
+          hint={
+            caveat
+              ? `${caveat}. No SKU with a floor on file is trading under it.`
+              : "No SKU is trading under its category minimum — there is nothing to escalate at the review."
+          }
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Below floor</SectionLabel>
+      {caveat ? (
+        <p className="mb-2 text-[0.72rem] text-negative">{caveat}.</p>
+      ) : null}
+      <ul className="divide-y divide-hairline">
+        {rows.map(({ item, position }) => {
+          const margin = productMargin(item);
+          const { floor } = position;
+          return (
+            <li
+              key={item.id}
+              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+            >
+              <SkuTile name={item.name} size="sm" ring="negative" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-ink">
+                  {item.name}
+                </div>
+                <div className="bw-num truncate text-[0.72rem] text-ink-muted">
+                  {item.sku} · {item.category}
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="bw-num text-sm font-semibold text-ink">
+                  {formatMargin(margin)}
+                </span>
+                <Pill tone="negative">
+                  {formatMargin(floor - margin).replace("%", "")}pt under
+                </Pill>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </Panel>
+  );
+}
+
+function ExceptionOrdersList() {
+  const { orders } = useReportData();
+  const rows = ordersOnException(orders);
+  if (!rows.length) {
+    return (
+      <Panel>
+        <SectionLabel>Orders on exception</SectionLabel>
+        <EmptyState
+          title="The queue is clear"
+          hint="No order is waiting on a decision — the review can skip the exception queue."
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Orders on exception</SectionLabel>
+      <ul className="divide-y divide-hairline">
+        {[...rows]
+          .sort((a, b) => a.placedAt.localeCompare(b.placedAt))
+          .map((order) => {
+            const age = ageInDays(order.placedAt);
+            return (
+              <li
+                key={order.id}
+                className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+              >
+                <SkuTile
+                  name={order.customerName}
+                  size="sm"
+                  shape="round"
+                  ring="negative"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="bw-num shrink-0 text-[0.72rem] text-ink-muted">
+                      #{order.number}
+                    </span>
+                    <span className="truncate text-sm font-medium text-ink">
+                      {order.customerName}
+                    </span>
+                    <Pill tone="negative">
+                      {ORDER_EXCEPTION_LABEL[order.exception]}
+                    </Pill>
+                  </div>
+                  <div className="truncate text-[0.72rem] text-ink-muted">
+                    {order.destination}
+                  </div>
+                </div>
+                <div className="flex shrink-0 flex-col items-end">
+                  <span className="bw-num text-sm font-semibold text-ink">
+                    {formatMoney(order.total)}
+                  </span>
+                  <span className="bw-num text-[0.68rem] text-ink-muted">
+                    {age === 0 ? "today" : `${age}d ago`}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+      </ul>
+    </Panel>
+  );
+}
+
+function PendingMarkdownsList() {
+  const { promotions, products, floors } = useReportData();
+  const rows = promotions.filter((p) => p.status === "pending");
+  if (!rows.length) {
+    return (
+      <Panel>
+        <SectionLabel>Markdowns pending</SectionLabel>
+        <EmptyState
+          title="Nothing waiting on a decision"
+          hint="Every markdown the desk has raised has been approved or declined."
+        />
+      </Panel>
+    );
+  }
+  return (
+    <Panel>
+      <SectionLabel>Markdowns pending</SectionLabel>
+      <ul className="divide-y divide-hairline">
+        {rows.map((promotion) => {
+          const item = products.find((p) => p.id === promotion.productId);
+          const floor =
+            floors.find((f) => f.category === item?.category)?.floor ?? null;
+          const margin = promotionMargin(item, promotion);
+          // Tri-state, so a markdown whose floor is missing is not painted as a
+          // healthy one: `unknown` keeps the markdown ring and the neutral ink.
+          //
+          // The MARGIN still prints — it is a real, computed figure, and blanking
+          // it would throw away a fact the ledger does have. What must not happen
+          // is the FLOOR line going quiet: this comment used to claim both figures
+          // rendered as em dashes while the code printed a real margin beside a
+          // bare `floor —`, which reads as "nothing to report" rather than "never
+          // checked". The line below says which it is, the way the catalog's own
+          // row does ("· no floor").
+          const status = promotionFloorStatus(floors, item, promotion);
+          const below = status === "below";
+          return (
+            <li
+              key={promotion.id}
+              className="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0"
+            >
+              <SkuTile
+                name={item?.name ?? promotion.name}
+                size="sm"
+                ring={below ? "negative" : "markdown"}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium text-ink">
+                    {promotion.name}
+                  </span>
+                  <Pill tone="markdown">−{promotion.discountPercent}%</Pill>
+                </div>
+                <div className="truncate text-[0.72rem] text-ink-muted">
+                  {item?.name ?? "Unknown product"} · {item?.category ?? "—"}
+                </div>
+              </div>
+              <div className="flex shrink-0 flex-col items-end">
+                <span
+                  className={cn(
+                    "bw-num text-sm font-semibold",
+                    below ? "text-negative" : "text-ink",
+                  )}
+                >
+                  {margin === null ? "—" : formatMargin(margin)}
+                </span>
+                <span className="bw-num text-[0.68rem] text-ink-muted">
+                  {floor === null
+                    ? "no floor on file"
+                    : `floor ${formatMargin(floor)}`}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </Panel>
+  );
+}
+
+const TradingList = ({
+  props,
+}: RendererProps<{
+  kind: "belowFloor" | "exceptionOrders" | "pendingMarkdowns";
+}>) => {
+  if (props.kind === "belowFloor") return <BelowFloorList />;
+  if (props.kind === "exceptionOrders") return <ExceptionOrdersList />;
+  return <PendingMarkdownsList />;
+};
+
+export const renderers = {
+  Stack,
+  Row,
+  Grid,
+  Section,
+  Heading,
+  Text,
+  StatCard,
+  CategoryBreakdown,
+  TradingList,
+};

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/category-argument.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/category-argument.test.tsx
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { z } from "zod";
+import {
+  CATEGORY_VOCABULARY,
+  categoryParameter,
+  resolveCategoryScope,
+} from "./category-argument";
+import * as store from "./data/store";
+import { CATEGORIES } from "./data/types";
+import type { Operator } from "./data/types";
+
+/**
+ * BEAT 1 — the signature visual, driven by a MODEL-SUPPLIED argument.
+ *
+ * `showMarginLadder`'s category was a `z.string()`, and the fallback for a value
+ * that matched nothing applied to the FLOORS only. So a near-miss — "Shoes" for
+ * "Footwear" — drew all five rails, filtered the products to zero, and rendered
+ * a full, confident, EMPTY ladder. That is the worst available outcome for this
+ * component: it looks like an answer.
+ *
+ * Two halves are tested, because neither is sufficient:
+ *
+ *  - the SCHEMA now enumerates the five categories, which is what puts them in
+ *    front of the model;
+ *  - the RENDER refuses an off-vocabulary value, because the schema is NOT
+ *    enforced before a render runs. `useComponent` forwards
+ *    `partialJSONParse(toolCall.function.arguments)` straight through
+ *    (`use-render-tool-call.tsx`), and a render-only tool posts an empty tool
+ *    result, so an unvalidated argument reaches the DOM and nothing is reported
+ *    back. A tightened schema alone would be decorative.
+ *
+ * The `arriving` case is the third assertion and it is not hypothetical:
+ * arguments stream, so `"F"`, `"Fo"`, `"Foot"` all reach this render on the way
+ * to `"Footwear"`. A refusal there would flash red on every ladder the demo
+ * draws.
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+const components = new Map<string, ComponentRegistration>();
+
+/** Only the parts of a `useComponent` registration these tests exercise. */
+interface ComponentRegistration {
+  name: string;
+  parameters?: z.ZodType<unknown>;
+  render: (props: Record<string, unknown>) => ReactNode;
+}
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: () => {} }),
+  usePathname: () => "/commerce",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+  useComponent: (registration: ComponentRegistration) => {
+    components.set(registration.name, registration);
+  },
+  useFrontendTool: () => {},
+  useHumanInTheLoop: () => {},
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("./data/ledger-context", async () => {
+  const real = await import("./data/store");
+  return {
+    useCommerceLedger: () => ({
+      data: real.snapshot(),
+      refresh: async () => true,
+      operator: real.operators()[0] satisfies Operator,
+      setOperatorId: () => {},
+    }),
+  };
+});
+
+// Imported after the mocks so the module graph picks them up.
+const { CommerceTools } = await import("./tools");
+
+function ladder(): ComponentRegistration {
+  const registration = components.get("showMarginLadder");
+  if (!registration) throw new Error("showMarginLadder was not registered");
+  return registration;
+}
+
+/** Render the ladder component exactly as a tool call would, and read the DOM. */
+function renderLadder(args: Record<string, unknown>) {
+  const Ladder = ladder().render;
+  render(<>{Ladder(args)}</>);
+  const figure = document.querySelector("figure");
+  return {
+    /** The ladder itself — `MarginLadder` roots at a `<figure>`. */
+    figure,
+    /** One button per plotted product. */
+    dots: document.querySelectorAll("figure button").length,
+    /**
+     * Which rails are drawn. Read off the rendered text rather than a class
+     * name: a rail is labelled with its category and nothing else in the ladder
+     * names one, so this stays true through any styling change.
+     */
+    rails: CATEGORIES.filter((category) =>
+      (figure?.textContent ?? "").includes(category),
+    ),
+    text: document.body.textContent ?? "",
+  };
+}
+
+beforeEach(() => {
+  store.reset();
+  components.clear();
+  render(<CommerceTools />);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the advertised category vocabulary", () => {
+  it("enumerates the five real categories rather than accepting any string", () => {
+    const parameters = ladder().parameters;
+    if (!parameters) throw new Error("showMarginLadder declared no parameters");
+
+    for (const category of CATEGORIES) {
+      expect(parameters.safeParse({ category }).success, category).toBe(true);
+    }
+    // Omitted is still legal — that is the whole range.
+    expect(parameters.safeParse({}).success).toBe(true);
+    // And a near-miss is a validation error, not a blank view.
+    for (const bogus of ["Shoes", "footware", "Apparel", ""]) {
+      expect(parameters.safeParse({ category: bogus }).success, bogus).toBe(
+        false,
+      );
+    }
+  });
+
+  it("names the accepted values in the description the model reads", () => {
+    expect(categoryParameter.description).toContain("Footwear");
+    for (const category of CATEGORIES) {
+      expect(CATEGORY_VOCABULARY).toContain(category);
+    }
+  });
+});
+
+describe("an off-vocabulary category", () => {
+  it("does not render a confident empty ladder", () => {
+    const { figure, dots } = renderLadder({ category: "Shoes" });
+
+    // The finding itself: no ladder at all, rather than five rails and no dots.
+    expect(figure).toBeNull();
+    expect(dots).toBe(0);
+  });
+
+  it("says the category is unknown and lists the real ones", () => {
+    const { text } = renderLadder({ category: "Shoes" });
+
+    expect(text).toContain("Shoes");
+    expect(text).toMatch(/no “Shoes” category/);
+    for (const category of CATEGORIES) {
+      expect(text, category).toContain(category);
+    }
+  });
+
+  it("quotes a non-string argument back without laundering it into words", () => {
+    const { figure, text } = renderLadder({ category: { name: "Footwear" } });
+
+    expect(figure).toBeNull();
+    expect(text).not.toContain("[object Object]");
+  });
+});
+
+describe("every legitimate category still renders", () => {
+  it.each([...CATEGORIES])("plots %s on its own rail", (category) => {
+    const { figure, dots, rails } = renderLadder({ category });
+
+    expect(figure).not.toBeNull();
+    // One rail, its own, with real products on it.
+    expect(rails).toEqual([category]);
+    expect(dots).toBeGreaterThan(0);
+  });
+
+  it("accepts the same name in the wrong case rather than blanking", () => {
+    const { figure, rails } = renderLadder({ category: "  footwear " });
+
+    expect(figure).not.toBeNull();
+    expect(rails).toEqual(["Footwear"]);
+  });
+
+  it("draws every rail when no category was asked for", () => {
+    const { figure, rails, dots } = renderLadder({});
+
+    expect(figure).not.toBeNull();
+    expect(rails).toEqual([...CATEGORIES]);
+    expect(dots).toBe(store.snapshot().products.length);
+  });
+
+  it("draws the whole range while the argument is still streaming", () => {
+    // `partialJSONParse` hands the render every prefix of the value. A refusal
+    // here would flash red on every categorised ladder in the demo.
+    for (const prefix of ["F", "Fo", "Foot", "Knit"]) {
+      const { figure, dots } = renderLadder({ category: prefix });
+      expect(figure, prefix).not.toBeNull();
+      expect(dots, prefix).toBeGreaterThan(0);
+      cleanup();
+    }
+  });
+});
+
+describe("resolveCategoryScope", () => {
+  it("reports an absent or blank category as the whole range", () => {
+    expect(resolveCategoryScope(undefined)).toEqual({ kind: "all" });
+    expect(resolveCategoryScope(null)).toEqual({ kind: "all" });
+    expect(resolveCategoryScope("")).toEqual({ kind: "all" });
+    expect(resolveCategoryScope("   ")).toEqual({ kind: "all" });
+  });
+
+  it("canonicalizes every real category", () => {
+    for (const category of CATEGORIES) {
+      expect(resolveCategoryScope(category)).toEqual({ kind: "one", category });
+      expect(resolveCategoryScope(` ${category.toUpperCase()} `)).toEqual({
+        kind: "one",
+        category,
+      });
+    }
+  });
+
+  it("separates a streaming prefix from a value that is simply wrong", () => {
+    expect(resolveCategoryScope("Foot")).toEqual({
+      kind: "arriving",
+      value: "Foot",
+    });
+    expect(resolveCategoryScope("Shoes")).toEqual({
+      kind: "unknown",
+      value: "Shoes",
+    });
+    expect(resolveCategoryScope(42)).toEqual({ kind: "unknown", value: "42" });
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/category-argument.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/category-argument.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+import { CATEGORIES } from "./data/types";
+import type { Category } from "./data/types";
+
+/**
+ * THE CATEGORY ARGUMENT — the one model-authored value in this skin that has to
+ * name a member of a CLOSED set, and the two halves of getting that right.
+ *
+ * Same shape as `order-queue-levers.ts` and for the same reason: an untrusted
+ * argument arrives, and something pure has to turn it into a value the view can
+ * be drawn from. Both halves are needed, and neither substitutes for the other.
+ *
+ *  1. `categoryParameter` ADVERTISES the vocabulary. `z.enum(CATEGORIES)`
+ *     serializes to a JSON-Schema `enum` (zod-to-json-schema, via
+ *     `schemaToJsonSchema` in `@copilotkit/shared`), so the accepted values ride
+ *     along with the tool definition instead of being something the model has to
+ *     infer from the ledger readable — and the description repeats them, so they
+ *     are there for a model reading prose too. This is the half that PREVENTS a
+ *     near-miss.
+ *
+ *  2. `resolveCategoryScope` ENFORCES it at the point of use, because in a
+ *     render NOTHING ELSE DOES. A `useComponent` render is handed
+ *     `partialJSONParse(toolCall.function.arguments)` verbatim
+ *     (`use-render-tool-call.tsx` in `@copilotkit/react-core`); the schema it
+ *     registered is only ever serialized as documentation. There is no channel
+ *     to report the bad value back on either: a render-only tool has no handler,
+ *     and `executeSpecificTool` (core's `run-handler.ts`) then posts an EMPTY
+ *     tool result. So "Shoes" for "Footwear" used to filter the products to
+ *     nothing, leave the floors unfiltered by a fallback, and draw a full
+ *     five-rail ladder with zero dots on it — Bellwether's signature visual,
+ *     rendering a guess as an answer.
+ *
+ * The `arriving` state is not decoration. Arguments STREAM, and the render runs
+ * throughout, so every categorised call passes through `"F"`, `"Fo"`, `"Foot"`
+ * on its way to `"Footwear"`. Refusing those would flash a red card in front of
+ * the room on every single ladder the demo draws. A value that is still a prefix
+ * of a real category is therefore treated as "not arrived yet" and draws the
+ * whole range, exactly as an omitted category does — the same rule
+ * `normalizeQueueLevers` follows when a lever has not landed.
+ */
+
+/**
+ * A single category, as the model must spell it. Shared with
+ * `sandbox-functions.ts` so the OGUI sandbox and the chat's gen-UI advertise ONE
+ * vocabulary rather than two that can drift.
+ */
+export const categoryParameter = z
+  .enum(CATEGORIES)
+  .describe(
+    `Exact category name, spelling and case included. One of: ${CATEGORIES.join(", ")}.`,
+  );
+
+/** Every category, as the list a refusal has to end with. */
+export const CATEGORY_VOCABULARY = CATEGORIES.join(", ");
+
+export type CategoryScope =
+  /** No category asked for: the whole range. */
+  | { kind: "all" }
+  /** Still a prefix of a real category — the arguments are mid-stream. */
+  | { kind: "arriving"; value: string }
+  /** One real category, canonically spelled. */
+  | { kind: "one"; category: Category }
+  /** Off-vocabulary. Nothing may be drawn from this. */
+  | { kind: "unknown"; value: string };
+
+/**
+ * A short, safe rendering of whatever arrived. `String(value)` is not used: it
+ * turns `{}` into the deceptively word-like `"[object Object]"`, and this string
+ * is quoted back to the user inside the refusal.
+ */
+function label(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? typeof value;
+}
+
+/**
+ * The category as the ladder may actually be drawn from.
+ *
+ * Case and surrounding space are FOLDED rather than refused: "footwear" is
+ * unambiguously Footwear, and blanking the signature visual over a lowercase
+ * letter would be the same failure this function exists to prevent. Anything
+ * that is not a category and not a prefix of one is `unknown`, and the caller
+ * must say so instead of drawing.
+ */
+export function resolveCategoryScope(value: unknown): CategoryScope {
+  if (value === undefined || value === null) return { kind: "all" };
+  if (typeof value !== "string") {
+    return { kind: "unknown", value: label(value) };
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === "") return { kind: "all" };
+
+  const folded = trimmed.toLowerCase();
+  const exact = CATEGORIES.find(
+    (category) => category.toLowerCase() === folded,
+  );
+  if (exact) return { kind: "one", category: exact };
+
+  const prefixOfOne = CATEGORIES.some((category) =>
+    category.toLowerCase().startsWith(folded),
+  );
+  if (prefixOfOne) return { kind: "arriving", value: trimmed };
+  return { kind: "unknown", value: trimmed };
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/list-keys.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/list-keys.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { keyedList } from "./list-keys";
+
+/**
+ * The plan lists these keys serve are model-authored and de-duplicated NOWHERE
+ * on the way in, so "unique even when the values repeat" is the property under
+ * test — not an incidental nicety.
+ */
+describe("keyedList", () => {
+  it("keeps every row, in order", () => {
+    const rows = ["a", "b", "c"];
+    expect(keyedList(rows, (r) => r).map((k) => k.item)).toEqual(rows);
+  });
+
+  it("emits unique keys for duplicate values", () => {
+    const keys = keyedList(["a", "a", "a", "b"], (r) => r).map((k) => k.key);
+    expect(keys).toHaveLength(4);
+    expect(new Set(keys).size).toBe(4);
+  });
+
+  it("keys the first occurrence by value, not by position", () => {
+    const first = keyedList(["x", "dup", "dup"], (r) => r);
+    const shifted = keyedList(["y", "dup", "dup"], (r) => r);
+    // "dup"'s first-occurrence key is identical in both lists even though a
+    // different value sits ahead of it — an index-only key would not be.
+    expect(first[1].key).toBe(shifted[1].key);
+    expect(first[1].key).not.toBe(first[2].key);
+  });
+
+  it("cannot collide a repeat with a value that spells the repeat's key", () => {
+    // Without escaping, the second "a" ("a#2") would collide with the literal
+    // value "a#2" keyed on its first occurrence.
+    const keys = keyedList(["a", "a", "a#2"], (r) => r).map((k) => k.key);
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("stays unique when the identity is empty for several rows", () => {
+    // The plans route admits a row with an empty sku (name-only), so the
+    // identity we derive can legitimately be "" more than once.
+    const rows = [
+      { sku: "", name: "" },
+      { sku: "", name: "" },
+    ];
+    const keys = keyedList(rows, (r) => r.sku || r.name).map((k) => k.key);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("derives the key from the identity function, not the item", () => {
+    const rows = [
+      { sku: "BW-1", units: 10 },
+      { sku: "BW-1", units: 40 },
+    ];
+    const keys = keyedList(rows, (r) => r.sku).map((k) => k.key);
+    expect(keys[0]).toContain("BW-1");
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("returns an empty list unchanged", () => {
+    expect(keyedList([], (r: string) => r)).toEqual([]);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/list-keys.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/list-keys.ts
@@ -1,0 +1,46 @@
+/**
+ * Stable, collision-free React keys for lists whose rows carry NO id.
+ *
+ * A restock plan's `highlights`, `lines` and `schedule` are authored by the
+ * MODEL reading an uploaded price sheet, and nothing on the way in makes them
+ * distinct: the tool's zod schema only caps their length, the plans route only
+ * maps/filters/slices, and `store.filePlan` only slices. So two identical
+ * highlight strings, or two rows for the same SKU (a repeated line on the sheet,
+ * or the same SKU quoted at two pack sizes), are a NORMAL outcome — and keying
+ * such a row by its own value hands React duplicate keys, which silently
+ * corrupts reconciliation instead of failing loudly.
+ *
+ * Keys are the row's identity plus its 1-based occurrence count, so the first
+ * occurrence of a value keeps a value-derived (order-independent) key and only
+ * repeats are disambiguated. `#` and `%` in the identity are percent-escaped
+ * first, which is what makes the result provably unique: the separator cannot
+ * appear inside the escaped identity, the escape is injective, and each
+ * (identity, occurrence) pair is by construction distinct.
+ */
+
+export interface Keyed<T> {
+  key: string;
+  item: T;
+}
+
+const escapeIdentity = (value: string) =>
+  value.replace(/[#%]/g, (char) => (char === "#" ? "%23" : "%25"));
+
+/**
+ * Pair every item with a unique React key derived from `identity(item)`.
+ *
+ * @param items    the rows to render, in render order
+ * @param identity the row's natural identity — need not be unique
+ */
+export function keyedList<T>(
+  items: readonly T[],
+  identity: (item: T) => string,
+): Keyed<T>[] {
+  const seen = new Map<string, number>();
+  return items.map((item) => {
+    const base = escapeIdentity(identity(item));
+    const occurrence = (seen.get(base) ?? 0) + 1;
+    seen.set(base, occurrence);
+    return { key: `${base}#${occurrence}`, item };
+  });
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/margin-ladder.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/margin-ladder.test.tsx
@@ -1,0 +1,456 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import {
+  FAN_LEGIBLE_MAX,
+  FAN_MAX_FRACTION,
+  MarginLadder,
+  fanLeft,
+  fanOffsets,
+  ladderCaption,
+  labelTransform,
+  placeLabels,
+  LABEL_ROW_PX,
+} from "@/skins/commerce/components/margin-ladder";
+import type {
+  LadderProduct,
+  PlacedDot,
+} from "@/skins/commerce/components/margin-ladder";
+import type { MarginFloor, Product } from "@/skins/commerce/data/types";
+
+/**
+ * THE LADDER'S CAPTION MAY NOT ALL-CLEAR A RANGE IT DID NOT CHECK.
+ *
+ * The caption is this component's verdict, and it used to be derived from a
+ * below-floor COUNT alone: zero → "Every product is trading above its category
+ * floor." An empty range has a below-floor count of zero too, so an EMPTY ladder
+ * printed the all-clear — zero violations found because zero products were
+ * examined, which is the strongest false reassurance the component can give, and
+ * the one indistinguishable from good news.
+ *
+ * Both empty shapes are reachable, not theoretical: `showMarginLadder` filters
+ * products by a MODEL-supplied category while falling back to the full floors
+ * list (so an invented or misspelt category draws every rail and no dots), and
+ * `ledger-context` mounts children with `products: []` on a failed first fetch.
+ */
+
+const FLOORS: MarginFloor[] = [
+  { category: "Footwear", floor: 0.4, target: 0.5 },
+  { category: "Accessories", floor: 0.55, target: 0.64 },
+];
+
+const product = (over: Partial<Product> = {}): Product => ({
+  id: "prd-x",
+  sku: "BW-X",
+  name: "Test Product",
+  category: "Footwear",
+  listPrice: 145,
+  unitCost: 88, // 39.3% margin — under the 40% Footwear floor
+  inventory: 480,
+  trailing30Units: 388,
+  status: "live",
+  vendor: "Vela Footworks",
+  ...over,
+});
+
+const belowSku = product({ id: "prd-below" });
+// 60% margin against the same 40% floor.
+const clearSku = product({ id: "prd-clear", listPrice: 200, unitCost: 80 });
+// "Home" has no floor in FLOORS: on no rail, checked against nothing.
+const homelessSku = product({ id: "prd-homeless", category: "Home" });
+
+const ALL_CLEAR = "Every product is trading above its category floor.";
+
+afterEach(cleanup);
+
+describe("ladderCaption", () => {
+  it("does NOT all-clear an empty range", () => {
+    const caption = ladderCaption({ below: 0, clear: 0, unknown: 0 });
+    expect(caption).not.toContain(ALL_CLEAR);
+    expect(caption).not.toMatch(/No plotted product is below/);
+    expect(caption).toMatch(/No products in this range/);
+    expect(caption).toMatch(/nothing has been checked/);
+  });
+
+  it("does NOT all-clear a range where nothing could be plotted", () => {
+    const caption = ladderCaption({ below: 0, clear: 0, unknown: 3 });
+    expect(caption).not.toContain(ALL_CLEAR);
+    // "No plotted product is below its floor" is vacuous with zero plotted.
+    expect(caption).not.toMatch(/No plotted product is below/);
+    expect(caption).toMatch(/Nothing is plotted/);
+    expect(caption).toMatch(/all 3 products/);
+    expect(caption).toMatch(/not checked/);
+  });
+
+  it("all-clears only a range that was fully checked", () => {
+    expect(ladderCaption({ below: 0, clear: 4, unknown: 0 })).toBe(ALL_CLEAR);
+  });
+
+  it("caveats a clean but partially checked range", () => {
+    const caption = ladderCaption({ below: 0, clear: 4, unknown: 1 });
+    expect(caption).toMatch(/No plotted product is below its floor/);
+    expect(caption).toMatch(/1 product has no category floor on file/);
+    expect(caption).toMatch(/not on any rail/);
+  });
+
+  it("counts violations, singular and plural", () => {
+    expect(ladderCaption({ below: 1, clear: 3, unknown: 0 })).toBe(
+      "1 product is below their category floor — shown in red, under the floor line.",
+    );
+    expect(ladderCaption({ below: 2, clear: 3, unknown: 0 })).toMatch(
+      /^2 products are below their category floor/,
+    );
+  });
+
+  it("reports violations AND unchecked SKUs together", () => {
+    const caption = ladderCaption({ below: 2, clear: 1, unknown: 2 });
+    expect(caption).toMatch(/^2 products are below their category floor/);
+    expect(caption).toMatch(/2 more have no floor on file and are not plotted/);
+  });
+});
+
+/**
+ * THE FAN MAY NOT HIDE A DOT, AND MAY NOT MOVE ONE ONTO THE NEXT RAIL.
+ *
+ * The ladder's entire job is letting someone count violations per category at a
+ * glance, so both of the old fan's failures were wrong READINGS:
+ *  - offsets came from a seven-entry px table indexed `idx % 7`, so the 8th
+ *    co-located SKU was drawn exactly on top of the 1st and the reader
+ *    undercounted, silently;
+ *  - the table reached ±45px while a column is ~75px inside a compact chat card,
+ *    and nothing in this component clips overflow, so a dot could be painted over
+ *    the NEIGHBOURING category's rail.
+ * Both are reachable from one prompt: `showMarginLadder` takes a category filter,
+ * which puts a whole category's range on one rail.
+ */
+const RUN_SIZES = [2, 3, 5, 7, 8, 9, 13, 40, 200];
+
+describe("collision fan geometry", () => {
+  it("gives every dot in a run a DISTINCT offset, well past the old 7 slots", () => {
+    for (const count of RUN_SIZES) {
+      const offsets = fanOffsets(count);
+      expect(offsets, `run of ${count}`).toHaveLength(count);
+      expect(new Set(offsets).size, `run of ${count}`).toBe(count);
+    }
+  });
+
+  it("never pushes a dot as far as the column's half-width", () => {
+    for (const count of RUN_SIZES) {
+      for (const offset of fanOffsets(count)) {
+        // Fractions of the COLUMN width: 0.5 is where a dot reaches the next
+        // column, and the cap leaves room for the dot's own radius too.
+        expect(Math.abs(offset), `run of ${count}`).toBeLessThanOrEqual(
+          FAN_MAX_FRACTION,
+        );
+        expect(Math.abs(offset), `run of ${count}`).toBeLessThan(0.5);
+      }
+    }
+  });
+
+  it("stays tight for a small run and widens only as the run grows", () => {
+    const spread = (count: number) => {
+      const offsets = fanOffsets(count);
+      return Math.max(...offsets) - Math.min(...offsets);
+    };
+    expect(fanOffsets(0)).toEqual([]);
+    expect(fanOffsets(1)).toEqual([0]);
+    expect(spread(2)).toBeGreaterThan(0);
+    expect(spread(3)).toBeGreaterThan(spread(2));
+    expect(spread(9)).toBeGreaterThan(spread(3));
+    // Saturated: past the cap the fan cannot widen, it can only subdivide.
+    expect(spread(40)).toBeCloseTo(2 * FAN_MAX_FRACTION, 6);
+  });
+
+  it("draws a 12-SKU pile-up as 12 distinct positions on the rail", () => {
+    const pile = Array.from({ length: 12 }, (_, i) =>
+      product({ id: `prd-pile-${i}`, name: `Pile ${i}` }),
+    );
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={pile} />,
+    );
+    const lefts = Array.from(
+      container.querySelectorAll<HTMLElement>("button[aria-label]"),
+    ).map((el) => el.style.left);
+    expect(lefts).toHaveLength(12);
+    expect(new Set(lefts).size).toBe(12);
+    for (const left of lefts) {
+      // jsdom folds `calc(50% - 14%)` down to `calc(36%)`, i.e. the dot's centre
+      // as a share of ITS OWN column: anything outside 0–100 is on a neighbour's
+      // rail, and the fan's cap keeps it well inside that.
+      const pct = Number(/([\d.]+)%/.exec(left)?.[1]);
+      expect(Number.isFinite(pct), left).toBe(true);
+      expect(pct, left).toBeGreaterThanOrEqual(50 - FAN_MAX_FRACTION * 100);
+      expect(pct, left).toBeLessThanOrEqual(50 + FAN_MAX_FRACTION * 100);
+      expect(pct, left).toBeGreaterThan(0);
+      expect(pct, left).toBeLessThan(100);
+    }
+  });
+
+  it("states the count when a pile-up is too dense to separate by eye", () => {
+    const pile = Array.from({ length: FAN_LEGIBLE_MAX + 1 }, (_, i) =>
+      product({ id: `prd-pile-${i}` }),
+    );
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={pile} />,
+    );
+    // Not "cap and say nothing": the reader is told how many are stacked here.
+    expect(container.textContent).toContain(`×${FAN_LEGIBLE_MAX + 1}`);
+  });
+
+  it("says nothing extra about a run the fan can separate", () => {
+    const pile = Array.from({ length: FAN_LEGIBLE_MAX }, (_, i) =>
+      product({ id: `prd-pile-${i}` }),
+    );
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={pile} />,
+    );
+    expect(container.textContent).not.toContain("×");
+  });
+});
+
+describe("MarginLadder caption wiring", () => {
+  it("prints no all-clear when there is nothing to plot", () => {
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={[]} />,
+    );
+    expect(container.textContent).not.toContain(ALL_CLEAR);
+    expect(container.textContent).toContain("No products in this range");
+  });
+
+  it("prints no all-clear when there are no rails at all", () => {
+    const { container } = render(
+      <MarginLadder floors={[]} products={[clearSku, belowSku]} />,
+    );
+    expect(container.textContent).not.toContain(ALL_CLEAR);
+    expect(container.textContent).toContain("Nothing is plotted");
+  });
+
+  it("still all-clears a real, fully checked range", () => {
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={[clearSku]} />,
+    );
+    expect(container.textContent).toContain(ALL_CLEAR);
+  });
+
+  it("still counts a real violation", () => {
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={[clearSku, belowSku]} />,
+    );
+    expect(container.textContent).toContain(
+      "1 product is below their category floor",
+    );
+  });
+
+  it("still caveats a product with no floor on file", () => {
+    const { container } = render(
+      <MarginLadder floors={FLOORS} products={[clearSku, homelessSku]} />,
+    );
+    expect(container.textContent).not.toContain(ALL_CLEAR);
+    expect(container.textContent).toContain(
+      "No plotted product is below its floor",
+    );
+  });
+});
+
+/**
+ * A BELOW-FLOOR LABEL MUST NAME ITS OWN DOT.
+ *
+ * The labels used to be drawn at a FIXED `left-1/2 translate-x-4` while their
+ * dots were fanned sideways by up to ±45px to escape each other. So on any rail
+ * where a violation shared a cluster, the name sat over empty rail — or over a
+ * NEIGHBOUR's dot, which is the failure that matters: below-floor SKUs are the
+ * only thing this component exists to point at, and a label pointing at the
+ * wrong one is worse than no label at all. Several violations on one rail made it
+ * worse still: every label landed on the same offset AND within a few pixels of
+ * the same height, so they printed on top of each other.
+ *
+ * Position is visual, so these assert the two invariants instead: a label's
+ * horizontal offset IS its dot's, and no two labels on a rail share a row.
+ */
+const dot = (over: Partial<PlacedDot> = {}): PlacedDot => ({
+  item: {
+    id: "prd-a",
+    sku: "BW-A",
+    name: "Test Product",
+    category: "Footwear",
+    listPrice: 100,
+    unitCost: 62,
+  } satisfies LadderProduct,
+  y: 40,
+  xFraction: 0,
+  margin: 0.38,
+  belowFloor: true,
+  ...over,
+});
+
+const named = (id: string, over: Partial<PlacedDot> = {}): PlacedDot =>
+  dot({ ...over, item: { ...dot().item, id, sku: id, name: id } });
+
+describe("placeLabels", () => {
+  it("labels only the below-floor dots", () => {
+    const labels = placeLabels([
+      named("below-1", { belowFloor: true, y: 30 }),
+      named("clear-1", { belowFloor: false, y: 120 }),
+    ]);
+    expect(labels.map((l) => l.item.id)).toEqual(["below-1"]);
+  });
+
+  it("copies each dot's fan offset onto its own label", () => {
+    // A fanned cluster: same height, pushed apart sideways.
+    const dots = [
+      named("a", { y: 40, xFraction: 0 }),
+      named("b", { y: 44, xFraction: 0.15 }),
+      named("c", { y: 48, xFraction: -0.15 }),
+    ];
+    const labels = placeLabels(dots);
+    for (const label of labels) {
+      const own = dots.find((d) => d.item.id === label.item.id);
+      expect(own).toBeDefined();
+      expect(label.xFraction).toBe(own?.xFraction);
+    }
+  });
+
+  it("gives every label on a rail its own row", () => {
+    // Three violations within a few pixels — the case that produced the report.
+    const labels = placeLabels([
+      named("a", { y: 34, xFraction: 0 }),
+      named("b", { y: 38, xFraction: 0.15 }),
+      named("c", { y: 42, xFraction: -0.15 }),
+    ]);
+    const ys = labels.map((l) => l.y).sort((p, q) => p - q);
+    expect(new Set(ys).size).toBe(labels.length);
+    for (let i = 1; i < ys.length; i += 1) {
+      expect(ys[i] - ys[i - 1]).toBeGreaterThanOrEqual(LABEL_ROW_PX);
+    }
+  });
+
+  it("leaves a lone label sitting on its dot rather than pushing it", () => {
+    const [label] = placeLabels([named("a", { y: 40, xFraction: 0 })]);
+    // Within half a line of the dot's own height: no separation was needed.
+    expect(Math.abs(label.y - 40)).toBeLessThan(LABEL_ROW_PX / 2);
+  });
+
+  it("runs a right-fanned label's text back towards its rail", () => {
+    const [right] = placeLabels([named("a", { xFraction: 0.3 })]);
+    const [left] = placeLabels([named("b", { xFraction: -0.3 })]);
+    expect(right.side).toBe("left");
+    expect(left.side).toBe("right");
+    // The OFFSET no longer lives in the transform — it goes through
+    // `fanLeft(xFraction)` on `left`, in the same unit as the dot's. The transform
+    // now carries only the gap and the side flip, so what is asserted here is that
+    // a left-running label ENDS at its dot (`-100%`) while a right-running one
+    // starts at it, and that each label still carries its own dot's offset (below).
+    expect(labelTransform(right)).toContain("-100%");
+    expect(labelTransform(left)).not.toContain("-100%");
+    expect(fanLeft(right.xFraction)).not.toBe(fanLeft(left.xFraction));
+    expect(right.xFraction).toBe(0.3);
+    expect(left.xFraction).toBe(-0.3);
+  });
+
+  it("does not reorder the caller's dots", () => {
+    const dots = [named("a", { y: 90 }), named("b", { y: 10 })];
+    placeLabels(dots);
+    expect(dots.map((d) => d.item.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("MarginLadder below-floor label wiring", () => {
+  // Footwear floor 40%; three SKUs land 0.5–1.5 points under it, close enough
+  // that their dots collide and fan sideways.
+  const FOOTWEAR: MarginFloor[] = [
+    { category: "Footwear", floor: 0.4, target: 0.5 },
+  ];
+  const CLUSTER: Product[] = [
+    product({
+      id: "prd-alpha",
+      name: "Alpha Trail",
+      listPrice: 100,
+      unitCost: 60.5,
+    }),
+    product({
+      id: "prd-bravo",
+      name: "Bravo Court",
+      listPrice: 100,
+      unitCost: 61,
+    }),
+    product({
+      id: "prd-charlie",
+      name: "Charlie Racer",
+      listPrice: 100,
+      unitCost: 61.5,
+    }),
+  ];
+  const FIRST_WORDS = ["Alpha", "Bravo", "Charlie"];
+
+  /**
+   * The fan offset a dot is actually drawn at, read off `left: calc(N%)`.
+   *
+   * Read from `left`, not from `transform`: the offset is a FRACTION of the
+   * column's width and goes through `fanLeft`, so the dot's transform carries only
+   * the `translate(-50%, 50%)` centring. Scraping the transform for a `px` offset
+   * is what this scraper used to do, and it found nothing once the unit changed.
+   */
+  const dotOffsets = (container: HTMLElement) => {
+    const offsets = new Map<string, number>();
+    for (const button of container.querySelectorAll("button[aria-label]")) {
+      const label = button.getAttribute("aria-label") ?? "";
+      if (!label.includes("below floor")) continue;
+      const style = button.getAttribute("style") ?? "";
+      const match = /left:\s*calc\((-?[\d.]+)%\)/.exec(style);
+      expect(match, `no fan offset in dot left: ${style}`).not.toBeNull();
+      // Back to the FRACTION the label also publishes. `fanLeft` renders
+      // `calc(50% + N%)`, which CSS collapses to a single percentage, so 41%
+      // means a fraction of -0.09. Comparing the label's fraction against the
+      // dot's percentage directly is a unit mismatch that reads as a real
+      // failure — convert here so the assertion compares like with like.
+      const fraction = Number(
+        (((match ? Number(match[1]) : 50) - 50) / 100).toFixed(4),
+      );
+      offsets.set(label.split(",")[0], fraction);
+    }
+    return offsets;
+  };
+
+  const labelNodes = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("span[data-fan-x]"));
+
+  it("draws each label at its own dot's offset, one per row", () => {
+    const { container } = render(
+      <MarginLadder floors={FOOTWEAR} products={CLUSTER} />,
+    );
+    const dots = dotOffsets(container);
+    expect(dots.size).toBe(3);
+    // The dots really did fan — otherwise this test proves nothing.
+    expect(new Set(dots.values()).size).toBe(3);
+
+    const labels = labelNodes(container);
+    expect(labels.map((el) => el.textContent).sort()).toEqual(FIRST_WORDS);
+
+    const bottoms: number[] = [];
+    for (const el of labels) {
+      const word = el.textContent ?? "";
+      const owner = [...dots.keys()].find((name) => name.startsWith(word));
+      expect(owner, `no dot named ${word}`).toBeDefined();
+      // THE INVARIANT: the label's offset is its dot's, not a constant.
+      expect(Number(el.getAttribute("data-fan-x"))).toBe(dots.get(owner!));
+      const bottom = /bottom:\s*(-?[\d.]+)px/.exec(
+        el.getAttribute("style") ?? "",
+      );
+      expect(bottom, "label has no bottom").not.toBeNull();
+      bottoms.push(Number(bottom?.[1]));
+    }
+
+    // ...and no two labels share a row, so none is printed over another.
+    const ordered = [...bottoms].sort((p, q) => p - q);
+    expect(new Set(ordered).size).toBe(3);
+    for (let i = 1; i < ordered.length; i += 1) {
+      expect(ordered[i] - ordered[i - 1]).toBeGreaterThanOrEqual(LABEL_ROW_PX);
+    }
+  });
+
+  it("labels nothing in the compact transcript variant", () => {
+    const { container } = render(
+      <MarginLadder floors={FOOTWEAR} products={CLUSTER} compact />,
+    );
+    expect(labelNodes(container)).toHaveLength(0);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/margin-ladder.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/margin-ladder.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  LADDER_FLOOR_RATIO,
+  formatMargin,
+  formatMoney,
+  ladderRatio,
+  marginAt,
+  tallyFloorStatus,
+} from "../data/derive";
+import type { FloorTally } from "../data/derive";
+import type { Category, MarginFloor, Product } from "../data/types";
+import { SkuTile } from "./sku-tile";
+
+/**
+ * THE MARGIN LADDER — Bellwether's signature element.
+ *
+ * One vertical rail per category, each anchored to its OWN margin floor: the
+ * floor line sits at the same height on every rail regardless of whether that
+ * category's floor is 38% or 55%. That anchoring is the whole idea. A
+ * conventional margin chart plots gross margin on a shared axis, which makes
+ * Accessories tower over Home and tells a merchandiser nothing they did not
+ * already know. Anchoring to the floor puts every product on the same "distance
+ * from the line I am not allowed to cross" scale, so "the Harbor Parka is under
+ * its floor" and "the Lark Runner is under its floor" line up at the same height
+ * and become comparable at a glance — which is exactly the question a
+ * merchandiser is actually asking, and exactly the shape of the preference
+ * beat 4 recalls.
+ *
+ * Anything below its floor is drawn BELOW the floor line, in the negative
+ * colour, with its name always visible. Those are the actionable SKUs, so they
+ * are the only ones that get a label without being hovered. Every one of those
+ * labels tracks its own dot — see `placeLabels`, which owns that guarantee.
+ *
+ * The geometry that makes the anchoring true lives in `derive.ladderRatio` /
+ * `derive.LADDER_FLOOR_RATIO` — a floor-relative axis shared by every rail. Read
+ * the comment there before changing any position in here.
+ */
+
+export interface LadderProduct {
+  id: string;
+  sku: string;
+  name: string;
+  category: Category;
+  listPrice: number;
+  unitCost: number;
+}
+
+export interface PlacedDot {
+  item: LadderProduct;
+  /** Pixels above the rail's base. */
+  y: number;
+  /**
+   * Horizontal nudge applied when dots would overlap, as a FRACTION OF THE
+   * COLUMN'S WIDTH — not pixels. Never read it raw: pass it to `fanLeft()`,
+   * which is the only place the unit is turned into CSS, so a dot and anything
+   * that has to track a dot (its below-floor label) cannot drift apart.
+   */
+  xFraction: number;
+  margin: number;
+  belowFloor: boolean;
+}
+
+/**
+ * A collision run the fan cannot visually separate at the width this ladder may
+ * actually be drawn at. Rendered as a count badge, because the alternative —
+ * overlapping dots and no number — is a reader silently undercounting the very
+ * thing the ladder exists to let them count.
+ */
+interface DotCluster {
+  /** The run's first dot id; stable enough to key the badge on. */
+  id: string;
+  /** Pixels above the rail's base, at the middle of the run. */
+  y: number;
+  size: number;
+}
+
+const COLLISION_PX = 19;
+
+/**
+ * THE COLLISION FAN — the ladder's HORIZONTAL geometry. (The vertical mapping is
+ * `derive.ladderRatio` and is a separate, load-bearing thing; do not mix them.)
+ *
+ * Every offset here is a FRACTION OF THE COLUMN WIDTH, because a column has no
+ * fixed width: `flex-1 min-w-0` over five categories gives ~75px inside the chat
+ * transcript and 3x that on the catalog page, and the ladder is drawn in both.
+ * This replaced a fixed px table (`[0, 15, -15, 30, -30, 45, -45]` indexed
+ * `idx % 7`), which failed twice over:
+ *  - the 8th dot in a run was handed the 1st dot's slot, so past seven
+ *    co-located SKUs dots overlapped EXACTLY and the reader undercounted;
+ *  - ±45px on a ~75px column is outside that column, and nothing here clips
+ *    overflow, so a dot could be drawn over the NEIGHBOURING category's rail and
+ *    read as belonging to a category it is not in — a wrong reading, not a
+ *    cosmetic one.
+ * Both are fixed by scaling to the run's size AND to the column: the fan widens
+ * only as far as the run needs, and never past `FAN_MAX_FRACTION` of the column.
+ */
+
+/**
+ * The widest a fanned dot may sit from its rail, as a fraction of the column.
+ * Strictly under 0.5 (the half-width at which a dot reaches the next column),
+ * with room left for the dot's own radius.
+ */
+export const FAN_MAX_FRACTION = 0.36;
+/** Gap between neighbouring dots in a run small enough to get its way. */
+const FAN_STEP_FRACTION = 0.09;
+/**
+ * The narrowest column the ladder is realistically drawn in: five categories
+ * inside a compact chat card, plus the compact dot's diameter. Together they
+ * give the number of dots a saturated fan can still separate BY EYE at that
+ * width — past that, the badge carries the count instead of the dots.
+ */
+const NARROWEST_COLUMN_PX = 64;
+const COMPACT_DOT_PX = 10;
+export const FAN_LEGIBLE_MAX =
+  Math.floor((2 * FAN_MAX_FRACTION * NARROWEST_COLUMN_PX) / COMPACT_DOT_PX) + 1;
+
+/**
+ * Horizontal offsets for `count` colliding dots, as fractions of the column
+ * width, in the run's own (y-ascending) order — so the fan reads left-to-right
+ * in the order the dots climb the rail.
+ *
+ * Guarantees, both of them asserted in this component's test:
+ *  - every offset is DISTINCT, at every count (no fixed table, no modulo);
+ *  - `|offset| <= FAN_MAX_FRACTION`, so no dot can reach a neighbouring rail.
+ */
+export function fanOffsets(count: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [0];
+  const amplitude = Math.min(
+    FAN_MAX_FRACTION,
+    (FAN_STEP_FRACTION * (count - 1)) / 2,
+  );
+  // `amplitude * (2i/(n-1) - 1)` rather than `-amplitude + i * step`: the former
+  // lands on exactly ±amplitude at the ends, so the bound holds without a float
+  // epsilon creeping over it.
+  return Array.from(
+    { length: count },
+    (_, i) => amplitude * ((2 * i) / (count - 1) - 1),
+  );
+}
+
+/**
+ * The CSS `left` for something sitting at fan offset `xFraction`. The one place
+ * the fraction becomes CSS: a percentage on `left` resolves against the COLUMN's
+ * width (unlike a percentage in `translate`, which resolves against the element's
+ * own size), which is what makes a width-relative fan expressible without
+ * measuring anything.
+ */
+export function fanLeft(xFraction: number): string {
+  const pct = Number((xFraction * 100).toFixed(3));
+  // The sign goes in the OPERATOR, never in the operand: `calc(50% + -12%)` is
+  // rejected by enough parsers to be worth avoiding, and a rejected `left` is a
+  // dot back on the rail's centre with nothing to show it moved.
+  return `calc(50% ${pct < 0 ? "-" : "+"} ${Math.abs(pct)}%)`;
+}
+
+/** Text starts this far from its dot's centre, clear of the dot itself. */
+const LABEL_GAP_PX = 10;
+/**
+ * One label owns a horizontal band this tall and no two labels may share one.
+ * Sized to the label's line box (0.65rem text), so separating two labels by this
+ * much is what makes them unable to overlap whatever their text turns out to be
+ * — a width this component cannot know at layout time.
+ */
+export const LABEL_ROW_PX = 14;
+/** Drops the text's line box onto its dot's centre. */
+const LABEL_DROP_PX = 6;
+
+function place(
+  items: LadderProduct[],
+  floor: MarginFloor,
+  railHeight: number,
+): { dots: PlacedDot[]; clusters: DotCluster[] } {
+  const dots = items
+    .map((item) => {
+      const margin = marginAt(item.listPrice, item.unitCost);
+      return {
+        item,
+        y: ladderRatio(margin, floor.floor) * railHeight,
+        xFraction: 0,
+        margin,
+        belowFloor: margin < floor.floor,
+      } satisfies PlacedDot;
+    })
+    .sort((a, b) => a.y - b.y);
+
+  // Fan out anything that would land on top of its neighbour.
+  const clusters: DotCluster[] = [];
+  let runStart = 0;
+  for (let i = 1; i <= dots.length; i += 1) {
+    const breaks =
+      i === dots.length || dots[i].y - dots[i - 1].y >= COLLISION_PX;
+    if (!breaks) continue;
+    const run = dots.slice(runStart, i);
+    if (run.length > 1) {
+      const offsets = fanOffsets(run.length);
+      run.forEach((dot, idx) => {
+        dot.xFraction = offsets[idx];
+      });
+      if (run.length > FAN_LEGIBLE_MAX) {
+        clusters.push({
+          id: run[0].item.id,
+          y: (run[0].y + run[run.length - 1].y) / 2,
+          size: run.length,
+        });
+      }
+    }
+    runStart = i;
+  }
+  return { dots, clusters };
+}
+
+export interface PlacedLabel {
+  item: LadderProduct;
+  /**
+   * The fan offset of the dot this label names — IDENTICAL to `dot.xFraction`,
+   * which is the entire point of this type. A FRACTION of the column's width, not
+   * pixels: pass it to `fanLeft()` exactly as the dot does, so the label and the
+   * dot cannot be positioned by two different units.
+   */
+  xFraction: number;
+  /** Pixels above the rail's base. */
+  y: number;
+  /** Which way the text runs from its dot. */
+  side: "left" | "right";
+}
+
+/**
+ * WHERE A BELOW-FLOOR NAME GOES — pure, because a label that names the wrong dot
+ * is worse than no label, and "which dot does this word belong to" is not
+ * something a rendered pixel can be asked afterwards.
+ *
+ * Two rules, and they exist because the labels were previously drawn at a FIXED
+ * `left-1/2 translate-x-4` while their dots were fanned horizontally by up to
+ * ±45px:
+ *
+ *  - `x` is copied from the dot, never chosen. A label whose dot was fanned and
+ *    which did not move with it points at empty rail — and at a NEIGHBOUR's dot
+ *    if that neighbour happens to sit where the label ended up.
+ *  - two labels on one rail may not share a horizontal band. A fanned cluster is
+ *    by definition within `COLLISION_PX` vertically, so the dots separate
+ *    sideways but their labels — text of unknown width running from each dot —
+ *    would still collide. Text needs its own ROW, so each label is pushed up to
+ *    the first free one. Under a `LADDER_FLOOR_RATIO` band ~46px tall on a full
+ *    rail that is three violations before a label rises past the floor line,
+ *    which is still inside the rail and still unambiguous, because it kept its
+ *    dot's `x`.
+ *
+ * `side` is the same idea applied outward: a dot fanned RIGHT runs its text back
+ * to the left, so a label never leaves the column its rail owns just because its
+ * dot sits near the edge.
+ */
+export function placeLabels(dots: PlacedDot[]): PlacedLabel[] {
+  const labels: PlacedLabel[] = [];
+  const ordered = dots.filter((d) => d.belowFloor).sort((a, b) => a.y - b.y);
+  for (const dot of ordered) {
+    const previous = labels[labels.length - 1];
+    const wanted = dot.y - LABEL_DROP_PX;
+    labels.push({
+      item: dot.item,
+      xFraction: dot.xFraction,
+      y: previous ? Math.max(wanted, previous.y + LABEL_ROW_PX) : wanted,
+      side: dot.xFraction > 0 ? "left" : "right",
+    });
+  }
+  return labels;
+}
+
+/**
+ * The label's own transform — the GAP and the side flip only.
+ *
+ * The fan offset itself is NOT in here: it goes through `fanLeft(label.xFraction)`
+ * on the `left` property, exactly as the dot's does, because the offset is a
+ * fraction of the column's width and this transform is in pixels. Putting a
+ * fraction through a `px` interpolation is precisely the mismatch the rename from
+ * `x` to `xFraction` exists to make impossible — a label would have sat ~0.3px
+ * from centre while its dot sat 30% away.
+ *
+ * It stays a transform rather than a Tailwind translate utility for the same
+ * reason the dot's does: a utility class would be OVERWRITTEN by an inline
+ * `transform`, not composed with it. `-100%` is what makes a left-running label
+ * END at its dot instead of starting there.
+ */
+export function labelTransform(label: PlacedLabel): string {
+  return label.side === "right"
+    ? `translateX(${LABEL_GAP_PX}px)`
+    : `translateX(calc(-100% - ${LABEL_GAP_PX}px))`;
+}
+
+/**
+ * THE LADDER'S ONE-LINE SUMMARY — pure, so every state is testable and no branch
+ * can be added without deciding what an EMPTY range says.
+ *
+ * The rule this encodes: an all-clear may only be printed when something was
+ * actually checked. `below === 0` does not earn one on its own, because that is
+ * also what an empty range yields — and "no product is below its floor" out of
+ * zero products examined is the most reassuring sentence this component could
+ * print and the least true. So the first question is how many products were
+ * measured against a floor at all (`below + clear`), not how many failed.
+ *
+ * An empty range is reachable, not theoretical. `showMarginLadder` filters
+ * `products` by a MODEL-supplied category string while falling back to the full
+ * `floors` list, so any category the model invents or misspells draws every rail
+ * and no dots; and `ledger-context` mounts children with `products: []` on a
+ * failed first fetch, which is the demo-day shape.
+ *
+ * Rails come from `floors`, so `unknown` — a product whose category has no floor
+ * on file — is exactly the set that is on NO rail: silently absent rather than
+ * visibly fine. It is reported separately in every branch for that reason.
+ */
+export function ladderCaption(tally: FloorTally): string {
+  const { below, clear, unknown } = tally;
+  const checked = below + clear;
+  const products = (n: number) => (n === 1 ? "product" : "products");
+  const have = (n: number) => (n === 1 ? "has" : "have");
+  const are = (n: number) => (n === 1 ? "is" : "are");
+
+  // Nothing was measured against anything: say so, and say why.
+  if (checked === 0) {
+    return unknown === 0
+      ? "No products in this range — nothing has been checked against a floor."
+      : `Nothing is plotted: all ${unknown} ${products(unknown)} in this range ${have(unknown)} no category floor on file, so ${unknown === 1 ? "it was" : "they were"} not checked against one.`;
+  }
+
+  if (below === 0) {
+    return unknown === 0
+      ? "Every product is trading above its category floor."
+      : `No plotted product is below its floor, but ${unknown} ${products(unknown)} ${have(unknown)} no category floor on file and ${are(unknown)} not on any rail.`;
+  }
+
+  const headline = `${below} ${products(below)} ${are(below)} below their category floor — shown in red, under the floor line.`;
+  return unknown === 0
+    ? headline
+    : `${headline} ${unknown} more ${have(unknown)} no floor on file and ${are(unknown)} not plotted.`;
+}
+
+export function MarginLadder({
+  floors,
+  products,
+  compact = false,
+  highlightIds,
+  className,
+}: {
+  floors: MarginFloor[];
+  products: Product[];
+  /** Narrow variant for the chat transcript. */
+  compact?: boolean;
+  /** Draw a markdown ring on these SKUs — the ones a tool just touched. */
+  highlightIds?: string[];
+  className?: string;
+}) {
+  const [hovered, setHovered] = useState<string | null>(null);
+  const railHeight = compact ? 160 : 232;
+  const highlighted = useMemo(
+    () => new Set(highlightIds ?? []),
+    [highlightIds],
+  );
+
+  const columns = useMemo(
+    () =>
+      floors.map((floor) => {
+        const { dots, clusters } = place(
+          products
+            .filter((p) => p.category === floor.category)
+            .map((p) => ({
+              id: p.id,
+              sku: p.sku,
+              name: p.name,
+              category: p.category,
+              listPrice: p.listPrice,
+              unitCost: p.unitCost,
+            })),
+          floor,
+          railHeight,
+        );
+        // Labels are derived HERE, from the very dots that will be drawn, rather
+        // than positioned independently at render time — the two cannot drift.
+        // `clusters` rides along from `place`: it carries the ×N badge for a run
+        // too long to fan legibly, which is the other half of not lying about
+        // what is on the rail.
+        return { floor, dots, clusters, labels: placeLabels(dots) };
+      }),
+    [floors, products, railHeight],
+  );
+
+  // ONE tally behind the caption — plotted, below-floor and no-floor-on-file can
+  // therefore never disagree with each other. It also replaced a `columns`-derived
+  // below-floor count: that count could only ever be a number, and a number is
+  // what let the caption treat "zero violations" and "zero products" as the same
+  // state. `ladderCaption` owns that distinction; see its comment.
+  const tally = useMemo(
+    () => tallyFloorStatus(floors, products),
+    [floors, products],
+  );
+  const caption = ladderCaption(tally);
+
+  // ONE height for every floor line, computed OUTSIDE the column loop so no
+  // future edit can quietly make it a function of the category again. That is
+  // the invariant this whole component is built on.
+  const floorY = LADDER_FLOOR_RATIO * railHeight;
+
+  return (
+    <figure className={cn("w-full", className)}>
+      <div
+        className="flex items-end gap-1"
+        // Rail + the mt-4 gutter under it + the caption block (two lines
+        // compact, three once the floor percentage is shown).
+        style={{ height: railHeight + (compact ? 50 : 70) }}
+      >
+        {columns.map(({ floor, dots, clusters, labels }) => {
+          // The target DOES move per category — it is real data (9 to 12 points
+          // over the floor), not the shared anchor.
+          const targetY = ladderRatio(floor.target, floor.floor) * railHeight;
+          return (
+            <div
+              key={floor.category}
+              className="flex min-w-0 flex-1 flex-col items-center"
+            >
+              <div className="relative w-full" style={{ height: railHeight }}>
+                {/* The rail. `.bw-rail` carries the ink gradient so it tracks
+                    the live theme tokens rather than a hard-coded colour. */}
+                <div
+                  className="bw-rail absolute left-1/2 top-0 h-full w-2.5 -translate-x-1/2 rounded-full"
+                  aria-hidden
+                />
+                {/* The margin floor — the line the gate is enforced against, and
+                    the one place a rail earns a warning colour. Drawn wider than
+                    the rail so it reads as a threshold across the column rather
+                    than as a segment of the rail itself. Its width is capped as a
+                    SHARE of the column for the same reason the dot fan is: a flat
+                    2.25rem is wider than the column once five categories share a
+                    compact chat card, and nothing here clips overflow, so it
+                    would read as the neighbouring category's floor. */}
+                <div
+                  className="bw-rail-floor absolute left-1/2 h-[2px] w-[min(2.25rem,86%)] -translate-x-1/2 rounded-full"
+                  style={{ bottom: floorY }}
+                  aria-hidden
+                />
+                {/* The planned margin. Quiet — a reference, not an alarm. */}
+                <div
+                  className="bw-rail-target absolute left-1/2 h-[2px] w-[min(1.5rem,58%)] -translate-x-1/2 rounded-full"
+                  style={{ bottom: targetY }}
+                  aria-hidden
+                />
+
+                {dots.map((dot) => {
+                  const isHovered = hovered === dot.item.id;
+                  return (
+                    <button
+                      key={dot.item.id}
+                      type="button"
+                      onMouseEnter={() => setHovered(dot.item.id)}
+                      onMouseLeave={() => setHovered(null)}
+                      onFocus={() => setHovered(dot.item.id)}
+                      onBlur={() => setHovered(null)}
+                      aria-label={`${dot.item.name}, ${dot.item.category}, ${formatMargin(
+                        dot.margin,
+                      )} margin${dot.belowFloor ? ", below floor" : ""}`}
+                      className="absolute rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                      style={{
+                        // The fan rides on `left`, where its percentage resolves
+                        // against the COLUMN's width; `transform` then only
+                        // centres the dot on that point. Keep the centring
+                        // INLINE — a Tailwind `-translate-x-1/2` would be
+                        // overwritten by this style rather than composed with it,
+                        // which silently shifts every dot half its width off the
+                        // rail.
+                        left: fanLeft(dot.xFraction),
+                        bottom: dot.y,
+                        transform: "translate(-50%, 50%)",
+                        zIndex: isHovered ? 30 : dot.belowFloor ? 20 : 10,
+                      }}
+                    >
+                      <span
+                        className={cn(
+                          "block rounded-full border-2 transition-transform",
+                          compact ? "h-2.5 w-2.5" : "h-3 w-3",
+                          // Full-strength ink with a surface-coloured border: at
+                          // reduced opacity these disappeared into their own
+                          // rail, which is the one thing a dot on a rail must
+                          // not do.
+                          dot.belowFloor
+                            ? "bw-flag border-surface bg-negative"
+                            : highlighted.has(dot.item.id)
+                              ? "border-brand-violet bg-brand"
+                              : "border-surface bg-brand",
+                          isHovered && "scale-150",
+                        )}
+                      />
+                    </button>
+                  );
+                })}
+
+                {/* A pile-up denser than the fan can separate at this width does
+                    NOT get to pass as a handful of dots: the badge states how
+                    many SKUs are in it, so nobody counts blobs and undercounts.
+                    `pointer-events-none` keeps every dot underneath hoverable,
+                    and each dot is still its own labelled button, so the badge is
+                    a visual aid only — hence `aria-hidden`. */}
+                {clusters.map((cluster) => (
+                  <span
+                    key={`${cluster.id}-cluster`}
+                    className="bw-num pointer-events-none absolute left-1/2 -translate-x-1/2 translate-y-1/2 rounded-full border border-hairline bg-surface px-1 text-[0.6rem] font-semibold leading-tight text-ink"
+                    style={{ bottom: cluster.y, zIndex: 25 }}
+                    aria-hidden
+                  >
+                    ×{cluster.size}
+                  </span>
+                ))}
+
+                {/* Below-floor names are always visible: they are the rows
+                    anyone is actually here to act on. Everything else labels on
+                    hover. Geometry comes from `placeLabels` — read its comment
+                    before moving one, and note that `data-fan-x` is the dot
+                    offset this label is REQUIRED to share with its dot. */}
+                {!compact &&
+                  labels.map((label) => (
+                    <span
+                      key={`${label.item.id}-label`}
+                      data-fan-x={label.xFraction}
+                      className="bw-num pointer-events-none absolute whitespace-nowrap text-[0.65rem] font-semibold text-negative"
+                      style={{
+                        // Same `fanLeft` the dot uses, off the same fraction, so
+                        // the label cannot be positioned in a different unit from
+                        // the thing it names. `left-1/2` is gone from the class
+                        // list because `fanLeft` already includes the 50% centre.
+                        left: fanLeft(label.xFraction),
+                        bottom: label.y,
+                        transform: labelTransform(label),
+                      }}
+                    >
+                      {label.item.name.split(" ")[0]}
+                    </span>
+                  ))}
+              </div>
+
+              <div className="mt-4 text-center">
+                <div className="text-[0.72rem] font-semibold text-ink">
+                  {floor.category}
+                </div>
+                <div className="bw-num text-[0.62rem] text-ink-muted">
+                  {dots.length} {dots.length === 1 ? "SKU" : "SKUs"}
+                </div>
+                {!compact ? (
+                  <div className="bw-num mt-0.5 text-[0.6rem] text-negative">
+                    floor {formatMargin(floor.floor)}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Hover detail. A fixed slot rather than a floating tooltip, so the
+          ladder never reflows and never clips inside the chat column. */}
+      <div className="mt-3 flex min-h-[2.25rem] items-center justify-between gap-3 rounded-md border border-hairline bg-surface-muted px-3 py-1.5">
+        {hovered ? (
+          (() => {
+            const dot = columns
+              .flatMap((c) => c.dots)
+              .find((d) => d.item.id === hovered);
+            if (!dot) return null;
+            return (
+              <>
+                <span className="flex min-w-0 items-center gap-2">
+                  <SkuTile name={dot.item.name} size="xs" />
+                  <span className="truncate text-[0.75rem] font-medium text-ink">
+                    {dot.item.name}
+                  </span>
+                  <span className="bw-num hidden truncate text-[0.7rem] text-ink-muted sm:inline">
+                    {dot.item.sku}
+                  </span>
+                </span>
+                <span className="bw-num shrink-0 text-[0.72rem] font-semibold text-ink">
+                  {formatMoney(dot.item.listPrice)}
+                  <span
+                    className={cn(
+                      "ml-2 font-medium",
+                      dot.belowFloor ? "text-negative" : "text-ink-muted",
+                    )}
+                  >
+                    {formatMargin(dot.margin)}
+                    {dot.belowFloor ? " · below floor" : " margin"}
+                  </span>
+                </span>
+              </>
+            );
+          })()
+        ) : (
+          <span className="text-[0.72rem] text-ink-muted">{caption}</span>
+        )}
+      </div>
+      <figcaption className="sr-only">
+        Margin ladder. Each category is a rail anchored to its own margin floor;
+        each dot is one product at its gross margin.
+      </figcaption>
+    </figure>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/primitives.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/primitives.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Bellwether's small shared vocabulary. Everything here styles itself with the
+ * shell's semantic utilities (`bg-surface`, `text-ink`, `border-hairline`, …)
+ * so the whole skin reskins from `theme.css` with no component edits.
+ */
+
+/** The standard panel. One radius, one hairline, one soft shadow, everywhere. */
+export function Panel({
+  children,
+  className,
+  padded = true,
+}: {
+  children: ReactNode;
+  className?: string;
+  padded?: boolean;
+}) {
+  return (
+    <section
+      className={cn(
+        "rounded-lg border border-hairline bg-surface shadow-soft",
+        padded && "p-5",
+        className,
+      )}
+    >
+      {children}
+    </section>
+  );
+}
+
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <header className="mb-5 flex items-end justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-ink">
+          {title}
+        </h1>
+        {subtitle ? (
+          <p className="mt-1 text-sm text-ink-muted">{subtitle}</p>
+        ) : null}
+      </div>
+      {actions ? (
+        <div className="flex items-center gap-2">{actions}</div>
+      ) : null}
+    </header>
+  );
+}
+
+/** An eyebrow above a group. Uppercase, tracked, quiet — it labels, nothing more. */
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="mb-3 text-[0.7rem] font-semibold uppercase tracking-[0.09em] text-ink-muted">
+      {children}
+    </h2>
+  );
+}
+
+type Tone = "neutral" | "brand" | "positive" | "negative" | "markdown";
+
+const TONE_CLASS: Record<Tone, string> = {
+  neutral: "bg-surface-muted text-ink-muted border-hairline",
+  brand: "bg-brand-soft text-brand border-brand/30",
+  positive: "bg-positive-soft text-positive border-positive/25",
+  negative: "bg-negative-soft text-negative border-negative/25",
+  // `--brand-violet` is Bellwether's rose MARKDOWN accent (see theme.css), and
+  // it is reserved for discounts and promotions so a markdown chip is the one
+  // thing on a dense page that reads instantly from across a room.
+  markdown: "bg-brand-violet/12 text-brand-violet border-brand-violet/30",
+};
+
+export function Pill({
+  children,
+  tone = "neutral",
+  className,
+}: {
+  children: ReactNode;
+  tone?: Tone;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[0.68rem] font-medium leading-4",
+        TONE_CLASS[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** A headline figure with its label underneath. Tabular so digits don't jitter. */
+export function Metric({
+  label,
+  value,
+  hint,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: Tone;
+}) {
+  return (
+    <div className="rounded-md border border-hairline bg-surface-muted px-4 py-3">
+      <div
+        className={cn(
+          "bw-num text-xl font-semibold tracking-tight",
+          tone === "negative" && "text-negative",
+          tone === "positive" && "text-positive",
+          tone === "brand" && "text-brand",
+          tone === "neutral" && "text-ink",
+          tone === "markdown" && "text-brand-violet",
+        )}
+      >
+        {value}
+      </div>
+      <div className="mt-0.5 text-[0.72rem] font-medium text-ink-muted">
+        {label}
+      </div>
+      {hint ? (
+        <div className="mt-0.5 text-[0.68rem] text-ink-muted">{hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * An empty state that tells you what to do next. Never a shrug — the frontend
+ * brief is explicit that emptiness is an invitation to act, and in a demo an
+ * unexplained blank panel reads as a bug.
+ */
+export function EmptyState({
+  title,
+  hint,
+  icon,
+}: {
+  title: string;
+  hint: string;
+  icon?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-md border border-dashed border-hairline px-6 py-10 text-center">
+      {icon ? <div className="mb-2 text-ink-muted">{icon}</div> : null}
+      <p className="text-sm font-medium text-ink">{title}</p>
+      <p className="mt-1 max-w-sm text-[0.78rem] text-ink-muted">{hint}</p>
+    </div>
+  );
+}
+
+/**
+ * A control that the AGENT set, rather than the user.
+ *
+ * Beat 3c turns on the audience being able to SEE that a filter and a sort were
+ * applied by the assistant — "it performed a maneuver, not a link". So an
+ * agent-set control gets the brand tint plus a weight change; a user-set one
+ * stays quiet. Banking and Rowan use the same treatment on their sort and
+ * top-N controls.
+ */
+export function activeSelectClass(active: boolean): string {
+  return cn(
+    "rounded-md border px-2.5 py-1.5 text-[0.78rem] transition-colors",
+    active
+      ? "border-brand/50 bg-brand-soft font-semibold text-brand"
+      : "border-hairline bg-surface text-ink-muted hover:text-ink",
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/recording-context.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/recording-context.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+
+/**
+ * BEAT 6, role #3 — RECORDING.
+ *
+ * While the merchandiser demonstrates the below-floor markdown unlock on the
+ * Promotions page, the agent holds the chat with a waiting card and this context
+ * narrates each real action as it happens. Two things about the design are
+ * deliberate:
+ *
+ *  - It records what the human ACTUALLY DID, not what the UI offered. The code
+ *    that lifts the gate is captured from the waiver the human actually filed
+ *    (`getDemonstratedCode`), so the saved procedure names the real code rather
+ *    than a guess. If the human files a DECOY, the recording faithfully captures
+ *    the decoy — and the approve still fails, which is the honest outcome and a
+ *    far better demo than a recorder that quietly corrects them.
+ *
+ *  - `beginRecording` / `endRecording` are REF-COUNTED. The waiting card can
+ *    re-render, remount on a thread switch, or briefly double-mount in React
+ *    strict mode; a boolean flag would be switched off by the first unmount and
+ *    the feed would go dead mid-demonstration while everything still looked
+ *    fine. A counter survives all three.
+ */
+
+export interface RecordedStep {
+  id: string;
+  label: string;
+  at: number;
+  /** Set when the step is the one that filed a margin waiver. */
+  code?: string;
+}
+
+interface RecordingValue {
+  isRecording: boolean;
+  steps: RecordedStep[];
+  beginRecording: () => void;
+  endRecording: () => void;
+  logStep: (label: string, code?: string) => void;
+  /** The waiver code the human actually filed during this demonstration. */
+  getDemonstratedCode: () => string | null;
+  reset: () => void;
+}
+
+const RecordingContext = createContext<RecordingValue | null>(null);
+
+export function RecordingProvider({ children }: { children: ReactNode }) {
+  const [depth, setDepth] = useState(0);
+  const [steps, setSteps] = useState<RecordedStep[]>([]);
+  // A ref as well as state: `logStep` is called from event handlers that may
+  // have closed over a stale `depth`, and dropping a step because the closure
+  // was one render behind is invisible until the feed is missing a line.
+  const depthRef = useRef(0);
+
+  const beginRecording = useCallback(() => {
+    depthRef.current += 1;
+    setDepth(depthRef.current);
+  }, []);
+
+  const endRecording = useCallback(() => {
+    depthRef.current = Math.max(0, depthRef.current - 1);
+    setDepth(depthRef.current);
+  }, []);
+
+  const logStep = useCallback((label: string, code?: string) => {
+    if (depthRef.current === 0) return;
+    setSteps((prev) => [
+      ...prev,
+      { id: `${Date.now()}-${prev.length}`, label, at: Date.now(), code },
+    ]);
+  }, []);
+
+  const value = useMemo<RecordingValue>(
+    () => ({
+      isRecording: depth > 0,
+      steps,
+      beginRecording,
+      endRecording,
+      logStep,
+      getDemonstratedCode: () =>
+        [...steps].toReversed().find((s) => s.code)?.code ?? null,
+      reset: () => setSteps([]),
+    }),
+    [depth, steps, beginRecording, endRecording, logStep],
+  );
+
+  return (
+    <RecordingContext.Provider value={value}>
+      {children}
+    </RecordingContext.Provider>
+  );
+}
+
+/**
+ * Safe to call from anywhere, including pages that mount outside the provider
+ * during a route transition. Returns inert no-ops rather than throwing: a page
+ * that logs a step is doing optional narration, and crashing the order book
+ * because the recorder was not mounted would be a much worse failure than a
+ * missing line in a feed.
+ */
+export function useRecording(): RecordingValue {
+  return (
+    useContext(RecordingContext) ?? {
+      isRecording: false,
+      steps: [],
+      beginRecording: () => {},
+      endRecording: () => {},
+      logStep: () => {},
+      getDemonstratedCode: () => null,
+      reset: () => {},
+    }
+  );
+}
+
+/**
+ * The edge glow that tells a room recording is live. Mounted once, below the
+ * CopilotKit provider, and pointer-events-none so it never intercepts the very
+ * clicks it exists to watch.
+ */
+export function RecordingVignette() {
+  const { isRecording } = useRecording();
+  if (!isRecording) return null;
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-[1300]"
+      style={{
+        boxShadow: "inset 0 0 0 3px hsl(var(--brand-violet) / 0.6)",
+        animation: "bw-record-breathe 2.4s ease-in-out infinite",
+      }}
+    />
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/sku-tile.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/sku-tile.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { initials, tileHue } from "../data/derive";
+
+/**
+ * A product's (or a customer's) tile.
+ *
+ * Bellwether uses no product photography — a demo catalog of stock imagery reads
+ * as fake the moment anyone looks twice, and a real one is not ours to ship.
+ * Instead every SKU gets a tile in a colour deterministically derived from its
+ * name (see `tileHue`), so it keeps the same colour on the catalog, on the
+ * ladder, in the order rows, and inside chat gen-UI. That consistency is what
+ * turns a list of rows into a set of recognisable products.
+ *
+ * The hue is applied at low saturation and high lightness on purpose. The chrome
+ * is ink blue and the one loud colour is the rose markdown accent; if fourteen
+ * product tiles were fully saturated they would win every screen they appear on
+ * and the markdown chips would stop meaning anything.
+ *
+ * `square` is the product variant (a swatch reads as a good), `round` the person
+ * variant (a face does not).
+ */
+export function SkuTile({
+  name,
+  size = "md",
+  shape = "square",
+  className,
+  ring,
+}: {
+  name: string;
+  size?: "xs" | "sm" | "md" | "lg";
+  shape?: "square" | "round";
+  className?: string;
+  /** Draw an emphasis ring — used for the SKU a tool just acted on. */
+  ring?: "brand" | "negative" | "markdown" | null;
+}) {
+  const hue = tileHue(name);
+  const dimensions = {
+    xs: "h-6 w-6 text-[0.58rem]",
+    sm: "h-8 w-8 text-[0.68rem]",
+    md: "h-10 w-10 text-[0.72rem]",
+    lg: "h-14 w-14 text-sm",
+  }[size];
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "inline-flex shrink-0 select-none items-center justify-center font-semibold tracking-wide",
+        shape === "round" ? "rounded-full" : "rounded-md",
+        dimensions,
+        ring === "brand" &&
+          "ring-2 ring-brand ring-offset-2 ring-offset-surface",
+        ring === "negative" &&
+          "ring-2 ring-negative ring-offset-2 ring-offset-surface",
+        ring === "markdown" &&
+          "ring-2 ring-brand-violet ring-offset-2 ring-offset-surface",
+        className,
+      )}
+      style={{
+        backgroundColor: `hsl(${hue} 40% 92%)`,
+        color: `hsl(${hue} 48% 28%)`,
+      }}
+    >
+      {initials(name)}
+    </span>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/use-ask-copilot.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/use-ask-copilot.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+  useAgent,
+  useCopilotChatConfiguration,
+  useCopilotKit,
+} from "@copilotkit/react-core/v2";
+
+/**
+ * Send a message to Bellwether on the user's behalf: open the docked panel,
+ * append the message, and start a run — the same addMessage + runAgent path a
+ * suggestion pill takes, so the conversation reads exactly as if the merchandiser
+ * had typed it. Used by the sidebar Help control.
+ *
+ * PORTED, not imported. A skin's only inbound dependency is the shell's `Skin`
+ * contract, so `src/skins/commerce/**` must never reach into another skin's
+ * folder — even for a hook this small.
+ */
+export function useAskCopilot() {
+  // No explicit agentId: inherit the surrounding CopilotChatConfiguration's
+  // agentId (the active skin's id, "commerce"), so this drives the SAME
+  // agent/thread the docked chat panel uses.
+  const { agent } = useAgent();
+  const { copilotkit } = useCopilotKit();
+  const configuration = useCopilotChatConfiguration();
+  const setModalOpen = configuration?.setModalOpen;
+
+  return useCallback(
+    async (message: string) => {
+      setModalOpen?.(true);
+      agent.addMessage({
+        id: crypto.randomUUID(),
+        role: "user",
+        content: message,
+      });
+      try {
+        await copilotkit.runAgent({ agent });
+      } catch (error) {
+        console.error("askCopilot: runAgent failed", error);
+      }
+    },
+    [agent, copilotkit, setModalOpen],
+  );
+}
+
+export default useAskCopilot;

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/use-in-flight.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/use-in-flight.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useInFlight } from "./use-in-flight";
+
+/**
+ * The guard itself, tested apart from the buttons.
+ *
+ * It has to be, because jsdom does NOT dispatch a click to a `disabled` button: a
+ * rendered double-click therefore only ever proves the visible half (that the
+ * lever went disabled), never that `run` is a mutex in its own right. These four
+ * go at the mechanism directly.
+ *
+ * They live beside the hook rather than in the page that first used it — the hook
+ * is shared by `pages/promotions.tsx` and `pages/returns.tsx`, and a mechanism
+ * test filed under one caller is a test the next caller does not know exists.
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useInFlight", () => {
+  /** A promise the test settles by hand, so "in flight" is a real state. */
+  function deferred<T>() {
+    let settle: (value: T) => void = () => {};
+    const promise = new Promise<T>((resolve) => {
+      settle = resolve;
+    });
+    return { promise, settle };
+  }
+
+  it("refuses a second action while the first is still outstanding", async () => {
+    const { result } = renderHook(() => useInFlight());
+    const first = deferred<boolean>();
+    let secondRan = false;
+
+    let firstResult: Promise<boolean> = Promise.resolve(false);
+    let secondResult: Promise<boolean> = Promise.resolve(false);
+    await act(async () => {
+      firstResult = result.current.run("finalize", () => first.promise);
+      secondResult = result.current.run("finalize", async () => {
+        secondRan = true;
+        return true;
+      });
+    });
+
+    // The whole point: the second action never even ran, so the store never saw
+    // the repeat that would have come back ALREADY_FINALIZED.
+    expect(secondRan).toBe(false);
+    await expect(secondResult).resolves.toBe(false);
+
+    await act(async () => first.settle(true));
+    await expect(firstResult).resolves.toBe(true);
+  });
+
+  it("frees the guard once the first action settles", async () => {
+    const { result } = renderHook(() => useInFlight());
+    await act(async () => {
+      await result.current.run("finalize", async () => true);
+    });
+    let ran = false;
+    await act(async () => {
+      await result.current.run("finalize", async () => {
+        ran = true;
+        return true;
+      });
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("frees the guard even when the action THROWS, and resolves false", async () => {
+    const { result } = renderHook(() => useInFlight());
+    let thrown: boolean | undefined;
+    await act(async () => {
+      // Must not reject: every call site is a bare `void run(...)`.
+      thrown = await result.current.run("file", async () => {
+        throw new TypeError("Failed to fetch");
+      });
+    });
+    expect(thrown).toBe(false);
+
+    let ran = false;
+    await act(async () => {
+      await result.current.run("file", async () => {
+        ran = true;
+        return true;
+      });
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("reports which action is in flight, and nothing once it settles", async () => {
+    const { result } = renderHook(() => useInFlight());
+    const first = deferred<boolean>();
+    expect(result.current.busy).toBeNull();
+
+    let pending: Promise<boolean> = Promise.resolve(false);
+    await act(async () => {
+      pending = result.current.run("wvr-1", () => first.promise);
+    });
+    expect(result.current.busy).toBe("wvr-1");
+
+    await act(async () => {
+      first.settle(true);
+      await pending;
+    });
+    expect(result.current.busy).toBeNull();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/components/use-in-flight.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/components/use-in-flight.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * ONE write in flight per surface, guarded SYNCHRONOUSLY.
+ *
+ * `useState` alone does not close the window. Two clicks dispatched before React
+ * commits the `disabled` attribute both read the same `busy === null` out of
+ * their closure, so the write fires TWICE — and every write in this skin is
+ * guarded by the store against exactly that: the second call comes back
+ * `ALREADY_FINALIZED`, `ALREADY_DECIDED` or `ALREADY_REFUNDED` and the surface
+ * paints a refusal on an action that SUCCEEDED. Being told the thing you just did
+ * failed is the worst available outcome on a demo control surface, because the
+ * presenter's only recourse on stage is to do it again.
+ *
+ * So `busy` is the VISIBLE half — it disables the levers and renders
+ * "Finalizing…" — and the ref is what makes `run` a mutex on its own, so a lever
+ * that forgets `disabled` (or an element that has no such attribute to forget)
+ * cannot reopen the hole. Both halves are wanted; only the ref is sufficient.
+ *
+ * The guard is per-SURFACE rather than per-button: while a waiver is being filed
+ * the panel's other levers are refused too, since interleaving them is the same
+ * race by another route (finalize a draft while the filing that would replace it
+ * is still in flight).
+ *
+ * THE GRANULARITY RULE, which is what decides where a caller mounts an instance:
+ * an instance must be AT LEAST AS COARSE as the MESSAGE CHANNEL the writes it
+ * guards share. Two controls that report into one slot must share one instance, or
+ * a refusal from the first is erased by the second's success and the refused write
+ * ends up saying nothing at all — the same silent no-op this hook exists to
+ * prevent, reached through the report instead of the request. All three callers
+ * are worked examples: `pages/promotions.tsx` mounts ONE per card (four levers,
+ * two surfaces, one record); `pages/returns.tsx` mounts one per PAGE for its
+ * decisions, because every decision reports through the page's single notice —
+ * while its refund control, which has its own inline slot, holds its own; and
+ * `pages/orders.tsx` mounts one per ROW, because its hold and clear-exception
+ * levers speak about one order and report into that row's own slot.
+ *
+ * Coarser is therefore not automatically safer: the rule sets a FLOOR, and the
+ * channel is what sets it. Orders' rows deliberately do not share a guard, since
+ * a write on one row can never speak for another row's slot.
+ *
+ * `run` resolves the action's own "did it land" boolean, and `false` when it
+ * declined to start OR when the action never completed at all — so a caller may
+ * treat the resolved value as "this write definitely landed" and nothing else.
+ * It never REJECTS, which is why every call site can be a bare `void run(...)`:
+ * a rejecting `fetch` used to escape the click handler as an unhandled rejection,
+ * and a caller that had asked "did it land" would then never get an answer and
+ * would fall through to clearing what the user typed.
+ *
+ * It lives in `components/` beside the skin's other shared hook rather than inside
+ * the page that first needed it, because a hook exported from a PAGE does not read
+ * as importable: the second page that needed this grew a weaker `useState`-only
+ * copy instead — no mutex and no `finally`, so a rejecting fetch wedged its button
+ * on "Issuing…" until the presenter reloaded. One definition, every caller.
+ *
+ * Exported (rather than inlined at each surface) also for its own test: jsdom does
+ * not dispatch clicks to a `disabled` button, so a rendered double-click can only
+ * ever exercise the visible half.
+ */
+export function useInFlight() {
+  const inFlight = useRef<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const run = useCallback(
+    async (key: string, action: () => Promise<boolean>): Promise<boolean> => {
+      if (inFlight.current !== null) return false;
+      inFlight.current = key;
+      setBusy(key);
+      try {
+        return await action();
+      } catch (error) {
+        // The write handlers themselves surface every REFUSAL on the surface.
+        // This is the narrower case they cannot: the request never produced a
+        // response, so there is nothing to report about — least of all success.
+        console.error(`[commerce] the ${key} write did not complete`, error);
+        return false;
+      } finally {
+        inFlight.current = null;
+        setBusy(null);
+      }
+    },
+    [],
+  );
+
+  return { busy, run };
+}
+
+/** One mounted guard, for a surface that hands its own down to a child. */
+export type InFlight = ReturnType<typeof useInFlight>;

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/derive.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/derive.test.ts
@@ -1,0 +1,629 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CATEGORY_ORDER,
+  EXCEPTION_FILTERS,
+  FLOOR_WORKLIST_RANK,
+  HOLD_REASONS,
+  LADDER_ABOVE_FLOOR,
+  LADDER_BELOW_FLOOR,
+  LADDER_CEILING,
+  LADDER_FLOOR_RATIO,
+  ORDER_EXCEPTION_LABEL,
+  belowFloorCount,
+  countBelow,
+  discountedPrice,
+  ladderRatio,
+  marginAt,
+  marginPosition,
+  noFloorCaveat,
+  noMarkdownFloorCaveat,
+  nullableBelowFloor,
+  productFloorStatus,
+  productMargin,
+  promotionFloorStatus,
+  refundCeilingLabel,
+  refundGuidance,
+  tallyFloorStatus,
+  tallyStatuses,
+  weeksOfCover,
+  windowLabel,
+} from "./derive";
+import { SEED_FLOORS, SEED_PRODUCTS } from "./seed";
+import { ORDER_EXCEPTIONS } from "./types";
+import type { MarginFloor, Product, Promotion } from "./types";
+
+const FLOORS: MarginFloor[] = [
+  { category: "Footwear", floor: 0.4, target: 0.5 },
+  { category: "Accessories", floor: 0.55, target: 0.64 },
+];
+
+const product = (over: Partial<Product> = {}): Product => ({
+  id: "prd-x",
+  sku: "BW-X",
+  name: "Test Product",
+  category: "Footwear",
+  listPrice: 145,
+  unitCost: 88,
+  inventory: 480,
+  trailing30Units: 388,
+  status: "live",
+  vendor: "Vela Footworks",
+  ...over,
+});
+
+/**
+ * BEAT 3c's completeness invariant.
+ *
+ * This is the one assertion in the file that is about STAGECRAFT rather than
+ * arithmetic, and it is here because the failure it guards is invisible: an
+ * exception value the agent can set but the page has no control for filters the
+ * rows perfectly and lights nothing up, so the audience sees a filtered list
+ * with nothing on screen crediting the assistant. That shipped once, for three
+ * of seven values.
+ */
+describe("EXCEPTION_FILTERS", () => {
+  it("offers a control for every real exception, plus all/any", () => {
+    const real = ORDER_EXCEPTIONS.filter((e) => e !== "none");
+    expect([...EXCEPTION_FILTERS]).toEqual(["all", "any", ...real]);
+  });
+
+  it("drops `none`, which `all` already expresses", () => {
+    expect(EXCEPTION_FILTERS).not.toContain("none");
+  });
+
+  /**
+   * The same invariant for the WRITE side. `HOLD_REASONS` is asserted into the
+   * non-empty tuple `z.enum()` needs, which is the one thing `filter` cannot
+   * prove — so its membership and its non-emptiness are pinned here instead.
+   */
+  it("holds an order for every real exception and for nothing else", () => {
+    expect([...HOLD_REASONS]).toEqual(
+      ORDER_EXCEPTIONS.filter((e) => e !== "none"),
+    );
+    expect(HOLD_REASONS.length).toBeGreaterThan(0);
+    expect(HOLD_REASONS).not.toContain("none");
+  });
+
+  it("labels every filter it offers", () => {
+    const labels: Record<string, string> = {
+      all: "All",
+      any: "Any exception",
+      ...ORDER_EXCEPTION_LABEL,
+    };
+    for (const filter of EXCEPTION_FILTERS) {
+      expect(labels[filter]).toBeTruthy();
+    }
+  });
+});
+
+describe("margin arithmetic", () => {
+  it("computes margin at a price and guards a zero or negative price", () => {
+    expect(marginAt(100, 40)).toBeCloseTo(0.6, 5);
+    expect(marginAt(0, 40)).toBe(0);
+    expect(marginAt(-10, 40)).toBe(0);
+  });
+
+  it("prices a discount to the cent", () => {
+    expect(discountedPrice(128, 40)).toBe(76.8);
+    expect(discountedPrice(240, 35)).toBe(156);
+    expect(discountedPrice(100, 0)).toBe(100);
+  });
+
+  it("mirrors the store: clamped ratio, RAW below-floor test", () => {
+    // The split is the whole reason both exist. Clamping positions the dot on
+    // the ladder rail; it must never be allowed to hide a violation.
+    const under = marginPosition(FLOORS, "Footwear", 0.2);
+    expect(under?.ratio).toBe(0);
+    expect(under?.belowFloor).toBe(true);
+
+    const over = marginPosition(FLOORS, "Footwear", LADDER_CEILING + 0.1);
+    expect(over?.ratio).toBe(1);
+    expect(over?.belowFloor).toBe(false);
+
+    // Exactly at the floor is NOT a violation — the gate is `<`, not `<=`.
+    const atFloor = marginPosition(FLOORS, "Footwear", 0.4);
+    expect(atFloor?.belowFloor).toBe(false);
+    expect(atFloor?.ratio).toBe(0);
+  });
+
+  it("returns null for a category with no floor on file", () => {
+    expect(marginPosition(FLOORS, "Home", 0.5)).toBeNull();
+  });
+
+  it("flags the seeded Lark Runner shape as below its floor", () => {
+    const lark = product(); // 145 / 88 → 39.3% against a 40% Footwear floor
+    expect(productMargin(lark)).toBeCloseTo(0.393, 3);
+    expect(productFloorStatus(FLOORS, lark)).toBe("below");
+  });
+});
+
+/**
+ * A MISSING FLOOR MUST NEVER READ AS COMPLIANT.
+ *
+ * `isBelowFloor` used to end `?? false`, so a product whose category had no floor
+ * on file came back `false` — indistinguishable from "checked, and fine". Every
+ * consumer then painted the worst possible answer: a green `belowFloorSkus: 0`
+ * all-clear on the exact figure this skin's signature visual and its beat-6 gate
+ * are about. The server refuses to guess the same condition at all
+ * (`store.floorFor` throws `UNKNOWN_CATEGORY` rather than return a zeroed floor
+ * that "would make every margin look healthy"), so the client asserted the
+ * opposite of what the server would not even assume.
+ *
+ * These assertions are the whole reason `FloorStatus` has three values.
+ */
+describe("a category with no floor on file", () => {
+  const homeless = product({ category: "Home" }); // no Home floor in FLOORS
+
+  it("is reported as unknown, and specifically NOT as clear", () => {
+    const status = productFloorStatus(FLOORS, homeless);
+    expect(status).toBe("unknown");
+    expect(status).not.toBe("clear");
+    // The old boolean shape, restated: nothing may coerce this to "compliant".
+    expect(nullableBelowFloor(status)).toBeNull();
+    expect(nullableBelowFloor(status)).not.toBe(false);
+  });
+
+  it("does NOT produce a `belowFloorSkus: 0` all-clear", () => {
+    // One unmeasurable SKU and nothing else: the count a KPI card or the
+    // sandbox's getTradingKpis would publish must be null, never 0.
+    expect(belowFloorCount(FLOORS, [homeless])).toBeNull();
+    expect(belowFloorCount(FLOORS, [homeless])).not.toBe(0);
+
+    // And it still refuses a number when there ARE known violations mixed in —
+    // a partial count presented as the count is the same lie in a smaller font.
+    expect(belowFloorCount(FLOORS, [homeless, product()])).toBeNull();
+  });
+
+  it("is tallied apart from the compliant products, never folded into them", () => {
+    const clear = product({ listPrice: 200, unitCost: 80 }); // 60% vs 40% floor
+    const tally = tallyFloorStatus(FLOORS, [homeless, clear, product()]);
+    expect(tally).toEqual({ below: 1, clear: 1, unknown: 1 });
+  });
+
+  it("has a caveat to render, so a consumer can say why", () => {
+    expect(noFloorCaveat(0)).toBeNull();
+    expect(noFloorCaveat(1)).toContain("1 SKU");
+    expect(noFloorCaveat(3)).toContain("3 SKUs");
+    // The promotions desk counts MARKDOWNS, and its caveat has to name them —
+    // a sentence about SKUs sends the reader to the wrong page.
+    expect(noMarkdownFloorCaveat(1)).toContain("1 markdown has");
+    expect(noMarkdownFloorCaveat(2)).toContain("2 markdowns have");
+    expect(noMarkdownFloorCaveat(0)).toBeNull();
+  });
+
+  it("withholds the headline figure for ANY set of verdicts, not just products", () => {
+    // `countBelow` is what the promotions desk counts markdowns with. Same rule,
+    // one implementation: an unknown anywhere in the set means no defensible
+    // total, and a below-floor row still reports itself.
+    expect(countBelow(tallyStatuses(["below", "clear"]))).toBe(1);
+    expect(countBelow(tallyStatuses(["below", "unknown"]))).toBeNull();
+    expect(countBelow(tallyStatuses(["unknown"]))).not.toBe(0);
+    expect(countBelow(tallyStatuses([]))).toBe(0);
+  });
+
+  it("ranks an unchecked row above the cleared ones on every worklist", () => {
+    // Both the catalog's rows and the promotions desk's cards sort by this, so a
+    // row nobody verified cannot sink beneath the rows that were.
+    const { below, unknown, clear } = FLOOR_WORKLIST_RANK;
+    expect(below).toBeLessThan(unknown);
+    expect(unknown).toBeLessThan(clear);
+  });
+
+  it("treats a markdown on it as unknown rather than approvable", () => {
+    const promotion: Promotion = {
+      id: "promo-x",
+      name: "Test markdown",
+      productId: homeless.id,
+      discountPercent: 40,
+      startsAt: "2026-01-01",
+      endsAt: "2026-01-14",
+      submittedBy: "op-nadia",
+      submittedAt: "2026-01-01T00:00:00.000Z",
+      status: "pending",
+      marginWaiverId: null,
+    };
+    expect(promotionFloorStatus(FLOORS, homeless, promotion)).toBe("unknown");
+    // A markdown whose product cannot be resolved is equally unknown, not clear.
+    expect(promotionFloorStatus(FLOORS, undefined, promotion)).toBe("unknown");
+    // …while a real floor still decides normally: 145 at −40% is 24.7% margin.
+    expect(promotionFloorStatus(FLOORS, product(), promotion)).toBe("below");
+  });
+});
+
+describe("normal data is unchanged by the tri-state", () => {
+  it("still finds exactly the two seeded below-floor products", () => {
+    const floors = [...SEED_FLOORS];
+    const products = [...SEED_PRODUCTS];
+    const tally = tallyFloorStatus(floors, products);
+    expect(tally.unknown).toBe(0);
+    expect(tally.below).toBe(2);
+    expect(tally.clear).toBe(SEED_PRODUCTS.length - 2);
+
+    // The headline figure is a real number — the em-dash path is for a broken
+    // ledger only, and must not appear on the seeded demo.
+    expect(belowFloorCount(floors, products)).toBe(2);
+
+    const below = products.filter(
+      (p) => productFloorStatus(floors, p) === "below",
+    );
+    expect(below.map((p) => p.id).sort()).toEqual([
+      "prd-harbor-parka",
+      "prd-lark-runner",
+    ]);
+  });
+
+  it("maps a checked product onto the boolean the model used to get", () => {
+    expect(nullableBelowFloor(productFloorStatus(FLOORS, product()))).toBe(
+      true,
+    );
+    expect(
+      nullableBelowFloor(
+        productFloorStatus(FLOORS, product({ listPrice: 200, unitCost: 80 })),
+      ),
+    ).toBe(false);
+  });
+
+  it("gives an empty range a real zero, not an unknown", () => {
+    // No products means nothing went unchecked — an all-clear here is honest.
+    expect(belowFloorCount(FLOORS, [])).toBe(0);
+  });
+});
+
+describe("weeksOfCover", () => {
+  it("computes weeks of cover at the trailing-30 run rate", () => {
+    // 480 on hand / (388 per 4.33 weeks) ≈ 5.4 weeks
+    expect(weeksOfCover(product())).toBeCloseTo(5.4, 1);
+  });
+
+  it("returns null rather than Infinity for a product selling nothing", () => {
+    expect(weeksOfCover(product({ trailing30Units: 0 }))).toBeNull();
+  });
+});
+
+/**
+ * WINDOW LABELS ARE CALENDAR ARITHMETIC, AND THE CLOCK IS PINNED TO PROVE IT.
+ *
+ * `startsAt`/`endsAt` are date-only `YYYY-MM-DD` strings minted in UTC by
+ * `store.daysFromNowDate`, so they denote a DAY. `daysUntil` used to subtract
+ * one from `Date.now()` — an instant — and round, which made every label move
+ * with the wall clock: past 12:00:00 UTC a window ending today crossed −0.5 days
+ * and rounded to −1, so the promotions page and the agent both narrated "ended
+ * yesterday" on the day it ends. No seeded window ends today, so the seed hid
+ * it, and it only reproduced in the afternoon.
+ *
+ * Hence the two pinned times below. 00:30 UTC and 23:30 UTC sit on either side
+ * of that old 12:00 flip, so the SAME window must produce the SAME label at
+ * both — that equality is the regression, and a wobble of ±1 anywhere in the
+ * table fails it. Exact day counts (not shapes) are assertable precisely
+ * because the clock no longer leaks in.
+ */
+describe("windowLabel", () => {
+  /** The anchor "today", 2026-08-10, in UTC. */
+  const TODAY_UTC = Date.UTC(2026, 7, 10);
+
+  /** Date-only, UTC — exactly how `store.daysFromNowDate` writes these. */
+  const isoDate = (offsetDays: number) =>
+    new Date(TODAY_UTC + offsetDays * 86_400_000).toISOString().slice(0, 10);
+
+  /** Move the pinned clock within that same UTC day. */
+  const at = (hour: number, minute: number) =>
+    vi.setSystemTime(new Date(TODAY_UTC + hour * 3_600_000 + minute * 60_000));
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Straddles the old rounding flip: at 00:30 a same-day window rounded to 0,
+  // at 23:30 to −1.
+  const TIMES: ReadonlyArray<readonly [string, number, number]> = [
+    ["00:30 UTC", 0, 30],
+    ["23:30 UTC", 23, 30],
+  ];
+
+  for (const [when, hour, minute] of TIMES) {
+    describe(`at ${when}`, () => {
+      beforeEach(() => at(hour, minute));
+
+      it("says a window ending today ENDS today, not that it ended yesterday", () => {
+        expect(windowLabel(isoDate(-6), isoDate(0))).toBe("ends today");
+      });
+
+      it("says a one-day window ends today, not merely that it started", () => {
+        expect(windowLabel(isoDate(0), isoDate(0))).toBe("ends today");
+      });
+
+      it("counts a future window in whole calendar days", () => {
+        expect(windowLabel(isoDate(6), isoDate(27))).toBe("starts in 6 days");
+        expect(windowLabel(isoDate(1), isoDate(9))).toBe("starts tomorrow");
+      });
+
+      it("still opens a window that starts today and runs on", () => {
+        expect(windowLabel(isoDate(0), isoDate(5))).toBe("starts today");
+      });
+
+      it("counts a live window's remaining days", () => {
+        expect(windowLabel(isoDate(-2), isoDate(5))).toBe(
+          "live, ends in 5 days",
+        );
+      });
+
+      it("counts a past window back from yesterday", () => {
+        expect(windowLabel(isoDate(-6), isoDate(-1))).toBe("ended yesterday");
+        expect(windowLabel(isoDate(-30), isoDate(-7))).toBe("ended 7 days ago");
+      });
+    });
+  }
+
+  it("gives a window ONE label whatever the hour", () => {
+    const labels = new Set<string>();
+    for (let hour = 0; hour < 24; hour += 1) {
+      at(hour, 30);
+      labels.add(windowLabel(isoDate(-6), isoDate(0)));
+    }
+    expect([...labels]).toEqual(["ends today"]);
+  });
+});
+
+/**
+ * THE LADDER'S ONE INVARIANT.
+ *
+ * The margin ladder's entire claim is that every category's floor line sits at
+ * the SAME height, so "how far am I from the line I may not cross" is comparable
+ * across categories at a glance. That is a property of `ladderRatio` alone, and
+ * it is the kind of property that breaks silently: a per-category term slipped
+ * into the denominator still renders a plausible chart. It shipped broken once —
+ * normalizing each rail over `[floor - 0.12, LADDER_CEILING]` put Home's floor at
+ * 24.5% of the rail and Accessories' at 37.5%, ~30px apart on a 232px rail, so
+ * the two seeded violations did not line up.
+ */
+describe("ladderRatio", () => {
+  const RAIL = 232; // the full-size rail, in px
+
+  it("puts the floor at ONE height on every rail, whatever the floor is", () => {
+    const positions = SEED_FLOORS.map((f) => ladderRatio(f.floor, f.floor));
+
+    // Every seeded floor — 38% through 55% — maps to the same spot…
+    expect(new Set(positions).size).toBe(1);
+    // …which is the exported constant the component draws the line at.
+    expect(positions[0]).toBe(LADDER_FLOOR_RATIO);
+
+    // Stated in the pixels that actually matter: no spread at all.
+    const pixels = positions.map((r) => r * RAIL);
+    expect(Math.max(...pixels) - Math.min(...pixels)).toBe(0);
+  });
+
+  it("holds for floors far outside the seeded range", () => {
+    // Not a property of these five numbers — a property of the mapping.
+    for (const floor of [0, 0.05, 0.2, 0.38, 0.55, 0.8, 0.95]) {
+      expect(ladderRatio(floor, floor)).toBeCloseTo(LADDER_FLOOR_RATIO, 12);
+    }
+  });
+
+  it("gives one margin point the same pixels on every rail", () => {
+    // The other half of a shared axis: equal DISTANCE from the floor must be
+    // equal distance on screen, or "2 points under" reads differently by column.
+    for (const delta of [-0.04, -0.005, 0, 0.03, 0.18]) {
+      const ratios = SEED_FLOORS.map((f) =>
+        ladderRatio(f.floor + delta, f.floor),
+      );
+      expect(new Set(ratios.map((r) => r.toFixed(12))).size).toBe(1);
+    }
+  });
+
+  it("draws a violation below the shared floor line and a healthy SKU above", () => {
+    const home = { floor: 0.38 };
+    const accessories = { floor: 0.55 };
+    // The two seeded violations: Harbor Parka is 0.57pt under a 42% floor and
+    // Lark Runner 0.69pt under a 40% floor.
+    expect(ladderRatio(0.4143, 0.42)).toBeLessThan(LADDER_FLOOR_RATIO);
+    expect(ladderRatio(0.3931, 0.4)).toBeLessThan(LADDER_FLOOR_RATIO);
+    // …and they land within a pixel of each other, which is the comparison the
+    // ladder exists to make.
+    const gap =
+      Math.abs(ladderRatio(0.4143, 0.42) - ladderRatio(0.3931, 0.4)) * RAIL;
+    expect(gap).toBeLessThan(1);
+
+    expect(ladderRatio(home.floor + 0.05, home.floor)).toBeGreaterThan(
+      LADDER_FLOOR_RATIO,
+    );
+    expect(
+      ladderRatio(accessories.floor + 0.05, accessories.floor),
+    ).toBeGreaterThan(LADDER_FLOOR_RATIO);
+  });
+
+  it("clamps to the rail rather than escaping it", () => {
+    expect(ladderRatio(0.4 - LADDER_BELOW_FLOOR - 0.5, 0.4)).toBe(0);
+    expect(ladderRatio(0.4 + LADDER_ABOVE_FLOOR + 0.5, 0.4)).toBe(1);
+  });
+
+  it("keeps every seeded product and target inside the plotted range", () => {
+    // The headrooms are sized to this data; if a future seed puts a SKU outside
+    // them it clamps to an end of the rail and stops being readable. Assert on
+    // the RAW ratio, since the clamp is exactly what would hide the problem.
+    for (const floor of SEED_FLOORS) {
+      const span = LADDER_BELOW_FLOOR + LADDER_ABOVE_FLOOR;
+      const raw = (margin: number) =>
+        (margin - floor.floor + LADDER_BELOW_FLOOR) / span;
+
+      expect(raw(floor.target)).toBeGreaterThan(0);
+      expect(raw(floor.target)).toBeLessThan(1);
+
+      for (const item of SEED_PRODUCTS.filter(
+        (p) => p.category === floor.category,
+      )) {
+        const margin = marginAt(item.listPrice, item.unitCost);
+        expect(raw(margin), `${item.name} is off the rail`).toBeGreaterThan(0);
+        expect(raw(margin), `${item.name} is off the rail`).toBeLessThan(1);
+      }
+    }
+  });
+});
+
+describe("CATEGORY_ORDER", () => {
+  it("is a stable presentation order shared by every surface", () => {
+    // The ladder, the catalog filter and the canvas brief all read this. If they
+    // disagreed, two views of the same range would look like two ranges.
+    expect([...CATEGORY_ORDER]).toEqual([
+      "Outerwear",
+      "Knitwear",
+      "Footwear",
+      "Accessories",
+      "Home",
+    ]);
+  });
+});
+
+/**
+ * BEAT 3a's control, where the guidance and the rule meet.
+ *
+ * The bug this pins: the placeholder printed `formatMoney(itemValue)` — rounded
+ * to whole dollars — while the button compared the typed amount EXACTLY against
+ * `itemValue`. On a $152.50 return the card invited "up to $153" and then refused
+ * 153 with a disabled button and no explanation. The app's own instruction was
+ * the thing that misled the operator, which is worse than a wrong number.
+ *
+ * No seeded return has cents today (340, 96, 152, 96, 290 — `SEED_RETURNS`
+ * requires a whole number of units at the order line's price, and every seeded
+ * `unitPrice` is whole), so the defect is LATENT. It stops being latent the
+ * moment any price carries cents, and `store.issueRefund` already stores refunds
+ * to the cent.
+ */
+/** What an operator reading the placeholder would actually type. */
+const invitedFigure = (placeholder: string) =>
+  placeholder.replace(/[^0-9.]/g, "");
+
+describe("refundGuidance", () => {
+  it("accepts the amount its own placeholder invites, to the cent", () => {
+    for (const itemValue of [152.5, 96.99, 340, 0.05, 1234.56]) {
+      const { placeholder } = refundGuidance(itemValue, "");
+      const typed = invitedFigure(placeholder);
+      const invited = refundGuidance(itemValue, typed);
+      expect(invited.valid, `${placeholder} refused "${typed}"`).toBe(true);
+      expect(invited.amount).toBe(itemValue);
+    }
+  });
+
+  it("states the ceiling once — the placeholder is built from the label", () => {
+    // Two figures for one `itemValue` is the same defect wearing a different
+    // hat: the row column, the "Charged …" label and the placeholder all print
+    // this, and a rounded one next to an exact one contradicts the instruction.
+    const { placeholder, ceiling } = refundGuidance(152.5, "");
+    expect(ceiling).toBe("$152.50");
+    expect(ceiling).toBe(refundCeilingLabel(152.5));
+    expect(placeholder).toBe("up to $152.50");
+    expect(placeholder).toContain(ceiling);
+  });
+
+  it("keeps whole-dollar ceilings free of noise cents", () => {
+    // The seeded demo values are whole, and the fix must not repaint them as
+    // "$340.00" on stage.
+    expect(refundGuidance(340, "").placeholder).toBe("up to $340");
+  });
+
+  it("mirrors the store's range rule and nothing more", () => {
+    // `store.issueRefund`: > 0 and <= itemValue. The UI states it; the store
+    // owns it.
+    expect(refundGuidance(152.5, "152.51").valid).toBe(false);
+    expect(refundGuidance(152.5, "0").valid).toBe(false);
+    expect(refundGuidance(152.5, "").valid).toBe(false);
+    expect(refundGuidance(152.5, "abc").valid).toBe(false);
+    expect(refundGuidance(152.5, "$40.25").valid).toBe(true);
+    expect(refundGuidance(152.5, "$40.25").amount).toBe(40.25);
+  });
+
+  /**
+   * THE CLASS: a typo must be REFUSED, never silently rewritten into a
+   * different figure that then passes every rule.
+   *
+   * `Number(typed.replace(/[^0-9.]/g, ""))` — the original spelling — deleted
+   * whatever it did not recognise and kept going, so on the one path in this app
+   * that moves money a slip became a valid instruction: `-50` was issued as a
+   * real $50 refund, and `1e5` as $15. The store cannot catch either; both are
+   * finite, positive and under the ceiling by the time it sees them.
+   */
+  it("refuses a malformed figure instead of rewriting it", () => {
+    for (const typed of [
+      "-50", // a sign is a different number — this was $50
+      "+50",
+      "1e5", // the `e` vanished and the digits joined — this was $15
+      "1E5",
+      "50.00.1", // two dots — this was $50.001
+      "5 0", // internal space — this was $50
+      "50px",
+      "50$", // a trailing symbol is not formatting this app prints
+      "1,23", // grouping no locale writes — this was $123
+      "1,2,3",
+      ",50",
+      "abc",
+      ".",
+      "$",
+    ]) {
+      const { amount, valid, empty, problem } = refundGuidance(152.5, typed);
+      expect(valid, `"${typed}" was accepted`).toBe(false);
+      expect(Number.isFinite(amount), `"${typed}" produced a figure`).toBe(
+        false,
+      );
+      expect(empty, `"${typed}" read as untyped`).toBe(false);
+      expect(problem, `"${typed}" was refused silently`).toBeTruthy();
+    }
+  });
+
+  it("tolerates the formatting its own labels use", () => {
+    // Everything here is the SAME number as written, only dressed: surrounding
+    // space, the leading `$` the placeholder prints, and the thousands comma
+    // `formatMoneyExact` emits.
+    expect(refundGuidance(152.5, "  50  ")).toMatchObject({
+      amount: 50,
+      valid: true,
+    });
+    expect(refundGuidance(152.5, "$50")).toMatchObject({
+      amount: 50,
+      valid: true,
+    });
+    expect(refundGuidance(152.5, "$ 50")).toMatchObject({
+      amount: 50,
+      valid: true,
+    });
+    expect(refundGuidance(2000, "1,234.56")).toMatchObject({
+      amount: 1234.56,
+      valid: true,
+    });
+    // Mid-typing shapes that are unambiguous as written.
+    expect(refundGuidance(152.5, "50.")).toMatchObject({
+      amount: 50,
+      valid: true,
+    });
+    expect(refundGuidance(152.5, ".5")).toMatchObject({
+      amount: 0.5,
+      valid: true,
+    });
+  });
+
+  it("tells an untyped input apart from a refused one", () => {
+    // A control the operator has not touched must not be scolded; the button is
+    // disabled either way, but only one of the two is a mistake.
+    for (const blank of ["", "   "]) {
+      const guidance = refundGuidance(152.5, blank);
+      expect(guidance.valid).toBe(false);
+      expect(guidance.empty).toBe(true);
+      expect(guidance.problem).toBeNull();
+    }
+    const refused = refundGuidance(152.5, "-50");
+    expect(refused.empty).toBe(false);
+    expect(refused.problem).toBeTruthy();
+  });
+
+  it("says the range out loud when the figure is readable but out of range", () => {
+    // Readable, so the operator gets the ceiling rather than "unreadable" —
+    // still a MIRROR of `store.issueRefund`, never a second authority.
+    const over = refundGuidance(152.5, "152.51");
+    expect(over.amount).toBe(152.51);
+    expect(over.valid).toBe(false);
+    expect(over.problem).toContain("$152.50");
+    expect(refundGuidance(152.5, "0").problem).toContain("$152.50");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/derive.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/derive.ts
@@ -1,0 +1,756 @@
+/**
+ * Pure derivations shared by the pages, the gen-UI components, the agent's
+ * readables and the sandbox functions.
+ *
+ * These deliberately DO NOT import `store.ts`. The store is the server's
+ * in-memory ledger; importing it from a client component would bundle the whole
+ * seed into the browser and create a second, silently divergent copy of the
+ * data — so everything here takes the floors it needs as an argument, sourced
+ * from the one snapshot the ledger context fetched.
+ */
+
+import { CATEGORIES, ORDER_EXCEPTIONS, ORDER_STATUSES } from "./types";
+import type {
+  Category,
+  MarginFloor,
+  MarginPosition,
+  Order,
+  OrderException,
+  Product,
+  Promotion,
+  ReturnReason,
+  ReturnRequest,
+} from "./types";
+
+const DAY_MS = 86_400_000;
+
+/**
+ * The order categories are presented in, everywhere. Re-exported from `types`
+ * so a component never has to reach past `derive` for one constant — and so the
+ * ladder, the catalog filter and the canvas brief can never disagree about the
+ * order, which would make two views of the same range look like two ranges.
+ */
+export const CATEGORY_ORDER: readonly Category[] = CATEGORIES;
+
+/**
+ * Must match `store.LADDER_CEILING` — the top of the `marginPosition` scale.
+ *
+ * NOT the top of a ladder rail: the ladder plots the floor-relative axis below
+ * (`ladderRatio`), which has no absolute ceiling. This constant belongs to
+ * `marginPosition`, whose per-row bar fills from that category's floor up to a
+ * shared absolute ceiling.
+ */
+export const LADDER_CEILING = 0.75;
+
+/**
+ * THE LADDER AXIS — floor-relative, and therefore genuinely SHARED.
+ *
+ * Every rail plots `margin - floor` on ONE axis spanning
+ * `[-LADDER_BELOW_FLOOR, +LADDER_ABOVE_FLOOR]` margin points. Two consequences,
+ * and they are the ladder's whole thesis:
+ *
+ *  - the floor lands at `LADDER_FLOOR_RATIO` on EVERY rail, whether that
+ *    category's floor is 38% or 55%, so "under its floor" is one height across
+ *    the range and the two seeded violations line up;
+ *  - one margin point is the same number of pixels on every rail and on both
+ *    sides of the line, so "8 points under" and "1 point under" are as far apart
+ *    as they sound.
+ *
+ * An earlier version normalized each rail over `[floor - 0.12, LADDER_CEILING]`,
+ * which is what NOT to do: the span shrinks as the floor rises, so the floor
+ * line drifted from 24.5% of the rail (Home, 38%) to 37.5% (Accessories, 55%) —
+ * a ~30px spread on a 232px rail, and no cross-category comparison at all.
+ *
+ * The two headrooms are sized to the range they have to hold without clamping:
+ * the widest seeded margin sits 18.3 points over its floor and the most generous
+ * target 12 points over, so 24 points of room above; violations are fractions of
+ * a point, so 6 points below is ample and keeps the pixels-per-point scale
+ * usefully tight.
+ *
+ * The ladder needs this rather than `marginPosition`'s ratio because that helper
+ * clamps at the floor — right for a row's bar, wrong for a rail, where a stack
+ * of violations pinned to one line cannot show how far under they are.
+ */
+export const LADDER_BELOW_FLOOR = 0.06;
+export const LADDER_ABOVE_FLOOR = 0.24;
+const LADDER_SPAN = LADDER_BELOW_FLOOR + LADDER_ABOVE_FLOOR;
+
+/**
+ * Where the floor line sits on every rail, 0 at the base and 1 at the top.
+ * A CONSTANT — that is the point. Equal to `ladderRatio(f, f)` for any `f`.
+ */
+export const LADDER_FLOOR_RATIO = LADDER_BELOW_FLOOR / LADDER_SPAN;
+
+/**
+ * Where a margin sits on a ladder rail, 0 at the rail's base and 1 at its top.
+ * Clamped, so a value outside the plotted range pins to an end rather than
+ * escaping the rail.
+ */
+export function ladderRatio(margin: number, floor: number): number {
+  const raw = (margin - floor + LADDER_BELOW_FLOOR) / LADDER_SPAN;
+  return Math.min(1, Math.max(0, raw));
+}
+
+export const formatMoney = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+/** Keeps the cents when a refund or a discounted price actually has them. */
+export const formatMoneyExact = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: Number.isInteger(n) ? 0 : 2,
+    maximumFractionDigits: 2,
+  }).format(n);
+
+/**
+ * BEAT 3a's refund ceiling, as the app STATES it — always exact.
+ *
+ * Every surface that prints "what was charged" for a return goes through this
+ * one function, so the goodwill card and the returns row cannot render the same
+ * `itemValue` as two different figures.
+ */
+export const refundCeilingLabel = (itemValue: number) =>
+  formatMoneyExact(itemValue);
+
+/**
+ * BEAT 3a's refund control, resolved: the figure the input INVITES and the rule
+ * that ACCEPTS it, derived together from one `itemValue` so they cannot disagree.
+ *
+ * They used to be written apart, and they drifted the worst way round. The
+ * placeholder printed `formatMoney(itemValue)`, which ROUNDS to whole dollars,
+ * while the button compared the typed amount EXACTLY against `itemValue` (the
+ * same ceiling `store.issueRefund` enforces as `REFUND_EXCEEDS_VALUE`). On a
+ * return charged $152.50 the app therefore invited "up to $153" and then sat
+ * there with the button disabled and nothing on screen saying why — the app's
+ * own instruction was the thing that misled the operator.
+ *
+ * `amount` is what to submit; it is only meaningful when `valid`. The range rule
+ * is stated here for the UI's benefit only — the STORE owns it (`http.ts` refuses
+ * a non-number at the boundary, `store.issueRefund` owns `> 0` / `<= itemValue`),
+ * and this must stay a mirror of it, never a second authority.
+ */
+export function refundGuidance(itemValue: number, typed: string) {
+  const ceiling = refundCeilingLabel(itemValue);
+  const amount = parseMoneyFigure(typed);
+  const readable = Number.isFinite(amount);
+  const valid = readable && amount > 0 && amount <= itemValue;
+  return {
+    /** The charged figure, for any label that prints it. */
+    ceiling,
+    /** The input's placeholder — built FROM `ceiling`, so it states the same figure. */
+    placeholder: `up to ${ceiling}`,
+    amount,
+    valid,
+    /**
+     * Nothing has been typed yet. `valid` is `false` either way, but this is the
+     * ONE reason for it that is not the operator's mistake — a control nobody
+     * has touched must not be scolded.
+     */
+    empty: typed.trim().length === 0,
+    /**
+     * Why the figure was refused, as a sentence to put next to the input. `null`
+     * when there is nothing to say — the figure is good, or nothing is typed.
+     *
+     * A disabled button and no explanation is the exact failure this function's
+     * header was written about; a refusal the operator cannot see is only half a
+     * fix. Still a MIRROR: it restates the ceiling the placeholder already
+     * states, and decides nothing.
+     */
+    problem: refundProblem({ valid, readable, typed, ceiling }),
+  };
+}
+
+/**
+ * ONE money figure as typed, or `NaN` when the input is not one.
+ *
+ * WHY THIS IS NOT A `.replace(/[^0-9.]/g, "")`. That was the original spelling,
+ * and on the one path in this app that moves money it turned a typo into a
+ * DIFFERENT, fully valid instruction: `-50` was issued as a real $50 refund and
+ * `1e5` as $15 (the `e` deleted, the digits joined). Neither can be caught
+ * downstream — by the time `store.issueRefund` sees them they are finite,
+ * positive and under the ceiling — and `""` and `"abc"` both coerced to `0`, so a
+ * refusal could not be told from an untouched field either.
+ *
+ * The rule, then: tolerate FORMATTING, refuse a DIFFERENT NUMBER.
+ *
+ * | Input                  | Verdict   | Why                                     |
+ * | ---------------------- | --------- | --------------------------------------- |
+ * | `"  50  "`             | `50`      | surrounding space is not a character     |
+ * | `"$50"`, `"$ 50"`      | `50`      | one LEADING `$` — how `placeholder` and  |
+ * |                        |           | the "Charged …" label print the ceiling  |
+ * | `"1,234.56"`           | `1234.56` | grouped exactly as `formatMoneyExact`    |
+ * |                        |           | prints it, so it is what gets copied     |
+ * | `"40.25"`, `"50."`, `".5"` | as written | unambiguous decimal, mid-typing    |
+ * |                        |           | shapes included                          |
+ * | `"40.255"`             | `40.255`  | over-precise, NOT malformed — the store  |
+ * |                        |           | rounds to cents and owns that            |
+ * | `"-50"`, `"+50"`       | REFUSED   | a sign is a different number             |
+ * | `"1e5"`, `"1E5"`       | REFUSED   | an exponent is a different number        |
+ * | `"50.00.1"`            | REFUSED   | two dots name no figure                  |
+ * | `"1,23"`, `"1,2,3"`, `",50"` | REFUSED | grouping no locale writes; keeping |
+ * |                        |           | the digits alone silently means `123`    |
+ * | `"5 0"`, `"50px"`, `"50$"`, `"abc"` | REFUSED | stray characters mean the  |
+ * |                        |           | input was not the figure it looks like   |
+ * | `""`, `"   "`, `"$"`, `"."` | REFUSED | no digit at all (`empty` above tells |
+ * |                        |           | the untyped case apart for the UI)       |
+ *
+ * `NaN` rather than `null` is the refusal, so `amount` stays a `number` for both
+ * consumers: a caller that ignored `valid` and submitted it would be refused
+ * again at the boundary (`http.requireAmount` rejects a non-finite number),
+ * never quietly charged a figure nobody typed.
+ */
+const MONEY_FIGURE = /^(?:\d{1,3}(?:,\d{3})+|\d*)(?:\.\d*)?$/;
+
+function parseMoneyFigure(typed: string): number {
+  const trimmed = typed.trim();
+  // A single LEADING currency symbol only — that is the one place our own labels
+  // put it. A trailing or repeated `$` is a stray character like any other.
+  const bare = (
+    trimmed.startsWith("$") ? trimmed.slice(1) : trimmed
+  ).trimStart();
+  // A figure needs a digit: this is what refuses "", "$" and "." before the
+  // shape test, which would otherwise accept all three as an empty match.
+  if (!/\d/.test(bare)) return NaN;
+  if (!MONEY_FIGURE.test(bare)) return NaN;
+  const amount = Number(bare.replace(/,/g, ""));
+  // A digit string long enough to overflow to Infinity is not a figure either.
+  return Number.isFinite(amount) ? amount : NaN;
+}
+
+function refundProblem({
+  valid,
+  readable,
+  typed,
+  ceiling,
+}: {
+  valid: boolean;
+  readable: boolean;
+  typed: string;
+  ceiling: string;
+}): string | null {
+  if (valid || typed.trim().length === 0) return null;
+  if (!readable)
+    return "That is not an amount I can read — type a figure like 40.25.";
+  return `Enter an amount over $0 and no more than ${ceiling}.`;
+}
+
+/** "$2.3k" — for axis labels and dense chips where the full figure won't fit. */
+export const formatCompact = (n: number) =>
+  n >= 1000
+    ? `$${(n / 1000).toFixed(n >= 10_000 ? 0 : 1)}k`
+    : `$${Math.round(n)}`;
+
+export const formatPercent = (ratio: number) => `${Math.round(ratio * 100)}%`;
+
+/** One decimal — margins live in a narrow band and whole percent hides moves. */
+export const formatMargin = (ratio: number) => `${(ratio * 100).toFixed(1)}%`;
+
+export function floorFor(
+  floors: MarginFloor[],
+  category: Category,
+): MarginFloor | undefined {
+  return floors.find((f) => f.category === category);
+}
+
+/** Gross margin at a given price. Guards a zero price rather than dividing by it. */
+export function marginAt(price: number, unitCost: number): number {
+  if (!Number.isFinite(price) || price <= 0) return 0;
+  return (price - unitCost) / price;
+}
+
+/** The price a discount actually sells at. Rounded to cents, not to dollars. */
+export function discountedPrice(
+  listPrice: number,
+  discountPercent: number,
+): number {
+  return Math.round(listPrice * (1 - discountPercent / 100) * 100) / 100;
+}
+
+/**
+ * Where a margin sits against its category floor. Mirrors `store.marginPosition`
+ * exactly — including the split between the CLAMPED `ratio` (which positions the
+ * dot on the rail) and the RAW `belowFloor` test (which decides whether it is
+ * flagged). Clamping the ratio must never be allowed to hide a violation.
+ */
+export function marginPosition(
+  floors: MarginFloor[],
+  category: Category,
+  margin: number,
+): MarginPosition | null {
+  const policy = floorFor(floors, category);
+  if (!policy) return null;
+  const span = LADDER_CEILING - policy.floor;
+  const raw = span === 0 ? 0.5 : (margin - policy.floor) / span;
+  return {
+    category,
+    margin,
+    floor: policy.floor,
+    target: policy.target,
+    ratio: Math.min(1, Math.max(0, raw)),
+    belowFloor: margin < policy.floor,
+  };
+}
+
+/** A product's margin at LIST price — the figure the catalog and ladder show. */
+export function productMargin(item: Product): number {
+  return marginAt(item.listPrice, item.unitCost);
+}
+
+export function productPosition(
+  floors: MarginFloor[],
+  item: Product,
+): MarginPosition | null {
+  return marginPosition(floors, item.category, productMargin(item));
+}
+
+/** The margin a promotion would trade at once its discount applies. */
+export function promotionMargin(
+  item: Product | undefined,
+  promotion: Promotion,
+): number | null {
+  if (!item) return null;
+  return marginAt(
+    discountedPrice(item.listPrice, promotion.discountPercent),
+    item.unitCost,
+  );
+}
+
+/**
+ * WHETHER SOMETHING CLEARS ITS FLOOR — with `"unknown"` as a first-class answer.
+ *
+ * There used to be an `isBelowFloor(): boolean` here that ended `?? false`, so a
+ * product whose category had no floor on file read as COMPLIANT and the KPIs
+ * painted a green `0 below floor` all-clear. That is the worst failure this skin
+ * has, because it is indistinguishable from good news: below-floor detection is
+ * the subject of the margin ladder AND of the beat-6 gate.
+ *
+ * `store.floorFor` (the server) refuses to guess the same condition — it throws
+ * `UNKNOWN_CATEGORY` rather than return a zeroed floor that "would make every
+ * margin look healthy". This is the same stance, expressed the way a client can
+ * afford: a THIRD state instead of a throw. A throw here would blank the page or
+ * the canvas on a partial ledger, which trades a false all-clear for a dead
+ * screen — worse in front of a room, and still not information. `"unknown"`
+ * forces every consumer to say something, and the ones that publish a headline
+ * figure (`belowFloorCount`) publish `null` rather than a number they cannot
+ * stand behind.
+ *
+ * A missing floor is reachable, not theoretical: the ledger arrives over
+ * `/api/commerce/v1/ledger` through an unvalidated `as CommerceStoreState` cast
+ * (see `ledger-context.tsx`), the provider mounts children on a FAILED first
+ * fetch with `floors: []`, `useReportData()` falls back to `floors: []` outside
+ * its provider, the sandbox snapshot starts empty, and `CATEGORIES` in `types.ts`
+ * and `SEED_FLOORS` in `seed.ts` are two independent lists with no drift guard.
+ */
+export type FloorStatus = "below" | "clear" | "unknown";
+
+function statusFrom(position: MarginPosition | null): FloorStatus {
+  if (!position) return "unknown";
+  return position.belowFloor ? "below" : "clear";
+}
+
+export function productFloorStatus(
+  floors: MarginFloor[],
+  item: Product,
+): FloorStatus {
+  return statusFrom(productPosition(floors, item));
+}
+
+/** As above, for the margin a markdown would actually trade at. */
+export function promotionFloorStatus(
+  floors: MarginFloor[],
+  item: Product | undefined,
+  promotion: Promotion,
+): FloorStatus {
+  const margin = promotionMargin(item, promotion);
+  if (!item || margin === null) return "unknown";
+  return statusFrom(marginPosition(floors, item.category, margin));
+}
+
+/**
+ * The wire form of a `FloorStatus` for anything the MODEL reads — a readable, a
+ * sandbox DTO. `null` for unknown, never `false`: a model handed
+ * `belowFloor: false` will say the SKU is fine, which is the false all-clear
+ * again, one layer down.
+ */
+export function nullableBelowFloor(status: FloorStatus): boolean | null {
+  return status === "unknown" ? null : status === "below";
+}
+
+export interface FloorTally {
+  /** Trading under its category floor. */
+  below: number;
+  /** Clears its category floor. */
+  clear: number;
+  /** No floor on file for its category — checked against NOTHING, so counted
+   * apart from `clear` rather than folded into it. */
+  unknown: number;
+}
+
+/**
+ * The tally over ANY set of floor verdicts — products, markdowns, a withheld
+ * slice. Kept separate from `tallyFloorStatus` because the promotions desk
+ * measures MARKDOWNS (`promotionFloorStatus`), and it must not have to re-derive
+ * "how many could not be checked" with its own loop: that is precisely how a
+ * green zero grew back on the Promotions page after this vocabulary landed.
+ */
+export function tallyStatuses(statuses: Iterable<FloorStatus>): FloorTally {
+  const tally: FloorTally = { below: 0, clear: 0, unknown: 0 };
+  for (const status of statuses) tally[status] += 1;
+  return tally;
+}
+
+export function tallyFloorStatus(
+  floors: MarginFloor[],
+  products: Product[],
+): FloorTally {
+  return tallyStatuses(products.map((p) => productFloorStatus(floors, p)));
+}
+
+/**
+ * A tally's headline "how many broke the floor" figure — `null` the moment
+ * ANYTHING in the set could not be checked, because a partial count presented as
+ * the count is the same lie in a smaller font. Per-row status is unaffected: a
+ * violation still reports `"below"` on its own row, so nothing is lost except a
+ * total nobody can defend.
+ */
+export function countBelow(tally: FloorTally): number | null {
+  return tally.unknown > 0 ? null : tally.below;
+}
+
+/** `countBelow` over a product range — the catalog's headline SKU figure. */
+export function belowFloorCount(
+  floors: MarginFloor[],
+  products: Product[],
+): number | null {
+  return countBelow(tallyFloorStatus(floors, products));
+}
+
+/**
+ * Below-floor first, then anything that could NOT be checked, then the rest.
+ *
+ * Every worklist in this skin ranks by this — the catalog's rows and the
+ * promotions desk's cards — because they are the same claim about the same
+ * question: an UNCHECKED row is not a clean one, so it may not sink below the
+ * rows that were actually cleared. Shared rather than written per page so the two
+ * cannot disagree about where an unmeasurable row belongs.
+ */
+export const FLOOR_WORKLIST_RANK: Record<FloorStatus, number> = {
+  below: 0,
+  unknown: 1,
+  clear: 2,
+};
+
+/**
+ * The caveat every below-floor readout owes when the set was not fully
+ * checkable. `null` when there is nothing to caveat, so a caller can render it
+ * unconditionally.
+ *
+ * The noun is a parameter because the same sentence is owed by two different
+ * desks — the catalog counts SKUs, the promotions desk counts markdowns — and a
+ * caveat that names the wrong thing invites the reader to look for it in the
+ * wrong place.
+ */
+export function noFloorCaveat(
+  unknown: number,
+  noun: { one: string; many: string } = { one: "SKU", many: "SKUs" },
+): string | null {
+  if (unknown <= 0) return null;
+  return unknown === 1
+    ? `1 ${noun.one} has no category margin floor on file and was not checked`
+    : `${unknown} ${noun.many} have no category margin floor on file and were not checked`;
+}
+
+/** The markdown-flavoured `noFloorCaveat`, so no caller spells the noun twice. */
+export function noMarkdownFloorCaveat(unknown: number): string | null {
+  return noFloorCaveat(unknown, { one: "markdown", many: "markdowns" });
+}
+
+/**
+ * Whole days since an ISO timestamp. Never negative.
+ *
+ * INSTANT-based, deliberately — unlike `daysUntil` below. `placedAt`,
+ * `requestedAt` and `submittedAt` are full timestamps (`store.daysAgoIso`), and
+ * "how long has this order been sitting" is elapsed time rather than a calendar
+ * difference: an order placed 30 hours ago is one day old however many midnights
+ * happened in between. Both operands are instants here, so the comparison is
+ * already like-with-like and nothing about it drifts with the time of day.
+ */
+export function ageInDays(iso: string): number {
+  return Math.max(
+    0,
+    Math.floor((Date.now() - new Date(iso).getTime()) / DAY_MS),
+  );
+}
+
+/**
+ * The UTC calendar day an instant falls on, as a whole-day index off the epoch.
+ *
+ * The epoch is itself midnight UTC, so flooring an instant by the day gives the
+ * UTC day number directly, and a date-only `YYYY-MM-DD` string — which
+ * `new Date()` parses as midnight UTC — lands exactly on its own index.
+ */
+function utcDayIndex(ms: number): number {
+  return Math.floor(ms / DAY_MS);
+}
+
+/**
+ * Signed whole CALENDAR DAYS from today until a date-only `YYYY-MM-DD` value:
+ * `0` today, `1` tomorrow, negative once the date is past.
+ *
+ * DAY-based, not instant-based, and that is the whole point. A date-only value
+ * denotes a day rather than a moment, so subtracting it from `Date.now()` — a
+ * full timestamp — and rounding compares two different kinds of thing, and the
+ * answer then moves with the wall clock. That is exactly what this used to do:
+ * a promotion ending TODAY parses as today 00:00 UTC, so from 12:00:00 UTC
+ * onward the difference passed −0.5 days, rounded to −1, and the promotions page
+ * read "ended yesterday" ON THE DAY IT ENDS. Every other window label wobbled
+ * ±1 through the same day. The seed hid it (no seeded window ends today) and it
+ * only reproduced in the afternoon, which is the worst pair of properties a bug
+ * can have on a demo screen.
+ *
+ * The frame is **UTC**, chosen to match the writer: `store.daysFromNowDate`
+ * mints these strings with `.toISOString().slice(0, 10)`, which is the UTC day.
+ * Reading them back in local time would mean a seed written "0 days from now"
+ * could parse as yesterday or tomorrow west or east of Greenwich. One frame at
+ * both ends is what makes the round trip exact.
+ */
+export function daysUntil(isoDate: string): number {
+  return utcDayIndex(new Date(isoDate).getTime()) - utcDayIndex(Date.now());
+}
+
+/** "starts in 6 days", "ends today", "ended 7 days ago" — a promotion window. */
+export function windowLabel(startsAt: string, endsAt: string): string {
+  const start = daysUntil(startsAt);
+  const end = daysUntil(endsAt);
+  if (end < 0) return end === -1 ? "ended yesterday" : `ended ${-end} days ago`;
+  if (start > 0)
+    return start === 1 ? "starts tomorrow" : `starts in ${start} days`;
+  // "ends today" outranks "starts today" so a ONE-DAY window says the urgent
+  // half. Testing `start === 0` first (as this did) meant a promotion that
+  // opens and closes today announced only that it had opened — the last thing a
+  // merchandiser needs to know about it is that today is the last chance.
+  if (end === 0) return "ends today";
+  if (start === 0) return "starts today";
+  return `live, ends in ${end} days`;
+}
+
+/** Weeks of cover at the trailing-30 run rate. `null` when nothing is selling. */
+export function weeksOfCover(item: Product): number | null {
+  if (item.trailing30Units <= 0) return null;
+  const weeklyRate = item.trailing30Units / 4.33;
+  return Math.round((item.inventory / weeklyRate) * 10) / 10;
+}
+
+/**
+ * THE exception queue, as ONE predicate.
+ *
+ * An order is in the queue when it still carries an exception AND has not been
+ * cancelled. The `status` clause is load-bearing, not defensive: `setOrderStatus`
+ * moves an order to `cancelled` WITHOUT clearing the exception it was carrying,
+ * and `PATCH /api/commerce/v1/orders/[id]` accepts that status, so a
+ * cancelled-with-exception row is reachable in a live demo. A cancelled order
+ * needs no decision, so it is not work in the queue and its value is not at risk.
+ *
+ * Every count, money figure and list of "orders on exception" MUST come through
+ * here: the Orders KPI row, the a2ui brief's StatCard and TradingList, and the
+ * OGUI sandbox functions. Those render SIDE BY SIDE — a generated panel sits on
+ * the canvas next to the app's own cards, off the same ledger — so a hand-copied
+ * clause that drops half the predicate puts two different answers to one question
+ * on screen at the same time. That is exactly what shipped: `getOrders`'
+ * `exceptionsOnly` filter tested `exception !== "none"` alone, so a generated
+ * panel listed a longer queue than the card beside it.
+ *
+ * NOT the same thing as the Orders page's `exception=any` LEVER, which tests
+ * `exception !== "none"` on its own because it composes with a SEPARATE status
+ * lever the user drives explicitly (`pages/orders.tsx`'s `visible` useMemo).
+ */
+export function isOnException(
+  order: Pick<Order, "status" | "exception">,
+): boolean {
+  return order.exception !== "none" && order.status !== "cancelled";
+}
+
+/** The exception queue itself. Input order is preserved; sort at the call site. */
+export function ordersOnException<
+  T extends Pick<Order, "status" | "exception">,
+>(orders: readonly T[]): T[] {
+  return orders.filter(isOnException);
+}
+
+/**
+ * The money sitting in the exception queue.
+ *
+ * Takes the FULL order book rather than a pre-filtered list, so the figure and
+ * the count it is shown next to can never be derived from two different sets.
+ */
+export function valueAtRisk(
+  orders: readonly Pick<Order, "status" | "exception" | "total">[],
+): number {
+  return ordersOnException(orders).reduce((sum, order) => sum + order.total, 0);
+}
+
+/**
+ * An OPEN return — one the desk still has to touch.
+ *
+ * Both `refunded` and `declined` are FINISHED states: a declined return has had
+ * its decision and will never be refunded. The Returns page has always drawn the
+ * line there (`pages/returns.tsx`), while the sandbox's `openReturns` KPI counted
+ * declined rows as open — so a generated panel reported more outstanding work
+ * than the page it sat beside. Same defect class as `isOnException` above, same
+ * fix: one predicate, no hand-copies.
+ */
+export function isOpenReturn(request: Pick<ReturnRequest, "status">): boolean {
+  return request.status !== "refunded" && request.status !== "declined";
+}
+
+/** The open returns themselves. Input order is preserved. */
+export function openReturns<T extends Pick<ReturnRequest, "status">>(
+  requests: readonly T[],
+): T[] {
+  return requests.filter(isOpenReturn);
+}
+
+/**
+ * The exception filter values the Orders page renders as controls, BUILT from
+ * `ORDER_EXCEPTIONS` rather than hand-copied.
+ *
+ * `all` and `any` are filter-only ideas — "any" means every order still carrying
+ * an exception, which is the beat-3c lever. `none` is dropped because "orders
+ * with no exception" is what `all` minus `any` already expresses, and a control
+ * for it would read as a third synonym for the same thing.
+ *
+ * Every remaining value MUST have a control. `showOrderQueue`'s schema is BUILT
+ * from this list (`z.enum(EXCEPTION_FILTERS)`, no longer a hand-copy of it), and
+ * a value the agent can set but the page cannot show breaks
+ * beat 3c in the way that is hardest to notice: the rows filter correctly and no
+ * control lights up. Deriving the list is what makes that impossible rather than
+ * merely fixed once — `derive.test.ts` pins it.
+ */
+export const EXCEPTION_FILTERS = [
+  "all",
+  "any",
+  ...ORDER_EXCEPTIONS.filter((e) => e !== "none"),
+] as const;
+
+export type ExceptionFilter = (typeof EXCEPTION_FILTERS)[number];
+
+/** Why an order can be HELD — every exception except the happy path. */
+export type HoldReason = Exclude<OrderException, "none">;
+
+/**
+ * The reasons `holdOrder` may be called with, BUILT from `ORDER_EXCEPTIONS` for
+ * the same reason `EXCEPTION_FILTERS` above is and `notifyCustomer`'s template
+ * enum is: one vocabulary, not two that drift. The tool used to repeat these five
+ * strings as a hand-written `z.enum([...])`, so an exception added to the store —
+ * and therefore filterable on the Orders page, labelled by
+ * `ORDER_EXCEPTION_LABEL` and reachable by `showOrderQueue` — would be the one
+ * exception the agent could not actually put an order INTO.
+ *
+ * `none` is dropped because holding an order for no exception is not a state the
+ * ledger has: `isOnException` reads `none` as "not queue work", so a hold filed
+ * under it would write a held order that no queue view shows.
+ *
+ * Taken as the TAIL of `ORDER_EXCEPTIONS`, which lists the happy path first,
+ * rather than by `.filter()`: `z.enum()` only accepts a non-empty TUPLE, and
+ * `filter` erases the tuple shape (a cast back to one is not even sound — an
+ * empty array satisfies the array type). Destructuring keeps it, and there is no
+ * assertion anywhere in the chain. Should `none` ever move or another value be
+ * added ahead of it, `derive.test.ts`'s membership pin fails.
+ */
+const [, ...HOLD_REASON_TAIL] = ORDER_EXCEPTIONS;
+
+export const HOLD_REASONS: readonly [HoldReason, ...HoldReason[]] =
+  HOLD_REASON_TAIL;
+
+/**
+ * The status filter values the Orders page renders as controls, BUILT from
+ * `ORDER_STATUSES` for exactly the reason `EXCEPTION_FILTERS` above is built
+ * from `ORDER_EXCEPTIONS`: `showOrderQueue`'s schema advertises this same list,
+ * and a status the agent can set that the page has no control for is beat 3c
+ * failing silently.
+ *
+ * `cancelled` is on the list and is honoured END TO END, which is a deliberate
+ * position and not an oversight: the page draws the control, its `visible` list
+ * renders those rows, the page readable describes them, and the sandbox's
+ * `getOrders` returns them. Only the skin's global ledger readable used to hide
+ * them, which made `cancelled` the one status the agent could ask for and then
+ * could not talk about — and, once it had navigated, put a page readable listing
+ * rows against a ledger readable claiming they did not exist.
+ *
+ * What a cancelled order is NOT is queue work. That distinction belongs to
+ * `isOnException` alone (see its header); it is never re-expressed as an
+ * order-book filter.
+ */
+export const ORDER_STATUS_FILTERS = ["all", ...ORDER_STATUSES] as const;
+
+export type StatusFilter = (typeof ORDER_STATUS_FILTERS)[number];
+
+/**
+ * The sort orders the Orders page can apply, and therefore the only ones
+ * `showOrderQueue` may advertise. The page types its comparator table as
+ * `Record<OrderSort, …>` and the lever card types its chip labels the same way,
+ * so a sort with no comparator — or a comparator with no chip label — does not
+ * compile.
+ */
+export const ORDER_SORTS = ["aging_desc", "aging_asc", "value_desc"] as const;
+
+export type OrderSort = (typeof ORDER_SORTS)[number];
+
+export const ORDER_EXCEPTION_LABEL: Record<OrderException, string> = {
+  none: "Clear",
+  "fraud-review": "Fraud review",
+  "address-invalid": "Address invalid",
+  oversell: "Oversell",
+  "carrier-delay": "Carrier delay",
+  "payment-declined": "Payment declined",
+};
+
+export const RETURN_REASON_LABEL: Record<ReturnReason, string> = {
+  sizing: "Sizing",
+  damaged: "Damaged",
+  "not-as-described": "Not as described",
+  "changed-mind": "Changed mind",
+  "late-delivery": "Late delivery",
+};
+
+export const CHANNEL_LABEL: Record<Order["channel"], string> = {
+  web: "Web",
+  retail: "Retail",
+  wholesale: "Wholesale",
+  marketplace: "Marketplace",
+};
+
+/** The units on an order — shown alongside the value on every row. */
+export function orderUnits(order: Order): number {
+  return order.lines.reduce((sum, line) => sum + line.quantity, 0);
+}
+
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] ?? "";
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? "") : "";
+  return (first + last).toUpperCase();
+}
+
+/**
+ * A stable hue per SKU or customer, derived from the string.
+ *
+ * Bellwether puts a small tile on nearly every row, and random colours would
+ * make the catalog read as confetti while identical colours would make it read
+ * as a spreadsheet. A deterministic hash gives each product a colour it KEEPS —
+ * across pages, across reloads, and inside chat gen-UI — so a SKU becomes
+ * recognisable at a glance. The range is applied at low saturation (see
+ * `SkuTile`) so the ink-blue chrome stays the loudest thing on screen.
+ */
+export function tileHue(key: string): number {
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash * 31 + key.charCodeAt(i)) % 360;
+  }
+  return hash;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/find-record.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/find-record.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { findOrder, findProduct, findReturn } from "./find-record";
+import type { Order, Product, ReturnRequest } from "./types";
+
+/**
+ * A needle that identifies NOTHING must resolve to nothing.
+ *
+ * Each finder ends in a substring match, and `"anything".includes("")` is true,
+ * so before the guard in `find-record.ts` an empty or whitespace-only needle
+ * resolved to `rows[0]` — and `holdOrder` / `notifyCustomer` / `postOrderNote`
+ * wrote to whatever record happened to be first. The needle comes from the model
+ * out of conversation, so blank is ordinary input, and the consequence is a
+ * wrong-record WRITE with a confident receipt naming the wrong customer.
+ *
+ * `rows[0]` in every fixture below is therefore the row a regression would
+ * return: the assertions are `toBeUndefined()`, not "not the row I asked for".
+ */
+
+const order = (over: Partial<Order>): Order => ({
+  id: "ord-1",
+  number: "4471",
+  customerName: "Priya Raghavan",
+  customerEmail: "priya@example.com",
+  channel: "web",
+  destination: "Lisbon, PT",
+  placedAt: new Date().toISOString(),
+  status: "open",
+  exception: "fraud-review",
+  lines: [{ productId: "bw-1", quantity: 2, unitPrice: 40 }],
+  total: 80,
+  notes: [],
+  ...over,
+});
+
+const product = (over: Partial<Product>): Product => ({
+  id: "bw-1",
+  sku: "BW-CDR-HDY",
+  name: "Cedar Hoodie",
+  category: "Knitwear",
+  listPrice: 120,
+  unitCost: 70,
+  inventory: 400,
+  trailing30Units: 90,
+  status: "live",
+  vendor: "Cedar Mills",
+  ...over,
+});
+
+const returnRequest = (over: Partial<ReturnRequest>): ReturnRequest => ({
+  id: "ret-1",
+  orderId: "ord-1",
+  orderNumber: "4471",
+  customerName: "Priya Raghavan",
+  productId: "bw-1",
+  reason: "damaged",
+  detail: "Arrived scuffed.",
+  requestedAt: new Date().toISOString(),
+  status: "requested",
+  itemValue: 120,
+  refundAmount: null,
+  ...over,
+});
+
+const ORDERS: Order[] = [
+  order({}),
+  order({ id: "ord-2", number: "4463", customerName: "Dana Reyes" }),
+];
+
+const PRODUCTS: Product[] = [
+  product({}),
+  product({
+    id: "bw-2",
+    sku: "BW-ALD-THR",
+    name: "Alder Throw",
+    category: "Home",
+  }),
+];
+
+const RETURNS: ReturnRequest[] = [
+  returnRequest({}),
+  returnRequest({
+    id: "ret-2",
+    orderId: "ord-2",
+    orderNumber: "4463",
+    customerName: "Dana Reyes",
+  }),
+];
+
+/** Everything a model might emit when it has no reference to hand. */
+const BLANK = ["", " ", "   ", "\t", "\n ", "#", "##", " # "];
+
+describe("findOrder / findProduct / findReturn — a blank needle matches NOTHING", () => {
+  it.each(BLANK)("findOrder(%j) is undefined", (needle) => {
+    expect(findOrder(ORDERS, needle)).toBeUndefined();
+  });
+
+  it.each(BLANK)("findProduct(%j) is undefined", (needle) => {
+    expect(findProduct(PRODUCTS, needle)).toBeUndefined();
+  });
+
+  it.each(BLANK)("findReturn(%j) is undefined", (needle) => {
+    expect(findReturn(RETURNS, needle)).toBeUndefined();
+  });
+
+  it("does not fall back to the first row when a real needle misses", () => {
+    expect(findOrder(ORDERS, "9999")).toBeUndefined();
+    expect(findProduct(PRODUCTS, "Birch Parka")).toBeUndefined();
+    expect(findReturn(RETURNS, "Someone Else")).toBeUndefined();
+  });
+});
+
+describe("findOrder — the references that must still resolve", () => {
+  it("resolves by id, number, #number and padded number", () => {
+    expect(findOrder(ORDERS, "ord-2")?.id).toBe("ord-2");
+    expect(findOrder(ORDERS, "4463")?.id).toBe("ord-2");
+    expect(findOrder(ORDERS, "#4463")?.id).toBe("ord-2");
+    expect(findOrder(ORDERS, "  #4463 ")?.id).toBe("ord-2");
+  });
+
+  it("resolves by exact customer name, case-insensitively, and by substring", () => {
+    expect(findOrder(ORDERS, "Dana Reyes")?.id).toBe("ord-2");
+    expect(findOrder(ORDERS, "dana reyes")?.id).toBe("ord-2");
+    expect(findOrder(ORDERS, "Dana")?.id).toBe("ord-2");
+  });
+});
+
+describe("findProduct — the references that must still resolve", () => {
+  it("resolves by id, SKU and name", () => {
+    expect(findProduct(PRODUCTS, "bw-2")?.id).toBe("bw-2");
+    expect(findProduct(PRODUCTS, "bw-ald-thr")?.id).toBe("bw-2");
+    expect(findProduct(PRODUCTS, "Alder Throw")?.id).toBe("bw-2");
+    expect(findProduct(PRODUCTS, " alder ")?.id).toBe("bw-2");
+  });
+});
+
+describe("findReturn — the references that must still resolve", () => {
+  it("resolves by id, customer name and order number", () => {
+    expect(findReturn(RETURNS, "ret-2")?.id).toBe("ret-2");
+    expect(findReturn(RETURNS, "Dana Reyes")?.id).toBe("ret-2");
+    expect(findReturn(RETURNS, "#4463")?.id).toBe("ret-2");
+    expect(findReturn(RETURNS, "Dana")?.id).toBe("ret-2");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/find-record.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/find-record.ts
@@ -1,0 +1,84 @@
+import type { Order, Product, ReturnRequest } from "./types";
+
+/**
+ * Resolving the loose reference an AGENT supplies ("BW-1041", "#4471", "Dana",
+ * "the cedar hoodie") to one ledger row.
+ *
+ * These live here, as pure functions over the rows, rather than as closures
+ * inside `../tools.tsx`, for two reasons: the write tools that call them are the
+ * agent's mutation paths, and a closure is not directly testable.
+ *
+ * ── The bug this module exists to make unrepresentable ──────────────────────
+ *
+ * Every finder below ends in a SUBSTRING match, and `"anything".includes("")`
+ * is TRUE. So an empty needle used to match the FIRST row: a tool called with a
+ * blank or whitespace-only argument resolved to `rows[0]`, and `holdOrder` /
+ * `notifyCustomer` / `postOrderNote` then mutated an arbitrary wrong record and
+ * returned a confident success receipt naming a customer nobody had mentioned.
+ *
+ * The needle comes from the model, out of conversation, so a blank one is an
+ * ORDINARY occurrence rather than an edge case — and the failure mode is a
+ * wrong-record WRITE, not a miss. The guard therefore lives ONCE, here at
+ * normalisation: a needle that identifies nothing normalises to `null`, and
+ * every finder returns `undefined` before it matches anything. The call sites
+ * already refuse on `undefined` ("No order matches …"), so refusing is the
+ * behaviour they get for free.
+ */
+
+/**
+ * Fold a caller-supplied reference into the comparison key the finders use, or
+ * `null` when it identifies nothing.
+ *
+ * A leading `#` is dropped so "#4471" finds order 4471, which also means a bare
+ * "#" — a plausible thing for a model to emit when it has no number to hand —
+ * normalises to nothing rather than to the empty substring that matches
+ * everything.
+ */
+export function normalizeNeedle(
+  needle: string | null | undefined,
+): string | null {
+  const key = (needle ?? "").trim().replace(/^#+/, "").trim().toLowerCase();
+  return key.length > 0 ? key : null;
+}
+
+export function findOrder(
+  rows: readonly Order[],
+  needle: string,
+): Order | undefined {
+  const key = normalizeNeedle(needle);
+  if (key === null) return undefined;
+  return (
+    rows.find((o) => o.id === needle) ??
+    rows.find((o) => o.number === key) ??
+    rows.find((o) => o.customerName.toLowerCase() === key) ??
+    rows.find((o) => o.customerName.toLowerCase().includes(key))
+  );
+}
+
+export function findProduct(
+  rows: readonly Product[],
+  needle: string,
+): Product | undefined {
+  const key = normalizeNeedle(needle);
+  if (key === null) return undefined;
+  return (
+    rows.find((p) => p.id === needle) ??
+    rows.find((p) => p.sku.toLowerCase() === key) ??
+    rows.find((p) => p.name.toLowerCase() === key) ??
+    rows.find((p) => p.name.toLowerCase().includes(key))
+  );
+}
+
+export function findReturn(
+  rows: readonly ReturnRequest[],
+  needle: string,
+): ReturnRequest | undefined {
+  const key = normalizeNeedle(needle);
+  if (key === null) return undefined;
+  return (
+    rows.find((r) => r.id === needle) ??
+    rows.find((r) => r.customerName.toLowerCase() === key) ??
+    rows.find((r) => r.orderNumber === key) ??
+    rows.find((r) => r.customerName.toLowerCase().includes(key))
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/http.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/http.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { errorResponse, requireAmount } from "./http";
+import {
+  JUSTIFICATION_MAX_LENGTH,
+  JUSTIFICATION_MIN_LENGTH,
+} from "./waiver-codes";
+
+/**
+ * The route error mapper. These assertions exist because the failure mode they
+ * pin is INVISIBLE: the lookup key is a thrown Error's `message`, so an Error
+ * whose message happened to name an `Object.prototype` member used to resolve
+ * truthy through the prototype chain, take the "known code" branch with no
+ * `status`, and answer **200** — a failed mutation reported to the agent and to
+ * the page as a success, with nothing in the server log. It still compiled, and
+ * every route kept rendering.
+ */
+describe("commerce errorResponse", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const silenceLog = () =>
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+  it("maps a known code to its status and symptom-only message", async () => {
+    const res = errorResponse(
+      new Error("BELOW_MARGIN_FLOOR"),
+      "POST promotions/[id]/approve",
+    );
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toEqual({
+      error: "BELOW_MARGIN_FLOOR",
+      message: "Discounted margin falls below the category floor.",
+    });
+  });
+
+  // Beat 5's validation codes have to reach the caller as 400s. Left unmapped
+  // they would fall through to the logged 500 below, which reads as "our bug"
+  // rather than "you sent a template we do not send".
+  it.each([
+    ["UNKNOWN_TEMPLATE", "That is not a message template we send."],
+    ["ACTOR_NAME_TOO_LONG", "That name is longer than the record accepts."],
+    ["NOTE_TOO_LONG", "That note is longer than the record accepts."],
+  ])("maps %s to a 400", async (code, message) => {
+    const res = errorResponse(new Error(code), "POST orders/[id]/notify");
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: code, message });
+  });
+
+  it("maps a refused justification to a 422 that names the bounds", async () => {
+    // Safe to be specific here — the bounds are about the TEXT, so unlike
+    // BELOW_MARGIN_FLOOR this message cannot leak which codes justify.
+    const res = errorResponse(
+      new Error("INVALID_JUSTIFICATION"),
+      "POST margin-waivers",
+    );
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("INVALID_JUSTIFICATION");
+    expect(body.message).toContain(String(JUSTIFICATION_MIN_LENGTH));
+    expect(body.message).toContain(String(JUSTIFICATION_MAX_LENGTH));
+    expect(body.message).not.toMatch(/code|VENDOR-FUND|justifying/i);
+  });
+
+  // Every code the order state machine can raise has to be MAPPED. An unmapped
+  // one is not a harmless 500: `holdOrder` reports the status back to the
+  // agent, so a refused-but-unmapped transition reads as a server fault to
+  // retry rather than a rule to respect.
+  it.each([
+    ["ORDER_ALREADY_SETTLED", 409],
+    ["ILLEGAL_ORDER_TRANSITION", 409],
+    ["EXCEPTION_ON_SETTLED_ORDER", 422],
+  ])("maps the order-state refusal %s to %i", async (code, status) => {
+    const log = silenceLog();
+    const res = errorResponse(new Error(code), "PATCH orders/[id]");
+    expect(res.status).toBe(status);
+    await expect(res.json()).resolves.toMatchObject({ error: code });
+    // Mapped, therefore never logged as an internal fault.
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  // The regression. `"toString"`, `"constructor"`, `"valueOf"` and
+  // `"__proto__"` are all inherited members of a plain object literal; each one
+  // used to be treated as a mapped code and answered 200.
+  it.each([
+    "toString",
+    "constructor",
+    "valueOf",
+    "hasOwnProperty",
+    "__proto__",
+  ])("does not treat the inherited key %s as a known code", async (message) => {
+    const log = silenceLog();
+    const res = errorResponse(new Error(message), "PATCH orders/[id]");
+    expect(res.status).toBe(500);
+    expect(res.status).not.toBeLessThan(300); // never a 2xx
+    await expect(res.json()).resolves.toEqual({
+      error: "INTERNAL_ERROR",
+      message: "Something went wrong on our side.",
+    });
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps an unrecognised code to a logged 500, not a retryable 400", async () => {
+    const log = silenceLog();
+    const boom = new Error("SOMETHING_NOBODY_MAPPED");
+    const res = errorResponse(boom, "POST plans");
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: "INTERNAL_ERROR",
+      message: "Something went wrong on our side.",
+    });
+    expect(log).toHaveBeenCalledWith("[commerce/api] POST plans", boom);
+  });
+
+  // The map-absence guard. The integrity codes belong in the unrecognised
+  // branch: a mapped code gets a status and a bespoke message and is NEVER
+  // logged, which is precisely the treatment a dangling reference must not get.
+  // Adding either code to `CODES` turns this red.
+  it.each(["DANGLING_PRODUCT_REF", "DANGLING_PROMOTION_REF"])(
+    "leaves the integrity code %s unmapped, so it stays a logged 500",
+    async (code) => {
+      const log = silenceLog();
+      const res = errorResponse(
+        new Error(code),
+        "POST promotions/[id]/approve",
+      );
+      expect(res.status).toBe(500);
+      // Not a 404, and not a bespoke message the agent could narrate as a rule
+      // of the domain.
+      await expect(res.json()).resolves.toEqual({
+        error: "INTERNAL_ERROR",
+        message: "Something went wrong on our side.",
+      });
+      expect(log).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("maps a non-Error throw to the same logged 500", async () => {
+    const log = silenceLog();
+    const res = errorResponse("not an error at all", "POST orders/[id]/notes");
+    expect(res.status).toBe(500);
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("commerce requireAmount", () => {
+  it("passes a real JSON number through untouched", () => {
+    expect(requireAmount(85)).toBe(85);
+    expect(requireAmount(85.5)).toBe(85.5);
+  });
+
+  // `true` and `"12"` are the money bug: `Number()` turned them into 1 and 12,
+  // both of which satisfy every rule `issueRefund` has and settled the return.
+  it.each([true, false, "12", "", [], null, undefined, {}, 1e999])(
+    "refuses %o rather than coercing it to a figure",
+    (value) => {
+      expect(() => requireAmount(value)).toThrow("INVALID_AMOUNT");
+    },
+  );
+
+  // Deliberate: the domain range is single-sourced in `store.issueRefund` so the
+  // ceiling holds however a refund is issued. If someone adds `<= 0` here, one
+  // rule now lives in two files — delete it there first, or not at all.
+  it("leaves the domain range to the store", () => {
+    expect(requireAmount(-5)).toBe(-5);
+    expect(requireAmount(0)).toBe(0);
+    expect(requireAmount(9_999_999_999)).toBe(9_999_999_999);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/http.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/http.ts
@@ -1,0 +1,291 @@
+/**
+ * Shared error mapping — and body decoding — for the `/api/commerce/v1/*` routes.
+ *
+ * The store throws Errors whose message is a stable CODE; this turns a code into
+ * an HTTP status and a human message in one place. Centralising it is not just
+ * tidiness — it is how the beat-6 gate stays honest. `BELOW_MARGIN_FLOOR` has
+ * exactly ONE message string in the whole app, and it is written here where the
+ * "symptom only, never the fix" rule is visible to anyone editing it.
+ */
+
+import {
+  JUSTIFICATION_MAX_LENGTH,
+  JUSTIFICATION_MIN_LENGTH,
+} from "./waiver-codes";
+
+/**
+ * Codes the routes may surface, mapped to status + a symptom-only message.
+ *
+ * A `Map` (not a plain object) is load-bearing, for the same reason the page
+ * table in `src/skins/keel/skin.tsx` is one: the key is a thrown Error's
+ * `message`, which is not a closed set — anything raised inside a route's `try`
+ * lands here, including `req.json()`'s SyntaxError and any future `throw` a
+ * store helper grows. A plain-object lookup walks the prototype chain, so
+ * `"toString"`, `"constructor"`, `"valueOf"`, `"__proto__"`, … all resolve
+ * TRUTHY, take the "known code" branch, and hand `status: undefined` to
+ * `Response.json` — which defaults to **200**. A failed mutation would be
+ * reported to the agent and to the page as a success, with nothing logged.
+ * `Map.get` only ever sees own entries, so that state is unrepresentable rather
+ * than guarded per call site. `Record<string, …>` could not catch it: the
+ * annotation was a lie about a plain object.
+ */
+const CODES: Map<string, { status: number; message: string }> = new Map([
+  ["NOT_FOUND", { status: 404, message: "That record does not exist." }],
+  ["ALREADY_DECIDED", { status: 409, message: "That was already decided." }],
+  [
+    "ALREADY_REFUNDED",
+    { status: 409, message: "That return has already been refunded." },
+  ],
+  [
+    "RETURN_NOT_APPROVED",
+    {
+      status: 409,
+      message: "A return has to be approved before it can be refunded.",
+    },
+  ],
+  [
+    "ALREADY_FINALIZED",
+    { status: 400, message: "That waiver has already been finalized." },
+  ],
+
+  // ── The order state machine (store.orderStatusBlocker) ────────────────────
+  // 409 for "conflicts with the state this order is already in", matching the
+  // ALREADY_* family above; 422 for the (status, exception) PAIR being one no
+  // order may hold, matching INVALID_AMOUNT below.
+  [
+    "ORDER_ALREADY_SETTLED",
+    {
+      status: 409,
+      message: "A fulfilled or cancelled order can no longer be changed.",
+    },
+  ],
+  [
+    "ILLEGAL_ORDER_TRANSITION",
+    {
+      status: 409,
+      message: "That order cannot move to that status from where it is.",
+    },
+  ],
+  [
+    "EXCEPTION_ON_SETTLED_ORDER",
+    {
+      status: 422,
+      message:
+        "A fulfilled or cancelled order cannot carry an exception — " +
+        "clear it in the same change.",
+    },
+  ],
+  ["INVALID_AMOUNT", { status: 422, message: "That is not a usable amount." }],
+
+  // ── Beat 5's writes: the closed template set and the field bounds ──────────
+  // A notification template is a CLOSED set of four (`NOTIFICATION_TEMPLATES` in
+  // `types.ts`) and the free-text fields are length-bounded, because both the
+  // Orders page and the beat-3b readable render what was stored. These are the
+  // only codes in this map raised by a caller sending something out of range
+  // rather than by a domain rule, so they are 400s: the request is wrong, and a
+  // first-party caller that hits one has a bug worth surfacing as such.
+  [
+    "UNKNOWN_TEMPLATE",
+    { status: 400, message: "That is not a message template we send." },
+  ],
+  [
+    "ACTOR_NAME_TOO_LONG",
+    { status: 400, message: "That name is longer than the record accepts." },
+  ],
+  [
+    "NOTE_TOO_LONG",
+    { status: 400, message: "That note is longer than the record accepts." },
+  ],
+  [
+    "REFUND_EXCEEDS_VALUE",
+    {
+      status: 422,
+      message: "A refund cannot exceed what was charged for the item.",
+    },
+  ],
+
+  // ── BEAT 6: the gate ──────────────────────────────────────────────────────
+  // SYMPTOM ONLY. This names the problem — the discounted margin falls under
+  // the category floor — and must NEVER mention margin waivers, justifying
+  // codes, or any part of the unlock. An agent that can read the recipe out of
+  // the error derives it in one round-trip, and the demonstration stops proving
+  // that it learned anything. If you are tempted to make this message "more
+  // helpful", don't.
+  [
+    "BELOW_MARGIN_FLOOR",
+    {
+      status: 422,
+      message: "Discounted margin falls below the category floor.",
+    },
+  ],
+
+  // Rejected WITHOUT enumerating the catalogue, for the same reason.
+  [
+    "INVALID_WAIVER_CODE",
+    { status: 422, message: "That is not a recognized margin waiver code." },
+  ],
+  // Safe to be specific: the bounds are about the TEXT, not about which codes
+  // justify, so naming them leaks nothing about the unlock — and a caller that
+  // cannot tell why its filing was refused just retries the same empty string.
+  // The numbers come from the constants so the message cannot drift from the
+  // rule it describes.
+  [
+    "INVALID_JUSTIFICATION",
+    {
+      status: 422,
+      message: `A margin waiver needs a written justification of ${JUSTIFICATION_MIN_LENGTH} to ${JUSTIFICATION_MAX_LENGTH} characters.`,
+    },
+  ],
+  [
+    "UNKNOWN_CATEGORY",
+    { status: 500, message: "No margin floor is defined for that category." },
+  ],
+
+  // ── DELIBERATELY ABSENT: the integrity codes ──────────────────────────────
+  // `DANGLING_PRODUCT_REF` and `DANGLING_PROMOTION_REF` (see `data/store.ts`)
+  // must NOT be added here. They are raised when one of our own records points
+  // at a record that no longer exists — never a caller mistake — and the
+  // unrecognised branch below is exactly the treatment they need: a 500 AND a
+  // `console.error`. Mapping them would make them quiet, because the known-code
+  // branch does not log; a bespoke message would also invite the agent to
+  // narrate our broken ledger as though it were a rule of the domain. This is
+  // pinned by `http.test.ts` — adding either code turns that test red.
+]);
+
+/**
+ * Map a thrown store error onto a Response.
+ *
+ * An UNRECOGNISED throw is a **500**, not a 400. Every code above is raised
+ * deliberately by `data/store.ts`; anything else reaching here is by definition
+ * not a rule the domain models — a bug in this app, a store helper that grew a
+ * new `throw` nobody mapped, or a malformed body from one of our OWN callers
+ * (every writer of these routes is first-party: the skin's tools and pages, both
+ * of which `JSON.stringify` what they send). Calling that a 400 told the agent
+ * "you sent something wrong, adjust and retry", so it would retry a server bug
+ * forever and narrate a client mistake that never happened; and it meant no
+ * commerce route could emit a 5xx at all. 500 + the `console.error` below makes
+ * a real fault loud in both places it has to be loud: the browser/agent and the
+ * server log.
+ *
+ * Do NOT add a `SyntaxError` branch here to soften that. A `SyntaxError` reaching
+ * this function is indistinguishable from one thrown by our own code several
+ * frames down, so treating it as a client mistake would be the same misreport in
+ * the other direction. The place to tell an unreadable BODY apart from a store
+ * fault is the route boundary, before the store's `try` — see `readJsonBody`
+ * below, which the five id-addressed write routes use to answer a deliberate
+ * 400. Anything that gets past it and throws is genuinely ours.
+ */
+export function errorResponse(error: unknown, context: string): Response {
+  const code = error instanceof Error ? error.message : "";
+  const known = CODES.get(code);
+  if (known) {
+    return Response.json(
+      { error: code, message: known.message },
+      { status: known.status },
+    );
+  }
+  console.error(`[commerce/api] ${context}`, error);
+  return Response.json(
+    { error: "INTERNAL_ERROR", message: "Something went wrong on our side." },
+    { status: 500 },
+  );
+}
+
+/** A parsed body is only ever read field-by-field by these routes. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The outcome of decoding one request body: either the fields to validate, or
+ * the finished 400 to return. A discriminated union rather than a `body | null`
+ * because the failure carries a Response the route must not rebuild.
+ */
+export type JsonBodyResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: Response };
+
+/**
+ * Decode a request body OUTSIDE the store's `try`, so an unreadable body and a
+ * store defect stay DIFFERENT failures.
+ *
+ * `await req.json()` used to sit inside the same `try` that wrapped the store
+ * call, which put a `SyntaxError` from a truncated or non-JSON body through
+ * `errorResponse` — where it is, correctly, an unrecognised code and therefore a
+ * logged 500. That is the accepted cost written into `errorResponse`'s own note
+ * above, and the fix belongs HERE rather than there: special-casing
+ * `SyntaxError` inside `errorResponse` would misreport a genuine server-side
+ * `SyntaxError` (one thrown by our own code, several frames down) as a client
+ * mistake — the same defect one level lower. Splitting the two domains at the
+ * route boundary is what makes the distinction sound: at this line, the only
+ * thing that can fail is reading the caller's bytes, so a failure here IS a bad
+ * request and nothing else. Everything the store raises still reaches
+ * `errorResponse` untouched, unrecognised codes included.
+ *
+ * `recordId` is REQUIRED, and appears both in the log line and in the message.
+ * "malformed body" with no id told a presenter watching the server log that
+ * something failed but not which order, and these five routes are the ones the
+ * demo drives by id.
+ *
+ * A top-level non-object (`5`, `"x"`, `[]`, `null`) parses fine and simply
+ * carries no fields, so it is normalised to an empty bag and falls through to
+ * each route's own field validation exactly as it did when `req.json()` handed
+ * back `any`. It is not a parse failure and must not be reported as one.
+ */
+export async function readJsonBody(
+  req: { json: () => Promise<unknown> },
+  context: string,
+  recordId: string,
+): Promise<JsonBodyResult> {
+  let parsed: unknown;
+  try {
+    parsed = await req.json();
+  } catch (error) {
+    console.warn(
+      `[commerce/api] ${context} id=${recordId} unreadable request body`,
+      error,
+    );
+    return {
+      ok: false,
+      response: Response.json(
+        {
+          error: "MALFORMED_BODY",
+          message: `That request body is not readable JSON (record ${recordId}).`,
+        },
+        { status: 400 },
+      ),
+    };
+  }
+  return { ok: true, body: isRecord(parsed) ? parsed : {} };
+}
+
+/**
+ * Read a money figure out of a parsed JSON body, refusing COERCION.
+ *
+ * `Number(body?.amount)` was the original spelling in the refund route, and it
+ * is a money bug rather than a validation nicety: `Number(true)` is `1`, a
+ * finite, positive, under-the-ceiling figure that satisfies every rule
+ * `issueRefund` has and therefore SETTLES the return — terminally, for a dollar,
+ * with a 200. `Number("12")` is likewise a refund nobody's JSON meant to
+ * authorize. (`[]`, `null` and `""` all coerce to 0 and were caught by the
+ * store's `<= 0` rule, which is why the hole was invisible: five of the seven
+ * malformed bodies already answered 422.)
+ *
+ * So the type is checked here, at the only place untrusted JSON enters, and a
+ * non-number is refused OUTRIGHT rather than converted into whatever number
+ * JavaScript thinks it resembles. `Number.isFinite` rides along because
+ * `JSON.parse` turns an overflowing literal (`1e999`) into `Infinity`, which is
+ * a `number` and is not a figure.
+ *
+ * What this deliberately does NOT do is re-check the domain range. `> 0` and
+ * `<= itemValue` stay in `store.issueRefund`, single-sourced, so the ceiling
+ * applies however a refund is issued; forking them into the route would make one
+ * rule live in two files and drift. The two halves are complementary: this
+ * guarantees the store receives a real finite number, the store decides whether
+ * that number is an acceptable refund.
+ */
+export function requireAmount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error("INVALID_AMOUNT");
+  return value;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/json-body-route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/json-body-route.test.ts
@@ -1,0 +1,256 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PATCH as patchOrder } from "@/app/api/commerce/v1/orders/[id]/route";
+import { POST as postNote } from "@/app/api/commerce/v1/orders/[id]/notes/route";
+import { POST as postRefund } from "@/app/api/commerce/v1/returns/[id]/refund/route";
+import * as store from "./store";
+
+/**
+ * The two failure domains of a write route, kept apart.
+ *
+ * `await req.json()` used to sit INSIDE the same `try` that wrapped the store
+ * call, so a truncated or non-JSON body threw a `SyntaxError` into
+ * `errorResponse`, which — correctly, and deliberately — treats an unrecognised
+ * code as a logged 500. The result was that "the caller sent bytes we cannot
+ * parse" and "our own ledger is broken" arrived as the SAME response with the
+ * SAME log line, and neither line said which record the request was about.
+ *
+ * These assertions pin the split from both sides, because fixing one side alone
+ * is how this regresses: a malformed body has to be a deliberate 400 that NAMES
+ * the record and is NOT logged as an internal fault, and a genuine store fault
+ * has to keep its 500 AND its `console.error`. The `errorResponse` contract
+ * itself is untouched — see `http.test.ts`, which pins that an unrecognised code
+ * is still a 500.
+ */
+
+const ORDER = "ord-4471"; // seeded `open` with a fraud-review exception
+const APPROVED_RETURN = "ret-2210"; // seeded `approved`, itemValue 340
+
+/** A body that is not JSON at all, sent the way a real caller would send it. */
+const unreadable = (url: string, method: string) =>
+  new NextRequest(`http://localhost${url}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: "{ this is not json",
+  });
+
+const json = (url: string, method: string, body: unknown) =>
+  new NextRequest(`http://localhost${url}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const order = () => store.orders().find((o) => o.id === ORDER);
+const ret = () => store.returns().find((r) => r.id === APPROVED_RETURN);
+
+beforeEach(() => store.reset());
+afterEach(() => vi.restoreAllMocks());
+
+describe("PATCH orders/[id] — an unreadable body", () => {
+  it("answers a deliberate 400 that names the order, and writes nothing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await patchOrder(
+      unreadable(`/api/commerce/v1/orders/${ORDER}`, "PATCH"),
+      params(ORDER),
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("MALFORMED_BODY");
+    // The id is in the response, not merely in the log: the tools report the
+    // message straight back into the transcript.
+    expect(body.message).toContain(ORDER);
+
+    // Warned (a caller mistake worth seeing), never console.error'd (not ours).
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(`id=${ORDER}`);
+    expect(error).not.toHaveBeenCalled();
+
+    // Untouched: the order is still exactly as seeded.
+    expect(order()?.status).toBe("open");
+    expect(order()?.exception).toBe("fraud-review");
+  });
+
+  it("keeps a genuine store fault a LOGGED 500 naming the order", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(store, "setOrderStatus").mockImplementation(() => {
+      throw new Error("KABOOM_NOBODY_MAPPED");
+    });
+
+    const res = await patchOrder(
+      json(`/api/commerce/v1/orders/${ORDER}`, "PATCH", { status: "on-hold" }),
+      params(ORDER),
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: "INTERNAL_ERROR",
+      message: "Something went wrong on our side.",
+    });
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(String(error.mock.calls[0]?.[0])).toContain(`id=${ORDER}`);
+  });
+
+  it("still holds the order on a well-formed body", async () => {
+    const res = await patchOrder(
+      json(`/api/commerce/v1/orders/${ORDER}`, "PATCH", { status: "on-hold" }),
+      params(ORDER),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      id: ORDER,
+      status: "on-hold",
+    });
+    expect(order()?.status).toBe("on-hold");
+  });
+
+  // The vocabulary and presence 400s are a DIFFERENT refusal and must not have
+  // been folded into the parse one: they keep their own code and log nothing.
+  it.each([
+    ["an empty PATCH", {}],
+    ["an unknown status", { status: "teleported" }],
+    ["an unknown exception", { exception: "" }],
+  ])("still answers BAD_REQUEST for %s", async (_label, sent) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const res = await patchOrder(
+      json(`/api/commerce/v1/orders/${ORDER}`, "PATCH", sent),
+      params(ORDER),
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "BAD_REQUEST" });
+    expect(warn).not.toHaveBeenCalled();
+    expect(order()?.status).toBe("open");
+  });
+
+  // A top-level non-object parses fine — it just carries no fields — so it is
+  // the presence check's business, not the parser's.
+  it.each([["a number", 5] as const, ["a string", '"nope"'] as const])(
+    "treats %s body as fields-absent rather than unparseable",
+    async (_label, raw) => {
+      const res = await patchOrder(
+        new NextRequest(`http://localhost/api/commerce/v1/orders/${ORDER}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: String(raw),
+        }),
+        params(ORDER),
+      );
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toMatchObject({
+        error: "BAD_REQUEST",
+      });
+    },
+  );
+});
+
+describe("POST returns/[id]/refund — an unreadable body", () => {
+  it("answers a 400 naming the return WITHOUT settling it", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await postRefund(
+      unreadable(`/api/commerce/v1/returns/${APPROVED_RETURN}/refund`, "POST"),
+      params(APPROVED_RETURN),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "MALFORMED_BODY",
+      message: `That request body is not readable JSON (record ${APPROVED_RETURN}).`,
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(error).not.toHaveBeenCalled();
+
+    // The point of the route: nothing settled, so the money did not move.
+    expect(ret()?.status).toBe("approved");
+    expect(ret()?.refundAmount).toBeNull();
+  });
+
+  it("keeps a genuine store fault a LOGGED 500 naming the return", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(store, "issueRefund").mockImplementation(() => {
+      throw new Error("KABOOM_NOBODY_MAPPED");
+    });
+
+    const res = await postRefund(
+      json(`/api/commerce/v1/returns/${APPROVED_RETURN}/refund`, "POST", {
+        amount: 85.5,
+      }),
+      params(APPROVED_RETURN),
+    );
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INTERNAL_ERROR",
+    });
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(String(error.mock.calls[0]?.[0])).toContain(`id=${APPROVED_RETURN}`);
+  });
+
+  // The amount gate is the other half of the same body decode and still answers
+  // 422 rather than being swallowed by the parse 400 above.
+  it("still refuses a coercible amount with INVALID_AMOUNT", async () => {
+    const res = await postRefund(
+      json(`/api/commerce/v1/returns/${APPROVED_RETURN}/refund`, "POST", {
+        amount: true,
+      }),
+      params(APPROVED_RETURN),
+    );
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_AMOUNT",
+    });
+    expect(ret()?.status).toBe("approved");
+  });
+
+  it("still refunds a legitimate amount", async () => {
+    const res = await postRefund(
+      json(`/api/commerce/v1/returns/${APPROVED_RETURN}/refund`, "POST", {
+        amount: 85.5,
+      }),
+      params(APPROVED_RETURN),
+    );
+    expect(res.status).toBe(200);
+    expect(ret()?.status).toBe("refunded");
+    expect(ret()?.refundAmount).toBe(85.5);
+  });
+});
+
+// A third route, cheaply: the class was fixed in five places and a per-route
+// copy is exactly the kind of thing that gets one of them wrong.
+describe("POST orders/[id]/notes — an unreadable body", () => {
+  it("answers a 400 naming the order and posts no note", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const before = order()?.notes.length ?? 0;
+
+    const res = await postNote(
+      unreadable(`/api/commerce/v1/orders/${ORDER}/notes`, "POST"),
+      params(ORDER),
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "MALFORMED_BODY",
+    });
+    expect(String(warn.mock.calls[0]?.[0])).toContain(`id=${ORDER}`);
+    expect(order()?.notes).toHaveLength(before);
+  });
+
+  it("still posts a well-formed note", async () => {
+    const before = order()?.notes.length ?? 0;
+    const res = await postNote(
+      json(`/api/commerce/v1/orders/${ORDER}/notes`, "POST", {
+        text: "🚨 Held for fraud review.",
+        author: "Wren Adeyemi",
+      }),
+      params(ORDER),
+    );
+    expect(res.status).toBe(201);
+    expect(order()?.notes).toHaveLength(before + 1);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/ledger-context.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/ledger-context.test.tsx
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import {
+  CommerceLedgerProvider,
+  useCommerceLedger,
+} from "@/skins/commerce/data/ledger-context";
+import type { CommerceStoreState } from "@/skins/commerce/data/types";
+
+/**
+ * `refresh()` is what every write path in Bellwether calls after a mutation, so
+ * these two guarantees are the difference between "the desk shows what it just
+ * did" and "the desk reports success over pre-mutation rows":
+ *
+ *  1. It RESOLVES FALSE on a failed fetch. Resolving cleanly let every caller
+ *     print a receipt over a snapshot that was never re-read — a failure mode
+ *     indistinguishable from a slow network.
+ *  2. It does not commit state after the provider unmounts. The shell remounts
+ *     the whole runtime subtree keyed by skin id, so a skin switch during an
+ *     in-flight refresh is routine.
+ */
+
+const SNAPSHOT: CommerceStoreState = {
+  products: [],
+  floors: [],
+  orders: [],
+  notifications: [],
+  returns: [],
+  promotions: [],
+  waivers: [],
+  plans: [],
+  operators: [
+    {
+      id: "op-nadia",
+      name: "Nadia Okonjo",
+      role: "merch-lead",
+      team: "Merchandising",
+    },
+  ],
+};
+
+function jsonResponse(body: CommerceStoreState): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Captures the context value so a test can drive `refresh()` imperatively. */
+function Probe({
+  onReady,
+}: {
+  onReady: (refresh: () => Promise<boolean>) => void;
+}) {
+  onReady(useCommerceLedger().refresh);
+  return <span data-testid="mounted">ready</span>;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => jsonResponse(SNAPSHOT));
+  vi.stubGlobal("fetch", fetchMock);
+  // The provider logs every failed fetch; swallow it so a passing run is quiet.
+  consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  consoleError.mockRestore();
+  vi.unstubAllGlobals();
+});
+
+/** Mount the provider and wait out its initial `/ledger` fetch. */
+async function mountProvider() {
+  let refresh: (() => Promise<boolean>) | null = null;
+  const view = render(
+    <CommerceLedgerProvider>
+      <Probe
+        onReady={(fn) => {
+          refresh = fn;
+        }}
+      />
+    </CommerceLedgerProvider>,
+  );
+  // Flush the mount effect's promise chain so `loaded` flips and children mount.
+  await act(async () => {});
+  if (!refresh) throw new Error("provider never mounted its children");
+  return { view, refresh: refresh as () => Promise<boolean> };
+}
+
+describe("CommerceLedgerProvider.refresh", () => {
+  it("mounts children after the initial fetch and reports a good refresh", async () => {
+    const { view, refresh } = await mountProvider();
+    expect(view.queryByTestId("mounted")).not.toBeNull();
+
+    let result: boolean | null = null;
+    await act(async () => {
+      result = await refresh();
+    });
+    expect(result).toBe(true);
+  });
+
+  it("resolves FALSE when the ledger fetch is refused", async () => {
+    const { refresh } = await mountProvider();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    let result: boolean | null = null;
+    await act(async () => {
+      result = await refresh();
+    });
+
+    // The whole point: a caller can tell "done" from "done, but the screen is
+    // behind". A `void`-resolving refresh made these indistinguishable.
+    expect(result).toBe(false);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("resolves FALSE when the fetch itself rejects", async () => {
+    const { refresh } = await mountProvider();
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+
+    let result: boolean | null = null;
+    await act(async () => {
+      result = await refresh();
+    });
+    expect(result).toBe(false);
+  });
+
+  it("does not commit state — and reports FALSE — when the response lands after unmount", async () => {
+    const { view, refresh } = await mountProvider();
+
+    // A refresh whose response we hold open until after the provider unmounts.
+    let release: (value: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    let result: boolean | null = null;
+    const pending = refresh().then((value) => {
+      result = value;
+    });
+
+    // The skin switch: the shell remounts the runtime subtree, unmounting this
+    // provider while the refresh is still in flight.
+    view.unmount();
+
+    await act(async () => {
+      release(jsonResponse(SNAPSHOT));
+      await pending;
+    });
+
+    // `false` here IS the cancellation guard: `if (!live.current) return false`
+    // is the single line that both skips `setData` and produces this answer, so
+    // a `true` means the provider committed a snapshot after unmounting. React
+    // 19 dropped the unmounted-setState warning, so the return value is the only
+    // observable left — which is also why the failure channel and the guard are
+    // one change rather than two.
+    expect(result).toBe(false);
+    // Nothing was logged: no fetch failed and no React warning fired.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/ledger-context.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/ledger-context.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import type { CommerceStoreState, Operator } from "./types";
+
+/**
+ * Bellwether's single client-side source of truth.
+ *
+ * Mounted in the skin's `RuntimeProviders` — i.e. ABOVE `CopilotKitProvider` —
+ * for one specific reason: `useRuntimeProperties` reads the signed-in operator
+ * out of this context, and `properties` is a PROP of `CopilotKitProvider`, so
+ * its source has to exist before that provider's first commit. A child racing
+ * an imperative `setProperties` after mount is the exact bug the contract's
+ * `RuntimeProviders` slot exists to prevent.
+ *
+ * Because it sits above the provider it is also visible to everything below —
+ * `Tools`, the layout, and every page — so the order queue, the ladder, the
+ * promotions table and the agent's readables all read the SAME snapshot. That
+ * consistency is load-bearing for beat 3b: the agent is asked to describe what
+ * is literally on screen, and it cannot do that if a panel and a readable are
+ * one fetch apart.
+ */
+
+interface LedgerContextValue {
+  data: CommerceStoreState;
+  /**
+   * Re-fetch after a mutation. Every write path calls this.
+   *
+   * Resolves `true` ONLY when a fresh snapshot was actually committed to this
+   * context — `false` when the fetch failed, or when the provider unmounted
+   * before the response landed. Any caller that goes on to tell the user (or the
+   * agent) that the write is done MUST check it: a `false` means the rows on
+   * screen are still the pre-mutation ones, and "done" printed over them is
+   * indistinguishable from a slow network.
+   */
+  refresh: () => Promise<boolean>;
+  operator: Operator;
+  setOperatorId: (id: string) => void;
+}
+
+const LedgerContext = createContext<LedgerContextValue | null>(null);
+
+const EMPTY: CommerceStoreState = {
+  products: [],
+  floors: [],
+  orders: [],
+  notifications: [],
+  returns: [],
+  promotions: [],
+  waivers: [],
+  plans: [],
+  operators: [],
+};
+
+const FALLBACK_OPERATOR: Operator = {
+  id: "op-nadia",
+  name: "Nadia Okonjo",
+  role: "merch-lead",
+  team: "Merchandising",
+};
+
+export function CommerceLedgerProvider({ children }: { children: ReactNode }) {
+  const [data, setData] = useState<CommerceStoreState>(EMPTY);
+  const [loaded, setLoaded] = useState(false);
+  const [operatorId, setOperatorId] = useState<string>(FALLBACK_OPERATOR.id);
+
+  /**
+   * ONE liveness flag for EVERY async path in this provider — the mount fetch
+   * below and `refresh` both consult it before touching state, and the mount
+   * effect's cleanup is what clears it.
+   *
+   * It is provider-lifetime rather than per-effect on purpose. `refresh` is
+   * called from click handlers and tool handlers, not from an effect, so it has
+   * no cleanup of its own to hang a local `cancelled` off; and the shell
+   * remounts the entire runtime subtree keyed by skin id, so a skin switch while
+   * a mutation's refresh is still in flight unmounts this provider. That is
+   * routine operation, not a rare race.
+   */
+  const live = useRef(true);
+
+  // Note the `await` comes FIRST: nothing here sets state synchronously, which
+  // is what keeps the mount effect below off React's cascading-render path
+  // (`react-hooks/set-state-in-effect`). An in-flight flag set before the fetch
+  // would put it straight back on it, and no consumer wanted one.
+  //
+  // It reports failure by RESOLVING FALSE rather than rejecting. Rejecting would
+  // blank the app mid-demo for what is almost always a dev-server restart, and
+  // would turn sixteen bare `await refresh()` call sites into unhandled
+  // rejections. Resolving `void` — the shape this replaced — was the other
+  // extreme: every one of those call sites went on to report success over rows
+  // that had never been re-fetched.
+  const refresh = useCallback(async (): Promise<boolean> => {
+    try {
+      const res = await fetch("/api/commerce/v1/ledger", { cache: "no-store" });
+      if (!res.ok) throw new Error(`ledger fetch failed: ${res.status}`);
+      const snapshot = (await res.json()) as CommerceStoreState;
+      // Unmounted while the fetch was in flight: setting state here is the
+      // React warning, and claiming success is the worse half — nothing was
+      // committed, so the answer is `false`.
+      if (!live.current) return false;
+      setData(snapshot);
+      setLoaded(true);
+      return true;
+    } catch (error) {
+      // Keep the last good snapshot on screen and let the next mutation's
+      // refresh recover; the caller is told, so it can stop short of claiming
+      // the screen is current.
+      console.error("[commerce] ledger refresh failed", error);
+      if (live.current) setLoaded(true);
+      return false;
+    }
+  }, []);
+
+  // The FIRST load is inlined as a promise chain rather than a call to
+  // `refresh`. `react-hooks/set-state-in-effect` traces through the callback
+  // boundary, so invoking any setState-calling function synchronously in an
+  // effect body trips it — setting state inside a `.then` does not. The `live`
+  // guard is the second reason to prefer this shape: it stops a slow first fetch
+  // from setting state after the provider has already unmounted.
+  useEffect(() => {
+    live.current = true;
+    fetch("/api/commerce/v1/ledger", { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`ledger fetch failed: ${res.status}`);
+        return res.json() as Promise<CommerceStoreState>;
+      })
+      .then((snapshot) => {
+        if (!live.current) return;
+        setData(snapshot);
+        setLoaded(true);
+      })
+      .catch((error) => {
+        console.error("[commerce] initial ledger fetch failed", error);
+        // Still mark loaded: children must mount even on a failed first fetch,
+        // or a dev-server hiccup leaves the whole skin rendering nothing with no
+        // indication of why.
+        if (live.current) setLoaded(true);
+      });
+    return () => {
+      live.current = false;
+    };
+  }, []);
+
+  const operator = useMemo(
+    () =>
+      data.operators.find((o) => o.id === operatorId) ??
+      data.operators[0] ??
+      FALLBACK_OPERATOR,
+    [data.operators, operatorId],
+  );
+
+  const value = useMemo<LedgerContextValue>(
+    () => ({ data, refresh, operator, setOperatorId }),
+    [data, refresh, operator],
+  );
+
+  // Render nothing until the first load resolves. This looks heavy-handed for a
+  // provider, but it is what makes the runtime identity correct on the FIRST run
+  // of a session: `useRuntimeProperties` reads `operator` from here, so mounting
+  // children early would hand CopilotKitProvider a placeholder operator and
+  // scope the opening messages of a demo to the wrong memory bucket — which then
+  // looks like "memory didn't work".
+  if (!loaded) return null;
+
+  return (
+    <LedgerContext.Provider value={value}>{children}</LedgerContext.Provider>
+  );
+}
+
+/**
+ * Read the ledger. Throws when used outside the provider rather than returning
+ * an empty snapshot: a silently-empty catalog renders as "no products", which is
+ * indistinguishable from a real empty state and would send someone hunting
+ * through the seed file instead of the provider tree.
+ */
+export function useCommerceLedger(): LedgerContextValue {
+  const ctx = useContext(LedgerContext);
+  if (!ctx) {
+    throw new Error(
+      "useCommerceLedger must be used inside <CommerceLedgerProvider>",
+    );
+  }
+  return ctx;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/plans-route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/plans-route.test.ts
@@ -1,0 +1,362 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/commerce/v1/plans/route";
+import * as store from "./store";
+
+/**
+ * BEAT 3d's write path — the validation in front of the DURABLE artifact.
+ *
+ * Every assertion here pins the same failure mode, and it is the worst kind this
+ * app has: the route used to COERCE whatever the model sent and report success.
+ * A twelve-SKU price sheet became an eight-row plan, `null` became the bullet
+ * "null", `{}` became "[object Object]", `"$52"` and a genuine `$0` both became
+ * `0`, and an empty season became a card with no title. The tool answered "Filed
+ * the plan" in every one of those cases, the agent then narrated FROM the record,
+ * and the record outlives the thread. A refusal is recoverable; a plausible-
+ * looking wrong artifact is not, because nobody in the room can see it.
+ */
+
+const post = (body: unknown) =>
+  POST({ json: async () => body } as unknown as NextRequest);
+
+/** The shape beat 3d actually files, from the four-line seeded price sheet. */
+const validPlan = () => ({
+  vendor: "Kestrel Mills",
+  season: "Autumn knitwear",
+  summary: "Autumn knit buy at the quoted landed costs.",
+  highlights: ["Cedar Hoodie up to $51", "FOB mill, net 45"],
+  lines: [
+    { sku: "BW-CDR-HDY", name: "Cedar Hoodie", landedCost: 51, units: 1200 },
+    { sku: "BW-ALD-CRW", name: "Alder Crewneck", landedCost: 52, units: 900 },
+  ],
+  schedule: [
+    { week: "Week 1", item: "PO countersigned" },
+    { week: "Week 6", item: "Bulk leaves the mill" },
+  ],
+  filedBy: "Nadia Okonjo",
+});
+
+beforeEach(() => store.reset());
+
+describe("POST /api/commerce/v1/plans — the happy path still files", () => {
+  it("files the plan the demo's own price sheet produces, intact", async () => {
+    const before = store.plans().length;
+    const res = await post(validPlan());
+    expect(res.status).toBe(201);
+
+    const plan = await res.json();
+    expect(store.plans()).toHaveLength(before + 1);
+    expect(plan.vendor).toBe("Kestrel Mills");
+    expect(plan.season).toBe("Autumn knitwear");
+    expect(plan.highlights).toEqual([
+      "Cedar Hoodie up to $51",
+      "FOB mill, net 45",
+    ]);
+    expect(plan.lines).toHaveLength(2);
+    expect(plan.schedule).toHaveLength(2);
+    expect(plan.filedBy).toBe("Nadia Okonjo");
+  });
+
+  it("defaults an OMITTED season and filedBy rather than refusing them", async () => {
+    const { season, filedBy, ...rest } = validPlan();
+    expect(season).toBeTruthy(); // the fields really are omitted below
+    expect(filedBy).toBeTruthy();
+
+    const res = await post(rest);
+    expect(res.status).toBe(201);
+    const plan = await res.json();
+    expect(plan.season).toBe("Unscheduled");
+    expect(plan.filedBy).toBe("Bellwether");
+  });
+
+  it("treats absent arrays as empty, so a summary-only plan still files", async () => {
+    const res = await post({
+      vendor: "Kestrel Mills",
+      summary: "Placeholder while the sheet is countersigned.",
+    });
+    expect(res.status).toBe(201);
+    const plan = await res.json();
+    expect(plan.highlights).toEqual([]);
+    expect(plan.lines).toEqual([]);
+    expect(plan.schedule).toEqual([]);
+  });
+});
+
+describe("POST /api/commerce/v1/plans — over-limit is REFUSED, never trimmed", () => {
+  const row = (n: number) => ({
+    sku: `BW-SKU-${n}`,
+    name: `Style ${n}`,
+    landedCost: 40 + n,
+    units: 100 * (n + 1),
+  });
+
+  it("refuses a twelve-SKU sheet instead of storing eight rows", async () => {
+    const before = store.plans().length;
+    const res = await post({
+      ...validPlan(),
+      lines: Array.from({ length: 12 }, (_, i) => row(i)),
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("PLAN_TOO_LARGE");
+    expect(body.message).toContain("8"); // the limit is named, so a retry can fit
+    expect(body.message).toContain("12"); // and so is what was sent
+    // The whole point: nothing was written.
+    expect(store.plans()).toHaveLength(before);
+  });
+
+  it("refuses a fourth highlight instead of dropping it", async () => {
+    const res = await post({
+      ...validPlan(),
+      highlights: ["one", "two", "three", "four"],
+    });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "PLAN_TOO_LARGE",
+    });
+  });
+
+  it("refuses a ninth schedule step instead of dropping it", async () => {
+    const res = await post({
+      ...validPlan(),
+      schedule: Array.from({ length: 9 }, (_, i) => ({
+        week: `Week ${i + 1}`,
+        item: `Step ${i + 1}`,
+      })),
+    });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "PLAN_TOO_LARGE",
+    });
+  });
+
+  it("accepts EXACTLY the limit, so the budget is a cap and not an off-by-one", async () => {
+    const res = await post({
+      ...validPlan(),
+      highlights: ["one", "two", "three"],
+      lines: Array.from({ length: 8 }, (_, i) => row(i)),
+      schedule: Array.from({ length: 8 }, (_, i) => ({
+        week: `Week ${i + 1}`,
+        item: `Step ${i + 1}`,
+      })),
+    });
+    expect(res.status).toBe(201);
+    const plan = await res.json();
+    expect(plan.lines).toHaveLength(8);
+    expect(plan.schedule).toHaveLength(8);
+    expect(plan.highlights).toHaveLength(3);
+  });
+});
+
+describe("POST /api/commerce/v1/plans — no String() coercion reaches the artifact", () => {
+  it.each([
+    ["null", null],
+    ["an object", { text: "nope" }],
+    ["a number", 12],
+    ["an empty string", ""],
+    ["whitespace", "   "],
+  ])("refuses %s in highlights rather than storing it", async (_label, bad) => {
+    const before = store.plans().length;
+    const res = await post({
+      ...validPlan(),
+      highlights: ["Cedar Hoodie up to $51", bad],
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("INVALID_PLAN_FIELD");
+    expect(body.message).toContain("highlights[1]");
+    expect(store.plans()).toHaveLength(before);
+  });
+
+  it("never lets 'null' or '[object Object]' onto a filed plan", async () => {
+    await post({ ...validPlan(), highlights: [null] });
+    await post({ ...validPlan(), highlights: [{}] });
+    const stored = store.plans().flatMap((p) => p.highlights);
+    expect(stored).not.toContain("null");
+    expect(stored).not.toContain("[object Object]");
+  });
+
+  it("refuses a highlights that is not an array at all", async () => {
+    const res = await post({ ...validPlan(), highlights: "just one fact" });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_PLAN_FIELD",
+      message: "highlights must be an array.",
+    });
+  });
+
+  it("refuses an object vendor rather than filing '[object Object]'", async () => {
+    const res = await post({ ...validPlan(), vendor: { name: "Kestrel" } });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "BAD_REQUEST" });
+    expect(store.plans().map((p) => p.vendor)).not.toContain("[object Object]");
+  });
+
+  it("refuses an object filedBy rather than attributing the plan to '[object Object]'", async () => {
+    const res = await post({ ...validPlan(), filedBy: { name: "Nadia" } });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_PLAN_FIELD",
+      message: "filedBy must be a non-empty string.",
+    });
+  });
+
+  it.each([
+    ["a null row", null],
+    ["a string row", "BW-CDR-HDY"],
+    ["an array row", ["BW-CDR-HDY"]],
+  ])("refuses %s in lines", async (_label, bad) => {
+    const res = await post({ ...validPlan(), lines: [bad] });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_PLAN_FIELD",
+      message: "lines[0] must be an object.",
+    });
+  });
+
+  it("refuses a line with a blank sku, which the page uses as its React key", async () => {
+    const res = await post({
+      ...validPlan(),
+      lines: [{ sku: "", name: "Cedar Hoodie", landedCost: 51, units: 1200 }],
+    });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      message: "lines[0].sku must be a non-empty string.",
+    });
+  });
+
+  it("refuses a repeated sku, which would collide the card's React keys", async () => {
+    const line = {
+      sku: "BW-CDR-HDY",
+      name: "Cedar Hoodie",
+      landedCost: 51,
+      units: 1200,
+    };
+    const res = await post({ ...validPlan(), lines: [line, { ...line }] });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_PLAN_FIELD",
+      message: "lines[].sku must not repeat; the page keys its rows off them.",
+    });
+  });
+
+  it("refuses a schedule step missing its week or item", async () => {
+    const res = await post({
+      ...validPlan(),
+      schedule: [{ week: "Week 1", item: null }],
+    });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      message: "schedule[0].item must be a non-empty string.",
+    });
+  });
+});
+
+describe("POST /api/commerce/v1/plans — the money the margin narrative is built on", () => {
+  const withCost = (landedCost: unknown, units: unknown = 1200) => ({
+    ...validPlan(),
+    lines: [{ sku: "BW-CDR-HDY", name: "Cedar Hoodie", landedCost, units }],
+  });
+
+  it.each([
+    ["a negative cost", -500],
+    ["an absurd cost", 1e9],
+    ["a currency string", "$52"],
+    ["a numeric string", "52"],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["null", null],
+    ["undefined", undefined],
+  ])("refuses %s instead of filing 0", async (_label, cost) => {
+    const before = store.plans().length;
+    const res = await post(withCost(cost));
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("INVALID_PLAN_FIELD");
+    expect(body.message).toContain("lines[0].landedCost");
+    expect(store.plans()).toHaveLength(before);
+  });
+
+  it.each([
+    ["a negative unit count", -10],
+    ["a fractional unit count", 12.5],
+    ["an absurd unit count", 1e12],
+  ])("refuses %s", async (_label, units) => {
+    const res = await post(withCost(51, units));
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_PLAN_FIELD",
+    });
+  });
+
+  // The distinguishability requirement: `Number(x) || 0` mapped a genuine zero
+  // and every unparseable value onto the same stored 0. A genuine zero has to
+  // survive, and survive as a NUMBER, or the card renders "$NaN".
+  it("keeps a genuine 0 cost, distinct from everything refused above", async () => {
+    const res = await post(withCost(0, 0));
+    expect(res.status).toBe(201);
+    const plan = await res.json();
+    expect(plan.lines[0].landedCost).toBe(0);
+    expect(typeof plan.lines[0].landedCost).toBe("number");
+    expect(plan.lines[0].units).toBe(0);
+  });
+});
+
+describe("POST /api/commerce/v1/plans — season", () => {
+  it.each([
+    ["an empty season", ""],
+    ["a whitespace season", "  "],
+  ])("refuses %s rather than filing a blank card title", async (_l, season) => {
+    const before = store.plans().length;
+    const res = await post({ ...validPlan(), season });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_PLAN_FIELD",
+      message: "season must be a non-empty string.",
+    });
+    expect(store.plans()).toHaveLength(before);
+  });
+
+  it("trims a padded season instead of storing the padding", async () => {
+    const res = await post({ ...validPlan(), season: "  Autumn knitwear " });
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toMatchObject({
+      season: "Autumn knitwear",
+    });
+  });
+});
+
+describe("POST /api/commerce/v1/plans — the required scalars keep their 400", () => {
+  it.each([
+    ["no vendor", { summary: "Autumn knit buy." }],
+    ["no summary", { vendor: "Kestrel Mills" }],
+    ["a blank vendor", { vendor: "   ", summary: "Autumn knit buy." }],
+  ])("answers 400 for %s", async (_label, body) => {
+    const res = await post(body);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "BAD_REQUEST",
+      message: "A plan needs a vendor and a summary.",
+    });
+  });
+});
+
+describe("POST /api/commerce/v1/plans — a real fault is still a logged 500", () => {
+  it("does not report a malformed body as a validation refusal", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST({
+      json: async () => {
+        throw new SyntaxError("Unexpected token < in JSON");
+      },
+    } as unknown as NextRequest);
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INTERNAL_ERROR",
+    });
+    expect(log).toHaveBeenCalledTimes(1);
+    log.mockRestore();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-pdf.layout.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-pdf.layout.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest";
+import { buildPriceSheetPdf, PRICE_SHEET_METRICS } from "./price-sheet-pdf";
+import type { PriceSheetInput } from "./price-sheet-pdf";
+
+/**
+ * BEAT 3d's document. This PDF is PROJECTED ON SCREEN and then fed to the model
+ * as an attachment, so its typography is part of the claim it is making.
+ *
+ * The invariant under test is alignment, which is visual and therefore untestable
+ * as pixels here. What IS testable is the mechanism alignment rests on: the table
+ * is spaced by CHARACTER COUNT (`padEnd`), which is only true in a monospaced
+ * font. Drawn in Helvetica — as this file did until the columns were moved to
+ * Courier — every row starts its next column somewhere new and the table renders
+ * visibly ragged while still being a perfectly valid PDF. Nothing type-checks it
+ * and no other test opens the bytes, so these assertions are the only thing
+ * standing between a regression and a ragged table on stage.
+ *
+ * So: parse the emitted PDF, and assert (a) every font the content stream
+ * references is actually declared — a dangling `/Fn` is worse than ragged, it is
+ * blank — (b) every columnar line is drawn in a Courier face, (c) the column
+ * origins are identical on every row, and (d) no row can overflow the page.
+ *
+ * TWO UNITS LIVE IN THIS FILE, and mixing them up is how the byte-layout guard
+ * below nearly became decorative:
+ *
+ *   - GLYPHS. Alignment, truncation and page-fit are claims about what is drawn,
+ *     so they count characters — `parsePdf` decodes UTF-8 for them.
+ *   - BYTES. `/Length` and every xref offset are byte offsets by spec, so the
+ *     structural assertions count bytes — `byteImage` decodes one byte to one
+ *     character so that string indices ARE byte offsets.
+ *
+ * The builder computes both `/Length` and its xref offsets from JS string length
+ * (UTF-16 code units) and then emits UTF-8, so those two agree ONLY while the
+ * document is pure ASCII. That is not a happy accident to be left implicit: it is
+ * `toAscii`'s job, and "emits a pure-ASCII document however the input is spelled"
+ * below is the test that pins it. Nothing else does.
+ */
+
+const INPUT: PriceSheetInput = {
+  vendor: "Kestrel Mills",
+  season: "Autumn",
+  lines: [
+    {
+      sku: "BW-HRR-TEE",
+      name: "Harrier Pocket Tee",
+      currentCost: 12,
+      quotedCost: 13,
+      minimumUnits: 1200,
+    },
+    {
+      sku: "BW-MER-CRW-XL",
+      // Deliberately longer than the style column, to prove truncation keeps a
+      // gutter rather than shoving the cost column right.
+      name: "Merino Crewneck, Extended Sizing, Heather",
+      currentCost: 44,
+      quotedCost: 48,
+      minimumUnits: 600,
+    },
+    {
+      sku: "BW-ALD-CRW",
+      name: "Alder Crewneck",
+      quotedCost: 52,
+      minimumUnits: 900,
+    },
+  ],
+};
+
+/** A single drawn line of text: which font resource, at what size, and what. */
+interface DrawnLine {
+  font: string;
+  size: number;
+  text: string;
+}
+
+interface ParsedPdf {
+  /** Resource name -> object number, from the page's /Font dictionary. */
+  fontResources: Map<string, number>;
+  /** Object number -> BaseFont, from each declared font object. */
+  baseFonts: Map<number, string>;
+  lines: DrawnLine[];
+}
+
+/**
+ * A deliberately small PDF reader: enough to see the page's font dictionary, the
+ * font objects, and the `Tf`/`Tj` pairs in the content stream. It parses the
+ * emitted bytes rather than re-deriving them from the builder's internals, so it
+ * would catch a font that is referenced but never declared.
+ */
+function parsePdf(bytes: Uint8Array): ParsedPdf {
+  const source = new TextDecoder().decode(bytes);
+
+  const fontDict = /\/Font\s*<<([^>]*)>>/.exec(source);
+  expect(
+    fontDict,
+    "the page declares a /Font resource dictionary",
+  ).toBeTruthy();
+  const fontResources = new Map<string, number>();
+  for (const match of fontDict![1].matchAll(/\/(\w+)\s+(\d+)\s+0\s+R/g)) {
+    fontResources.set(match[1], Number(match[2]));
+  }
+
+  const baseFonts = new Map<number, string>();
+  for (const match of source.matchAll(
+    /(\d+) 0 obj\n<< \/Type \/Font [^>]*\/BaseFont \/([\w-]+) >>/g,
+  )) {
+    baseFonts.set(Number(match[1]), match[2]);
+  }
+
+  const streamBody = /stream\n([\s\S]*?)\nendstream/.exec(source);
+  expect(streamBody, "the page has a content stream").toBeTruthy();
+
+  const lines: DrawnLine[] = [];
+  let font = "";
+  let size = 0;
+  for (const raw of streamBody![1].split("\n")) {
+    const tf = /^\/(\w+) ([\d.]+) Tf$/.exec(raw);
+    if (tf) {
+      font = tf[1];
+      size = Number(tf[2]);
+      continue;
+    }
+    const tj = /^\((.*)\) Tj$/.exec(raw);
+    // Undo the literal-string escaping, so a line's length here is the number of
+    // GLYPHS drawn — which is what the alignment and width assertions reason about.
+    if (tj)
+      lines.push({ font, size, text: tj[1].replace(/\\([()\\])/g, "$1") });
+  }
+  return { fontResources, baseFonts, lines };
+}
+
+/**
+ * The document as BYTES, one byte per character.
+ *
+ * `latin1` is the only decoder with that property: every byte 0x00-0xff maps to
+ * exactly one code point, so `.length`, `.slice` and index arithmetic over the
+ * result are byte-exact even for a document that is not ASCII. The default UTF-8
+ * decoder is not usable here — it collapses a three-byte em dash into one
+ * character, which is precisely the drift these assertions exist to catch, so
+ * asserting byte offsets against a UTF-8 decode would desync the test the same
+ * way the builder desyncs and could never fail.
+ */
+const byteImage = (bytes: Uint8Array) =>
+  new TextDecoder("latin1").decode(bytes);
+
+/** Every xref entry points at the "N 0 obj" it claims to. Byte offsets. */
+function expectCorrectXref(source: string) {
+  expect(source.startsWith("%PDF-1.4\n")).toBe(true);
+  expect(source.endsWith("%%EOF\n")).toBe(true);
+
+  const startxref = Number(/startxref\n(\d+)/.exec(source)![1]);
+  expect(source.slice(startxref, startxref + 4)).toBe("xref");
+  const entries = [...source.matchAll(/^(\d{10}) 00000 n $/gm)].map((m) =>
+    Number(m[1]),
+  );
+  expect(entries.length).toBeGreaterThan(0);
+  entries.forEach((offset, index) => {
+    expect(source.slice(offset, offset + `${index + 1} 0 obj`.length)).toBe(
+      `${index + 1} 0 obj`,
+    );
+  });
+  expect(Number(/\/Size (\d+)/.exec(source)![1])).toBe(entries.length + 1);
+}
+
+/** The declared `/Length` is the stream's byte count, not its glyph count. */
+function expectCorrectStreamLength(source: string) {
+  const declared = Number(/\/Length (\d+)/.exec(source)![1]);
+  expect(/stream\n([\s\S]*?)\nendstream/.exec(source)![1].length).toBe(
+    declared,
+  );
+}
+
+const baseFontOf = (pdf: ParsedPdf, resource: string) =>
+  pdf.baseFonts.get(pdf.fontResources.get(resource) ?? -1);
+
+/** Lines whose spacing carries meaning: the cost table and the ship schedule. */
+function columnarLines(pdf: ParsedPdf) {
+  const table = pdf.lines.filter((l) => /^SKU\s|^BW-/.test(l.text));
+  const schedule = pdf.lines.filter((l) => /^Week \d/.test(l.text));
+  return { table, schedule };
+}
+
+describe("price sheet PDF", () => {
+  const pdf = parsePdf(buildPriceSheetPdf(INPUT));
+
+  it("is a well-formed single-page PDF with a correct xref", () => {
+    expectCorrectXref(byteImage(buildPriceSheetPdf(INPUT)));
+  });
+
+  it("declares every font the content stream references", () => {
+    // A dangling /Fn renders blank or corrupt in most readers — strictly worse
+    // than the ragged table this fix was about.
+    const referenced = new Set(pdf.lines.map((l) => l.font));
+    expect(referenced.size).toBeGreaterThan(1);
+    for (const resource of referenced) {
+      expect(
+        pdf.fontResources.get(resource),
+        `${resource} is in the page's /Font dictionary`,
+      ).toBeTypeOf("number");
+      expect(
+        baseFontOf(pdf, resource),
+        `${resource} resolves to a declared font object`,
+      ).toBeTypeOf("string");
+    }
+  });
+
+  it("declares a /Length that matches the content stream it wraps", () => {
+    expectCorrectStreamLength(byteImage(buildPriceSheetPdf(INPUT)));
+  });
+
+  it("draws every columnar line in a monospaced face", () => {
+    // THE FIX. Character padding only aligns in a fixed-advance font; these lines
+    // are padded, so they must not be drawn in Helvetica.
+    const { table, schedule } = columnarLines(pdf);
+    expect(table.length).toBe(INPUT.lines.length + 1); // header + one per SKU
+    expect(schedule.length).toBe(5);
+    for (const line of [...table, ...schedule]) {
+      expect(baseFontOf(pdf, line.font), line.text).toMatch(/^Courier/);
+    }
+    // ...and the prose around them is NOT mono, or the sheet stops looking like a
+    // document. The signature line is the check.
+    const signature = pdf.lines.find((l) => l.text === "Ilse Ruijter");
+    expect(baseFontOf(pdf, signature!.font)).toBe("Helvetica-Bold");
+  });
+
+  it("starts every table column at the identical character offset", () => {
+    const { columns } = PRICE_SHEET_METRICS;
+    const costAt = columns.sku + columns.style;
+    const moqAt = costAt + columns.cost;
+    const { table } = columnarLines(pdf);
+
+    for (const { text } of table) {
+      // Each column begins with a non-space at its own fixed offset, and the
+      // preceding character is a space — i.e. the gutter survived truncation.
+      for (const at of [columns.sku, costAt, moqAt]) {
+        expect(text[at], `${JSON.stringify(text)} at ${at}`).not.toBe(" ");
+        expect(text[at - 1], `gutter before ${at}`).toBe(" ");
+      }
+    }
+    // The header and the body agree on where the columns are.
+    expect(table[0].text.indexOf("Style")).toBe(columns.sku);
+    expect(table[0].text.indexOf("Cost")).toBe(costAt);
+    expect(table[0].text.indexOf("MOQ")).toBe(moqAt);
+    for (const { text } of table.slice(1)) {
+      expect(text[costAt]).toBe("$");
+      expect(text.slice(moqAt)).toMatch(/^\d+ units$/);
+    }
+  });
+
+  it("aligns the ship schedule's milestone column too", () => {
+    const { weekLabelWidth } = PRICE_SHEET_METRICS;
+    for (const { text } of columnarLines(pdf).schedule) {
+      // "Week 1" and "Week 10" are different lengths; padding to a fixed cell is
+      // what keeps the milestones flush.
+      expect(text[weekLabelWidth]).not.toBe(" ");
+      expect(text[weekLabelWidth - 1]).toBe(" ");
+    }
+  });
+
+  it("keeps every mono line inside the drawable width", () => {
+    // Fixed advance also makes overflow arithmetic — worth asserting, because a
+    // wider column set would silently run off the right edge of the page.
+    const { monoAdvance, drawableWidth } = PRICE_SHEET_METRICS;
+    const { table, schedule } = columnarLines(pdf);
+    for (const line of [...table, ...schedule]) {
+      expect(
+        line.text.length * monoAdvance * line.size,
+        `${line.text} fits`,
+      ).toBeLessThanOrEqual(drawableWidth);
+    }
+  });
+
+  it("truncates an over-long style without shifting the cost column", () => {
+    const { columns } = PRICE_SHEET_METRICS;
+    const long = columnarLines(pdf).table.find((l) =>
+      l.text.startsWith("BW-MER-CRW-XL"),
+    )!;
+    const style = long.text.slice(columns.sku, columns.sku + columns.style);
+    expect(style.length).toBe(columns.style);
+    // Truncated to width - 1, so a gutter always survives.
+    expect(style.trimEnd().length).toBe(columns.style - 1);
+    expect(long.text.slice(0, columns.sku)).toBe(
+      "BW-MER-CRW-XL".padEnd(columns.sku),
+    );
+  });
+});
+
+/**
+ * THE INVARIANT EVERYTHING ABOVE RESTS ON, and the one nothing used to check.
+ *
+ * `toAscii` (`price-sheet-pdf.ts`) is what makes this a document whose characters
+ * and bytes are the same thing — which is what lets the builder compute `/Length`
+ * and its xref offsets from JS string length, and what lets base-14 fonts render
+ * every glyph the stream asks for. It was asserted NOWHERE: relax it for an
+ * accented vendor name and you get mojibake plus a corrupt byte table, with a
+ * green suite. So this block feeds NON-ASCII down every text path and asserts the
+ * OUTPUT is still ASCII — which is also the only way to prove the fold is applied
+ * on every path in, rather than on the paths one fixture happens to use.
+ */
+describe("price sheet PDF — ASCII invariant", () => {
+  /**
+   * Every text path into the document: the vendor (drawn twice — masthead and
+   * signature), the season, a SKU, a style name in the table, and a style name in
+   * the prose `costMovementLines` derives. Numbers cannot carry non-ASCII and the
+   * rest of the page is literal, so this is the whole surface.
+   */
+  const NON_ASCII_INPUT: PriceSheetInput = {
+    vendor: "Kestrel Mills — Émile & Fils",
+    season: "Autumn ’26 — “Harvest”",
+    lines: [
+      {
+        sku: "BW-CRÈ-TEE",
+        name: "Crème Brûlée Tee",
+        currentCost: 12,
+        quotedCost: 13,
+        minimumUnits: 1200,
+      },
+      {
+        sku: "BW-MOS-SCF",
+        name: "Moss Scarf £18 / €21",
+        currentCost: 44,
+        quotedCost: 44,
+        minimumUnits: 600,
+      },
+      {
+        sku: "BW-ALD-CRW",
+        name: "Alder 2×3 rib…",
+        quotedCost: 52,
+        minimumUnits: 900,
+      },
+    ],
+  };
+
+  it("emits a pure-ASCII document however the input is spelled", () => {
+    const bytes = buildPriceSheetPdf(NON_ASCII_INPUT);
+    const source = byteImage(bytes);
+    const offenders = [...bytes].flatMap((byte, at) =>
+      byte < 0x80
+        ? []
+        : [
+            `0x${byte.toString(16)} at byte ${at}, near ` +
+              JSON.stringify(source.slice(Math.max(0, at - 24), at + 24)),
+          ],
+    );
+    // Reported rather than counted: a single leak is usually one unfolded
+    // character, and its offset is the fastest way to the path that let it in.
+    expect(offenders.slice(0, 3), "bytes outside ASCII").toEqual([]);
+  });
+
+  it("folds what it can and substitutes what it cannot, on every path", () => {
+    const drawn = parsePdf(buildPriceSheetPdf(NON_ASCII_INPUT)).lines.map(
+      (l) => l.text,
+    );
+    // Masthead and signature — the two places the vendor is drawn.
+    expect(drawn).toContain("KESTREL MILLS - ?MILE & FILS");
+    expect(drawn).toContain("Head of Wholesale, Kestrel Mills - ?mile & Fils");
+    // The season, folded: curly quotes and an em dash have ASCII equivalents.
+    expect(drawn).toContain(`Autumn '26 - "Harvest" price sheet`);
+    // Derived prose, which quotes a style name back.
+    expect(drawn).toContain("Cr?me Br?l?e Tee: up from $12 to $13 per unit.");
+    // Table cells: the SKU column and a name carrying folded punctuation.
+    expect(drawn.some((t) => t.startsWith("BW-CR?-TEE"))).toBe(true);
+    expect(drawn.some((t) => t.includes("Alder 2x3 rib..."))).toBe(true);
+  });
+
+  it("keeps /Length and the xref byte-exact for that document too", () => {
+    // The structural guards, re-run over the hostile input. Byte-exact by
+    // construction (`byteImage`), so this fails rather than desyncing in step with
+    // the builder if a non-ASCII byte ever reaches the page.
+    const source = byteImage(buildPriceSheetPdf(NON_ASCII_INPUT));
+    expectCorrectXref(source);
+    expectCorrectStreamLength(source);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-pdf.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-pdf.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { GET } from "@/app/api/commerce/v1/price-sheet/route";
+import { buildPriceSheetPdf } from "./price-sheet-pdf";
+import type { PriceSheetLine } from "./price-sheet-pdf";
+import * as store from "./store";
+
+/**
+ * BEAT 3d's document — the narrative in it has to be TRUE of its own rows.
+ *
+ * The sheet used to carry a hardcoded explanation, "Driven by merino price and
+ * the new freight surcharge below", under a rise the route puts on the Cedar
+ * Hoodie and the Fern Cardigan while quoting the sheet's only merino SKU (Moss
+ * Merino Scarf) FLAT. This is the one document the agent is asked to read out
+ * loud, so a sentence its own numbers contradict does not stay in the PDF — it
+ * comes back as something the assistant asserts to the room, sourced from an
+ * artifact the audience was just shown.
+ *
+ * The vendor is a query parameter, so the row set is not fixed: these tests pin
+ * the narrative against SEVERAL row sets, including one where nothing rose and
+ * one where every style is new, so no direction, material or count can be baked
+ * back in.
+ */
+
+/** Pull the visible text back out of the one-page PDF the builder emits. */
+function pdfText(bytes: Uint8Array): string {
+  const raw = new TextDecoder().decode(bytes);
+  return [...raw.matchAll(/\((.*?)\) Tj/g)]
+    .map((m) => m[1].replace(/\\([()\\])/g, "$1"))
+    .join("\n");
+}
+
+/**
+ * The lines between the "Cost movement" heading and the next section.
+ *
+ * THROWS rather than returning `[]` when the heading is gone: several assertions
+ * below are of the form "the section says nothing rose", which an empty section
+ * satisfies. Renaming the heading would have turned those into green checks on a
+ * section that was never read. A locator that cannot find its region must fail,
+ * not hand back a shape that passes.
+ */
+function movementSection(text: string): string[] {
+  const lines = text.split("\n");
+  const start = lines.indexOf("Cost movement");
+  if (start === -1) {
+    throw new Error(
+      "the price sheet has no `Cost movement` heading, so this section cannot be read",
+    );
+  }
+  const end = lines.indexOf("Terms", start);
+  return lines.slice(start + 1, end === -1 ? undefined : end);
+}
+
+interface Claim {
+  name: string;
+  direction: string;
+  from: number;
+  to: number;
+}
+
+/** Every per-style movement claim the section makes. */
+function claims(section: string[]): Claim[] {
+  return section.flatMap((line) => {
+    const m = /^(.+): (up|down) from \$(\d+) to \$(\d+) per unit\.$/.exec(line);
+    return m
+      ? [{ name: m[1], direction: m[2], from: Number(m[3]), to: Number(m[4]) }]
+      : [];
+  });
+}
+
+/** The quoted-cost table, keyed by style name. */
+function tableCosts(text: string): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const line of text.split("\n")) {
+    const m = /^(BW-[A-Z-]+)\s+(.+?)\s+\$(\d+)\s+(\d+) units$/.exec(line);
+    if (m) out.set(m[2], Number(m[3]));
+  }
+  return out;
+}
+
+const sheetFor = async (vendor?: string) => {
+  const url =
+    "http://bellwether.test/api/commerce/v1/price-sheet" +
+    (vendor ? `?vendor=${encodeURIComponent(vendor)}` : "");
+  const res = await GET(new Request(url));
+  expect(res.status).toBe(200);
+  return pdfText(new Uint8Array(await res.arrayBuffer()));
+};
+
+beforeEach(() => store.reset());
+
+describe.each([["Kestrel Mills"], ["Halden Home"]])(
+  "GET /api/commerce/v1/price-sheet?vendor=%s — the narrative matches the rows",
+  (vendor) => {
+    it("only claims a move for styles whose quote differs from their cost", async () => {
+      const text = await sheetFor(vendor);
+      const section = movementSection(text);
+      const table = tableCosts(text);
+      const costOf = new Map(
+        store.products().map((p) => [p.name, p.unitCost] as const),
+      );
+
+      const moves = claims(section);
+      expect(moves.length).toBeGreaterThan(0);
+      expect(table.size).toBeGreaterThan(0);
+
+      for (const claim of moves) {
+        // "from" is what the app pays, "to" is what this sheet's own table quotes.
+        expect(costOf.get(claim.name)).toBe(claim.from);
+        expect(table.get(claim.name)).toBe(claim.to);
+        expect(claim.direction).toBe(claim.to > claim.from ? "up" : "down");
+      }
+
+      // A style quoted at its current cost is never described as moving.
+      const flat = [...table].filter(([name, quoted]) => {
+        const current = costOf.get(name);
+        return current !== undefined && current === quoted;
+      });
+      expect(flat.length).toBeGreaterThan(0); // the sheet really does hold one flat
+      for (const [name] of flat) {
+        expect(moves.map((c) => c.name)).not.toContain(name);
+      }
+    });
+
+    it("carries claim lines and one derived count sentence — no other prose", async () => {
+      const section = movementSection(await sheetFor(vendor));
+      // Every line but the last is a per-style claim and NOTHING else, so no
+      // explanation can ride along with it.
+      for (const line of section.slice(0, -1)) {
+        expect(line).toMatch(/^.+: (up|down) from \$\d+ to \$\d+ per unit\.$/);
+      }
+      const summary = section.at(-1) ?? "";
+      expect(summary).toMatch(
+        /^Of \d+ carried-over styles?: [\d a-z,]+\.( \d+ styles? quoted for the first time\.)?$/,
+      );
+      // Materials belong to style names in the table, never to the narrative.
+      expect(summary).not.toMatch(
+        /driven by|because|due to|surcharge|merino|wool|cotton|linen|leather/i,
+      );
+    });
+
+    it("counts the carried-over styles the way the table does", async () => {
+      const text = await sheetFor(vendor);
+      const section = movementSection(text);
+      const table = tableCosts(text);
+      const costOf = new Map(
+        store.products().map((p) => [p.name, p.unitCost] as const),
+      );
+      const carried = [...table.keys()].filter((n) => costOf.has(n));
+      const moves = claims(section);
+      const up = moves.filter((c) => c.direction === "up").length;
+      const held = carried.length - moves.length;
+
+      const summary = section.at(-1) ?? "";
+      expect(summary).toContain(`Of ${carried.length} carried-over styles:`);
+      expect(summary).toContain(`${up} up`);
+      expect(summary).toContain(`${held} holding at last cost`);
+      // The one style the app has never seen is counted, not described as a move.
+      const fresh = table.size - carried.length;
+      expect(summary).toContain(`${fresh} style quoted for the first time.`);
+    });
+  },
+);
+
+describe("buildPriceSheetPdf — row sets the seeded vendors do not produce", () => {
+  const line = (
+    name: string,
+    currentCost: number | undefined,
+    quotedCost: number,
+  ): PriceSheetLine => ({
+    sku: `BW-${name.slice(0, 3).toUpperCase()}-XXX`,
+    name,
+    currentCost,
+    quotedCost,
+    minimumUnits: 600,
+  });
+
+  const sheet = (lines: PriceSheetLine[]) =>
+    movementSection(
+      pdfText(
+        buildPriceSheetPdf({ vendor: "Test Vendor", season: "Autumn", lines }),
+      ),
+    );
+
+  it("says nothing rose when a vendor holds every quote", () => {
+    const section = sheet([
+      line("Flax Linen Throw", 55, 55),
+      line("Terra Mug Set", 21, 21),
+    ]);
+    expect(section.join("\n")).not.toMatch(/\bup\b/);
+    expect(claims(section)).toEqual([]);
+    expect(section.at(-1)).toBe(
+      "Of 2 carried-over styles: 2 holding at last cost.",
+    );
+  });
+
+  it("says down when a vendor quotes down, rather than assuming a rise", () => {
+    const section = sheet([
+      line("Terra Mug Set", 21, 18),
+      line("Ember Candle", 19, 19),
+    ]);
+    expect(claims(section)).toEqual([
+      { name: "Terra Mug Set", direction: "down", from: 21, to: 18 },
+    ]);
+    expect(section.at(-1)).toBe(
+      "Of 2 carried-over styles: 1 down, 1 holding at last cost.",
+    );
+  });
+
+  it("reports a mixed sheet in both directions", () => {
+    const section = sheet([
+      line("Cedar Hoodie", 47, 51),
+      line("Terra Mug Set", 21, 18),
+    ]);
+    expect(claims(section).map((c) => c.direction)).toEqual(["up", "down"]);
+    expect(section.at(-1)).toBe("Of 2 carried-over styles: 1 up, 1 down.");
+  });
+
+  it("omits the section entirely when every style is new to the range", () => {
+    const text = pdfText(
+      buildPriceSheetPdf({
+        vendor: "Test Vendor",
+        season: "Autumn",
+        lines: [line("Alder Crewneck", undefined, 52)],
+      }),
+    );
+    expect(text).toContain("Quoted landed costs");
+    expect(text).not.toContain("Cost movement");
+  });
+
+  it("agrees with itself for a single carried style", () => {
+    const section = sheet([line("Cedar Hoodie", 47, 51)]);
+    expect(section.at(-1)).toBe("Of 1 carried-over style: 1 up.");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-pdf.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-pdf.ts
@@ -1,0 +1,382 @@
+/**
+ * BEAT 3d — the uploaded document, generated rather than checked in.
+ *
+ * Banking ships a static `public/sample-invoice-q2.pdf`. Bellwether generates
+ * its vendor price sheet instead, for one reason: the sheet's SHIP WINDOW has to
+ * agree with the seeded scenario, and the seed materializes dates relative to
+ * `now` so a demo given a year from now still shows a queue with sensible aging.
+ * A committed PDF would say "ships week of 12 August 2026" forever, and the
+ * schedule is one of the things the agent is asked to lift out of the document.
+ *
+ * The PDF is written by hand rather than with a library. It is a single page of
+ * base-14 text (Helvetica for prose, Courier for anything columnar) with no
+ * images, no compression and no embedded fonts, which makes it about a hundred
+ * lines of string building and saves a dependency whose only job would be this
+ * file. Anything more elaborate should use a real library instead of growing
+ * this.
+ *
+ * WHY COURIER FOR THE TABLES. The columns here are aligned by CHARACTER COUNT
+ * (`padEnd`), which is only true alignment in a monospaced font — in Helvetica
+ * "BW-ALD-CRW" and "BW-HRR-TEE" are different widths, so every row would start
+ * its next column somewhere new and the table would render visibly ragged. The
+ * alternative — keep Helvetica and draw each column at an explicit x-offset —
+ * needs a glyph-width table to guarantee a long style name cannot overrun into
+ * the next column, which is more code than this whole file. Courier's every
+ * glyph is exactly 600/1000 em, so both the alignment AND the overflow bound
+ * reduce to arithmetic on character counts. Set `mono` on any line whose spacing
+ * carries meaning; leave it off for prose.
+ *
+ * Server-safe: plain TS, no React, no "use client".
+ */
+
+/**
+ * Fold typographic characters down to ASCII.
+ *
+ * The page below declares base-14 fonts, whose built-in encoding is WinAnsi
+ * — one byte per glyph. The content stream is emitted with `TextEncoder`, which
+ * is UTF-8, so a single "—" goes out as three bytes and a reader renders three
+ * garbage glyphs ("â€""). It also desynchronizes `/Length`, which is computed
+ * from JS string length rather than byte length. Both problems disappear if the
+ * stream is ASCII, and an ASCII price sheet is no worse to read, so this folds
+ * rather than reaching for a font-embedding library.
+ */
+const ASCII_FOLD: Record<string, string> = {
+  "—": "-",
+  "–": "-",
+  "’": "'",
+  "‘": "'",
+  "“": '"',
+  "”": '"',
+  "…": "...",
+  "×": "x",
+  "·": "-",
+};
+
+function toAscii(text: string): string {
+  return text
+    .replace(/[—–’‘“”…×·]/g, (ch) => ASCII_FOLD[ch] ?? "?")
+    .replace(/[^\x20-\x7e]/g, "?");
+}
+
+/** Escape the three characters that are special inside a PDF literal string. */
+function pdfEscape(text: string): string {
+  return toAscii(text)
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+}
+
+interface Line {
+  text: string;
+  /** Point size. */
+  size?: number;
+  bold?: boolean;
+  /** Draw in Courier, so `padEnd` spacing in `text` is genuinely aligned. */
+  mono?: boolean;
+  /** Extra leading before this line, in points. */
+  gap?: number;
+}
+
+const PAGE_HEIGHT = 792;
+const PAGE_WIDTH = 612;
+const MARGIN = 58;
+
+/**
+ * Resource names for the four base-14 faces the page declares, paired with the
+ * `BaseFont` each resolves to. `buildPdf` emits one font object per entry, so a
+ * face can never be referenced by the content stream without also being declared
+ * — a dangling `/Fn` renders blank or corrupt in most readers.
+ */
+const FONTS = [
+  { name: "F1", baseFont: "Helvetica" },
+  { name: "F2", baseFont: "Helvetica-Bold" },
+  { name: "F3", baseFont: "Courier" },
+  { name: "F4", baseFont: "Courier-Bold" },
+] as const;
+
+/** Every Courier glyph advances 600/1000 em. This is what makes columns true. */
+const MONO_ADVANCE = 0.6;
+
+/**
+ * A PDF resource name ("/F1"), built with `concat` rather than as a template. A
+ * PDF name genuinely starts with "/", but the repo's LOCK_SKIN lint guard reads a
+ * template opening with a lone "/" as a hardcoded skin route prefix — a false
+ * positive here, and this phrasing sidesteps it without weakening the rule for
+ * the links it exists to catch.
+ */
+const pdfName = (name: string) => "/".concat(name);
+
+function fontFor(line: Line): string {
+  if (line.mono) return line.bold ? "F4" : "F3";
+  return line.bold ? "F2" : "F1";
+}
+
+function contentStream(lines: Line[]): string {
+  let y = PAGE_HEIGHT - MARGIN;
+  const parts: string[] = ["BT"];
+  for (const line of lines) {
+    y -= (line.gap ?? 0) + (line.size ?? 10.5) + 3.5;
+    const font = pdfName(fontFor(line));
+    parts.push(
+      `${font} ${line.size ?? 10.5} Tf`,
+      `1 0 0 1 ${MARGIN} ${y} Tm`,
+      `(${pdfEscape(line.text)}) Tj`,
+    );
+  }
+  parts.push("ET");
+  return parts.join("\n");
+}
+
+/**
+ * Assemble a minimal, valid one-page PDF with a correct xref table.
+ *
+ * BYTES VS CHARACTERS — the assumption this function is built on. `/Length` and
+ * every xref offset are BYTE offsets by spec, and both are computed below from JS
+ * string length, which counts UTF-16 code units. The two agree ONLY while the
+ * document is pure ASCII, which is `toAscii`'s job above and is pinned by "emits a
+ * pure-ASCII document however the input is spelled" in
+ * `price-sheet-pdf.layout.test.ts`. If that fold is ever relaxed — an accented
+ * vendor name is the obvious reason — this arithmetic silently emits a corrupt
+ * document, and both numbers have to move to `new TextEncoder().encode(...).length`
+ * at the same time.
+ */
+function buildPdf(lines: Line[]): Uint8Array {
+  const stream = contentStream(lines);
+  // The four fixed objects come first, so /F1 is object 5.
+  const FIRST_FONT_OBJECT = 5;
+  const fontResources = FONTS.map(
+    (font, index) => `${pdfName(font.name)} ${FIRST_FONT_OBJECT + index} 0 R`,
+  ).join(" ");
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PAGE_WIDTH} ${PAGE_HEIGHT}] ` +
+      `/Resources << /Font << ${fontResources} >> >> /Contents 4 0 R >>`,
+    `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`,
+    ...FONTS.map(
+      (font) =>
+        `<< /Type /Font /Subtype /Type1 /BaseFont ${pdfName(font.baseFont)} >>`,
+    ),
+  ];
+
+  let body = "%PDF-1.4\n";
+  // Byte offsets have to be recorded as the body is assembled — the xref table
+  // is the one part of a PDF a reader genuinely refuses to guess at.
+  const offsets: number[] = [];
+  objects.forEach((object, index) => {
+    offsets.push(body.length);
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+
+  const xrefOffset = body.length;
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    xref += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  const trailer =
+    `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n` +
+    `startxref\n${xrefOffset}\n%%EOF\n`;
+
+  return new TextEncoder().encode(body + xref + trailer);
+}
+
+const LONG_DATE = new Intl.DateTimeFormat("en-GB", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+
+const DAY_MS = 86_400_000;
+const dateIn = (days: number) =>
+  LONG_DATE.format(new Date(Date.now() + days * DAY_MS));
+
+export interface PriceSheetLine {
+  sku: string;
+  name: string;
+  /** What the app currently pays. Present only for SKUs already in the range. */
+  currentCost?: number;
+  /** What the vendor is quoting for the new run. */
+  quotedCost: number;
+  minimumUnits: number;
+}
+
+export interface PriceSheetInput {
+  vendor: string;
+  season: string;
+  lines: PriceSheetLine[];
+}
+
+/** A style the app already buys, so its quoted cost can be compared. */
+interface CarriedLine extends PriceSheetLine {
+  currentCost: number;
+}
+
+const isCarried = (line: PriceSheetLine): line is CarriedLine =>
+  line.currentCost !== undefined;
+
+const plural = (count: number, noun: string) =>
+  `${count} ${noun}${count === 1 ? "" : "s"}`;
+
+/**
+ * The "Cost movement" section, DERIVED from the rows.
+ *
+ * Every clause here has to be computable from `lines`, because the agent lifts
+ * this section out of the document and narrates it as fact. The vendor is a
+ * query parameter (`/api/commerce/v1/price-sheet?vendor=…`), so the row set is
+ * not fixed: a different vendor can quote fewer styles, quote them all flat, or
+ * quote them DOWN. Nothing here may name a material, assert a cause, or assume
+ * a direction — an earlier version claimed the rises were "driven by merino
+ * price" while the only merino SKU in the sheet was quoted flat, which is
+ * exactly the kind of sentence the document must never contain.
+ */
+function costMovementLines(all: PriceSheetLine[]): Line[] {
+  const carried = all.filter(isCarried);
+  if (carried.length === 0) return [];
+
+  const moved = carried.filter((l) => l.quotedCost !== l.currentCost);
+  const up = moved.filter((l) => l.quotedCost > l.currentCost).length;
+  const down = moved.length - up;
+  const held = carried.length - moved.length;
+  const fresh = all.length - carried.length;
+
+  const out: Line[] = [
+    { text: "Cost movement", size: 12, bold: true, gap: 16 },
+  ];
+  moved.forEach((line, index) => {
+    const direction = line.quotedCost > line.currentCost ? "up" : "down";
+    out.push({
+      text:
+        `${line.name}: ${direction} from $${line.currentCost} ` +
+        `to $${line.quotedCost} per unit.`,
+      gap: index === 0 ? 6 : 0,
+    });
+  });
+
+  const counts: string[] = [];
+  if (up) counts.push(`${up} up`);
+  if (down) counts.push(`${down} down`);
+  if (held) counts.push(`${held} holding at last cost`);
+  let summary =
+    `Of ${plural(carried.length, "carried-over style")}: ` +
+    `${counts.join(", ")}.`;
+  if (fresh) summary += ` ${plural(fresh, "style")} quoted for the first time.`;
+  out.push({ text: summary, gap: 6 });
+
+  return out;
+}
+
+/**
+ * Column widths of the quoted-cost table, in CHARACTERS — the header and every
+ * body row are built from this ONE object, so they cannot drift apart. Before it
+ * existed the header's spacing was hand-typed while the rows used their own
+ * `padEnd` literals; the two happened to agree, and nothing held them there.
+ */
+const COLUMNS = { sku: 15, style: 22, cost: 9 } as const;
+
+/** Width of the ship schedule's week-label column, in characters. */
+const WEEK_LABEL_WIDTH = 8;
+
+/**
+ * One fixed-width cell. Truncating to `width - 1` guarantees at least one space
+ * of gutter, so an over-long value can never push the next column out of line —
+ * the failure mode a `padEnd`-only cell has.
+ */
+const cell = (text: string, width: number) =>
+  text.slice(0, width - 1).padEnd(width, " ");
+
+/** A row of the quoted-cost table. Drawn mono, so the columns are real. */
+const tableRow = (
+  sku: string,
+  style: string,
+  cost: string,
+  moq: string,
+): Line => ({
+  text:
+    cell(sku, COLUMNS.sku) +
+    cell(style, COLUMNS.style) +
+    cell(cost, COLUMNS.cost) +
+    moq,
+  mono: true,
+});
+
+/** A row of the ship schedule. Also mono: its label column is padded too. */
+const scheduleRow = (
+  label: string,
+  milestone: string,
+  days: number,
+  gap?: number,
+): Line => ({
+  text: `${cell(label, WEEK_LABEL_WIDTH)}${milestone} (${dateIn(days)})`,
+  mono: true,
+  gap,
+});
+
+/**
+ * The alignment contract, exported so it can be ASSERTED rather than eyeballed on
+ * a rendered page: the column widths every row is built from, the monospaced
+ * advance that makes character padding true, and the drawable width a row has to
+ * fit inside. `price-sheet-pdf.test.ts` reads these and checks the emitted bytes
+ * against them; nothing in the app reads them.
+ */
+export const PRICE_SHEET_METRICS = {
+  columns: COLUMNS,
+  weekLabelWidth: WEEK_LABEL_WIDTH,
+  monoAdvance: MONO_ADVANCE,
+  drawableWidth: PAGE_WIDTH - 2 * MARGIN,
+} as const;
+
+/**
+ * The price sheet the agent reads. Its contents are deliberately RICHER than
+ * the app's own catalog: the freight terms, the minimum order quantities, the
+ * quoted cost movement and the ship schedule exist ONLY here. A restock plan
+ * built from the document is therefore visibly different from one the agent
+ * could have assembled from the catalog alone — which is how the room knows the
+ * file was actually read rather than politely acknowledged.
+ */
+export function buildPriceSheetPdf(input: PriceSheetInput): Uint8Array {
+  const lines: Line[] = [
+    { text: input.vendor.toUpperCase(), size: 16, bold: true },
+    { text: `${input.season} price sheet`, size: 10, gap: 2 },
+    { text: "Prepared for Bellwether - Merchandising", size: 10 },
+    { text: `Quote valid until ${dateIn(21)}`, size: 10 },
+
+    { text: "Quoted landed costs", size: 12, bold: true, gap: 18 },
+    { ...tableRow("SKU", "Style", "Cost", "MOQ"), bold: true, gap: 6 },
+  ];
+
+  for (const line of input.lines) {
+    lines.push(
+      tableRow(
+        line.sku,
+        line.name,
+        `$${line.quotedCost}`,
+        `${line.minimumUnits} units`,
+      ),
+    );
+  }
+
+  lines.push(...costMovementLines(input.lines));
+
+  lines.push(
+    { text: "Terms", size: 12, bold: true, gap: 16 },
+    { text: "FOB mill. Freight surcharge of 4% applies to all", gap: 6 },
+    { text: "shipments under 1,000 units. Net 45 from ship date." },
+    { text: "30% deposit due with the purchase order." },
+
+    { text: "Ship schedule", size: 12, bold: true, gap: 16 },
+    scheduleRow("Week 1", "Purchase order countersigned", 7, 6),
+    scheduleRow("Week 3", "Lab dips and strike-offs approved", 21),
+    scheduleRow("Week 6", "Bulk leaves the mill", 42),
+    scheduleRow("Week 9", "Landed at the Reno DC", 63),
+    scheduleRow("Week 10", "On sale", 70),
+
+    {
+      text: "Countersign and return with the purchase order to hold this quote.",
+      gap: 22,
+    },
+    { text: "Ilse Ruijter", gap: 16, bold: true },
+    { text: `Head of Wholesale, ${input.vendor}`, size: 10 },
+  );
+
+  return buildPdf(lines);
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-route.test.ts
@@ -1,0 +1,432 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PriceSheetInput } from "./price-sheet-pdf";
+import { FRESH_STYLES } from "./price-sheet-styles";
+import { SEED_PRODUCTS } from "./seed";
+import * as store from "./store";
+
+/**
+ * The beat-3d document route.
+ *
+ * These assertions exist because the failure they pin is INVISIBLE end to end.
+ * `GET /api/commerce/v1/price-sheet` used to be the one commerce route with no
+ * `try`/`catch`, so a throw from `buildPriceSheetPdf` left no record of its own
+ * and produced whatever Next emits for an uncaught handler error. Downstream,
+ * `stagePriceSheetAttachment` maps any non-2xx to `staged === false`, and
+ * `sendRestockRequestWithPriceSheet` sends the pill's prompt regardless — so the
+ * model is told "here's the autumn price sheet, read it" with nothing attached
+ * and answers from the catalog it can already see. On stage that reads as a
+ * working demo; it proves the opposite of what the beat exists to prove.
+ *
+ * So the contract under test is narrow and behavioural: a throwing PDF writer
+ * must produce a non-2xx the consumer can distinguish from a PDF, AND a server
+ * log carrying enough context to identify the request.
+ */
+
+// Hoisted so the `vi.mock` factory below (which is itself hoisted above the
+// imports) can close over the spy.
+const { pdfSpy } = vi.hoisted(() => ({
+  // Typed with the writer's own signature, so `pdfSpy.mock.calls` reads as
+  // `PriceSheetInput` and the row assertions below need no cast.
+  pdfSpy: vi.fn<(input: PriceSheetInput) => Uint8Array>(),
+}));
+
+vi.mock("@/skins/commerce/data/price-sheet-pdf", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./price-sheet-pdf")>()),
+  buildPriceSheetPdf: pdfSpy,
+}));
+
+const { GET } = await import("@/app/api/commerce/v1/price-sheet/route");
+const realPdf =
+  await vi.importActual<typeof import("./price-sheet-pdf")>(
+    "./price-sheet-pdf",
+  );
+
+const request = (url = "http://localhost/api/commerce/v1/price-sheet") =>
+  new Request(url);
+
+/** The input the route handed the PDF writer on its most recent call. */
+const lastSheet = (): PriceSheetInput => {
+  const call = pdfSpy.mock.calls.at(-1);
+  if (!call) throw new Error("buildPriceSheetPdf was never called");
+  return call[0];
+};
+
+describe("GET /api/commerce/v1/price-sheet", () => {
+  let log: ReturnType<typeof vi.spyOn>;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    log = vi.spyOn(console, "error").mockImplementation(() => {});
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Default to the real writer, so the happy-path cases exercise the actual
+    // PDF bytes and only the failure cases opt into throwing.
+    pdfSpy.mockImplementation(realPdf.buildPriceSheetPdf);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    pdfSpy.mockReset();
+  });
+
+  it("still serves the generated PDF on the happy path", async () => {
+    const res = await GET(request());
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("content-disposition")).toContain(
+      "price-sheet-kestrel-mills.pdf",
+    );
+
+    // Real PDF bytes, not an error envelope the consumer would hand to the model
+    // as if it were a document.
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.byteLength).toBeGreaterThan(0);
+    expect(new TextDecoder().decode(body.slice(0, 5))).toBe("%PDF-");
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  // THE REGRESSION. Before the fix this call rejected out of the handler.
+  it("answers a logged 500 when the PDF writer throws", async () => {
+    const boom = new Error("pdf writer exploded");
+    pdfSpy.mockImplementation(() => {
+      throw boom;
+    });
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      error: "INTERNAL_ERROR",
+      message: "Something went wrong on our side.",
+    });
+    expect(log).toHaveBeenCalledWith(
+      "[commerce/api] GET price-sheet?vendor=Kestrel Mills",
+      boom,
+    );
+  });
+
+  // A non-2xx is the only thing `stagePriceSheetAttachment` checks, so this is
+  // the assertion that the consumer can tell failure from success at all. A 2xx
+  // carrying an error envelope would be handed to the model as a "PDF".
+  it("never answers a 2xx when the PDF writer throws", async () => {
+    pdfSpy.mockImplementation(() => {
+      throw new Error("pdf writer exploded");
+    });
+
+    const res = await GET(request());
+
+    expect(res.ok).toBe(false);
+    expect(res.headers.get("content-type")).not.toContain("application/pdf");
+  });
+
+  // A non-Error throw must not slip through as a success either — `errorResponse`
+  // reads `error.message`, which does not exist here.
+  it("answers a logged 500 when the PDF writer throws a non-Error", async () => {
+    pdfSpy.mockImplementation(() => {
+      throw "not an error at all";
+    });
+
+    const res = await GET(request());
+
+    expect(res.status).toBe(500);
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+
+  // The log line has to distinguish one failing request from another, otherwise
+  // it cannot answer "which price sheet failed?" — the whole point of logging it.
+  it("names the requested vendor in the log line", async () => {
+    pdfSpy.mockImplementation(() => {
+      throw new Error("pdf writer exploded");
+    });
+
+    // A vendor that exists in the seed, so the 404 above does not short-circuit
+    // before the writer runs.
+    const vendor = "Kestrel Mills";
+    await GET(
+      request(
+        `http://localhost/api/commerce/v1/price-sheet?vendor=${encodeURIComponent(vendor)}`,
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      `[commerce/api] GET price-sheet?vendor=${vendor}`,
+      expect.any(Error),
+    );
+  });
+
+  // The vendor-miss 404 is a deliberate domain answer and must NOT be reclassified
+  // as an internal error by the new catch, nor logged as one.
+  it("leaves the vendor-miss 404 alone", async () => {
+    const res = await GET(
+      request(
+        "http://localhost/api/commerce/v1/price-sheet?vendor=Nobody%20Mills",
+      ),
+    );
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({ error: "NOT_FOUND" });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The vendor miss has to leave a SERVER-side record.
+   *
+   * A seed vendor rename is the failure this exists for: the pill fetches this
+   * route with no `vendor`, so the route's default stops matching every product,
+   * the sheet 404s, and beat 3d's attachment quietly stops existing. The consumer
+   * chain does alert the presenter — but it can only say "HTTP 404, see the server
+   * logs", and nothing was ever written there.
+   */
+  describe("the vendor-miss log", () => {
+    // A `console.warn`, not a `console.error`: this is a deliberate domain answer,
+    // and `errorResponse` owns the error channel for genuine faults. The 404 test
+    // above pins the other half — that it is still not an error.
+    it("warns, naming the requested vendor", async () => {
+      await GET(
+        request(
+          "http://localhost/api/commerce/v1/price-sheet?vendor=Nobody%20Mills",
+        ),
+      );
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      const line = String(warn.mock.calls[0]?.[0]);
+      expect(line).toContain("[commerce/api]");
+      expect(line).toContain("price-sheet?vendor=Nobody Mills");
+    });
+
+    // "Which vendors ARE stocked?" is the next question a reader of that line has,
+    // and it is what turns a rename from a mystery into a one-line diagnosis.
+    it("names the vendors that are stocked", async () => {
+      await GET(
+        request(
+          "http://localhost/api/commerce/v1/price-sheet?vendor=Nobody%20Mills",
+        ),
+      );
+
+      const line = String(warn.mock.calls[0]?.[0]);
+      for (const vendor of new Set(SEED_PRODUCTS.map((p) => p.vendor))) {
+        expect(line).toContain(vendor);
+      }
+    });
+
+    /**
+     * THE RENAME SCENARIO ITSELF, which is the only way the DEFAULT vendor misses:
+     * the pill sends no `vendor` at all, so a reseed that renames Kestrel Mills
+     * turns beat 3d's own request into a miss. The line has to name the RESOLVED
+     * default rather than the raw empty string, or it says nothing about which
+     * sheet failed — the same rule the catch's log line follows.
+     */
+    it("names the resolved default when an empty vendor misses", async () => {
+      vi.spyOn(store, "products").mockReturnValue([]);
+
+      await GET(
+        request("http://localhost/api/commerce/v1/price-sheet?vendor="),
+      );
+
+      expect(String(warn.mock.calls[0]?.[0])).toContain(
+        "price-sheet?vendor=Kestrel Mills",
+      );
+      // Nothing is stocked at all, so the line says so rather than trailing off.
+      expect(String(warn.mock.calls[0]?.[0])).toContain("(none)");
+    });
+
+    // A served sheet must stay quiet, or the log stops meaning anything.
+    it("stays silent on the happy path", async () => {
+      await GET(request());
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * EVERY ROW BELONGS TO THE VENDOR REQUESTED.
+   *
+   * THE REGRESSION. The route used to push one hard-coded row — "BW-ALD-CRW /
+   * Alder Crewneck" — onto every sheet, so `?vendor=Ardent%20Leather` returned a
+   * leather-goods supplier's sheet quoting a knit crewneck. This document is beat
+   * 3d's ingested artifact: the model lifts its rows out and narrates them as
+   * fact, so a row from the wrong vendor makes the assistant assert a supplier
+   * relationship that does not exist.
+   *
+   * Read from the writer's INPUT rather than from the rendered bytes: the rows are
+   * what the assertion is about, and the PDF is a rendering of them.
+   */
+  describe("row provenance", () => {
+    const vendors = [...new Set(SEED_PRODUCTS.map((p) => p.vendor))].sort();
+
+    const sheetFor = async (vendor: string) => {
+      const res = await GET(
+        request(
+          `http://localhost/api/commerce/v1/price-sheet?vendor=${encodeURIComponent(vendor)}`,
+        ),
+      );
+      expect(res.status).toBe(200);
+      return lastSheet();
+    };
+
+    it.each(vendors)("quotes %s only its own styles", async (vendor) => {
+      const sheet = await sheetFor(vendor);
+      const own = new Set(
+        SEED_PRODUCTS.filter((p) => p.vendor === vendor).map((p) => p.sku),
+      );
+      const fresh = FRESH_STYLES.get(vendor);
+
+      expect(sheet.vendor).toBe(vendor);
+      expect(sheet.lines.length).toBeGreaterThan(0);
+      for (const line of sheet.lines) {
+        // Either a style this vendor carries, or this vendor's own fresh style.
+        // Nothing else may appear on the page.
+        expect(own.has(line.sku) || line.sku === fresh?.sku).toBe(true);
+      }
+    });
+
+    // Stated the other way round, so the assertion fails on the exact shape of the
+    // original defect: another vendor's fresh style leaking onto this sheet.
+    it.each(vendors)(
+      "never quotes %s another vendor's style",
+      async (vendor) => {
+        const sheet = await sheetFor(vendor);
+        const foreign = new Set([
+          ...SEED_PRODUCTS.filter((p) => p.vendor !== vendor).map((p) => p.sku),
+          ...[...FRESH_STYLES.entries()]
+            .filter(([name]) => name !== vendor)
+            .map(([, fresh]) => fresh.sku),
+        ]);
+
+        for (const line of sheet.lines) {
+          expect(foreign.has(line.sku)).toBe(false);
+        }
+      },
+    );
+
+    // The named case from the report, spelled out: a leather-goods vendor and a
+    // knit crewneck.
+    it("does not quote Ardent Leather the Alder Crewneck", async () => {
+      const sheet = await sheetFor("Ardent Leather");
+
+      expect(sheet.lines.map((l) => l.sku)).not.toContain("BW-ALD-CRW");
+      expect(sheet.lines.map((l) => l.name)).not.toContain("Alder Crewneck");
+      expect(sheet.lines.map((l) => l.sku)).toContain("BW-SDL-WLT");
+    });
+
+    // Beat 3d's hook has to survive the fix: exactly one row the catalog cannot
+    // supply, and it is the one with no current cost to compare against.
+    it.each(vendors)(
+      "gives %s exactly one first-time style",
+      async (vendor) => {
+        const sheet = await sheetFor(vendor);
+        const catalogSkus = new Set(SEED_PRODUCTS.map((p) => p.sku));
+        const first = sheet.lines.filter((l) => !catalogSkus.has(l.sku));
+
+        expect(first).toHaveLength(1);
+        expect(first[0]?.currentCost).toBeUndefined();
+        expect(first[0]?.sku).toBe(FRESH_STYLES.get(vendor)?.sku);
+      },
+    );
+
+    // And the carried rows keep their current cost, which is what the document's
+    // derived "Cost movement" section compares the quote against.
+    it("keeps the current cost on every carried row", async () => {
+      const sheet = await sheetFor("Kestrel Mills");
+      const carried = sheet.lines.filter((l) => l.sku !== "BW-ALD-CRW");
+
+      expect(carried.length).toBeGreaterThan(0);
+      for (const line of carried) {
+        const seeded = SEED_PRODUCTS.find((p) => p.sku === line.sku);
+        expect(line.currentCost).toBe(seeded?.unitCost);
+      }
+    });
+  });
+
+  /**
+   * The `vendor` lever, absent vs present-but-unusable.
+   *
+   * `?vendor=` used to read as the empty string, which is not nullish, so the
+   * `??` default never applied: the filter matched no seeded product and the
+   * route 404'd on a vendor nobody named. Downstream that is beat 3d's silent
+   * failure again — `stagePriceSheetAttachment` sees a non-2xx, returns `false`,
+   * and the prompt is sent with no document attached.
+   *
+   * The rule under test is the orders page's lever rule (`parseTopLever` in
+   * `pages/orders.tsx`): trim, then IGNORE a value that cannot be used rather
+   * than failing the request on it. So an unusable `vendor` is the same request
+   * as no `vendor` at all, and a genuinely-named unknown vendor still 404s.
+   */
+  describe("the vendor lever", () => {
+    const priceSheet = (query: string) =>
+      GET(request(`http://localhost/api/commerce/v1/price-sheet${query}`));
+
+    // The reference answer every unusable value has to match, byte for byte.
+    const servesTheDefaultSheet = async (res: Response) => {
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/pdf");
+      expect(res.headers.get("content-disposition")).toContain(
+        "price-sheet-kestrel-mills.pdf",
+      );
+      expect(log).not.toHaveBeenCalled();
+    };
+
+    // THE REGRESSION. `?vendor=` is what a cleared field or a
+    // `URLSearchParams.set("vendor", "")` produces; before the fix it 404'd.
+    it("treats an empty vendor as an absent one", async () => {
+      await servesTheDefaultSheet(await priceSheet("?vendor="));
+    });
+
+    // Whitespace-only is unusable for the same reason and must not be a 404
+    // either — `%20` and `+` are both a single space in a query string.
+    it.each(["?vendor=%20", "?vendor=+", "?vendor=%20%20%09"])(
+      "treats a whitespace-only vendor as an absent one (%s)",
+      async (query) => {
+        await servesTheDefaultSheet(await priceSheet(query));
+      },
+    );
+
+    // The trim is not only a guard: surrounding space on a REAL name resolves
+    // rather than 404ing, which is the same trim the top lever applies.
+    it("trims surrounding whitespace off a real vendor", async () => {
+      const res = await priceSheet("?vendor=%20Halden%20Home%20");
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-disposition")).toContain(
+        "price-sheet-halden-home.pdf",
+      );
+      expect(log).not.toHaveBeenCalled();
+    });
+
+    // A real, exactly-named vendor other than the default is unchanged.
+    it("still serves a named vendor's own sheet", async () => {
+      const res = await priceSheet("?vendor=Halden%20Home");
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("application/pdf");
+      expect(res.headers.get("content-disposition")).toContain(
+        "price-sheet-halden-home.pdf",
+      );
+    });
+
+    // And a vendor the caller genuinely named but the seed does not stock is
+    // still a 404 — the fallback must not swallow a real miss into the default.
+    it("still 404s a genuinely unknown vendor", async () => {
+      const res = await priceSheet("?vendor=%20Nobody%20Mills%20");
+
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toMatchObject({ error: "NOT_FOUND" });
+    });
+
+    // The hoisted `vendor` is the log line's only request-varying input, so the
+    // resolved default — not the raw empty string — has to be what it names.
+    it("names the resolved default in the log line for an empty vendor", async () => {
+      pdfSpy.mockImplementation(() => {
+        throw new Error("pdf writer exploded");
+      });
+
+      await priceSheet("?vendor=");
+
+      expect(log).toHaveBeenCalledWith(
+        "[commerce/api] GET price-sheet?vendor=Kestrel Mills",
+        expect.any(Error),
+      );
+    });
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-styles.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-styles.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { FRESH_STYLES, freshStyleFor } from "./price-sheet-styles";
+import { SEED_PRODUCTS } from "./seed";
+import type { Category } from "./types";
+
+/**
+ * BEAT 3d — the fresh row's provenance.
+ *
+ * The regression these pin: the price-sheet route pushed ONE hard-coded row
+ * ("BW-ALD-CRW / Alder Crewneck") onto every sheet, whatever vendor was asked
+ * for, so `?vendor=Ardent%20Leather` produced a leather-goods supplier quoting a
+ * knit crewneck. The document is beat 3d's ingested artifact — the model lifts
+ * facts out of it and narrates them — so a row from the wrong vendor is the app
+ * asserting a supplier relationship that does not exist.
+ *
+ * These assertions are about the TABLE's invariants. `price-sheet-route.test.ts`
+ * asserts the rows the route actually emits.
+ */
+
+const vendorsInSeed = [...new Set(SEED_PRODUCTS.map((p) => p.vendor))].sort();
+
+const categoriesOf = (vendor: string) =>
+  new Set(
+    SEED_PRODUCTS.filter((p) => p.vendor === vendor).map((p) => p.category),
+  );
+
+describe("FRESH_STYLES", () => {
+  // Every seeded vendor needs an entry, or its sheet loses the row that proves
+  // the document was read. Adding a vendor to the seed turns this red.
+  it.each(vendorsInSeed)("has an entry for %s", (vendor) => {
+    expect(FRESH_STYLES.get(vendor)).toBeDefined();
+  });
+
+  // THE REGRESSION, at the table level: a vendor may only be quoted a style in a
+  // category it genuinely supplies.
+  it.each(vendorsInSeed)(
+    "quotes %s a style in a category it actually supplies",
+    (vendor) => {
+      const fresh = FRESH_STYLES.get(vendor);
+      expect(fresh).toBeDefined();
+      expect([...categoriesOf(vendor)]).toContain(fresh?.category);
+    },
+  );
+
+  // A fresh SKU that collides with a seeded one reads as a style the catalog
+  // already carries, which defeats the point of the row.
+  it("never reuses a seeded SKU or style name", () => {
+    const seededSkus = new Set(SEED_PRODUCTS.map((p) => p.sku));
+    const seededNames = new Set(SEED_PRODUCTS.map((p) => p.name));
+
+    for (const fresh of FRESH_STYLES.values()) {
+      expect(seededSkus.has(fresh.sku)).toBe(false);
+      expect(seededNames.has(fresh.name)).toBe(false);
+    }
+  });
+
+  // The shape of the original defect: one row shared by every vendor. Distinct
+  // SKUs and names per vendor is what makes each sheet that vendor's own.
+  it("gives every vendor its own SKU and style name", () => {
+    const skus = [...FRESH_STYLES.values()].map((f) => f.sku);
+    const names = [...FRESH_STYLES.values()].map((f) => f.name);
+
+    expect(new Set(skus).size).toBe(skus.length);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  // Quote figures, not catalog facts — but a nonsense figure would be narrated as
+  // a real quote, so they have to be usable money.
+  it("quotes a positive cost and a positive minimum for every vendor", () => {
+    for (const fresh of FRESH_STYLES.values()) {
+      expect(fresh.quotedCost).toBeGreaterThan(0);
+      expect(fresh.minimumUnits).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("freshStyleFor", () => {
+  const rows = (...categories: Category[]) =>
+    categories.map((category) => ({ category }));
+
+  it("returns the vendor's style when the vendor supplies that category", () => {
+    expect(freshStyleFor("Kestrel Mills", rows("Knitwear"))?.sku).toBe(
+      "BW-ALD-CRW",
+    );
+  });
+
+  // The live-catalog check, which is what makes a reseed drop the row rather than
+  // misattribute it: the table says Knitwear, the vendor's rows say otherwise.
+  it("drops the row when the vendor no longer supplies that category", () => {
+    expect(
+      freshStyleFor("Kestrel Mills", rows("Home", "Footwear")),
+    ).toBeUndefined();
+  });
+
+  it("returns nothing for a vendor with no entry", () => {
+    expect(freshStyleFor("Nobody Mills", rows("Knitwear"))).toBeUndefined();
+  });
+
+  // A `Map` rather than a plain object: `vendor` is a caller-supplied query
+  // string, and a prototype hit would put a garbage row on the sheet.
+  it.each(["constructor", "toString", "__proto__", "valueOf"])(
+    "does not resolve %s off the prototype chain",
+    (vendor) => {
+      expect(freshStyleFor(vendor, rows("Knitwear"))).toBeUndefined();
+    },
+  );
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-styles.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/price-sheet-styles.ts
@@ -1,0 +1,127 @@
+/**
+ * BEAT 3d — the ONE row of the vendor price sheet that cannot come from the
+ * catalog, per vendor.
+ *
+ * The fresh row is the beat's proof of reading: a style the app has never carried,
+ * so an agent that names its quoted cost demonstrably read the attachment rather
+ * than answering from the catalog it can already see.
+ *
+ * WHY IT IS KEYED BY VENDOR. The route used to push ONE hard-coded row —
+ * "BW-ALD-CRW / Alder Crewneck" — onto every sheet it generated, so
+ * `?vendor=Ardent%20Leather` returned a leather-goods supplier's sheet quoting a
+ * knit crewneck. That is not a cosmetic mismatch: this document is the one the
+ * model lifts facts OUT of and narrates as fact, so the sheet was manufacturing a
+ * supplier relationship that does not exist and the agent would assert it on
+ * stage.
+ *
+ * So each entry names a style in a category that vendor genuinely supplies, and
+ * `freshStyleFor` re-checks `category` against the LIVE catalog rows before the
+ * row is emitted. Two consequences worth keeping:
+ *
+ *   - A reseed that moves a vendor out of a category DROPS its fresh row rather
+ *     than misattributing it. The document is then that vendor's carried styles
+ *     alone, and `costMovementLines` simply omits its "quoted for the first time"
+ *     clause — coherent, just a weaker hook for that vendor. Losing a beat's hook
+ *     for one vendor is recoverable; a false claim about a supplier is not.
+ *   - A vendor with NO entry (one a future reseed adds) gets no fresh row at all,
+ *     for the same reason. Add an entry here when you add a vendor —
+ *     `price-sheet-styles.test.ts` fails until you do.
+ *
+ * The SKUs use the app's own "BW-" namespace and must NOT collide with a seeded
+ * SKU or name: a colliding code would read as a style the catalog already
+ * carries, which defeats the whole point of the row. Pinned by the test file.
+ *
+ * `quotedCost` and `minimumUnits` are the QUOTE's own figures rather than catalog
+ * facts, which is why they are stated here rather than derived; keep each in the
+ * ballpark of that vendor's seeded costs so the sheet reads like a real quote from
+ * that supplier.
+ *
+ * Server-safe: plain TS, no React, no "use client" — it is imported by a route.
+ */
+
+import type { Category } from "./types";
+
+export interface FreshStyle {
+  sku: string;
+  name: string;
+  /** Must be a category the vendor actually supplies, or the row is dropped. */
+  category: Category;
+  quotedCost: number;
+  minimumUnits: number;
+}
+
+/**
+ * A `Map` rather than a plain object for the same reason `CODES` in `http.ts` is
+ * one: the key is the caller-supplied `?vendor=` string, and a plain-object lookup
+ * walks the prototype chain — `?vendor=constructor` would resolve TRUTHY and put a
+ * garbage row on the sheet.
+ */
+export const FRESH_STYLES: Map<string, FreshStyle> = new Map([
+  [
+    "Kestrel Mills",
+    {
+      sku: "BW-ALD-CRW",
+      name: "Alder Crewneck",
+      category: "Knitwear",
+      quotedCost: 52,
+      minimumUnits: 900,
+    } satisfies FreshStyle,
+  ],
+  [
+    "Northfield Outfitters",
+    {
+      sku: "BW-RDG-ANK",
+      name: "Ridge Anorak",
+      category: "Outerwear",
+      quotedCost: 185,
+      minimumUnits: 400,
+    } satisfies FreshStyle,
+  ],
+  [
+    "Vela Footworks",
+    {
+      sku: "BW-COV-TRL",
+      name: "Cove Trail Shoe",
+      category: "Footwear",
+      quotedCost: 96,
+      minimumUnits: 800,
+    } satisfies FreshStyle,
+  ],
+  [
+    "Halden Home",
+    {
+      sku: "BW-BSN-BWL",
+      name: "Basin Stoneware Bowl",
+      category: "Home",
+      quotedCost: 28,
+      minimumUnits: 1000,
+    } satisfies FreshStyle,
+  ],
+  [
+    "Ardent Leather",
+    {
+      sku: "BW-SDL-WLT",
+      name: "Saddle Card Wallet",
+      category: "Accessories",
+      quotedCost: 44,
+      minimumUnits: 750,
+    } satisfies FreshStyle,
+  ],
+]);
+
+/**
+ * The fresh row this vendor may be quoted, or `undefined` when it cannot be
+ * asserted.
+ *
+ * `catalog` is the vendor's OWN live rows (already filtered by the caller), so the
+ * category check is against what the vendor supplies right now rather than against
+ * the table's own promise about itself.
+ */
+export const freshStyleFor = (
+  vendor: string,
+  catalog: readonly { category: Category }[],
+): FreshStyle | undefined => {
+  const fresh = FRESH_STYLES.get(vendor);
+  if (!fresh) return undefined;
+  return catalog.some((p) => p.category === fresh.category) ? fresh : undefined;
+};

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/refund-route.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/refund-route.test.ts
@@ -1,0 +1,122 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it } from "vitest";
+import { POST } from "@/app/api/commerce/v1/returns/[id]/refund/route";
+import * as store from "./store";
+
+/**
+ * BEAT 3a's route, tested where the untrusted JSON actually enters.
+ *
+ * This lives beside the store rather than beside the route because the two
+ * halves of one rule are here: the route owns "is this even a number the body
+ * carried", the store owns "is that number a usable refund". A test of either
+ * half alone passes while a real refund settles for the wrong figure.
+ *
+ * The failure this pins is not a 500 or a bad message — it is a SETTLED refund.
+ * `Number(body?.amount)` used to coerce, so `{"amount": true}` became `1`: a
+ * finite, positive, under-the-ceiling figure that walked past every guard the
+ * store has and marked Marguerite Bell's return `refunded` for one dollar,
+ * terminally, with a 200. Every assertion below therefore also checks that the
+ * return is STILL approved with no refundAmount, because "422" alone would not
+ * have caught the bug had the write happened first.
+ */
+
+const APPROVED = "ret-2210"; // seeded `approved`, itemValue 340
+
+const post = (id: string, body: unknown) =>
+  POST(
+    new NextRequest(`http://localhost/api/commerce/v1/returns/${id}/refund`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+
+const target = () => store.returns().find((r) => r.id === APPROVED);
+
+beforeEach(() => store.reset());
+
+describe("POST returns/[id]/refund — the amount is not coerced", () => {
+  // `true` is the headline: it coerced to a real $1 refund. The rest are the
+  // same hole in other clothes — a string that looks like money, and the three
+  // values `Number` turns into 0.
+  it.each([
+    { label: "a boolean", amount: true },
+    { label: "a numeric string", amount: "12" },
+    { label: "an empty array", amount: [] },
+    { label: "null", amount: null },
+    { label: "an empty string", amount: "" },
+    { label: "an object", amount: { valueOf: 50 } },
+  ])("refuses $label without settling the return", async ({ amount }) => {
+    const res = await post(APPROVED, { amount });
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toEqual({
+      error: "INVALID_AMOUNT",
+      message: "That is not a usable amount.",
+    });
+    expect(target()?.status).toBe("approved");
+    expect(target()?.refundAmount).toBeNull();
+  });
+
+  it("refuses a body with no amount at all", async () => {
+    const res = await post(APPROVED, {});
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "INVALID_AMOUNT",
+    });
+    expect(target()?.status).toBe("approved");
+  });
+
+  // These arrive as genuine JSON numbers, so the type gate lets them through —
+  // the store's own range rules are what refuse them, and this asserts the
+  // route still reaches them rather than having grown a second copy that drifts.
+  it.each([
+    { label: "a negative amount", amount: -5, error: "INVALID_AMOUNT" },
+    { label: "zero", amount: 0, error: "INVALID_AMOUNT" },
+    // JSON.parse turns an overflowing literal into Infinity.
+    { label: "an overflowing literal", amount: 1e999, error: "INVALID_AMOUNT" },
+    {
+      label: "an absurdly large amount",
+      amount: 9_999_999_999,
+      error: "REFUND_EXCEEDS_VALUE",
+    },
+    {
+      label: "a dollar over what was charged",
+      amount: 341,
+      error: "REFUND_EXCEEDS_VALUE",
+    },
+  ])(
+    "refuses $label without settling the return",
+    async ({ amount, error }) => {
+      const res = await post(APPROVED, { amount });
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({ error });
+      expect(target()?.status).toBe("approved");
+      expect(target()?.refundAmount).toBeNull();
+    },
+  );
+
+  it("still refunds a legitimate amount on an approved return", async () => {
+    const res = await post(APPROVED, { amount: 85.5 });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      id: APPROVED,
+      status: "refunded",
+      refundAmount: 85.5,
+    });
+    expect(target()?.status).toBe("refunded");
+  });
+
+  // The status precondition is a different rule from this one and both have to
+  // hold: a well-typed figure on an undecided return is still refused.
+  it("leaves the approved-only precondition intact", async () => {
+    const res = await post("ret-2204", { amount: 50 });
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "RETURN_NOT_APPROVED",
+    });
+    expect(
+      store.returns().find((r) => r.id === "ret-2204")?.refundAmount,
+    ).toBeNull();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/seed.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/seed.ts
@@ -1,0 +1,850 @@
+/**
+ * Bellwether's seeded scenario — the state every demo starts from.
+ *
+ * Dates are stored as RELATIVE OFFSETS and materialized against `now` in
+ * `store.materialize()`. A committed absolute timestamp would make the exception
+ * queue read "placed 400 days ago" to anyone running the demo a year from now,
+ * and beat 3c's whole pitch is "the ten OLDEST orders still stuck".
+ *
+ * Two things in here are load-bearing for the beats rather than decoration:
+ *
+ *  - **Two products sit below their category margin floor already** (Harbor
+ *    Parka, Lark Runner). Beat 1's ladder needs something to flag on first
+ *    render, and beat 4's recalled preference ("below floor first") needs
+ *    something to actually reorder.
+ *  - **Two pending promotions are below floor AFTER their discount** (Cedar
+ *    Hoodie, Slate Chelsea Boot), plus one that is comfortably above it (Terra
+ *    Mug Set). Beat 6 is taught on Cedar and replayed unaided on Slate — the
+ *    case demonstrated on stage is resolved by the demonstration, so a second
+ *    gated case is the only way to prove it learned. Terra exists so the gate
+ *    cannot be mistaken for "approval always fails".
+ */
+
+import type { Category, MarginFloor, Operator } from "./types";
+
+// A tiny alias so the seed's literal unions stay readable below.
+type SeedCategory = Category;
+
+/**
+ * Category margin policy. `floor` is what the BELOW_MARGIN_FLOOR gate enforces;
+ * `target` is the plan. Accessories carries the highest floor because it is the
+ * range's margin engine; Home the lowest because it trades on basket size.
+ */
+export const SEED_FLOORS: readonly MarginFloor[] = [
+  { category: "Outerwear", floor: 0.42, target: 0.52 },
+  { category: "Knitwear", floor: 0.45, target: 0.56 },
+  { category: "Footwear", floor: 0.4, target: 0.5 },
+  { category: "Accessories", floor: 0.55, target: 0.64 },
+  { category: "Home", floor: 0.38, target: 0.5 },
+];
+
+export interface SeedProduct {
+  id: string;
+  sku: string;
+  name: string;
+  category: SeedCategory;
+  listPrice: number;
+  unitCost: number;
+  inventory: number;
+  trailing30Units: number;
+  status: "live" | "backorder" | "discontinued";
+  vendor: string;
+}
+
+export const SEED_PRODUCTS: readonly SeedProduct[] = [
+  {
+    id: "prd-cedar-hoodie",
+    sku: "BW-CDR-HDY",
+    name: "Cedar Hoodie",
+    category: "Knitwear",
+    listPrice: 128,
+    unitCost: 47,
+    inventory: 640,
+    trailing30Units: 412,
+    status: "live",
+    vendor: "Kestrel Mills",
+  },
+  {
+    id: "prd-aspen-shell",
+    sku: "BW-ASP-SHL",
+    name: "Aspen Shell Jacket",
+    category: "Outerwear",
+    listPrice: 340,
+    unitCost: 168,
+    inventory: 92,
+    trailing30Units: 58,
+    status: "live",
+    vendor: "Northfield Outfitters",
+  },
+  {
+    id: "prd-fern-cardigan",
+    sku: "BW-FRN-CRD",
+    name: "Fern Cardigan",
+    category: "Knitwear",
+    listPrice: 168,
+    unitCost: 71,
+    inventory: 210,
+    trailing30Units: 96,
+    status: "live",
+    vendor: "Kestrel Mills",
+  },
+  {
+    // BELOW FLOOR at list: 41.4% against a 42% Outerwear floor. Landed cost
+    // moved after the range was priced, which is exactly how this happens in a
+    // real buying office.
+    id: "prd-harbor-parka",
+    sku: "BW-HBR-PRK",
+    name: "Harbor Parka",
+    category: "Outerwear",
+    listPrice: 420,
+    unitCost: 246,
+    inventory: 34,
+    trailing30Units: 21,
+    status: "live",
+    vendor: "Northfield Outfitters",
+  },
+  {
+    // BELOW FLOOR at list: 39.3% against a 40% Footwear floor.
+    id: "prd-lark-runner",
+    sku: "BW-LRK-RNR",
+    name: "Lark Runner",
+    category: "Footwear",
+    listPrice: 145,
+    unitCost: 88,
+    inventory: 480,
+    trailing30Units: 388,
+    status: "live",
+    vendor: "Vela Footworks",
+  },
+  {
+    id: "prd-slate-boot",
+    sku: "BW-SLT-CHB",
+    name: "Slate Chelsea Boot",
+    category: "Footwear",
+    listPrice: 240,
+    unitCost: 132,
+    inventory: 118,
+    trailing30Units: 44,
+    status: "live",
+    vendor: "Vela Footworks",
+  },
+  {
+    id: "prd-flax-throw",
+    sku: "BW-FLX-THR",
+    name: "Flax Linen Throw",
+    category: "Home",
+    listPrice: 96,
+    unitCost: 55,
+    inventory: 300,
+    trailing30Units: 132,
+    status: "live",
+    vendor: "Halden Home",
+  },
+  {
+    id: "prd-terra-mug",
+    sku: "BW-TRA-MUG",
+    name: "Terra Mug Set",
+    category: "Home",
+    listPrice: 48,
+    unitCost: 21,
+    inventory: 900,
+    trailing30Units: 512,
+    status: "live",
+    vendor: "Halden Home",
+  },
+  {
+    id: "prd-willow-tote",
+    sku: "BW-WLW-TOT",
+    name: "Willow Tote",
+    category: "Accessories",
+    listPrice: 180,
+    unitCost: 66,
+    inventory: 260,
+    trailing30Units: 174,
+    status: "live",
+    vendor: "Ardent Leather",
+  },
+  {
+    id: "prd-brass-belt",
+    sku: "BW-BRS-BLT",
+    name: "Brass Buckle Belt",
+    category: "Accessories",
+    listPrice: 88,
+    unitCost: 36,
+    inventory: 150,
+    trailing30Units: 63,
+    status: "live",
+    vendor: "Ardent Leather",
+  },
+  {
+    id: "prd-moss-scarf",
+    sku: "BW-MSS-SCF",
+    name: "Moss Merino Scarf",
+    category: "Accessories",
+    listPrice: 76,
+    unitCost: 33,
+    inventory: 420,
+    trailing30Units: 201,
+    status: "live",
+    vendor: "Kestrel Mills",
+  },
+  {
+    id: "prd-pine-flannel",
+    sku: "BW-PNE-FLN",
+    name: "Pine Flannel",
+    category: "Knitwear",
+    listPrice: 112,
+    unitCost: 58,
+    inventory: 380,
+    trailing30Units: 155,
+    status: "live",
+    vendor: "Kestrel Mills",
+  },
+  {
+    id: "prd-ember-candle",
+    sku: "BW-EMB-CND",
+    name: "Ember Candle",
+    category: "Home",
+    listPrice: 42,
+    unitCost: 19,
+    inventory: 1100,
+    trailing30Units: 640,
+    status: "live",
+    vendor: "Halden Home",
+  },
+  {
+    id: "prd-onyx-duffel",
+    sku: "BW-ONX-DFL",
+    name: "Onyx Duffel",
+    category: "Accessories",
+    listPrice: 260,
+    unitCost: 104,
+    inventory: 46,
+    trailing30Units: 29,
+    status: "backorder",
+    vendor: "Ardent Leather",
+  },
+];
+
+export interface SeedOrder {
+  id: string;
+  number: string;
+  customerName: string;
+  customerEmail: string;
+  channel: "web" | "retail" | "wholesale" | "marketplace";
+  destination: string;
+  placedDaysAgo: number;
+  status: "open" | "on-hold" | "fulfilled" | "cancelled";
+  exception:
+    | "none"
+    | "fraud-review"
+    | "address-invalid"
+    | "oversell"
+    | "carrier-delay"
+    | "payment-declined";
+  lines: { productId: string; quantity: number; unitPrice: number }[];
+  total: number;
+}
+
+/**
+ * The order book. Ages are spread from today back to five weeks so beat 3c's
+ * "ten oldest still on an exception" is a genuinely different list from "the ten
+ * most recent" — a filter that changes nothing is not a demonstration.
+ *
+ * Order 4471 is beat 5's trigger: a fraud-review exception on a high-value
+ * first-time order, which is the shape the seeded procedure is written for.
+ *
+ * ── TWO COUNTS HERE ARE LOAD-BEARING FOR BEAT 3c ────────────────────────────
+ *
+ * 1. **FIFTEEN orders carry an exception, thirteen of them still `open`.** The
+ *    beat sets a `top=10` lever, and a limit that truncates nothing is a lever
+ *    that LOOKS like it worked while doing nothing — the queue renders as though
+ *    it were filtered and the audience is asked to take the maneuver on faith.
+ *    Both lever shapes the agent can reach for must exceed ten: the sanctioned
+ *    `exception=any` with `status=all` (15 rows), and the `status=open` variant a
+ *    user can still ask for by name (13 rows). `store.test.ts` pins both.
+ *
+ * 2. **Every exception order added for that count is NEWER than 4471's three
+ *    days**, which keeps 4471 inside the ten oldest. Truncation is an exclusion
+ *    just like a status filter: if 4471 fell past rank 10 it would drop out of
+ *    the view beat 3c built, taking beat 5's hold pill and forced-🚨 note with
+ *    it — the exact failure the status-filter guidance in `agent.ts` and
+ *    `showOrderQueue` exists to prevent. So the six rows the limit cuts are the
+ *    freshest arrivals, which is also how an exception desk really reads: the
+ *    old ones are the escalations, the new ones are today's noise. They cluster
+ *    on purpose — a carrier hub disruption and a run of gateway declines — so
+ *    six same-week exceptions read as two incidents rather than as filler.
+ *
+ * Sub-day offsets on that cluster are deliberate: they keep every `placedAt`
+ * distinct, so "oldest first" is a total order rather than a tie the sort has to
+ * break arbitrarily on stage.
+ *
+ * ── ORDER NUMBERS ARE MONOTONIC WITH PLACEMENT TIME ─────────────────────────
+ *
+ * Older order ⇒ strictly lower number, because order numbers are issued
+ * sequentially in every real commerce system. This is not cosmetic: beat 3c
+ * puts the queue on screen sorted OLDEST FIRST, so a reversed sequence makes
+ * the number column count DOWN in front of the room, and an audience reading
+ * the screen concludes the data is fake before it concludes anything about the
+ * agent. `store.test.ts` pins the invariant rather than the values, so the
+ * numbers below can be re-spaced freely as long as the ordering holds.
+ *
+ * 4471 is the one number that is pinned by identity — tests, `suggestions.ts`
+ * and the demo script all name it — so it stays put and everything else is
+ * numbered around it: the thirteen orders older than its three days take
+ * numbers below 4471, the eight newer arrivals take numbers above.
+ */
+export const SEED_ORDERS: readonly SeedOrder[] = [
+  {
+    id: "ord-4471",
+    number: "4471",
+    customerName: "Dorian Vale",
+    customerEmail: "d.vale@fastmail.example",
+    channel: "web",
+    destination: "Miami, FL",
+    placedDaysAgo: 3,
+    status: "open",
+    exception: "fraud-review",
+    lines: [
+      { productId: "prd-aspen-shell", quantity: 2, unitPrice: 340 },
+      { productId: "prd-onyx-duffel", quantity: 2, unitPrice: 260 },
+    ],
+    total: 1200,
+  },
+  {
+    id: "ord-4409",
+    number: "4409",
+    customerName: "Ines Aranda",
+    customerEmail: "ines.aranda@example.com",
+    channel: "web",
+    destination: "Portland, OR",
+    placedDaysAgo: 34,
+    status: "open",
+    exception: "oversell",
+    lines: [{ productId: "prd-onyx-duffel", quantity: 1, unitPrice: 260 }],
+    total: 260,
+  },
+  {
+    id: "ord-4419",
+    number: "4419",
+    customerName: "Sam Oduya",
+    customerEmail: "s.oduya@example.com",
+    channel: "marketplace",
+    destination: "Chicago, IL",
+    placedDaysAgo: 29,
+    status: "open",
+    exception: "address-invalid",
+    lines: [{ productId: "prd-cedar-hoodie", quantity: 3, unitPrice: 128 }],
+    total: 384,
+  },
+  {
+    id: "ord-4423",
+    number: "4423",
+    customerName: "Priya Raghavan",
+    customerEmail: "praghavan@example.com",
+    channel: "web",
+    destination: "Austin, TX",
+    placedDaysAgo: 27,
+    status: "on-hold",
+    exception: "payment-declined",
+    lines: [{ productId: "prd-harbor-parka", quantity: 1, unitPrice: 420 }],
+    total: 420,
+  },
+  {
+    id: "ord-4429",
+    number: "4429",
+    customerName: "Marguerite Bell",
+    customerEmail: "m.bell@example.com",
+    channel: "web",
+    destination: "Boston, MA",
+    placedDaysAgo: 24,
+    status: "fulfilled",
+    exception: "none",
+    lines: [{ productId: "prd-aspen-shell", quantity: 1, unitPrice: 340 }],
+    total: 340,
+  },
+  {
+    id: "ord-4433",
+    number: "4433",
+    customerName: "Tobias Renner",
+    customerEmail: "t.renner@example.com",
+    channel: "wholesale",
+    destination: "Denver, CO",
+    placedDaysAgo: 22,
+    status: "open",
+    exception: "carrier-delay",
+    lines: [{ productId: "prd-pine-flannel", quantity: 24, unitPrice: 95 }],
+    total: 2280,
+  },
+  {
+    id: "ord-4439",
+    number: "4439",
+    customerName: "Hana Kobayashi",
+    customerEmail: "h.kobayashi@example.com",
+    channel: "web",
+    destination: "Seattle, WA",
+    placedDaysAgo: 19,
+    status: "open",
+    exception: "oversell",
+    lines: [{ productId: "prd-onyx-duffel", quantity: 2, unitPrice: 260 }],
+    total: 520,
+  },
+  {
+    id: "ord-4443",
+    number: "4443",
+    customerName: "Elias Nkemdirim",
+    customerEmail: "e.nkem@example.com",
+    channel: "retail",
+    destination: "Brooklyn, NY",
+    placedDaysAgo: 17,
+    status: "fulfilled",
+    exception: "none",
+    lines: [
+      { productId: "prd-terra-mug", quantity: 2, unitPrice: 48 },
+      { productId: "prd-ember-candle", quantity: 3, unitPrice: 42 },
+    ],
+    total: 222,
+  },
+  {
+    id: "ord-4447",
+    number: "4447",
+    customerName: "Nadia Sorenson",
+    customerEmail: "n.sorenson@example.com",
+    channel: "web",
+    destination: "Madison, WI",
+    placedDaysAgo: 15,
+    status: "open",
+    exception: "address-invalid",
+    lines: [{ productId: "prd-willow-tote", quantity: 1, unitPrice: 180 }],
+    total: 180,
+  },
+  {
+    id: "ord-4453",
+    number: "4453",
+    customerName: "Owen Brightwell",
+    customerEmail: "o.brightwell@example.com",
+    channel: "web",
+    destination: "Santa Fe, NM",
+    placedDaysAgo: 12,
+    status: "on-hold",
+    exception: "fraud-review",
+    lines: [{ productId: "prd-slate-boot", quantity: 3, unitPrice: 240 }],
+    total: 720,
+  },
+  {
+    id: "ord-4457",
+    number: "4457",
+    customerName: "Camille Fournier",
+    customerEmail: "c.fournier@example.com",
+    channel: "marketplace",
+    destination: "Montréal, QC",
+    placedDaysAgo: 10,
+    status: "fulfilled",
+    exception: "none",
+    lines: [{ productId: "prd-moss-scarf", quantity: 4, unitPrice: 76 }],
+    total: 304,
+  },
+  {
+    id: "ord-4461",
+    number: "4461",
+    customerName: "Jonah Mbeki",
+    customerEmail: "j.mbeki@example.com",
+    channel: "web",
+    destination: "Atlanta, GA",
+    placedDaysAgo: 8,
+    status: "open",
+    exception: "carrier-delay",
+    lines: [{ productId: "prd-lark-runner", quantity: 2, unitPrice: 145 }],
+    total: 290,
+  },
+  {
+    id: "ord-4465",
+    number: "4465",
+    customerName: "Roos van Dijk",
+    customerEmail: "r.vandijk@example.com",
+    channel: "web",
+    destination: "Amsterdam, NL",
+    placedDaysAgo: 6,
+    status: "fulfilled",
+    exception: "none",
+    lines: [{ productId: "prd-flax-throw", quantity: 2, unitPrice: 96 }],
+    total: 192,
+  },
+  {
+    id: "ord-4469",
+    number: "4469",
+    customerName: "Aiko Tanaka",
+    customerEmail: "a.tanaka@example.com",
+    channel: "retail",
+    destination: "San Jose, CA",
+    placedDaysAgo: 4,
+    status: "open",
+    exception: "none",
+    lines: [{ productId: "prd-fern-cardigan", quantity: 1, unitPrice: 168 }],
+    total: 168,
+  },
+  // ── The carrier hub disruption (two orders, same lane) ────────────────────
+  {
+    id: "ord-4473",
+    number: "4473",
+    customerName: "Marisol Ferrer",
+    customerEmail: "m.ferrer@example.com",
+    channel: "web",
+    destination: "Sacramento, CA",
+    placedDaysAgo: 2.7,
+    status: "open",
+    exception: "carrier-delay",
+    lines: [
+      { productId: "prd-pine-flannel", quantity: 1, unitPrice: 112 },
+      { productId: "prd-moss-scarf", quantity: 1, unitPrice: 76 },
+    ],
+    total: 188,
+  },
+  // ── The gateway decline run (two orders, same BIN range) ──────────────────
+  {
+    id: "ord-4476",
+    number: "4476",
+    customerName: "Emeka Diallo",
+    customerEmail: "e.diallo@example.com",
+    channel: "marketplace",
+    destination: "Philadelphia, PA",
+    placedDaysAgo: 2.2,
+    status: "open",
+    exception: "payment-declined",
+    lines: [{ productId: "prd-aspen-shell", quantity: 1, unitPrice: 340 }],
+    total: 340,
+  },
+  {
+    id: "ord-4477",
+    number: "4477",
+    customerName: "Beatrix Lund",
+    customerEmail: "b.lund@example.com",
+    channel: "web",
+    destination: "Oslo, NO",
+    placedDaysAgo: 2,
+    status: "open",
+    exception: "none",
+    lines: [{ productId: "prd-brass-belt", quantity: 2, unitPrice: 88 }],
+    total: 176,
+  },
+  {
+    id: "ord-4478",
+    number: "4478",
+    customerName: "Sylvie Marchand",
+    customerEmail: "s.marchand@example.com",
+    channel: "web",
+    destination: "Ottawa, ON",
+    placedDaysAgo: 1.9,
+    status: "open",
+    exception: "address-invalid",
+    lines: [
+      { productId: "prd-willow-tote", quantity: 1, unitPrice: 180 },
+      { productId: "prd-brass-belt", quantity: 1, unitPrice: 88 },
+    ],
+    total: 268,
+  },
+  {
+    id: "ord-4481",
+    number: "4481",
+    customerName: "Ravi Anand",
+    customerEmail: "r.anand@example.com",
+    channel: "web",
+    destination: "Raleigh, NC",
+    placedDaysAgo: 1.4,
+    status: "open",
+    exception: "payment-declined",
+    lines: [{ productId: "prd-slate-boot", quantity: 1, unitPrice: 240 }],
+    total: 240,
+  },
+  {
+    id: "ord-4483",
+    number: "4483",
+    customerName: "Gil Okafor",
+    customerEmail: "g.okafor@example.com",
+    channel: "web",
+    destination: "Houston, TX",
+    placedDaysAgo: 1,
+    status: "open",
+    exception: "none",
+    lines: [{ productId: "prd-cedar-hoodie", quantity: 1, unitPrice: 128 }],
+    total: 128,
+  },
+  {
+    // Wholesale trades below list, exactly as 4433's flannel does.
+    id: "ord-4485",
+    number: "4485",
+    customerName: "Greta Halvorsen",
+    customerEmail: "g.halvorsen@example.com",
+    channel: "wholesale",
+    destination: "Milwaukee, WI",
+    placedDaysAgo: 0.6,
+    status: "open",
+    exception: "carrier-delay",
+    lines: [{ productId: "prd-flax-throw", quantity: 18, unitPrice: 78 }],
+    total: 1404,
+  },
+  {
+    // Oversold the Onyx Duffel, which is the one SKU seeded on backorder — the
+    // same shortfall 4409 and 4439 are waiting on.
+    id: "ord-4487",
+    number: "4487",
+    customerName: "Tomas Leal",
+    customerEmail: "t.leal@example.com",
+    channel: "retail",
+    destination: "Phoenix, AZ",
+    placedDaysAgo: 0.3,
+    status: "open",
+    exception: "oversell",
+    lines: [{ productId: "prd-onyx-duffel", quantity: 1, unitPrice: 260 }],
+    total: 260,
+  },
+];
+
+export interface SeedReturn {
+  id: string;
+  orderId: string;
+  orderNumber: string;
+  customerName: string;
+  productId: string;
+  reason:
+    | "sizing"
+    | "damaged"
+    | "not-as-described"
+    | "changed-mind"
+    | "late-delivery";
+  detail: string;
+  requestedDaysAgo: number;
+  status: "requested" | "approved" | "refunded" | "declined";
+  itemValue: number;
+  refundAmount: number | null;
+}
+
+/**
+ * The returns desk. `ret-2210` is beat 3a's case: already approved by a human,
+ * waiting only on the goodwill figure the merchant types into the chat card.
+ *
+ * `itemValue` MUST be a whole number of units at the price the referenced order
+ * line actually charged, and no more units than that line carried — and any
+ * count the `detail` prose states must be either that unit count or the line's
+ * quantity. The assistant quotes the prose verbatim while its arithmetic comes
+ * from the fields, so a third quantity makes it contradict its own record on
+ * screen. `store.test.ts` pins the invariant over every return.
+ */
+export const SEED_RETURNS: readonly SeedReturn[] = [
+  {
+    id: "ret-2210",
+    orderId: "ord-4429",
+    orderNumber: "4429",
+    customerName: "Marguerite Bell",
+    productId: "prd-aspen-shell",
+    reason: "sizing",
+    detail:
+      "Ordered a medium, needs a large. Happy to keep it if we can make the price work.",
+    requestedDaysAgo: 5,
+    status: "approved",
+    itemValue: 340,
+    refundAmount: null,
+  },
+  {
+    id: "ret-2207",
+    orderId: "ord-4443",
+    orderNumber: "4443",
+    customerName: "Elias Nkemdirim",
+    productId: "prd-terra-mug",
+    reason: "damaged",
+    detail: "Two mugs arrived chipped; photos attached to the ticket.",
+    requestedDaysAgo: 9,
+    status: "refunded",
+    itemValue: 96,
+    refundAmount: 96,
+  },
+  {
+    id: "ret-2204",
+    orderId: "ord-4457",
+    orderNumber: "4457",
+    customerName: "Camille Fournier",
+    productId: "prd-moss-scarf",
+    reason: "changed-mind",
+    // Order 4457 carries FOUR scarves and `itemValue` pays for two of them, so
+    // the prose says four and two. It used to say "Bought three, keeping one",
+    // which made three different quantities out of one return — and the
+    // assistant quotes this line verbatim while its arithmetic comes from the
+    // fields, so it contradicted itself on screen mid-refund.
+    detail: "Bought four as gifts, keeping two — the other two go back unworn.",
+    requestedDaysAgo: 6,
+    status: "requested",
+    itemValue: 152,
+    refundAmount: null,
+  },
+  {
+    id: "ret-2201",
+    orderId: "ord-4465",
+    orderNumber: "4465",
+    customerName: "Roos van Dijk",
+    productId: "prd-flax-throw",
+    reason: "not-as-described",
+    detail: "Colour reads much greyer than the product photography.",
+    requestedDaysAgo: 3,
+    status: "requested",
+    itemValue: 96,
+    refundAmount: null,
+  },
+  {
+    id: "ret-2198",
+    orderId: "ord-4461",
+    orderNumber: "4461",
+    customerName: "Jonah Mbeki",
+    productId: "prd-lark-runner",
+    reason: "late-delivery",
+    detail: "Arrived after the event they were bought for.",
+    requestedDaysAgo: 1,
+    status: "requested",
+    itemValue: 290,
+    refundAmount: null,
+  },
+];
+
+export interface SeedPromotion {
+  id: string;
+  name: string;
+  productId: string;
+  discountPercent: number;
+  startsInDays: number;
+  endsInDays: number;
+  submittedBy: string;
+  submittedDaysAgo: number;
+  status: "pending" | "approved" | "declined";
+}
+
+/**
+ * BEAT 6's material. Two pending markdowns break the floor and one does not:
+ *
+ *  - `promo-cedar` — 40% off a 63% SKU lands at 38.8% against a 45% Knitwear
+ *    floor. This is the one taught on stage.
+ *  - `promo-slate` — 35% off a 45% SKU lands at 15.4% against a 40% Footwear
+ *    floor. This is the unaided replay, and it must be a DIFFERENT product from
+ *    the one demonstrated, because the demonstration resolves its own case.
+ *  - `promo-terra` — 20% off a 56% SKU lands at 45.3% against a 38% Home floor,
+ *    so it approves in one call with no waiver at all.
+ */
+export const SEED_PROMOTIONS: readonly SeedPromotion[] = [
+  {
+    id: "promo-fern",
+    name: "Fern Cardigan preview event",
+    productId: "prd-fern-cardigan",
+    discountPercent: 15,
+    startsInDays: -21,
+    endsInDays: -7,
+    submittedBy: "Theo Vance",
+    submittedDaysAgo: 24,
+    status: "approved",
+  },
+  {
+    id: "promo-terra",
+    name: "Terra Mug gifting push",
+    productId: "prd-terra-mug",
+    discountPercent: 20,
+    startsInDays: 4,
+    endsInDays: 25,
+    submittedBy: "Theo Vance",
+    submittedDaysAgo: 2,
+    status: "pending",
+  },
+  {
+    id: "promo-cedar",
+    name: "Cedar Hoodie autumn markdown",
+    productId: "prd-cedar-hoodie",
+    discountPercent: 40,
+    startsInDays: 6,
+    endsInDays: 27,
+    submittedBy: "Theo Vance",
+    submittedDaysAgo: 3,
+    status: "pending",
+  },
+  {
+    id: "promo-slate",
+    name: "Slate Boot end-of-season",
+    productId: "prd-slate-boot",
+    discountPercent: 35,
+    startsInDays: 9,
+    endsInDays: 37,
+    submittedBy: "Theo Vance",
+    submittedDaysAgo: 5,
+    status: "pending",
+  },
+];
+
+export interface SeedPlan {
+  id: string;
+  vendor: string;
+  season: string;
+  summary: string;
+  highlights: string[];
+  lines: { sku: string; name: string; landedCost: number; units: number }[];
+  schedule: { week: string; item: string }[];
+  filedDaysAgo: number;
+  filedBy: string;
+}
+
+/**
+ * One historical restock plan, so the Catalog page's Plans panel is never empty
+ * before the demo files its first one. An empty panel reads as a broken feature
+ * rather than as a fresh account.
+ */
+export const SEED_PLANS: readonly SeedPlan[] = [
+  {
+    id: "pln-spring-kestrel",
+    vendor: "Kestrel Mills",
+    season: "Spring basics",
+    summary:
+      "Carry-over knit basics at the negotiated spring cost, held flat against last season to protect the Knitwear floor.",
+    highlights: [
+      "Cedar Hoodie cost held at $47 for the full run",
+      "Six-week lead time confirmed in writing",
+      "Moss Scarf moved to the same shipment to save freight",
+    ],
+    lines: [
+      {
+        sku: "BW-CDR-HDY",
+        name: "Cedar Hoodie",
+        landedCost: 47,
+        units: 1200,
+      },
+      {
+        sku: "BW-MSS-SCF",
+        name: "Moss Merino Scarf",
+        landedCost: 33,
+        units: 800,
+      },
+    ],
+    schedule: [
+      { week: "Week 1", item: "PO issued and deposit released" },
+      { week: "Week 4", item: "Pre-production samples approved" },
+      { week: "Week 6", item: "Bulk ships from mill" },
+    ],
+    filedDaysAgo: 46,
+    filedBy: "Nadia Okonjo",
+  },
+];
+
+/**
+ * Two operators, and the difference between them is the point: Nadia is the
+ * seeded persona the demo runs as, so Bellwether already knows how she reads a
+ * margin review. Theo has taught it nothing.
+ */
+export const SEED_OPERATORS: readonly Operator[] = [
+  {
+    id: "op-nadia",
+    name: "Nadia Okonjo",
+    role: "merch-lead",
+    team: "Merchandising",
+  },
+  {
+    id: "op-theo",
+    name: "Theo Vance",
+    role: "ops-manager",
+    team: "Fulfillment",
+  },
+];
+
+export const DEFAULT_OPERATOR_ID = "op-nadia";

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/store.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/store.test.ts
@@ -1,0 +1,973 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { errorResponse } from "./http";
+import * as store from "./store";
+import { NOTIFICATION_TEMPLATES } from "./types";
+import type { Promotion } from "./types";
+import { JUSTIFICATION_MAX_LENGTH } from "./waiver-codes";
+
+beforeEach(() => store.reset());
+
+/**
+ * The server-side ledger, with the emphasis on the two things the demo cannot
+ * survive being wrong: the beat-6 gate, and the beat-3a refund's refusal to let
+ * a figure escape into anything the agent can read.
+ */
+describe("seed", () => {
+  it("seeds exactly two below-floor products, so beats 1 and 4 have something to flag", () => {
+    const below = store.products().filter(store.isBelowFloor);
+    expect(below.map((p) => p.id).sort()).toEqual([
+      "prd-harbor-parka",
+      "prd-lark-runner",
+    ]);
+  });
+
+  it("seeds TWO gated markdowns and one clean one", () => {
+    const pending = store
+      .promotions()
+      .filter((p) => store.promotionApprovalBlocker(p) === null);
+    const gated = store
+      .promotions()
+      .filter(
+        (p) => store.promotionApprovalBlocker(p) === "BELOW_MARGIN_FLOOR",
+      );
+
+    // Two gated: one is taught on stage, the other is the unaided replay. The
+    // demonstration RESOLVES its own case, so a single gated record would leave
+    // beat 6 with nothing to prove it learned anything.
+    expect(gated.map((p) => p.id).sort()).toEqual([
+      "promo-cedar",
+      "promo-slate",
+    ]);
+    // And one that approves in a single call, so the gate cannot be mistaken
+    // for "approval always fails".
+    expect(pending.map((p) => p.id)).toContain("promo-terra");
+  });
+
+  it("keeps every order's total and product references honest", () => {
+    for (const order of store.orders()) {
+      const lineSum = order.lines.reduce(
+        (sum, line) => sum + line.quantity * line.unitPrice,
+        0,
+      );
+      expect(order.total, `total on ${order.number}`).toBe(lineSum);
+      for (const line of order.lines) {
+        expect(store.product(line.productId), line.productId).toBeDefined();
+      }
+    }
+  });
+
+  it("keeps every return's item value and prose agreeing with its order line", () => {
+    // THREE numbers describe one return — the units the order actually carried,
+    // the units `itemValue` is worth, and any count the `detail` prose states —
+    // and the assistant mixes all three in one breath: it quotes the prose
+    // VERBATIM while its arithmetic comes from the fields. `ret-2204` shipped as
+    // "Bought three" against a four-unit line and a two-unit `itemValue`: three
+    // different quantities for one return, so the assistant contradicted the
+    // record it was reading from, live, while a refund was being decided.
+    //
+    // Pinned as an INVARIANT over every return rather than as values, so the
+    // seed's figures and prose stay freely editable afterwards.
+    const NUMBER_WORDS: Record<string, number> = {
+      one: 1,
+      two: 2,
+      three: 3,
+      four: 4,
+      five: 5,
+      six: 6,
+      seven: 7,
+      eight: 8,
+      nine: 9,
+      ten: 10,
+      eleven: 11,
+      twelve: 12,
+    };
+    const statedCounts = (detail: string): number[] =>
+      (
+        detail
+          .toLowerCase()
+          .match(
+            /\b(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b/g,
+          ) ?? []
+      ).map((token) => NUMBER_WORDS[token] ?? Number(token));
+
+    for (const request of store.returns()) {
+      const parent = store.order(request.orderId);
+      expect(parent, `order behind ${request.id}`).toBeDefined();
+      const line = parent?.lines.find((l) => l.productId === request.productId);
+      expect(
+        line,
+        `${request.id}'s line on ${request.orderNumber}`,
+      ).toBeDefined();
+      if (!line) continue;
+
+      // `itemValue` is "what the item was originally charged at", so it can only
+      // be a whole number of units at the price the order actually charged, and
+      // never more units than the order carried.
+      expect(
+        request.itemValue % line.unitPrice,
+        `${request.id} itemValue ${request.itemValue} against unit price ${line.unitPrice}`,
+      ).toBe(0);
+      const returnedUnits = request.itemValue / line.unitPrice;
+      expect(
+        returnedUnits,
+        `${request.id} returned units`,
+      ).toBeGreaterThanOrEqual(1);
+      expect(returnedUnits, `${request.id} returned units`).toBeLessThanOrEqual(
+        line.quantity,
+      );
+
+      // Any count the prose states must be one of the two counts that are real:
+      // how many were bought, or how many are going back. A third number is the
+      // bug — and a prose number that means something else (a duration, a size)
+      // must not be spelled as a bare count.
+      for (const stated of statedCounts(request.detail)) {
+        expect(
+          [returnedUnits, line.quantity],
+          `${request.id} prose states ${stated}: "${request.detail}"`,
+        ).toContain(stated);
+      }
+    }
+  });
+
+  it("numbers orders monotonically with placement time, oldest lowest", () => {
+    // Order numbers are issued sequentially in every real commerce system, and
+    // beat 3c puts the queue on screen sorted OLDEST FIRST. A reversed sequence
+    // makes the number column count DOWN in front of the room, which reads as
+    // broken data — the audience stops trusting the ledger before it evaluates
+    // the agent. Pinned as an INVARIANT, not as values: the seed may re-space
+    // its numbers freely so long as older still means lower.
+    const byAge = [...store.orders()].sort((a, b) =>
+      a.placedAt.localeCompare(b.placedAt),
+    );
+    for (let i = 1; i < byAge.length; i++) {
+      const older = byAge[i - 1];
+      const newer = byAge[i];
+      expect(
+        Number(newer.number),
+        `${newer.number} (placed ${newer.placedAt}) must outrank ${older.number} (placed ${older.placedAt})`,
+      ).toBeGreaterThan(Number(older.number));
+    }
+  });
+
+  it("resolves an order by its human-facing number as well as its id", () => {
+    // The agent reads "order 4471" off the page; refusing that spelling would
+    // be a routing failure dressed up as a 404.
+    expect(store.order("4471")?.id).toBe("ord-4471");
+    expect(store.order("ord-4471")?.number).toBe("4471");
+    expect(store.order("nope")).toBeUndefined();
+  });
+});
+
+/**
+ * BEAT 3c — the `top=10` lever must actually CUT something.
+ *
+ * The beat's whole claim is that the assistant reached into the app's real
+ * controls. A limit that truncates nothing is the worst possible outcome for
+ * that claim: the queue renders exactly as it would have anyway, the control
+ * tints, and the room is asked to believe a maneuver happened. It shipped that
+ * way — nine exception orders against a limit of ten.
+ *
+ * The queue clause lives in `pages/orders.tsx`'s `visible` useMemo, which is a
+ * client component reading its levers off `useSearchParams`; it is mirrored here
+ * rather than imported. Both clauses below are one line, and the counts they
+ * measure — not the mirroring — are what these tests defend.
+ */
+/** `sort=aging_desc` — oldest first, exactly as `SORTS.aging_desc` compares. */
+const oldestFirst = <T extends { placedAt: string }>(rows: T[]): T[] =>
+  [...rows].sort((a, b) => a.placedAt.localeCompare(b.placedAt));
+
+describe("BEAT 3c — the top-N lever", () => {
+  const TOP = 10;
+  /** `exception=any` — every order still carrying one. Status left at "all". */
+  const onException = () =>
+    store.orders().filter((o) => o.exception !== "none");
+
+  it("leaves more than ten rows in the view the beat actually builds", () => {
+    // status=all & exception=any — the lever set the tool description and the
+    // prompt both steer towards, because a pinned status empties itself the
+    // moment beat 5 puts an order on hold.
+    expect(onException().length).toBeGreaterThan(TOP);
+  });
+
+  it("still exceeds ten when the status lever is pinned to open", () => {
+    // A user can still ask for open orders by name, and the limit has to bite in
+    // that view too.
+    expect(
+      onException().filter((o) => o.status === "open").length,
+    ).toBeGreaterThan(TOP);
+  });
+
+  it("keeps order 4471 inside the ten oldest, so beat 5's writes stay visible", () => {
+    // Truncation excludes rows just as a status filter does. Beat 5 posts a hold
+    // and a forced-🚨 note onto 4471 while the room is looking at the view beat
+    // 3c built — so every exception order seeded to make the limit bite must be
+    // NEWER than 4471, leaving it inside the visible ten.
+    const visible = oldestFirst(onException()).slice(0, TOP);
+    expect(visible.map((o) => o.id)).toContain("ord-4471");
+    // …and the limit really is cutting rows, not just fitting.
+    expect(onException().length - visible.length).toBeGreaterThan(0);
+  });
+});
+
+describe("margin", () => {
+  it("computes gross margin at a price and guards a zero price", () => {
+    expect(store.marginAt(100, 40)).toBeCloseTo(0.6, 5);
+    expect(store.marginAt(0, 40)).toBe(0);
+  });
+
+  it("keeps the clamped ratio separate from the raw below-floor test", () => {
+    // The ratio positions a dot on the ladder rail and is clamped to [0,1];
+    // `belowFloor` is the RAW comparison. Clamping must never hide a violation.
+    const under = store.marginPosition("Footwear", 0.2); // floor 0.40
+    expect(under.ratio).toBe(0);
+    expect(under.belowFloor).toBe(true);
+
+    const over = store.marginPosition("Footwear", 0.95); // above the ceiling
+    expect(over.ratio).toBe(1);
+    expect(over.belowFloor).toBe(false);
+  });
+
+  it("prices a discount to the cent, not to the dollar", () => {
+    expect(store.discountedPrice(128, 40)).toBe(76.8);
+    expect(store.discountedPrice(48, 20)).toBe(38.4);
+  });
+});
+
+describe("BEAT 6 — the gate", () => {
+  const CEDAR = "promo-cedar";
+
+  it("refuses a below-floor markdown with a symptom-only code", () => {
+    expect(() => store.approvePromotion(CEDAR)).toThrow("BELOW_MARGIN_FLOOR");
+  });
+
+  it("approves a markdown that stays above its category floor", () => {
+    const { promotion } = store.approvePromotion("promo-terra");
+    expect(promotion.status).toBe("approved");
+  });
+
+  it("a DECOY waiver files, finalizes, links — and still does not lift the gate", () => {
+    const waiver = store.openMarginWaiver(CEDAR, "MERCH-DISC", "judgement");
+    expect(waiver.status).toBe("draft");
+
+    const finalized = store.finalizeMarginWaiver(waiver.id);
+    expect(finalized.status).toBe("approved");
+    // It really is on file — the history is honest about it...
+    expect(store.waiversFor(CEDAR)).toHaveLength(1);
+    expect(store.promotions().find((p) => p.id === CEDAR)?.marginWaiverId).toBe(
+      waiver.id,
+    );
+    // ...and it still does not clear the floor.
+    expect(() => store.approvePromotion(CEDAR)).toThrow("BELOW_MARGIN_FLOOR");
+  });
+
+  it("a JUSTIFYING waiver lifts the gate only once it is finalized", () => {
+    const waiver = store.openMarginWaiver(CEDAR, "VENDOR-FUND", "signed co-op");
+    // A draft is not enough — filing is not approving.
+    expect(() => store.approvePromotion(CEDAR)).toThrow("BELOW_MARGIN_FLOOR");
+
+    store.finalizeMarginWaiver(waiver.id);
+    const { promotion } = store.approvePromotion(CEDAR);
+    expect(promotion.status).toBe("approved");
+  });
+
+  it("never lets a DECOY finalized afterwards steal the credit for the unlock", () => {
+    // `marginWaiverId` names the waiver the markdown's approvability rests on.
+    // If a decoy finalized later displaced it, the record would credit the code
+    // that justifies nothing — contradicting the beat on screen.
+    const justifying = store.openMarginWaiver(CEDAR, "EOL-CLEAR", "range exit");
+    store.finalizeMarginWaiver(justifying.id);
+    expect(store.promotions().find((p) => p.id === CEDAR)?.marginWaiverId).toBe(
+      justifying.id,
+    );
+
+    const decoy = store.openMarginWaiver(CEDAR, "VOL-LIFT", "units will come");
+    store.finalizeMarginWaiver(decoy.id);
+
+    // The credit stays with the waiver that actually cleared the floor...
+    expect(store.promotions().find((p) => p.id === CEDAR)?.marginWaiverId).toBe(
+      justifying.id,
+    );
+    // ...the history is still honest that both were filed and finalized...
+    expect(
+      store
+        .waiversFor(CEDAR)
+        .map((w) => w.code)
+        .sort(),
+    ).toEqual(["EOL-CLEAR", "VOL-LIFT"]);
+    expect(store.waiversFor(CEDAR).every((w) => w.status === "approved")).toBe(
+      true,
+    );
+    // ...and the gate stays lifted.
+    expect(store.hasApprovedJustifyingWaiver(CEDAR)).toBe(true);
+    expect(store.approvePromotion(CEDAR).promotion.status).toBe("approved");
+  });
+
+  it("upgrades the credit when the justifying waiver arrives second", () => {
+    const decoy = store.openMarginWaiver(CEDAR, "MERCH-DISC", "judgement");
+    store.finalizeMarginWaiver(decoy.id);
+    expect(store.promotions().find((p) => p.id === CEDAR)?.marginWaiverId).toBe(
+      decoy.id,
+    );
+
+    // ≥ JUSTIFICATION_MIN_LENGTH: filings now require real written paperwork,
+    // so "on file" (7 chars) is refused as INVALID_JUSTIFICATION.
+    const justifying = store.openMarginWaiver(
+      CEDAR,
+      "COMP-MATCH",
+      "competitor match confirmed, quote on file",
+    );
+    store.finalizeMarginWaiver(justifying.id);
+    // A decoy holding the slot is not a justifying link, so it yields to one.
+    expect(store.promotions().find((p) => p.id === CEDAR)?.marginWaiverId).toBe(
+      justifying.id,
+    );
+  });
+
+  it("rejects an unknown code without revealing the catalogue", () => {
+    expect(() =>
+      store.openMarginWaiver(CEDAR, "MADE-UP", "signed co-op"),
+    ).toThrow("INVALID_WAIVER_CODE");
+    expect(() =>
+      store.openMarginWaiver("nope", "VENDOR-FUND", "signed co-op"),
+    ).toThrow("NOT_FOUND");
+  });
+
+  it("refuses a waiver filed with no written justification", () => {
+    // The gate is only as real as the paperwork behind it. A JUSTIFYING code
+    // with an empty justification used to file, finalize and lift the floor
+    // while recording nothing about why — which made the "file the paperwork"
+    // half of the beat a formality the agent could satisfy with `""`.
+    const nonAnswers = ["", "   ", "\n\t ", "x", "n/a", "ok", "none"];
+    for (const empty of nonAnswers) {
+      expect(
+        () => store.openMarginWaiver(CEDAR, "VENDOR-FUND", empty),
+        JSON.stringify(empty),
+      ).toThrow("INVALID_JUSTIFICATION");
+    }
+    // Nothing was recorded, and the floor is still armed.
+    expect(store.waiversFor(CEDAR)).toHaveLength(0);
+    expect(() => store.approvePromotion(CEDAR)).toThrow("BELOW_MARGIN_FLOOR");
+  });
+
+  it("refuses an unbounded justification, and a non-string one", () => {
+    // The text is written into the durable store from a model-authored tool
+    // argument, so it needs a ceiling as well as a floor.
+    expect(() =>
+      store.openMarginWaiver(
+        CEDAR,
+        "VENDOR-FUND",
+        "co-op ".repeat(JUSTIFICATION_MAX_LENGTH),
+      ),
+    ).toThrow("INVALID_JUSTIFICATION");
+    // Exactly at the ceiling is fine; one over is not.
+    const atMax = "c".repeat(JUSTIFICATION_MAX_LENGTH);
+    expect(
+      store.openMarginWaiver(CEDAR, "VENDOR-FUND", atMax).justification,
+    ).toHaveLength(JUSTIFICATION_MAX_LENGTH);
+    expect(() =>
+      store.openMarginWaiver(CEDAR, "VENDOR-FUND", `${atMax}c`),
+    ).toThrow("INVALID_JUSTIFICATION");
+    // And `String({})` is 15 characters of nothing — the coercion the routes'
+    // house pattern would otherwise have laundered past the floor.
+    for (const wrong of [{}, [], null, undefined, 12345678, true]) {
+      expect(
+        () => store.openMarginWaiver(CEDAR, "VENDOR-FUND", wrong),
+        JSON.stringify(wrong ?? null),
+      ).toThrow("INVALID_JUSTIFICATION");
+    }
+  });
+
+  it("still lifts the gate for a real justification, and trims it", () => {
+    const waiver = store.openMarginWaiver(
+      CEDAR,
+      "VENDOR-FUND",
+      "  signed co-op on file with Buying  ",
+    );
+    expect(waiver.justification).toBe("signed co-op on file with Buying");
+    store.finalizeMarginWaiver(waiver.id);
+    expect(store.approvePromotion(CEDAR).promotion.status).toBe("approved");
+  });
+
+  it("a waiver on ONE markdown never unlocks another", () => {
+    const waiver = store.openMarginWaiver(CEDAR, "VENDOR-FUND", "signed co-op");
+    store.finalizeMarginWaiver(waiver.id);
+    store.approvePromotion(CEDAR);
+    // promo-slate is the unaided replay; teaching on Cedar must not clear it.
+    expect(() => store.approvePromotion("promo-slate")).toThrow(
+      "BELOW_MARGIN_FLOOR",
+    );
+  });
+
+  /**
+   * Paperwork only means something while the decision is still open.
+   *
+   * A waiver filed against a markdown that has ALREADY been approved or declined
+   * is retro-justification: it files, it finalizes, and `creditWaiver` writes its
+   * id onto the promotion — so the Promotions page credits a code as the reason a
+   * markdown became approvable when in fact nobody consulted it. These three pin
+   * both halves of the precondition (filing AND finalizing) and both decided
+   * states.
+   */
+  it("refuses a waiver filed against a markdown that was already decided", () => {
+    // promo-fern is seeded APPROVED: the retro-justification case.
+    expect(() =>
+      store.openMarginWaiver("promo-fern", "VENDOR-FUND", "signed co-op"),
+    ).toThrow("ALREADY_DECIDED");
+
+    // And DECLINED, which is terminal — nothing returns a promotion to pending,
+    // so a waiver against it could never lift anything.
+    store.declinePromotion("promo-slate");
+    expect(() =>
+      store.openMarginWaiver("promo-slate", "VENDOR-FUND", "signed co-op"),
+    ).toThrow("ALREADY_DECIDED");
+
+    // Nothing was recorded against either, so `waiversFor` — which the page
+    // renders — stays honest.
+    expect(store.waiversFor("promo-fern")).toHaveLength(0);
+    expect(store.waiversFor("promo-slate")).toHaveLength(0);
+  });
+
+  it("refuses to finalize a draft once the markdown has been decided", () => {
+    // Why guarding `openMarginWaiver` alone is not enough: this draft was opened
+    // legitimately, WHILE promo-terra was still pending. promo-terra is the
+    // markdown that approves in one call, so the decision lands without the
+    // waiver ever being consulted — and finalizing afterwards would link it.
+    const waiver = store.openMarginWaiver(
+      "promo-terra",
+      "VENDOR-FUND",
+      "signed co-op on file",
+    );
+    store.approvePromotion("promo-terra");
+
+    expect(() => store.finalizeMarginWaiver(waiver.id)).toThrow(
+      "ALREADY_DECIDED",
+    );
+    // The refusal is whole: no half-finalized waiver, and no link written.
+    const stored = store.waivers().find((w) => w.id === waiver.id);
+    expect(stored?.status).toBe("draft");
+    expect(stored?.finalizedAt).toBeNull();
+    expect(
+      store.promotions().find((p) => p.id === "promo-terra")?.marginWaiverId,
+    ).toBeNull();
+  });
+
+  it("still runs the beat-6 sequence on the taught case AND the replay", () => {
+    // The ordering the beat actually performs — file under a justifying code,
+    // finalize, approve — on BOTH seeded below-floor markdowns: the one taught on
+    // stage and the one the agent replays unaided. If the guards above ever
+    // reached into this sequence, beat 6 would be gone.
+    for (const id of ["promo-cedar", "promo-slate"]) {
+      const waiver = store.openMarginWaiver(
+        id,
+        "VENDOR-FUND",
+        "signed co-op on file with Buying",
+      );
+      expect(store.finalizeMarginWaiver(waiver.id).status).toBe("approved");
+      expect(store.approvePromotion(id).promotion.status).toBe("approved");
+      expect(store.promotions().find((p) => p.id === id)?.marginWaiverId).toBe(
+        waiver.id,
+      );
+    }
+  });
+
+  it("refuses to finalize the same waiver twice, or to re-approve", () => {
+    const waiver = store.openMarginWaiver(CEDAR, "VENDOR-FUND", "co-op filed");
+    store.finalizeMarginWaiver(waiver.id);
+    expect(() => store.finalizeMarginWaiver(waiver.id)).toThrow(
+      "ALREADY_FINALIZED",
+    );
+    store.approvePromotion(CEDAR);
+    expect(() => store.approvePromotion(CEDAR)).toThrow("ALREADY_DECIDED");
+  });
+});
+
+/**
+ * A DANGLING reference is not a not-found.
+ *
+ * `NOT_FOUND` means "the record you named is not here" — a caller error, and one
+ * the agent can act on by naming a different record. A promotion whose
+ * `productId` resolves to nothing means our own ledger is inconsistent, which no
+ * caller can act on. Both used to raise `NOT_FOUND`, so `approvePromotion`
+ * answered a broken invariant with the very same `404 "That record does not
+ * exist."` it answers a typo with, and logged nothing at all — the two states
+ * were indistinguishable from outside. These assertions pin them apart at both
+ * layers: the code the store raises, and what `errorResponse` does with it.
+ */
+describe("ledger integrity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Corrupt one seeded promotion's product reference. `reset()` undoes it. */
+  const dangleProduct = (promotionId: string): Promotion => {
+    const promotion = store.promotions().find((p) => p.id === promotionId);
+    if (!promotion) throw new Error(`no seeded promotion ${promotionId}`);
+    promotion.productId = "prd-that-was-deleted";
+    return promotion;
+  };
+
+  it("has no dangling reference in the seed today", () => {
+    // The defect is only reachable from a CORRUPTED store, and that is worth
+    // keeping true: this is what fails if a future seed edit ships a real one.
+    for (const promotion of store.promotions()) {
+      expect(store.product(promotion.productId), promotion.id).toBeDefined();
+    }
+    for (const request of store.returns()) {
+      expect(store.product(request.productId), request.id).toBeDefined();
+    }
+  });
+
+  it("still reports a promotion id nobody has as the routine not-found", () => {
+    expect(() => store.approvePromotion("promo-nope")).toThrow("NOT_FOUND");
+    expect(() => store.declinePromotion("promo-nope")).toThrow("NOT_FOUND");
+    expect(() =>
+      store.openMarginWaiver("promo-nope", "VENDOR-FUND", "x"),
+    ).toThrow("NOT_FOUND");
+  });
+
+  it("reports a promotion pointing at a missing product as an integrity fault", () => {
+    // promo-terra is the markdown that otherwise approves in one call, so the
+    // only thing standing between it and success here is the dangling ref.
+    const promotion = dangleProduct("promo-terra");
+    expect(store.promotionApprovalBlocker(promotion)).toBe(
+      "DANGLING_PRODUCT_REF",
+    );
+    expect(() => store.approvePromotion("promo-terra")).toThrow(
+      "DANGLING_PRODUCT_REF",
+    );
+    // …and the approval did not half-land.
+    expect(store.promotions().find((p) => p.id === "promo-terra")?.status).toBe(
+      "pending",
+    );
+  });
+
+  it("reports a waiver pointing at a missing promotion, and finalizes nothing", () => {
+    const waiver = store.openMarginWaiver(
+      "promo-cedar",
+      "VENDOR-FUND",
+      "signed co-op",
+    );
+    waiver.promotionId = "promo-that-was-deleted";
+    expect(() => store.finalizeMarginWaiver(waiver.id)).toThrow(
+      "DANGLING_PROMOTION_REF",
+    );
+    // The refusal is whole. This used to finalize the waiver, answer 200, and
+    // drop the promotion link in silence.
+    const stored = store.waivers().find((w) => w.id === waiver.id);
+    expect(stored?.status).toBe("draft");
+    expect(stored?.finalizedAt).toBeNull();
+  });
+
+  // End to end through the REAL mapper the approve route uses, because the whole
+  // point of the finding is what the CALLER and the LOG can tell apart.
+  it("hands the caller and the server log two different answers", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    const respond = (run: () => unknown): Response => {
+      try {
+        run();
+      } catch (error) {
+        return errorResponse(error, "POST promotions/[id]/approve");
+      }
+      throw new Error("expected the store to refuse");
+    };
+
+    // A caller error: actionable, and not worth a line in the log.
+    const missing = respond(() => store.approvePromotion("promo-nope"));
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({
+      error: "NOT_FOUND",
+    });
+    expect(log).not.toHaveBeenCalled();
+
+    // Our bug: never dressed up as a routine 404, and loud on the server.
+    dangleProduct("promo-terra");
+    const broken = respond(() => store.approvePromotion("promo-terra"));
+    expect(broken.status).toBe(500);
+    await expect(broken.json()).resolves.toMatchObject({
+      error: "INTERNAL_ERROR",
+    });
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][1]).toMatchObject({
+      message: "DANGLING_PRODUCT_REF",
+    });
+  });
+});
+
+describe("BEAT 3a — the refund", () => {
+  it("records the amount on the return and marks it refunded", () => {
+    const updated = store.issueRefund("ret-2210", 85);
+    expect(updated.status).toBe("refunded");
+    expect(updated.refundAmount).toBe(85);
+  });
+
+  it("refuses an amount above what was charged, and a second refund", () => {
+    // A refund over the item value is a data-entry slip, not a policy call —
+    // letting it through would quietly distort the margin figures the whole app
+    // is about.
+    expect(() => store.issueRefund("ret-2210", 999_999)).toThrow(
+      "REFUND_EXCEEDS_VALUE",
+    );
+    expect(() => store.issueRefund("ret-2210", 0)).toThrow("INVALID_AMOUNT");
+    store.issueRefund("ret-2210", 85);
+    expect(() => store.issueRefund("ret-2210", 10)).toThrow("ALREADY_REFUNDED");
+  });
+
+  it("refuses to refund a return nobody approved, or one that was declined", () => {
+    // A refund settles the return terminally. Three of the five seeded returns
+    // are still `requested`, and the agent's return finder matches on a fuzzy
+    // substring — so without this guard a loose phrase settles a return that
+    // was never decided.
+    expect(() => store.issueRefund("ret-2204", 50)).toThrow(
+      "RETURN_NOT_APPROVED",
+    );
+    const untouched = store.returns().find((r) => r.id === "ret-2204");
+    expect(untouched?.status).toBe("requested");
+    expect(untouched?.refundAmount).toBeNull();
+
+    // And a human's explicit refusal is not something a refund may overwrite.
+    store.decideReturn("ret-2201", "declined");
+    expect(() => store.issueRefund("ret-2201", 50)).toThrow(
+      "RETURN_NOT_APPROVED",
+    );
+    const declined = store.returns().find((r) => r.id === "ret-2201");
+    expect(declined?.status).toBe("declined");
+    expect(declined?.refundAmount).toBeNull();
+  });
+
+  it("still refunds the approved return the demo actually uses", () => {
+    // ret-2210 is seeded `approved`; beat 3a must keep working unaided.
+    expect(store.issueRefund("ret-2210", 85).status).toBe("refunded");
+    // As must approve-then-refund, the Returns desk's own two-step.
+    expect(store.decideReturn("ret-2204", "approved").status).toBe("approved");
+    expect(store.issueRefund("ret-2204", 50).refundAmount).toBe(50);
+  });
+
+  it("refuses a second decision on a return that was already decided", () => {
+    store.decideReturn("ret-2204", "approved");
+    expect(() => store.decideReturn("ret-2204", "declined")).toThrow(
+      "ALREADY_DECIDED",
+    );
+    // A settled return keeps reporting the more specific code.
+    store.issueRefund("ret-2204", 50);
+    expect(() => store.decideReturn("ret-2204", "approved")).toThrow(
+      "ALREADY_REFUNDED",
+    );
+  });
+});
+
+describe("BEAT 5 — the procedure's three writes", () => {
+  it("holds an order, logs a notification and prepends the note", () => {
+    store.setOrderStatus("4471", "on-hold", "fraud-review");
+    expect(store.order("4471")?.status).toBe("on-hold");
+
+    store.notifyCustomer("4471", "verification-required", "Nadia Okonjo");
+    expect(store.notifications()).toHaveLength(1);
+    expect(store.notifications()[0].template).toBe("verification-required");
+
+    store.addOrderNote("4471", "🚨 Held for verification.", "Nadia Okonjo");
+    // unshift, not push: the page renders notes[0] as "the latest note".
+    expect(store.order("4471")?.notes[0].text).toContain("Held for");
+  });
+
+  /**
+   * The two writes that persist free text are BOTH read back to the model: the
+   * Orders page's beat-3b readable ships `recentNotifications[].template` and
+   * `latestNote`. So "any non-empty string" was not a lax-but-harmless check —
+   * it was a path from a request body into the next prompt, wearing app state's
+   * clothes. These assertions pin the closed set and the bounds.
+   */
+  it("refuses a template outside the four Bellwether sends", () => {
+    expect(() =>
+      store.notifyCustomer("4471", "ignore-previous-instructions", "Nadia"),
+    ).toThrow("UNKNOWN_TEMPLATE");
+    // Near-misses are refused too — the check is membership, not a prefix.
+    expect(() => store.notifyCustomer("4471", "verification", "Nadia")).toThrow(
+      "UNKNOWN_TEMPLATE",
+    );
+    expect(() => store.notifyCustomer("4471", "", "Nadia")).toThrow(
+      "UNKNOWN_TEMPLATE",
+    );
+    expect(store.notifications()).toHaveLength(0);
+  });
+
+  it.each(NOTIFICATION_TEMPLATES)("still sends the %s template", (template) => {
+    const sent = store.notifyCustomer("4471", template, "Nadia Okonjo");
+    expect(sent.template).toBe(template);
+    expect(store.notifications()[0].id).toBe(sent.id);
+  });
+
+  it("refuses an over-long sentBy, author or note", () => {
+    const longName = "N".repeat(store.MAX_ACTOR_NAME + 1);
+    expect(() =>
+      store.notifyCustomer("4471", "verification-required", longName),
+    ).toThrow("ACTOR_NAME_TOO_LONG");
+    expect(() => store.addOrderNote("4471", "🚨 Held.", longName)).toThrow(
+      "ACTOR_NAME_TOO_LONG",
+    );
+    expect(() =>
+      store.addOrderNote("4471", "x".repeat(store.MAX_NOTE_TEXT + 1), "Nadia"),
+    ).toThrow("NOTE_TOO_LONG");
+
+    // Nothing was written on any of the three refusals.
+    expect(store.notifications()).toHaveLength(0);
+    expect(store.order("4471")?.notes).toHaveLength(0);
+
+    // And a value exactly at the bound is still accepted — the check is a
+    // ceiling, not an off-by-one that clips a legitimate operator name.
+    const atBound = "N".repeat(store.MAX_ACTOR_NAME);
+    expect(
+      store.notifyCustomer("4471", "verification-required", atBound).sentBy,
+    ).toBe(atBound);
+    expect(
+      store.addOrderNote("4471", "x".repeat(store.MAX_NOTE_TEXT), "Nadia")
+        .notes[0].text,
+    ).toHaveLength(store.MAX_NOTE_TEXT);
+  });
+});
+
+/**
+ * THE ORDER STATE MACHINE.
+ *
+ * Without it the PATCH route accepted any status/exception combination it could
+ * spell, and two of those combinations are demo-destroying rather than merely
+ * untidy:
+ *
+ *  - `cancelled → open` resurrected a cancelled order;
+ *  - `fulfilled` alongside a live exception put a SHIPPED order in the
+ *    exception queue and added its total to the `valueAtRisk` KPI the room is
+ *    being asked to read as money still at risk.
+ *
+ * Both are reachable from the agent: `holdOrder` PATCHes a status, and the
+ * order finder matches on a loose phrase, so a wrong row is one fuzzy match
+ * away.
+ */
+/**
+ * These reference orders by ID, never by NUMBER.
+ *
+ * Order numbers are re-spaceable data: the monotonicity test above pins "older
+ * means lower" as an INVARIANT and explicitly licenses the seed to renumber
+ * freely. This block was originally written against hardcoded numbers and every
+ * case broke the moment the seed was renumbered to satisfy that invariant —
+ * `store.order()` accepts either spelling, so the failures surfaced as
+ * `NOT_FOUND` rather than as anything about the state machine. Ids are the stable
+ * handle; the CONSTANTS below say which seeded shape each case needs, so a future
+ * reseed can repoint them in one place.
+ */
+const OPEN_CLEAN_A = "ord-4469"; // open, exception: none
+const OPEN_CLEAN_B = "ord-4477"; // open, exception: none
+const OPEN_CLEAN_C = "ord-4483"; // open, exception: none
+const HELD = "ord-4453"; // on-hold, fraud-review
+const OPEN_WITH_EXCEPTION = "ord-4471"; // open, fraud-review — beat 5's subject
+
+describe("the order state machine", () => {
+  it("refuses to resurrect a cancelled order", () => {
+    expect(store.setOrderStatus(OPEN_CLEAN_A, "cancelled").status).toBe(
+      "cancelled",
+    );
+    expect(() => store.setOrderStatus(OPEN_CLEAN_A, "open")).toThrow(
+      "ORDER_ALREADY_SETTLED",
+    );
+    expect(store.order(OPEN_CLEAN_A)?.status).toBe("cancelled");
+  });
+
+  it("refuses to change a fulfilled order at all", () => {
+    store.setOrderStatus(OPEN_CLEAN_B, "fulfilled");
+    expect(() =>
+      store.setOrderStatus(OPEN_CLEAN_B, "on-hold", "oversell"),
+    ).toThrow("ORDER_ALREADY_SETTLED");
+    expect(store.order(OPEN_CLEAN_B)?.status).toBe("fulfilled");
+    expect(store.order(OPEN_CLEAN_B)?.exception).toBe("none");
+  });
+
+  it("refuses a fulfilled order that carries an exception", () => {
+    // The KPI-inflating pair, written explicitly...
+    expect(() =>
+      store.setOrderStatus(OPEN_CLEAN_B, "fulfilled", "fraud-review"),
+    ).toThrow("EXCEPTION_ON_SETTLED_ORDER");
+    expect(store.order(OPEN_CLEAN_B)?.status).toBe("open");
+
+    // ...and reached the other way, by settling an order that already has one
+    // and saying nothing about it.
+    expect(() =>
+      store.setOrderStatus(OPEN_WITH_EXCEPTION, "fulfilled"),
+    ).toThrow("EXCEPTION_ON_SETTLED_ORDER");
+    expect(() =>
+      store.setOrderStatus(OPEN_WITH_EXCEPTION, "cancelled"),
+    ).toThrow("EXCEPTION_ON_SETTLED_ORDER");
+    expect(store.order(OPEN_WITH_EXCEPTION)?.status).toBe("open");
+
+    // Clearing it in the same write is the sanctioned path.
+    expect(
+      store.setOrderStatus(OPEN_WITH_EXCEPTION, "cancelled", "none").status,
+    ).toBe("cancelled");
+  });
+
+  it("makes a held order be released before it can ship", () => {
+    // A hold STOPS fulfillment; shipping straight out of one contradicts what
+    // the hold did.
+    expect(() => store.setOrderStatus(HELD, "fulfilled", "none")).toThrow(
+      "ILLEGAL_ORDER_TRANSITION",
+    );
+    store.setOrderStatus(HELD, "open", "none");
+    expect(store.setOrderStatus(HELD, "fulfilled").status).toBe("fulfilled");
+  });
+
+  it("still allows every transition the demo beats rely on", () => {
+    // BEAT 5, step 1 — open → on-hold with the exception that caused it.
+    const held = store.setOrderStatus(
+      OPEN_WITH_EXCEPTION,
+      "on-hold",
+      "fraud-review",
+    );
+    expect(held.status).toBe("on-hold");
+    expect(held.exception).toBe("fraud-review");
+
+    // Re-holding under a restated exception is a legitimate correction.
+    const reheld = store.setOrderStatus(
+      OPEN_WITH_EXCEPTION,
+      "on-hold",
+      "payment-declined",
+    );
+    expect(reheld.exception).toBe("payment-declined");
+
+    // The Orders page's "clear the exception" control, on a HELD row.
+    const released = store.setOrderStatus(OPEN_WITH_EXCEPTION, "open", "none");
+    expect(released.status).toBe("open");
+    expect(released.exception).toBe("none");
+
+    // ...and on a row that is already open, which is the common case. An
+    // idempotent open → open must not be mistaken for an illegal transition.
+    expect(store.setOrderStatus(OPEN_CLEAN_C, "open", "none").exception).toBe(
+      "none",
+    );
+
+    // The page's hold button, which sends a status and no exception at all.
+    expect(store.setOrderStatus(OPEN_CLEAN_C, "on-hold").status).toBe(
+      "on-hold",
+    );
+
+    // And a clean order can still be shipped or cancelled outright.
+    expect(store.setOrderStatus(OPEN_CLEAN_A, "fulfilled").status).toBe(
+      "fulfilled",
+    );
+    expect(store.setOrderStatus(OPEN_CLEAN_B, "cancelled").status).toBe(
+      "cancelled",
+    );
+  });
+
+  it("will not pin a fresh exception onto a settled order", () => {
+    // `setOrderException` is deliberately status-free, and CLEARING needs no
+    // precondition — but SETTING one is the same already-settled class the
+    // status writer refuses: it puts a shipped or cancelled order back into the
+    // exception queue and back into the `valueAtRisk` KPI, by the one path that
+    // does not consult the state machine.
+    store.setOrderStatus(OPEN_CLEAN_A, "fulfilled");
+    expect(() => store.setOrderException(OPEN_CLEAN_A, "oversell")).toThrow(
+      "EXCEPTION_ON_SETTLED_ORDER",
+    );
+    expect(store.order(OPEN_CLEAN_A)?.exception).toBe("none");
+
+    store.setOrderStatus(OPEN_CLEAN_B, "cancelled");
+    expect(() =>
+      store.setOrderException(OPEN_CLEAN_B, "carrier-delay"),
+    ).toThrow("EXCEPTION_ON_SETTLED_ORDER");
+    expect(store.order(OPEN_CLEAN_B)?.exception).toBe("none");
+
+    // Clearing still works on any status — `"none"` is the one value every
+    // status may legally hold — and so does the live-order case the Orders page
+    // and beat 5 actually use.
+    expect(store.setOrderException(OPEN_CLEAN_A, "none").exception).toBe(
+      "none",
+    );
+    expect(store.setOrderException(OPEN_WITH_EXCEPTION, "none").exception).toBe(
+      "none",
+    );
+    expect(
+      store.setOrderException(OPEN_WITH_EXCEPTION, "oversell").exception,
+    ).toBe("oversell");
+  });
+
+  it("leaves the terminal statuses with nowhere to go", () => {
+    expect(store.ORDER_TRANSITIONS.fulfilled).toEqual([]);
+    expect(store.ORDER_TRANSITIONS.cancelled).toEqual([]);
+  });
+
+  it("accepts every order the seed constructs", () => {
+    // The seed materializes rows directly into state, so it bypasses the
+    // machine entirely. Checking it against `isLegalOrderState` — the SAME
+    // predicate the mutation enforces, not a second copy of the rule — is what
+    // keeps a guard from quietly outlawing the demo's own starting data.
+    const rows = store.orders();
+    expect(rows.length).toBeGreaterThan(0);
+    for (const o of rows) {
+      expect(
+        store.isLegalOrderState(o.status, o.exception),
+        `seeded order ${o.number} is ${o.status} / ${o.exception}`,
+      ).toBe(true);
+      // Every seeded status must be one the table knows about.
+      expect(store.ORDER_TRANSITIONS[o.status], o.number).toBeDefined();
+    }
+    // Not a vacuous pass: the seed really does contain settled rows (which must
+    // therefore be exception-free) and exception-bearing rows.
+    expect(rows.filter((o) => o.status === "fulfilled").length).toBeGreaterThan(
+      0,
+    );
+    expect(rows.filter((o) => o.exception !== "none").length).toBeGreaterThan(
+      0,
+    );
+  });
+});
+
+describe("BEAT 3d — the durable artifact", () => {
+  it("files a plan into the store and truncates the model-authored arrays", () => {
+    const before = store.plans().length;
+    const plan = store.filePlan({
+      vendor: "Kestrel Mills",
+      season: "Autumn",
+      summary: "Autumn knit buy.",
+      highlights: ["a", "b", "c", "d"],
+      lines: [
+        {
+          sku: "BW-CDR-HDY",
+          name: "Cedar Hoodie",
+          landedCost: 51,
+          units: 1200,
+        },
+      ],
+      schedule: [{ week: "Week 1", item: "PO countersigned" }],
+      filedBy: "Nadia Okonjo",
+    });
+    expect(store.plans()).toHaveLength(before + 1);
+    expect(plan.highlights).toHaveLength(3); // capped at three
+    expect(store.plans()[0].id).toBe(plan.id); // newest first
+  });
+});
+
+describe("reset", () => {
+  it("puts every beat back, and leaves beat 6 gated again", () => {
+    const waiver = store.openMarginWaiver(
+      "promo-cedar",
+      "VENDOR-FUND",
+      "signed co-op",
+    );
+    store.finalizeMarginWaiver(waiver.id);
+    store.approvePromotion("promo-cedar");
+    store.issueRefund("ret-2210", 85);
+    store.setOrderStatus("4471", "on-hold", "fraud-review");
+    store.notifyCustomer("4471", "verification-required", "N");
+
+    store.reset();
+
+    expect(store.waivers()).toHaveLength(0);
+    expect(store.notifications()).toHaveLength(0);
+    expect(store.order("4471")?.status).toBe("open");
+    expect(store.order("4471")?.notes).toHaveLength(0);
+    expect(store.returns().find((r) => r.id === "ret-2210")?.status).toBe(
+      "approved",
+    );
+    // The gate is armed again — this is what makes the demo re-runnable.
+    expect(() => store.approvePromotion("promo-cedar")).toThrow(
+      "BELOW_MARGIN_FLOOR",
+    );
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/store.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/store.ts
@@ -1,0 +1,713 @@
+/**
+ * Bellwether's server-side ledger.
+ *
+ * An in-memory module, exactly like `src/skins/people/data/store.ts` and
+ * `src/skins/banking/data/store.ts`: state lives for the life of the Node
+ * process and `reset()` re-materializes it from the seed. Every
+ * `/api/commerce/v1/*` route reads and writes through here, which is what makes
+ * beat 3d true — a filed restock plan belongs to the APPLICATION, so deleting
+ * the chat thread cannot take it away.
+ *
+ * Mutations that can legitimately be refused throw an Error whose `message` is
+ * a stable CODE (`NOT_FOUND`, `BELOW_MARGIN_FLOOR`, `INVALID_WAIVER_CODE`, …).
+ * The routes map those codes onto HTTP statuses; nothing parses prose.
+ *
+ * A DANGLING reference is a different animal and carries its own codes
+ * (`DANGLING_PRODUCT_REF`, `DANGLING_PROMOTION_REF`). `NOT_FOUND` means "the
+ * record you named is not here" — a caller error, and something the agent can
+ * act on by naming a different record. A promotion whose `productId` resolves to
+ * nothing means OUR ledger is internally inconsistent: no caller can act on it,
+ * and nobody should have to guess. Both used to raise `NOT_FOUND`, so an
+ * integrity failure was reported as a routine `404 "That record does not
+ * exist."` with nothing logged anywhere. `data/http.ts` deliberately leaves the
+ * dangling codes OUT of its code map so they take its logged-500 branch — read
+ * the comment there before adding them to it.
+ */
+
+import {
+  isJustifying,
+  isValidWaiverCode,
+  normalizeJustification,
+} from "./waiver-codes";
+import { isNotificationTemplate } from "./types";
+import {
+  DEFAULT_OPERATOR_ID,
+  SEED_FLOORS,
+  SEED_ORDERS,
+  SEED_PLANS,
+  SEED_PRODUCTS,
+  SEED_PROMOTIONS,
+  SEED_RETURNS,
+  SEED_OPERATORS,
+} from "./seed";
+import type {
+  Category,
+  CommerceStoreState,
+  MarginFloor,
+  MarginPosition,
+  MarginWaiver,
+  Operator,
+  Order,
+  OrderException,
+  OrderNotification,
+  OrderStatus,
+  Product,
+  Promotion,
+  RestockPlan,
+  ReturnRequest,
+} from "./types";
+
+export { DEFAULT_OPERATOR_ID };
+
+const DAY_MS = 86_400_000;
+
+/**
+ * The top of the `marginPosition` scale — the absolute margin a per-row bar
+ * reads as "full". Margins above this are rare enough in this range that giving
+ * them their own headroom would squash the interesting band, where the floor
+ * sits, into the bottom fifth of the bar.
+ *
+ * NOT the top of a ladder rail: the ladder plots a floor-RELATIVE axis
+ * (`derive.ladderRatio`), which is what puts every category's floor line at one
+ * height. Mirrored in `derive.LADDER_CEILING`.
+ */
+export const LADDER_CEILING = 0.75;
+
+/** Full ISO timestamp, n days before now. Negative n is in the future. */
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * DAY_MS).toISOString();
+}
+
+/** `YYYY-MM-DD`, n days from now. Negative n is in the past. */
+function daysFromNowDate(days: number): string {
+  return new Date(Date.now() + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+/** Whole days between an ISO timestamp and now. Never negative. */
+export function ageInDays(iso: string): number {
+  return Math.max(
+    0,
+    Math.floor((Date.now() - new Date(iso).getTime()) / DAY_MS),
+  );
+}
+
+/**
+ * Turn the relative-offset seed into dated records. Called at module init and
+ * again on every `reset()`, so a presenter Reset re-freshens the order aging
+ * rather than restoring timestamps that were already stale.
+ */
+function materialize(): CommerceStoreState {
+  return {
+    floors: SEED_FLOORS.map((f) => ({ ...f })),
+    products: SEED_PRODUCTS.map((p) => ({ ...p })),
+    orders: SEED_ORDERS.map((o) => ({
+      id: o.id,
+      number: o.number,
+      customerName: o.customerName,
+      customerEmail: o.customerEmail,
+      channel: o.channel,
+      destination: o.destination,
+      placedAt: daysAgoIso(o.placedDaysAgo),
+      status: o.status,
+      exception: o.exception,
+      lines: o.lines.map((l) => ({ ...l })),
+      total: o.total,
+      notes: [],
+    })),
+    notifications: [],
+    returns: SEED_RETURNS.map((r) => ({
+      id: r.id,
+      orderId: r.orderId,
+      orderNumber: r.orderNumber,
+      customerName: r.customerName,
+      productId: r.productId,
+      reason: r.reason,
+      detail: r.detail,
+      requestedAt: daysAgoIso(r.requestedDaysAgo),
+      status: r.status,
+      itemValue: r.itemValue,
+      refundAmount: r.refundAmount,
+    })),
+    promotions: SEED_PROMOTIONS.map((p) => ({
+      id: p.id,
+      name: p.name,
+      productId: p.productId,
+      discountPercent: p.discountPercent,
+      startsAt: daysFromNowDate(p.startsInDays),
+      endsAt: daysFromNowDate(p.endsInDays),
+      submittedBy: p.submittedBy,
+      submittedAt: daysAgoIso(p.submittedDaysAgo),
+      status: p.status,
+      marginWaiverId: null,
+    })),
+    waivers: [],
+    plans: SEED_PLANS.map((p) => ({
+      id: p.id,
+      vendor: p.vendor,
+      season: p.season,
+      summary: p.summary,
+      highlights: [...p.highlights],
+      lines: p.lines.map((l) => ({ ...l })),
+      schedule: p.schedule.map((s) => ({ ...s })),
+      filedAt: daysAgoIso(p.filedDaysAgo),
+      filedBy: p.filedBy,
+    })),
+    operators: SEED_OPERATORS.map((o) => ({ ...o })),
+  };
+}
+
+let state: CommerceStoreState = materialize();
+
+/** Monotonic suffix so generated ids are readable and stable within a run. */
+let counter = 0;
+function nextId(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${Date.now().toString(36)}${counter.toString(36)}`;
+}
+
+export function reset(): void {
+  state = materialize();
+  counter = 0;
+}
+
+// ── Reads ───────────────────────────────────────────────────────────────────
+
+export const products = (): Product[] => state.products;
+export const floors = (): MarginFloor[] => state.floors;
+export const orders = (): Order[] => state.orders;
+export const notifications = (): OrderNotification[] => state.notifications;
+export const returns = (): ReturnRequest[] => state.returns;
+export const promotions = (): Promotion[] => state.promotions;
+export const waivers = (): MarginWaiver[] => state.waivers;
+export const plans = (): RestockPlan[] => state.plans;
+export const operators = (): Operator[] => state.operators;
+
+export function product(id: string): Product | undefined {
+  return state.products.find((p) => p.id === id);
+}
+
+export function order(id: string): Order | undefined {
+  // Accept the human-facing order NUMBER as well as the id. The agent resolves
+  // "order 4471" from context and either spelling is a reasonable thing for it
+  // to send; refusing one of them would be a routing failure dressed as a 404.
+  return (
+    state.orders.find((o) => o.id === id) ??
+    state.orders.find((o) => o.number === id)
+  );
+}
+
+export function floorFor(category: Category): MarginFloor {
+  const found = state.floors.find((f) => f.category === category);
+  // Every product carries a Category from the union and the seed defines a
+  // floor for all five, so this is unreachable — but throwing a coded error
+  // beats returning a zeroed floor that would make every margin look healthy.
+  if (!found) throw new Error("UNKNOWN_CATEGORY");
+  return found;
+}
+
+// ── Derived ─────────────────────────────────────────────────────────────────
+
+/** Gross margin at a given price. Guards a zero price rather than dividing by it. */
+export function marginAt(price: number, unitCost: number): number {
+  if (!Number.isFinite(price) || price <= 0) return 0;
+  return (price - unitCost) / price;
+}
+
+/** The price a discount actually sells at. Rounded to cents, not to dollars. */
+export function discountedPrice(
+  listPrice: number,
+  discountPercent: number,
+): number {
+  return Math.round(listPrice * (1 - discountPercent / 100) * 100) / 100;
+}
+
+/**
+ * Where a margin sits against its category floor. `ratio` is clamped to [0, 1]
+ * because it drives the dot's position on the ladder rail; `belowFloor` is
+ * computed from the RAW comparison, so clamping never hides a violation.
+ * Keeping those two separate is what lets a below-floor SKU render pinned to the
+ * bottom of the rail AND flagged.
+ */
+export function marginPosition(
+  category: Category,
+  margin: number,
+): MarginPosition {
+  const { floor, target } = floorFor(category);
+  const span = LADDER_CEILING - floor;
+  const raw = span === 0 ? 0.5 : (margin - floor) / span;
+  return {
+    category,
+    margin,
+    floor,
+    target,
+    ratio: Math.min(1, Math.max(0, raw)),
+    belowFloor: margin < floor,
+  };
+}
+
+export function isBelowFloor(item: Product): boolean {
+  return (
+    marginAt(item.listPrice, item.unitCost) < floorFor(item.category).floor
+  );
+}
+
+/**
+ * BEAT 6, the discriminating half. A waiver only counts when it is filed
+ * against THIS promotion, has been finalized to `approved`, AND carries a
+ * justifying code. A decoy code satisfies the first two and fails the third —
+ * which is exactly why "the agent filed a waiver" is not the same as "the agent
+ * cleared the gate".
+ */
+export function hasApprovedJustifyingWaiver(promotionId: string): boolean {
+  return state.waivers.some(
+    (w) =>
+      w.promotionId === promotionId &&
+      w.status === "approved" &&
+      isJustifying(w.code),
+  );
+}
+
+export function waiversFor(promotionId: string): MarginWaiver[] {
+  return state.waivers.filter((w) => w.promotionId === promotionId);
+}
+
+/** The margin a promotion would actually trade at once its discount applies. */
+export function promotionMargin(promotion: Promotion): number | null {
+  const item = product(promotion.productId);
+  if (!item) return null;
+  return marginAt(
+    discountedPrice(item.listPrice, promotion.discountPercent),
+    item.unitCost,
+  );
+}
+
+/** The gate, as a pure predicate. `null` = allowed; a string = the refusal code. */
+export function promotionApprovalBlocker(promotion: Promotion): string | null {
+  if (promotion.status !== "pending") return "ALREADY_DECIDED";
+  const item = product(promotion.productId);
+  // NOT a not-found: the promotion the caller named exists. A promotion pointing
+  // at a product that does not is our broken invariant, so it gets a code the
+  // routes turn into a logged 500 rather than a 404 the agent would "fix" by
+  // retrying with a different id.
+  if (!item) return "DANGLING_PRODUCT_REF";
+  const margin = marginAt(
+    discountedPrice(item.listPrice, promotion.discountPercent),
+    item.unitCost,
+  );
+  if (margin >= floorFor(item.category).floor) return null;
+  if (hasApprovedJustifyingWaiver(promotion.id)) return null;
+  return "BELOW_MARGIN_FLOOR";
+}
+
+// ── The order state machine ─────────────────────────────────────────────────
+
+/**
+ * The statuses an order has SETTLED into. Two consequences, and both are rules
+ * rather than conventions (see `orderStatusBlocker`): nothing moves OUT of one,
+ * and nothing IN one may carry an exception.
+ */
+const SETTLED_STATUSES: readonly OrderStatus[] = ["fulfilled", "cancelled"];
+
+const isSettled = (status: OrderStatus): boolean =>
+  SETTLED_STATUSES.includes(status);
+
+/**
+ * Where an order in each status may go next — the transition table, declared
+ * once, here, because this is the layer that owns the invariant. The routes and
+ * the Orders page both write through `setOrderStatus`, so neither gets to hold
+ * its own opinion about what is legal.
+ *
+ * A `Record` keyed on the union (rather than the `Map` `http.ts` needs) is the
+ * right shape precisely BECAUSE the key set is closed: TypeScript then refuses
+ * an incomplete table, so adding a sixth status cannot compile until someone
+ * has said where it may go. Nothing untrusted is ever used as a key — the
+ * lookup key is the order's OWN status, and the candidate is checked with
+ * `includes`.
+ *
+ *  - `open` may go anywhere, including to itself: the Orders page's
+ *    "clear the exception" control PATCHes `{status:"open", exception:"none"}`
+ *    onto rows that are already open.
+ *  - `on-hold` may return to `open` (released) or be `cancelled`, and may be
+ *    re-held to restate the exception — but it may NOT jump straight to
+ *    `fulfilled`. A hold exists to STOP fulfillment; shipping out of one
+ *    contradicts the thing the hold did. Release it first. (Same precondition
+ *    class as `issueRefund`'s "a return has to be approved before it can be
+ *    refunded".)
+ *  - `fulfilled` and `cancelled` are terminal, which is what makes
+ *    `cancelled → open` — resurrecting a cancelled order — unrepresentable.
+ */
+export const ORDER_TRANSITIONS: Record<OrderStatus, readonly OrderStatus[]> = {
+  open: ["open", "on-hold", "fulfilled", "cancelled"],
+  "on-hold": ["on-hold", "open", "cancelled"],
+  fulfilled: [],
+  cancelled: [],
+};
+
+/**
+ * Whether a (status, exception) PAIR is one an order may legally hold.
+ *
+ * The exception queue and the `valueAtRisk` KPI the demo narrates are both
+ * derived from `exception !== "none"`, so a settled order that kept an
+ * exception would inflate both — a shipped order counted as money still at
+ * risk. Exported so the seed can be checked against the SAME rule the mutation
+ * enforces (`store.test.ts`) rather than against a second copy of it.
+ */
+export function isLegalOrderState(
+  status: OrderStatus,
+  exception: OrderException,
+): boolean {
+  return !isSettled(status) || exception === "none";
+}
+
+/**
+ * The order state machine, as a pure predicate — `null` = allowed, a string =
+ * the refusal code. Mirrors `promotionApprovalBlocker`'s shape.
+ *
+ * `exception` is the OPTIONAL restatement a caller may send; when it is omitted
+ * the order keeps the one it has, so the pair being validated is the pair the
+ * order would actually end up in. That is why fulfilling an exception-bearing
+ * order is refused unless the caller clears the exception in the same write:
+ * settling an order is a decision about the exception too, and making it
+ * explicit beats silently dropping the flag.
+ */
+export function orderStatusBlocker(
+  current: Order,
+  status: OrderStatus,
+  exception?: OrderException,
+): string | null {
+  if (isSettled(current.status)) return "ORDER_ALREADY_SETTLED";
+  if (!ORDER_TRANSITIONS[current.status].includes(status))
+    return "ILLEGAL_ORDER_TRANSITION";
+  if (!isLegalOrderState(status, exception ?? current.exception))
+    return "EXCEPTION_ON_SETTLED_ORDER";
+  return null;
+}
+
+// ── Mutations ───────────────────────────────────────────────────────────────
+
+/** BEAT 5, step 1. Puts an order on hold and records why. */
+export function setOrderStatus(
+  id: string,
+  status: OrderStatus,
+  exception?: OrderException,
+): Order {
+  const target = order(id);
+  if (!target) throw new Error("NOT_FOUND");
+  const blocker = orderStatusBlocker(target, status, exception);
+  if (blocker) throw new Error(blocker);
+  target.status = status;
+  if (exception) target.exception = exception;
+  return target;
+}
+
+/**
+ * Set an order's exception and NOTHING else — deliberately status-free.
+ *
+ * The Orders page's "Clear the exception" button used to PATCH
+ * `{ status: "open", exception: "none" }`, so clearing the exception on an order
+ * beat 5 had just put on hold silently RELEASED the hold as well: the first of
+ * the stored procedure's three writes disappeared while the control claimed only
+ * to have cleared a flag. A mutation that names one field cannot do that, which
+ * is why the status-free path exists at this layer rather than as a
+ * read-modify-write in the caller (which would race, and would have to re-assert
+ * a status it never meant to touch).
+ *
+ * Needs no state-machine precondition when CLEARING: `"none"` is the one
+ * exception value every status may legally hold, so clearing can only ever move
+ * an order TOWARDS a legal pair, never into an illegal one. SETTING one does
+ * need it — see below.
+ */
+export function setOrderException(
+  id: string,
+  exception: OrderException,
+): Order {
+  const target = order(id);
+  if (!target) throw new Error("NOT_FOUND");
+  // Same already-settled class the status writer refuses, by the one path that
+  // does not consult the state machine: pinning a live exception onto a fulfilled
+  // or cancelled order puts a settled row back into the exception queue and back
+  // into the `valueAtRisk` KPI the room is asked to read as money still at risk.
+  // Single-sourced through `isLegalOrderState`, so this path and
+  // `orderStatusBlocker` cannot drift apart, and so clearing stays legal on every
+  // status.
+  if (!isLegalOrderState(target.status, exception))
+    throw new Error("EXCEPTION_ON_SETTLED_ORDER");
+  target.exception = exception;
+  return target;
+}
+
+/**
+ * Bounds on the free text beat 5's writes accept.
+ *
+ * These are not cosmetic. A note's text and a notification's template are BOTH
+ * rendered on the Orders page and BOTH fed to the beat-3b on-screen readable
+ * (`latestNote` and `recentNotifications[].template` in `pages/orders.tsx`), so
+ * whatever lands in the record is read back to the model as app state. An
+ * unbounded field lets a caller push an essay — or something shaped like
+ * instructions — through a durable record and into the next prompt. Refusing at
+ * the store means every writer is bounded, not just the route that exists today.
+ *
+ * The values are sized for what the demo actually sends: an operator's display
+ * name, and the one-sentence note the `postOrderNote` tool asks the model for.
+ */
+export const MAX_ACTOR_NAME = 80;
+export const MAX_NOTE_TEXT = 280;
+
+/** BEAT 5, step 3. The 🚨 prefix is forced by the tool, not by this layer. */
+export function addOrderNote(id: string, text: string, author: string): Order {
+  const target = order(id);
+  if (!target) throw new Error("NOT_FOUND");
+  if (text.length > MAX_NOTE_TEXT) throw new Error("NOTE_TOO_LONG");
+  if (author.length > MAX_ACTOR_NAME) throw new Error("ACTOR_NAME_TOO_LONG");
+  target.notes.unshift({
+    id: nextId("note"),
+    text,
+    author,
+    createdAt: new Date().toISOString(),
+  });
+  return target;
+}
+
+/**
+ * BEAT 5, step 2. A real, listed record — not a console log dressed as one.
+ *
+ * `template` is typed `string` because it arrives off the wire, and is narrowed
+ * here against `NOTIFICATION_TEMPLATES` rather than trusted: the four templates
+ * are a closed set, and an off-vocabulary value would be persisted, rendered raw
+ * on the Orders page and handed to the beat-3b readable for the agent to narrate.
+ */
+export function notifyCustomer(
+  id: string,
+  template: string,
+  sentBy: string,
+): OrderNotification {
+  const target = order(id);
+  if (!target) throw new Error("NOT_FOUND");
+  if (!isNotificationTemplate(template)) throw new Error("UNKNOWN_TEMPLATE");
+  if (sentBy.length > MAX_ACTOR_NAME) throw new Error("ACTOR_NAME_TOO_LONG");
+  const notification: OrderNotification = {
+    id: nextId("ntf"),
+    orderId: target.id,
+    template,
+    sentAt: new Date().toISOString(),
+    sentBy,
+  };
+  state.notifications.unshift(notification);
+  return notification;
+}
+
+/**
+ * BEAT 3a. The figure arrives here straight from the chat card the merchant
+ * typed it into; it is never in a prompt, a tool argument the model authored,
+ * or a transcript. The caller gets back the return record WITHOUT the amount
+ * echoed into any agent-visible string — see the route and the tool.
+ */
+export function issueRefund(id: string, amount: number): ReturnRequest {
+  const target = state.returns.find((r) => r.id === id);
+  if (!target) throw new Error("NOT_FOUND");
+  if (target.status === "refunded") throw new Error("ALREADY_REFUNDED");
+  // A refund SETTLES the return terminally, so the decision has to exist
+  // first: `requested` was never approved and `declined` was refused outright.
+  // The Returns page only offers the control on an approved row; this is that
+  // same rule where the invariant actually lives, which matters because the
+  // agent's return finder matches on a fuzzy substring — a loose phrase can
+  // land on a row nobody decided.
+  if (target.status !== "approved") throw new Error("RETURN_NOT_APPROVED");
+  if (!Number.isFinite(amount) || amount <= 0)
+    throw new Error("INVALID_AMOUNT");
+  // A refund above what was charged is a data-entry slip, not a policy call —
+  // refuse it here rather than letting it quietly distort the margin figures
+  // the whole app is about.
+  if (amount > target.itemValue) throw new Error("REFUND_EXCEEDS_VALUE");
+  target.refundAmount = Math.round(amount * 100) / 100;
+  target.status = "refunded";
+  return target;
+}
+
+export function decideReturn(
+  id: string,
+  status: "approved" | "declined",
+): ReturnRequest {
+  const target = state.returns.find((r) => r.id === id);
+  if (!target) throw new Error("NOT_FOUND");
+  if (target.status === "refunded") throw new Error("ALREADY_REFUNDED");
+  // Same precondition class as `declinePromotion`: a decision only applies to a
+  // return still awaiting one. Without it a `declined` return could be flipped
+  // to `approved` and then refunded, which would launder the refusal the guard
+  // in `issueRefund` exists to respect. The refunded case above is kept ahead of
+  // this so a settled return still reports the more specific code.
+  if (target.status !== "requested") throw new Error("ALREADY_DECIDED");
+  target.status = status;
+  return target;
+}
+
+/** BEAT 3d. The durable artifact. */
+export function filePlan(input: {
+  vendor: string;
+  season: string;
+  summary: string;
+  highlights: string[];
+  lines: { sku: string; name: string; landedCost: number; units: number }[];
+  schedule: { week: string; item: string }[];
+  filedBy: string;
+}): RestockPlan {
+  const plan: RestockPlan = {
+    id: nextId("pln"),
+    vendor: input.vendor,
+    season: input.season,
+    summary: input.summary,
+    highlights: input.highlights.slice(0, 3),
+    lines: input.lines.slice(0, 8),
+    schedule: input.schedule.slice(0, 8),
+    filedAt: new Date().toISOString(),
+    filedBy: input.filedBy,
+  };
+  state.plans.unshift(plan);
+  return plan;
+}
+
+// ── BEAT 6: the unlock ──────────────────────────────────────────────────────
+
+export function openMarginWaiver(
+  promotionId: string,
+  code: string,
+  /**
+   * `unknown`, not `string`: this is a model-authored value straight off a JSON
+   * body, and `normalizeJustification` is the only thing that decides whether it
+   * is a justification at all. Declaring it `string` invited the caller to
+   * `String()`-coerce first, which turns `{}` into 15 passing characters.
+   */
+  justification: unknown,
+): MarginWaiver {
+  const promotion = state.promotions.find((p) => p.id === promotionId);
+  if (!promotion) throw new Error("NOT_FOUND");
+  // Same precondition class as `declinePromotion` and `decideReturn`, and the
+  // same code: a waiver justifies a decision that is still to be made. BOTH
+  // decided states are refused, for two different reasons.
+  //
+  //  - APPROVED: the waiver is retro-justification. It would finalize, and
+  //    `creditWaiver` would write its id onto the promotion — so the Promotions
+  //    page (and the trade brief the room is reading) names a code as the reason
+  //    the markdown became approvable when nobody consulted it. The record gets
+  //    rewritten after the fact, which is worse than the filing being pointless.
+  //  - DECLINED: inert by construction. `declined` is terminal — nothing returns
+  //    a promotion to `pending` — so the waiver can never lift anything, and only
+  //    adds a row to the `waiversFor` history the page renders.
+  //
+  // Checked before the code and the justification so a decided markdown gets an
+  // answer about the RECORD rather than one about its paperwork, which would
+  // invite a retry under a different code. It leaks nothing either way: the
+  // refusal is the same whatever code was sent.
+  if (promotion.status !== "pending") throw new Error("ALREADY_DECIDED");
+  // Rejected WITHOUT enumerating the catalogue — listing the valid codes here
+  // would hand the agent the recipe in one round-trip and beat 6 would stop
+  // proving that it learned anything.
+  if (!isValidWaiverCode(code)) throw new Error("INVALID_WAIVER_CODE");
+  // A justifying code with no written justification is not paperwork, and it
+  // must not lift the floor. Length bounds only — this refusal says nothing
+  // about WHICH codes justify, so it cannot leak beat 6's recipe.
+  const text = normalizeJustification(justification);
+  if (text === null) throw new Error("INVALID_JUSTIFICATION");
+  const waiver: MarginWaiver = {
+    id: nextId("wvr"),
+    promotionId,
+    code,
+    justification: text,
+    status: "draft",
+    openedAt: new Date().toISOString(),
+    finalizedAt: null,
+  };
+  state.waivers.push(waiver);
+  return waiver;
+}
+
+/**
+ * `promotion.marginWaiverId` names the waiver the markdown's approvability RESTS
+ * ON — not whichever waiver was finalized most recently. The distinction only
+ * shows up once a promotion carries more than one waiver, and then it is the
+ * whole point of beat 6: a JUSTIFYING waiver is what cleared the gate, so a
+ * DECOY finalized afterwards must never displace it, or the record (and the
+ * artifact the audience is reading) credits the code that proves nothing.
+ *
+ * So: a justifying link is permanent, and everything else fills the slot. A
+ * decoy still gets linked when it is the only waiver on file — a lone decoy is
+ * honestly the one thing the desk did, and `hasApprovedJustifyingWaiver`, not
+ * this field, is what decides whether the gate lifts.
+ */
+function creditWaiver(promotion: Promotion, waiver: MarginWaiver): void {
+  const credited = state.waivers.find((w) => w.id === promotion.marginWaiverId);
+  if (credited && isJustifying(credited.code)) return;
+  promotion.marginWaiverId = waiver.id;
+}
+
+export function finalizeMarginWaiver(id: string): MarginWaiver {
+  const waiver = state.waivers.find((w) => w.id === id);
+  if (!waiver) throw new Error("NOT_FOUND");
+  if (waiver.status === "approved") throw new Error("ALREADY_FINALIZED");
+  // The same dangling-reference class as `approvePromotion`, resolved BEFORE
+  // anything is written so a corrupted ledger cannot leave a half-finalized
+  // waiver behind. Every waiver took its `promotionId` from a promotion
+  // `openMarginWaiver` had already resolved, and promotions are never deleted, so
+  // a miss here is our bug. This used to be `if (promotion)`: the waiver
+  // finalized, the route answered 200, and the link was dropped in silence —
+  // the one outcome worse than reporting the wrong code.
+  const promotion = state.promotions.find((p) => p.id === waiver.promotionId);
+  if (!promotion) throw new Error("DANGLING_PROMOTION_REF");
+  // The other half of `openMarginWaiver`'s precondition, and the reason that one
+  // cannot carry it alone: a draft opened legitimately WHILE the markdown was
+  // pending can still be finalized after it was approved or declined, and
+  // `creditWaiver` below would then write the link onto a decided record — the
+  // "attaches itself after the fact" case, reached without ever filing against a
+  // decided promotion. Resolved here, before any write, so a refusal leaves no
+  // half-finalized waiver behind (same discipline as the dangling check above).
+  if (promotion.status !== "pending") throw new Error("ALREADY_DECIDED");
+  waiver.status = "approved";
+  waiver.finalizedAt = new Date().toISOString();
+  // Link it for display. A DECOY waiver is genuinely on file and is still
+  // linked when nothing better is credited — but it must never DISPLACE a
+  // justifying one, or the page would name a non-justifying code as the reason
+  // the markdown became approvable. `creditWaiver` owns that rule; only
+  // `hasApprovedJustifyingWaiver` decides whether the gate actually lifts.
+  //
+  // `promotion` is resolved above, before any write, so the dangling-reference
+  // case throws instead of silently dropping the link.
+  creditWaiver(promotion, waiver);
+  return waiver;
+}
+
+/**
+ * BEAT 6, the gate itself. Throws `BELOW_MARGIN_FLOOR` — a SYMPTOM-ONLY code.
+ * Neither this nor the route's message may ever mention margin waivers; naming
+ * the fix in the error is the single easiest way to destroy this beat.
+ */
+export function approvePromotion(id: string): {
+  promotion: Promotion;
+  product: Product;
+} {
+  const promotion = state.promotions.find((p) => p.id === id);
+  if (!promotion) throw new Error("NOT_FOUND");
+  const blocker = promotionApprovalBlocker(promotion);
+  if (blocker) throw new Error(blocker);
+
+  const item = product(promotion.productId);
+  // Unreachable through the blocker above, which already reports this exact
+  // state as `DANGLING_PRODUCT_REF`; kept because `product()` is
+  // `Product | undefined` and this function promises a `Product`. It raises the
+  // same integrity code, never the plain `NOT_FOUND` it used to.
+  if (!item) throw new Error("DANGLING_PRODUCT_REF");
+  promotion.status = "approved";
+  return { promotion, product: item };
+}
+
+export function declinePromotion(id: string): Promotion {
+  const promotion = state.promotions.find((p) => p.id === id);
+  if (!promotion) throw new Error("NOT_FOUND");
+  if (promotion.status !== "pending") throw new Error("ALREADY_DECIDED");
+  promotion.status = "declined";
+  return promotion;
+}
+
+/** The whole ledger, for the client's single-fetch hook. */
+export function snapshot(): CommerceStoreState {
+  return state;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/types.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/types.ts
@@ -1,0 +1,306 @@
+/**
+ * Bellwether's domain model. Server-safe (plain types + string unions, no React)
+ * so `store.ts`, the REST routes and the agent-side modules can all import it.
+ */
+
+/**
+ * The merchandising categories, as a const tuple with the union derived from it —
+ * the same shape as `ORDER_EXCEPTIONS` and `NOTIFICATION_TEMPLATES` below, for
+ * the same reason plus one more.
+ *
+ * The extra reason: a tuple is what `z.enum()` accepts. A category parameter the
+ * MODEL fills — `getProducts` in `sandbox-functions.ts`, `showMarginLadder` in
+ * `tools.tsx` — must advertise this exact vocabulary and refuse anything else,
+ * because a near-miss ("Shoes", "footwear") silently filters to nothing and the
+ * generated view renders convincingly blank. With the list only available as
+ * `readonly Category[]` the schema could not be an enum, so it was `z.string()`
+ * and the vocabulary never reached the model at all.
+ */
+export const CATEGORIES = [
+  "Outerwear",
+  "Knitwear",
+  "Footwear",
+  "Accessories",
+  "Home",
+] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+
+/**
+ * The minimum gross margin merchandising will trade a category at. `floor` is
+ * the hard edge the BELOW_MARGIN_FLOOR gate is enforced against (see
+ * store.promotionApprovalBlocker); `target` is what the category is planned to
+ * earn and is what the ladder renders its target tick at.
+ */
+export interface MarginFloor {
+  category: Category;
+  /** Gross margin as a ratio, e.g. 0.42 for 42%. */
+  floor: number;
+  /** The planned margin for the category. Always above `floor`. */
+  target: number;
+}
+
+export type ProductStatus = "live" | "backorder" | "discontinued";
+
+export interface Product {
+  id: string;
+  /** The merchandising SKU code shown on every row, e.g. "BW-CDR-HDY". */
+  sku: string;
+  name: string;
+  category: Category;
+  /** Full retail price in whole dollars. */
+  listPrice: number;
+  /** Landed unit cost in whole dollars. Drives every margin figure. */
+  unitCost: number;
+  /** Units on hand across all locations. */
+  inventory: number;
+  /** Units sold in the trailing 30 days — the velocity signal on the catalog. */
+  trailing30Units: number;
+  status: ProductStatus;
+  vendor: string;
+}
+
+/**
+ * An order's lifecycle state, declared as a const tuple for the same reason
+ * `ORDER_EXCEPTIONS` below is: the Orders page's status controls and the
+ * `showOrderQueue` lever schema are BUILT from this list
+ * (`ORDER_STATUS_FILTERS` in `derive.ts`) rather than repeating it, so a status
+ * the agent can ask for and the page has no control for cannot exist.
+ *
+ * Listed in the order the page draws the controls in.
+ */
+export const ORDER_STATUSES = [
+  "open",
+  "on-hold",
+  "fulfilled",
+  "cancelled",
+] as const;
+
+export type OrderStatus = (typeof ORDER_STATUSES)[number];
+
+/**
+ * Why an order needs a human. `"none"` is the happy path; everything else puts
+ * the order in the exception queue that the Orders page is built around.
+ *
+ * Declared as a const tuple and the union derived from it, so the Orders page's
+ * filter controls can be BUILT from this list rather than repeating it. Beat 3c
+ * turns on every value the agent can set having a control that lights up when it
+ * does; a hand-copied subset silently filtered the rows with nothing on screen
+ * crediting the assistant. See `EXCEPTION_FILTERS` in `derive.ts`.
+ */
+export const ORDER_EXCEPTIONS = [
+  "none",
+  "fraud-review",
+  "address-invalid",
+  "oversell",
+  "carrier-delay",
+  "payment-declined",
+] as const;
+
+export type OrderException = (typeof ORDER_EXCEPTIONS)[number];
+
+export interface OrderNote {
+  id: string;
+  text: string;
+  author: string;
+  createdAt: string;
+}
+
+/**
+ * The messages Bellwether will actually send a customer. A CLOSED set, declared
+ * here rather than only in the `notifyCustomer` tool's zod enum, because the
+ * route is what persists the record and the store is what the Orders page and
+ * the beat-3b readable read back. The tool's enum is built FROM this list
+ * (`src/skins/commerce/tools.tsx`) so there is one vocabulary, not two that
+ * drift: a template that only the wire accepts would be rendered raw on the page
+ * and narrated by the agent as though it were app state.
+ */
+export const NOTIFICATION_TEMPLATES = [
+  "verification-required",
+  "address-confirmation",
+  "delay-apology",
+  "restock-eta",
+] as const;
+
+export type NotificationTemplate = (typeof NOTIFICATION_TEMPLATES)[number];
+
+export function isNotificationTemplate(
+  value: unknown,
+): value is NotificationTemplate {
+  return (NOTIFICATION_TEMPLATES as readonly unknown[]).includes(value);
+}
+
+/** A customer notification the app has actually sent — beat 5's second write. */
+export interface OrderNotification {
+  id: string;
+  orderId: string;
+  template: NotificationTemplate;
+  sentAt: string;
+  sentBy: string;
+}
+
+export interface OrderLine {
+  productId: string;
+  quantity: number;
+  /** Unit price actually charged, after any promotion. */
+  unitPrice: number;
+}
+
+export interface Order {
+  id: string;
+  /** The human-facing order number, e.g. "4471". */
+  number: string;
+  customerName: string;
+  customerEmail: string;
+  channel: "web" | "retail" | "wholesale" | "marketplace";
+  destination: string;
+  /** ISO timestamp, materialized from the seed's relative offset at store init. */
+  placedAt: string;
+  status: OrderStatus;
+  exception: OrderException;
+  lines: OrderLine[];
+  /** Order total in whole dollars. */
+  total: number;
+  notes: OrderNote[];
+}
+
+export type ReturnReason =
+  | "sizing"
+  | "damaged"
+  | "not-as-described"
+  | "changed-mind"
+  | "late-delivery";
+
+export type ReturnStatus = "requested" | "approved" | "refunded" | "declined";
+
+/**
+ * BEAT 3a — the refundable object. The goodwill figure is typed by the merchant
+ * into a card in the chat and goes straight to REST; it is never a tool argument
+ * the model authored, and it never appears in a tool result.
+ */
+export interface ReturnRequest {
+  id: string;
+  orderId: string;
+  orderNumber: string;
+  customerName: string;
+  productId: string;
+  reason: ReturnReason;
+  detail: string;
+  requestedAt: string;
+  status: ReturnStatus;
+  /** What the item was originally charged at. */
+  itemValue: number;
+  /** Set only once a refund has actually been issued. */
+  refundAmount: number | null;
+}
+
+export type PromotionStatus = "pending" | "approved" | "declined";
+
+/**
+ * BEAT 6 — the gated object. Approving one flips `status` to `"approved"` and
+ * writes NOTHING onto the product (`approvePromotion` in `store.ts`; it returns
+ * the joined product only so the route can echo it). There is no live-markdown
+ * field to write, and that is deliberate: the markdown price and the margin it
+ * would trade at are DERIVED from `listPrice` + `discountPercent` wherever a
+ * promotion is shown (`discountedPrice` / `promotionMargin` in `derive.ts`),
+ * while the catalog and the margin ladder stay at LIST price by design
+ * (`productMargin`). Do not "restore" a product-level discount here — it would
+ * double-count against the derived figure and move the ladder.
+ *
+ * Approval is refused with 422 BELOW_MARGIN_FLOOR when the discounted margin
+ * sits under the category's floor and no APPROVED, JUSTIFYING margin waiver is
+ * on file against this promotion. The gate reads waivers by `promotionId`
+ * (`hasApprovedJustifyingWaiver`), NOT the `marginWaiverId` link below, which
+ * exists for display.
+ */
+export interface Promotion {
+  id: string;
+  name: string;
+  productId: string;
+  /** Whole percent off list, e.g. 40. */
+  discountPercent: number;
+  /** ISO date the markdown is meant to go live. */
+  startsAt: string;
+  /** ISO date it ends. */
+  endsAt: string;
+  submittedBy: string;
+  submittedAt: string;
+  status: PromotionStatus;
+  /**
+   * The waiver this markdown's approvability RESTS ON — null until one is
+   * finalized. A justifying link is never displaced by a decoy finalized later
+   * (see `creditWaiver` in `store.ts`), so this field can be read as "the code
+   * that cleared the floor" whenever one exists.
+   */
+  marginWaiverId: string | null;
+}
+
+export type MarginWaiverStatus = "draft" | "approved";
+
+/**
+ * BEAT 6 — the unlock artifact. Filed under a code from the catalogue in
+ * `waiver-codes.ts`; only a JUSTIFYING code lifts the gate once the waiver is
+ * finalized.
+ */
+export interface MarginWaiver {
+  id: string;
+  promotionId: string;
+  code: string;
+  justification: string;
+  status: MarginWaiverStatus;
+  openedAt: string;
+  finalizedAt: string | null;
+}
+
+/**
+ * BEAT 3d — the durable artifact. Written to the STORE, not to the thread, so
+ * deleting the conversation leaves it standing on the Catalog page.
+ */
+export interface RestockPlan {
+  id: string;
+  vendor: string;
+  season: string;
+  summary: string;
+  /** At most three; `store.filePlan` truncates (the tool's schema also caps at 3). */
+  highlights: string[];
+  /** The SKUs the plan covers, with the landed cost the price sheet quoted. */
+  lines: { sku: string; name: string; landedCost: number; units: number }[];
+  /** Launch schedule, typically lifted from an uploaded price sheet. */
+  schedule: { week: string; item: string }[];
+  filedAt: string;
+  filedBy: string;
+}
+
+/** The signed-in operator. Bellwether scopes durable memory per person id. */
+export interface Operator {
+  id: string;
+  name: string;
+  role: "merch-lead" | "ops-manager" | "buyer";
+  team: "Merchandising" | "Fulfillment" | "Buying";
+}
+
+/** Everything the store holds. Cloned wholesale on reset. */
+export interface CommerceStoreState {
+  products: Product[];
+  floors: MarginFloor[];
+  orders: Order[];
+  notifications: OrderNotification[];
+  returns: ReturnRequest[];
+  promotions: Promotion[];
+  waivers: MarginWaiver[];
+  plans: RestockPlan[];
+  operators: Operator[];
+}
+
+/** Where a product's margin sits against its category floor — the ladder's core value. */
+export interface MarginPosition {
+  category: Category;
+  /** Gross margin as a ratio at the price being evaluated. */
+  margin: number;
+  floor: number;
+  target: number;
+  /** 0 at the category floor, 1 at the ladder ceiling. Clamped for rendering, NOT for the gate. */
+  ratio: number;
+  /** True when the margin is genuinely under the floor. */
+  belowFloor: boolean;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/waiver-codes.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/waiver-codes.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  isJustifying,
+  isValidWaiverCode,
+  JUSTIFICATION_MAX_LENGTH,
+  JUSTIFICATION_MIN_LENGTH,
+  JUSTIFYING_WAIVER_CODES,
+  MARGIN_WAIVER_CODES,
+  normalizeJustification,
+  waiverCodeLabel,
+} from "./waiver-codes";
+
+/**
+ * BEAT 6's catalogue. These assertions exist because the beat's whole value
+ * rests on a distinction that is invisible in the UI and unenforced by types:
+ * some codes are VALID but do not JUSTIFY. Collapse the two and "the agent filed
+ * a waiver" silently becomes "the agent cleared the gate", which still compiles,
+ * still renders, and quietly turns the demonstration into theatre.
+ */
+describe("margin waiver codes", () => {
+  it("accepts catalogued codes and rejects invented ones", () => {
+    expect(isValidWaiverCode("VENDOR-FUND")).toBe(true);
+    expect(isValidWaiverCode("MERCH-DISC")).toBe(true); // a decoy is still valid
+    expect(isValidWaiverCode("MADE-UP")).toBe(false);
+    expect(isValidWaiverCode("vendor-fund")).toBe(false); // case-sensitive
+  });
+
+  it("splits justifying codes from recorded-only decoys", () => {
+    // Evidence that exists outside the conversation — these lift the gate.
+    expect(isJustifying("VENDOR-FUND")).toBe(true);
+    expect(isJustifying("EOL-CLEAR")).toBe(true);
+    expect(isJustifying("COMP-MATCH")).toBe(true);
+    // Forecasts and judgement calls with nothing on file. Recorded for history,
+    // and they do NOT lift the gate.
+    expect(isJustifying("MERCH-DISC")).toBe(false);
+    expect(isJustifying("VOL-LIFT")).toBe(false);
+    expect(isJustifying("LOYALTY")).toBe(false);
+  });
+
+  it("is not justifying for an invalid code", () => {
+    expect(isJustifying("MADE-UP")).toBe(false);
+  });
+
+  it("offers decoys, so a guess cannot be right by construction", () => {
+    // If every catalogued code justified, an agent that guessed would always
+    // clear the gate and beat 6 would prove nothing about what it learned.
+    const decoys = MARGIN_WAIVER_CODES.filter((c) => !isJustifying(c.code));
+    expect(decoys.length).toBeGreaterThan(0);
+    expect(JUSTIFYING_WAIVER_CODES.length).toBeLessThan(
+      MARGIN_WAIVER_CODES.length,
+    );
+  });
+
+  it("never reveals in its blurbs which codes justify", () => {
+    // The filing UI renders these verbatim. A blurb that named the MECHANISM —
+    // the gate, the floor, whether it justifies — would hand the recipe to
+    // anything that can read the page.
+    //
+    // Deliberately narrow: an earlier version of this regex included `approv`
+    // and tripped on "the approved seasonal plan", which describes the EVIDENCE
+    // on file rather than the code's effect. Matching a code's justification
+    // narrative is a false positive; matching the gate is the real leak.
+    const tell = /justif|gate|floor|override|guarantee/i;
+    for (const entry of MARGIN_WAIVER_CODES) {
+      expect(entry.blurb).not.toMatch(tell);
+    }
+  });
+
+  it("every justifying code is actually in the catalogue", () => {
+    // A typo here would make the gate permanently unopenable.
+    for (const code of JUSTIFYING_WAIVER_CODES) {
+      expect(isValidWaiverCode(code)).toBe(true);
+    }
+  });
+
+  it("labels every catalogued code and falls back to the raw code", () => {
+    for (const entry of MARGIN_WAIVER_CODES) {
+      expect(waiverCodeLabel(entry.code)).toBe(entry.label);
+    }
+    expect(waiverCodeLabel("MADE-UP")).toBe("MADE-UP");
+  });
+});
+
+/**
+ * The written justification a waiver is filed with. A justifying code with an
+ * EMPTY justification used to clear beat 6's floor, which turned the paperwork
+ * half of the unlock into a formality — and the field was unbounded on the way
+ * into a durable store.
+ */
+describe("normalizeJustification", () => {
+  it("accepts a real justification and trims it", () => {
+    expect(normalizeJustification("  signed co-op on file  ")).toBe(
+      "signed co-op on file",
+    );
+  });
+
+  it("rejects the non-answers the field actually attracts", () => {
+    for (const value of ["", " ", "   \n\t", "x", "-", "n/a", "ok", "none"]) {
+      expect(normalizeJustification(value), JSON.stringify(value)).toBeNull();
+    }
+  });
+
+  it("measures the TRIMMED length against both bounds", () => {
+    const pad = " ".repeat(20);
+    expect(
+      normalizeJustification(pad + "c".repeat(JUSTIFICATION_MIN_LENGTH) + pad),
+    ).toHaveLength(JUSTIFICATION_MIN_LENGTH);
+    // One under the floor is not saved by surrounding whitespace...
+    expect(
+      normalizeJustification(
+        pad + "c".repeat(JUSTIFICATION_MIN_LENGTH - 1) + pad,
+      ),
+    ).toBeNull();
+    // ...and one over the ceiling is not saved by it either.
+    expect(
+      normalizeJustification(pad + "c".repeat(JUSTIFICATION_MAX_LENGTH) + pad),
+    ).toHaveLength(JUSTIFICATION_MAX_LENGTH);
+    expect(
+      normalizeJustification("c".repeat(JUSTIFICATION_MAX_LENGTH + 1)),
+    ).toBeNull();
+  });
+
+  it("rejects anything that is not a string", () => {
+    // The routes' house pattern is `String(body?.x ?? "")`, and `String({})` is
+    // the 15-character "[object Object]" — long enough to pass any length floor.
+    // That is why this takes `unknown` rather than trusting a coerced string.
+    expect(String({})).toHaveLength(15); // pins the premise, not the behaviour
+    const wrongTypes = [{}, [], null, undefined, 0, 12345678, true, () => {}];
+    for (const value of wrongTypes) {
+      expect(normalizeJustification(value)).toBeNull();
+    }
+  });
+
+  it("keeps the floor below the ceiling", () => {
+    expect(JUSTIFICATION_MIN_LENGTH).toBeGreaterThan(0);
+    expect(JUSTIFICATION_MIN_LENGTH).toBeLessThan(JUSTIFICATION_MAX_LENGTH);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/data/waiver-codes.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/data/waiver-codes.ts
@@ -1,0 +1,137 @@
+/**
+ * BEAT 6 — the unlock catalogue.
+ *
+ * Approving a markdown that breaks the category margin floor is gated (422
+ * BELOW_MARGIN_FLOOR). The unlock is: file a margin waiver under a code →
+ * finalize it → approve. What makes that a real DEMONSTRATION rather than a
+ * scripted workflow is this catalogue's shape, and all three properties are
+ * load-bearing:
+ *
+ *   1. Only JUSTIFYING codes lift the gate.
+ *   2. DECOY codes are VALID — they file, they finalize, they are recorded in
+ *      the waiver history — and they do NOT justify. So "the agent filed a
+ *      waiver" is not the same as "the agent cleared the gate", and an agent
+ *      that guessed cannot fake its way through.
+ *   3. Unknown codes are rejected WITHOUT enumerating the catalogue. If the
+ *      error listed the valid codes, an agent could brute-force the recipe in
+ *      one round-trip and the demonstration would prove nothing.
+ *
+ * The agent is never told which codes justify. It learns that by watching a
+ * merchandiser file one — mirroring `src/skins/people/data/band-exception-codes.ts`
+ * and `src/skins/banking/data/policy-exception-codes.ts`.
+ */
+
+export interface MarginWaiverCode {
+  code: string;
+  label: string;
+  /** Shown in the filing UI. Never says whether the code justifies. */
+  blurb: string;
+}
+
+/**
+ * Everything the filing UI offers. Deliberately mixed — the justifying and the
+ * decoy codes read equally plausible to someone (or something) guessing.
+ */
+export const MARGIN_WAIVER_CODES: readonly MarginWaiverCode[] = [
+  {
+    code: "VENDOR-FUND",
+    label: "Vendor-funded markdown",
+    blurb: "The supplier is carrying the discount under a signed co-op.",
+  },
+  {
+    code: "EOL-CLEAR",
+    label: "End-of-life clearance",
+    blurb: "The SKU is exiting the range in the approved seasonal plan.",
+  },
+  {
+    code: "COMP-MATCH",
+    label: "Documented price match",
+    blurb: "A competitor's published price is on file with Buying.",
+  },
+  {
+    code: "MERCH-DISC",
+    label: "Merchandiser discretion",
+    blurb: "The category lead is asking for it on judgement alone.",
+  },
+  {
+    code: "VOL-LIFT",
+    label: "Expected volume lift",
+    blurb: "We think the units will make up the margin.",
+  },
+  {
+    code: "LOYALTY",
+    label: "Loyalty goodwill",
+    blurb: "A gesture to repeat customers in the segment.",
+  },
+];
+
+/**
+ * The subset that actually lifts the gate. The common thread is MONEY OR PAPER
+ * THAT EXISTS OUTSIDE THE CONVERSATION — a signed co-op, an approved range exit,
+ * a filed competitor price. The decoys are all forecasts and judgement calls
+ * with nothing on file, which is exactly why trading policy does not accept
+ * them.
+ */
+export const JUSTIFYING_WAIVER_CODES: readonly string[] = [
+  "VENDOR-FUND",
+  "EOL-CLEAR",
+  "COMP-MATCH",
+];
+
+export function isValidWaiverCode(code: string): boolean {
+  return MARGIN_WAIVER_CODES.some((entry) => entry.code === code);
+}
+
+export function isJustifying(code: string): boolean {
+  return JUSTIFYING_WAIVER_CODES.includes(code);
+}
+
+export function waiverCodeLabel(code: string): string {
+  return (
+    MARGIN_WAIVER_CODES.find((entry) => entry.code === code)?.label ?? code
+  );
+}
+
+/**
+ * Bounds on the written justification a waiver is filed with.
+ *
+ * The gate is only as real as the paperwork behind it. A waiver filed under a
+ * JUSTIFYING code with an empty justification used to lift beat 6's floor while
+ * recording nothing whatsoever about why — the code alone did the work, and the
+ * "file the paperwork" half of the demonstration became a formality that the
+ * agent could satisfy by sending `""`. The floor below is what makes the filed
+ * record mean something.
+ *
+ * The ceiling is the other half: this text is written into the durable store and
+ * rendered in the waiver history, so an unbounded field is a storage hazard fed
+ * straight from a model-authored tool argument.
+ *
+ * 8 characters is about two short words — enough for the terse-but-real entries
+ * the field actually attracts ("co-op filed"), and low enough that what fails is
+ * only ever a non-answer: `""`, `"   "`, `"x"`, `"n/a"`, `"ok"`, `"none"`.
+ */
+export const JUSTIFICATION_MIN_LENGTH = 8;
+export const JUSTIFICATION_MAX_LENGTH = 500;
+
+/**
+ * Normalize a filed justification, or `null` when it is not a usable one.
+ *
+ * Takes `unknown` on purpose. The value arrives from a JSON body, and the
+ * routes' house pattern (`String(body?.x ?? "")`) would launder a non-string
+ * into a string that PASSES a length floor — `String({})` is the 15-character
+ * `"[object Object]"`. Rejecting the wrong type here, at the one place the rule
+ * is defined, keeps that unrepresentable rather than guarded per call site.
+ *
+ * Lives beside the catalogue rather than in the route so the rule holds however
+ * a waiver is filed — the agent's `openMarginWaiver` tool, the merchandiser's
+ * own filing panel, and any future caller all reach it through the store. Same
+ * reasoning as the refund ceiling living in `store.issueRefund` rather than in
+ * `POST returns/[id]/refund`.
+ */
+export function normalizeJustification(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length < JUSTIFICATION_MIN_LENGTH) return null;
+  if (trimmed.length > JUSTIFICATION_MAX_LENGTH) return null;
+  return trimmed;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/design-skill.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/design-skill.ts
@@ -1,0 +1,49 @@
+/**
+ * The OGUI design brief, injected as agent context so anything
+ * `generateSandboxedUi` produces looks like it belongs to Bellwether rather than
+ * to a generic dashboard template.
+ *
+ * Written as instructions about RESTRAINT as much as about style: generated UI
+ * defaults to gradient hero numbers and rainbow chart palettes, and either would
+ * clash badly with an app whose entire visual argument is a quiet ink-blue
+ * chrome carrying exactly one loud colour, reserved for markdowns.
+ */
+export const BELLWETHER_DESIGN_SKILL = `
+Bellwether is a commerce operations console. Generated UI must look like part of
+it — a back office behind a storefront, not the storefront.
+
+Palette. Deep ink blue is the only brand colour: hsl(206 72% 30%) for accents and
+fills, hsl(210 66% 21%) for the darker end of any gradient, and a very pale
+hsl(206 62% 95%) for soft backgrounds. Hot rose, hsl(336 78% 44%), is reserved
+for discounts, markdowns and promotions and is used for NOTHING else — it is the
+one colour that has to still mean something after ten screens. Positive is
+hsl(162 58% 33%); anything below policy or otherwise wrong is hsl(4 74% 48%).
+Surfaces are white on a hsl(210 22% 95%) canvas, text is hsl(212 32% 12%) with
+hsl(210 12% 44%) for secondary.
+
+Shape and space. 0.625rem corners on cards, 1px hairline borders in
+hsl(210 20% 89%), one soft shadow, generous padding. No heavy borders, no
+double-outlined cards, no drop shadows on text.
+
+Type. System sans throughout. One weight step between a label and its value, no
+more. Every figure — price, cost, margin percent, unit count, day count — uses
+tabular numerals so columns line up and a changed digit reads as a change.
+
+Products. Any SKU shown gets a small SQUARE tile with its initials, in a
+desaturated colour derived from its name (roughly hsl(H 40% 92%) background with
+hsl(H 48% 28%) text). People get the same tile, round instead of square. Never
+invent product photography.
+
+Margin. When margin appears, show it against its category FLOOR, not on a bare
+axis — the distance from the floor is the whole story, and a margin figure with
+no floor beside it is decoration. Below-floor values are the only thing that ever
+gets the negative colour.
+
+Restraint. One accent per view. Do not build gradient hero numbers, multi-colour
+chart palettes, or decorative icons. Margins, exceptions and cover are the
+interesting part; let them carry the view. Empty states say what to do next,
+never just "no data".
+
+Figures. Never type a number into generated markup. Every value comes from the
+exposed sandbox functions, so the UI stays bound to the real ledger.
+`.trim();

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/floor-unknown.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/floor-unknown.test.tsx
@@ -1,0 +1,405 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { RendererProps } from "@copilotkit/a2ui-renderer";
+import type {
+  CommerceStoreState,
+  MarginFloor,
+  Operator,
+  Product,
+  Promotion,
+} from "./data/types";
+
+/**
+ * THE CLASS: a surface publishing a floor verdict it never checked.
+ *
+ * A category can have NO margin floor on file — reachable, not theoretical (see
+ * `derive.FloorStatus`'s header: an unvalidated `/ledger` cast, a provider that
+ * mounts children on a FAILED first fetch with `floors: []`, `useReportData()`
+ * outside its provider, an empty sandbox snapshot). In that state "is this
+ * markdown below the floor?" has no answer, and `false` is the worst one
+ * available: it is indistinguishable from "checked, and it is fine" on the exact
+ * question the margin ladder and the beat-6 gate are ABOUT.
+ *
+ * Every case below runs a ledger whose SECOND category has no floor, and pins the
+ * three obligations apart, because they are three different lies:
+ *
+ *  - ON SCREEN — an unknown floor must be visibly unknown. Not green, not red,
+ *    and not a bare figure either (a real margin printed in neutral ink with no
+ *    caveat reads as "checked, fine").
+ *  - IN AN AGENT READABLE / SANDBOX DTO — `null`, never `false`, and never a
+ *    silently truncated list. A dropped row is worse than a declared unknown,
+ *    because the model cannot tell the difference.
+ *  - IN A COUNT — `null` or an explicit "not checked" companion, never a green
+ *    `0` that means "we did not look".
+ */
+
+const FLOORS: MarginFloor[] = [
+  { category: "Knitwear", floor: 0.45, target: 0.52 },
+  // NOTE: no `Home` floor. `Home` is a real `Category`, so nothing upstream
+  // refuses the product below — it is simply unmeasurable.
+];
+
+/** Knitwear, floored: 40% off $100/$37 trades at 38.3% against a 45% floor. */
+const CHECKED: Product = {
+  id: "prd-cedar",
+  sku: "BW-CDR-HDY",
+  name: "Cedar Hoodie",
+  category: "Knitwear",
+  listPrice: 100,
+  unitCost: 37,
+  inventory: 120,
+  trailing30Units: 40,
+  status: "live",
+  vendor: "Northline Mills",
+};
+
+/** Knitwear, floored, and genuinely under it at LIST price: 40% vs a 45% floor. */
+const BELOW_AT_LIST: Product = {
+  id: "prd-lark",
+  sku: "BW-LRK-CDG",
+  name: "Lark Cardigan",
+  category: "Knitwear",
+  listPrice: 100,
+  unitCost: 60,
+  inventory: 40,
+  trailing30Units: 12,
+  status: "live",
+  vendor: "Northline Mills",
+};
+
+/** Home, UNfloored: a real 50% margin measured against nothing at all. */
+const UNCHECKED: Product = {
+  id: "prd-ash-vase",
+  sku: "BW-ASH-VSE",
+  name: "Ash Stoneware Vase",
+  category: "Home",
+  listPrice: 100,
+  unitCost: 50,
+  inventory: 80,
+  trailing30Units: 20,
+  status: "live",
+  vendor: "Kiln & Field",
+};
+
+function promotion(overrides: Partial<Promotion>): Promotion {
+  return {
+    id: "promo-cedar",
+    name: "Cedar Hoodie autumn markdown",
+    productId: CHECKED.id,
+    discountPercent: 40,
+    startsAt: new Date(2026, 8, 1).toISOString(),
+    endsAt: new Date(2026, 8, 22).toISOString(),
+    submittedBy: "Theo Vance",
+    submittedAt: new Date(2026, 7, 28).toISOString(),
+    status: "pending",
+    marginWaiverId: null,
+    ...overrides,
+  };
+}
+
+const BELOW = promotion({});
+/** 30% off $100/$50 trades at 28.6% — against a floor nobody wrote down. */
+const UNKNOWN = promotion({
+  id: "promo-vase",
+  name: "Ash Vase clearance",
+  productId: UNCHECKED.id,
+  discountPercent: 30,
+});
+
+const OPERATOR: Operator = {
+  id: "op-nadia",
+  name: "Nadia Okonjo",
+  role: "merch-lead",
+  team: "Merchandising",
+};
+
+function ledger(overrides: Partial<CommerceStoreState> = {}) {
+  return {
+    products: [CHECKED, BELOW_AT_LIST, UNCHECKED],
+    floors: FLOORS,
+    orders: [],
+    notifications: [],
+    returns: [],
+    promotions: [BELOW, UNKNOWN],
+    waivers: [],
+    plans: [],
+    operators: [OPERATOR],
+    ...overrides,
+  } satisfies CommerceStoreState;
+}
+
+const state: { data: CommerceStoreState } = { data: ledger() };
+
+/** Every readable registered during a render, newest last. */
+const readables: { description: string; value: string }[] = [];
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: (entry: { description: string; value: string }) => {
+    readables.push(entry);
+  },
+}));
+
+vi.mock("./data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: state.data,
+    refresh: async () => true,
+    operator: OPERATOR,
+    setOperatorId: () => {},
+  }),
+}));
+
+vi.mock("./components/recording-context", () => ({
+  useRecording: () => ({
+    isRecording: false,
+    steps: [],
+    beginRecording: () => {},
+    endRecording: () => {},
+    logStep: () => {},
+    getDemonstratedCode: () => null,
+    reset: () => {},
+  }),
+}));
+
+const { PromotionsPage } = await import("./pages/promotions");
+const { CatalogPage } = await import("./pages/catalog");
+const { renderers } = await import("./catalog/renderers");
+const { ReportDataProvider } = await import("./report-data");
+const { sandboxFunctions, setSandboxSnapshot } =
+  await import("./sandbox-functions");
+
+beforeEach(() => {
+  state.data = ledger();
+  readables.length = 0;
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The one readable the page under test registered, parsed. */
+const readable = (): Record<string, unknown> => {
+  expect(readables).toHaveLength(1);
+  return JSON.parse(readables[0].value) as Record<string, unknown>;
+};
+
+const rowFor = (parsed: Record<string, unknown>, name: string) => {
+  const rows = parsed.rows as Record<string, unknown>[];
+  const row = rows.find((r) => r.name === name || r.sku === name);
+  if (!row) throw new Error(`No readable row for ${name}`);
+  return row;
+};
+
+/** The tile with this label, as rendered by `primitives.Metric`. */
+const metric = (label: string) => {
+  const node = screen.getByText(label).parentElement;
+  if (!node) throw new Error(`No metric tile labelled ${label}`);
+  return node;
+};
+
+// ── the agent readables ─────────────────────────────────────────────────────
+
+describe("the Promotions readable never publishes an unchecked `false`", () => {
+  it("reports `belowFloor: null` for a markdown with no floor on file", () => {
+    render(<PromotionsPage />);
+    const parsed = readable();
+
+    // The checked case is unaffected — this is the assertion that proves the
+    // null below is about the MISSING floor and not about a broken derivation.
+    expect(rowFor(parsed, BELOW.name).belowFloor).toBe(true);
+
+    const unchecked = rowFor(parsed, UNKNOWN.name);
+    expect(unchecked.floor).toBeNull();
+    expect(unchecked.belowFloor).toBeNull();
+    expect(unchecked.belowFloor).not.toBe(false);
+  });
+
+  it("publishes no green zero for the pending below-floor count", () => {
+    // One pending markdown IS below its floor and one cannot be checked, so
+    // there is no defensible total: `null` plus the companion count.
+    state.data = ledger({ promotions: [UNKNOWN] });
+    render(<PromotionsPage />);
+    const parsed = readable();
+    const book = parsed.book as Record<string, unknown>;
+
+    expect(book.pendingBelowFloor).toBeNull();
+    expect(book.pendingBelowFloor).not.toBe(0);
+    expect(book.pendingWithNoFloorOnFile).toBe(1);
+  });
+
+  it("keeps whole-book figures out of the 'currently viewing' shape", () => {
+    render(<PromotionsPage />);
+    const parsed = readable();
+
+    // The status filter does not narrow these, so they may not sit flat beside
+    // `filters` / `visibleCount` — the defect `orders.tsx` documents as removed.
+    expect(parsed.pendingTotal).toBeUndefined();
+    expect(parsed.pendingBelowFloor).toBeUndefined();
+    expect(parsed.book).toBeTruthy();
+    expect(readables[0].description).toMatch(/book/i);
+  });
+});
+
+describe("the Catalog readable scopes its book-wide floor figures", () => {
+  it("nests the whole-range count, caveat and median under `book`", () => {
+    render(<CatalogPage />);
+    const parsed = readable();
+
+    expect(parsed.belowFloorCount).toBeUndefined();
+    expect(parsed.skusWithNoFloorOnFile).toBeUndefined();
+    expect(parsed.medianMargin).toBeUndefined();
+
+    const book = parsed.book as Record<string, unknown>;
+    expect(book.belowFloorCount).toBeNull();
+    expect(book.skusWithNoFloorOnFile).toBe(1);
+    expect(book.medianMargin).toBeTruthy();
+    expect(readables[0].description).toMatch(/book/i);
+  });
+
+  it("still reports each row's own status, `null` for the unchecked one", () => {
+    render(<CatalogPage />);
+    const parsed = readable();
+    expect(rowFor(parsed, CHECKED.sku).belowFloor).toBe(false);
+    expect(rowFor(parsed, UNCHECKED.sku).belowFloor).toBeNull();
+  });
+});
+
+// ── the screen ──────────────────────────────────────────────────────────────
+
+describe("the Promotions page shows an unchecked markdown as unchecked", () => {
+  it("does not paint its margin as a healthy one", () => {
+    state.data = ledger({ promotions: [UNKNOWN] });
+    const { container } = render(<PromotionsPage />);
+
+    // 28.6% is a REAL figure and stays on screen — what must not happen is it
+    // being coloured as if it had cleared something.
+    const margin = screen.getByText("28.6%");
+    expect(margin.className).not.toContain("text-positive");
+    expect(margin.className).not.toContain("text-negative");
+    // ...and the card says why, rather than leaving a bare percentage that reads
+    // as "checked, fine".
+    expect(container.textContent).toMatch(/no (margin )?floor on file/i);
+  });
+
+  it("shows an em dash, not a green 0, on the 'Break the floor' tile", () => {
+    state.data = ledger({ promotions: [UNKNOWN] });
+    render(<PromotionsPage />);
+
+    const tile = metric("Break the floor");
+    expect(tile.textContent).not.toMatch(/\b0\b/);
+    expect(tile.textContent).toContain("—");
+    expect(tile.textContent).toMatch(/not checked|no category margin floor/i);
+    expect(tile.querySelector(".text-positive")).toBeNull();
+  });
+
+  it("still flags the checked violation in red", () => {
+    state.data = ledger({ promotions: [BELOW] });
+    render(<PromotionsPage />);
+
+    expect(screen.getByText("38.3%").className).toContain("text-negative");
+    expect(metric("Break the floor").textContent).toContain("1");
+  });
+});
+
+const TradingList = renderers.TradingList as (
+  props: RendererProps<{ kind: string }>,
+) => React.ReactElement;
+
+describe("the a2ui pending-markdowns list agrees with its own comment", () => {
+  const renderList = (promotions: Promotion[]) =>
+    render(
+      <ReportDataProvider
+        value={{
+          products: [CHECKED, UNCHECKED],
+          floors: FLOORS,
+          orders: [],
+          promotions,
+        }}
+      >
+        <TradingList
+          props={{ kind: "pendingMarkdowns" }}
+          // The RendererProps render-callback, not React children.
+          // eslint-disable-next-line react/no-children-prop
+          children={() => null as unknown as React.ReactNode}
+        />
+      </ReportDataProvider>,
+    );
+
+  it("says the floor is missing instead of printing a bare dash", () => {
+    const { container } = renderList([UNKNOWN]);
+
+    // The margin is a checked fact and stays. The FLOOR is what is missing, and
+    // an em dash alone reads as "nothing to report" rather than "not checked".
+    expect(screen.getByText("28.6%")).toBeTruthy();
+    expect(container.textContent).toMatch(/no floor on file/i);
+    expect(container.textContent).not.toMatch(/floor\s+—/);
+  });
+
+  it("leaves the checked violation red and floored", () => {
+    const { container } = renderList([BELOW]);
+    expect(screen.getByText("38.3%").className).toContain("text-negative");
+    expect(container.textContent).toContain("floor 45.0%");
+  });
+});
+
+// ── the sandbox DTO ─────────────────────────────────────────────────────────
+
+type SandboxProduct = {
+  sku: string;
+  belowFloor: boolean | null;
+  floorRatio: number | null;
+};
+
+const call = async (name: string, args: unknown): Promise<unknown> => {
+  const found = sandboxFunctions.find((f) => f.name === name);
+  if (!found) throw new Error(`No sandbox function named "${name}"`);
+  return found.handler(args);
+};
+
+describe("the sandbox never hands generated UI a truncated floor list", () => {
+  beforeEach(() => {
+    setSandboxSnapshot(ledger());
+  });
+
+  it("keeps the unchecked SKU in the filtered list, flagged null", async () => {
+    const rows = (await call("getProducts", {
+      notClearingFloorOnly: true,
+    })) as SandboxProduct[];
+
+    // THE DEFECT: filtering on `=== "below"` DROPPED the unmeasurable SKU, so a
+    // generated panel drew a complete-looking list that had silently lost a row.
+    expect(rows.map((r) => r.sku).sort()).toEqual(
+      [BELOW_AT_LIST.sku, UNCHECKED.sku].sort(),
+    );
+    expect(rows.find((r) => r.sku === BELOW_AT_LIST.sku)?.belowFloor).toBe(
+      true,
+    );
+    expect(rows.find((r) => r.sku === UNCHECKED.sku)?.belowFloor).toBeNull();
+  });
+
+  it("tells the model an unchecked SKU is not one of the violations", () => {
+    // The description is the ONLY view the model gets of this shape — no sample
+    // result is ever registered — so "null means unchecked, do not count it" has
+    // to be said there or it is said nowhere.
+    const fn = sandboxFunctions.find((f) => f.name === "getProducts");
+    expect(fn?.description).toMatch(/no floor on file/i);
+    expect(fn?.description).toMatch(/not checked|unchecked/i);
+    expect(fn?.description).toMatch(/never count it|not.*count/i);
+  });
+
+  it("refuses the RENAMED filter's old key instead of silently widening", async () => {
+    // Zod strips an unrecognized key, so without `.strict()` this would come back
+    // as the whole range — a superset drawn under a "below floor" title.
+    await expect(call("getProducts", { belowFloorOnly: true })).rejects.toThrow(
+      /rejected its arguments/i,
+    );
+  });
+
+  it("leaves an unfiltered read complete either way", async () => {
+    const rows = (await call("getProducts", {})) as SandboxProduct[];
+    expect(rows).toHaveLength(3);
+    expect(rows.find((r) => r.sku === CHECKED.sku)?.belowFloor).toBe(false);
+    expect(rows.find((r) => r.sku === UNCHECKED.sku)?.belowFloor).toBeNull();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/identity.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/identity.ts
@@ -1,0 +1,68 @@
+import { createElement } from "react";
+
+/**
+ * The Bellwether mark — a bell, with its clapper drawn as a separate dot that
+ * sits just below the rim.
+ *
+ * A bellwether is the lead animal of a flock, the one carrying the bell that the
+ * rest follow, and by extension the thing you watch to know where everything
+ * else is going. That is exactly what this console is: a merchandiser's read on
+ * where the range is heading. The clapper is offset rather than centred so the
+ * mark reads as a bell mid-ring — a leading indicator in motion, not a static
+ * notification icon.
+ *
+ * Everything is drawn in `currentColor` so the mark inherits whatever colour it
+ * mounts into — ink blue in the nav rail, ink in the skin selector, and the chat
+ * header's own foreground.
+ */
+function BellwetherLogo({ className }: { className?: string }) {
+  return createElement(
+    "svg",
+    {
+      className,
+      viewBox: "0 0 24 24",
+      fill: "none",
+      xmlns: "http://www.w3.org/2000/svg",
+      "aria-hidden": true,
+    },
+    // The crown loop the bell hangs from.
+    createElement("circle", {
+      cx: 12,
+      cy: 4.1,
+      r: 1.7,
+      stroke: "currentColor",
+      strokeWidth: 1.6,
+    }),
+    // The body: a skirt that flares from the crown out to the rim.
+    createElement("path", {
+      d: "M5.6 17.2c0-6 2-9.4 6.4-9.4s6.4 3.4 6.4 9.4",
+      stroke: "currentColor",
+      strokeWidth: 1.7,
+      strokeLinecap: "round",
+    }),
+    // The rim.
+    createElement("path", {
+      d: "M4.2 17.4h15.6",
+      stroke: "currentColor",
+      strokeWidth: 1.7,
+      strokeLinecap: "round",
+    }),
+    // The clapper, swung off-centre.
+    createElement("circle", {
+      cx: 13.6,
+      cy: 20.2,
+      r: 1.5,
+      fill: "currentColor",
+    }),
+  );
+}
+
+export const commerceIdentity = {
+  brand: "Bellwether",
+  tagline: "Storefront operations, from order to margin.",
+  logo: BellwetherLogo,
+  favicon: "🏷️",
+  assistantName: "Bellwether",
+  greeting:
+    "I'm Bellwether. I can read whatever page you're on, work the exception queue, and move markdowns and returns through the desk. Pick a suggestion below to start.",
+} as const;

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/forget-memories.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/forget-memories.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { forgetAllMemories } from "./forget-memories";
+
+afterEach(() => vi.restoreAllMocks());
+
+const API = {
+  apiUrl: "http://x:7450",
+  apiKey: "k",
+  userId: "bellwether-nadia",
+};
+
+const listOf = (
+  memories: Array<{ id: string; scope?: string }> | unknown,
+  status = 200,
+) => new Response(JSON.stringify({ memories }), { status });
+
+const noContent = () => new Response(null, { status: 204 });
+
+const deletedUrls = (fetchMock: ReturnType<typeof vi.fn>) =>
+  fetchMock.mock.calls
+    .filter(([, init]) => init?.method === "DELETE")
+    .map(([url]) => String(url));
+
+/** A fetch that never answers, and only settles when its signal aborts. */
+const hangUntilAborted = () => (_url: string, init?: RequestInit) =>
+  new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    if (!signal) return; // no signal wired => hangs forever, and the test fails
+    signal.addEventListener("abort", () =>
+      reject(signal.reason ?? new Error("aborted")),
+    );
+  });
+
+describe("forgetAllMemories", () => {
+  it("enumerates, dedups ids, deletes each once, and re-lists to PROVE the bucket is clear", async () => {
+    const fetchMock = vi
+      .fn()
+      // include a duplicate id to prove dedup
+      .mockResolvedValueOnce(
+        listOf([{ id: "a" }, { id: "b" }, { id: "b" }, { id: "c" }]),
+      )
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(noContent())
+      // verification pass: nothing left
+      .mockResolvedValueOnce(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result).toMatchObject({
+      forgot: 3,
+      alreadyGone: 0,
+      failed: [],
+      passes: 2,
+      complete: true,
+    });
+    expect(result.incompleteReason).toBeUndefined();
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://x:7450/api/memories",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer k",
+          "x-cpki-user-id": "bellwether-nadia",
+        }),
+      }),
+    );
+    expect(deletedUrls(fetchMock)).toEqual([
+      "http://x:7450/api/memories/a",
+      "http://x:7450/api/memories/b",
+      "http://x:7450/api/memories/c",
+    ]);
+  });
+
+  it("leaves project-scoped rows alone and reports the count", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        listOf([
+          { id: "a", scope: "user" },
+          { id: "p1", scope: "project" },
+          { id: "p2", scope: "project" },
+        ]),
+      )
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(
+        listOf([
+          { id: "p1", scope: "project" },
+          { id: "p2", scope: "project" },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result).toMatchObject({
+      forgot: 1,
+      skippedProjectScoped: 2,
+      complete: true,
+    });
+    expect(deletedUrls(fetchMock)).toEqual(["http://x:7450/api/memories/a"]);
+  });
+
+  // ── DEFECT 1: a 404 must not abort the sweep ────────────────────────────────
+  it("treats a 404 on delete as success and keeps sweeping the remaining rows", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listOf([{ id: "a" }, { id: "b" }, { id: "c" }]))
+      .mockResolvedValueOnce(new Response("gone", { status: 404 }))
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result).toMatchObject({
+      forgot: 2,
+      alreadyGone: 1,
+      failed: [],
+      complete: true,
+    });
+    // The rows AFTER the 404 were still attempted — the old code threw here.
+    expect(deletedUrls(fetchMock)).toEqual([
+      "http://x:7450/api/memories/a",
+      "http://x:7450/api/memories/b",
+      "http://x:7450/api/memories/c",
+    ]);
+  });
+
+  it("reports a genuine delete failure instead of swallowing it or aborting", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listOf([{ id: "a" }, { id: "b" }]))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }))
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(listOf([{ id: "a" }]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result.forgot).toBe(1);
+    expect(result.complete).toBe(false);
+    expect(result.incompleteReason).toMatch(/failed to delete/);
+    expect(result.failed).toEqual([
+      { id: "a", reason: expect.stringMatching(/500[\s\S]*boom/) },
+    ]);
+    // b was still deleted despite a failing first.
+    expect(deletedUrls(fetchMock)).toEqual([
+      "http://x:7450/api/memories/a",
+      "http://x:7450/api/memories/b",
+    ]);
+  });
+
+  it("does not retry a row that already failed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listOf([{ id: "a" }]))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }))
+      .mockResolvedValueOnce(listOf([{ id: "a" }]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result.passes).toBe(2);
+    expect(deletedUrls(fetchMock)).toEqual(["http://x:7450/api/memories/a"]);
+    expect(result.complete).toBe(false);
+  });
+
+  // ── DEFECT 2: one bare list is NOT assumed exhaustive ───────────────────────
+  it("keeps sweeping until a list comes back empty, so a truncated page leaves nothing behind", async () => {
+    const fetchMock = vi
+      .fn()
+      // page 1 of a paginated backend
+      .mockResolvedValueOnce(listOf([{ id: "a" }, { id: "b" }]))
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(noContent())
+      // deleting page 1 revealed page 2
+      .mockResolvedValueOnce(listOf([{ id: "c" }]))
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result).toMatchObject({ forgot: 3, passes: 3, complete: true });
+    expect(deletedUrls(fetchMock)).toEqual([
+      "http://x:7450/api/memories/a",
+      "http://x:7450/api/memories/b",
+      "http://x:7450/api/memories/c",
+    ]);
+  });
+
+  it("reports partial rather than success when the pass budget runs out", async () => {
+    let n = 0;
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === "DELETE") return Promise.resolve(noContent());
+      n += 1;
+      // a bottomless backend: every list hands back one more unseen row
+      return Promise.resolve(listOf([{ id: `row-${n}` }]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories({ ...API, maxPasses: 3 });
+
+    expect(result.passes).toBe(3);
+    expect(result.forgot).toBe(3);
+    expect(result.complete).toBe(false);
+    expect(result.incompleteReason).toMatch(/pass budget \(3\)/);
+  });
+
+  it("refuses to claim success when the backend re-lists rows it said it deleted", async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) =>
+      Promise.resolve(
+        init?.method === "DELETE" ? noContent() : listOf([{ id: "zombie" }]),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories({ ...API, maxPasses: 5 });
+
+    // Counted ONCE, not once per pass, and not reported as clear.
+    expect(result.forgot).toBe(1);
+    expect(result.passes).toBe(2);
+    expect(result.complete).toBe(false);
+    expect(result.incompleteReason).toMatch(/already deleted/);
+  });
+
+  // ── DEFECT 3: the envelope is validated, and errors name THIS layer ─────────
+  it("fails with a message naming this module when the list envelope changes shape", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [{ id: "a" }] }), { status: 200 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(forgetAllMemories(API)).rejects.toThrow(
+      /\[commerce\/forget-memories\][\s\S]*unexpected GET \/api\/memories envelope/,
+    );
+    // and NOT the misleading downstream symptom
+    await expect(forgetAllMemories(API)).rejects.not.toThrow(
+      /reading 'filter'/,
+    );
+  });
+
+  it("fails when a row is missing its id, naming the row index", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(listOf([{ id: "a" }, { scope: "user" }])),
+    );
+    await expect(forgetAllMemories(API)).rejects.toThrow(
+      /\[commerce\/forget-memories\][\s\S]*row 1.*\{ id: string \}/,
+    );
+  });
+
+  it("fails when a row's scope is not a string, rather than risking a project row", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(listOf([{ id: "a", scope: 7 }])),
+    );
+    await expect(forgetAllMemories(API)).rejects.toThrow(
+      /\[commerce\/forget-memories\][\s\S]*scope must be a string/,
+    );
+  });
+
+  it("fails when the list body is not JSON at all", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response("<html>502</html>", { status: 200 })),
+    );
+    await expect(forgetAllMemories(API)).rejects.toThrow(
+      /\[commerce\/forget-memories\][\s\S]*not JSON/,
+    );
+  });
+
+  it("throws when listing fails, since nothing can be enumerated", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(new Response("nope", { status: 401 })),
+    );
+    await expect(forgetAllMemories(API)).rejects.toThrow(
+      /\[commerce\/forget-memories\][\s\S]*401/,
+    );
+  });
+
+  // ── DEFECT 4: every request is bounded ──────────────────────────────────────
+  it("passes an AbortSignal on every request", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listOf([{ id: "a" }]))
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await forgetAllMemories(API);
+
+    expect(fetchMock.mock.calls).toHaveLength(3);
+    for (const [, init] of fetchMock.mock.calls) {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("aborts a hung LIST within the timeout instead of hanging the reset", async () => {
+    vi.stubGlobal("fetch", vi.fn(hangUntilAborted()));
+
+    const started = Date.now();
+    await expect(forgetAllMemories({ ...API, timeoutMs: 30 })).rejects.toThrow(
+      /\[commerce\/forget-memories\][\s\S]*TimeoutError/,
+    );
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it("aborts a hung DELETE within the timeout and reports it as a failure", async () => {
+    const hang = hangUntilAborted();
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === "DELETE") return hang(url, init);
+      return Promise.resolve(listOf([{ id: "a" }]));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const started = Date.now();
+    const result = await forgetAllMemories({ ...API, timeoutMs: 30 });
+
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(result.forgot).toBe(0);
+    expect(result.complete).toBe(false);
+    expect(result.failed).toEqual([
+      { id: "a", reason: expect.stringMatching(/30ms.*TimeoutError/) },
+    ]);
+  });
+
+  it("counts project-scoped rows as a union across passes, not just the last page", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        listOf([{ id: "a" }, { id: "p1", scope: "project" }]),
+      )
+      .mockResolvedValueOnce(noContent())
+      .mockResolvedValueOnce(
+        listOf([
+          { id: "p1", scope: "project" },
+          { id: "p2", scope: "project" },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result.skippedProjectScoped).toBe(2);
+    expect(result.complete).toBe(true);
+  });
+
+  it("never claims a clear it did not even attempt", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories({ ...API, maxPasses: 0 });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.complete).toBe(false);
+    expect(result.incompleteReason).toMatch(/no list pass ran/);
+  });
+
+  it("strips a trailing slash from apiUrl", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+    await forgetAllMemories({ ...API, apiUrl: "http://x:7450/" });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://x:7450/api/memories",
+      expect.anything(),
+    );
+  });
+
+  it("reports a clear, complete sweep when memory is already empty", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(listOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await forgetAllMemories(API);
+
+    expect(result).toMatchObject({
+      forgot: 0,
+      alreadyGone: 0,
+      skippedProjectScoped: 0,
+      failed: [],
+      passes: 1,
+      complete: true,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/forget-memories.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/forget-memories.ts
@@ -1,0 +1,368 @@
+/**
+ * Scope-complete clear of durable memory via the Intelligence REST endpoints.
+ * Server-safe plain .ts.
+ *
+ * A BARE `GET /api/memories` (no query string) is the only enumeration this
+ * backend offers. It rejects ANY query string on that path with 400
+ * MEMORY_VALIDATION_ERROR, and the bare GET already enumerates every scope
+ * (user + project) in one response — so one list is inherently scope-complete
+ * and no scope can be silently missed. Scope filtering only exists on
+ * `POST /api/memories/recall`, which is top-k semantic search rather than
+ * enumeration and is therefore unfit for a guaranteed clear.
+ *
+ * ── WHY THIS SWEEPS IN PASSES ────────────────────────────────────────────────
+ * The list endpoint's pagination contract is UNKNOWN, and it cannot be probed:
+ * `ListMemoriesResponse` in the platform client
+ * (`packages/runtime/src/v2/runtime/intelligence-platform/client.ts`) is a bare
+ * `{ memories }` envelope with no `nextCursor`/`total` — unlike `listThreads`,
+ * which does carry a cursor — and the 400-on-query-string rule means we cannot
+ * pass `?limit=`/`?cursor=` to find out. Assuming ONE list is exhaustive is
+ * therefore an assumption we are not entitled to: a default page size would
+ * leave rows undeleted while the caller reports success.
+ *
+ * So instead of guessing a pagination parameter, this VERIFIES it saw
+ * everything: list → delete what it saw → list again. Deleting a truncated
+ * page's rows is what makes the next page's rows visible, so the loop converges
+ * on a genuinely empty list, and the sweep only claims `complete: true` when a
+ * list pass came back with nothing left to delete. Bounded by `maxPasses` so a
+ * backend that keeps re-listing deleted rows cannot spin forever.
+ *
+ * The booth failure all of this guards against: a reset that misses rows,
+ * reports a plausible count, reads as success — and leaves beat 6 already
+ * taught, so the agent "learns" a procedure it demonstrably already knew.
+ */
+
+/** Prefixes every thrown message so a failure names THIS layer, not its caller. */
+const LAYER = "[commerce/forget-memories]";
+
+/**
+ * Per-request timeout. Five buckets are swept SERIALLY on a presenter reset, so
+ * an unbounded fetch means the Reset button spins forever against a wedged
+ * backend — the one moment a presenter has no time to debug anything.
+ */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Bound on list→delete passes. See the pagination note in the header. */
+const DEFAULT_MAX_PASSES = 10;
+
+export interface ForgetMemoriesParams {
+  apiUrl: string;
+  apiKey: string;
+  userId: string;
+  /** Per-request timeout in ms. Defaults to {@link DEFAULT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /** Max list→delete passes. Defaults to {@link DEFAULT_MAX_PASSES}. */
+  maxPasses?: number;
+}
+
+interface MemoryRow {
+  id: string;
+  scope?: string;
+}
+
+/** One row this sweep could NOT confirm gone. */
+export interface ForgetFailure {
+  id: string;
+  reason: string;
+}
+
+export interface ForgetResult {
+  /** Rows this sweep deleted (2xx). */
+  forgot: number;
+  /**
+   * Rows that were ALREADY gone when the DELETE landed (404/410). Counted as
+   * success — the row is absent either way, which is the only thing the reset
+   * cares about — but reported separately so `forgot` stays literally true.
+   */
+  alreadyGone: number;
+  /**
+   * Project-scoped rows this deliberately left alone. Surfaced in the reset
+   * response so a presenter can SEE that something project-scoped is present —
+   * see the `skipProjectScope` note below for why that matters.
+   */
+  skippedProjectScoped: number;
+  /**
+   * Rows that failed to delete for a reason other than "already gone". These do
+   * NOT abort the sweep: one 500 on one row used to abandon this bucket AND
+   * every remaining bucket, so a single bad row left four buckets untouched.
+   */
+  failed: ForgetFailure[];
+  /** How many list→delete passes ran. */
+  passes: number;
+  /**
+   * TRUE only when a list pass proved there was nothing deletable left. False
+   * means PARTIAL: the caller must not report the clear as done.
+   */
+  complete: boolean;
+  /** Set whenever `complete` is false; says which way it fell short. */
+  incompleteReason?: string;
+}
+
+export async function forgetAllMemories(
+  params: ForgetMemoriesParams,
+): Promise<ForgetResult> {
+  const {
+    apiUrl,
+    apiKey,
+    userId,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxPasses = DEFAULT_MAX_PASSES,
+  } = params;
+  const base = apiUrl.replace(/\/$/, "");
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "x-cpki-user-id": userId,
+  };
+
+  let forgot = 0;
+  let alreadyGone = 0;
+  let passes = 0;
+  /**
+   * Project-scoped ids seen across ALL passes, as a union rather than a
+   * last-pass count: a paginated list can split them across pages, and the
+   * point of this number is that a presenter can trust it.
+   */
+  const skippedProjectIds = new Set<string>();
+  const failed: ForgetFailure[] = [];
+  const failedIds = new Set<string>();
+  /** Ids this sweep already confirmed absent — never re-deleted, never re-counted. */
+  const confirmedGone = new Set<string>();
+  let incompleteReason: string | undefined;
+
+  while (passes < maxPasses) {
+    passes += 1;
+    const memories = await listMemories(base, headers, timeoutMs);
+
+    /**
+     * PROJECT-SCOPED ROWS ARE DELIBERATELY LEFT ALONE.
+     *
+     * Verified against the running Intelligence stack: the bare list returns
+     * every `scope: "project"` row for ANY user id, because project scope is
+     * global to the backend instance rather than partitioned per product. All
+     * the skins in this app share one instance locally. So a scope-complete
+     * delete here would silently destroy banking's seeded procedure every time a
+     * presenter resets Bellwether — deleting data this skin does not own, to
+     * solve a problem it does not have.
+     *
+     * Bellwether owns nothing at project scope BY CONSTRUCTION: its seed file
+     * writes user scope, and its prompt and teach-mode tools all instruct
+     * `save_memory` to use user scope. So skipping project rows still leaves
+     * beat 6 unlearned after a reset, which is the invariant that matters.
+     *
+     * The residual risk is a model that ignores the scope instruction and saves
+     * project-scoped anyway — reset would then miss it and beat 6 would start
+     * out already taught. That is why the count is RETURNED rather than
+     * swallowed: `dev/reset` reports it, so a non-zero number after a
+     * Bellwether-only session is the signal to go look.
+     */
+    const deletable = memories.filter((m) => m.scope !== "project");
+    for (const row of memories) {
+      if (row.scope === "project") skippedProjectIds.add(row.id);
+    }
+
+    // Dedup defensively — the API should not repeat ids, but a clear has to be
+    // idempotent per id regardless.
+    const listed = new Set(deletable.map((m) => m.id));
+    const pending = [...listed].filter(
+      (id) => !failedIds.has(id) && !confirmedGone.has(id),
+    );
+
+    if (pending.length === 0) {
+      // Nothing new to delete, so this is the last pass. Decide honestly WHY.
+      const zombies = [...listed].filter((id) => confirmedGone.has(id));
+      if (zombies.length > 0) {
+        // The backend still enumerates rows it told us it deleted. Reporting
+        // success here is exactly the lie this module exists to stop.
+        incompleteReason =
+          `the backend still lists ${zombies.length} row(s) this sweep already ` +
+          `deleted (first: ${zombies[0]})`;
+      } else if (failedIds.size > 0) {
+        incompleteReason = `${failedIds.size} row(s) failed to delete`;
+      }
+      break;
+    }
+
+    for (const id of pending) {
+      const outcome = await deleteMemory(base, headers, id, timeoutMs);
+      if (outcome.kind === "deleted") {
+        forgot += 1;
+        confirmedGone.add(id);
+      } else if (outcome.kind === "absent") {
+        // A 404 means the row is gone — a harmless race (a concurrent reset, a
+        // backend TTL) that used to throw and abandon every remaining bucket.
+        alreadyGone += 1;
+        confirmedGone.add(id);
+      } else {
+        failed.push({ id, reason: outcome.reason });
+        failedIds.add(id);
+      }
+    }
+
+    // Loop: a truncated page hides rows behind the ones just deleted, so only a
+    // list that comes back with nothing pending proves the bucket is clear.
+    if (passes === maxPasses) {
+      incompleteReason =
+        `pass budget (${maxPasses}) exhausted with rows still being returned; ` +
+        `remaining rows are unverified`;
+    }
+  }
+
+  if (failed.length > 0 && !incompleteReason) {
+    incompleteReason = `${failed.length} row(s) failed to delete`;
+  }
+  if (passes === 0) {
+    // maxPasses <= 0. Nothing was even listed, so "clear" is unprovable.
+    incompleteReason = `no list pass ran (maxPasses was ${maxPasses})`;
+  }
+
+  return {
+    forgot,
+    alreadyGone,
+    skippedProjectScoped: skippedProjectIds.size,
+    failed,
+    passes,
+    complete: incompleteReason === undefined,
+    ...(incompleteReason === undefined ? {} : { incompleteReason }),
+  };
+}
+
+/**
+ * Enumerate one bucket. THROWS on any failure: without a list there is nothing
+ * to delete and nothing truthful to report, so aborting is correct here — unlike
+ * a single failed DELETE, which is counted and stepped over.
+ */
+async function listMemories(
+  base: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<MemoryRow[]> {
+  let res: Response;
+  try {
+    res = await fetch(`${base}/api/memories`, {
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    throw new Error(
+      `${LAYER} list memories failed after ${timeoutMs}ms or in transport: ${describeError(err)}`,
+      { cause: err },
+    );
+  }
+  if (!res.ok) {
+    throw new Error(
+      `${LAYER} list memories failed: ${res.status} ${await safeText(res)}`,
+    );
+  }
+  let payload: unknown;
+  try {
+    payload = await res.json();
+  } catch (err) {
+    throw new Error(
+      `${LAYER} GET /api/memories returned a body that is not JSON: ${describeError(err)}`,
+      { cause: err },
+    );
+  }
+  return parseMemoryRows(payload);
+}
+
+/**
+ * Validate the list envelope instead of casting it.
+ *
+ * An unchecked `as MemoriesListResponse` turned an envelope change into
+ * "Cannot read properties of undefined (reading 'filter')" thrown from the
+ * middle of a reset — a message that names neither this module nor the
+ * backend, so it sends whoever is debugging to the wrong layer entirely.
+ *
+ * A present-but-non-string `scope` is an ERROR rather than a shrug: the
+ * project-scope skip above is a `!== "project"` comparison, so an unreadable
+ * scope could get banking's seeded project rows deleted.
+ */
+function parseMemoryRows(payload: unknown): MemoryRow[] {
+  if (!isRecord(payload) || !Array.isArray(payload.memories)) {
+    throw new Error(
+      `${LAYER} unexpected GET /api/memories envelope: expected ` +
+        `{ memories: [{ id, scope? }] }, got ${preview(payload)}`,
+    );
+  }
+  return payload.memories.map((entry: unknown, index: number) => {
+    if (!isRecord(entry) || typeof entry.id !== "string" || entry.id === "") {
+      throw new Error(
+        `${LAYER} unexpected GET /api/memories row ${index}: expected ` +
+          `{ id: string }, got ${preview(entry)}`,
+      );
+    }
+    const { id, scope } = entry;
+    if (scope !== undefined && typeof scope !== "string") {
+      throw new Error(
+        `${LAYER} unexpected GET /api/memories row ${index} (id ${id}): ` +
+          `scope must be a string when present, got ${preview(scope)}`,
+      );
+    }
+    return scope === undefined ? { id } : { id, scope };
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type DeleteOutcome =
+  | { kind: "deleted" }
+  | { kind: "absent" }
+  | { kind: "failed"; reason: string };
+
+async function deleteMemory(
+  base: string,
+  headers: Record<string, string>,
+  id: string,
+  timeoutMs: number,
+): Promise<DeleteOutcome> {
+  let res: Response;
+  try {
+    res = await fetch(`${base}/api/memories/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    return {
+      kind: "failed",
+      reason: `no response after ${timeoutMs}ms or in transport: ${describeError(err)}`,
+    };
+  }
+  // 204 No Content on success; `ok` covers it.
+  if (res.ok) return { kind: "deleted" };
+  // Already absent — the desired end state, reached by someone else.
+  if (res.status === 404 || res.status === 410) return { kind: "absent" };
+  return {
+    kind: "failed",
+    reason: `HTTP ${res.status} ${await safeText(res)}`,
+  };
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}
+
+/** Body text for an error message; never throws, never floods the log. */
+async function safeText(res: Response): Promise<string> {
+  try {
+    return truncate(await res.text());
+  } catch {
+    return "<unreadable body>";
+  }
+}
+
+function preview(value: unknown): string {
+  if (value === undefined) return "undefined";
+  try {
+    return truncate(JSON.stringify(value) ?? String(value));
+  } catch {
+    return `<unserializable ${typeof value}>`;
+  }
+}
+
+function truncate(text: string, max = 200): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/seed-memories.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/seed-memories.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { seedMemories, SEED_MEMORIES } from "./seed-memories";
+
+afterEach(() => vi.restoreAllMocks());
+
+const API = {
+  apiUrl: "http://x:7450",
+  apiKey: "k",
+  userId: "bellwether-nadia",
+};
+
+describe("seedMemories", () => {
+  it("stores every seed memory and bounds each request with an AbortSignal", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stored = await seedMemories(API);
+
+    expect(stored).toBe(SEED_MEMORIES.length);
+    expect(fetchMock.mock.calls).toHaveLength(SEED_MEMORIES.length);
+    for (const [url, init] of fetchMock.mock.calls) {
+      expect(url).toBe("http://x:7450/api/memories");
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it("aborts a hung POST within the timeout and counts it as not stored", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(init.signal?.reason ?? new Error("aborted")),
+            );
+          }),
+      ),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const started = Date.now();
+    const stored = await seedMemories({ ...API, timeoutMs: 30 });
+
+    expect(stored).toBe(0);
+    // Bounded: without a signal this promise never settles and the reset spins.
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/seed-memories.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/seed-memories.ts
@@ -1,0 +1,140 @@
+/**
+ * BEATS 4 AND 5 — the memory Bellwether is supposed to start out already having.
+ * Server-safe plain .ts. Called by `dev/reset` immediately after wiping learned
+ * memory, so the demo is re-armed before the presenter says a word.
+ *
+ * "It already knows me" is a FILE, not emergent behaviour. Three rules govern
+ * what belongs here, each of them learned the hard way in the banking skin:
+ *
+ *  1. Seed a standing PREFERENCE, not a fact. "Nadia's favourite category"
+ *     proves storage. "Read the range by category, below-floor first, as margin
+ *     percent rather than revenue" proves APPLIED learning, because recall
+ *     visibly changes the answer to a question the user never re-explained.
+ *
+ *  2. The procedure must run FULLY AUTOMATICALLY. Banking's equivalent once
+ *     opened a confirmation card mid-procedure; when a presenter moved on
+ *     without answering it, that tool call sat unresolved and the NEXT message
+ *     failed the whole thread with "Tool result is missing for tool call ...".
+ *     A procedure with no half-finished state has nothing to leave behind, so
+ *     "run all of them immediately, in order, without asking for confirmation"
+ *     is written into the memory text itself, not just the prompt.
+ *
+ *  3. NEVER seed beat 6's procedure. The below-floor markdown approval is the
+ *     one Bellwether has to be taught on stage. Seed it and the agent already
+ *     knows the answer, never offers to record, and the entire teach arc
+ *     disappears — which is exactly the kind of failure that still compiles and
+ *     still looks fine right up until the demo. The beat-5 memory below says so
+ *     explicitly so the two procedures can never be confused for one another.
+ */
+
+/**
+ * Per-request timeout. A presenter reset seeds several buckets serially right
+ * after sweeping five of them, all in one request — with no bound, one wedged
+ * POST leaves the Reset button spinning forever. A timeout here fails the way
+ * this function already fails: counted and logged, never thrown.
+ */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface SeedMemoriesParams {
+  apiUrl: string;
+  apiKey: string;
+  userId: string;
+  /** Per-request timeout in ms. Defaults to {@link DEFAULT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+interface SeedMemory {
+  kind: "topical" | "episodic" | "operational";
+  scope: "user" | "project";
+  content: string;
+}
+
+export const SEED_MEMORIES: readonly SeedMemory[] = [
+  {
+    // ── BEAT 4 ──────────────────────────────────────────────────────────────
+    // A standing preference about SHAPE, so recall changes the answer rather
+    // than adding a fact. Note it names three separate, checkable behaviours
+    // (group by category / below-floor first / margin percent not revenue) — a
+    // single-clause preference is too easy for the audience to read as a
+    // coincidence.
+    kind: "topical",
+    scope: "user",
+    content:
+      "Nadia Okonjo reads trading by CATEGORY, never by vendor. She wants any " +
+      "product sitting below its category margin floor called out FIRST, ahead " +
+      "of everything else, and she reads a product's health as its GROSS " +
+      "MARGIN PERCENT rather than as revenue or units. Apply this to every " +
+      "margin summary without being asked, and say which preference you applied.",
+  },
+  {
+    // ── BEAT 5 ──────────────────────────────────────────────────────────────
+    // A PROCEDURE, so recall produces visible ACTION — three tool calls in a
+    // row, each changing something on screen — rather than a reformatted
+    // answer. The parenthetical disjointness clause is load-bearing: without it
+    // the agent conflates this with beat 6 and starts offering to record a
+    // procedure it already has.
+    kind: "operational",
+    // `user`, NOT `project` — banking scopes its equivalent procedure to
+    // `project`, and that turned out to be the wrong model here. Verified
+    // against the running Intelligence stack: a project-scoped memory is
+    // returned for EVERY user id in the instance, not just the ones in some
+    // project. Since all six skins in this app point at one instance, a
+    // project-scoped procedure is effectively global — Bellwether's fraud
+    // procedure would surface inside banking's demo and vice versa, each looking
+    // like the memory system had confused two products. User scope is
+    // partitioned correctly, and Bellwether's memories belong to one operator
+    // anyway (see intelligence/user-id.ts).
+    scope: "user",
+    content:
+      "Procedure for when an order is suspected of fraud or looks wrong (this " +
+      "is NOT the procedure for approving a markdown that breaks the margin " +
+      "floor — they are different situations, do not confuse them, and do not " +
+      "offer to record anything here): (1) call holdOrder on that order with " +
+      "the reason 'fraud-review' so fulfillment stops, (2) call notifyCustomer " +
+      "with the 'verification-required' template so the customer is asked to " +
+      "confirm the purchase, (3) call postOrderNote with one short line saying " +
+      "what was held and why. Run all three immediately, in order, without " +
+      "asking for confirmation, then confirm what was done in one short sentence.",
+  },
+  // DO NOT seed the below-floor markdown approval procedure. That is beat 6, and
+  // it is taught live. See rule 3 in the header.
+];
+
+/**
+ * Write the seed memories for one identity; returns how many were stored.
+ *
+ * Never throws. A booth reset must still report success for the DATA store even
+ * when the memory backend is unhappy — a presenter needs the order book restored
+ * far more urgently than they need a stack trace — so failures are counted and
+ * logged, not propagated.
+ */
+export async function seedMemories(
+  params: SeedMemoriesParams,
+): Promise<number> {
+  const { apiUrl, apiKey, userId, timeoutMs = DEFAULT_TIMEOUT_MS } = params;
+  const base = apiUrl.replace(/\/$/, "");
+  let stored = 0;
+
+  for (const memory of SEED_MEMORIES) {
+    try {
+      const res = await fetch(`${base}/api/memories`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "X-Cpki-User-Id": userId,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify(memory),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (res.ok) stored += 1;
+      else
+        console.error(`[commerce/seed-memories] ${userId}: HTTP ${res.status}`);
+    } catch (err) {
+      console.error(`[commerce/seed-memories] ${userId}: ${String(err)}`);
+    }
+  }
+
+  return stored;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/user-id.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/user-id.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as store from "../data/store";
+import {
+  commerceIdentifyUser,
+  DEMO_DEFAULT_USER_ID,
+  memoryScopeUserIds,
+  memorySeedTargetUserIds,
+  resolveUserId,
+  resolveUserName,
+} from "./user-id";
+import type { IdentityInput } from "./user-id";
+
+/**
+ * COMPILE-TIME half of the drift guard, and the reason it is worth the four
+ * lines: `runtimeReachableIds()` below enumerates identity inputs by hand, so it
+ * can only stay complete if someone WIDENING `IdentityInput` is forced to look at
+ * it. Add a third dimension (a team, a tenant, an org) and `tsc --noEmit` fails
+ * right here with a missing property — instead of the reset silently leaving that
+ * dimension's buckets unforgotten, which is not observable from any test result.
+ */
+const ENUMERATED_IDENTITY_DIMENSIONS: Record<
+  keyof Required<IdentityInput>,
+  true
+> = { operatorId: true, role: true };
+
+/**
+ * THE RESET/RUNTIME IDENTITY DRIFT GUARD.
+ *
+ * The presenter reset forgets and re-seeds durable memory for a SET of user ids.
+ * The runtime writes memory under whatever `resolveUserId` returns. Nothing in
+ * the type system ties the two together, and every way they can disagree is
+ * SILENT — the reset returns `ok: true` with a plausible `forgot` count, recall
+ * quietly reads an empty bucket, and a procedure taught on stage survives into
+ * the next run. So this file is the only thing standing between a refactor and a
+ * demo that proves nothing.
+ *
+ * The failure it was written for actually shipped: the reset carried a hardcoded
+ * list of three `bellwether-*` ids, while `resolveUserId` short-circuits on a
+ * pinned `INTELLIGENCE_USER_ID` that `playwright.config.ts` sets to banking's
+ * `jordan-beamson`. Every e2e commerce run therefore read and wrote BANKING's
+ * bucket, and the reset scrubbed three buckets nothing was using.
+ *
+ * The enumeration below is deliberately INDEPENDENT of the source's own: it goes
+ * through `commerceIdentifyUser` (the entry point the runtime actually calls) and
+ * takes its operator inputs from the live ledger (`store.operators()`, what the
+ * `/ledger` endpoint serves the client), in exactly the property shape
+ * `useCommerceRuntimeProperties` forwards. If the two enumerations ever disagree,
+ * one of them is wrong and the demo is broken.
+ */
+function runtimeReachableIds(): Set<string> {
+  const ids = new Set<string>();
+  // Nothing forwarded — the COMMON case on a run, not an edge case.
+  ids.add(commerceIdentifyUser(undefined).id);
+  ids.add(commerceIdentifyUser({}).id);
+  for (const operator of store.operators()) {
+    // Exactly what `useCommerceRuntimeProperties` sends.
+    ids.add(
+      commerceIdentifyUser({ userId: operator.id, userRole: operator.role }).id,
+    );
+    // A role arrived without a recognised operator id.
+    ids.add(commerceIdentifyUser({ userRole: operator.role }).id);
+    // An operator the identity map does not know: the role-slug branch. This is
+    // the one an author trips by adding a person to `seed.ts` and forgetting
+    // `OPERATOR_IDENTITY`.
+    ids.add(
+      commerceIdentifyUser({ userId: "op-not-in-map", userRole: operator.role })
+        .id,
+    );
+  }
+  return ids;
+}
+
+beforeEach(() => {
+  store.reset();
+  // Unpinned unless a test says otherwise. `stubEnv` with "" (not undefined) so
+  // the falsy check in `resolveUserId` takes the unpinned path regardless of the
+  // developer's ambient .env.
+  vi.stubEnv("INTELLIGENCE_USER_ID", "");
+  // Deleted, not blanked: `resolveUserName` reads it with `??`, so an empty
+  // string would be preferred over the pinned id and mask the pinned-name path.
+  vi.stubEnv("INTELLIGENCE_USER_NAME", undefined);
+});
+
+describe("memoryScopeUserIds (the presenter reset's bucket set)", () => {
+  it("equals every id the runtime can resolve, unpinned", () => {
+    expect(new Set(memoryScopeUserIds())).toEqual(runtimeReachableIds());
+  });
+
+  it("equals every id the runtime can resolve when INTELLIGENCE_USER_ID is pinned", () => {
+    // The regression: Playwright pins this to banking's id, so the reset MUST
+    // follow the pin into that bucket instead of scrubbing `bellwether-*`.
+    vi.stubEnv("INTELLIGENCE_USER_ID", "jordan-beamson");
+    expect(new Set(memoryScopeUserIds())).toEqual(runtimeReachableIds());
+    // And the pin collapses the set: one bucket, the pinned one.
+    expect([...memoryScopeUserIds()]).toEqual(["jordan-beamson"]);
+  });
+
+  it("covers the default bucket and both mapped operators when unpinned", () => {
+    // Named explicitly, because "derived from resolveUserId" is only reassuring
+    // if the derivation reaches the buckets the demo actually depends on: the
+    // default one (where mid-demo teaching lands) and each operator's own.
+    expect(memoryScopeUserIds()).toContain(DEMO_DEFAULT_USER_ID);
+    expect(memoryScopeUserIds()).toContain("bellwether-nadia-okonjo");
+    expect(memoryScopeUserIds()).toContain("bellwether-theo-vance");
+  });
+
+  it("is read per call, not frozen at module load", () => {
+    // A module-level constant would answer for whatever the env was at import
+    // time — which is how the pinned case got missed in the first place.
+    vi.stubEnv("INTELLIGENCE_USER_ID", "pinned-a");
+    expect([...memoryScopeUserIds()]).toEqual(["pinned-a"]);
+    vi.stubEnv("INTELLIGENCE_USER_ID", "");
+    expect(memoryScopeUserIds().length).toBeGreaterThan(1);
+  });
+
+  it("enumerates every dimension IdentityInput has", () => {
+    // The runtime assertion is nearly free; the value is the type annotation on
+    // ENUMERATED_IDENTITY_DIMENSIONS, which makes `tsc --noEmit` fail when a new
+    // identity dimension is added — the case where a reset would silently stop
+    // covering every bucket the runtime can reach.
+    expect(Object.keys(ENUMERATED_IDENTITY_DIMENSIONS).sort()).toEqual([
+      "operatorId",
+      "role",
+    ]);
+  });
+
+  it("has no duplicates, so a reset never forgets one bucket twice", () => {
+    const ids = memoryScopeUserIds();
+    expect(ids.length).toBe(new Set(ids).size);
+  });
+});
+
+describe("memorySeedTargetUserIds (the buckets beats 4/5 are seeded into)", () => {
+  // Both env states, because the pinned one is the case that actually broke: a
+  // hardcoded seed list stays a valid subset unpinned and stops being one the
+  // moment a pin redirects the runtime elsewhere.
+  it.each([
+    ["unpinned", ""],
+    ["pinned", "jordan-beamson"],
+  ])("only ever seeds a bucket the reset also forgets (%s)", (_label, pin) => {
+    // A seed target outside the forget set accumulates duplicate memories on
+    // every reset; a seed target outside the RUNTIME's set is dead seed that
+    // recall never reads. Containment in the forget set rules out both, because
+    // the forget set is the runtime's set.
+    vi.stubEnv("INTELLIGENCE_USER_ID", pin);
+    const scopes = new Set(memoryScopeUserIds());
+    const targets = memorySeedTargetUserIds();
+    expect(targets.length).toBeGreaterThan(0);
+    for (const target of targets) {
+      expect(scopes).toContain(target);
+    }
+  });
+
+  it("seeds the default bucket AND the seeded operator, unpinned", () => {
+    // Both, on purpose: runs frequently resolve to the default bucket because
+    // `properties` do not always reach `identifyUser`, so seeding only the
+    // operator leaves beat 4 recalling nothing.
+    expect([...memorySeedTargetUserIds()].sort()).toEqual(
+      ["bellwether-demo-user", "bellwether-nadia-okonjo"].sort(),
+    );
+  });
+
+  it("follows a pinned INTELLIGENCE_USER_ID onto the single bucket runs will read", () => {
+    vi.stubEnv("INTELLIGENCE_USER_ID", "jordan-beamson");
+    expect([...memorySeedTargetUserIds()]).toEqual(["jordan-beamson"]);
+  });
+});
+
+describe("resolveUserId / resolveUserName", () => {
+  it("maps each operator 1:1 so two on-screen people never share a scope", () => {
+    expect(resolveUserId({ operatorId: "op-nadia" })).toBe(
+      "bellwether-nadia-okonjo",
+    );
+    expect(resolveUserId({ operatorId: "op-theo" })).toBe(
+      "bellwether-theo-vance",
+    );
+    expect(resolveUserId({ operatorId: "op-nadia" })).not.toBe(
+      resolveUserId({ operatorId: "op-theo" }),
+    );
+  });
+
+  it("falls back to a namespaced role slug, then the demo default", () => {
+    expect(
+      resolveUserId({ operatorId: "op-unknown", role: "merch-lead" }),
+    ).toBe("bellwether-merch-lead");
+    expect(resolveUserId({})).toBe(DEMO_DEFAULT_USER_ID);
+  });
+
+  it("lets a pinned id win over a mapped operator", () => {
+    vi.stubEnv("INTELLIGENCE_USER_ID", "pinned-scope");
+    expect(resolveUserId({ operatorId: "op-nadia" })).toBe("pinned-scope");
+    expect(resolveUserName({ operatorId: "op-nadia" })).toBe("pinned-scope");
+  });
+
+  it("namespaces every unpinned id to bellwether, so Rowan's memories cannot leak in", () => {
+    for (const id of memoryScopeUserIds()) {
+      expect(id.startsWith("bellwether-")).toBe(true);
+    }
+  });
+});
+
+/**
+ * The operator table is keyed by `properties.userId`, which is client-forwarded
+ * and therefore untrusted. When that table was a plain object literal, an
+ * `operatorId` of `"toString"` / `"constructor"` / `"__proto__"` walked the
+ * PROTOTYPE CHAIN, resolved truthy past the `operatorId && …` guard, and then
+ * `.userId` / `.userName` on the inherited member was `undefined` — so this
+ * function, which decides the durable-memory scope, handed Intelligence an
+ * `undefined` bucket. Silently: writes and reads would go somewhere nobody
+ * intended, and beats 4/5/6 depend on that scope being exactly right.
+ *
+ * These are the identifiers a plain-object lookup leaks, not an arbitrary fuzz
+ * list: `"__proto__"` yields `Object.prototype`, the other two yield functions.
+ */
+describe("operator lookup rejects inherited Object.prototype keys", () => {
+  const INHERITED_KEYS = [
+    "toString",
+    "constructor",
+    "__proto__",
+    "valueOf",
+    "hasOwnProperty",
+  ] as const;
+
+  it.each(INHERITED_KEYS)(
+    "does not resolve %s as an operator, and never yields an undefined id",
+    (key) => {
+      // No role: must land on the demo default, exactly as any other unmapped id.
+      expect(resolveUserId({ operatorId: key })).toBe(DEMO_DEFAULT_USER_ID);
+      // With a role: must take the role-slug branch, not the "mapped" branch.
+      expect(resolveUserId({ operatorId: key, role: "merch-lead" })).toBe(
+        "bellwether-merch-lead",
+      );
+      // The name half of the same table, which had the identical guard.
+      expect(resolveUserName({ operatorId: key })).toBe("Bellwether Demo User");
+      expect(resolveUserName({ operatorId: key, role: "merch-lead" })).toBe(
+        "Bellwether merch-lead",
+      );
+    },
+  );
+
+  it.each(INHERITED_KEYS)(
+    "keeps %s out of the memory scope the runtime actually identifies with",
+    (key) => {
+      // Through `commerceIdentifyUser`, the entry point the runtime calls with
+      // whatever the client forwarded.
+      const identity = commerceIdentifyUser({ userId: key });
+      expect(identity.id).toBe(DEMO_DEFAULT_USER_ID);
+      expect(identity.name).toBe("Bellwether Demo User");
+      // The precise failure mode: a string, never undefined and never a
+      // stringified function leaking Object.prototype into a memory bucket.
+      expect(typeof identity.id).toBe("string");
+      expect(typeof identity.name).toBe("string");
+      // And it must never be mistaken for one of the real operators.
+      expect(identity.id).not.toBe("bellwether-nadia-okonjo");
+      expect(identity.id).not.toBe("bellwether-theo-vance");
+    },
+  );
+
+  it("still resolves every seeded operator exactly as before", () => {
+    // The other half of the fix: refuse the illegitimate keys WITHOUT changing
+    // which id any legitimate operator produces — the reset's forget/seed sets
+    // are derived from these, so a shift here would silently move the buckets.
+    const expected = new Map([
+      ["op-nadia", { id: "bellwether-nadia-okonjo", name: "Nadia Okonjo" }],
+      ["op-theo", { id: "bellwether-theo-vance", name: "Theo Vance" }],
+    ]);
+    for (const operator of store.operators()) {
+      const mapped = expected.get(operator.id);
+      // Guards the assertion itself: if `seed.ts` grows an operator, this fails
+      // here rather than silently asserting nothing about the new person.
+      expect(
+        mapped,
+        `no expectation recorded for ${operator.id}`,
+      ).toBeDefined();
+      expect(resolveUserId({ operatorId: operator.id })).toBe(mapped!.id);
+      expect(resolveUserName({ operatorId: operator.id })).toBe(mapped!.name);
+      // Including through the runtime entry point, with the role forwarded the
+      // way `useCommerceRuntimeProperties` actually sends it.
+      expect(
+        commerceIdentifyUser({ userId: operator.id, userRole: operator.role }),
+      ).toEqual({ id: mapped!.id, name: mapped!.name });
+    }
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/user-id.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/intelligence/user-id.ts
@@ -1,0 +1,205 @@
+/**
+ * Resolve a stable end-user identity for Bellwether's Intelligence requests
+ * (thread + durable-memory scoping). SERVER-SAFE: plain .ts, no "use client",
+ * no JSX — it is reached through the server-only `src/shell/agent-registry.ts`.
+ *
+ * Precedence: pinned env > mapped operator id > role-derived > demo default.
+ * The pinned env wins so CI (Playwright/aimock) stays deterministic on one
+ * seeded identity.
+ *
+ * The ids are namespaced `bellwether-*` rather than reusing another skin's,
+ * which matters more here than it looks: the seeded beat-4 preference is "review
+ * margin by category, below-floor first". If Bellwether shared a memory scope
+ * with Rowan, that preference would surface inside Rowan's compensation answers
+ * and Rowan's would surface inside Bellwether's — and both demos would look like
+ * the memory system had confused two products.
+ *
+ * ⚠ Namespacing the id only isolates `scope: "user"` memories. Verified against
+ * the running Intelligence stack: a `scope: "project"` row comes back for EVERY
+ * user id in the instance, so project scope is NOT a per-skin boundary when
+ * several skins share one backend — which they do locally. That is why
+ * Bellwether seeds and saves everything at user scope; see
+ * `intelligence/seed-memories.ts`.
+ */
+
+import { DEFAULT_OPERATOR_ID, SEED_OPERATORS } from "../data/seed";
+
+/**
+ * Operator id (data/seed.ts) → memory scope. 1:1, so two on-screen people never
+ * share one scope. Nadia is the seeded persona the demo runs as; Theo is
+ * deliberately a colleague Bellwether has NOT learned anything from yet.
+ *
+ * A `Map` (not a plain object) is load-bearing for security, exactly as in
+ * `src/skins/keel/intelligence/user-id.ts` and `src/skins/commerce/data/http.ts`:
+ * the key is `properties.userId`, client-forwarded and therefore untrusted. A
+ * plain-object lookup walks the prototype chain, so `"toString"`,
+ * `"constructor"`, `"valueOf"`, `"__proto__"`, … all resolve TRUTHY, pass the
+ * `operatorId && …` guard, and then `.userId` / `.userName` on the inherited
+ * member is `undefined`. That is the worst possible outcome for THIS function:
+ * it decides the durable-memory scope, so Intelligence would read and write
+ * memories under an `undefined` bucket nobody intended — silently — and the
+ * memory-recall and stored-procedure beats depend on that scope being right.
+ * `Map.get` only ever sees own entries, so the bad state is unrepresentable
+ * rather than guarded per call site. `Record<string, …>` could not catch it: the
+ * annotation was a lie about a plain object.
+ */
+const OPERATOR_IDENTITY: Map<string, { userId: string; userName: string }> =
+  new Map([
+    [
+      "op-nadia",
+      { userId: "bellwether-nadia-okonjo", userName: "Nadia Okonjo" },
+    ],
+    ["op-theo", { userId: "bellwether-theo-vance", userName: "Theo Vance" }],
+  ]);
+
+/**
+ * Where memory lands when no operator is mapped and no role is set. Memory
+ * taught during a live demo often ends up here, so a presenter reset MUST clear
+ * it too — otherwise a previous run's learned procedure survives and beat 6
+ * silently starts out already knowing the answer.
+ */
+export const DEMO_DEFAULT_USER_ID = "bellwether-demo-user";
+
+export type IdentityInput = { operatorId?: string; role?: string };
+
+function roleSlug(role?: string): string {
+  if (!role) return DEMO_DEFAULT_USER_ID;
+  const slug = role
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  return slug ? `bellwether-${slug}` : DEMO_DEFAULT_USER_ID;
+}
+
+export function resolveUserId({
+  operatorId,
+  role,
+}: IdentityInput = {}): string {
+  const pinned = process.env.INTELLIGENCE_USER_ID;
+  if (pinned) return pinned;
+  const mapped = operatorId ? OPERATOR_IDENTITY.get(operatorId) : undefined;
+  if (mapped) return mapped.userId;
+  return roleSlug(role);
+}
+
+/**
+ * ── THE RESET/RUNTIME IDENTITY CONTRACT ────────────────────────────────────
+ *
+ * Every identity input the runtime can hand `commerceIdentifyUser`, DERIVED from
+ * the operator roster in `data/seed.ts` rather than restated here.
+ *
+ * This function exists because the presenter reset used to carry its own
+ * hardcoded list of buckets to forget and re-seed, and that list could not
+ * possibly be right:
+ *
+ *  - `resolveUserId` short-circuits on a pinned `INTELLIGENCE_USER_ID`, and
+ *    `playwright.config.ts` pins it to banking's `jordan-beamson`. So every e2e
+ *    commerce run read and wrote BANKING's memory bucket while the reset scrubbed
+ *    three `bellwether-*` buckets nothing was using — beats 4/5 recalled nothing,
+ *    and a procedure taught in beat 6 SURVIVED the reset.
+ *  - An operator present in the roster but absent from `OPERATOR_IDENTITY`
+ *    resolves to a `bellwether-<role>` slug, which the hardcoded list also
+ *    lacked.
+ *
+ * All three failures are silent: the reset returns `ok: true` with a plausible
+ * `forgot` count and the demo just quietly proves nothing. So the reset now asks
+ * THIS module which buckets exist, and there is exactly one copy of the answer.
+ */
+function possibleIdentityInputs(): readonly IdentityInput[] {
+  return [
+    // Nothing forwarded. This is the COMMON case on a run, not an edge case:
+    // observed in the dev log, the client's `properties` do not always reach
+    // `identifyUser` on the run path, so recall frequently looks at the default
+    // bucket rather than the mapped operator.
+    {},
+    // One per on-screen operator, in exactly the shape
+    // `useCommerceRuntimeProperties` forwards: { userId, userRole }. Mapped
+    // operators yield their 1:1 scope; an UNMAPPED one falls through to its role
+    // slug, and deriving from the roster is what keeps that covered when someone
+    // adds an operator to `seed.ts` and forgets `OPERATOR_IDENTITY`.
+    ...SEED_OPERATORS.map((o) => ({ operatorId: o.id, role: o.role })),
+    // Role forwarded without a recognised operator id — the role-slug branch.
+    ...SEED_OPERATORS.map((o) => ({ role: o.role })),
+  ];
+}
+
+/**
+ * Every memory bucket this process's runtime can read or write, in the order the
+ * inputs above produce them. The presenter reset forgets exactly this set.
+ *
+ * Read at CALL time, never frozen into a module constant: the pinned-env branch
+ * collapses the whole set to `[pinned]`, and a constant evaluated at import
+ * would answer for whatever the env happened to be when the module first loaded.
+ */
+export function memoryScopeUserIds(): readonly string[] {
+  return [
+    ...new Set(possibleIdentityInputs().map((input) => resolveUserId(input))),
+  ];
+}
+
+/**
+ * The buckets beat 4's and beat 5's memories are seeded into — the default one
+ * AND the seeded operator's, on purpose.
+ *
+ * Banking and Rowan both hit the same thing and settled here: because runs
+ * frequently resolve to the DEFAULT bucket (see `possibleIdentityInputs`),
+ * seeding only the mapped operator leaves recall looking at an empty bucket and
+ * beat 4 fails with the agent cheerfully saying it has no saved format — while
+ * the memories sit perfectly well stored one id over. So seed the default
+ * bucket, because that is where recall actually looks, AND the mapped operator,
+ * so the per-operator story is already correct the day the properties path is
+ * fixed. Two extra POSTs on reset is a cheap price for a beat that otherwise
+ * fails silently and looks like the memory system is broken.
+ *
+ * Goes through `resolveUserId` for the same reason the forget set does: under a
+ * pinned `INTELLIGENCE_USER_ID` both entries collapse onto the pinned bucket,
+ * which is the only one the runtime will read.
+ *
+ * ⚠ Until properties forwarding is fixed, switching operator in the sidebar does
+ * NOT re-scope memory — Nadia and Theo both resolve to `bellwether-demo-user` on
+ * a run. The "Theo has taught it nothing" contrast is not demoable yet.
+ */
+export function memorySeedTargetUserIds(): readonly string[] {
+  const seededOperator = SEED_OPERATORS.find(
+    (o) => o.id === DEFAULT_OPERATOR_ID,
+  );
+  return [
+    ...new Set([
+      resolveUserId({}),
+      resolveUserId({
+        operatorId: DEFAULT_OPERATOR_ID,
+        role: seededOperator?.role,
+      }),
+    ]),
+  ];
+}
+
+export function resolveUserName({
+  operatorId,
+  role,
+}: IdentityInput = {}): string {
+  if (process.env.INTELLIGENCE_USER_ID) {
+    return (
+      process.env.INTELLIGENCE_USER_NAME ?? process.env.INTELLIGENCE_USER_ID
+    );
+  }
+  const mapped = operatorId ? OPERATOR_IDENTITY.get(operatorId) : undefined;
+  if (mapped) return mapped.userName;
+  return role ? `Bellwether ${role}` : "Bellwether Demo User";
+}
+
+/**
+ * Bellwether's `IdentifyRunUser`, registered in `agent-registry.ts`. The client
+ * forwards the active operator through CopilotKit `properties`
+ * ({ userRole, userId }); this maps them onto a stable per-operator scope
+ * WITHOUT the shared API route importing anything skin-specific.
+ */
+export function commerceIdentifyUser(
+  properties: { userRole?: string; userId?: string } | undefined,
+): { id: string; name: string } {
+  const input: IdentityInput = {
+    operatorId: properties?.userId,
+    role: properties?.userRole,
+  };
+  return { id: resolveUserId(input), name: resolveUserName(input) };
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/layout.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/layout.tsx
@@ -1,0 +1,377 @@
+"use client";
+import "./theme.css"; // side-effect import registers the .theme-commerce block
+
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { HelpCircle, RotateCcw } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { useSkin } from "@/shell/skin-provider";
+import { useSkinHref, useSkinSegments } from "@/shell/skin-path";
+import { usePresenterReset } from "@/shell/presenter-reset-context";
+import { useCanvas } from "@/shell/canvas/canvas-context";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useCommerceLedger } from "./data/ledger-context";
+import { describeError, resetLandedWrites } from "./settle";
+import { useAskCopilot } from "./components/use-ask-copilot";
+import { SkuTile } from "./components/sku-tile";
+
+const SIDEBAR_WIDTH_PX = 240;
+
+/**
+ * The page each nav segment reports itself as to the agent. The index route is
+ * `/commerce`, which IS the order book — reporting `""` there would tell the
+ * agent "the current page is empty string", so it gets a real name.
+ */
+const ROUTE_READABLE_NAME: Record<string, string> = {
+  "": "orders",
+  catalog: "catalog",
+  promotions: "promotions",
+  returns: "returns",
+};
+
+const CONFIRM_RESET = "Reset the demo? This restores the seeded scenario.";
+
+/**
+ * The four things the reset needs from the browser, injected so the whole
+ * sequence is testable without a document. `navigate` is a REAL document load
+ * (`location.assign`), never a router push: the point is to drop every piece of
+ * client state the reset invalidated, and a soft nav keeps all of it.
+ */
+export interface PresenterResetIo {
+  confirm: (message: string) => boolean;
+  notify: (message: string) => void;
+  navigate: () => void;
+  post: () => Promise<Response>;
+}
+
+/**
+ * What the reset route's response says about THE SERVER STORE — the only
+ * question this client has to answer, because `store.reset()` runs in the route
+ * BEFORE anything that can fail and is never rolled back.
+ *
+ *  - `true`  — the body named the store in `reset`, so every row this document
+ *              is holding is gone. True of the 200s AND of both 502s.
+ *  - `false` — a body the route composed before it mutated anything (today only
+ *              the 403 gate, which carries `error` and no `reset`), so the
+ *              screen is still true and must be left alone.
+ *  - `null`  — unreadable or unrecognised body: a Next-generated error page, a
+ *              proxy, an empty 500. The store MAY be wiped and the client cannot
+ *              tell, which is treated as wiped (see `runPresenterReset`).
+ */
+interface ResetVerdict {
+  storeWiped: boolean | null;
+  /** The route's presenter-facing memory sentence, or `""` if it sent none. */
+  memoryError: string;
+  /** The gate's own explanation, or `""`. Only used when the store is intact. */
+  message: string;
+}
+
+async function readResetVerdict(res: Response): Promise<ResetVerdict> {
+  try {
+    const body = (await res.json()) as Record<string, unknown>;
+    const reset = body.reset;
+    return {
+      storeWiped: Array.isArray(reset)
+        ? reset.includes("store")
+        : typeof body.error === "string"
+          ? // Refused, not attempted: the gate is the only response this route
+            // composes without a `reset` list, and it returns before the wipe.
+            false
+          : null,
+      memoryError: typeof body.memoryError === "string" ? body.memoryError : "",
+      message: typeof body.message === "string" ? body.message : "",
+    };
+  } catch {
+    // Not a swallowed error — this IS the "cannot tell" verdict, and the caller
+    // acts on it. The parse failure itself says nothing a presenter can use.
+    return { storeWiped: null, memoryError: "", message: "" };
+  }
+}
+
+/**
+ * The presenter/booth Reset, end to end.
+ *
+ * The rule it exists to enforce: **the moment the server store is (or may be)
+ * wiped, nothing this document is holding may keep asserting the old world.**
+ * There are two narrators, and a partial failure used to leave both of them
+ * lying:
+ *
+ *  1. THE SCREEN. `store.reset()` is the route's first act, so a 502 (memory
+ *     wiped but not fully re-seeded) and a mid-sweep throw BOTH mean the ledger
+ *     is already back to seed. Branching on `res.ok` alone neither navigated nor
+ *     refreshed on those paths, so the page went on rendering pre-reset rows —
+ *     and the page is also what the agent's readables describe, so "what's on my
+ *     screen?" described the vanished state too.
+ *  2. THE AGENT'S RECITAL. `settle.ts`'s module-level journal of landed writes
+ *     is dropped by a document load and by nothing else. No navigate meant the
+ *     journal outlived the ledger, and the next failure on one of those records
+ *     recited writes the reset had taken away as still standing.
+ *
+ * So every outcome except a PROVABLY untouched store ends the same way: clear
+ * the journal, show the warning, hard navigate. The asymmetry is deliberate — a
+ * needless reload costs a few seconds of stage time, while a stale page costs
+ * the demo, and the presenter pressed Reset precisely to throw this state away.
+ *
+ * The warning is not decoration either: the 502's `memoryError` is the one
+ * sentence that says beat 6 may start out ALREADY TAUGHT, which changes what the
+ * presenter does next (run Reset again, or skip the teach beat). Reporting a
+ * bare "HTTP 502" over the top of it threw that away.
+ */
+export async function runPresenterReset(io: PresenterResetIo): Promise<void> {
+  if (!io.confirm(CONFIRM_RESET)) return;
+
+  const leave = (warning: string) => {
+    // Cleared EXPLICITLY as well as by the navigate below. Belt and braces on
+    // purpose: the journal must be gone even if the document load never lands
+    // (a modal left open, a `beforeunload`, a browser that refuses the assign),
+    // because a surviving entry is a recital about records the reset emptied.
+    resetLandedWrites();
+    // Ordered. `notify` is modal, so the presenter reads it and THEN the page
+    // goes away; reversed, the navigation can dismiss the only copy of the
+    // sentence saying memory may still be dirty.
+    if (warning) io.notify(warning);
+    io.navigate();
+  };
+
+  let res: Response;
+  try {
+    res = await io.post();
+  } catch (err) {
+    // No response at all, so the store's state is unknowable — and this store is
+    // in-memory, so the likeliest cause (the dev server restarting mid-call) has
+    // itself already reset it. Reloading is the reading that cannot be wrong in
+    // the demo-destroying direction; if the server really is gone the browser
+    // says so, which the presenter has to know either way.
+    leave(
+      `Reset could not be confirmed: ${describeError(err)}. The demo data may ` +
+        `already have been reset, so this page is reloading. If it does not come ` +
+        `back, the server is down.`,
+    );
+    return;
+  }
+
+  const verdict = await readResetVerdict(res);
+
+  if (verdict.storeWiped === false) {
+    // Refused before it mutated anything. Nothing on screen is stale and the
+    // journal is still true, so navigating would throw away a working demo.
+    io.notify(
+      `The demo was NOT reset (HTTP ${res.status}). ` +
+        `${verdict.message || "See the server logs."} Nothing has changed.`,
+    );
+    return;
+  }
+
+  if (res.ok) {
+    leave("");
+    return;
+  }
+
+  leave(
+    `Reset incomplete (HTTP ${res.status}). The demo data WAS reset, so this ` +
+      `page is reloading. Memory was not: ` +
+      `${verdict.memoryError || "see the server logs"}. Run Reset again before ` +
+      `you present — the memory beats may otherwise start out already taught.`,
+  );
+}
+
+export function CommerceLayout({ children }: { children: ReactNode }) {
+  const skin = useSkin();
+  // EVERY in-skin link goes through skinHref — never a hardcoded `/${skin.id}/…`.
+  // Under LOCK_SKIN the deploy is served AT `/` with the skin segment absent
+  // from the URL space, and a hardcoded prefix would put it straight back into
+  // the address bar on the first nav click. `pnpm lint` enforces this.
+  const skinHref = useSkinHref(skin.id);
+  // useSkinSegments strips a LEADING skin id if present, so this is correct
+  // whether or not the pathname carries the prefix. Do NOT hand-roll it as
+  // `pathname.split("/").slice(2)` — that eats the first real segment on a
+  // locked deploy, where there is no prefix to skip.
+  const restHead = useSkinSegments(skin.id)[0] ?? "";
+  const resetEnabled = usePresenterReset();
+  const askCopilot = useAskCopilot();
+  const { operator, data, setOperatorId } = useCommerceLedger();
+  const { clear } = useCanvas();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const Logo = skin.identity.logo;
+
+  // ── BEAT 3b: THE ROUTE READABLE ──────────────────────────────────────────
+  // Without this the agent has no idea which page is open, so "what's on my
+  // screen?" answers identically everywhere and the beat dies silently — the
+  // answers are plausible, just not page-specific. Each PAGE registers its own
+  // readable for what is visibly rendered; this one only says WHERE the user is.
+  useAgentContext({
+    description:
+      "The page the user is currently looking at in the Bellwether commerce " +
+      "operations app.",
+    value: ROUTE_READABLE_NAME[restHead] ?? restHead,
+  });
+
+  // Who is signed in — Bellwether scopes durable memory per operator, so the
+  // agent should speak to the right person by name.
+  useAgentContext({
+    description: "The signed-in Bellwether operator.",
+    value: JSON.stringify({
+      id: operator.id,
+      name: operator.name,
+      role: operator.role,
+      team: operator.team,
+    }),
+  });
+
+  // Dismiss a canvas surface when the user navigates away, including a
+  // query-string-only change (beat 3c pushes `?status=…&sort=…`, which is a nav
+  // as far as the user is concerned but would otherwise leave a stale brief
+  // covering the page they just asked to see).
+  useEffect(() => {
+    clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, searchParams?.toString()]);
+
+  const handleReset = () =>
+    runPresenterReset({
+      confirm: (message) => window.confirm(message),
+      notify: (message) => window.alert(message),
+      // Hard navigate to the skin root for a pristine slate — fresh store,
+      // cleared canvas, new thread on the next message — and the clean starting
+      // URL, which is `/` itself on a locked single-tenant deploy.
+      navigate: () => window.location.assign(skinHref()),
+      post: () => fetch("/api/commerce/v1/dev/reset", { method: "POST" }),
+    });
+
+  return (
+    // h-full + overflow-hidden — NOT h-screen, NOT min-h-screen. This chrome
+    // fills the shell's app CARD, which the frame has already inset by its own
+    // padding, so a viewport-height root overflows the card by exactly that
+    // much. It must still be BOUNDED: an unbounded container scrolls the whole
+    // document, taking the pinned nav with it and rendering <main>'s own
+    // overflow-y-auto inert.
+    <div className="flex h-full overflow-hidden bg-canvas text-ink">
+      <aside
+        className="hidden h-full shrink-0 flex-col border-r border-hairline bg-surface px-3 py-5 md:flex"
+        style={{ width: SIDEBAR_WIDTH_PX }}
+      >
+        <div className="mb-6 flex items-center gap-2.5 px-2">
+          <Logo className="h-7 w-7 text-brand" />
+          <div className="min-w-0">
+            <div className="truncate text-base font-semibold tracking-tight text-ink">
+              {skin.identity.brand}
+            </div>
+            <div className="truncate text-[0.68rem] text-ink-muted">
+              Commerce Ops
+            </div>
+          </div>
+        </div>
+
+        <nav className="flex flex-col gap-0.5">
+          {skin.nav.map((route) => {
+            const href = skinHref(route.segment);
+            // Compare SEGMENTS, not whole pathnames: under a lock the href is
+            // prefix-free while the matched route is not, so `pathname === href`
+            // is not reliably true for the active entry.
+            const active = restHead === route.segment;
+            const Icon = route.icon;
+            return (
+              <Link
+                key={route.segment || "index"}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  active
+                    ? "bg-brand-soft text-brand"
+                    : "text-ink-muted hover:bg-surface-muted hover:text-ink",
+                )}
+              >
+                {Icon ? <Icon className="h-4 w-4" /> : null}
+                {route.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* Meta-utility strip — skin-authored chrome, pinned to the bottom. A
+            new skin gets none of these for free; the shell provides no Reset,
+            no theme toggle and no Help. */}
+        <div className="mt-auto">
+          <TooltipProvider delayDuration={200}>
+            <div className="flex items-center gap-1 border-t border-hairline px-1 pt-3">
+              {resetEnabled ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => void handleReset()}
+                      aria-label="Reset demo state"
+                      className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand"
+                    >
+                      <RotateCcw className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Reset demo state</TooltipContent>
+                </Tooltip>
+              ) : null}
+              {/* A real control here, not a dead one: theme.css sets
+                  `--nw-dark-capable: 1` and ships a `.dark .theme-commerce`
+                  block. */}
+              <ThemeToggle />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Ask Bellwether for help"
+                    onClick={() =>
+                      void askCopilot(
+                        "What can you help me with in Bellwether? Give me a short list.",
+                      )
+                    }
+                    className="flex h-9 w-9 items-center justify-center rounded-md text-ink-muted transition-colors hover:bg-brand-soft hover:text-brand"
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Ask Bellwether for help</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+
+          {/* Who is signed in. Switching operator re-scopes Intelligence memory
+              through `useRuntimeProperties`, which is the point: Nadia has
+              taught Bellwether how she reads a margin review, Theo has taught it
+              nothing. */}
+          <div className="mt-3 flex items-center gap-2 rounded-md border border-hairline bg-surface-muted px-2 py-2">
+            <SkuTile name={operator.name} size="sm" shape="round" />
+            <label className="min-w-0 flex-1">
+              <span className="sr-only">Signed in as</span>
+              <select
+                value={operator.id}
+                onChange={(event) => setOperatorId(event.target.value)}
+                className="w-full cursor-pointer truncate bg-transparent text-[0.75rem] font-medium text-ink outline-none"
+              >
+                {data.operators.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.name}
+                  </option>
+                ))}
+              </select>
+              <span className="block truncate text-[0.65rem] text-ink-muted">
+                {operator.team}
+              </span>
+            </label>
+          </div>
+        </div>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto px-6 py-6">{children}</main>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/margin-summary.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/margin-summary.test.tsx
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SUMMARY_ROW_CAP, selectSummaryRows } from "./margin-summary";
+import { MarginSummaryList } from "./tools";
+import { SEED_FLOORS, SEED_PRODUCTS } from "./data/seed";
+import type { Category, MarginFloor, Product } from "./data/types";
+import { productFloorStatus } from "./data/derive";
+
+/**
+ * BEAT 4's margin summary used to render `rows.slice(0, 12)` and nothing else.
+ * Against the seeded range that withholds two SKUs, and under `byCategory` —
+ * where the ranked order is alphabetical by category — the two it withheld were
+ * both Outerwear SKUs, one of them below its floor. The list read as complete.
+ *
+ * These tests pin the three properties that failure violated: the withheld count
+ * is stated, no category vanishes unnamed, and below-floor rows still survive the
+ * cap under `belowFloorFirst`.
+ *
+ * No `@testing-library/jest-dom` in this app, so DOM assertions are plain.
+ */
+const floors = [...SEED_FLOORS] as MarginFloor[];
+const products = SEED_PRODUCTS.map((p) => ({ ...p }) as Product);
+
+const categoriesOf = (rows: Product[]) => new Set(rows.map((r) => r.category));
+const belowFloor = (rows: Product[]) =>
+  rows.filter((r) => productFloorStatus(floors, r) === "below");
+
+afterEach(cleanup);
+
+describe("the seeded range the cap is judged against", () => {
+  it("carries more SKUs than the cap, so truncation is real", () => {
+    // 14 seeded SKUs against a cap of 12. If someone trims the seed to fit the
+    // cap, every assertion below would pass vacuously — so it is asserted.
+    expect(products).toHaveLength(14);
+    expect(products.length).toBeGreaterThan(SUMMARY_ROW_CAP);
+  });
+
+  it("spreads those SKUs over five categories, one of which fits in the tail", () => {
+    const perCategory = new Map<Category, number>();
+    for (const item of products) {
+      perCategory.set(item.category, (perCategory.get(item.category) ?? 0) + 1);
+    }
+    expect(Object.fromEntries(perCategory)).toEqual({
+      Knitwear: 3,
+      Outerwear: 2,
+      Footwear: 2,
+      Home: 3,
+      Accessories: 4,
+    });
+    // Two of them trade under their own category floor.
+    expect(belowFloor(products).map((p) => p.name)).toEqual([
+      "Harbor Parka",
+      "Lark Runner",
+    ]);
+  });
+});
+
+describe("selectSummaryRows", () => {
+  it("says nothing when everything fits", () => {
+    const selection = selectSummaryRows(products.slice(0, 5), floors, {
+      byCategory: true,
+      belowFloorFirst: true,
+    });
+    expect(selection.visible).toHaveLength(5);
+    expect(selection.withheld).toBe(0);
+    expect(selection.droppedCategories).toEqual([]);
+    expect(selection.caption).toBeNull();
+  });
+
+  it("states how many rows the cap withheld, out of how many", () => {
+    const selection = selectSummaryRows(products, floors, {
+      byCategory: false,
+      belowFloorFirst: true,
+    });
+    expect(selection.visible).toHaveLength(SUMMARY_ROW_CAP);
+    expect(selection.withheld).toBe(2);
+    expect(selection.caption).toContain("2 of 14 SKUs not shown");
+  });
+
+  it("names any category that disappeared entirely under byCategory", () => {
+    // The regression case exactly: grouped by category, below-floor rows NOT
+    // hoisted, so the cap eats the alphabetical tail whole.
+    const selection = selectSummaryRows(products, floors, {
+      byCategory: true,
+      belowFloorFirst: false,
+    });
+    expect(categoriesOf(selection.visible).has("Outerwear")).toBe(false);
+    expect(selection.droppedCategories).toEqual(["Outerwear"]);
+    expect(selection.caption).toContain("Nothing from Outerwear appears here");
+  });
+
+  it("counts a withheld below-floor row in the caption rather than losing it", () => {
+    const selection = selectSummaryRows(products, floors, {
+      byCategory: true,
+      belowFloorFirst: false,
+    });
+    // Harbor Parka is below its Outerwear floor and is one of the two withheld.
+    expect(belowFloor(selection.visible).map((p) => p.name)).toEqual([
+      "Lark Runner",
+    ]);
+    expect(selection.caption).toContain("1 below floor");
+  });
+
+  it("keeps every below-floor row above the cut under belowFloorFirst", () => {
+    for (const byCategory of [true, false]) {
+      const selection = selectSummaryRows(products, floors, {
+        byCategory,
+        belowFloorFirst: true,
+      });
+      expect(
+        belowFloor(selection.visible)
+          .map((p) => p.name)
+          .sort(),
+      ).toEqual(["Harbor Parka", "Lark Runner"]);
+    }
+  });
+
+  it("ranks a SKU with no floor on file with the exceptions, not the clean rows", () => {
+    // Drop the Home floor: its three SKUs become "unknown" — unchecked, not
+    // cleared — and must sort ahead of every clear row.
+    const partialFloors = floors.filter((f) => f.category !== "Home");
+    const selection = selectSummaryRows(products, partialFloors, {
+      byCategory: true,
+      belowFloorFirst: true,
+      cap: 5,
+    });
+    expect(selection.visible.map((p) => p.category)).toEqual([
+      "Footwear",
+      "Outerwear",
+      "Home",
+      "Home",
+      "Home",
+    ]);
+    // Every unchecked row therefore SURVIVES the cap, so the caption carries no
+    // flag clause — the withheld nine all cleared their floors.
+    expect(selection.caption).toBe(
+      "9 of 14 SKUs not shown. Nothing from Accessories, Knitwear appears here.",
+    );
+  });
+
+  it("accounts for unchecked withheld rows separately from below-floor ones", () => {
+    const selection = selectSummaryRows(products, [], {
+      byCategory: false,
+      belowFloorFirst: true,
+      cap: 1,
+    });
+    // No floors at all: nothing is below floor, everything is unchecked.
+    expect(selection.caption).toContain("13 not checked");
+    expect(selection.caption).not.toContain("below floor");
+  });
+});
+
+describe("MarginSummaryList", () => {
+  const renderList = (
+    overrides: Partial<{
+      byCategory: boolean;
+      belowFloorFirst: boolean;
+      asMarginPercent: boolean;
+      products: Product[];
+    }> = {},
+  ) =>
+    render(
+      <MarginSummaryList
+        products={overrides.products ?? products}
+        floors={floors}
+        byCategory={overrides.byCategory ?? true}
+        belowFloorFirst={overrides.belowFloorFirst ?? false}
+        asMarginPercent={overrides.asMarginPercent ?? true}
+        note="You read these by category."
+      />,
+    );
+
+  it("renders the withheld count on screen, not just in the selection", () => {
+    const { container } = renderList();
+    expect(container.querySelectorAll("li")).toHaveLength(SUMMARY_ROW_CAP);
+    expect(screen.getByText(/2 of 14 SKUs not shown/).textContent).toContain(
+      "Nothing from Outerwear appears here",
+    );
+  });
+
+  it("renders no caption when the whole range fits", () => {
+    renderList({ products: products.slice(0, 4) });
+    expect(screen.queryByText(/SKUs not shown/)).toBeNull();
+  });
+
+  it("still shows the note it was given", () => {
+    renderList();
+    expect(screen.getByText("You read these by category.")).toBeTruthy();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/margin-summary.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/margin-summary.ts
@@ -1,0 +1,150 @@
+import type { Category, MarginFloor, Product } from "./data/types";
+import type { FloorStatus } from "./data/derive";
+import {
+  FLOOR_WORKLIST_RANK,
+  productFloorStatus,
+  productMargin,
+  tallyFloorStatus,
+} from "./data/derive";
+
+/**
+ * Row selection for BEAT 4's `showMarginSummary` list.
+ *
+ * Pure on purpose: the ordering and the truncation are the part of that
+ * component worth testing, and they are testable here without a CopilotKit
+ * provider, a ledger fetch or a DOM. `MarginSummaryList` in `./tools` renders
+ * exactly what this returns, caption included.
+ *
+ * ── WHY THE CAPTION EXISTS ──────────────────────────────────────────────────
+ *
+ * The list is capped so a fourteen-SKU range does not push the rest of the
+ * transcript off screen. The cap is fine; a SILENT cap is not. Bellwether's
+ * whole claim is that margin is comparable across categories, and under
+ * `byCategory` the ranked order is alphabetical by category — so the cap drops
+ * TRAILING CATEGORIES rather than trailing rows. Against the seeded range
+ * (14 SKUs, cap 12) `byCategory` without `belowFloorFirst` withholds both
+ * Outerwear SKUs, one of which is below its floor. A reader cannot tell that
+ * from a category that had nothing to report: the list reads as complete and
+ * the missing violation reads as an all-clear.
+ *
+ * So every withheld row is accounted for in one sentence, which names three
+ * things a reader would otherwise have to guess at:
+ *
+ *  1. how many rows were withheld, out of how many;
+ *  2. how many of those were below floor or could not be checked at all;
+ *  3. which categories vanished ENTIRELY, by name.
+ *
+ * A per-category quota was the alternative and was rejected: it would inject a
+ * category's best row ahead of worse-margin rows from other categories, so the
+ * list would stop being "the rows that most need attention, in order" — the
+ * property the ranking below exists to give it.
+ */
+export const SUMMARY_ROW_CAP = 12;
+
+/**
+ * "Below floor first" ordering. A SKU whose category has no floor on file sorts
+ * with the exceptions, not with the clean rows: it has not been cleared, it has
+ * not been checked.
+ *
+ * An ALIAS of `derive.FLOOR_WORKLIST_RANK` rather than its own table — the
+ * catalog's rows, the promotions desk's cards and this list all rank the same
+ * three verdicts, and a private copy is exactly how one of them would later fold
+ * `unknown` back in with `clear`.
+ */
+export const SUMMARY_RANK: Record<FloorStatus, number> = FLOOR_WORKLIST_RANK;
+
+export interface SummaryRowSelection {
+  /** The rows to render, in display order. */
+  visible: Product[];
+  /** How many ranked rows the cap withheld. */
+  withheld: number;
+  /** Categories with a withheld row and NO surviving row — gone entirely. */
+  droppedCategories: Category[];
+  /** The sentence the list owes the reader; `null` when nothing was withheld. */
+  caption: string | null;
+}
+
+export interface SummaryRowOptions {
+  byCategory: boolean;
+  belowFloorFirst: boolean;
+  /** Defaults to `SUMMARY_ROW_CAP`. */
+  cap?: number;
+}
+
+/**
+ * Rank the range the way the summary reads it, then cap it and account for
+ * whatever the cap withheld.
+ *
+ * `belowFloorFirst` is what keeps violations above the cut — with it set, every
+ * below-floor (and every unchecked) row sorts ahead of every clean one, so a
+ * violation can only be withheld once the exceptions alone overflow the cap.
+ * With it unset the caption is the only thing standing between a withheld
+ * violation and a false all-clear, which is why the counts are computed from the
+ * withheld rows themselves rather than from the cap arithmetic.
+ */
+export function selectSummaryRows(
+  products: readonly Product[],
+  floors: MarginFloor[],
+  options: SummaryRowOptions,
+): SummaryRowSelection {
+  const { byCategory, belowFloorFirst, cap = SUMMARY_ROW_CAP } = options;
+
+  const ranked = [...products].sort((a, b) => {
+    if (belowFloorFirst) {
+      const aOut = SUMMARY_RANK[productFloorStatus(floors, a)];
+      const bOut = SUMMARY_RANK[productFloorStatus(floors, b)];
+      if (aOut !== bOut) return aOut - bOut;
+    }
+    if (byCategory && a.category !== b.category)
+      return a.category.localeCompare(b.category);
+    return productMargin(a) - productMargin(b);
+  });
+
+  const visible = ranked.slice(0, Math.max(0, cap));
+  const withheldRows = ranked.slice(visible.length);
+
+  const shown = new Set(visible.map((item) => item.category));
+  const droppedCategories: Category[] = [];
+  for (const item of withheldRows) {
+    if (shown.has(item.category) || droppedCategories.includes(item.category))
+      continue;
+    droppedCategories.push(item.category);
+  }
+
+  return {
+    visible,
+    withheld: withheldRows.length,
+    droppedCategories,
+    caption: describeWithheld(
+      withheldRows,
+      ranked.length,
+      floors,
+      droppedCategories,
+    ),
+  };
+}
+
+function describeWithheld(
+  withheldRows: Product[],
+  total: number,
+  floors: MarginFloor[],
+  droppedCategories: Category[],
+): string | null {
+  if (withheldRows.length === 0) return null;
+
+  const tally = tallyFloorStatus(floors, withheldRows);
+  const flags: string[] = [];
+  if (tally.below > 0) flags.push(`${tally.below} below floor`);
+  if (tally.unknown > 0) flags.push(`${tally.unknown} not checked`);
+
+  const head =
+    `${withheldRows.length} of ${total} SKUs not shown` +
+    (flags.length > 0 ? ` (${flags.join(", ")})` : "") +
+    ".";
+  const tail =
+    droppedCategories.length > 0
+      ? ` Nothing from ${droppedCategories.join(", ")} appears here.`
+      : "";
+
+  return `${head}${tail}`;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/order-queue-levers.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/order-queue-levers.test.tsx
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { z } from "zod";
+import {
+  normalizeQueueLevers,
+  queueLeverChips,
+  queueLeverQuery,
+} from "./order-queue-levers";
+import {
+  EXCEPTION_FILTERS,
+  ORDER_SORTS,
+  ORDER_STATUS_FILTERS,
+  isOnException,
+} from "./data/derive";
+import * as store from "./data/store";
+import type { CommerceStoreState, Operator, Order } from "./data/types";
+
+/**
+ * BEAT 3c — the lever set the agent may ask for, versus what the app actually
+ * does with it.
+ *
+ * The beat's claim is that the assistant reached into the app's REAL controls,
+ * and two things shipped that falsify it in front of the room:
+ *
+ *  1. `showOrderQueue` advertised `status: "cancelled"` while the skin's global
+ *     ledger readable filtered cancelled orders OUT — so the one status only the
+ *     agent could reach was the one it could not then describe, and once it HAD
+ *     navigated, the page readable listed rows the ledger readable denied
+ *     existed. Fixed by making the order book whole and saying "not queue work"
+ *     with `isOnException` instead of by dropping the row.
+ *
+ *  2. The card's chips defaulted: the Sort chip's ternary ended in a bare
+ *     `"oldest first"`, so an `args.sort` that had not streamed in yet asserted
+ *     `aging_desc` on the agent's behalf; status, exception and top-N did the
+ *     same via `?? "all"`. A chip now appears only for a lever that was really
+ *     set, and it is drawn from the same normalized record the URL is built
+ *     from.
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+// ── The mock surface `CommerceTools` needs ──────────────────────────────────
+// Filled at render time, never while these factories are hoisted.
+const pushed: string[] = [];
+const readables: { description: string; value: string }[] = [];
+const interrupts = new Map<string, ToolRegistration>();
+const ledger: { value: CommerceStoreState | null } = { value: null };
+
+/** Only the parts of a registration these tests exercise. */
+interface ToolRegistration {
+  name: string;
+  parameters: z.ZodType<unknown>;
+  render?: (props: {
+    args?: Record<string, unknown>;
+    respond?: (value: string) => Promise<unknown>;
+    result?: unknown;
+    toolCallId?: string;
+  }) => ReactNode;
+}
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: (href: string) => {
+      pushed.push(href);
+    },
+  }),
+  usePathname: () => "/commerce",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: (entry: { description: string; value: string }) => {
+    readables.push(entry);
+  },
+  useComponent: () => {},
+  useFrontendTool: () => {},
+  useHumanInTheLoop: (registration: ToolRegistration) => {
+    interrupts.set(registration.name, registration);
+  },
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("./data/ledger-context", async () => {
+  const real = await import("./data/store");
+  return {
+    useCommerceLedger: () => ({
+      data: ledger.value ?? real.snapshot(),
+      refresh: async () => true,
+      operator: real.operators()[0] satisfies Operator,
+      setOperatorId: () => {},
+    }),
+  };
+});
+
+// Imported after the mocks so the module graph picks them up.
+const { CommerceTools } = await import("./tools");
+
+/**
+ * The seed carries no cancelled order — `cancelled` is only reachable at runtime
+ * — so one is manufactured the way `setOrderStatus` produces it: cancelled while
+ * STILL CARRYING the exception it was cancelled with. That is the row every
+ * queue view has to drop and every order-book view has to keep.
+ */
+function ledgerWithCancelledException(): {
+  state: CommerceStoreState;
+  cancelled: Order;
+} {
+  const base = store.snapshot();
+  const victim = base.orders.find(isOnException);
+  if (!victim) throw new Error("seed has no order on exception");
+  const cancelled: Order = { ...victim, status: "cancelled" };
+  return {
+    state: {
+      ...base,
+      orders: base.orders.map((o) => (o.id === victim.id ? cancelled : o)),
+    },
+    cancelled,
+  };
+}
+
+/** The skin's global ledger readable, parsed. */
+function ledgerReadable(): {
+  orders: { id: string; status: string; onException: boolean }[];
+} {
+  const entry = readables.find((r) =>
+    r.description.includes("Bellwether commerce ledger"),
+  );
+  if (!entry) throw new Error("the global ledger readable was not registered");
+  return JSON.parse(entry.value) as {
+    orders: { id: string; status: string; onException: boolean }[];
+  };
+}
+
+function queueTool(): ToolRegistration {
+  const tool = interrupts.get("showOrderQueue");
+  if (!tool) throw new Error("showOrderQueue was not registered");
+  return tool;
+}
+
+/** The chip pills the card actually draws, in order. */
+function renderedChips(args: Record<string, unknown> | undefined): string[] {
+  const tool = queueTool();
+  render(<>{tool.render?.({ args, toolCallId: "call-1" })}</>);
+  return [...document.querySelectorAll("li")].map(
+    (li) => li.textContent?.trim() ?? "",
+  );
+}
+
+beforeEach(() => {
+  store.reset();
+  pushed.length = 0;
+  readables.length = 0;
+  interrupts.clear();
+  ledger.value = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the advertised lever set", () => {
+  it("offers exactly the vocabularies the Orders page has controls for", () => {
+    render(<CommerceTools />);
+    const shape = (
+      queueTool().parameters as unknown as {
+        shape: Record<string, { options?: readonly string[] }>;
+      }
+    ).shape;
+
+    expect(shape.status.options).toEqual([...ORDER_STATUS_FILTERS]);
+    expect(shape.exception.options).toEqual([...EXCEPTION_FILTERS]);
+    expect(shape.sort.options).toEqual([...ORDER_SORTS]);
+  });
+
+  it("refuses a top-N the Orders page would ignore", () => {
+    render(<CommerceTools />);
+    const parameters = queueTool().parameters;
+    const base = { status: "all", exception: "any", sort: "aging_desc" };
+
+    expect(
+      parameters.safeParse({ ...base, top: 10, reason: "x" }).success,
+    ).toBe(true);
+    // 0, negative and fractional limits are what `parseTopLever` throws away, so
+    // the schema must not offer them in the first place.
+    for (const top of [0, -3, 2.5]) {
+      expect(
+        parameters.safeParse({ ...base, top, reason: "x" }).success,
+        `top=${top}`,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("every advertised status is describable", () => {
+  it("keeps cancelled orders in the ledger readable, flagged as not queue work", () => {
+    const { state, cancelled } = ledgerWithCancelledException();
+    ledger.value = state;
+
+    render(<CommerceTools />);
+    const rows = ledgerReadable().orders;
+
+    const row = rows.find((r) => r.id === cancelled.id);
+    expect(row).toBeDefined();
+    expect(row?.status).toBe("cancelled");
+    // Present, and correctly NOT counted as queue work.
+    expect(row?.onException).toBe(false);
+  });
+
+  it("describes every row each status lever can put on screen", () => {
+    const { state } = ledgerWithCancelledException();
+    ledger.value = state;
+
+    render(<CommerceTools />);
+    const described = new Set(ledgerReadable().orders.map((r) => r.id));
+
+    for (const lever of ORDER_STATUS_FILTERS) {
+      // The Orders page's own status clause: "all", else an exact match.
+      const onScreen = state.orders.filter(
+        (o) => lever === "all" || o.status === lever,
+      );
+      expect(onScreen.length, `status=${lever} shows nothing`).toBeGreaterThan(
+        0,
+      );
+      for (const order of onScreen) {
+        expect(described.has(order.id), `status=${lever} → ${order.id}`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("agrees with isOnException on which rows are queue work", () => {
+    const { state } = ledgerWithCancelledException();
+    ledger.value = state;
+
+    render(<CommerceTools />);
+    const rows = ledgerReadable().orders;
+
+    for (const order of state.orders) {
+      expect(rows.find((r) => r.id === order.id)?.onException, order.id).toBe(
+        isOnException(order),
+      );
+    }
+  });
+});
+
+describe("a chip asserts only what was set", () => {
+  it("draws no chip strip at all while the arguments are still streaming", () => {
+    render(<CommerceTools />);
+    expect(renderedChips(undefined)).toEqual([]);
+    // And says so in prose rather than promising a list that is not there.
+    expect(
+      screen.getByText(/I can open the Orders page for you\./),
+    ).toBeTruthy();
+  });
+
+  it("omits the Sort chip when no sort was set", () => {
+    render(<CommerceTools />);
+    const chips = renderedChips({ status: "all", exception: "any" });
+
+    expect(chips).toEqual(["Status · all", "Exception · any"]);
+    expect(chips.some((c) => c.startsWith("Sort"))).toBe(false);
+  });
+
+  it("draws one chip per lever once they have all arrived", () => {
+    render(<CommerceTools />);
+
+    expect(
+      renderedChips({
+        status: "open",
+        exception: "oversell",
+        sort: "value_desc",
+        top: 10,
+      }),
+    ).toEqual([
+      "Status · open",
+      "Exception · oversell",
+      "Sort · largest value",
+      "Show · top 10",
+    ]);
+  });
+
+  it("opens exactly the view the chips promised", () => {
+    render(<CommerceTools />);
+    const args = { exception: "any", sort: "aging_desc", top: 10 };
+    render(
+      <>
+        {queueTool().render?.({
+          args,
+          // A real `respond`, so the card's own "cannot settle" warning is not
+          // what this test is measuring.
+          respond: async () => undefined,
+          toolCallId: "call-2",
+        })}
+      </>,
+    );
+
+    screen.getByRole("button", { name: "Open it" }).click();
+
+    expect(pushed).toEqual(["/commerce?exception=any&sort=aging_desc&top=10"]);
+  });
+});
+
+// ── The pure lever contract ────────────────────────────────────────────────
+
+describe("normalizeQueueLevers", () => {
+  it("keeps every value the page's own vocabularies contain", () => {
+    for (const status of ORDER_STATUS_FILTERS) {
+      expect(normalizeQueueLevers({ status }).status).toBe(status);
+    }
+    for (const exception of EXCEPTION_FILTERS) {
+      expect(normalizeQueueLevers({ exception }).exception).toBe(exception);
+    }
+    for (const sort of ORDER_SORTS) {
+      expect(normalizeQueueLevers({ sort }).sort).toBe(sort);
+    }
+  });
+
+  it("reports an unset lever as null rather than as a default", () => {
+    expect(normalizeQueueLevers(undefined)).toEqual({
+      status: null,
+      exception: null,
+      sort: null,
+      top: null,
+    });
+    expect(normalizeQueueLevers({ status: "open" })).toEqual({
+      status: "open",
+      exception: null,
+      sort: null,
+      top: null,
+    });
+  });
+
+  it("drops a value outside the page's vocabulary", () => {
+    const levers = normalizeQueueLevers({
+      status: "archived",
+      exception: "none",
+      sort: "value_asc",
+    });
+    // `none` is deliberately absent from EXCEPTION_FILTERS — see its header.
+    expect(levers).toEqual({
+      status: null,
+      exception: null,
+      sort: null,
+      top: null,
+    });
+  });
+
+  it("drops a top-N the page would ignore", () => {
+    expect(normalizeQueueLevers({ top: 10 }).top).toBe(10);
+    for (const top of [0, -3, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(normalizeQueueLevers({ top }).top, `top=${top}`).toBeNull();
+    }
+  });
+});
+
+describe("queueLeverChips and queueLeverQuery agree", () => {
+  it("never draws a chip for a lever the URL will not carry", () => {
+    const cases: Parameters<typeof normalizeQueueLevers>[0][] = [
+      undefined,
+      {},
+      { status: "open" },
+      { sort: "aging_asc" },
+      { top: 5 },
+      { top: 2.5 },
+      { status: "cancelled", exception: "all", sort: "value_desc", top: 3 },
+      { status: "all", exception: "any", sort: "aging_desc", top: 10 },
+      { status: "bogus", exception: "bogus", sort: "bogus" },
+    ];
+
+    for (const args of cases) {
+      const levers = normalizeQueueLevers(args);
+      const chips = queueLeverChips(levers);
+      const query = new URLSearchParams(queueLeverQuery(levers));
+      const label = JSON.stringify(args);
+
+      // `all` is expressed by an ABSENT param, so a chip for it is expected
+      // without a param; every other chip must have one, and vice versa.
+      expect(
+        chips.some((c) => c.startsWith("Status")),
+        `status chip ${label}`,
+      ).toBe(levers.status !== null);
+      expect(query.has("status"), `status param ${label}`).toBe(
+        levers.status !== null && levers.status !== "all",
+      );
+      expect(
+        chips.some((c) => c.startsWith("Exception")),
+        `exception chip ${label}`,
+      ).toBe(levers.exception !== null);
+      expect(query.has("exception"), `exception param ${label}`).toBe(
+        levers.exception !== null && levers.exception !== "all",
+      );
+      expect(
+        chips.some((c) => c.startsWith("Sort")),
+        `sort chip ${label}`,
+      ).toBe(levers.sort !== null);
+      expect(query.has("sort"), `sort param ${label}`).toBe(
+        levers.sort !== null,
+      );
+      expect(
+        chips.some((c) => c.startsWith("Show")),
+        `top chip ${label}`,
+      ).toBe(levers.top !== null);
+      expect(query.get("top"), `top param ${label}`).toBe(
+        levers.top === null ? null : String(levers.top),
+      );
+    }
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/order-queue-levers.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/order-queue-levers.ts
@@ -1,0 +1,127 @@
+import {
+  EXCEPTION_FILTERS,
+  ORDER_SORTS,
+  ORDER_STATUS_FILTERS,
+} from "./data/derive";
+import type { ExceptionFilter, OrderSort, StatusFilter } from "./data/derive";
+import { parseTopLever } from "./pages/orders";
+
+/**
+ * BEAT 3c's lever contract, pulled out of the `showOrderQueue` card so the chips
+ * it draws, the URL it pushes and the Orders page's own controls cannot say
+ * three different things.
+ *
+ * Beat 3c's whole claim is that the assistant reached into the app's REAL
+ * controls. Two ways the card falsified that, both of which this module makes
+ * unrepresentable:
+ *
+ *  1. A CHIP FOR A LEVER NOBODY SET. The Sort chip was written as a ternary
+ *     ending in a bare `: "oldest first"`, so an `args.sort` that had not
+ *     arrived yet — arguments STREAM, and the card renders throughout — asserted
+ *     `aging_desc` on the agent's behalf, and could then flip to something else.
+ *     Status, exception and top-N each did the same through a `?? "all"`. Now a
+ *     lever that was not set gets NO chip: `queueLeverChips` reads the same
+ *     normalized record `queueLeverQuery` builds the URL from, so a chip cannot
+ *     claim a maneuver the navigation will not perform.
+ *
+ *  2. A VALUE THE VIEW WOULD NOT HONOUR. `top` is a raw number on the wire, and
+ *     the page IGNORES anything that is not a positive integer (see
+ *     `parseTopLever`) — so `top: 2.5` drew a "top 2.5" chip over a full,
+ *     unlimited list. It is now run through the page's OWN parser, on the very
+ *     string the query string will carry, which is why the two cannot drift.
+ *
+ * Everything the schema advertises is likewise taken from the page's control
+ * vocabularies (`ORDER_STATUS_FILTERS`, `EXCEPTION_FILTERS`, `ORDER_SORTS` in
+ * `data/derive`) rather than hand-copied, so the advertised lever set IS the
+ * control set.
+ */
+
+/**
+ * The card sees arguments MID-STREAM, so every field is optional and no field
+ * can be trusted to hold a schema value yet. Deliberately widened past the
+ * schema's own types for that reason: this is the untrusted shape, and
+ * `normalizeQueueLevers` is what turns it into the trusted one.
+ */
+export interface QueueLeverArgs {
+  status?: string;
+  exception?: string;
+  sort?: string;
+  top?: number;
+}
+
+/** A lever is `null` when it was not set, or was set to something unusable. */
+export interface QueueLevers {
+  status: StatusFilter | null;
+  exception: ExceptionFilter | null;
+  sort: OrderSort | null;
+  top: number | null;
+}
+
+/** Chip labels for the sorts. `Record<OrderSort, …>` — no sort can lack one. */
+const SORT_CHIP_LABEL: Record<OrderSort, string> = {
+  aging_desc: "oldest first",
+  aging_asc: "newest first",
+  value_desc: "largest value",
+};
+
+const member = <T extends string>(
+  vocabulary: readonly string[],
+  value: unknown,
+): T | null =>
+  typeof value === "string" && vocabulary.includes(value) ? (value as T) : null;
+
+/**
+ * The levers as the navigation will actually apply them. A value outside the
+ * page's vocabulary is dropped rather than passed through — the same rule
+ * `parseTopLever` follows, and the same rule the page applies when it reads the
+ * query string back.
+ */
+export function normalizeQueueLevers(
+  args: QueueLeverArgs | undefined,
+): QueueLevers {
+  return {
+    status: member<StatusFilter>(ORDER_STATUS_FILTERS, args?.status),
+    exception: member<ExceptionFilter>(EXCEPTION_FILTERS, args?.exception),
+    sort: member<OrderSort>(ORDER_SORTS, args?.sort),
+    // Through the page's own parser, on the exact string `queueLeverQuery` would
+    // put in the URL, so "what the chip claims" and "what the page will do" are
+    // one decision instead of two.
+    top:
+      args?.top === undefined || args.top === null
+        ? null
+        : parseTopLever(String(args.top)),
+  };
+}
+
+/**
+ * The query string for these levers.
+ *
+ * `all` is omitted for status and exception because ABSENT is how the page
+ * expresses it — the "all" control tints when the param is missing, so writing
+ * `?status=all` would be a longer URL for the identical view.
+ */
+export function queueLeverQuery(levers: QueueLevers): string {
+  const params = new URLSearchParams();
+  if (levers.status && levers.status !== "all")
+    params.set("status", levers.status);
+  if (levers.exception && levers.exception !== "all")
+    params.set("exception", levers.exception);
+  if (levers.sort) params.set("sort", levers.sort);
+  if (levers.top !== null) params.set("top", String(levers.top));
+  return params.toString();
+}
+
+/**
+ * One chip per lever that was actually set — and nothing for one that was not.
+ *
+ * An empty list is a legitimate state (arguments still streaming); the card
+ * draws no chip strip at all rather than a row of invented defaults.
+ */
+export function queueLeverChips(levers: QueueLevers): string[] {
+  const chips: string[] = [];
+  if (levers.status) chips.push(`Status · ${levers.status}`);
+  if (levers.exception) chips.push(`Exception · ${levers.exception}`);
+  if (levers.sort) chips.push(`Sort · ${SORT_CHIP_LABEL[levers.sort]}`);
+  if (levers.top !== null) chips.push(`Show · top ${levers.top}`);
+  return chips;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/orders-clear-exception.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/orders-clear-exception.test.tsx
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { NextRequest } from "next/server";
+import { PATCH } from "@/app/api/commerce/v1/orders/[id]/route";
+import * as store from "./data/store";
+import type { CommerceStoreState, Operator, Order } from "./data/types";
+import { OrdersPage } from "./pages/orders";
+
+/**
+ * "Clear the exception" must clear the exception and NOTHING else.
+ *
+ * The bug this pins: the Orders page's clear button PATCHed
+ * `{ status: "open", exception: "none" }`, and the route REQUIRED a status, so
+ * clearing the flag on a held order also released the hold. That is beat 5's
+ * first write silently reverted by a control whose label promises one thing — and
+ * it is unrecoverable on stage, because the room watches the status pill flip
+ * back to `open` and concludes the stored procedure did not stick.
+ *
+ * Covered at two boundaries, because either one alone leaves the bug reachable:
+ * the ROUTE (a status-free PATCH must be accepted and must not move the status)
+ * and the PAGE (the button must actually send a status-free body — a page that
+ * re-added `status` would pass every route assertion below).
+ */
+
+// ── Mocks for the page half. Declared through `vi.hoisted` because `vi.mock` is
+// hoisted above the imports, so a factory closing over ordinary module-scope
+// consts would read them in their temporal dead zone when `./pages/orders`
+// pulls the ledger context at import time.
+const { LEDGER, OPERATOR, refresh } = vi.hoisted(() => {
+  const operator = {
+    id: "op-nadia",
+    name: "Nadia Okonjo",
+    role: "merch-lead" as const,
+    team: "Merchandising",
+  };
+  const row = (overrides: Record<string, unknown>) => ({
+    id: "ord-9001",
+    number: "9001",
+    customerName: "Priya Raghavan",
+    customerEmail: "priya@example.com",
+    channel: "web",
+    destination: "Lisbon, PT",
+    placedAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+    status: "open",
+    exception: "none",
+    lines: [{ productId: "bw-1", quantity: 2, unitPrice: 40 }],
+    total: 80,
+    notes: [],
+    ...overrides,
+  });
+  return {
+    OPERATOR: operator,
+    // `Promise<boolean>`, per the ledger context's contract: `true` is "a fresh
+    // snapshot was committed". This was `async () => {}` — a `Promise<void>`,
+    // which `vi.mock` does not type-check — so `undefined` was falsy and the
+    // "happy path" click below silently took the page's STALE-VIEW branch.
+    refresh: vi.fn(async () => true),
+    LEDGER: {
+      products: [],
+      floors: [],
+      orders: [
+        row({
+          id: "ord-held",
+          number: "4463",
+          status: "on-hold",
+          exception: "payment-declined",
+        }),
+        row({ id: "ord-clean", number: "4412" }),
+      ],
+      notifications: [],
+      returns: [],
+      promotions: [],
+      waivers: [],
+      plans: [],
+      operators: [operator],
+    },
+  };
+});
+
+vi.mock("@copilotkit/react-core/v2", () => ({ useAgentContext: () => {} }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("@/shell/skin-path", () => ({
+  useSkinHref: () => (path?: string) => path ?? "/",
+}));
+
+vi.mock("./data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: LEDGER as unknown as CommerceStoreState,
+    refresh,
+    operator: OPERATOR as Operator,
+    setOperatorId: () => {},
+  }),
+}));
+
+// ── Part 1: the route boundary, against the real store ──────────────────────
+
+const patch = (id: string, body: unknown) =>
+  PATCH({ json: async () => body } as unknown as NextRequest, {
+    params: Promise.resolve({ id }),
+  });
+
+/**
+ * Referenced by ID, not by number.
+ *
+ * Order numbers are re-spaceable data — the seed is required to keep "older means
+ * lower" and may renumber freely to do it, and it has. A test pinned to a number
+ * fails as `NOT_FOUND` when that happens, which says nothing about the behaviour
+ * under test. Ids are the stable handle; the comments record the SHAPE each
+ * constant needs so a future reseed can repoint them here.
+ */
+/** Seeded on-hold order, exception `payment-declined`. */
+const HELD = "ord-4423";
+/** Seeded open order, exception `fraud-review` — beat 5's subject. */
+const OPEN = "ord-4471";
+
+beforeEach(() => store.reset());
+afterEach(() => cleanup());
+
+describe("PATCH orders/[id] — clearing an exception leaves the status alone", () => {
+  it("keeps an ON-HOLD order on hold while clearing its exception", async () => {
+    expect(store.order(HELD)?.status).toBe("on-hold");
+    expect(store.order(HELD)?.exception).toBe("payment-declined");
+
+    const res = await patch(HELD, { exception: "none" });
+    expect(res.status).toBe(200);
+
+    expect(store.order(HELD)?.exception).toBe("none");
+    // The finding itself, in one assertion.
+    expect(store.order(HELD)?.status).toBe("on-hold");
+  });
+
+  it("survives beat 5's hold → notify → note chain, then a clear", async () => {
+    // Write 1: the hold.
+    const held = await patch(OPEN, {
+      status: "on-hold",
+      exception: "oversell",
+    });
+    expect(held.status).toBe(200);
+    // Write 2: the customer notification. Write 3: the forced-🚨 note.
+    store.notifyCustomer(OPEN, "verification-required", "Nadia Okonjo");
+    store.addOrderNote(OPEN, "🚨 Held pending verification.", "Nadia Okonjo");
+
+    // Now someone clears the flag from the Orders page.
+    expect((await patch(OPEN, { exception: "none" })).status).toBe(200);
+
+    const after = store.order(OPEN) as Order;
+    expect(after.exception).toBe("none");
+    // All three of beat 5's writes are still standing.
+    expect(after.status).toBe("on-hold");
+    expect(after.notes[0]?.text).toBe("🚨 Held pending verification.");
+    expect(store.notifications()[0]?.orderId).toBe("ord-4471");
+  });
+
+  it("still honours a status-only PATCH, preserving the exception", async () => {
+    const res = await patch(OPEN, { status: "on-hold" });
+    expect(res.status).toBe(200);
+    expect(store.order(OPEN)?.status).toBe("on-hold");
+    expect(store.order(OPEN)?.exception).toBe("fraud-review");
+  });
+
+  it("still applies status and exception together (beat 5's first write)", async () => {
+    const res = await patch(OPEN, { status: "on-hold", exception: "oversell" });
+    expect(res.status).toBe(200);
+    expect(store.order(OPEN)?.status).toBe("on-hold");
+    expect(store.order(OPEN)?.exception).toBe("oversell");
+  });
+
+  it("refuses an empty PATCH rather than reporting a write it did not make", async () => {
+    const res = await patch(HELD, {});
+    expect(res.status).toBe(400);
+    expect(store.order(HELD)?.status).toBe("on-hold");
+    expect(store.order(HELD)?.exception).toBe("payment-declined");
+  });
+
+  it("refuses an off-vocabulary exception sent WITHOUT a status", async () => {
+    const res = await patch(HELD, { exception: "sounds-plausible" });
+    expect(res.status).toBe(400);
+    expect(store.order(HELD)?.exception).toBe("payment-declined");
+  });
+
+  it("404s a status-free clear against an unknown order", async () => {
+    const res = await patch("no-such-order", { exception: "none" });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Part 2: the page boundary — what the button actually sends ───────────────
+
+describe("OrdersPage — the clear-exception button's request", () => {
+  it("PATCHes the exception ONLY, with no status field", () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OrdersPage />);
+    const button = screen.getByLabelText(
+      "Clear the exception on order 4463",
+    ) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    act(() => button.click());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/api/commerce/v1/orders/ord-held");
+    expect(init.method).toBe("PATCH");
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body).toEqual({ exception: "none" });
+    // Explicit: the key must be ABSENT, not merely equal to the current status.
+    expect("status" in body).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("disables the control where clearing is meaningless (no exception)", () => {
+    render(<OrdersPage />);
+    const clean = screen.getByLabelText(
+      "Clear the exception on order 4412",
+    ) as HTMLButtonElement;
+    expect(clean.disabled).toBe(true);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/catalog.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/catalog.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type {
+  CommerceStoreState,
+  RestockPlan,
+} from "@/skins/commerce/data/types";
+
+/**
+ * A filed restock plan's highlights, lines and schedule come from the MODEL
+ * reading an uploaded price sheet, and nothing between the tool call and this
+ * page de-duplicates them. So the Plans panel must render a plan whose rows
+ * repeat: every row present, and no duplicate React keys (which React reports on
+ * console.error, and which silently corrupts reconciliation when ignored).
+ */
+
+const plan: RestockPlan = {
+  id: "pln-dup",
+  vendor: "Kestrel Mills",
+  season: "Autumn knitwear",
+  summary: "Two pack sizes of the same SKU, quoted twice on the sheet.",
+  // The same fact twice — a model summarising a sheet section by section.
+  highlights: ["Lead time is six weeks", "Lead time is six weeks"],
+  // The same SKU twice — two pack sizes, or a row repeated on the sheet.
+  lines: [
+    { sku: "BW-CDR-HDY", name: "Cedar Hoodie", landedCost: 47, units: 600 },
+    { sku: "BW-CDR-HDY", name: "Cedar Hoodie", landedCost: 44, units: 600 },
+    {
+      sku: "BW-MSS-SCF",
+      name: "Moss Merino Scarf",
+      landedCost: 33,
+      units: 800,
+    },
+  ],
+  // The same step twice — two shipments in one week.
+  schedule: [
+    { week: "Week 1", item: "PO issued" },
+    { week: "Week 1", item: "PO issued" },
+  ],
+  filedAt: new Date().toISOString(),
+  filedBy: "Nadia Okonjo",
+};
+
+const ledger: CommerceStoreState = {
+  products: [],
+  floors: [],
+  orders: [],
+  notifications: [],
+  returns: [],
+  promotions: [],
+  waivers: [],
+  plans: [plan],
+  operators: [],
+};
+
+// The page's only two outbound couplings. Mocking them keeps this a render test
+// of the list, not of the provider stack or the runtime.
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => undefined,
+}));
+vi.mock("@/skins/commerce/data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: ledger,
+    refresh: async () => {},
+    operator: {
+      id: "op-nadia",
+      name: "Nadia Okonjo",
+      role: "merch-lead",
+      team: "Merchandising",
+    },
+    setOperatorId: () => {},
+  }),
+}));
+
+// Imported after the mocks are registered (vi.mock is hoisted, but keeping the
+// import here documents the dependency order for a reader).
+const { CatalogPage } = await import("@/skins/commerce/pages/catalog");
+
+let errors: unknown[][] = [];
+
+beforeEach(() => {
+  errors = [];
+  vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+    errors.push(args);
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Direct `<li>` children. Read off `children` rather than with a `:scope > li`
+ * selector: jsdom's selector engine mangles `:scope` when the host element
+ * carries a class with a dot in it (`mt-2.5`), which these lists do.
+ */
+const rowsOf = (list: Element) =>
+  Array.from(list.children).filter((el) => el.tagName === "LI");
+
+const duplicateKeyWarnings = () =>
+  errors.filter((args) =>
+    args.some(
+      (arg) => typeof arg === "string" && /same key|duplicate key/i.test(arg),
+    ),
+  );
+
+describe("CatalogPage — Restock plans with repeated rows", () => {
+  it("renders every highlight, line and schedule step even when they repeat", () => {
+    const { container } = render(<CatalogPage />);
+
+    // Products are empty, so the only <ul>s on the page are the plan's
+    // highlights then its lines; the schedule is the only <ol>.
+    const lists = container.querySelectorAll("ul");
+    expect(lists).toHaveLength(2);
+    expect(rowsOf(lists[0])).toHaveLength(plan.highlights.length);
+    expect(rowsOf(lists[1])).toHaveLength(plan.lines.length);
+    const schedule = container.querySelector("ol");
+    expect(schedule).not.toBeNull();
+    expect(rowsOf(schedule as HTMLElement)).toHaveLength(plan.schedule.length);
+
+    // Both quoted costs for the repeated SKU survive: a collapsed or reused row
+    // would drop one of them.
+    const text = container.textContent ?? "";
+    expect(text).toContain("$47");
+    expect(text).toContain("$44");
+  });
+
+  it("hands React no duplicate keys", () => {
+    render(<CatalogPage />);
+    expect(duplicateKeyWarnings()).toEqual([]);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/catalog.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/catalog.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { FileText, PackageSearch } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { useCommerceLedger } from "../data/ledger-context";
+import {
+  CATEGORY_ORDER,
+  FLOOR_WORKLIST_RANK,
+  belowFloorCount,
+  formatMargin,
+  formatMoney,
+  noFloorCaveat,
+  nullableBelowFloor,
+  productFloorStatus,
+  productMargin,
+  tallyFloorStatus,
+  weeksOfCover,
+} from "../data/derive";
+import type { FloorStatus } from "../data/derive";
+import type { Product } from "../data/types";
+import { keyedList } from "../components/list-keys";
+import { MarginLadder } from "../components/margin-ladder";
+import { SkuTile } from "../components/sku-tile";
+import {
+  activeSelectClass,
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+/**
+ * The range, and the margin ladder it is read through.
+ *
+ * This page carries two beats. It is where beat 1's signature visual actually
+ * lives full-size (the chat renders the compact variant of the same component),
+ * and it is where beat 3d's durable artifact lands: a restock plan filed from an
+ * uploaded vendor price sheet appears in the Plans panel at the bottom, keyed to
+ * the APPLICATION and not to the conversation. Delete the thread and it is still
+ * here, which is the entire claim that beat makes.
+ */
+
+/**
+ * Below-floor first, then anything that could NOT be checked, then the rest by
+ * margin ascending. The page is a worklist, so both kinds of SKU that need a
+ * decision sit at the top of it — an unchecked SKU is not a clean one.
+ *
+ * The rank itself is `derive.FLOOR_WORKLIST_RANK`, shared with the promotions
+ * desk's card order: two worklists ranking the same three verdicts must not each
+ * decide where an unmeasurable row belongs.
+ */
+
+function ProductRow({
+  item,
+  status,
+  floor,
+}: {
+  item: Product;
+  status: FloorStatus;
+  floor: number | null;
+}) {
+  const margin = productMargin(item);
+  const cover = weeksOfCover(item);
+  const belowFloor = status === "below";
+  return (
+    <li className="flex flex-wrap items-center gap-3 border-b border-hairline px-4 py-3 last:border-b-0">
+      <SkuTile
+        name={item.name}
+        size="sm"
+        ring={belowFloor ? "negative" : null}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[0.8rem] font-medium text-ink">
+          {item.name}
+        </p>
+        <p className="bw-num truncate text-[0.7rem] text-ink-muted">
+          {item.sku} · {item.category} · {item.vendor}
+        </p>
+      </div>
+      <span className="bw-num w-16 shrink-0 text-right text-[0.75rem] text-ink">
+        {formatMoney(item.listPrice)}
+      </span>
+      <span className="bw-num w-16 shrink-0 text-right text-[0.72rem] text-ink-muted">
+        {formatMoney(item.unitCost)}
+      </span>
+      <span
+        className={cn(
+          "bw-num w-28 shrink-0 text-right text-[0.75rem] font-semibold",
+          belowFloor ? "text-negative" : "text-ink",
+        )}
+        title={
+          floor !== null
+            ? `Category floor ${formatMargin(floor)}`
+            : `No margin floor on file for ${item.category} — this margin has not been checked`
+        }
+      >
+        {formatMargin(margin)}
+        {floor !== null ? (
+          <span className="ml-1 font-medium text-ink-muted">
+            {margin >= floor ? "+" : "−"}
+            {formatMargin(Math.abs(margin - floor)).replace("%", "")}pt
+          </span>
+        ) : (
+          // No floor on file. Say so on the row rather than printing a bare
+          // margin, which reads as "checked, and fine".
+          <span className="ml-1 font-medium text-ink-muted">· no floor</span>
+        )}
+      </span>
+      <span className="bw-num w-20 shrink-0 text-right text-[0.72rem] text-ink-muted">
+        {item.inventory.toLocaleString("en-US")}
+      </span>
+      <span className="bw-num w-16 shrink-0 text-right text-[0.72rem] text-ink-muted">
+        {cover === null ? "—" : `${cover}w`}
+      </span>
+      {item.status !== "live" ? (
+        <Pill tone="neutral">{item.status}</Pill>
+      ) : null}
+    </li>
+  );
+}
+
+export function CatalogPage() {
+  const { data } = useCommerceLedger();
+  const [category, setCategory] = useState<string>("all");
+
+  const visible = useMemo(() => {
+    const rows = data.products.filter(
+      (p) => category === "all" || p.category === category,
+    );
+    return [...rows].sort((a, b) => {
+      const aOut = FLOOR_WORKLIST_RANK[productFloorStatus(data.floors, a)];
+      const bOut = FLOOR_WORKLIST_RANK[productFloorStatus(data.floors, b)];
+      if (aOut !== bOut) return aOut - bOut;
+      return productMargin(a) - productMargin(b);
+    });
+  }, [data.products, data.floors, category]);
+
+  const tally = tallyFloorStatus(data.floors, data.products);
+  const belowFloorTotal = belowFloorCount(data.floors, data.products);
+  const floorCaveat = noFloorCaveat(tally.unknown);
+  const medianMargin = useMemo(() => {
+    const margins = data.products.map(productMargin).sort((a, b) => a - b);
+    if (!margins.length) return null;
+    const mid = Math.floor(margins.length / 2);
+    return margins.length % 2 === 0
+      ? (margins[mid - 1] + margins[mid]) / 2
+      : margins[mid];
+  }, [data.products]);
+  const stockAtCost = data.products.reduce(
+    (sum, p) => sum + p.inventory * p.unitCost,
+    0,
+  );
+
+  const floorOf = (item: Product) =>
+    data.floors.find((f) => f.category === item.category)?.floor ?? null;
+
+  // ── BEAT 3b ──────────────────────────────────────────────────────────────
+  // What is VISIBLY on this page — the active category filter, the rows
+  // actually rendered in the order shown, and the plans on file. Not the whole
+  // ledger: the global readable in tools.tsx already carries that, and the point
+  // of this one is that the agent can describe what the user can literally see.
+  useAgentContext({
+    description:
+      "The Catalog page the user is currently viewing: the active category " +
+      "filter, the product rows actually visible on screen in the order shown " +
+      "with their margin against the category floor, and the restock plans on " +
+      "file. `book` holds whole-range figures that the category filter does NOT " +
+      "narrow — never report those as the contents of this view. " +
+      "`book.belowFloorCount` is null when any SKU has no category floor on " +
+      "file (`book.skusWithNoFloorOnFile`): the range could not be fully " +
+      "checked, so do NOT read that null as zero or as an all-clear.",
+    value: JSON.stringify({
+      page: "catalog",
+      filters: { category },
+      visibleCount: visible.length,
+      // WHOLE-RANGE, and therefore nested. These three are computed over
+      // `data.products` regardless of the category filter, and they used to sit
+      // flat beside `filters` and `visibleCount` — the exact shape `orders.tsx`
+      // documents as removed, where an agent reports a book-wide total as the
+      // contents of a filtered view. `belowFloorCount` stays `null` when any SKU
+      // could not be checked, with the companion count so the null cannot be read
+      // as "none".
+      book: {
+        belowFloorCount: belowFloorTotal,
+        skusWithNoFloorOnFile: tally.unknown,
+        medianMargin: medianMargin === null ? null : formatMargin(medianMargin),
+      },
+      rows: visible.slice(0, 25).map((p) => ({
+        sku: p.sku,
+        name: p.name,
+        category: p.category,
+        listPrice: p.listPrice,
+        unitCost: p.unitCost,
+        margin: formatMargin(productMargin(p)),
+        floor: floorOf(p) === null ? null : formatMargin(floorOf(p) as number),
+        // `null`, never `false`, when the category has no floor: "not checked"
+        // and "checked and fine" are different claims.
+        belowFloor: nullableBelowFloor(productFloorStatus(data.floors, p)),
+        inventory: p.inventory,
+        weeksOfCover: weeksOfCover(p),
+      })),
+      plans: data.plans.map((plan) => ({
+        id: plan.id,
+        vendor: plan.vendor,
+        season: plan.season,
+        skus: plan.lines.map((l) => l.sku),
+      })),
+    }),
+  });
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <PageHeader
+        title="Catalog"
+        subtitle="Every SKU against its category margin floor, worst first."
+      />
+
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric label="SKUs" value={String(data.products.length)} />
+        {/* An em dash, never a green zero, when the range could not be fully
+            checked: this tile is the page's all-clear and it may only show one
+            when there is one. */}
+        <Metric
+          label="Below floor"
+          value={belowFloorTotal === null ? "—" : String(belowFloorTotal)}
+          hint={floorCaveat ?? undefined}
+          tone={
+            belowFloorTotal === null || belowFloorTotal > 0
+              ? "negative"
+              : "positive"
+          }
+        />
+        <Metric
+          label="Median margin"
+          value={medianMargin === null ? "—" : formatMargin(medianMargin)}
+          tone="brand"
+        />
+        <Metric label="Stock at cost" value={formatMoney(stockAtCost)} />
+      </div>
+
+      <Panel className="mb-5">
+        <SectionLabel>Margin ladder</SectionLabel>
+        <MarginLadder floors={data.floors} products={data.products} />
+      </Panel>
+
+      <div className="mb-3 flex flex-wrap items-center gap-1.5">
+        <span className="text-[0.7rem] font-medium text-ink-muted">
+          Category
+        </span>
+        {(["all", ...CATEGORY_ORDER] as const).map((candidate) => (
+          <button
+            key={candidate}
+            type="button"
+            onClick={() => setCategory(candidate)}
+            className={activeSelectClass(category === candidate)}
+          >
+            {candidate === "all" ? "All" : candidate}
+          </button>
+        ))}
+      </div>
+
+      <Panel padded={false}>
+        <div className="flex flex-wrap items-center gap-3 border-b border-hairline px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.06em] text-ink-muted">
+          <span className="h-8 w-8 shrink-0" />
+          <span className="min-w-0 flex-1">Product</span>
+          <span className="w-16 shrink-0 text-right">List</span>
+          <span className="w-16 shrink-0 text-right">Cost</span>
+          <span className="w-28 shrink-0 text-right">Margin vs floor</span>
+          <span className="w-20 shrink-0 text-right">On hand</span>
+          <span className="w-16 shrink-0 text-right">Cover</span>
+        </div>
+        {visible.length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              title="No products in this category"
+              hint="Switch back to All to see the whole range."
+              icon={<PackageSearch className="h-5 w-5" />}
+            />
+          </div>
+        ) : (
+          <ul>
+            {visible.map((item) => (
+              <ProductRow
+                key={item.id}
+                item={item}
+                status={productFloorStatus(data.floors, item)}
+                floor={floorOf(item)}
+              />
+            ))}
+          </ul>
+        )}
+      </Panel>
+
+      {/* BEAT 3d — the durable artifact surface. */}
+      <div className="mt-6">
+        <SectionLabel>Restock plans</SectionLabel>
+        {data.plans.length === 0 ? (
+          <Panel>
+            <EmptyState
+              title="No plans on file"
+              hint="Attach a vendor price sheet in the chat and ask Bellwether to file the restock plan — it lands here, in the app."
+              icon={<FileText className="h-5 w-5" />}
+            />
+          </Panel>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2">
+            {data.plans.map((plan) => (
+              <Panel key={plan.id}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-ink">
+                      {plan.season}
+                    </p>
+                    <p className="truncate text-[0.72rem] text-ink-muted">
+                      {plan.vendor} · filed by {plan.filedBy}
+                    </p>
+                  </div>
+                  <Pill tone="brand">{plan.lines.length} SKUs</Pill>
+                </div>
+
+                <p className="mt-2.5 text-[0.78rem] leading-relaxed text-ink">
+                  {plan.summary}
+                </p>
+
+                {plan.highlights.length > 0 ? (
+                  <ul className="mt-2.5 space-y-1">
+                    {keyedList(plan.highlights, (h) => h).map(
+                      ({ key, item: highlight }) => (
+                        <li
+                          key={key}
+                          className="flex gap-1.5 text-[0.72rem] text-ink-muted"
+                        >
+                          <span className="text-brand">•</span>
+                          {highlight}
+                        </li>
+                      ),
+                    )}
+                  </ul>
+                ) : null}
+
+                {plan.lines.length > 0 ? (
+                  <ul className="mt-3 divide-y divide-hairline border-t border-hairline pt-1">
+                    {keyedList(plan.lines, (l) => l.sku || l.name).map(
+                      ({ key, item: line }) => (
+                        <li
+                          key={key}
+                          className="flex items-center gap-2 py-1.5"
+                        >
+                          <SkuTile name={line.name || line.sku} size="xs" />
+                          <span className="min-w-0 flex-1 truncate text-[0.74rem] text-ink">
+                            {line.name || line.sku}
+                          </span>
+                          <span className="bw-num shrink-0 text-[0.72rem] font-medium text-ink">
+                            {formatMoney(line.landedCost)}
+                          </span>
+                          <span className="bw-num shrink-0 text-[0.68rem] text-ink-muted">
+                            ×{line.units.toLocaleString("en-US")}
+                          </span>
+                        </li>
+                      ),
+                    )}
+                  </ul>
+                ) : null}
+
+                {plan.schedule.length > 0 ? (
+                  <ol className="mt-3 space-y-1 border-l-2 border-brand/25 pl-3">
+                    {keyedList(plan.schedule, (s) => `${s.week} ${s.item}`).map(
+                      ({ key, item: step }) => (
+                        <li key={key} className="text-[0.72rem] text-ink">
+                          <span className="bw-num mr-1.5 font-medium text-ink-muted">
+                            {step.week}
+                          </span>
+                          {step.item}
+                        </li>
+                      ),
+                    )}
+                  </ol>
+                ) : null}
+              </Panel>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/orders.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/orders.test.tsx
@@ -1,0 +1,644 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { OrdersPage, parseTopLever } from "./orders";
+import * as store from "../data/store";
+import type { CommerceStoreState, Order } from "../data/types";
+
+/**
+ * BEAT 3c — the `top` lever, and specifically what it does with a value it
+ * cannot honour.
+ *
+ * `Math.max(1, Number(topParam) || 0)` shipped here, so `?top=abc`, `?top=0` and
+ * `?top=-3` all rendered a ONE-ROW queue. That is the one failure mode this beat
+ * cannot survive: a single row looks exactly like a legitimately narrow filter
+ * result, so a broken lever and a working one are indistinguishable to the room.
+ * An unusable value must therefore behave as if the lever were ABSENT — full
+ * list, "Top 10" control untinted — while `?top=10` must still truncate.
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+// The page reads its levers off `useSearchParams`; drive that deterministically.
+const query = { value: "" };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: () => {} }),
+  useSearchParams: () => new URLSearchParams(query.value),
+}));
+// The page registers a readable; the shell provider is not in this tree. The
+// beat-3b tests below read the value the page hands it, so record it rather than
+// dropping it.
+const readable = { value: "" };
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: ({ value }: { value: string }) => {
+    readable.value = value;
+  },
+}));
+// `useSkinHref(skin.id)` is the real thing (unlocked → "/commerce"); only the
+// identity it needs is stubbed, since no SkinProvider is mounted here.
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+// Serve the page the real seeded ledger — the counts these tests measure are the
+// seed's, and the whole point of the `top=10` case is that the seed has more. A
+// test that needs MORE rows than the seed carries (the readable/panel identity
+// tests) sets `ledgerOverride` instead; read lazily, at render, so the hoisted
+// factory never touches it before this module finishes evaluating.
+const ledgerOverride: { value: CommerceStoreState | null } = { value: null };
+
+/**
+ * What this page's `refresh()` reports, and how often it was asked.
+ *
+ * `refreshed: false` is a STALE VIEW — the write landed, the re-read did not (see
+ * `refresh`'s contract in `data/ledger-context`) — which the page must report
+ * differently from a refusal. It is a knob rather than a constant because the
+ * mock was `async () => {}`: a `Promise<void>` against a `Promise<boolean>`
+ * contract, which `vi.mock` does not type-check, so `undefined` was falsy and
+ * every write silently took the stale branch while the "happy path" looked green.
+ */
+const ledgerState = { refreshed: true, refreshes: 0 };
+
+vi.mock("../data/ledger-context", async () => {
+  const ledger = await import("../data/store");
+  return {
+    useCommerceLedger: () => ({
+      data: ledgerOverride.value ?? ledger.snapshot(),
+      refresh: async () => {
+        ledgerState.refreshes += 1;
+        return ledgerState.refreshed;
+      },
+    }),
+  };
+});
+
+/**
+ * The queue's rendered rows. The queue's `<ul>` is the page's only unclassed
+ * one — the customer-notifications list carries `divide-y` — so this counts
+ * order rows and nothing else.
+ */
+const rowCount = () => document.querySelectorAll("ul:not([class]) > li").length;
+
+/** The order numbers rendered in the queue, in the order shown. */
+const renderedOrderNumbers = () =>
+  Array.from(document.querySelectorAll("ul:not([class]) > li")).map(
+    (li) => li.querySelector("p .bw-num")?.textContent?.replace("#", "") ?? "",
+  );
+
+/**
+ * The order numbers rendered in the customer-notifications log, in order. That
+ * log is the page's only CLASSED `<ul>` (`divide-y`), the mirror of `rowCount`'s
+ * unclassed-`<ul>` selector.
+ */
+const renderedNotificationOrders = () =>
+  Array.from(document.querySelectorAll("ul.divide-y > li")).map(
+    (li) => li.querySelector(".bw-num")?.textContent?.replace("#", "") ?? "",
+  );
+
+/** What the page most recently handed `useAgentContext`, parsed. */
+const readableValue = () =>
+  JSON.parse(readable.value) as {
+    matchingCount: number;
+    visibleCount: number;
+    book: { totalOrders: number };
+    rows: { number: string }[];
+    recentNotifications: { order: string; template: string }[];
+  };
+
+/**
+ * The queue's count caption — "Top 10 of 13" with a limit, "13 orders" without.
+ * Anchored so it cannot match a KPI card or an ancestor's concatenated text.
+ */
+const queueCaption = () =>
+  screen.getByText(/^(Top \d+ of \d+|\d+ orders)$/).textContent;
+
+/** Is the "Top 10" control tinted (`activeSelectClass(true)`)? */
+const topTenActive = () =>
+  screen
+    .getByRole("button", { name: "Top 10" })
+    .className.includes("bg-brand-soft");
+
+/** Render the Orders page with a given query string. */
+function renderAt(search: string) {
+  cleanup();
+  query.value = search;
+  render(<OrdersPage />);
+}
+
+/** The rows the beat's view holds with NO limit applied: every exception order. */
+const EXCEPTION_ROWS = store
+  .snapshot()
+  .orders.filter((o) => o.exception !== "none").length;
+
+/** The lever set beat 3c actually builds, minus the limit. */
+const BEAT_VIEW = "exception=any&sort=aging_desc";
+
+beforeEach(() => {
+  ledgerOverride.value = null;
+  readable.value = "";
+  ledgerState.refreshed = true;
+  ledgerState.refreshes = 0;
+});
+
+afterEach(() => cleanup());
+
+describe("OrdersPage — the top-N lever", () => {
+  it("has more exception rows than the limit, or nothing below proves anything", () => {
+    expect(EXCEPTION_ROWS).toBeGreaterThan(10);
+  });
+
+  it("truncates to ten for ?top=10 and tints the control", () => {
+    renderAt(`${BEAT_VIEW}&top=10`);
+    expect(rowCount()).toBe(10);
+    expect(topTenActive()).toBe(true);
+  });
+
+  it.each(["abc", "0", "-3", "", "2.5", "10px"])(
+    "ignores ?top=%s entirely — full list, no limit, and NOT one row",
+    (value) => {
+      renderAt(`${BEAT_VIEW}&top=${value}`);
+      // The regression rendered exactly ONE row for every one of these.
+      expect(rowCount()).not.toBe(1);
+      expect(rowCount()).toBe(EXCEPTION_ROWS);
+      // ...and the limit controls stay untinted, so the screen says "no limit".
+      expect(topTenActive()).toBe(false);
+    },
+  );
+
+  it("renders the same view as if the lever were absent", () => {
+    renderAt(BEAT_VIEW);
+    const absent = rowCount();
+    renderAt(`${BEAT_VIEW}&top=abc`);
+    expect(rowCount()).toBe(absent);
+  });
+});
+
+/**
+ * BEAT 3c — the count caption, which is the ONE number the room is asked to read
+ * as proof the maneuver landed.
+ *
+ * It printed `of ${data.orders.length}` — every order in the ledger — so the
+ * beat's own lever set `?status=open&exception=any&top=10` read "Top 10 of 22"
+ * while 13 rows actually matched. A denominator that ignores the filters says the
+ * filters did nothing, which is the opposite of what the beat claims. So the
+ * denominator must be the FILTERED, pre-truncation count, and it must come off
+ * the same pipeline the rows do.
+ */
+describe("OrdersPage — the count caption's denominator", () => {
+  const seeded = () => store.snapshot();
+
+  /** The beat's own lever set: a status AND an exception filter, plus a limit. */
+  const FILTERED_VIEW = "status=open&exception=any&sort=aging_desc&top=10";
+
+  /** What that view admits before the limit, computed independently of the page. */
+  const matchingRows = () =>
+    seeded().orders.filter(
+      (o) => o.status === "open" && o.exception !== "none",
+    );
+
+  it("has a seed where those filters exclude rows AND the limit truncates", () => {
+    // Without both, neither assertion below can tell the two numbers apart.
+    expect(matchingRows().length).toBeLessThan(seeded().orders.length);
+    expect(matchingRows().length).toBeGreaterThan(10);
+  });
+
+  it("counts the rows the filters admit, not the whole book", () => {
+    renderAt(FILTERED_VIEW);
+    const matching = matchingRows().length;
+    expect(rowCount()).toBe(10);
+    expect(queueCaption()).toBe(`Top 10 of ${matching}`);
+    // The regression printed the full ledger as the denominator.
+    expect(queueCaption()).not.toBe(`Top 10 of ${seeded().orders.length}`);
+  });
+
+  it("counts the whole book when no filter excludes anything", () => {
+    renderAt("top=10");
+    expect(rowCount()).toBe(10);
+    expect(queueCaption()).toBe(`Top 10 of ${seeded().orders.length}`);
+  });
+
+  it("numbers the rows it actually rendered when the limit exceeds the matches", () => {
+    // `Math.min(top, …)` used to carry this; `visible` is already sliced, so its
+    // own length has to.
+    renderAt("status=fulfilled&top=10");
+    const fulfilled = seeded().orders.filter((o) => o.status === "fulfilled");
+    expect(fulfilled.length).toBeLessThan(10);
+    expect(rowCount()).toBe(fulfilled.length);
+    expect(queueCaption()).toBe(
+      `Top ${fulfilled.length} of ${fulfilled.length}`,
+    );
+  });
+
+  it("tells the agent the same denominator it prints on screen", () => {
+    // ONE derivation, two consumers: if these ever disagree, the readable and
+    // the caption have started filtering the ledger separately again.
+    renderAt(FILTERED_VIEW);
+    const described = readableValue();
+    expect(described.matchingCount).toBe(matchingRows().length);
+    expect(queueCaption()).toBe(
+      `Top ${described.visibleCount} of ${described.matchingCount}`,
+    );
+    // ...and the book-wide figures stay book-wide, under a key that says so.
+    expect(described.book.totalOrders).toBe(seeded().orders.length);
+  });
+});
+
+/**
+ * BEAT 3b — the readable must describe the screen it is on, exactly.
+ *
+ * Both lists it sends carried their OWN limit: `visible.slice(0, 25)` against a
+ * queue that renders every visible row, and `notifications.slice(0, 5)` against a
+ * panel that renders 6. The second one shipped: with six notifications on screen
+ * the assistant narrated five. Off by one is the version of wrong that survives a
+ * live demo unnoticed, and it falsifies the beat's only claim — that the agent
+ * sees what the presenter sees. So these tests do not assert a count; they assert
+ * the readable's list is IDENTICAL, element for element and in order, to what the
+ * DOM rendered.
+ */
+describe("OrdersPage — the beat-3b readable matches the rendered panels", () => {
+  /**
+   * A ledger deliberately larger than either former cap: the seed's orders are
+   * duplicated (44 rows > the old 25) and eight notifications are attached (> the
+   * panel's 6). Without the surplus, both caps sit unexercised and the assertions
+   * would pass against the bug.
+   */
+  function crowdedLedger(): CommerceStoreState {
+    const seeded = store.snapshot();
+    const orders = [
+      ...seeded.orders,
+      ...seeded.orders.map((order, index) => ({
+        ...order,
+        id: `${order.id}-copy`,
+        // Kept clear of the seed's four-digit numbers so every row is distinct.
+        number: `90${index}`,
+      })),
+    ];
+    const notifications = orders.slice(0, 8).map((order, index) => ({
+      id: `ntf-${index}`,
+      orderId: order.id,
+      template: "verification-required" as const,
+      sentAt: new Date(2026, 0, index + 1).toISOString(),
+      sentBy: "Nadia Okonjo",
+    }));
+    return { ...seeded, orders, notifications };
+  }
+
+  beforeEach(() => {
+    ledgerOverride.value = crowdedLedger();
+  });
+
+  it("sends the queue rows the queue actually renders, in the order shown", () => {
+    renderAt("");
+    const onScreen = renderedOrderNumbers();
+    // Guard: past the old 25-row cap, or the truncation is never exercised.
+    expect(onScreen.length).toBeGreaterThan(25);
+    expect(readableValue().rows.map((row) => row.number)).toEqual(onScreen);
+    expect(readableValue().visibleCount).toBe(onScreen.length);
+  });
+
+  it("still matches the queue when a lever truncates it", () => {
+    renderAt("exception=any&sort=aging_desc&top=10");
+    const onScreen = renderedOrderNumbers();
+    expect(onScreen).toHaveLength(10);
+    expect(readableValue().rows.map((row) => row.number)).toEqual(onScreen);
+  });
+
+  it("sends the notification rows the log actually renders, in the order shown", () => {
+    renderAt("");
+    const onScreen = renderedNotificationOrders();
+    // Guard: the ledger holds more than the panel shows, so the panel truncates.
+    expect(ledgerOverride.value?.notifications.length).toBeGreaterThan(
+      onScreen.length,
+    );
+    const described = readableValue().recentNotifications.map(
+      (row) => row.order,
+    );
+    expect(described).toEqual(onScreen);
+  });
+});
+
+/**
+ * The queue's TWO write controls — hold, and clear-exception — under the four
+ * things that actually happen to them: a double-click, a fetch that never
+ * answers, one row's refusal followed by another row's success, and a write that
+ * LANDS while the follow-up re-read does not.
+ *
+ * What they had instead: no in-flight guard, no `disabled`, no `try/catch`, and
+ * ONE page-level notice slot shared by every row. So —
+ *
+ *  1. A double-clicked hold fired two PATCHes; the second came back 409 from
+ *     `store.orderStatusBlocker` and painted `ILLEGAL_ORDER_TRANSITION` over a
+ *     hold that had SUCCEEDED. On stage the presenter's only recourse is to press
+ *     it again.
+ *  2. A rejecting `fetch` escaped the click handler as an unhandled rejection:
+ *     nothing on screen, and beat 5's first write silently gone.
+ *  3. One slot for the whole page meant row B's success called `setNotice(null)`
+ *     and ERASED the refusal row A had just printed — the same silent no-op,
+ *     reached through the report instead of the request.
+ *  4. A hold that landed while `refresh()` failed left the row reading `open`, so
+ *     the hold button stayed armed and invited a second write against a status
+ *     the store had already moved.
+ *
+ * The in-flight assertions use a fetch that does not resolve until the test says
+ * so, which is what makes them deterministic: the question is only ever "while
+ * write #1 is outstanding, did the second click reach the network".
+ */
+describe("OrdersPage — the queue's writes cannot fire twice, latch, or erase", () => {
+  /** Two OPEN, flagged rows, so a write on one can be raced against the other. */
+  const ROW_A: Order = {
+    id: "ord-a",
+    number: "8001",
+    customerName: "Priya Raghavan",
+    customerEmail: "priya@example.com",
+    channel: "web",
+    destination: "Lisbon, PT",
+    placedAt: new Date(Date.now() - 4 * 86_400_000).toISOString(),
+    status: "open",
+    exception: "oversell",
+    lines: [{ productId: "bw-1", quantity: 2, unitPrice: 40 }],
+    total: 80,
+    notes: [],
+  };
+  const ROW_B: Order = {
+    ...ROW_A,
+    id: "ord-b",
+    number: "8002",
+    customerName: "Ines Duarte",
+    placedAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+    exception: "fraud-review",
+  };
+
+  const twoOpenOrders = (): CommerceStoreState => ({
+    products: [],
+    floors: [],
+    orders: [ROW_A, ROW_B],
+    notifications: [],
+    returns: [],
+    promotions: [],
+    waivers: [],
+    plans: [],
+    operators: [],
+  });
+
+  interface Refusal {
+    status: number;
+    message: string;
+  }
+
+  /** Request urls seen, in order. */
+  const posted: string[] = [];
+  /** Resolvers for responses withheld while `hold` is true. */
+  const withheld: (() => void)[] = [];
+  const server: {
+    hold: boolean;
+    /** Answer a REPEAT of a write the way the order state machine does. */
+    refuseRepeats: boolean;
+    /** Refusals to serve, by order id — one row can be refused and not another. */
+    refuseFor: Record<string, Refusal>;
+    reject: boolean;
+  } = { hold: false, refuseRepeats: false, refuseFor: {}, reject: false };
+
+  const json = (status: number, message: string) =>
+    ({
+      ok: false,
+      status,
+      json: async () => ({ message }),
+    }) as unknown as Response;
+
+  /**
+   * Decide the response AT REQUEST TIME, not at release time — same reason as
+   * `returns.test.tsx`: both clicks of an unguarded double-click are outstanding
+   * together, so computing repeat-ness at release time would refuse both and make
+   * the bug invisible.
+   */
+  function decide(url: string): Response {
+    const repeat = posted.filter((seen) => seen === url).length > 1;
+    if (server.refuseRepeats && repeat)
+      return json(
+        409,
+        "That order cannot move to that status from where it is.",
+      );
+    const refusal = Object.entries(server.refuseFor).find(([id]) =>
+      url.endsWith(`/${id}`),
+    );
+    if (refusal) return json(refusal[1].status, refusal[1].message);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as unknown as Response;
+  }
+
+  beforeEach(() => {
+    ledgerOverride.value = twoOpenOrders();
+    posted.length = 0;
+    withheld.length = 0;
+    server.hold = false;
+    server.refuseRepeats = false;
+    server.refuseFor = {};
+    server.reject = false;
+    // The guard reports a fetch that never completed through `console.error`.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        posted.push(url);
+        if (server.reject)
+          return Promise.reject(new TypeError("Failed to fetch"));
+        const response = decide(url);
+        if (!server.hold) return Promise.resolve(response);
+        return new Promise<Response>((resolve) => {
+          withheld.push(() => resolve(response));
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  /** Drain the microtask queue and let React commit whatever it produced. */
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  /** Release every withheld response. */
+  const release = async () => {
+    server.hold = false;
+    withheld.splice(0).forEach((settle) => settle());
+    await flush();
+  };
+
+  /** PATCHes sent against one order. */
+  const callsFor = (id: string) =>
+    posted.filter((url) => url.endsWith(`/${id}`)).length;
+
+  const holdButton = (number: string) =>
+    screen.getByLabelText(`Hold order ${number}`);
+  const clearButton = (number: string) =>
+    screen.getByLabelText(`Clear the exception on order ${number}`);
+  const disabled = (element: HTMLElement) => element.hasAttribute("disabled");
+
+  it("PATCHes ONCE for a double-clicked hold, and paints no refusal", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    renderAt("");
+
+    const button = holdButton("8001");
+    fireEvent.click(button);
+    // The second click lands while write #1 is still outstanding.
+    fireEvent.click(button);
+    expect(callsFor("ord-a")).toBe(1);
+
+    await release();
+    expect(callsFor("ord-a")).toBe(1);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("PATCHes ONCE for a double-clicked clear-exception", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    renderAt("");
+
+    const button = clearButton("8001");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(callsFor("ord-a")).toBe(1);
+
+    await release();
+    expect(callsFor("ord-a")).toBe(1);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("will not let the row's OTHER lever start while a hold is outstanding", async () => {
+    server.hold = true;
+    renderAt("");
+
+    fireEvent.click(holdButton("8001"));
+    await flush();
+
+    // Both levers write the same record and report into the same slot, so the
+    // guard is the ROW's, not the button's.
+    expect(disabled(holdButton("8001"))).toBe(true);
+    expect(disabled(clearButton("8001"))).toBe(true);
+    fireEvent.click(clearButton("8001"));
+    expect(callsFor("ord-a")).toBe(1);
+
+    // ...and it is the row's rather than the page's: row B has its own notice
+    // slot, so nothing it does can speak for row A.
+    expect(disabled(holdButton("8002"))).toBe(false);
+
+    await release();
+    // The guard is released, so the row's OTHER write is available again. The
+    // hold's own lever is NOT, and must not be: that write landed, and this
+    // mocked ledger never re-reads, which is exactly the state a failed
+    // `refresh()` leaves behind — see the stale-view case below.
+    expect(disabled(clearButton("8001"))).toBe(false);
+  });
+
+  it("does not latch, and speaks, when the hold fetch never answers", async () => {
+    server.reject = true;
+    renderAt("");
+
+    fireEvent.click(holdButton("8001"));
+    await flush();
+
+    // THE LATCH: no `finally` and no guard release, so the row's levers used to
+    // stay dead for the rest of the demo.
+    expect(disabled(holdButton("8001"))).toBe(false);
+    // A write that vanished with the page silent is the same dead button as a
+    // refusal nobody printed.
+    expect(screen.getByRole("status").textContent).toMatch(
+      /nothing came back/i,
+    );
+    expect(ledgerState.refreshes).toBe(0);
+  });
+
+  it("keeps one row's refusal on screen when ANOTHER row's write succeeds", async () => {
+    server.refuseFor = {
+      "ord-a": { status: 409, message: "That order cannot be held from here." },
+    };
+    renderAt("");
+
+    fireEvent.click(holdButton("8001"));
+    await flush();
+    expect(
+      screen.getByText("That order cannot be held from here."),
+    ).toBeTruthy();
+
+    // Row B lands. With one page-wide slot its `setNotice(null)` took row A's
+    // refusal away, and the refused write ended up saying nothing at all.
+    fireEvent.click(holdButton("8002"));
+    await flush();
+
+    expect(
+      screen.getByText("That order cannot be held from here."),
+    ).toBeTruthy();
+  });
+
+  it("reports a landed hold whose re-read failed as done-but-behind, and does not re-arm it", async () => {
+    // The hold landed and only the ledger re-read failed, so the row still reads
+    // `open` and its button is still on screen — this is not a theoretical
+    // branch. The one thing it must not do is invite the write a second time.
+    ledgerState.refreshed = false;
+    renderAt("");
+
+    fireEvent.click(holdButton("8001"));
+    await flush();
+
+    expect(ledgerState.refreshes).toBe(1);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /could not be re-read/,
+    );
+    expect(disabled(holdButton("8001"))).toBe(true);
+    fireEvent.click(holdButton("8001"));
+    expect(callsFor("ord-a")).toBe(1);
+    // The row's other lever is a DIFFERENT write and stays available.
+    expect(disabled(clearButton("8001"))).toBe(false);
+  });
+});
+
+describe("parseTopLever", () => {
+  it("honours a positive integer", () => {
+    expect(parseTopLever("10")).toBe(10);
+    expect(parseTopLever("5")).toBe(5);
+    expect(parseTopLever("1")).toBe(1);
+    // Surrounding whitespace is a transport artifact, not a different value.
+    expect(parseTopLever(" 7 ")).toBe(7);
+  });
+
+  it("ignores every value it cannot honour, rather than clamping it to 1", () => {
+    for (const raw of [
+      null,
+      undefined,
+      "",
+      " ",
+      "abc",
+      "0",
+      "-3",
+      "2.5",
+      "1e2",
+      "+5",
+      "10px",
+      "NaN",
+      "Infinity",
+      // Too long to represent exactly; a limit nobody could have meant.
+      "99999999999999999999",
+    ]) {
+      expect(parseTopLever(raw), `top=${String(raw)}`).toBeNull();
+    }
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/orders.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/orders.tsx
@@ -1,0 +1,768 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Ban, Clock, MailCheck, PauseOctagon } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { useSkin } from "@/shell/skin-provider";
+import { useSkinHref } from "@/shell/skin-path";
+import { useCommerceLedger } from "../data/ledger-context";
+import {
+  CHANNEL_LABEL,
+  EXCEPTION_FILTERS,
+  ORDER_EXCEPTION_LABEL,
+  ORDER_STATUS_FILTERS,
+  ageInDays,
+  formatMoney,
+  orderUnits,
+  ordersOnException,
+  valueAtRisk,
+} from "../data/derive";
+import type { ExceptionFilter, OrderSort, StatusFilter } from "../data/derive";
+import type { Order, OrderException, OrderStatus } from "../data/types";
+import { describeError } from "../settle";
+import { SkuTile } from "../components/sku-tile";
+import { useInFlight } from "../components/use-in-flight";
+import {
+  activeSelectClass,
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+/**
+ * BEAT 3c — the lever surface.
+ *
+ * Status, exception, sort and top-N are all read from the QUERY STRING, which is
+ * what lets the agent perform a maneuver instead of following a link: it
+ * confirms the levers it is about to pull, navigates to
+ * `?status=open&exception=any&sort=aging_desc&top=10`, and this page reads them.
+ *
+ * FOUR levers rather than the usual two, on purpose — "make it complicated" is
+ * the note this beat came with. A single filter looks like a link with extra
+ * steps; a status, an exception class, a sort and a limit applied together look
+ * like someone who knows the tool.
+ *
+ * The controls it set are then VISIBLY highlighted (`activeSelectClass`), which
+ * is the half of the beat that is easy to skip and impossible to recover: if the
+ * page merely shows the right rows, the audience sees a filtered list and has to
+ * take on faith that the assistant did it. Tinting the controls shows them the
+ * assistant reaching into the app's real UI. Note it is the CONTROLS that light
+ * up, not the rows.
+ *
+ * This page is also where beat 5's three writes land — the hold shows as a
+ * status pill, the customer notification appears in its own panel, and the
+ * forced-🚨 note is printed under the order row. All three are on one screen so
+ * a stored procedure firing is something the room WATCHES rather than reads
+ * about in the transcript.
+ */
+
+/**
+ * Typed `Record<OrderSort, …>` against the shared lever vocabulary in `derive`,
+ * so a sort `showOrderQueue` advertises with no comparator here — or a
+ * comparator here the tool cannot ask for — is a type error rather than a lever
+ * that silently does nothing.
+ */
+const SORTS: Record<
+  OrderSort,
+  { label: string; compare: (a: Order, b: Order) => number }
+> = {
+  aging_desc: {
+    label: "Oldest first",
+    compare: (a: Order, b: Order) => a.placedAt.localeCompare(b.placedAt),
+  },
+  aging_asc: {
+    label: "Newest first",
+    compare: (a: Order, b: Order) => b.placedAt.localeCompare(a.placedAt),
+  },
+  value_desc: {
+    label: "Largest value",
+    compare: (a: Order, b: Order) => b.total - a.total,
+  },
+};
+
+type SortKey = OrderSort;
+
+/**
+ * The status controls, from the ONE list `showOrderQueue`'s schema is also built
+ * from (`ORDER_STATUS_FILTERS`) — including `cancelled`, which this page shows
+ * and the agent may therefore ask for. See that constant's header.
+ */
+const STATUSES: readonly StatusFilter[] = ORDER_STATUS_FILTERS;
+
+const EXCEPTION_FILTER_LABEL: Record<string, string> = {
+  all: "All",
+  any: "Any exception",
+  ...ORDER_EXCEPTION_LABEL,
+};
+
+/**
+ * The `top` lever, parsed the way every other lever on this page is parsed: a
+ * value this page cannot honour is IGNORED — the view renders exactly as it does
+ * with the lever absent — and is never coerced into a plausible-looking limit.
+ *
+ * This shipped as `Math.max(1, Number(raw) || 0)`, which turned every junk value
+ * into a limit of ONE: `?top=abc` → `NaN` → `|| 0` → `Math.max(1, 0)` → 1, and
+ * likewise `?top=0` and `?top=-3`. A one-row queue is the worst available answer
+ * for beat 3c, because it is indistinguishable on stage from a legitimately
+ * narrow filter result — the claim "the assistant reached the app's real
+ * controls" would then be carried by a screen nobody in the room can check.
+ * Falling back to the full list is self-evident instead: the "All" control stays
+ * tinted and the count reads as the unfiltered one.
+ *
+ * Only a positive integer is honoured. A fractional `?top=2.5` is rejected
+ * rather than rounded — neither the controls (`null | 5 | 10`) nor the
+ * `showOrderQueue` tool emit one, and choosing between floor and ceil would be
+ * inventing a limit nobody asked for.
+ */
+export function parseTopLever(raw: string | null | undefined): number | null {
+  if (raw === null || raw === undefined) return null;
+  const digits = raw.trim();
+  // Digits only: rejects "", " ", "abc", "-3", "2.5", "1e2", "+5", "10px".
+  if (!/^\d+$/.test(digits)) return null;
+  const parsed = Number(digits);
+  // A digit string too long to represent exactly is unusable too, and 0 is not a
+  // limit. Both land on "no limit" — never on 1.
+  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+/**
+ * How many of the most recent customer notifications the page shows.
+ *
+ * ONE number, read by BOTH the notifications panel and the beat-3b readable via
+ * the single `visibleNotifications` list below. It was two numbers — the panel
+ * sliced 6 and the readable sliced 5 — so with six notifications on screen the
+ * agent described five and was wrong about the visible state by exactly one row.
+ * Beat 3b's whole claim is that the assistant sees what the presenter sees, and
+ * an off-by-one is the version of being wrong that nobody in the room catches.
+ */
+const NOTIFICATION_ROWS = 6;
+
+/**
+ * Shown when a write landed but `refresh()` reported it could not re-read the
+ * ledger (see its contract in `data/ledger-context`). Distinct from a REFUSAL:
+ * the write did happen, only the view is behind.
+ */
+const STALE_LEDGER_NOTICE =
+  "That went through, but this page could not be re-read afterwards — the rows below may be out of date. Reload to confirm.";
+
+function statusTone(status: OrderStatus) {
+  if (status === "fulfilled") return "positive" as const;
+  if (status === "on-hold") return "negative" as const;
+  if (status === "cancelled") return "neutral" as const;
+  return "brand" as const;
+}
+
+/** This row's two write levers, keyed for the guard below. */
+type OrderWrite = "hold" | "clear";
+
+function OrderRow({
+  order,
+  rank,
+  notice,
+  onHold,
+  onClear,
+}: {
+  order: Order;
+  rank: number | null;
+  /**
+   * This ROW's refusal-or-stale-view slot. Per row, not per page: the two levers
+   * here report through it, and with one page-wide slot a success on any other
+   * row called `setNotice(null)` and took this row's refusal away — the refused
+   * write, the one the operator most needs explained, then said nothing at all.
+   */
+  notice: string | null;
+  /** Both resolve "did this write LAND" — see `patchOrder`. */
+  onHold: () => Promise<boolean>;
+  onClear: () => Promise<boolean>;
+}) {
+  const age = ageInDays(order.placedAt);
+  const flagged = order.exception !== "none";
+  /**
+   * ONE write in flight per ROW — hold and clear together, not one guard each.
+   *
+   * The granularity is set by the MESSAGE CHANNEL (see `useInFlight`'s header):
+   * both levers report into the single `notice` above, so two writes outstanding
+   * together means the one that finishes last speaks for both. They also write the
+   * same RECORD, which is the same race by another route — clearing the exception
+   * on an order whose hold is still in flight. Rows do NOT share a guard, because
+   * they do not share a slot.
+   */
+  const { busy, run } = useInFlight();
+  /**
+   * Which of this row's writes have LANDED. One-way on purpose, and never
+   * cleared: a landed write normally moves the row (the status pill flips, the
+   * exception pill goes) and its own lever disables on the data. The ONLY way a
+   * lever is still armed after its write landed is a `refresh()` that failed — and
+   * re-arming there offers the store a write it has already applied, which comes
+   * back 409 and paints a refusal on an action that succeeded.
+   */
+  const [landed, setLanded] = useState<Record<OrderWrite, boolean>>({
+    hold: false,
+    clear: false,
+  });
+
+  const write = (key: OrderWrite, action: () => Promise<boolean>) =>
+    void run(key, async () => {
+      const ok = await action();
+      if (ok) setLanded((prev) => ({ ...prev, [key]: true }));
+      return ok;
+    });
+
+  return (
+    <li className="border-b border-hairline px-4 py-3 last:border-b-0">
+      <div className="flex flex-wrap items-center gap-3">
+        {rank !== null ? (
+          <span className="bw-num w-5 shrink-0 text-right text-[0.7rem] font-semibold text-ink-muted">
+            {rank}
+          </span>
+        ) : null}
+        <SkuTile
+          name={order.customerName}
+          size="sm"
+          shape="round"
+          ring={flagged ? "negative" : null}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-[0.8rem] font-medium text-ink">
+            <span className="bw-num text-ink-muted">#{order.number}</span>{" "}
+            {order.customerName}
+          </p>
+          <p className="truncate text-[0.7rem] text-ink-muted">
+            {CHANNEL_LABEL[order.channel]} · {order.destination} ·{" "}
+            {orderUnits(order)} units
+          </p>
+        </div>
+        {flagged ? (
+          <Pill tone="negative">{ORDER_EXCEPTION_LABEL[order.exception]}</Pill>
+        ) : null}
+        <span
+          className={cn(
+            "bw-num inline-flex items-center gap-1 text-[0.72rem]",
+            age >= 21 ? "font-semibold text-negative" : "text-ink-muted",
+          )}
+          title={`Placed ${age} days ago`}
+        >
+          <Clock className="h-3 w-3" />
+          {age}d
+        </span>
+        <span className="bw-num w-20 shrink-0 text-right text-[0.75rem] font-medium text-ink">
+          {formatMoney(order.total)}
+        </span>
+        <Pill tone={statusTone(order.status)}>{order.status}</Pill>
+        {order.status === "open" || order.status === "on-hold" ? (
+          <span className="flex gap-1">
+            {/* Both levers disable while EITHER write on this row is
+                outstanding, and a lever whose write has landed stays down. */}
+            <button
+              type="button"
+              aria-label={`Hold order ${order.number}`}
+              onClick={() => write("hold", onHold)}
+              disabled={
+                order.status === "on-hold" || landed.hold || busy !== null
+              }
+              className="flex h-7 w-7 items-center justify-center rounded-md border border-hairline text-negative hover:bg-negative-soft disabled:opacity-30"
+            >
+              <PauseOctagon className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              aria-label={`Clear the exception on order ${order.number}`}
+              onClick={() => write("clear", onClear)}
+              disabled={!flagged || landed.clear || busy !== null}
+              className="flex h-7 w-7 items-center justify-center rounded-md border border-hairline text-ink-muted hover:bg-surface-muted disabled:opacity-30"
+            >
+              <Ban className="h-3.5 w-3.5" />
+            </button>
+          </span>
+        ) : null}
+      </div>
+
+      {/* This row's own place to speak. Both notices it can carry — a refusal,
+          and a write that landed while the re-read did not — are about THIS
+          order, so they belong beside it rather than in a page-wide slot that any
+          other row can overwrite. The stale note leads with "That went through",
+          which is what stops the shared negative styling from reading as "the
+          write failed". */}
+      {notice ? (
+        <p role="status" className="mt-2 text-[0.7rem] text-negative">
+          {notice}
+        </p>
+      ) : null}
+
+      {/* BEAT 5, write #3. A note is only a demo beat if the room can SEE it, so
+          the most recent one is printed under its order rather than hidden
+          behind a detail view. The 🚨 is forced by the tool, not typed here. */}
+      {order.notes[0] ? (
+        <p className="mt-2 rounded-md bg-brand-soft px-2.5 py-1.5 text-[0.72rem] text-ink">
+          {order.notes[0].text}
+          <span className="ml-2 text-ink-muted">— {order.notes[0].author}</span>
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
+export function OrdersPage() {
+  const { data, refresh } = useCommerceLedger();
+  const router = useRouter();
+  const skin = useSkin();
+  const skinHref = useSkinHref(skin.id);
+  const params = useSearchParams();
+  const [channel, setChannel] = useState<string>("all");
+  /**
+   * What each ROW has to say about its own last write, keyed by order id.
+   *
+   * The hold and clear-exception buttons print no receipt — the status pill
+   * changing IS the receipt — so anything that stops the pill from moving has to
+   * be said out loud or the button reads as dead. Two different things can: the
+   * route REFUSING the write, and a `refresh()` that could not re-read the ledger
+   * afterwards (see its contract in `data/ledger-context`). A row's slot carries
+   * both.
+   *
+   * PER ROW, not one for the page. It was one, and every landing write cleared it
+   * — so a refusal on one order was erased by an unrelated order's success, and
+   * the refused write said nothing at all. Same defect, and the same fix, as the
+   * per-surface slots in `pages/promotions.tsx`.
+   */
+  const [notices, setNotices] = useState<Record<string, string | null>>({});
+  const setNotice = (id: string, message: string | null) =>
+    setNotices((prev) => ({ ...prev, [id]: message }));
+
+  // Levers that can arrive from the URL.
+  const statusParam = params?.get("status") ?? null;
+  const exceptionParam = params?.get("exception") ?? null;
+  const sortParam = (params?.get("sort") ?? null) as SortKey | null;
+  const topParam = params?.get("top") ?? null;
+
+  // Same widening as the exception test below, for the same reason.
+  const status: StatusFilter =
+    statusParam && (STATUSES as readonly string[]).includes(statusParam)
+      ? (statusParam as StatusFilter)
+      : "all";
+  // Widened to `readonly string[]` for the membership test: EXCEPTION_FILTERS is
+  // a narrow const tuple, so `.includes()` would otherwise refuse an arbitrary
+  // query-string value as an argument — the very thing being validated here.
+  const exception: ExceptionFilter =
+    exceptionParam &&
+    (EXCEPTION_FILTERS as readonly string[]).includes(exceptionParam)
+      ? (exceptionParam as ExceptionFilter)
+      : "all";
+  const sort: SortKey =
+    sortParam && sortParam in SORTS ? sortParam : "aging_desc";
+  const top = parseTopLever(topParam);
+
+  const setLever = (key: string, value: string | null) => {
+    const next = new URLSearchParams(params?.toString() ?? "");
+    if (value === null) next.delete(key);
+    else next.set(key, value);
+    const query = next.toString();
+    // Through skinHref, never a hardcoded `/commerce` — under LOCK_SKIN the
+    // deploy is served at `/` and a literal prefix reappears in the address bar
+    // on the first click.
+    router.push(`${skinHref()}${query ? `?${query}` : ""}`);
+  };
+
+  /**
+   * ONE pipeline, TWO published lengths.
+   *
+   *  - `matching` — every row the levers admit, sorted, BEFORE the top-N limit.
+   *  - `visible`  — `matching` after the limit: exactly the rows rendered.
+   *
+   * Both come out of the same `useMemo` because they are the same derivation
+   * observed at two points, and the count caption below is the one number on
+   * screen that has to agree with the rows. It read
+   * `of ${data.orders.length}` — the WHOLE book — so
+   * `?status=open&exception=any&top=10` printed "Top 10 of 22" against 13
+   * matching rows. Beat 3c's entire claim is that the assistant set real
+   * filters; a denominator that ignores them tells the room the filters did
+   * nothing, in the one figure the audience is being asked to read. Deriving
+   * both here is what stops that recurring — a second `data.orders.filter(…)`
+   * next to the label is how it happened the first time.
+   */
+  const { matching, visible } = useMemo(() => {
+    const rows = data.orders
+      .filter((o) => {
+        if (status !== "all" && o.status !== status) return false;
+        if (exception === "any" && o.exception === "none") return false;
+        if (
+          exception !== "all" &&
+          exception !== "any" &&
+          o.exception !== exception
+        )
+          return false;
+        if (channel !== "all" && o.channel !== channel) return false;
+        return true;
+      })
+      // `filter` already returned a fresh array, so sorting it in place mutates
+      // nothing the ledger owns.
+      .sort(SORTS[sort].compare);
+    return { matching: rows, visible: top ? rows.slice(0, top) : rows };
+  }, [data.orders, status, exception, channel, sort, top]);
+
+  /**
+   * Both order controls write through here, so neither can drift from the other
+   * on the half that is easy to forget: a refused PATCH has to SAY so.
+   *
+   * Both of these used to call `refresh()` unconditionally, which repainted the
+   * identical rows on a 4xx — a click that did nothing, indistinguishable on
+   * stage from a slow network. That is no longer a theoretical branch: the route
+   * now runs every order write through the state machine in
+   * `store.orderStatusBlocker`, so a hold can legitimately come back 409
+   * (`ORDER_ALREADY_SETTLED`, `ILLEGAL_ORDER_TRANSITION`) and a clear can come
+   * back 422 (`EXCEPTION_ON_SETTLED_ORDER`) — for instance when the row on
+   * screen was fulfilled by someone else since the last snapshot.
+   *
+   * The route's own `message` is preferred over the fallback because those
+   * strings are written to be read by a human (`data/http.ts`), and a refusal the
+   * UI paraphrases into "it failed" is a refusal the room learns nothing from.
+   *
+   * TOTAL: a `fetch` that never answers at all is reported here rather than
+   * thrown. It used to throw straight out of the click handler as an unhandled
+   * rejection, so an offline browser or a dev server restarted mid-call took beat
+   * 5's first write with it and left the page silent.
+   *
+   * Resolves "did this write LAND", which is what the row's lever locks on. It is
+   * NOT "and the page now shows it": a landed write whose `refresh()` failed still
+   * resolves `true` and leaves the stale-view notice up — the same split
+   * `settle.ts`'s `staleNote` makes for the chat receipts. Reading that case as a
+   * refusal is what re-arms a lever over a write the store has already applied.
+   */
+  const patchOrder = async (
+    id: string,
+    body: { status?: OrderStatus; exception?: OrderException },
+    fallback: string,
+  ): Promise<boolean> => {
+    let res: Response;
+    try {
+      res = await fetch(`/api/commerce/v1/orders/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      setNotice(
+        id,
+        `${fallback}: ${describeError(error)}. ` +
+          "Nothing came back, so treat it as not applied.",
+      );
+      return false;
+    }
+    if (!res.ok) {
+      const problem = await res.json().catch(() => ({}));
+      setNotice(id, problem?.message ?? `${fallback} (${res.status}).`);
+      return false;
+    }
+    setNotice(id, (await refresh()) ? null : STALE_LEDGER_NOTICE);
+    return true;
+  };
+
+  const hold = (id: string) =>
+    patchOrder(id, { status: "on-hold" }, "That order could not be held");
+
+  // Clears the exception and NOTHING else. This used to also send
+  // `status: "open"`, which meant clearing the flag on an order beat 5 had just
+  // put on hold quietly RELEASED the hold — the first of the procedure's three
+  // writes vanished, and the button's label never said it would. The status is
+  // absent from the body rather than echoed back from `order.status`: echoing is
+  // a read-modify-write against a snapshot that may already be stale, and it
+  // would still be asserting a status this control has no business asserting.
+  const clearException = (id: string) =>
+    patchOrder(
+      id,
+      { exception: "none" },
+      "That exception could not be cleared",
+    );
+
+  // The notification rows on screen. Derived ONCE, here, so the panel below and
+  // the readable cannot slice the same list to two different lengths.
+  const visibleNotifications = useMemo(
+    () => data.notifications.slice(0, NOTIFICATION_ROWS),
+    [data.notifications],
+  );
+
+  const onException = ordersOnException(data.orders);
+  const atRisk = valueAtRisk(data.orders);
+  const oldest = onException.length
+    ? Math.max(...onException.map((o) => ageInDays(o.placedAt)))
+    : 0;
+
+  const orderNumber = (id: string) =>
+    data.orders.find((o) => o.id === id)?.number ?? id;
+
+  // ── BEAT 3b ──────────────────────────────────────────────────────────────
+  // The active levers AND the rows actually rendered after filtering, sorting
+  // and slicing — in the order shown. Asked "what's on my screen?" here, the
+  // agent must be able to say "the ten oldest orders still on an exception,
+  // Ines's oversell at the top, 34 days old" and be right about all of it.
+  //
+  // THE RULE, and the one thing to preserve when editing this readable: every
+  // list below is the SAME expression the corresponding panel renders — `visible`
+  // for the queue, `visibleNotifications` for the notification log — never a
+  // second slice of the same source. Both used to carry their own limit (`visible
+  // .slice(0, 25)`, `notifications.slice(0, 5)` against a panel showing 6), which
+  // makes the readable disagree with the screen it claims to describe and quietly
+  // falsifies the beat. A cap here would have to be a cap the panel applies too.
+  //
+  // The figures are split by SCOPE, and the keys say which is which. They used
+  // to sit flat — `ordersOnException` and `valueAtRisk`, both book-wide, beside
+  // `filters` and `visibleCount` — under a description promising "the page the
+  // user is currently viewing", so an agent asked what was on screen could
+  // truthfully read 15 exceptions off a queue showing 10 rows. Same hazard as the
+  // count caption's denominator, one layer down: a book-wide number presented as
+  // a description of the filtered view.
+  //
+  // `matchingCount` is the caption's denominator, off the same `matching` list
+  // the caption prints, so the agent can state the figure the room is reading.
+  useAgentContext({
+    description:
+      "The Orders page the user is currently viewing. `filters` are the active " +
+      "status, exception and channel filters plus the sort order and top-N " +
+      "limit; `matchingCount` is how many orders those filters admit before the " +
+      "limit and `visibleCount` how many `rows` remain after it (the rows " +
+      "actually on screen, in the order shown); `book` holds whole-ledger " +
+      "totals that the filters do NOT narrow — never report those as the " +
+      "contents of this view.",
+    value: JSON.stringify({
+      page: "orders",
+      filters: { status, exception, channel, sort, top },
+      book: {
+        totalOrders: data.orders.length,
+        ordersOnException: onException.length,
+        valueAtRisk: atRisk,
+        oldestExceptionAgeDays: oldest,
+      },
+      matchingCount: matching.length,
+      visibleCount: visible.length,
+      rows: visible.map((o) => ({
+        id: o.id,
+        number: o.number,
+        customer: o.customerName,
+        channel: CHANNEL_LABEL[o.channel],
+        destination: o.destination,
+        status: o.status,
+        exception: ORDER_EXCEPTION_LABEL[o.exception],
+        ageDays: ageInDays(o.placedAt),
+        total: o.total,
+        units: orderUnits(o),
+        latestNote: o.notes[0]?.text ?? null,
+      })),
+      recentNotifications: visibleNotifications.map((n) => ({
+        order: orderNumber(n.orderId),
+        template: n.template,
+      })),
+    }),
+  });
+
+  const showRank = sort === "aging_desc" || sort === "value_desc";
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <PageHeader
+        title="Orders"
+        subtitle="The exception queue first — everything the desk has to touch before it ships."
+      />
+
+      {/* THE OTHER FOUR NUMBERS ON THIS PAGE, and why they are NOT view-scoped.
+          All four are computed off the full ledger, and they stay that way:
+          `ordersOnException` / `valueAtRisk` are the shared derivations the a2ui
+          brief's StatCards and the OGUI sandbox KPIs publish off the same
+          snapshot (see their headers in `data/derive.ts`), and those panels sit
+          on the canvas BESIDE these cards. Filtering them here would put two
+          different answers to one question on screen at once — the exact defect
+          that file exists to prevent. So the scope is stated instead of changed:
+          this caption is what stops a book-wide figure from being read as a
+          description of the filtered queue below, which is the hazard the
+          "Top N of X" denominator actually fell into. */}
+      <SectionLabel>The whole order book</SectionLabel>
+
+      <div className="mb-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric
+          label="Open"
+          value={String(data.orders.filter((o) => o.status === "open").length)}
+          tone="brand"
+        />
+        <Metric
+          label="On exception"
+          value={String(onException.length)}
+          tone={onException.length > 0 ? "negative" : "positive"}
+        />
+        <Metric label="Value at risk" value={formatMoney(atRisk)} />
+        <Metric
+          label="Oldest exception"
+          value={`${oldest}d`}
+          tone={oldest >= 21 ? "negative" : "neutral"}
+        />
+      </div>
+
+      <Panel className="mb-4" padded={false}>
+        <div className="flex flex-wrap items-center gap-4 px-4 py-3">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Status
+            </span>
+            {STATUSES.map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() =>
+                  setLever("status", candidate === "all" ? null : candidate)
+                }
+                className={activeSelectClass(status === candidate)}
+              >
+                {candidate}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Exception
+            </span>
+            {EXCEPTION_FILTERS.map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() =>
+                  setLever("exception", candidate === "all" ? null : candidate)
+                }
+                className={activeSelectClass(exception === candidate)}
+              >
+                {EXCEPTION_FILTER_LABEL[candidate]}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Sort
+            </span>
+            {(Object.keys(SORTS) as SortKey[]).map((candidate) => (
+              <button
+                key={candidate}
+                type="button"
+                onClick={() => setLever("sort", candidate)}
+                className={activeSelectClass(sort === candidate)}
+              >
+                {SORTS[candidate].label}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Show
+            </span>
+            {[null, 5, 10].map((candidate) => (
+              <button
+                key={String(candidate)}
+                type="button"
+                onClick={() =>
+                  setLever("top", candidate === null ? null : String(candidate))
+                }
+                className={activeSelectClass(top === candidate)}
+              >
+                {candidate === null ? "All" : `Top ${candidate}`}
+              </button>
+            ))}
+          </div>
+
+          <label className="ml-auto flex items-center gap-1.5">
+            <span className="text-[0.7rem] font-medium text-ink-muted">
+              Channel
+            </span>
+            <select
+              value={channel}
+              onChange={(event) => setChannel(event.target.value)}
+              className="rounded-md border border-hairline bg-surface px-2 py-1.5 text-[0.78rem] text-ink outline-none focus:border-brand/50"
+            >
+              <option value="all">All channels</option>
+              {Object.entries(CHANNEL_LABEL).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </Panel>
+
+      {/* Numerator and denominator BOTH off the one pipeline above: `visible` is
+          what the queue renders, `matching` is what the levers admit before the
+          limit. `Math.min(top, …)` is gone with the bug — `visible` is already
+          sliced, so its own length is the honest numerator. */}
+      <SectionLabel>
+        {top
+          ? `Top ${visible.length} of ${matching.length}`
+          : `${visible.length} orders`}
+      </SectionLabel>
+
+      <Panel padded={false}>
+        {visible.length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              title="Nothing in this view"
+              hint="Widen the status or exception filter, or clear the top-N limit, to see the rest of the book."
+            />
+          </div>
+        ) : (
+          <ul>
+            {visible.map((order, index) => (
+              <OrderRow
+                key={order.id}
+                order={order}
+                rank={showRank ? index + 1 : null}
+                notice={notices[order.id] ?? null}
+                onHold={() => hold(order.id)}
+                onClear={() => clearException(order.id)}
+              />
+            ))}
+          </ul>
+        )}
+      </Panel>
+
+      {/* BEAT 5, write #2. A notification that only exists as a sentence in the
+          transcript is a step the room has to take on trust, so the ones the app
+          sends are listed here — the most recent NOTIFICATION_ROWS of them, and
+          the readable above describes exactly this list. */}
+      <div className="mt-6">
+        <SectionLabel>Customer notifications</SectionLabel>
+        <Panel padded={false}>
+          {visibleNotifications.length === 0 ? (
+            <div className="p-4">
+              <EmptyState
+                title="No notifications sent yet"
+                hint="Holding an order for verification sends the customer a message, and it is logged here."
+                icon={<MailCheck className="h-5 w-5" />}
+              />
+            </div>
+          ) : (
+            <ul className="divide-y divide-hairline">
+              {visibleNotifications.map((notification) => (
+                <li
+                  key={notification.id}
+                  className="flex items-center gap-3 px-4 py-2.5"
+                >
+                  <MailCheck className="h-4 w-4 shrink-0 text-positive" />
+                  <span className="bw-num shrink-0 text-[0.74rem] font-medium text-ink">
+                    #{orderNumber(notification.orderId)}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[0.76rem] text-ink">
+                    {notification.template}
+                  </span>
+                  <span className="shrink-0 text-[0.68rem] text-ink-muted">
+                    {notification.sentBy}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/promotions.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/promotions.test.tsx
@@ -1,0 +1,541 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { PromotionsPage } from "./promotions";
+import { JUSTIFICATION_MIN_LENGTH } from "../data/waiver-codes";
+import type {
+  CommerceStoreState,
+  MarginWaiver,
+  Operator,
+  Product,
+  Promotion,
+} from "../data/types";
+
+/**
+ * BEAT 6's control surface, under the two things a presenter actually does to it
+ * by accident: clicking twice, and getting refused.
+ *
+ * Both bugs this pins were on the SAME form and were the same mistake — a
+ * handler that did not model its own in-flight and failure states:
+ *
+ *  1. `Finalize` had no in-flight guard, so a double-click fired the POST twice.
+ *     The store settles a waiver once, so the second call came back
+ *     `ALREADY_FINALIZED` and the card painted a REFUSAL over an action that had
+ *     just succeeded. On stage the presenter is told the thing they did failed,
+ *     and their only recourse is to do it again. `Approve` and `Decline` had the
+ *     identical hole against `ALREADY_DECIDED`.
+ *  2. `setJustification("")` ran unconditionally after filing, even though the
+ *     filing helper reports refusal by RETURNING. So a refused filing wiped the
+ *     sentence the merchandiser had typed. That is no longer an exotic path:
+ *     the justification has a real minimum length server-side
+ *     (`INVALID_JUSTIFICATION`, 422) and the input bounds only the maximum, so a
+ *     short justification is refused as an ordinary case.
+ *
+ * The in-flight assertions use a fetch that does NOT resolve until the test says
+ * so, which is what makes them deterministic: the question is only ever "while
+ * write #1 is outstanding, did the second click reach the network", and that is
+ * answered synchronously.
+ *
+ * The GUARD itself is tested apart from these buttons, beside the hook it lives in
+ * — `components/use-in-flight.test.tsx`. It has to be: jsdom does not dispatch a
+ * click to a `disabled` button, so everything here can only ever prove the visible
+ * half of the guard.
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+const PRODUCT: Product = {
+  id: "prd-cedar-hoodie",
+  sku: "BW-CDR-HDY",
+  name: "Cedar Hoodie",
+  category: "Knitwear",
+  listPrice: 100,
+  unitCost: 37,
+  inventory: 120,
+  trailing30Units: 40,
+  status: "live",
+  vendor: "Northline Mills",
+};
+
+/** 40% off a $100/$37 SKU trades at 38.3% against a 45% floor — below it. */
+const PROMOTION: Promotion = {
+  id: "promo-cedar",
+  name: "Cedar Hoodie autumn markdown",
+  productId: PRODUCT.id,
+  discountPercent: 40,
+  startsAt: new Date(2026, 8, 1).toISOString(),
+  endsAt: new Date(2026, 8, 22).toISOString(),
+  submittedBy: "Theo Vance",
+  submittedAt: new Date(2026, 7, 28).toISOString(),
+  status: "pending",
+  marginWaiverId: null,
+};
+
+/** A draft waiver, so the panel renders its `Finalize` lever. */
+const DRAFT: MarginWaiver = {
+  id: "wvr-1",
+  promotionId: PROMOTION.id,
+  code: "VENDOR-FUND",
+  justification: "signed co-op on file",
+  status: "draft",
+  openedAt: new Date(2026, 7, 29).toISOString(),
+  finalizedAt: null,
+};
+
+const OPERATOR: Operator = {
+  id: "op-nadia",
+  name: "Nadia Okonjo",
+  role: "merch-lead",
+  team: "Merchandising",
+};
+
+function ledger(waivers: MarginWaiver[] = [DRAFT]): CommerceStoreState {
+  return {
+    products: [PRODUCT],
+    floors: [{ category: "Knitwear", floor: 0.45, target: 0.52 }],
+    orders: [],
+    notifications: [],
+    returns: [],
+    promotions: [PROMOTION],
+    waivers,
+    plans: [],
+    operators: [OPERATOR],
+  };
+}
+
+const state: { data: CommerceStoreState; refreshed: boolean; count: number } = {
+  data: ledger(),
+  // What `refresh()` resolves. `false` is a STALE VIEW — the write landed, the
+  // re-read did not — which the page reports differently from a refusal.
+  refreshed: true,
+  count: 0,
+};
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+}));
+
+vi.mock("../data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: state.data,
+    refresh: async () => {
+      state.count += 1;
+      return state.refreshed;
+    },
+    operator: OPERATOR,
+    setOperatorId: () => {},
+  }),
+}));
+
+const steps: { label: string; data?: string }[] = [];
+vi.mock("../components/recording-context", () => ({
+  useRecording: () => ({
+    isRecording: false,
+    steps: [],
+    beginRecording: () => {},
+    endRecording: () => {},
+    logStep: (label: string, data?: string) => steps.push({ label, data }),
+    getDemonstratedCode: () => null,
+    reset: () => {},
+  }),
+}));
+
+// ── the stub server ─────────────────────────────────────────────────────────
+
+interface Refusal {
+  status: number;
+  message: string;
+  /**
+   * Refuse only urls containing this fragment. Omitted, every request is refused.
+   * The cross-surface cases need ONE write refused and the other accepted — that
+   * is the whole shape of the bug they pin.
+   */
+  match?: string;
+}
+
+/** POST urls seen, in order. */
+const posted: string[] = [];
+/** Resolvers for responses withheld while `hold` is true. */
+const withheld: (() => void)[] = [];
+const server: {
+  hold: boolean;
+  /** Answer a REPEAT of a write the way the store's own idempotency does. */
+  refuseRepeats: boolean;
+  refuse: Refusal | null;
+} = { hold: false, refuseRepeats: false, refuse: null };
+
+/**
+ * Decide the response AT REQUEST TIME, not at release time.
+ *
+ * This matters for the withheld case: both clicks of an unguarded double-click
+ * are outstanding together, and if repeat-ness were computed when the responses
+ * are finally released, BOTH would look like repeats and both would be refused.
+ * The bug would then be invisible — the fixed code would fail too.
+ */
+function decide(url: string): Response {
+  const repeat = posted.filter((seen) => seen === url).length > 1;
+  if (server.refuseRepeats && repeat) {
+    const already = url.includes("/finalize")
+      ? "That waiver was already finalized."
+      : "That was already decided.";
+    return {
+      ok: false,
+      status: 409,
+      json: async () => ({ message: already }),
+    } as unknown as Response;
+  }
+  const refusal = server.refuse;
+  if (refusal && (!refusal.match || url.includes(refusal.match))) {
+    return {
+      ok: false,
+      status: refusal.status,
+      json: async () => ({ message: refusal.message }),
+    } as unknown as Response;
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ code: "VENDOR-FUND" }),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  state.data = ledger();
+  state.refreshed = true;
+  state.count = 0;
+  posted.length = 0;
+  withheld.length = 0;
+  steps.length = 0;
+  server.hold = false;
+  server.refuseRepeats = false;
+  server.refuse = null;
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      posted.push(url);
+      const response = decide(url);
+      if (!server.hold) return Promise.resolve(response);
+      return new Promise<Response>((resolve) => {
+        withheld.push(() => resolve(response));
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** Drain the microtask queue and let React commit whatever it produced. */
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+/** Release every withheld response. */
+const release = async () => {
+  server.hold = false;
+  withheld.splice(0).forEach((settle) => settle());
+  await flush();
+};
+
+const callsTo = (fragment: string) =>
+  posted.filter((url) => url.includes(fragment)).length;
+
+/**
+ * The refusal / stale-view line on the card. It is the only element carrying
+ * `text-negative` alongside `border-negative` — the below-floor explainer above
+ * it uses `text-ink` — so this reads the message and nothing else.
+ */
+const noticeText = () =>
+  document.querySelector("p.text-negative")?.textContent ?? null;
+
+const button = (name: string | RegExp) => screen.getByRole("button", { name });
+
+const justificationInput = () =>
+  screen.getByPlaceholderText("What is on file?") as HTMLInputElement;
+
+/** Type into the justification field the way a merchandiser would. */
+const type = (text: string) => {
+  fireEvent.change(justificationInput(), { target: { value: text } });
+};
+
+describe("PromotionsPage — an in-flight write is not re-entrant", () => {
+  it("fires Finalize ONCE for a double-click, and paints no error", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    render(<PromotionsPage />);
+
+    const finalize = button("Finalize");
+    fireEvent.click(finalize);
+    // The second click lands while write #1 is still outstanding. Before the
+    // guard this reached the network, came back ALREADY_FINALIZED, and painted a
+    // refusal on a card whose finalize had SUCCEEDED.
+    fireEvent.click(finalize);
+    expect(callsTo("/finalize")).toBe(1);
+
+    await release();
+
+    expect(callsTo("/finalize")).toBe(1);
+    expect(noticeText()).toBeNull();
+    // ...and the demonstration is recorded once, not once plus a failure.
+    expect(steps).toHaveLength(1);
+    expect(steps[0].label).toContain("Finalized");
+  });
+
+  it("says so on the button while the finalize is outstanding", async () => {
+    server.hold = true;
+    render(<PromotionsPage />);
+
+    fireEvent.click(button("Finalize"));
+    await flush();
+
+    const busy = button("Finalizing…");
+    expect(busy.hasAttribute("disabled")).toBe(true);
+
+    await release();
+    expect(button("Finalize").hasAttribute("disabled")).toBe(false);
+  });
+
+  it("fires Approve ONCE for a double-click, and paints no error", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    render(<PromotionsPage />);
+
+    const approve = button("Approve");
+    fireEvent.click(approve);
+    fireEvent.click(approve);
+    expect(callsTo("/approve")).toBe(1);
+
+    await release();
+
+    expect(callsTo("/approve")).toBe(1);
+    expect(noticeText()).toBeNull();
+  });
+
+  it("fires Decline ONCE for a double-click, and paints no error", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    render(<PromotionsPage />);
+
+    const decline = button("Decline");
+    fireEvent.click(decline);
+    fireEvent.click(decline);
+    expect(callsTo("/decline")).toBe(1);
+
+    await release();
+
+    expect(callsTo("/decline")).toBe(1);
+    expect(noticeText()).toBeNull();
+  });
+
+  it("will not let Decline start while Approve is in flight", async () => {
+    server.hold = true;
+    render(<PromotionsPage />);
+
+    fireEvent.click(button("Approve"));
+    fireEvent.click(button(/Decline/));
+    expect(callsTo("/decline")).toBe(0);
+
+    await release();
+  });
+
+  it("files ONE waiver for a double-click on File waiver", async () => {
+    server.hold = true;
+    render(<PromotionsPage />);
+    type("signed co-op on file");
+
+    const file = button("File waiver");
+    fireEvent.click(file);
+    fireEvent.click(file);
+    expect(callsTo("/margin-waivers")).toBe(1);
+
+    await release();
+    expect(callsTo("/margin-waivers")).toBe(1);
+  });
+
+  it("will not let Finalize start while a filing is in flight", async () => {
+    server.hold = true;
+    render(<PromotionsPage />);
+    type("signed co-op on file");
+
+    fireEvent.click(button("File waiver"));
+    fireEvent.click(button(/Finalize/));
+    expect(callsTo("/finalize")).toBe(0);
+
+    await release();
+  });
+});
+
+describe("PromotionsPage — a refused filing keeps what was typed", () => {
+  const TOO_SHORT = "short";
+
+  it("preserves the justification and shows the refusal on 422", async () => {
+    // The now-ordinary case: below the store's minimum length. The input bounds
+    // only the MAXIMUM, so this reaches the route and is refused.
+    expect(TOO_SHORT.length).toBeLessThan(JUSTIFICATION_MIN_LENGTH);
+    server.refuse = {
+      status: 422,
+      message: "That justification is not usable.",
+    };
+    render(<PromotionsPage />);
+
+    type(TOO_SHORT);
+    fireEvent.click(button("File waiver"));
+    await flush();
+
+    expect(noticeText()).toBe("That justification is not usable.");
+    // THE REGRESSION: this used to come back empty, so the merchandiser had to
+    // retype the sentence on stage before they could re-file.
+    expect(justificationInput().value).toBe(TOO_SHORT);
+    // A refusal is not a demonstration step either.
+    expect(steps).toHaveLength(0);
+  });
+
+  it("preserves it on a 404 too, and on a rejected fetch", async () => {
+    server.refuse = { status: 404, message: "No such promotion." };
+    render(<PromotionsPage />);
+    type("signed co-op on file");
+    fireEvent.click(button("File waiver"));
+    await flush();
+    expect(justificationInput().value).toBe("signed co-op on file");
+
+    // A fetch that never completes at all must not be read as success either.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new TypeError("Failed to fetch"))),
+    );
+    fireEvent.click(button("File waiver"));
+    await flush();
+    expect(justificationInput().value).toBe("signed co-op on file");
+  });
+
+  it("DOES clear it once the filing actually lands", async () => {
+    render(<PromotionsPage />);
+
+    type("signed co-op on file");
+    fireEvent.click(button("File waiver"));
+    await flush();
+
+    expect(callsTo("/margin-waivers")).toBe(1);
+    expect(noticeText()).toBeNull();
+    expect(justificationInput().value).toBe("");
+    expect(steps[0]?.data).toBe("VENDOR-FUND");
+  });
+
+  it("still clears it for a landed filing whose ledger re-read failed", async () => {
+    // `refresh()` resolving false is a STALE VIEW, not a refusal: the waiver IS
+    // on file, so the typed sentence has done its job and must still clear. The
+    // separate stale notice is what tells the presenter to reload — reading it as
+    // a refusal and holding the text would be the mirror-image bug.
+    state.refreshed = false;
+    render(<PromotionsPage />);
+
+    type("signed co-op on file");
+    fireEvent.click(button("File waiver"));
+    await flush();
+
+    expect(state.count).toBe(1);
+    expect(noticeText()).toMatch(/could not be re-read/);
+    expect(justificationInput().value).toBe("");
+  });
+});
+
+/**
+ * The card has TWO write surfaces — the decision levers and the waiver panel — and
+ * they used to share ONE message slot (`errors[promotion.id]`) while each held its
+ * OWN `useInFlight` instance. A per-instance mutex is no help when the ERROR
+ * CHANNEL is shared: whichever write finished last spoke for both, so a
+ * successful waiver filing's `setError(id, null)` took away the refusal the
+ * approve had just printed and the refused approve ended up saying NOTHING. That
+ * is the same silent no-op the guard exists to prevent, reached through the report
+ * instead of the request.
+ *
+ * Both halves are pinned here because each is reachable on its own:
+ *  - CONCURRENTLY, because one instance per surface let the second write start
+ *    while the first was still outstanding.
+ *  - SEQUENTIALLY, because one slot means the later write overwrites the earlier
+ *    one's outcome even when they never overlap.
+ */
+describe("PromotionsPage — one card's two write surfaces do not erase each other", () => {
+  const REFUSED_APPROVE = "That markdown trades under the category floor.";
+
+  it("will not let a waiver filing start while a decision is in flight", async () => {
+    server.hold = true;
+    server.refuse = {
+      status: 422,
+      message: REFUSED_APPROVE,
+      match: "/approve",
+    };
+    render(<PromotionsPage />);
+    type("signed co-op on file");
+
+    fireEvent.click(button("Approve"));
+    // Before the shared guard this reached the network, landed, and cleared the
+    // refusal the approve was about to print.
+    fireEvent.click(button("File waiver"));
+    expect(callsTo("/margin-waivers")).toBe(0);
+
+    await release();
+
+    expect(screen.getByText(REFUSED_APPROVE)).toBeTruthy();
+  });
+
+  it("keeps a refused approve on screen when a LATER waiver filing succeeds", async () => {
+    server.refuse = {
+      status: 422,
+      message: REFUSED_APPROVE,
+      match: "/approve",
+    };
+    render(<PromotionsPage />);
+
+    fireEvent.click(button("Approve"));
+    await flush();
+    expect(screen.getByText(REFUSED_APPROVE)).toBeTruthy();
+
+    // Filing the waiver is the merchandiser's ANSWER to that refusal — it is the
+    // sentence they are acting on, so a successful filing must not take it away.
+    type("signed co-op on file");
+    fireEvent.click(button("File waiver"));
+    await flush();
+
+    expect(callsTo("/margin-waivers")).toBe(1);
+    expect(justificationInput().value).toBe("");
+    expect(screen.getByText(REFUSED_APPROVE)).toBeTruthy();
+  });
+
+  it("keeps a refused filing on screen when a LATER decision succeeds", async () => {
+    // The mirror: the decision surface must not speak for the waiver surface
+    // either.
+    server.refuse = {
+      status: 422,
+      message: "That justification is not usable.",
+      match: "/margin-waivers",
+    };
+    render(<PromotionsPage />);
+
+    type("short");
+    fireEvent.click(button("File waiver"));
+    await flush();
+    expect(screen.getByText("That justification is not usable.")).toBeTruthy();
+
+    fireEvent.click(button("Decline"));
+    await flush();
+
+    expect(callsTo("/decline")).toBe(1);
+    expect(screen.getByText("That justification is not usable.")).toBeTruthy();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/promotions.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/promotions.tsx
@@ -1,0 +1,754 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, Check, Tag, X } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { useCommerceLedger } from "../data/ledger-context";
+import {
+  FLOOR_WORKLIST_RANK,
+  countBelow,
+  discountedPrice,
+  formatMargin,
+  formatMoney,
+  formatMoneyExact,
+  noMarkdownFloorCaveat,
+  nullableBelowFloor,
+  promotionFloorStatus,
+  promotionMargin,
+  tallyStatuses,
+  windowLabel,
+} from "../data/derive";
+import type { FloorStatus } from "../data/derive";
+import {
+  JUSTIFICATION_MAX_LENGTH,
+  MARGIN_WAIVER_CODES,
+  waiverCodeLabel,
+} from "../data/waiver-codes";
+import type { MarginWaiver, Product, Promotion } from "../data/types";
+import { useRecording } from "../components/recording-context";
+import { SkuTile } from "../components/sku-tile";
+import { useInFlight } from "../components/use-in-flight";
+import type { InFlight } from "../components/use-in-flight";
+import {
+  activeSelectClass,
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+/**
+ * BEAT 6 — the demonstration surface.
+ *
+ * This is the page a merchandiser is standing on when they show Bellwether how
+ * to get a below-floor markdown approved. Everything the unlock needs is real UI
+ * here — file a waiver under a code, finalize it, approve — and every one of
+ * those three actions calls `recording.logStep`, so the agent's waiting card
+ * narrates the demonstration as it happens.
+ *
+ * The waiver code goes into the recording as DATA (`logStep(label, code)`), not
+ * just as prose, because the whole point of the beat is that the saved procedure
+ * names the code that ACTUALLY WORKED. If the merchandiser picks a decoy, that
+ * decoy is what gets recorded and the approve still fails — an honest outcome,
+ * and a far better demo than a recorder that quietly corrects them.
+ *
+ * Note what this page does NOT do: it never marks the justifying codes. The
+ * catalogue in `data/waiver-codes.ts` is deliberately mixed and its blurbs never
+ * say whether a code lifts the gate. An agent reading this page's DOM learns the
+ * options, not the answer.
+ */
+
+const STATUS_FILTERS = ["all", "pending", "approved", "declined"] as const;
+type StatusFilter = (typeof STATUS_FILTERS)[number];
+
+/**
+ * A card's two WRITE SURFACES: the decision levers, and the waiver panel.
+ *
+ * They are separate message channels because they used to be one. Both wrote
+ * `errors[promotion.id]`, so a successful filing's `setError(id, null)` erased the
+ * refusal an approve had just printed and the refused approve — the one write the
+ * merchandiser most needs explained — ended up saying nothing. A per-surface mutex
+ * does not help when the CHANNEL is shared, and a shared channel is not fixed by a
+ * coarser mutex either: this skin needed both, and this type is the second half.
+ */
+type WriteSurface = "decision" | "waiver";
+
+/** Where a surface's refusal or stale-view note is kept, per promotion. */
+const slot = (id: string, surface: WriteSurface) => `${id}:${surface}`;
+
+function statusTone(status: Promotion["status"]) {
+  if (status === "approved") return "positive" as const;
+  if (status === "declined") return "neutral" as const;
+  return "markdown" as const;
+}
+
+function WaiverPanel({
+  promotion,
+  waivers,
+  error,
+  guard,
+  onFile,
+  onFinalize,
+}: {
+  promotion: Promotion;
+  waivers: MarginWaiver[];
+  error: string | null;
+  /**
+   * The CARD's guard, handed down rather than mounted here.
+   *
+   * This panel used to hold its own instance, which meant a filing could start
+   * while the card's approve was still outstanding — two writes against the same
+   * markdown, reporting into the same slot. See `PromotionCard`.
+   */
+  guard: InFlight;
+  onFile: (code: string, justification: string) => Promise<boolean>;
+  onFinalize: (waiverId: string) => Promise<boolean>;
+}) {
+  const [code, setCode] = useState(MARGIN_WAIVER_CODES[0].code);
+  const [justification, setJustification] = useState("");
+  const { busy, run } = guard;
+
+  const blurb = MARGIN_WAIVER_CODES.find((c) => c.code === code)?.blurb ?? "";
+
+  return (
+    <div className="mt-3 rounded-md border border-hairline bg-surface-muted p-3">
+      <SectionLabel>Margin waivers</SectionLabel>
+
+      {waivers.length > 0 ? (
+        <ul className="mb-3 divide-y divide-hairline">
+          {waivers.map((waiver) => (
+            <li
+              key={waiver.id}
+              className="flex flex-wrap items-center gap-2 py-1.5"
+            >
+              <Pill
+                tone={waiver.status === "approved" ? "positive" : "neutral"}
+              >
+                {waiver.code}
+              </Pill>
+              <span className="min-w-0 flex-1 truncate text-[0.72rem] text-ink-muted">
+                {waiverCodeLabel(waiver.code)}
+                {waiver.justification ? ` — ${waiver.justification}` : ""}
+              </span>
+              {waiver.status === "draft" ? (
+                <button
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() =>
+                    void run(waiver.id, () => onFinalize(waiver.id))
+                  }
+                  className="rounded-md bg-brand px-2.5 py-1 text-[0.7rem] font-semibold text-brand-foreground disabled:opacity-40"
+                >
+                  {busy === waiver.id ? "Finalizing…" : "Finalize"}
+                </button>
+              ) : (
+                <span className="text-[0.68rem] font-medium text-positive">
+                  finalized
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="min-w-[10rem] flex-1">
+          <span className="mb-1 block text-[0.68rem] font-medium text-ink-muted">
+            Waiver code
+          </span>
+          <select
+            value={code}
+            onChange={(event) => setCode(event.target.value)}
+            className="w-full rounded-md border border-hairline bg-surface px-2 py-1.5 text-[0.76rem] text-ink outline-none focus:border-brand/50"
+          >
+            {MARGIN_WAIVER_CODES.map((entry) => (
+              <option key={entry.code} value={entry.code}>
+                {entry.code} — {entry.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="min-w-[12rem] flex-[2]">
+          <span className="mb-1 block text-[0.68rem] font-medium text-ink-muted">
+            Justification
+          </span>
+          <input
+            value={justification}
+            onChange={(event) => setJustification(event.target.value)}
+            // Bounded here as well as in the store, so the merchandiser cannot
+            // type a filing the API will only refuse after the round-trip.
+            maxLength={JUSTIFICATION_MAX_LENGTH}
+            placeholder="What is on file?"
+            className="w-full rounded-md border border-hairline bg-surface px-2 py-1.5 text-[0.76rem] text-ink outline-none focus:border-brand/50"
+          />
+        </label>
+        <button
+          type="button"
+          disabled={busy !== null}
+          onClick={() =>
+            void run("file", async () => {
+              const filed = await onFile(code, justification);
+              // ONLY a filing that actually landed may take the sentence away.
+              // A refusal leaves it typed: `INVALID_JUSTIFICATION` on a
+              // too-short one is now an ORDINARY case, and `ALREADY_DECIDED` /
+              // `INVALID_WAIVER_CODE` are reachable too — so the merchandiser
+              // fixes the code and re-files instead of retyping on stage.
+              if (filed) setJustification("");
+              return filed;
+            })
+          }
+          className="rounded-md border border-brand/40 bg-brand-soft px-3 py-1.5 text-[0.75rem] font-semibold text-brand disabled:opacity-40"
+        >
+          {busy === "file" ? "Filing…" : "File waiver"}
+        </button>
+      </div>
+      {/* The WAIVER surface's own message slot. It used to share the card's, so a
+          successful filing's `setError(id, null)` took away the refusal the
+          decision levers had just printed — and a refused approve then said
+          nothing at all. Each surface speaks only about itself. */}
+      {error ? (
+        <p className="mt-2 rounded-md border border-negative/30 bg-negative-soft px-2.5 py-1.5 text-[0.73rem] text-negative">
+          {error}
+        </p>
+      ) : null}
+      <p className="mt-1.5 text-[0.66rem] text-ink-muted">{blurb}</p>
+      <p className="mt-1 text-[0.66rem] text-ink-muted">
+        A filed waiver has to be finalized before trading policy will look at
+        it. Not every code clears the floor — {promotion.name} still has to pass
+        the approval check afterwards.
+      </p>
+    </div>
+  );
+}
+
+function PromotionCard({
+  promotion,
+  product,
+  floor,
+  status,
+  waivers,
+  decisionError,
+  waiverError,
+  onApprove,
+  onDecline,
+  onFile,
+  onFinalize,
+}: {
+  promotion: Promotion;
+  product: Product | undefined;
+  floor: number | null;
+  /**
+   * The card's ONE floor verdict, derived by the page from
+   * `derive.promotionFloorStatus` and handed down.
+   *
+   * It used to be computed here as `margin < floor` ending `: false`, so a
+   * markdown whose category had no floor on file rendered as a cleared one — the
+   * green margin, no caveat, and (because the waiver desk keys off the same flag)
+   * no sign that anything was unresolved. `"unknown"` is a state this card has to
+   * SAY, not a falsy default.
+   */
+  status: FloorStatus;
+  waivers: MarginWaiver[];
+  decisionError: string | null;
+  waiverError: string | null;
+  onApprove: () => Promise<boolean>;
+  onDecline: () => Promise<boolean>;
+  onFile: (code: string, justification: string) => Promise<boolean>;
+  onFinalize: (waiverId: string) => Promise<boolean>;
+}) {
+  /**
+   * ONE guard for this whole card — approve, decline, file and finalize.
+   *
+   * Approve and decline are two decisions on the SAME markdown, and the store
+   * settles it once (`ALREADY_DECIDED`), so letting the second start would only
+   * ever produce a refusal for a decision that landed. The waiver panel is on the
+   * same instance for two reasons: its levers write the same RECORD (filing a
+   * waiver on a markdown that is being decided is that race by another route), and
+   * its outcomes land on the same card, where a write finishing second used to
+   * speak for a write that had already reported.
+   */
+  const guard = useInFlight();
+  const { busy, run } = guard;
+  const price = product
+    ? discountedPrice(product.listPrice, promotion.discountPercent)
+    : null;
+  const margin = promotionMargin(product, promotion);
+  const belowFloor = status === "below";
+  /** Measurable margin, no floor to measure it against. NOT an all-clear. */
+  const unchecked = status === "unknown";
+
+  return (
+    <Panel>
+      <div className="flex items-start gap-3">
+        <SkuTile
+          name={product?.name ?? promotion.name}
+          size="lg"
+          ring={belowFloor ? "negative" : "markdown"}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="truncate text-sm font-semibold text-ink">
+              {promotion.name}
+            </p>
+            <Pill tone={statusTone(promotion.status)}>{promotion.status}</Pill>
+            <Pill tone="markdown">−{promotion.discountPercent}%</Pill>
+          </div>
+          <p className="mt-0.5 truncate text-[0.72rem] text-ink-muted">
+            {product?.name ?? "Unknown product"} · {product?.category ?? "—"} ·{" "}
+            {windowLabel(promotion.startsAt, promotion.endsAt)} · raised by{" "}
+            {promotion.submittedBy}
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
+            <span className="bw-num text-[0.74rem] text-ink-muted">
+              List{" "}
+              <span className="font-medium text-ink">
+                {product ? formatMoney(product.listPrice) : "—"}
+              </span>
+            </span>
+            <span className="bw-num text-[0.74rem] text-ink-muted">
+              Markdown{" "}
+              <span className="font-medium text-brand-violet">
+                {price === null ? "—" : formatMoneyExact(price)}
+              </span>
+            </span>
+            <span className="bw-num text-[0.74rem] text-ink-muted">
+              Margin{" "}
+              {/* THREE colours, because green is an assertion. A markdown with
+                  no floor on file has cleared nothing, so it gets ordinary ink —
+                  the same stance `tools.tsx`'s neutral floor pill and the
+                  catalog's row take. */}
+              <span
+                className={cn(
+                  "font-semibold",
+                  belowFloor
+                    ? "text-negative"
+                    : unchecked
+                      ? "text-ink"
+                      : "text-positive",
+                )}
+              >
+                {margin === null ? "—" : formatMargin(margin)}
+              </span>
+              {floor !== null ? (
+                <span className="ml-1 text-ink-muted">
+                  vs floor {formatMargin(floor)}
+                </span>
+              ) : (
+                <span className="ml-1 text-ink-muted">· no floor on file</span>
+              )}
+            </span>
+          </div>
+
+          {/* An unmeasurable markdown says so, in ink rather than in alarm
+              colours: it is not a violation and it is not a clearance. Without
+              this line the row is a bare percentage, which reads as "checked,
+              fine" — the exact false all-clear `derive.FloorStatus` exists to
+              stop. */}
+          {unchecked ? (
+            <p className="mt-2.5 rounded-md border border-hairline bg-surface-muted px-2.5 py-1.5 text-[0.73rem] text-ink-muted">
+              No margin floor on file for {product?.category ?? "this category"}{" "}
+              — this markdown has NOT been checked against one.
+            </p>
+          ) : null}
+
+          {belowFloor ? (
+            <p className="mt-2.5 flex items-start gap-1.5 rounded-md border border-negative/30 bg-negative-soft px-2.5 py-1.5 text-[0.73rem] text-ink">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-negative" />
+              <span>
+                This markdown trades{" "}
+                <strong className="bw-num">
+                  {formatMargin((floor as number) - (margin as number)).replace(
+                    "%",
+                    "",
+                  )}
+                  pt
+                </strong>{" "}
+                under the {product?.category} floor.
+              </span>
+            </p>
+          ) : null}
+
+          {/* The DECISION surface's message slot — approve and decline, and
+              nothing else. */}
+          {decisionError ? (
+            <p className="mt-2 rounded-md border border-negative/30 bg-negative-soft px-2.5 py-1.5 text-[0.73rem] text-negative">
+              {decisionError}
+            </p>
+          ) : null}
+
+          {promotion.status === "pending" ? (
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                disabled={busy !== null}
+                onClick={() => void run("approve", onApprove)}
+                className="inline-flex items-center gap-1.5 rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground disabled:opacity-40"
+              >
+                <Check className="h-3.5 w-3.5" />
+                {busy === "approve" ? "Approving…" : "Approve"}
+              </button>
+              <button
+                type="button"
+                disabled={busy !== null}
+                onClick={() => void run("decline", onDecline)}
+                className="inline-flex items-center gap-1.5 rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink disabled:opacity-40"
+              >
+                <X className="h-3.5 w-3.5" />
+                {busy === "decline" ? "Declining…" : "Decline"}
+              </button>
+            </div>
+          ) : null}
+
+          {/* The waiver desk only appears where it is relevant — on a pending
+              markdown that is actually under its floor. Showing it everywhere
+              would turn the unlock into ambient UI the agent could read as an
+              obvious next step, which is precisely what beat 6 needs it not to
+              be.
+              `belowFloor` and not `!clear`, deliberately: the desk is premised on
+              a CONFIRMED violation, and an unmeasurable markdown has none to
+              waive — the server refuses its category outright
+              (`store.floorFor` throws `UNKNOWN_CATEGORY`), so a waiver filed
+              against it could not unlock anything. That row gets the caveat above
+              instead, which is information rather than a dead lever. */}
+          {promotion.status === "pending" && belowFloor ? (
+            <WaiverPanel
+              promotion={promotion}
+              waivers={waivers}
+              error={waiverError}
+              guard={guard}
+              onFile={onFile}
+              onFinalize={onFinalize}
+            />
+          ) : null}
+        </div>
+      </div>
+    </Panel>
+  );
+}
+
+export function PromotionsPage() {
+  const { data, refresh } = useCommerceLedger();
+  const recording = useRecording();
+  const [status, setStatus] = useState<StatusFilter>("pending");
+  const [errors, setErrors] = useState<Record<string, string | null>>({});
+
+  const productOf = (promotion: Promotion) =>
+    data.products.find((p) => p.id === promotion.productId);
+  const floorOf = (promotion: Promotion) => {
+    const item = productOf(promotion);
+    if (!item) return null;
+    return data.floors.find((f) => f.category === item.category)?.floor ?? null;
+  };
+  /**
+   * THE page's one floor verdict per markdown. Every surface below — the sort, the
+   * KPI tile, each card and the readable — reads this, so none of them can decide
+   * the question locally and land on `false` for a markdown nobody checked.
+   */
+  const floorStatusOf = (promotion: Promotion): FloorStatus =>
+    promotionFloorStatus(data.floors, productOf(promotion), promotion);
+
+  const visible = useMemo(() => {
+    const rows = data.promotions.filter(
+      (p) => status === "all" || p.status === status,
+    );
+    // Below-floor first, then the ones that could not be checked, then the rest —
+    // the shared worklist rank, so this desk and the catalog agree about where an
+    // unmeasurable row belongs. It used to score `!item || floor === null` as `1`,
+    // i.e. as CLEAN, which buried the one row nobody has verified underneath the
+    // rows that were.
+    return [...rows].sort(
+      (a, b) =>
+        FLOOR_WORKLIST_RANK[floorStatusOf(a)] -
+        FLOOR_WORKLIST_RANK[floorStatusOf(b)],
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.promotions, data.products, data.floors, status]);
+
+  const setError = (
+    id: string,
+    surface: WriteSurface,
+    message: string | null,
+  ) => setErrors((prev) => ({ ...prev, [slot(id, surface)]: message }));
+
+  /**
+   * The write landed but `refresh()` reported it could not re-read the ledger
+   * (see its contract in `data/ledger-context`). Without this the row keeps its
+   * old status and the page just looks like nothing happened.
+   */
+  const setStaleIfNeeded = (
+    id: string,
+    surface: WriteSurface,
+    refreshed: boolean,
+  ) => {
+    if (!refreshed) {
+      setError(
+        id,
+        surface,
+        "Done, but the page could not be re-read — reload it.",
+      );
+    }
+  };
+
+  /**
+   * Every write below resolves "did this write LAND" — `false` on a refusal,
+   * `true` once the store has it. It is not "and the page now shows it": a
+   * landed write whose ledger re-read failed still resolves `true` and leaves the
+   * stale-view notice up, because the thing the caller decides with this is
+   * whether it may throw away what the user typed.
+   */
+  const approve = async (promotion: Promotion): Promise<boolean> => {
+    const res = await fetch(
+      `/api/commerce/v1/promotions/${promotion.id}/approve`,
+      { method: "POST" },
+    );
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(
+        promotion.id,
+        "decision",
+        body?.message ?? `Approval refused (${res.status}).`,
+      );
+      recording.logStep(`Tried to approve ${promotion.name} — refused`);
+      return false;
+    }
+    setError(promotion.id, "decision", null);
+    recording.logStep(`Approved the markdown on ${promotion.name}`);
+    setStaleIfNeeded(promotion.id, "decision", await refresh());
+    return true;
+  };
+
+  /**
+   * The mirror of `approve`, refusal handling included. `store.declinePromotion`
+   * throws `ALREADY_DECIDED` (409) for a markdown someone else has already
+   * settled and `NOT_FOUND` (404) after a presenter reset; this used to
+   * `refresh()` regardless and log a "Declined …" step for a decline that never
+   * happened — a lie in the recording as well as a dead-looking button.
+   */
+  const decline = async (promotion: Promotion): Promise<boolean> => {
+    const res = await fetch(
+      `/api/commerce/v1/promotions/${promotion.id}/decline`,
+      { method: "POST" },
+    );
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(
+        promotion.id,
+        "decision",
+        body?.message ?? `Decline refused (${res.status}).`,
+      );
+      recording.logStep(`Tried to decline ${promotion.name} — refused`);
+      return false;
+    }
+    setError(promotion.id, "decision", null);
+    recording.logStep(`Declined ${promotion.name}`);
+    setStaleIfNeeded(promotion.id, "decision", await refresh());
+    return true;
+  };
+
+  const fileWaiver = async (
+    promotion: Promotion,
+    code: string,
+    justification: string,
+  ): Promise<boolean> => {
+    const res = await fetch("/api/commerce/v1/margin-waivers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        promotionId: promotion.id,
+        code,
+        justification,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(
+        promotion.id,
+        "waiver",
+        body?.message ?? `Could not file (${res.status}).`,
+      );
+      return false;
+    }
+    setError(promotion.id, "waiver", null);
+    // The CODE rides along as data, not just inside the label — this is what
+    // `getDemonstratedCode()` reads, and therefore what the saved procedure
+    // ends up naming.
+    recording.logStep(
+      `Filed a ${code} margin waiver on ${promotion.name}`,
+      code,
+    );
+    setStaleIfNeeded(promotion.id, "waiver", await refresh());
+    return true;
+  };
+
+  const finalizeWaiver = async (
+    promotion: Promotion,
+    waiverId: string,
+  ): Promise<boolean> => {
+    const res = await fetch(
+      `/api/commerce/v1/margin-waivers/${waiverId}/finalize`,
+      { method: "POST" },
+    );
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setError(
+        promotion.id,
+        "waiver",
+        body?.message ?? `Could not finalize (${res.status}).`,
+      );
+      return false;
+    }
+    setError(promotion.id, "waiver", null);
+    recording.logStep(`Finalized the ${body?.code ?? ""} waiver`.trim());
+    setStaleIfNeeded(promotion.id, "waiver", await refresh());
+    return true;
+  };
+
+  const pending = data.promotions.filter((p) => p.status === "pending");
+  /**
+   * The pending desk's floor tally, and the headline figure it can actually
+   * defend. `countBelow` returns `null` the moment one pending markdown could not
+   * be checked — this used to be a `.filter(...)` whose predicate returned `false`
+   * for that case, so the "Break the floor" tile printed a GREEN ZERO meaning
+   * "we did not look" next to a card the same page was refusing to verify.
+   */
+  const pendingTally = tallyStatuses(pending.map(floorStatusOf));
+  const pendingBelowFloor = countBelow(pendingTally);
+  const pendingFloorCaveat = noMarkdownFloorCaveat(pendingTally.unknown);
+
+  // ── BEAT 3b ──────────────────────────────────────────────────────────────
+  useAgentContext({
+    description:
+      "The Promotions page the user is currently viewing: the active status " +
+      "filter and the markdown rows actually visible on screen, each with the " +
+      "margin it would trade at after its discount and whether that breaks the " +
+      "category floor. `book` holds whole-ledger pending totals that the status " +
+      "filter does NOT narrow — never report those as the contents of this " +
+      "view. A row's `belowFloor` is null when its category has no margin floor " +
+      "on file: that markdown was NOT checked, which is not the same as clear, " +
+      "and `book.pendingBelowFloor` is null for the same reason whenever " +
+      "`book.pendingWithNoFloorOnFile` is above zero.",
+    value: JSON.stringify({
+      page: "promotions",
+      filters: { status },
+      book: {
+        pendingTotal: pending.length,
+        pendingBelowFloor,
+        pendingWithNoFloorOnFile: pendingTally.unknown,
+      },
+      visibleCount: visible.length,
+      rows: visible.slice(0, 25).map((promotion) => {
+        const item = productOf(promotion);
+        const floor = floorOf(promotion);
+        const price = item
+          ? discountedPrice(item.listPrice, promotion.discountPercent)
+          : null;
+        const margin = promotionMargin(item, promotion);
+        return {
+          id: promotion.id,
+          name: promotion.name,
+          product: item?.name ?? null,
+          category: item?.category ?? null,
+          discountPercent: promotion.discountPercent,
+          markdownPrice: price,
+          margin: margin === null ? null : formatMargin(margin),
+          floor: floor === null ? null : formatMargin(floor),
+          // `null`, never `false`, when there is no floor to compare against:
+          // a model handed `false` says the markdown is fine, which is the false
+          // all-clear one layer down from the screen.
+          belowFloor: nullableBelowFloor(floorStatusOf(promotion)),
+          status: promotion.status,
+          waivers: data.waivers
+            .filter((w) => w.promotionId === promotion.id)
+            .map((w) => ({ code: w.code, status: w.status })),
+        };
+      }),
+    }),
+  });
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <PageHeader
+        title="Promotions"
+        subtitle="Markdowns waiting on a decision, and what each one does to margin."
+      />
+
+      <div className="mb-5 grid grid-cols-3 gap-3">
+        <Metric
+          label="Pending"
+          value={String(pending.length)}
+          tone="markdown"
+        />
+        {/* An em dash, never a green zero, when a pending markdown could not be
+            checked: this tile is the desk's all-clear and it may only show one
+            when there is one. Mirrors the Catalog's "Below floor" tile exactly. */}
+        <Metric
+          label="Break the floor"
+          value={pendingBelowFloor === null ? "—" : String(pendingBelowFloor)}
+          hint={pendingFloorCaveat ?? undefined}
+          tone={
+            pendingBelowFloor === null || pendingBelowFloor > 0
+              ? "negative"
+              : "positive"
+          }
+        />
+        <Metric
+          label="Live this month"
+          value={String(
+            data.promotions.filter((p) => p.status === "approved").length,
+          )}
+        />
+      </div>
+
+      <div className="mb-4 flex flex-wrap items-center gap-1.5">
+        <span className="text-[0.7rem] font-medium text-ink-muted">Status</span>
+        {STATUS_FILTERS.map((candidate) => (
+          <button
+            key={candidate}
+            type="button"
+            onClick={() => setStatus(candidate)}
+            className={activeSelectClass(status === candidate)}
+          >
+            {candidate}
+          </button>
+        ))}
+      </div>
+
+      {visible.length === 0 ? (
+        <Panel>
+          <EmptyState
+            title="Nothing in this view"
+            hint="Switch the status filter to All to see every markdown the desk has looked at."
+            icon={<Tag className="h-5 w-5" />}
+          />
+        </Panel>
+      ) : (
+        <div className="space-y-3">
+          {visible.map((promotion) => (
+            <PromotionCard
+              key={promotion.id}
+              promotion={promotion}
+              product={productOf(promotion)}
+              floor={floorOf(promotion)}
+              status={floorStatusOf(promotion)}
+              waivers={data.waivers.filter(
+                (w) => w.promotionId === promotion.id,
+              )}
+              decisionError={errors[slot(promotion.id, "decision")] ?? null}
+              waiverError={errors[slot(promotion.id, "waiver")] ?? null}
+              onApprove={() => approve(promotion)}
+              onDecline={() => decline(promotion)}
+              onFile={(code, justification) =>
+                fileWaiver(promotion, code, justification)
+              }
+              onFinalize={(waiverId) => finalizeWaiver(promotion, waiverId)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/returns.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/returns.test.tsx
@@ -1,0 +1,443 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { ReturnsPage } from "./returns";
+import type {
+  CommerceStoreState,
+  Operator,
+  Product,
+  ReturnRequest,
+} from "../data/types";
+
+/**
+ * The returns desk's three write controls, under the three things that actually
+ * happen to them: a double-click, a fetch that never answers, and a write that
+ * LANDS while the follow-up re-read does not.
+ *
+ * BEAT 3a's refund is the money path, and it had no test of any kind. What it had
+ * instead:
+ *
+ *  1. `RefundControl` guarded with `useState` alone and had no `try/finally`, so a
+ *     rejecting fetch wedged the button on "Issuing…" permanently — mid-demo, with
+ *     no way back but a reload — and a double-click POSTed twice, the second
+ *     answering `ALREADY_REFUNDED` beside a refund that had landed.
+ *  2. Approve/Decline had no guard at all and never disabled, so a double-click
+ *     fired two PATCHes and painted `ALREADY_DECIDED` over a decision that
+ *     SUCCEEDED.
+ *  3. A LANDED refund whose `refresh()` failed came back as a MESSAGE, which the
+ *     control read as a refusal: it kept the typed figure and re-armed the button,
+ *     inviting a second refund for money that had already moved. The row still
+ *     reads "approved" on a failed re-read, so the control is still on screen —
+ *     this is not a theoretical branch.
+ *
+ * The in-flight assertions use a fetch that does NOT resolve until the test says
+ * so, which is what makes them deterministic: the question is only ever "while
+ * write #1 is outstanding, did the second click reach the network".
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+const PRODUCT: Product = {
+  id: "prd-cedar-hoodie",
+  sku: "BW-CDR-HDY",
+  name: "Cedar Hoodie",
+  category: "Knitwear",
+  listPrice: 120,
+  unitCost: 44,
+  inventory: 60,
+  trailing30Units: 30,
+  status: "live",
+  vendor: "Northline Mills",
+};
+
+const OPERATOR: Operator = {
+  id: "op-nadia",
+  name: "Nadia Okonjo",
+  role: "merch-lead",
+  team: "Merchandising",
+};
+
+/** Days ago, kept under 7 so no row paints an aging figure in `text-negative`. */
+const iso = (daysAgo: number) =>
+  new Date(Date.now() - daysAgo * 86_400_000).toISOString();
+
+/** Approved and unrefunded — the one row that renders `RefundControl`. */
+const APPROVED: ReturnRequest = {
+  id: "ret-approved",
+  orderId: "ord-1",
+  orderNumber: "4463",
+  customerName: "Priya Raghavan",
+  productId: PRODUCT.id,
+  reason: "damaged",
+  detail: "Scuffed at the cuff",
+  requestedAt: iso(3),
+  status: "approved",
+  itemValue: 120,
+  refundAmount: null,
+};
+
+/** Two undecided rows, so a decision on one can be raced against the other. */
+const REQUESTED: ReturnRequest = {
+  ...APPROVED,
+  id: "ret-requested",
+  orderNumber: "5501",
+  customerName: "Ines Duarte",
+  status: "requested",
+  requestedAt: iso(2),
+};
+
+const OTHER_REQUESTED: ReturnRequest = {
+  ...REQUESTED,
+  id: "ret-other",
+  orderNumber: "5502",
+  customerName: "Theo Vance",
+  requestedAt: iso(1),
+};
+
+function ledger(): CommerceStoreState {
+  return {
+    products: [PRODUCT],
+    floors: [{ category: "Knitwear", floor: 0.45, target: 0.52 }],
+    orders: [],
+    notifications: [],
+    returns: [APPROVED, REQUESTED, OTHER_REQUESTED],
+    promotions: [],
+    waivers: [],
+    plans: [],
+    operators: [OPERATOR],
+  };
+}
+
+const state: { data: CommerceStoreState; refreshed: boolean; count: number } = {
+  data: ledger(),
+  // What `refresh()` resolves. `false` is a STALE VIEW — the write landed, the
+  // re-read did not — which this page must report differently from a refusal.
+  refreshed: true,
+  count: 0,
+};
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+}));
+
+vi.mock("../data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: state.data,
+    refresh: async () => {
+      state.count += 1;
+      return state.refreshed;
+    },
+    operator: OPERATOR,
+    setOperatorId: () => {},
+  }),
+}));
+
+// ── the stub server ─────────────────────────────────────────────────────────
+
+interface Refusal {
+  status: number;
+  message: string;
+}
+
+/** Request urls seen, in order. */
+const posted: string[] = [];
+/** Resolvers for responses withheld while `hold` is true. */
+const withheld: (() => void)[] = [];
+const server: {
+  hold: boolean;
+  /** Answer a REPEAT of a write the way the store's own idempotency does. */
+  refuseRepeats: boolean;
+  refuse: Refusal | null;
+  reject: boolean;
+} = { hold: false, refuseRepeats: false, refuse: null, reject: false };
+
+/**
+ * Decide the response AT REQUEST TIME, not at release time — same reason as
+ * `promotions.test.tsx`: both clicks of an unguarded double-click are outstanding
+ * together, so computing repeat-ness at release time would refuse both and make
+ * the bug invisible.
+ */
+function decide(url: string): Response {
+  const repeat = posted.filter((seen) => seen === url).length > 1;
+  if (server.refuseRepeats && repeat) {
+    const already = url.endsWith("/refund")
+      ? "That return has already been refunded."
+      : "That was already decided.";
+    return {
+      ok: false,
+      status: 409,
+      json: async () => ({ message: already }),
+    } as unknown as Response;
+  }
+  const refusal = server.refuse;
+  if (refusal) {
+    return {
+      ok: false,
+      status: refusal.status,
+      json: async () => ({ message: refusal.message }),
+    } as unknown as Response;
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  state.data = ledger();
+  state.refreshed = true;
+  state.count = 0;
+  posted.length = 0;
+  withheld.length = 0;
+  server.hold = false;
+  server.refuseRepeats = false;
+  server.refuse = null;
+  server.reject = false;
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      posted.push(url);
+      if (server.reject)
+        return Promise.reject(new TypeError("Failed to fetch"));
+      const response = decide(url);
+      if (!server.hold) return Promise.resolve(response);
+      return new Promise<Response>((resolve) => {
+        withheld.push(() => resolve(response));
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** Drain the microtask queue and let React commit whatever it produced. */
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+/** Release every withheld response. */
+const release = async () => {
+  server.hold = false;
+  withheld.splice(0).forEach((settle) => settle());
+  await flush();
+};
+
+/** Requests whose url ends exactly here — `/refund` is a suffix of no other. */
+const callsEndingIn = (suffix: string) =>
+  posted.filter((url) => url.endsWith(suffix)).length;
+
+const button = (name: string | RegExp) => screen.getByRole("button", { name });
+const maybeButton = (name: string | RegExp) =>
+  screen.queryByRole("button", { name });
+const labelled = (label: string) => screen.getByLabelText(label);
+
+const amountInput = () =>
+  screen.getByPlaceholderText(/^up to /) as HTMLInputElement;
+
+const type = (text: string) => {
+  fireEvent.change(amountInput(), { target: { value: text } });
+};
+
+describe("RefundControl — the money path cannot fire twice or latch", () => {
+  it("POSTs the refund ONCE for a double-click", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    render(<ReturnsPage />);
+    type("50");
+
+    const issue = button("Issue refund");
+    fireEvent.click(issue);
+    // The second click lands while write #1 is still outstanding. Unguarded this
+    // reached the network, came back ALREADY_REFUNDED, and printed a refusal
+    // beside a refund that had really moved money.
+    fireEvent.click(issue);
+    expect(callsEndingIn("/refund")).toBe(1);
+
+    await release();
+    expect(callsEndingIn("/refund")).toBe(1);
+    expect(screen.queryByText(/already been refunded/)).toBeNull();
+  });
+
+  it("says so on the button while the refund is outstanding", async () => {
+    server.hold = true;
+    render(<ReturnsPage />);
+    type("50");
+
+    fireEvent.click(button("Issue refund"));
+    await flush();
+
+    const busy = button("Issuing…");
+    expect(busy.hasAttribute("disabled")).toBe(true);
+
+    await release();
+  });
+
+  it("does NOT latch on 'Issuing…' when the fetch never answers", async () => {
+    server.reject = true;
+    render(<ReturnsPage />);
+    type("50");
+
+    fireEvent.click(button("Issue refund"));
+    await flush();
+
+    // THE LATCH: no `finally`, so the button used to sit on "Issuing…" for the
+    // rest of the demo with no way back but a reload.
+    expect(maybeButton("Issuing…")).toBeNull();
+    // Nothing moved, so the control is armed again — and it has to SAY why,
+    // or a dead-looking button is all the operator gets.
+    expect(button("Issue refund").hasAttribute("disabled")).toBe(false);
+    expect(amountInput().value).toBe("50");
+    expect(screen.getByText(/did not go through/)).toBeTruthy();
+  });
+
+  it("keeps the typed figure and re-arms when the refund is REFUSED", async () => {
+    server.refuse = { status: 422, message: "That is over what was charged." };
+    render(<ReturnsPage />);
+    type("50");
+
+    fireEvent.click(button("Issue refund"));
+    await flush();
+
+    expect(screen.getByText("That is over what was charged.")).toBeTruthy();
+    // Nothing moved: the figure stays typed and the button is live again.
+    expect(amountInput().value).toBe("50");
+    expect(button("Issue refund").hasAttribute("disabled")).toBe(false);
+    expect(state.count).toBe(0);
+  });
+
+  it("will not re-arm after a refund that LANDED, even if a new figure is typed", async () => {
+    render(<ReturnsPage />);
+    type("50");
+
+    fireEvent.click(button("Issue refund"));
+    await flush();
+
+    expect(callsEndingIn("/refund")).toBe(1);
+    expect(amountInput().value).toBe("");
+    // The row only leaves this control's branch once the ledger re-read lands. If
+    // anything keeps it on screen, it must NOT invite a second refund for money
+    // that already moved — so typing a fresh figure does not bring the button
+    // back.
+    type("25");
+    expect(
+      button(/Issue refund|Refund issued|Issuing…/).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("reports a LANDED refund whose re-read failed as done-but-behind, not as a refusal", async () => {
+    // The money moved and only the ledger re-read failed. The row still reads
+    // "approved", so this control is still rendered — and the one thing it must
+    // not do is look like a refusal and invite a second attempt.
+    state.refreshed = false;
+    render(<ReturnsPage />);
+    type("50");
+
+    fireEvent.click(button("Issue refund"));
+    await flush();
+
+    expect(state.count).toBe(1);
+    expect(screen.getByText(/could not be re-read/)).toBeTruthy();
+    // The two halves that separate "it happened, the page is behind" from "it was
+    // refused": the figure is spent, and the button does not come back.
+    expect(amountInput().value).toBe("");
+    type("25");
+    expect(
+      button(/Issue refund|Refund issued|Issuing…/).hasAttribute("disabled"),
+    ).toBe(true);
+    expect(callsEndingIn("/refund")).toBe(1);
+  });
+});
+
+describe("ReturnsPage — a decision cannot fire twice or latch", () => {
+  const APPROVE = "Approve the return on order 5501";
+  const DECLINE = "Decline the return on order 5501";
+  const OTHER_APPROVE = "Approve the return on order 5502";
+
+  it("PATCHes ONCE for a double-clicked Approve, and paints no error", async () => {
+    server.hold = true;
+    server.refuseRepeats = true;
+    render(<ReturnsPage />);
+
+    const approve = labelled(APPROVE);
+    fireEvent.click(approve);
+    fireEvent.click(approve);
+    expect(callsEndingIn("/ret-requested")).toBe(1);
+
+    await release();
+    expect(callsEndingIn("/ret-requested")).toBe(1);
+    // ALREADY_DECIDED printed over a decision that succeeded is the whole bug.
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("disables both decision levers while one is outstanding", async () => {
+    server.hold = true;
+    render(<ReturnsPage />);
+
+    fireEvent.click(labelled(APPROVE));
+    await flush();
+
+    expect(labelled(APPROVE).hasAttribute("disabled")).toBe(true);
+    expect(labelled(DECLINE).hasAttribute("disabled")).toBe(true);
+
+    await release();
+    expect(labelled(APPROVE).hasAttribute("disabled")).toBe(false);
+  });
+
+  it("will not let Decline start while Approve is in flight", async () => {
+    server.hold = true;
+    render(<ReturnsPage />);
+
+    fireEvent.click(labelled(APPROVE));
+    fireEvent.click(labelled(DECLINE));
+    expect(posted).toHaveLength(1);
+
+    await release();
+  });
+
+  it("will not let a SECOND row's decision start either — they share one notice", async () => {
+    // The page has exactly one place to speak, so two decisions in flight
+    // together means the second one's outcome overwrites (or erases) the first's.
+    // The guard is page-wide for precisely that reason.
+    server.hold = true;
+    render(<ReturnsPage />);
+
+    fireEvent.click(labelled(APPROVE));
+    fireEvent.click(labelled(OTHER_APPROVE));
+    expect(callsEndingIn("/ret-other")).toBe(0);
+
+    await release();
+  });
+
+  it("does not latch, and speaks, when the decision fetch never answers", async () => {
+    server.reject = true;
+    render(<ReturnsPage />);
+
+    fireEvent.click(labelled(APPROVE));
+    await flush();
+
+    expect(labelled(APPROVE).hasAttribute("disabled")).toBe(false);
+    // A write that vanished with the page silent is the same dead button as a
+    // refusal nobody printed.
+    expect(screen.getByRole("status").textContent).toMatch(
+      /nothing came back/i,
+    );
+    expect(state.count).toBe(0);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/returns.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/returns.tsx
@@ -1,0 +1,482 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Clock, RotateCcw, X } from "lucide-react";
+import { useAgentContext } from "@copilotkit/react-core/v2";
+import { cn } from "@/lib/utils";
+import { useCommerceLedger } from "../data/ledger-context";
+import {
+  RETURN_REASON_LABEL,
+  ageInDays,
+  formatMoney,
+  formatMoneyExact,
+  openReturns,
+  refundCeilingLabel,
+  refundGuidance,
+} from "../data/derive";
+import type { ReturnRequest, ReturnStatus } from "../data/types";
+import { describeError } from "../settle";
+import { SkuTile } from "../components/sku-tile";
+import { useInFlight } from "../components/use-in-flight";
+import {
+  activeSelectClass,
+  EmptyState,
+  Metric,
+  PageHeader,
+  Panel,
+  Pill,
+  SectionLabel,
+} from "../components/primitives";
+
+/**
+ * The returns desk — and beat 3a's surface.
+ *
+ * A return that has been approved but not yet refunded is the one thing on this
+ * page waiting on a FIGURE, and that figure is the beat: the merchant types it
+ * into a card in the chat, it goes straight to REST, and the assistant is told
+ * only that a refund was issued and to whom. The same control exists here on the
+ * page, because an app where the only way to do something is to ask the
+ * assistant is not an app — it is a chatbot with a background image.
+ */
+
+const STATUS_FILTERS = [
+  "all",
+  "requested",
+  "approved",
+  "refunded",
+  "declined",
+] as const;
+type StatusFilter = (typeof STATUS_FILTERS)[number];
+
+function statusTone(status: ReturnStatus) {
+  if (status === "refunded") return "positive" as const;
+  if (status === "declined") return "neutral" as const;
+  if (status === "approved") return "brand" as const;
+  return "markdown" as const;
+}
+
+/**
+ * What a refund attempt resolves — the ONE place this page separates "the money
+ * moved" from "the screen agrees".
+ *
+ * `landed` is about the MONEY and nothing else. A refund that went through and
+ * whose ledger re-read failed is `landed: true, stale: true`, which is the same
+ * split `settle.ts`'s `staleNote` makes for the chat card's receipt. It used to be
+ * collapsed into one `string | null`: a landed-but-stale refund came back as a
+ * MESSAGE, the control read any message as a refusal, and it therefore kept the
+ * typed figure and re-armed the button — inviting a second refund for money that
+ * had already moved. On the one path in this app that moves money, that is the
+ * worst available shape of failure.
+ */
+type RefundOutcome =
+  | { landed: true; stale: boolean }
+  | { landed: false; refusal: string };
+
+/**
+ * Shown when the refund itself went through but `refresh()` reported it could not
+ * re-read the ledger. Says both halves, in that order: the money moved, and the
+ * rows are behind. Never phrased as a failure — see `RefundOutcome`.
+ */
+const REFUND_STALE_NOTICE =
+  "That refund went through, but this page could not be re-read afterwards — reload it to confirm.";
+
+function RefundControl({
+  request,
+  onRefund,
+}: {
+  request: ReturnRequest;
+  onRefund: (amount: number) => Promise<RefundOutcome>;
+}) {
+  const [value, setValue] = useState("");
+  const [note, setNote] = useState<string | null>(null);
+  /**
+   * A refund LANDED from this control. One-way on purpose, and never cleared: on
+   * a good re-read the row becomes `refunded` and this control unmounts, so the
+   * ONLY way it is still on screen after a landed refund is a re-read that failed
+   * — and re-arming the button there offers a second refund for money that has
+   * already moved.
+   */
+  const [issued, setIssued] = useState(false);
+  // One write in flight, guarded synchronously and released in a `finally`. This
+  // control had a `useState` boolean and no `try/finally`, so a rejecting fetch
+  // wedged the button on "Issuing…" for the rest of the demo.
+  const { busy, run } = useInFlight();
+
+  // Same single source as the chat card's control: the placeholder is built from
+  // the exact ceiling the button compares against. See `refundGuidance`.
+  const {
+    placeholder,
+    amount: parsed,
+    valid,
+    problem,
+  } = refundGuidance(request.itemValue, value);
+  // A refusal the operator cannot see is a button that reads as dead — the same
+  // complaint `refundGuidance`'s header makes. The route's own message wins when
+  // there is one; `problem` speaks only about what is in the box right now.
+  const feedback = note ?? problem;
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2">
+      <label className="flex items-center gap-1.5">
+        <span className="text-[0.68rem] font-medium text-ink-muted">
+          Refund
+        </span>
+        <input
+          value={value}
+          onChange={(event) => {
+            setValue(event.target.value);
+            setNote(null);
+          }}
+          disabled={issued}
+          inputMode="decimal"
+          autoComplete="off"
+          placeholder={placeholder}
+          className="bw-num w-32 rounded-md border border-hairline bg-surface px-2 py-1 text-[0.76rem] text-ink outline-none focus:border-brand/50 disabled:opacity-40"
+        />
+      </label>
+      <button
+        type="button"
+        disabled={!valid || busy !== null || issued}
+        onClick={() =>
+          void run(request.id, async () => {
+            const outcome = await onRefund(parsed);
+            if (!outcome.landed) {
+              // Nothing moved: say why, and leave the figure typed so the
+              // operator fixes it rather than retyping it on stage.
+              setNote(outcome.refusal);
+              return false;
+            }
+            setIssued(true);
+            setValue("");
+            setNote(outcome.stale ? REFUND_STALE_NOTICE : null);
+            return true;
+          })
+        }
+        className="rounded-md bg-brand px-3 py-1 text-[0.73rem] font-semibold text-brand-foreground disabled:opacity-40"
+      >
+        {issued ? "Refund issued" : busy !== null ? "Issuing…" : "Issue refund"}
+      </button>
+      {feedback ? (
+        <span
+          className={cn(
+            "text-[0.7rem]",
+            // A landed refund's note is not a refusal and must not be dressed as
+            // one: from the back of a room red text beside a spent control reads
+            // as "the money did not move".
+            issued ? "text-ink-muted" : "text-negative",
+          )}
+        >
+          {feedback}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Shown when a write landed but `refresh()` reported it could not re-read the
+ * ledger (see its contract in `data/ledger-context`). The approve/decline
+ * buttons have no receipt of their own — the row changing IS the receipt — so
+ * without this a failed re-read looks exactly like a button that does nothing.
+ * Distinct from a REFUSAL: the write did happen, only the view is behind.
+ */
+const STALE_LEDGER_NOTICE =
+  "That went through, but this page could not be re-read afterwards — the rows below may be out of date. Reload to confirm.";
+
+export function ReturnsPage() {
+  const { data, refresh } = useCommerceLedger();
+  const [status, setStatus] = useState<StatusFilter>("all");
+  // One slot for both things that can stop the row from moving: the route
+  // refusing the decision, and a `refresh()` that could not re-read afterwards.
+  const [notice, setNotice] = useState<string | null>(null);
+  /**
+   * ONE guard for every decision on this page, not one per row.
+   *
+   * The granularity is set by the MESSAGE CHANNEL, not by the record: every
+   * approve and decline on the page reports through the single `notice` above, so
+   * two decisions in flight together means the one that finishes last speaks for
+   * both — a refusal on row A erased by row B's success, which is the same silent
+   * no-op as a button that never fired. A per-row mutex would close the
+   * double-click hole and leave that one open.
+   *
+   * The refund control is deliberately NOT on this guard: it reports into its own
+   * inline slot beside its own button, so it owns its own instance.
+   */
+  const { busy, run } = useInFlight();
+
+  const productName = (id: string) =>
+    data.products.find((p) => p.id === id)?.name ?? "Unknown product";
+
+  const visible = useMemo(() => {
+    const rows = data.returns.filter(
+      (r) => status === "all" || r.status === status,
+    );
+    // Anything awaiting a decision or a refund floats to the top; settled rows
+    // sink. Within each group, oldest first — this is a queue, not an archive.
+    const rank = (r: ReturnRequest) =>
+      r.status === "approved" ? 0 : r.status === "requested" ? 1 : 2;
+    return [...rows].sort(
+      (a, b) => rank(a) - rank(b) || a.requestedAt.localeCompare(b.requestedAt),
+    );
+  }, [data.returns, status]);
+
+  /**
+   * Approve or decline, and report a refusal rather than repainting the same row.
+   *
+   * `store.decideReturn` throws `ALREADY_DECIDED` (409) for a row that has moved
+   * on since this snapshot — a double click, or the assistant deciding the same
+   * request from the chat — and `NOT_FOUND` (404) after a presenter reset. This
+   * used to `refresh()` regardless, so both answers looked exactly like a button
+   * that does nothing. The route's own `message` is preferred over the fallback:
+   * those strings (`data/http.ts`) are written to be read by a human.
+   *
+   * Resolves "did this decision LAND", for the guard above. Total: a `fetch` that
+   * never answers at all is reported here rather than thrown, because a throw out
+   * of the click handler is a decision that vanished with the page silent.
+   */
+  const decide = async (
+    id: string,
+    next: "approved" | "declined",
+  ): Promise<boolean> => {
+    let res: Response;
+    try {
+      res = await fetch(`/api/commerce/v1/returns/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+    } catch (error) {
+      setNotice(
+        `That return could not be ${next}: ${describeError(error)}. ` +
+          "Nothing came back, so treat it as not applied.",
+      );
+      return false;
+    }
+    if (!res.ok) {
+      const problem = await res.json().catch(() => ({}));
+      setNotice(
+        problem?.message ?? `That return could not be ${next} (${res.status}).`,
+      );
+      return false;
+    }
+    setNotice((await refresh()) ? null : STALE_LEDGER_NOTICE);
+    return true;
+  };
+
+  /**
+   * Beat 3a's write from the page. Reports the money and the view SEPARATELY —
+   * see `RefundOutcome` — and, like `decide`, is total: a refund that never
+   * reached the server is a refusal with a reason, not a throw out of a click
+   * handler.
+   */
+  const refund = async (id: string, amount: number): Promise<RefundOutcome> => {
+    let res: Response;
+    try {
+      res = await fetch(`/api/commerce/v1/returns/${id}/refund`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ amount }),
+      });
+    } catch (error) {
+      return {
+        landed: false,
+        refusal:
+          `That refund did not go through: ${describeError(error)}. ` +
+          "Nothing came back, so treat it as not applied.",
+      };
+    }
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return {
+        landed: false,
+        refusal: body?.message ?? `Refund failed (${res.status}).`,
+      };
+    }
+    // The money moved. Whether the SCREEN caught up is a separate fact, and the
+    // control renders it as a note rather than as a refusal.
+    return { landed: true, stale: !(await refresh()) };
+  };
+
+  const awaitingRefund = data.returns.filter((r) => r.status === "approved");
+  const open = openReturns(data.returns);
+  const refundedValue = data.returns.reduce(
+    (sum, r) => sum + (r.refundAmount ?? 0),
+    0,
+  );
+
+  // ── BEAT 3b ──────────────────────────────────────────────────────────────
+  useAgentContext({
+    description:
+      "The Returns page the user is currently viewing: the active status " +
+      "filter and the return rows actually visible on screen, in the order " +
+      "shown, with each one's reason, value and any refund already issued.",
+    value: JSON.stringify({
+      page: "returns",
+      filters: { status },
+      openTotal: open.length,
+      awaitingRefund: awaitingRefund.length,
+      refundedValue,
+      visibleCount: visible.length,
+      rows: visible.slice(0, 25).map((r) => ({
+        id: r.id,
+        orderNumber: r.orderNumber,
+        customer: r.customerName,
+        product: productName(r.productId),
+        reason: RETURN_REASON_LABEL[r.reason],
+        detail: r.detail,
+        status: r.status,
+        itemValue: r.itemValue,
+        refundAmount: r.refundAmount,
+        ageDays: ageInDays(r.requestedAt),
+      })),
+    }),
+  });
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <PageHeader
+        title="Returns"
+        subtitle="What is coming back, why, and what it costs to make it right."
+      />
+
+      {notice ? (
+        <p role="status" className="mb-4 text-[0.7rem] text-negative">
+          {notice}
+        </p>
+      ) : null}
+
+      <div className="mb-5 grid grid-cols-3 gap-3">
+        <Metric label="Open" value={String(open.length)} tone="brand" />
+        <Metric
+          label="Awaiting refund"
+          value={String(awaitingRefund.length)}
+          tone={awaitingRefund.length > 0 ? "markdown" : "positive"}
+        />
+        <Metric label="Refunded" value={formatMoney(refundedValue)} />
+      </div>
+
+      <div className="mb-4 flex flex-wrap items-center gap-1.5">
+        <span className="text-[0.7rem] font-medium text-ink-muted">Status</span>
+        {STATUS_FILTERS.map((candidate) => (
+          <button
+            key={candidate}
+            type="button"
+            onClick={() => setStatus(candidate)}
+            className={activeSelectClass(status === candidate)}
+          >
+            {candidate}
+          </button>
+        ))}
+      </div>
+
+      <SectionLabel>{visible.length} returns</SectionLabel>
+
+      <Panel padded={false}>
+        {visible.length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              title="Nothing in this view"
+              hint="Switch the status filter to All to see everything the desk has handled."
+              icon={<RotateCcw className="h-5 w-5" />}
+            />
+          </div>
+        ) : (
+          <ul>
+            {visible.map((request) => {
+              const age = ageInDays(request.requestedAt);
+              return (
+                <li
+                  key={request.id}
+                  className="border-b border-hairline px-4 py-3 last:border-b-0"
+                >
+                  <div className="flex flex-wrap items-center gap-3">
+                    <SkuTile
+                      name={productName(request.productId)}
+                      size="sm"
+                      ring={request.status === "approved" ? "markdown" : null}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[0.8rem] font-medium text-ink">
+                        {productName(request.productId)}
+                        <span className="ml-2 font-normal text-ink-muted">
+                          {request.customerName}
+                        </span>
+                      </p>
+                      <p className="bw-num truncate text-[0.7rem] text-ink-muted">
+                        #{request.orderNumber} · {request.detail}
+                      </p>
+                    </div>
+                    <Pill>{RETURN_REASON_LABEL[request.reason]}</Pill>
+                    <span
+                      className={cn(
+                        "bw-num inline-flex items-center gap-1 text-[0.72rem]",
+                        age >= 7
+                          ? "font-semibold text-negative"
+                          : "text-ink-muted",
+                      )}
+                      title={`Requested ${age} days ago`}
+                    >
+                      <Clock className="h-3 w-3" />
+                      {age}d
+                    </span>
+                    <span className="bw-num w-24 shrink-0 text-right text-[0.75rem] font-medium text-ink">
+                      {/* Both exact: on an approved row this column is the very
+                          ceiling the control below it invites, and a rounded
+                          figure here would contradict that placeholder. */}
+                      {request.refundAmount !== null
+                        ? formatMoneyExact(request.refundAmount)
+                        : refundCeilingLabel(request.itemValue)}
+                    </span>
+                    <Pill tone={statusTone(request.status)}>
+                      {request.status}
+                    </Pill>
+                    {request.status === "requested" ? (
+                      <span className="flex gap-1">
+                        {/* Both levers disable while ANY decision on the page is
+                            outstanding — the guard is the page's, not the row's.
+                            See `useInFlight` above. */}
+                        <button
+                          type="button"
+                          aria-label={`Approve the return on order ${request.orderNumber}`}
+                          disabled={busy !== null}
+                          onClick={() =>
+                            void run(`${request.id}:approved`, () =>
+                              decide(request.id, "approved"),
+                            )
+                          }
+                          className="flex h-7 w-7 items-center justify-center rounded-md border border-hairline text-positive hover:bg-positive-soft disabled:opacity-40"
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Decline the return on order ${request.orderNumber}`}
+                          disabled={busy !== null}
+                          onClick={() =>
+                            void run(`${request.id}:declined`, () =>
+                              decide(request.id, "declined"),
+                            )
+                          }
+                          className="flex h-7 w-7 items-center justify-center rounded-md border border-hairline text-ink-muted hover:bg-surface-muted disabled:opacity-40"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {request.status === "approved" ? (
+                    <RefundControl
+                      request={request}
+                      onRefund={(amount) => refund(request.id, amount)}
+                    />
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </Panel>
+    </div>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/pages/write-refusals.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/pages/write-refusals.test.tsx
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { CommerceStoreState, Operator } from "../data/types";
+import { OrdersPage } from "./orders";
+import { PromotionsPage } from "./promotions";
+import { ReturnsPage } from "./returns";
+
+/**
+ * Every page control that WRITES must report a refusal.
+ *
+ * The bug this pins: four write paths across these three pages called
+ * `refresh()` without looking at `res.ok`, so a 4xx repainted the identical rows
+ * and the click was indistinguishable from a slow network. Every one of them is a
+ * control a presenter may press on stage, and a silent no-op is the worst class
+ * of demo failure — the room cannot tell whether the app is broken or slow.
+ *
+ * The four, and the refusal each can now genuinely receive:
+ *   Orders  · hold             → 409 from the order state machine
+ *   Orders  · clear exception  → 422 EXCEPTION_ON_SETTLED_ORDER
+ *   Returns · approve/decline  → 409 ALREADY_DECIDED
+ *   Promos  · decline          → 409 ALREADY_DECIDED
+ *
+ * Each is asserted three ways, because any one alone leaves the bug reachable:
+ * the route's MESSAGE reaches the screen, the page does NOT go on to re-read the
+ * ledger (a refresh after a refusal is the silent repaint itself), and the happy
+ * path still refreshes and says nothing.
+ */
+
+// Hoisted for the same reason as `orders-clear-exception.test.tsx`: `vi.mock` is
+// lifted above these imports, so a factory closing over module-scope consts would
+// read them in their temporal dead zone when the pages pull the ledger context at
+// import time.
+const { LEDGER, OPERATOR, refresh, logStep } = vi.hoisted(() => {
+  const iso = (daysAgo: number) =>
+    new Date(Date.now() - daysAgo * 86_400_000).toISOString();
+  const operator = {
+    id: "op-nadia",
+    name: "Nadia Okonjo",
+    role: "merch-lead" as const,
+    team: "Merchandising" as const,
+  };
+  return {
+    OPERATOR: operator,
+    refresh: vi.fn(async () => true),
+    logStep: vi.fn(),
+    LEDGER: {
+      products: [
+        {
+          id: "bw-1",
+          sku: "BW-CDR-HDY",
+          name: "Cedar Hoodie",
+          category: "Knitwear",
+          listPrice: 120,
+          unitCost: 60,
+          inventory: 12,
+          trailing30Units: 30,
+          status: "live",
+          vendor: "Cedar Mills",
+        },
+      ],
+      // A 40% markdown on the product above trades at ~17% margin, well under
+      // this floor — so the promotion below renders as the below-floor card the
+      // Decline button actually lives on in the demo.
+      floors: [{ category: "Knitwear", floor: 0.5, target: 0.6 }],
+      orders: [
+        {
+          id: "ord-held",
+          number: "4463",
+          customerName: "Priya Raghavan",
+          customerEmail: "priya@example.com",
+          channel: "web",
+          destination: "Lisbon, PT",
+          placedAt: iso(4),
+          status: "open",
+          exception: "payment-declined",
+          lines: [{ productId: "bw-1", quantity: 2, unitPrice: 40 }],
+          total: 80,
+          notes: [],
+        },
+      ],
+      notifications: [],
+      returns: [
+        {
+          id: "ret-1",
+          orderId: "ord-held",
+          orderNumber: "4463",
+          customerName: "Priya Raghavan",
+          productId: "bw-1",
+          reason: "damaged",
+          detail: "Scuffed at the cuff",
+          requestedAt: iso(3),
+          status: "requested",
+          itemValue: 120,
+          refundAmount: null,
+        },
+      ],
+      promotions: [
+        {
+          id: "promo-1",
+          name: "Cedar Hoodie −40%",
+          productId: "bw-1",
+          discountPercent: 40,
+          startsAt: iso(-2),
+          endsAt: iso(-16),
+          submittedBy: "Ada Iyer",
+          submittedAt: iso(1),
+          status: "pending",
+          marginWaiverId: null,
+        },
+      ],
+      waivers: [],
+      plans: [],
+      operators: [operator],
+    },
+  };
+});
+
+vi.mock("@copilotkit/react-core/v2", () => ({ useAgentContext: () => {} }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("@/shell/skin-path", () => ({
+  useSkinHref: () => (path?: string) => path ?? "/",
+}));
+
+vi.mock("../data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: LEDGER as unknown as CommerceStoreState,
+    refresh,
+    operator: OPERATOR as Operator,
+    setOperatorId: () => {},
+  }),
+}));
+
+vi.mock("../components/recording-context", () => ({
+  useRecording: () => ({
+    depth: 0,
+    steps: [],
+    beginRecording: () => {},
+    endRecording: () => [],
+    logStep,
+  }),
+}));
+
+/** A route refusal, in the shape `data/http.ts` actually emits. */
+const refusal = (status: number, message: string) =>
+  vi.fn(async () => Response.json({ error: "CODE", message }, { status }));
+
+/** A 200 whose body the page never reads. */
+const accepted = () => vi.fn(async () => new Response("{}", { status: 200 }));
+
+beforeEach(() => {
+  refresh.mockClear();
+  refresh.mockResolvedValue(true);
+  logStep.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const click = async (label: string) => {
+  const button = screen.getByLabelText(label);
+  await act(async () => {
+    button.click();
+  });
+};
+
+const clickText = async (name: string) => {
+  const button = screen.getByRole("button", { name });
+  await act(async () => {
+    button.click();
+  });
+};
+
+describe("OrdersPage — a refused write is reported, not repainted", () => {
+  it("surfaces the route's message when the hold is refused", async () => {
+    vi.stubGlobal(
+      "fetch",
+      refusal(409, "That order cannot move to that status from where it is."),
+    );
+
+    render(<OrdersPage />);
+    await click("Hold order 4463");
+
+    expect(
+      screen.getByText(
+        "That order cannot move to that status from where it is.",
+      ),
+    ).toBeTruthy();
+    // The silent repaint itself: a refused write must not go on to re-read.
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the route's message when clearing the exception is refused", async () => {
+    vi.stubGlobal(
+      "fetch",
+      refusal(
+        422,
+        "A fulfilled or cancelled order cannot carry an exception — clear it in the same change.",
+      ),
+    );
+
+    render(<OrdersPage />);
+    await click("Clear the exception on order 4463");
+
+    expect(
+      screen.getByText(
+        "A fulfilled or cancelled order cannot carry an exception — clear it in the same change.",
+      ),
+    ).toBeTruthy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a status-bearing sentence when the body carries no message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<html>gateway</html>", { status: 502 })),
+    );
+
+    render(<OrdersPage />);
+    await click("Hold order 4463");
+
+    expect(
+      screen.getByText("That order could not be held (502)."),
+    ).toBeTruthy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes and says nothing on the happy path", async () => {
+    vi.stubGlobal("fetch", accepted());
+
+    render(<OrdersPage />);
+    await click("Hold order 4463");
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("still reports a stale view when the write landed but the re-read failed", async () => {
+    vi.stubGlobal("fetch", accepted());
+    refresh.mockResolvedValue(false);
+
+    render(<OrdersPage />);
+    await click("Hold order 4463");
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "could not be re-read",
+    );
+  });
+});
+
+describe("ReturnsPage — a refused decision is reported, not repainted", () => {
+  it("surfaces the route's message when the return was already decided", async () => {
+    vi.stubGlobal("fetch", refusal(409, "That was already decided."));
+
+    render(<ReturnsPage />);
+    await click("Approve the return on order 4463");
+
+    expect(screen.getByText("That was already decided.")).toBeTruthy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a status-bearing sentence naming the decision", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 })),
+    );
+
+    render(<ReturnsPage />);
+    await click("Decline the return on order 4463");
+
+    expect(
+      screen.getByText("That return could not be declined (500)."),
+    ).toBeTruthy();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes and says nothing on the happy path", async () => {
+    vi.stubGlobal("fetch", accepted());
+
+    render(<ReturnsPage />);
+    await click("Approve the return on order 4463");
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});
+
+describe("PromotionsPage — a refused decline is reported, not repainted", () => {
+  it("surfaces the route's message and records the attempt as refused", async () => {
+    vi.stubGlobal("fetch", refusal(409, "That was already decided."));
+
+    render(<PromotionsPage />);
+    await clickText("Decline");
+
+    expect(screen.getByText("That was already decided.")).toBeTruthy();
+    expect(refresh).not.toHaveBeenCalled();
+    // The recording must not claim a decline that never landed.
+    expect(logStep).toHaveBeenCalledWith(
+      "Tried to decline Cedar Hoodie −40% — refused",
+    );
+  });
+
+  it("still refreshes and records the decline on the happy path", async () => {
+    vi.stubGlobal("fetch", accepted());
+
+    render(<PromotionsPage />);
+    await clickText("Decline");
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(logStep).toHaveBeenCalledWith("Declined Cedar Hoodie −40%");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/presenter-reset.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/presenter-reset.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runPresenterReset } from "./layout";
+import { landedWritesOn, narrateWrite, resetLandedWrites } from "./settle";
+
+/**
+ * The presenter's Reset button is the control whose whole job is recovering
+ * under time pressure, on stage — so the one thing it may never do is leave the
+ * room looking at a state that no longer exists.
+ *
+ * `store.reset()` runs in the route BEFORE anything that can fail, and nothing
+ * rolls it back. So a 502 (memory wiped but not fully re-seeded) and an
+ * exception mid-sweep both mean THE STORE IS GONE. The pre-fix handler branched
+ * on `res.ok` alone: on either of those it neither navigated nor refreshed, so
+ *
+ *   - the page kept rendering pre-reset rows over a wiped store, and
+ *   - the module-level teach-mode journal in `settle.ts` survived, so a later
+ *     failure recited writes the reset had taken away, and
+ *   - the route's `memoryError` sentence — the only warning that beat 6 may
+ *     start out already taught — was thrown away and replaced with a bare
+ *     "HTTP 502".
+ *
+ * Two independent narrators (the screen, and the agent's recital) asserting a
+ * world that is gone. These assertions pin each half.
+ */
+
+const respond = (status: number, body: unknown): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as unknown as Response;
+
+/** A body no JSON parser can read — a Next error page, a proxy, an empty 500. */
+const unreadable = (status: number): Response =>
+  ({
+    ok: false,
+    status,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON at position 0");
+    },
+  }) as unknown as Response;
+
+/** The exact shape of the route's partial-memory failure. */
+const PARTIAL_502 = {
+  ok: false,
+  reset: ["store"],
+  memory: "partial",
+  seeded: 1,
+  expectedSeeds: 4,
+  memoryError:
+    "memory wipe did not finish (1 of 2 bucket(s), 3 row(s) failed to delete); " +
+    "a surviving memory can leave beat 6 already taught",
+};
+
+const io = (post: () => Promise<Response>, confirmed = true) => {
+  /** Every call in order, so "warned THEN left" can be asserted as an order. */
+  const calls: string[] = [];
+  const spies = {
+    confirm: vi.fn((message: string) => {
+      calls.push(`confirm:${message}`);
+      return confirmed;
+    }),
+    notify: vi.fn((message: string) => {
+      calls.push(`notify:${message}`);
+    }),
+    navigate: vi.fn(() => {
+      calls.push("navigate");
+    }),
+    post,
+  };
+  return { ...spies, calls };
+};
+
+/** Land a write on one order so the journal has something to lose. */
+const journalOneWrite = async () => {
+  await narrateWrite(
+    { action: "the hold on order 4463", subject: "ord-4463" },
+    async (landed) => {
+      landed("put on hold");
+      return "Order 4463 is on hold.";
+    },
+  );
+  expect(landedWritesOn("ord-4463")).toEqual(["put on hold"]);
+};
+
+beforeEach(() => {
+  resetLandedWrites();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("runPresenterReset — the happy path", () => {
+  it("navigates to the skin root and drops the journal", async () => {
+    await journalOneWrite();
+    const deps = io(async () =>
+      respond(200, { ok: true, reset: ["store", "memory"], memory: "seeded" }),
+    );
+
+    await runPresenterReset(deps);
+
+    expect(deps.navigate).toHaveBeenCalledTimes(1);
+    // Nothing to warn about, so no modal stands between the presenter and a
+    // clean app.
+    expect(deps.notify).not.toHaveBeenCalled();
+    expect(landedWritesOn("ord-4463")).toEqual([]);
+  });
+
+  it("does nothing at all when the confirm is declined", async () => {
+    const post = vi.fn(async () =>
+      respond(200, { ok: true, reset: ["store"] }),
+    );
+    const deps = io(post, false);
+
+    await runPresenterReset(deps);
+
+    expect(post).not.toHaveBeenCalled();
+    expect(deps.navigate).not.toHaveBeenCalled();
+    expect(deps.notify).not.toHaveBeenCalled();
+  });
+});
+
+describe("runPresenterReset — 502 with the store already wiped", () => {
+  it("navigates anyway, because the rows on screen no longer exist", async () => {
+    const deps = io(async () => respond(502, PARTIAL_502));
+
+    await runPresenterReset(deps);
+
+    // THE FINDING: the pre-fix handler stopped at the alert, leaving a wiped
+    // store rendered as pre-reset data.
+    expect(deps.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the route's memoryError sentence, not just a status code", async () => {
+    const deps = io(async () => respond(502, PARTIAL_502));
+
+    await runPresenterReset(deps);
+
+    const warning = deps.notify.mock.calls[0]?.[0] ?? "";
+    // The sentence exists precisely so the presenter knows beat 6 may start out
+    // already taught. Discarding it for "HTTP 502" is the loss this pins.
+    expect(warning).toContain("beat 6 already taught");
+    expect(warning).toContain("memory wipe did not finish");
+    // And it must still say the store DID go, or the presenter cannot tell
+    // whether the demo data is seeded.
+    expect(warning).toMatch(/WAS reset/i);
+  });
+
+  it("warns BEFORE it leaves, so the sentence is readable", async () => {
+    const deps = io(async () => respond(502, PARTIAL_502));
+
+    await runPresenterReset(deps);
+
+    const notifyAt = deps.calls.findIndex((c) => c.startsWith("notify:"));
+    const navigateAt = deps.calls.indexOf("navigate");
+    expect(notifyAt).toBeGreaterThanOrEqual(0);
+    expect(navigateAt).toBeGreaterThan(notifyAt);
+  });
+
+  it("clears the teach-mode journal, so no recital survives the wipe", async () => {
+    await journalOneWrite();
+    const deps = io(async () => respond(502, PARTIAL_502));
+
+    await runPresenterReset(deps);
+
+    // Belt and braces with the navigate: the journal must be gone even if the
+    // document load never lands. Otherwise the next failure on order 4463
+    // recites "put on hold … still stand" about a store that was emptied.
+    expect(landedWritesOn("ord-4463")).toEqual([]);
+  });
+});
+
+describe("runPresenterReset — the request never came back", () => {
+  it("reloads and says so instead of trusting the screen", async () => {
+    await journalOneWrite();
+    const deps = io(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    await runPresenterReset(deps);
+
+    // The store is in-memory, so the likeliest cause — the dev server
+    // restarting mid-call — has itself already reset it. Keeping the page is
+    // the one option that can be wrong in the demo-destroying direction.
+    expect(deps.navigate).toHaveBeenCalledTimes(1);
+    expect(deps.notify.mock.calls[0]?.[0] ?? "").toContain("Failed to fetch");
+    expect(landedWritesOn("ord-4463")).toEqual([]);
+  });
+
+  it("reloads when the body cannot be read at all", async () => {
+    const deps = io(async () => unreadable(500));
+
+    await runPresenterReset(deps);
+
+    // Unreadable body = the client cannot tell whether the store went. It runs
+    // AFTER the gate, so "assume wiped" is the only safe reading.
+    expect(deps.navigate).toHaveBeenCalledTimes(1);
+    expect(deps.notify).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runPresenterReset — refused before the store was touched", () => {
+  it("keeps the page when the route says it never reset anything", async () => {
+    await journalOneWrite();
+    const deps = io(async () =>
+      respond(403, {
+        error: "FORBIDDEN",
+        message: "Not available in production.",
+      }),
+    );
+
+    await runPresenterReset(deps);
+
+    // Nothing on screen is stale, so throwing away a working demo would be its
+    // own failure. The journal is still true, too.
+    expect(deps.navigate).not.toHaveBeenCalled();
+    expect(deps.notify.mock.calls[0]?.[0] ?? "").toContain(
+      "Not available in production.",
+    );
+    expect(landedWritesOn("ord-4463")).toEqual(["put on hold"]);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/providers.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/providers.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import type { ReactNode } from "react";
+import {
+  CommerceLedgerProvider,
+  useCommerceLedger,
+} from "./data/ledger-context";
+import {
+  RecordingProvider,
+  RecordingVignette,
+} from "./components/recording-context";
+import { setSandboxSnapshot } from "./sandbox-functions";
+
+/**
+ * Bellwether uses BOTH provider slots the contract offers, and the split
+ * matters.
+ *
+ * `RuntimeProviders` mounts ABOVE `CopilotKitProvider`. The ledger lives here
+ * because `useRuntimeProperties` reads the signed-in operator out of it, and
+ * `properties` is a PROP of `CopilotKitProvider` — so its source has to exist
+ * before that provider's first commit. A child racing an imperative
+ * `setProperties` after mount is precisely the bug this slot exists to prevent.
+ * Mounting above also means everything below (Tools, layout, pages) shares the
+ * one ledger fetch.
+ *
+ * `Providers` mounts BELOW it, for anything that consumes CopilotKit context —
+ * here, the teach-mode recording context and its canvas-edge vignette.
+ */
+
+/** Above CopilotKitProvider. */
+export function CommerceRuntimeProviders({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <CommerceLedgerProvider>{children}</CommerceLedgerProvider>;
+}
+
+/**
+ * Threaded into `CopilotKitProvider`'s `properties` prop by the shell, and
+ * forwarded to the server as the run body's forwardedProps, where
+ * `commerceIdentifyUser` maps it onto a durable-memory scope.
+ *
+ * Memoized on the two primitive fields rather than the operator object: the
+ * ledger re-creates that object on every refresh, and an unstable `properties`
+ * identity would re-scope the run on every mutation.
+ *
+ * Deliberately does NOT set `a2uiCatalogAvailable` — the shell adds that itself
+ * when a catalog is present.
+ */
+export function useCommerceRuntimeProperties():
+  | Record<string, unknown>
+  | undefined {
+  const { operator } = useCommerceLedger();
+  return useMemo(
+    () => ({ userId: operator.id, userRole: operator.role }),
+    [operator.id, operator.role],
+  );
+}
+
+/**
+ * Keeps the module-scope snapshot the OGUI sandbox functions read in sync with
+ * the live ledger. Renders nothing. Without it those functions answer from an
+ * empty ledger and generated UI comes back convincingly blank.
+ */
+function SandboxDataSync() {
+  const { data } = useCommerceLedger();
+  useEffect(() => {
+    setSandboxSnapshot(data);
+  }, [data]);
+  return null;
+}
+
+/** Below CopilotKitProvider. */
+export function CommerceProviders({ children }: { children: ReactNode }) {
+  return (
+    <RecordingProvider>
+      <SandboxDataSync />
+      {children}
+      <RecordingVignette />
+    </RecordingProvider>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/refund.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/refund.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readRefundedCustomer, submitRefund } from "./refund";
+import { STALE_VIEW_NOTE } from "./settle";
+
+/**
+ * BEAT 3a's write. The property under test is not "the happy path works" — it is
+ * that the interrupt is settled on EVERY path. An unsettled interrupt blocks the
+ * agent run indefinitely behind a card that still looks live, and nothing logs it,
+ * so the only defence is a test that enumerates the ways out.
+ */
+const request = { id: "ret-1", customerName: "Dana Reyes" };
+
+function ok() {
+  return { ok: true, json: async () => ({}) } as unknown as Response;
+}
+function refused(status: number, message?: string) {
+  return {
+    ok: false,
+    status,
+    json: async () => (message ? { message } : {}),
+  } as unknown as Response;
+}
+
+let respond: ReturnType<typeof vi.fn>;
+let refresh: ReturnType<typeof vi.fn>;
+let onIssued: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  respond = vi.fn(async () => {});
+  // `refresh` resolves a BOOLEAN — `true` when the ledger re-read landed. A mock
+  // resolving `undefined` would silently exercise the stale-view branch on the
+  // happy path and pin the wrong receipt.
+  refresh = vi.fn(async () => true);
+  onIssued = vi.fn();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+function stubFetch(impl: () => Promise<Response>) {
+  vi.stubGlobal("fetch", vi.fn(impl));
+}
+
+describe("submitRefund", () => {
+  it("posts the amount, refreshes, and settles with a figure-free line", async () => {
+    stubFetch(async () => ok());
+    const failure = await submitRefund({
+      request,
+      amount: 42.5,
+      respond,
+      refresh,
+      onIssued,
+    });
+
+    expect(failure).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/commerce/v1/returns/ret-1/refund",
+      expect.objectContaining({ body: JSON.stringify({ amount: 42.5 }) }),
+    );
+    expect(refresh).toHaveBeenCalled();
+    expect(onIssued).toHaveBeenCalled();
+    // Beat 3a: the assistant learns THAT it happened and never the amount.
+    expect(respond).toHaveBeenCalledWith(
+      "Refund issued on Dana Reyes's return.",
+    );
+    expect(String(respond.mock.calls[0][0])).not.toContain("42.5");
+  });
+
+  it("settles with the server's reason when the refund is refused", async () => {
+    stubFetch(async () => refused(422, "REFUND_EXCEEDS_CHARGE"));
+    const failure = await submitRefund({
+      request,
+      amount: 999,
+      respond,
+      refresh,
+      onIssued,
+    });
+
+    expect(failure).toBeNull(); // settled — the run is not wedged
+    expect(respond).toHaveBeenCalledWith(
+      "Could not refund Dana Reyes: REFUND_EXCEEDS_CHARGE",
+    );
+    expect(onIssued).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the status code when the error body is unreadable", async () => {
+    stubFetch(
+      async () =>
+        ({
+          ok: false,
+          status: 500,
+          json: async () => {
+            throw new Error("not json");
+          },
+        }) as unknown as Response,
+    );
+
+    await submitRefund({ request, amount: 10, respond, refresh, onIssued });
+    expect(respond).toHaveBeenCalledWith("Could not refund Dana Reyes: 500");
+  });
+
+  it("STILL settles the interrupt when the fetch itself rejects", async () => {
+    // The regression this whole change exists for: a rejected fetch used to
+    // escape the click handler, leaving the run blocked forever.
+    stubFetch(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const failure = await submitRefund({
+      request,
+      amount: 10,
+      respond,
+      refresh,
+      onIssued,
+    });
+
+    expect(failure).toBeNull();
+    expect(respond).toHaveBeenCalledWith(
+      "Could not refund Dana Reyes: Failed to fetch",
+    );
+    expect(onIssued).not.toHaveBeenCalled();
+  });
+
+  it("does not claim failure when the refund landed and only the refresh broke", async () => {
+    stubFetch(async () => ok());
+    refresh = vi.fn(async () => {
+      throw new Error("ledger fetch failed: 503");
+    });
+
+    await submitRefund({ request, amount: 10, respond, refresh, onIssued });
+
+    // A receipt saying the refund FAILED after the money moved is worse than no
+    // receipt at all — so this still leads with "Refund issued". It also appends
+    // the stale-view note, because the ledger re-read did not land and the page
+    // is therefore behind. Those two are not in tension: the write succeeded and
+    // the screen is out of date, and the receipt says exactly that.
+    expect(respond).toHaveBeenCalledWith(
+      "Refund issued on Dana Reyes's return." + STALE_VIEW_NOTE,
+    );
+    expect(onIssued).toHaveBeenCalled();
+  });
+
+  it("says nothing about staleness when the ledger re-read did land", async () => {
+    stubFetch(async () => ok());
+    refresh = vi.fn(async () => true);
+
+    await submitRefund({ request, amount: 10, respond, refresh, onIssued });
+
+    expect(respond).toHaveBeenCalledWith(
+      "Refund issued on Dana Reyes's return.",
+    );
+    expect(String(respond.mock.calls[0][0])).not.toContain("reload it");
+  });
+
+  it("appends the stale-view note when the re-read resolves false", async () => {
+    stubFetch(async () => ok());
+    refresh = vi.fn(async () => false);
+
+    await submitRefund({ request, amount: 10, respond, refresh, onIssued });
+
+    expect(respond).toHaveBeenCalledWith(
+      "Refund issued on Dana Reyes's return." + STALE_VIEW_NOTE,
+    );
+    // The refund still happened, so the replay memory is still written.
+    expect(onIssued).toHaveBeenCalled();
+  });
+
+  it("reports back — and withholds the replay memory — when respond is missing", async () => {
+    stubFetch(async () => ok());
+    const failure = await submitRefund({
+      request,
+      amount: 10,
+      respond: undefined,
+      refresh,
+      onIssued,
+    });
+
+    expect(failure).toBeTruthy();
+    // The interrupt is NOT settled, so nothing may record it as answered.
+    expect(onIssued).not.toHaveBeenCalled();
+  });
+
+  it("never throws, so the card's spinner can always come back down", async () => {
+    stubFetch(async () => {
+      throw new Error("offline");
+    });
+    respond = vi.fn(async () => {
+      throw new Error("stream closed too");
+    });
+    await expect(
+      submitRefund({ request, amount: 10, respond, refresh, onIssued }),
+    ).resolves.toBeTruthy();
+  });
+});
+
+/**
+ * The replay half of the same contract. On thread reopen the settled sentence is
+ * the ONLY record of the refund, so the card recovers the customer from it — and
+ * it must recover it from every sentence `submitRefund` can actually write,
+ * stale-view note included. An end-anchored reader stopped matching the day that
+ * note was introduced, and a refund that really happened replayed as a failure.
+ */
+describe("readRefundedCustomer", () => {
+  it("reads the customer back out of every success sentence submitRefund writes", async () => {
+    for (const refreshed of [true, false]) {
+      respond = vi.fn(async () => {});
+      stubFetch(async () => ok());
+      await submitRefund({
+        request,
+        amount: 10,
+        respond,
+        refresh: vi.fn(async () => refreshed),
+        onIssued,
+      });
+      const settled = String(respond.mock.calls[0][0]);
+      expect(readRefundedCustomer(settled)).toBe("Dana Reyes");
+    }
+  });
+
+  it("reports no customer for a cancel or a refusal", () => {
+    expect(readRefundedCustomer("The user cancelled the refund.")).toBeNull();
+    expect(readRefundedCustomer("Could not refund Dana Reyes: 422")).toBeNull();
+    expect(readRefundedCustomer("")).toBeNull();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/refund.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/refund.ts
@@ -1,0 +1,113 @@
+import { describeError, settleInterrupt, staleNote } from "./settle";
+import type { RespondFn } from "./settle";
+import type { ReturnRequest } from "./data/types";
+
+/**
+ * The one sentence a SUCCESSFUL refund settles with — nothing else in this skin
+ * may produce it, and `readRefundedCustomer` below is the only thing that reads
+ * it. `staleNote` may follow it; no figure ever does (rule 4 in `tools.tsx`).
+ */
+const refundIssuedLine = (customerName: string) =>
+  `Refund issued on ${customerName}'s return.`;
+
+/**
+ * The customer name the settled result REPORTS, or `null` when the result is not
+ * a success line at all (a cancel, or a refusal sentence).
+ *
+ * On thread replay this string is the only surviving record of the refund — the
+ * `answeredRefunds` map is live-session state — so the card must recover the name
+ * from it. That is exactly why the two halves live together here: the reader used
+ * to be an END-ANCHORED regex inside the card, which stopped matching the moment
+ * `submitRefund` began appending `STALE_VIEW_NOTE`, and a refund that had really
+ * been issued replayed as a NEGATIVE receipt printing the raw sentence.
+ */
+export function readRefundedCustomer(settled: string): string | null {
+  return /^Refund issued on (.+?)'s return\./.exec(settled.trim())?.[1] ?? null;
+}
+
+/**
+ * BEAT 3a's write, lifted out of `tools.tsx`'s render closure.
+ *
+ * Every other tool in this skin inlines its own fetch; this one does not, and the
+ * reason is worth the inconsistency. This handler is what GUARANTEES the refund
+ * interrupt gets settled — on success, on a refusal, and on a fetch that never
+ * completed — and a guarantee buried in a JSX prop cannot be tested. Here it can:
+ * see `refund.test.ts`.
+ *
+ * Total by construction: every path ends in a `settleInterrupt`, and it never
+ * throws. That is what lets `RefundCard` treat a throw from its handler as
+ * impossible and keep its "Issuing…" button honest.
+ */
+export async function submitRefund({
+  request,
+  amount,
+  respond,
+  refresh,
+  onIssued,
+}: {
+  request: Pick<ReturnRequest, "id" | "customerName">;
+  amount: number;
+  respond: RespondFn | undefined;
+  /**
+   * Re-reads the ledger so the page catches up. Contracted not to reject;
+   * resolves `false` when the re-read did not land, which is appended to the
+   * receipt as `staleNote` rather than reported as a failed refund.
+   */
+  refresh: () => Promise<boolean>;
+  /**
+   * Record the replay memory for this call. Invoked ONLY once the interrupt has
+   * really been settled as a success — written any earlier, a failed handoff
+   * would leave the map claiming an answered call the run is still waiting on.
+   */
+  onIssued: () => void;
+}): Promise<string | null> {
+  let issued = false;
+  // Assume the worst until a re-read actually lands, so every path that skips
+  // the refresh (or whose refresh throws) reports the screen as behind rather
+  // than silently claiming it is current.
+  let refreshed = false;
+  try {
+    const res = await fetch(`/api/commerce/v1/returns/${request.id}/refund`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ amount }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return await settleInterrupt(
+        respond,
+        `Could not refund ${request.customerName}: ${body?.message ?? res.status}`,
+      );
+    }
+    issued = true;
+    refreshed = await refresh();
+  } catch (error) {
+    if (!issued) {
+      // Offline, or the dev server restarted mid-click. The refund did not
+      // happen — say so, and settle, because an unsettled interrupt does not
+      // just look broken, it wedges the run.
+      return await settleInterrupt(
+        respond,
+        `Could not refund ${request.customerName}: ${describeError(error)}`,
+      );
+    }
+    // The money moved and only the on-screen ledger refresh failed. Reporting
+    // failure here would be a receipt for a write that DID happen — the mirror
+    // image of the replay bug called out in `tools.tsx`, and just as bad. Fall
+    // through to the success line.
+    console.error(
+      "[commerce] refund landed but the ledger refresh failed",
+      error,
+    );
+  }
+  // The ONLY thing the assistant ever learns. No figure, by design — plus, when
+  // the ledger re-read did not land, the fact that the screen is behind. Saying
+  // so is NOT reporting a failed refund: the money moved either way, and this is
+  // the one note that distinguishes "done, screen is stale" from "done".
+  const failure = await settleInterrupt(
+    respond,
+    refundIssuedLine(request.customerName) + staleNote(refreshed),
+  );
+  if (!failure) onIssued();
+  return failure;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/report-data.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/report-data.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { ReactNode } from "react";
+import type { MarginFloor, Order, Product, Promotion } from "./data/types";
+
+/**
+ * Binds Bellwether's live ledger into the a2ui catalog renderers.
+ *
+ * This context is the reason the agent cannot fabricate a figure on the brief:
+ * data NEVER travels inside the A2UI operations. The agent selects WHAT to show
+ * and the renderers (StatCard/CategoryBreakdown/TradingList) read the real
+ * products / floors / orders / promotions from here — the same snapshot the
+ * pages render — so every number on the canvas is client-computed, not
+ * model-authored.
+ */
+export interface ReportData {
+  products: Product[];
+  floors: MarginFloor[];
+  orders: Order[];
+  promotions: Promotion[];
+}
+
+const ReportDataContext = createContext<ReportData | null>(null);
+
+export function ReportDataProvider({
+  value,
+  children,
+}: {
+  value: ReportData;
+  children: ReactNode;
+}) {
+  return (
+    <ReportDataContext.Provider value={value}>
+      {children}
+    </ReportDataContext.Provider>
+  );
+}
+
+/**
+ * Live trading data for the a2ui brief renderers. Returns empty arrays if a
+ * renderer somehow mounts outside the provider (shouldn't happen on the canvas)
+ * so a renderer degrades to its own empty state rather than throwing.
+ */
+export function useReportData(): ReportData {
+  return (
+    useContext(ReportDataContext) ?? {
+      products: [],
+      floors: [],
+      orders: [],
+      promotions: [],
+    }
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/sandbox-functions.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/sandbox-functions.test.ts
@@ -1,0 +1,416 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  formatMargin,
+  openReturns,
+  ordersOnException,
+  productMargin,
+  valueAtRisk,
+} from "./data/derive";
+import * as store from "./data/store";
+import { sandboxFunctions, setSandboxSnapshot } from "./sandbox-functions";
+import { CATEGORIES } from "./data/types";
+import type { CommerceStoreState, Order } from "./data/types";
+
+/**
+ * The OGUI sandbox functions, tested for ONE thing: that a generated panel
+ * cannot disagree with the app card sitting next to it — or with the ledger.
+ *
+ * This is not a hypothetical. Generated UI renders full-region on the shared
+ * canvas, off the same ledger the pages read, so a set predicate hand-copied
+ * into this file does not fail loudly — it puts a second, larger number on
+ * screen beside the first one. Both defects below shipped that way: the
+ * `exceptionsOnly` filter counted cancelled orders as queue work, and
+ * `openReturns` counted declined returns as open.
+ *
+ * So every assertion here compares the sandbox's answer against the SHARED
+ * derivation the pages and the a2ui StatCards use (`ordersOnException`,
+ * `valueAtRisk`, `openReturns` in `data/derive.ts`) — a re-introduced local
+ * copy fails here rather than on stage.
+ *
+ * The later blocks cover the two ways a boundary can be wrong while still
+ * RENDERING: an argument the schema does not really constrain (a near-miss
+ * category filtering to nothing, which draws an empty view that looks like an
+ * answer) and a figure whose unit is not stated (a bare `0.418` that renders as
+ * "0.42%" or "42%" with equal confidence).
+ */
+
+beforeEach(() => {
+  store.reset();
+  setSandboxSnapshot(store.snapshot());
+});
+
+const fn = (name: string) => {
+  const found = sandboxFunctions.find((f) => f.name === name);
+  if (!found) throw new Error(`No sandbox function named "${name}"`);
+  return found;
+};
+
+type OrderRow = { id: string; status: string; total: number };
+type TradingKpis = {
+  ordersOnException: number;
+  valueAtRisk: number;
+  openReturns: number;
+};
+type ProductRow = {
+  id: string;
+  category: string;
+  marginRatio: number;
+  marginLabel: string;
+  floorRatio: number | null;
+  floorLabel: string | null;
+};
+type FloorRow = {
+  category: string;
+  floorRatio: number;
+  floorLabel: string;
+  targetRatio: number;
+  targetLabel: string;
+};
+type PromoRow = {
+  id: string;
+  marginRatio: number | null;
+  marginLabel: string | null;
+  floorRatio: number | null;
+  floorLabel: string | null;
+};
+
+const getOrders = async (args: {
+  status?: string;
+  exceptionsOnly?: boolean;
+}): Promise<OrderRow[]> => (await fn("getOrders").handler(args)) as OrderRow[];
+
+const getTradingKpis = async (): Promise<TradingKpis> =>
+  (await fn("getTradingKpis").handler({})) as TradingKpis;
+
+const getProducts = async (args: {
+  category?: string;
+  notClearingFloorOnly?: boolean;
+}): Promise<ProductRow[]> =>
+  (await fn("getProducts").handler(args)) as ProductRow[];
+
+const getMarginFloors = async (): Promise<FloorRow[]> =>
+  (await fn("getMarginFloors").handler({})) as FloorRow[];
+
+const getPromotions = async (args: { status?: string }): Promise<PromoRow[]> =>
+  (await fn("getPromotions").handler(args)) as PromoRow[];
+
+/**
+ * A ledger holding a CANCELLED order that still carries the exception it was
+ * cancelled with — the row the two predicates disagreed about.
+ *
+ * Reachable in a live demo: `PATCH /api/commerce/v1/orders/[id]` accepts
+ * `status: "cancelled"` and `store.setOrderStatus` writes it without touching
+ * `exception`. Built by hand here rather than through that mutation so the
+ * fixture keeps testing the sandbox even if the store later starts clearing the
+ * exception on a settle — whatever rows the sandbox is handed, it must read them
+ * the way the app does.
+ */
+function ledgerWithCancelledException(): {
+  ledger: CommerceStoreState;
+  cancelled: Order;
+} {
+  const base = store.snapshot();
+  const victim = base.orders.find((o) => o.exception !== "none");
+  if (!victim) throw new Error("The seed carries no exception order");
+  const cancelled: Order = { ...victim, status: "cancelled" };
+  return {
+    ledger: {
+      ...base,
+      orders: base.orders.map((o) => (o.id === victim.id ? cancelled : o)),
+    },
+    cancelled,
+  };
+}
+
+describe("getOrders — exceptionsOnly", () => {
+  it("drops a cancelled order, exactly as every other queue view does", async () => {
+    const baseline = ordersOnException(store.orders()).length;
+    expect(baseline).toBeGreaterThan(1);
+
+    const { ledger, cancelled } = ledgerWithCancelledException();
+    setSandboxSnapshot(ledger);
+
+    const rows = await getOrders({ exceptionsOnly: true });
+
+    // One fewer than the untouched queue — the cancelled row, and only it.
+    expect(rows).toHaveLength(baseline - 1);
+    expect(rows.map((r) => r.id)).not.toContain(cancelled.id);
+    expect(rows.map((r) => r.id).sort()).toEqual(
+      ordersOnException(ledger.orders)
+        .map((o) => o.id)
+        .sort(),
+    );
+  });
+
+  it("cannot return a cancelled row even when the status lever asks for one", async () => {
+    const { ledger, cancelled } = ledgerWithCancelledException();
+    setSandboxSnapshot(ledger);
+
+    // status=cancelled AND exceptionsOnly is a contradiction now that a
+    // cancelled order is by definition not queue work. Empty is the honest
+    // answer; the old predicate returned the row.
+    const queue = await getOrders({
+      status: "cancelled",
+      exceptionsOnly: true,
+    });
+    expect(queue).toEqual([]);
+    // Without the exception filter the row is still reachable — the fix narrowed
+    // the QUEUE, it did not hide the order.
+    const all = await getOrders({ status: "cancelled" });
+    expect(all.map((r) => r.id)).toEqual([cancelled.id]);
+  });
+});
+
+describe("getTradingKpis", () => {
+  it("matches the app's own exception count and value at risk", async () => {
+    const { ledger, cancelled } = ledgerWithCancelledException();
+    const untouchedValue = valueAtRisk(store.orders());
+    setSandboxSnapshot(ledger);
+
+    const kpis = await getTradingKpis();
+
+    expect(kpis.ordersOnException).toBe(
+      ordersOnException(ledger.orders).length,
+    );
+    expect(kpis.valueAtRisk).toBe(valueAtRisk(ledger.orders));
+    // The cancelled order's money is no longer at risk, and it is the only
+    // difference from the untouched ledger.
+    expect(kpis.valueAtRisk).toBe(untouchedValue - cancelled.total);
+  });
+
+  it("agrees with getOrders row for row, so one panel cannot contradict another", async () => {
+    const { ledger } = ledgerWithCancelledException();
+    setSandboxSnapshot(ledger);
+
+    const kpis = await getTradingKpis();
+    const rows = await getOrders({ exceptionsOnly: true });
+
+    expect(rows).toHaveLength(kpis.ordersOnException);
+    expect(rows.reduce((sum, r) => sum + r.total, 0)).toBe(kpis.valueAtRisk);
+  });
+
+  it("counts a declined return as closed, exactly as the Returns page does", async () => {
+    const baseline = openReturns(store.returns()).length;
+    expect(baseline).toBeGreaterThan(1);
+
+    // The real path: the Returns page's decline button and the REST route both
+    // land here, so a declined return is ordinary demo state, not a contrivance.
+    const declined = store.decideReturn("ret-2201", "declined");
+    expect(declined.status).toBe("declined");
+    setSandboxSnapshot(store.snapshot());
+
+    const kpis = await getTradingKpis();
+
+    expect(kpis.openReturns).toBe(baseline - 1);
+    expect(kpis.openReturns).toBe(openReturns(store.returns()).length);
+    // Both finished states are excluded — refunded was already, declined now.
+    // Spelled out as an arithmetic identity so neither half can regress alone.
+    const finished = store
+      .returns()
+      .filter((r) => r.status === "refunded" || r.status === "declined");
+    expect(finished).toHaveLength(2);
+    expect(kpis.openReturns).toBe(store.returns().length - finished.length);
+  });
+});
+
+describe("the schemas are enforced, not merely advertised", () => {
+  /**
+   * The runtime does not validate these arguments — the provider serializes
+   * `parameters` into agent context as documentation and the renderer hands the
+   * bare handler to the iframe. So the schema has to be applied by the file that
+   * declares it, and these tests are what says it still is. An unenforced schema
+   * is invisible: the handler filters on a value nothing matches and returns `[]`,
+   * which the generated panel draws as an empty table.
+   */
+  it("refuses an off-vocabulary category rather than answering with an empty range", async () => {
+    await expect(getProducts({ category: "Shoes" })).rejects.toThrow(
+      /getProducts rejected its arguments/,
+    );
+    // The message has to carry the vocabulary, or the model cannot correct
+    // itself — it is the only feedback channel a sandbox call has.
+    await expect(getProducts({ category: "Shoes" })).rejects.toThrow(
+      /Footwear/,
+    );
+    // And it must say the call read nothing, so the script does not fall back to
+    // drawing an empty view.
+    await expect(getProducts({ category: "Shoes" })).rejects.toThrow(
+      /Nothing was read/,
+    );
+  });
+
+  it("refuses a case near-miss, which is what a model actually guesses", async () => {
+    await expect(getProducts({ category: "footwear" })).rejects.toThrow(
+      /getProducts rejected its arguments/,
+    );
+  });
+
+  it("serves every category in the vocabulary, and together they cover the range", async () => {
+    const perCategory = await Promise.all(
+      CATEGORIES.map((category) => getProducts({ category })),
+    );
+
+    CATEGORIES.forEach((category, index) => {
+      const rows = perCategory[index]!;
+      // Every declared category is a real, populated filter — a value the schema
+      // offers and the ledger cannot serve is the same blank view by another route.
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.every((r) => r.category === category)).toBe(true);
+    });
+
+    // No product is unreachable, so the enum is the WHOLE vocabulary rather than
+    // a subset that quietly hides part of the range.
+    expect(perCategory.flat()).toHaveLength(store.products().length);
+  });
+
+  it("refuses an off-vocabulary status on the other filters too", async () => {
+    await expect(getOrders({ status: "Open" })).rejects.toThrow(
+      /getOrders rejected its arguments/,
+    );
+    await expect(getPromotions({ status: "live" })).rejects.toThrow(
+      /getPromotions rejected its arguments/,
+    );
+    await expect(fn("getReturns").handler({ status: "open" })).rejects.toThrow(
+      /getReturns rejected its arguments/,
+    );
+  });
+
+  it("still accepts a no-argument call on the parameterless functions", async () => {
+    // `undefined` arrives when generated UI calls `getTradingKpis()` with no
+    // args; a `z.object({})` schema rejects `undefined`, so the wrapper defaults
+    // it. Enforcement must not break the most common call in the file.
+    await expect(fn("getTradingKpis").handler(undefined)).resolves.toBeTruthy();
+    await expect(
+      fn("getMarginFloors").handler(undefined),
+    ).resolves.toBeTruthy();
+    const products = (await fn("getProducts").handler(
+      undefined,
+    )) as ProductRow[];
+    expect(products).toHaveLength(store.products().length);
+  });
+});
+
+describe("every margin crosses the boundary with its unit", () => {
+  /**
+   * A margin is the one figure here that renders plausibly WRONG. `0.418` is
+   * "0.42%" or "41.8%" depending on a guess the model has no way to check, and
+   * `discountPercent: 40` sits in the same object to make the wrong guess look
+   * reasonable. So each one goes over as a `…Ratio` fraction of 1 for geometry
+   * plus a `…Label` built by the app's own `formatMargin` — which also makes the
+   * generated panel read identically to the app card beside it, one decimal and
+   * all.
+   */
+  it("getProducts pairs each ratio with the app's own label", async () => {
+    const rows = await getProducts({});
+    expect(rows.length).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      const item = store.product(row.id)!;
+      expect(row.marginRatio).toBeCloseTo(productMargin(item), 10);
+      expect(row.marginRatio).toBeGreaterThan(0);
+      expect(row.marginRatio).toBeLessThan(1);
+      // Byte-identical to what the catalog and the ladder print.
+      expect(row.marginLabel).toBe(formatMargin(productMargin(item)));
+      expect(row.marginLabel).toMatch(/^\d+\.\d%$/);
+      expect(row.floorRatio).not.toBeNull();
+      expect(row.floorLabel).toBe(formatMargin(row.floorRatio as number));
+    }
+  });
+
+  it("getMarginFloors labels the floor and the target", async () => {
+    const rows = await getMarginFloors();
+    expect(rows).toHaveLength(store.floors().length);
+
+    for (const row of rows) {
+      const policy = store.floors().find((f) => f.category === row.category)!;
+      expect(row.floorRatio).toBe(policy.floor);
+      expect(row.floorLabel).toBe(formatMargin(policy.floor));
+      expect(row.targetRatio).toBe(policy.target);
+      expect(row.targetLabel).toBe(formatMargin(policy.target));
+    }
+  });
+
+  it("getPromotions labels the markdown margin it would trade at", async () => {
+    const rows = await getPromotions({ status: "all" });
+    expect(rows.length).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      expect(row.marginLabel).toBe(
+        row.marginRatio === null ? null : formatMargin(row.marginRatio),
+      );
+      expect(row.floorLabel).toBe(
+        row.floorRatio === null ? null : formatMargin(row.floorRatio),
+      );
+    }
+    // At least one seeded markdown trades below its floor — the beat-6 case — so
+    // the labelled figures are exercised on the row the demo turns on.
+    expect(rows.some((r) => r.marginRatio !== null)).toBe(true);
+  });
+
+  it("keeps a label null rather than formatting a margin it does not have", async () => {
+    const base = store.snapshot();
+    // A ledger whose floors never arrived (a failed `/ledger` fetch mounts the
+    // provider with `floors: []`) and a markdown pointing at a product that is
+    // not in the range. Both are reachable, and neither may produce a "0.0%"
+    // that reads as a real floor.
+    setSandboxSnapshot({
+      ...base,
+      floors: [],
+      promotions: base.promotions.map((p, i) =>
+        i === 0 ? { ...p, productId: "prd-missing" } : p,
+      ),
+    });
+
+    const rows = await getPromotions({ status: "all" });
+    const orphan = rows[0]!;
+    expect(orphan.marginRatio).toBeNull();
+    expect(orphan.marginLabel).toBeNull();
+    expect(orphan.floorRatio).toBeNull();
+    expect(orphan.floorLabel).toBeNull();
+
+    const products = await getProducts({});
+    expect(products.every((p) => p.floorRatio === null)).toBe(true);
+    expect(products.every((p) => p.floorLabel === null)).toBe(true);
+    // The unit fix must not reintroduce the false all-clear: no floor on file
+    // still reports `null`, never `false`.
+    expect(
+      products.every(
+        (p) => (p as unknown as { belowFloor: unknown }).belowFloor === null,
+      ),
+    ).toBe(true);
+  });
+
+  it("ships no bare `margin` or `floor` key for a view to misread", async () => {
+    const rows = [
+      ...(await getProducts({})),
+      ...(await getPromotions({ status: "all" })),
+      ...(await getMarginFloors()),
+    ] as unknown as Record<string, unknown>[];
+
+    for (const row of rows) {
+      // An unlabelled ratio under a bare name is exactly what shipped. Naming the
+      // unit is only half the fix; the ambiguous name has to be gone.
+      expect(Object.keys(row)).not.toContain("margin");
+      expect(Object.keys(row)).not.toContain("floor");
+      expect(Object.keys(row)).not.toContain("target");
+    }
+  });
+
+  it("documents the unit in the description, the model's only view of the shape", () => {
+    // Only `name`, `description` and the JSON-schema-ified `parameters` reach the
+    // agent — never a sample result. If the description does not state the unit,
+    // nothing does.
+    for (const name of ["getProducts", "getMarginFloors", "getPromotions"]) {
+      expect(fn(name).description).toMatch(/fractions? of 1/);
+      expect(fn(name).description).toMatch(/render the label/);
+    }
+    for (const name of [
+      "getProducts",
+      "getOrders",
+      "getPromotions",
+      "getReturns",
+      "getTradingKpis",
+    ]) {
+      expect(fn(name).description).toMatch(/US dollars/);
+    }
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/sandbox-functions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/sandbox-functions.ts
@@ -1,0 +1,403 @@
+import { z } from "zod";
+import type { SandboxFunction } from "@copilotkit/react-core/v2";
+import { categoryParameter } from "./category-argument";
+import type { CommerceStoreState } from "./data/types";
+import {
+  ORDER_EXCEPTION_LABEL,
+  RETURN_REASON_LABEL,
+  ageInDays,
+  belowFloorCount,
+  discountedPrice,
+  formatMargin,
+  isOnException,
+  nullableBelowFloor,
+  openReturns,
+  orderUnits,
+  ordersOnException,
+  productFloorStatus,
+  productMargin,
+  promotionFloorStatus,
+  promotionMargin,
+  tallyFloorStatus,
+  valueAtRisk,
+  weeksOfCover,
+} from "./data/derive";
+
+/**
+ * Functions exposed INSIDE the OGUI sandboxed iframe, so generated UI can bind
+ * to Bellwether's real ledger instead of the model typing numbers into markup.
+ *
+ * Five things this file is careful about:
+ *
+ *  1. It projects onto explicit DTOs rather than passing records through. The
+ *     sandbox is a different trust boundary, and a spread of the raw order
+ *     object would carry customer email addresses across it for no reason. Only
+ *     what a generated view could legitimately draw goes over.
+ *
+ *  2. It reads a module-scope snapshot rather than a hook, because these are
+ *     plain functions invoked from an iframe with no React context. The snapshot
+ *     is kept current by `<SandboxDataSync />`, mounted in the skin's Providers
+ *     — without that component these return an empty ledger, which renders as a
+ *     plausible-looking but entirely blank generated UI.
+ *
+ *  3. It never hand-writes a set predicate. "On exception" and "open return" are
+ *     shared derivations (`isOnException` / `isOpenReturn` in `data/derive.ts`)
+ *     because generated UI lands on the canvas BESIDE the app's own cards, off
+ *     the same ledger. A local copy of a predicate here does not fail loudly —
+ *     it puts a second, larger number next to the first one on screen. Both
+ *     `exceptionsOnly` and `openReturns` below had drifted that way.
+ *
+ *  4. Every parameter is enumerated to its real domain AND enforced (see
+ *     `define` below). A `z.string()` category is the same failure as a drifted
+ *     predicate wearing different clothes: the handler filters to nothing, the
+ *     generated panel renders a convincingly empty view, and the model is never
+ *     told it guessed the vocabulary wrong. The category enum itself lives in
+ *     `./category-argument`, shared with the chat's `showMarginLadder`, so the
+ *     sandbox and the transcript advertise ONE vocabulary.
+ *
+ *  5. Every figure that crosses this boundary states its unit. Counts and days
+ *     are named by their field (`units`, `ageDays`, `weeksOfCover`), money is
+ *     declared as US dollars in the function's `description`, and every margin
+ *     goes over TWICE — a `…Ratio` fraction of 1 for geometry and a `…Label`
+ *     display string built by the app's own `formatMargin`. An unlabelled `0.42`
+ *     is the ambiguity that matters most here: the same value renders as "0.42%"
+ *     or "42%" with equal confidence, and `discountPercent: 40` sits in the same
+ *     object to muddy the guess. Shipping the label removes the guess AND makes
+ *     the generated panel read identically to the app card beside it, one
+ *     decimal and all. Money gets a description rather than a label because the
+ *     figures the app prints are whole dollars either way, and generated UI has
+ *     no reason to scale them.
+ *
+ * A note on the returns: the model NEVER sees these DTOs before drawing against
+ * them. Only `name`, `description` and the JSON-schema-ified `parameters` are
+ * registered as agent context (`sandboxFunctionsDescriptors` in
+ * `CopilotKitProvider`), so a `description` is the ONLY place the shape and units
+ * of a result can be documented. Keep the descriptions below in step with the
+ * projections.
+ */
+
+let snapshot: CommerceStoreState | null = null;
+
+export function setSandboxSnapshot(next: CommerceStoreState) {
+  snapshot = next;
+}
+
+const empty: CommerceStoreState = {
+  products: [],
+  floors: [],
+  orders: [],
+  notifications: [],
+  returns: [],
+  promotions: [],
+  waivers: [],
+  plans: [],
+  operators: [],
+};
+
+const read = () => snapshot ?? empty;
+
+/**
+ * A sandbox function that ENFORCES the schema it advertises.
+ *
+ * The runtime does not do this for us and is not going to: the provider
+ * serializes `parameters` into agent context as documentation, and the renderer
+ * then hands the bare `handler` to the iframe (`api[fn.name] = fn.handler` in
+ * `OpenGenerativeUIRenderer`). Nothing parses the arguments on the way in. So a
+ * schema written here and not applied here is a comment — the handler receives
+ * whatever the generated script passed, and `p.category === "Shoes"` matches no
+ * row and returns `[]`.
+ *
+ * Refusing is strictly better than that empty array. A rejected promise inside
+ * the generated script is visible — it hits the script's own error path instead
+ * of drawing an empty table that looks like an answer — and the message names the
+ * accepted values, which is the only way the model can correct itself.
+ */
+function define<S extends z.ZodType>(spec: {
+  name: string;
+  description: string;
+  parameters: S;
+  handler: (args: z.output<S>) => unknown;
+}): SandboxFunction {
+  return {
+    name: spec.name,
+    description: spec.description,
+    parameters: spec.parameters,
+    handler: async (args: unknown) => {
+      // `args ?? {}` because a no-argument call arrives as `undefined`, which a
+      // `z.object({})` schema would otherwise reject.
+      const parsed = spec.parameters.safeParse(args ?? {});
+      if (!parsed.success) {
+        const detail = parsed.error.issues
+          .map(
+            (issue) =>
+              `${issue.path.join(".") || "arguments"}: ${issue.message}`,
+          )
+          .join("; ");
+        throw new Error(
+          `${spec.name} rejected its arguments (${detail}). Nothing was read, ` +
+            `so do not draw an empty view — call again with a value the schema lists.`,
+        );
+      }
+      return spec.handler(parsed.data);
+    },
+  };
+}
+
+/** `formatMargin`, null-safe: every margin below can legitimately be absent. */
+const marginLabel = (ratio: number | null) =>
+  ratio === null ? null : formatMargin(ratio);
+
+export const sandboxFunctions: SandboxFunction[] = [
+  define({
+    name: "getProducts",
+    description:
+      "Every product in the range with its price, landed cost, gross margin, " +
+      "category margin floor, inventory and weeks of cover. `listPrice` and " +
+      "`unitCost` are whole US dollars. Margin arrives twice: `marginRatio` and " +
+      "`floorRatio` are fractions of 1 (0.418 means 41.8%) for bar heights and " +
+      "arithmetic, while `marginLabel` and `floorLabel` are the display strings " +
+      "the app's own cards show — render the label, never a percent you " +
+      "computed. `floorRatio`, `floorLabel` and `belowFloor` are all null when " +
+      "the category has no floor on file: that SKU was NOT checked, which is " +
+      "neither an all-clear nor a violation, so label it as unchecked and never " +
+      "count it among the products below their floor. " +
+      "`weeksOfCover` is weeks at the trailing-30 run rate, null when nothing " +
+      "is selling.",
+    /**
+     * `.strict()` because this schema was RENAMED (`belowFloorOnly` →
+     * `notClearingFloorOnly`, see below). Zod strips an unrecognized key by
+     * default, so a call still carrying the old name would silently lose its
+     * filter and return the WHOLE range — which a panel titled "below floor"
+     * would then draw as violations. Refusing names the accepted keys; that is the
+     * same trade `define` above is built on.
+     */
+    parameters: z
+      .object({
+        category: categoryParameter
+          .optional()
+          .describe("Restrict to one category."),
+        /**
+         * NOT `belowFloorOnly`, and the rename is the fix rather than a tidy-up.
+         *
+         * That filter tested `productFloorStatus(...) === "below"`, so a SKU whose
+         * category has no floor on file was silently DROPPED: generated UI got a
+         * short list with nothing saying it was short, and the model could not
+         * tell a clean range from an unchecked one. Including the unmeasurable
+         * rows — each already flagged `belowFloor: null` — is the honest shape,
+         * because every row then describes its own verdict and the list is
+         * COMPLETE for the category. The name has to describe what comes back:
+         * "not clearing its floor" is true of both a violation and an unchecked
+         * SKU, where "below floor" is only true of the first.
+         */
+        notClearingFloorOnly: z
+          .boolean()
+          .optional()
+          .describe(
+            "Only products that do not CLEAR their category floor: those " +
+              "trading under it (belowFloor true) plus those whose category has " +
+              "no floor on file (belowFloor null, never checked). Nothing is " +
+              "dropped, so the list is complete.",
+          ),
+      })
+      .strict(),
+    handler: ({ category, notClearingFloorOnly }) => {
+      const { products, floors } = read();
+      return products
+        .filter((p) => !category || p.category === category)
+        .filter(
+          (p) =>
+            !notClearingFloorOnly || productFloorStatus(floors, p) !== "clear",
+        )
+        .map((p) => {
+          const margin = productMargin(p);
+          const floor =
+            floors.find((f) => f.category === p.category)?.floor ?? null;
+          return {
+            id: p.id,
+            sku: p.sku,
+            name: p.name,
+            category: p.category,
+            listPrice: p.listPrice,
+            unitCost: p.unitCost,
+            marginRatio: margin,
+            marginLabel: formatMargin(margin),
+            floorRatio: floor,
+            floorLabel: marginLabel(floor),
+            // `null` — alongside a `null` floor — when the category has no floor
+            // on file. A `false` here would tell generated UI the SKU is fine.
+            belowFloor: nullableBelowFloor(productFloorStatus(floors, p)),
+            inventory: p.inventory,
+            trailing30Units: p.trailing30Units,
+            weeksOfCover: weeksOfCover(p),
+            status: p.status,
+            vendor: p.vendor,
+          };
+        });
+    },
+  }),
+  define({
+    name: "getMarginFloors",
+    description:
+      "The category margin policy: the floor a markdown may not break and the " +
+      "planned target margin for each category. `floorRatio` and `targetRatio` " +
+      "are fractions of 1 (0.42 means 42%); `floorLabel` and `targetLabel` are " +
+      "the display strings the app shows — render the label.",
+    parameters: z.object({}),
+    handler: () =>
+      read().floors.map((f) => ({
+        category: f.category,
+        floorRatio: f.floor,
+        floorLabel: formatMargin(f.floor),
+        targetRatio: f.target,
+        targetLabel: formatMargin(f.target),
+      })),
+  }),
+  define({
+    name: "getOrders",
+    description:
+      "The order book — status, exception, value, units and how many days each " +
+      "order has been waiting. `total` is whole US dollars, `units` is items on " +
+      "the order, and `ageDays` is whole days since it was placed.",
+    parameters: z.object({
+      status: z
+        .enum(["all", "open", "on-hold", "fulfilled", "cancelled"])
+        .optional()
+        .describe("Defaults to all."),
+      exceptionsOnly: z
+        .boolean()
+        .optional()
+        .describe(
+          "Only orders still in the exception queue — carrying an exception " +
+            "and not cancelled.",
+        ),
+    }),
+    handler: ({ status = "all", exceptionsOnly }) => {
+      const { orders } = read();
+      return orders
+        .filter((o) => status === "all" || o.status === status)
+        .filter((o) => !exceptionsOnly || isOnException(o))
+        .map((o) => ({
+          id: o.id,
+          number: o.number,
+          customer: o.customerName,
+          channel: o.channel,
+          destination: o.destination,
+          status: o.status,
+          exception: ORDER_EXCEPTION_LABEL[o.exception],
+          total: o.total,
+          units: orderUnits(o),
+          ageDays: ageInDays(o.placedAt),
+        }));
+    },
+  }),
+  define({
+    name: "getPromotions",
+    description:
+      "Markdowns and promotions with the margin each would actually trade at " +
+      "once its discount applies, and whether that breaks the category floor. " +
+      "`discountPercent` is whole percent off list (40 means 40% off). " +
+      "`discountedPrice` is US dollars and may carry cents. `marginRatio` and " +
+      "`floorRatio` are fractions of 1 (0.418 means 41.8%); `marginLabel` and " +
+      "`floorLabel` are the display strings the app shows — render the label. " +
+      "All four, and `belowFloor`, are null when the product or its floor is " +
+      "missing.",
+    parameters: z.object({
+      status: z
+        .enum(["all", "pending", "approved", "declined"])
+        .optional()
+        .describe("Defaults to pending."),
+    }),
+    handler: ({ status = "pending" }) => {
+      const { promotions, products, floors } = read();
+      return promotions
+        .filter((p) => status === "all" || p.status === status)
+        .map((promo) => {
+          const item = products.find((p) => p.id === promo.productId);
+          const floor =
+            floors.find((f) => f.category === item?.category)?.floor ?? null;
+          const price = item
+            ? discountedPrice(item.listPrice, promo.discountPercent)
+            : null;
+          const margin = promotionMargin(item, promo);
+          return {
+            id: promo.id,
+            name: promo.name,
+            product: item?.name ?? "Unknown",
+            category: item?.category ?? null,
+            discountPercent: promo.discountPercent,
+            discountedPrice: price,
+            marginRatio: margin,
+            marginLabel: marginLabel(margin),
+            floorRatio: floor,
+            floorLabel: marginLabel(floor),
+            // `null` when the product or its floor is missing: generated UI must
+            // not be able to draw an uncheckable markdown as a compliant one.
+            belowFloor: nullableBelowFloor(
+              promotionFloorStatus(floors, item, promo),
+            ),
+            status: promo.status,
+          };
+        });
+    },
+  }),
+  define({
+    name: "getReturns",
+    description:
+      "The returns desk — reason, value, status and any refund already issued. " +
+      "`itemValue` and `refundAmount` are US dollars; `refundAmount` is null " +
+      "until a refund has actually been issued. `ageDays` is whole days since " +
+      "the return was requested.",
+    parameters: z.object({
+      status: z
+        .enum(["all", "requested", "approved", "refunded", "declined"])
+        .optional()
+        .describe("Defaults to all."),
+    }),
+    handler: ({ status = "all" }) => {
+      const { returns, products } = read();
+      return returns
+        .filter((r) => status === "all" || r.status === status)
+        .map((r) => ({
+          id: r.id,
+          orderNumber: r.orderNumber,
+          customer: r.customerName,
+          product:
+            products.find((p) => p.id === r.productId)?.name ?? "Unknown",
+          reason: RETURN_REASON_LABEL[r.reason],
+          status: r.status,
+          itemValue: r.itemValue,
+          refundAmount: r.refundAmount,
+          ageDays: ageInDays(r.requestedAt),
+        }));
+    },
+  }),
+  define({
+    name: "getTradingKpis",
+    description:
+      "Headline trading figures: open orders, how many carry an exception, " +
+      "products below their margin floor, pending markdowns, and the value " +
+      "sitting in the exception queue. `valueAtRisk` is whole US dollars; every " +
+      "other figure is a count. `belowFloorSkus` is null when " +
+      "`skusWithNoFloorOnFile` is above zero — the range could not be fully " +
+      "checked, so do NOT render it as a zero or as an all-clear.",
+    parameters: z.object({}),
+    handler: () => {
+      const { orders, products, floors, promotions, returns } = read();
+      return {
+        openOrders: orders.filter((o) => o.status === "open").length,
+        // The exception set and the at-risk total come from the SHARED
+        // predicates, so this KPI block cannot drift from the Orders page the way
+        // it used to. The below-floor figure stays `null` whenever any SKU could
+        // not be checked — see the description above, which promises exactly that.
+        ordersOnException: ordersOnException(orders).length,
+        valueAtRisk: valueAtRisk(orders),
+        belowFloorSkus: belowFloorCount(floors, products),
+        skusWithNoFloorOnFile: tallyFloorStatus(floors, products).unknown,
+        pendingPromotions: promotions.filter((p) => p.status === "pending")
+          .length,
+        openReturns: openReturns(returns).length,
+        categories: [...new Set(products.map((p) => p.category))],
+      };
+    },
+  }),
+];

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/settle.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/settle.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describeError, settleInterrupt } from "./settle";
+
+/**
+ * These assertions exist because an unsettled human-in-the-loop interrupt WEDGES
+ * the agent run, and the two ways of getting there are both invisible: `respond`
+ * is `undefined` while tool arguments stream, and its promise can reject. The
+ * original code wrote `respond?.(message)`, which compiles, lints, renders, and
+ * silently drops the response in both cases.
+ */
+describe("settleInterrupt", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("delivers the message and reports success as null", async () => {
+    const respond = vi.fn(async () => {});
+    await expect(
+      settleInterrupt(respond, "Refund issued."),
+    ).resolves.toBeNull();
+    expect(respond).toHaveBeenCalledWith("Refund issued.");
+  });
+
+  it("does NOT silently no-op when respond is unavailable", async () => {
+    const failure = await settleInterrupt(undefined, "Refund issued.");
+    // The whole point: a sentence comes back, so the card has something to show
+    // and the user has a reason to click again.
+    expect(failure).toBeTruthy();
+    expect(failure).toMatch(/try again/i);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("reports a rejected respond instead of throwing out of the click", async () => {
+    const respond = vi.fn(async () => {
+      throw new Error("stream closed");
+    });
+    const failure = await settleInterrupt(respond, "Refund issued.");
+    expect(failure).toContain("stream closed");
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("never throws, whatever respond does", async () => {
+    const respond = vi.fn(() => Promise.reject("not an Error at all"));
+    await expect(
+      settleInterrupt(respond, "Refund issued."),
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe("describeError", () => {
+  it("prefers an Error message", () => {
+    expect(describeError(new Error("Failed to fetch"))).toBe("Failed to fetch");
+  });
+
+  it("stringifies non-Errors and never yields an empty line", () => {
+    expect(describeError("boom")).toBe("boom");
+    expect(describeError(undefined)).toBe("unknown error");
+    expect(describeError(new Error(""))).toBe("unknown error");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/settle.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/settle.ts
@@ -1,0 +1,267 @@
+/**
+ * How this skin reports a write that did not go the way it was supposed to.
+ * Deliberately React-free so all of it can be unit-tested on its own.
+ *
+ * Two halves, one rule. The rule is that NO path may end without a result:
+ *
+ *  - `settleInterrupt` — every human-in-the-loop card's only way to call
+ *    `respond`. An unsettled interrupt wedges the agent run (see below).
+ *  - `narrateWrite` — every plain `useFrontendTool` write handler's wrapper. A
+ *    handler that throws returns no result at all, so the agent cannot narrate
+ *    the step and the room is shown a write that silently vanished.
+ *
+ * ── The HITL half ────────────────────────────────────────────────────────────
+ *
+ * An unsettled interrupt does not merely LOOK broken: it wedges the agent run.
+ * The run blocks waiting for a response that will now never arrive, the card sits
+ * on screen, and — the part that makes this expensive — nothing anywhere says so.
+ * There are two ways a card lands there, and both are silent:
+ *
+ *  1. `respond` is OPTIONAL in `useHumanInTheLoop`'s render props. It is typed
+ *     `undefined` while the tool arguments are still streaming (status
+ *     `InProgress`) and again once the call is `Complete`. So the idiomatic
+ *     `respond?.(message)` is a NO-OP precisely when the user clicks early: the
+ *     button reacts, nothing is delivered, and the run hangs.
+ *  2. `respond` returns a `Promise<void>` over a live SSE transport, so it can
+ *     REJECT. A bare `respond?.(…)` drops that rejection on the floor, and an
+ *     `await` with no `catch` propagates it out of a click handler where React
+ *     will not render anything for it.
+ *
+ * So no card calls `respond` directly. Every one routes through
+ * `settleInterrupt`, which resolves to `null` when the interrupt is settled and
+ * to a human-readable sentence when it could not be. A card handed a sentence
+ * MUST show it and re-enable its own controls: the run is still waiting, so
+ * clicking again is the user's only path forward, and a card stuck on "Issuing…"
+ * takes that away.
+ */
+
+/** The live half of `useHumanInTheLoop`'s `respond` union. */
+export type RespondFn = (result: unknown) => Promise<void>;
+
+/**
+ * Appended to a mutation's result when the write landed but the follow-up
+ * `refresh()` did NOT (see `refresh`'s contract in `data/ledger-context`).
+ *
+ * Every handler writes over REST and then re-reads the ledger, so a failed
+ * re-read leaves the page showing pre-mutation rows while the receipt says the
+ * work is done — the one failure mode indistinguishable from a slow network.
+ * Rule 4 in `tools.tsx` still applies: this carries no figures and no ids, only
+ * the fact that the screen is behind.
+ *
+ * It lives HERE rather than in `tools.tsx` because `refund.ts` needs it too:
+ * beat 3a's write was lifted out of the render closure, so the only place that
+ * knows whether its `refresh()` succeeded is inside `submitRefund`. One
+ * definition, both callers — a second copy would drift.
+ */
+export const STALE_VIEW_NOTE =
+  " The page could not be re-read afterwards, so it may still be showing the previous value — reload it to confirm.";
+
+/** `""` on a good refresh, the note above on a failed one. */
+export const staleNote = (refreshed: boolean) =>
+  refreshed ? "" : STALE_VIEW_NOTE;
+
+/** Whatever was thrown, as one short line fit to put in front of a user. */
+export function describeError(error: unknown): string {
+  // Never resolves to "" or to a bare "Error": these strings get appended to a
+  // sentence shown to the user, and a dangling "Could not refund Dana: " reads
+  // as a rendering bug rather than as a failure.
+  if (error instanceof Error) return error.message.trim() || "unknown error";
+  const text = String(error ?? "").trim();
+  return text || "unknown error";
+}
+
+/**
+ * Deliver `message` as this interrupt's result.
+ *
+ * @returns `null` once the interrupt is settled, or a sentence to show the user
+ * explaining that it is NOT settled and they should retry. Never throws — a
+ * throw from here would be the very failure it exists to prevent.
+ */
+export async function settleInterrupt(
+  respond: RespondFn | undefined,
+  message: string,
+): Promise<string | null> {
+  if (!respond) {
+    // Not a theoretical branch: the card renders during `InProgress`, when the
+    // arguments are still streaming and `respond` genuinely is undefined.
+    console.error(
+      "[commerce] cannot settle this interrupt — respond() is not available yet",
+      { message },
+    );
+    return "I couldn't hand that back to the assistant — it wasn't ready to receive it yet. Try again.";
+  }
+  try {
+    await respond(message);
+    return null;
+  } catch (error) {
+    console.error("[commerce] settling the interrupt failed", error);
+    return `I couldn't hand that back to the assistant: ${describeError(error)}. Try again.`;
+  }
+}
+
+// ══ The plain-tool-handler half ════════════════════════════════════════════
+
+/**
+ * BEAT 5's partial-progress journal.
+ *
+ * The stored procedure is THREE separate tool calls against ONE order — hold it,
+ * post the note, notify the customer. They land independently, so a transport
+ * failure on the second leaves the ledger half-mutated, and the agent (which sees
+ * nothing but tool results) cannot say so unless a result tells it. This map is
+ * that memory: `narrateWrite` records each write that actually LANDED against the
+ * record it landed on, and a later failure on the SAME record recites them.
+ *
+ * Module-level and unbounded, and neither is a leak:
+ *
+ *  - It is keyed by record id, so a failure only ever recites writes made against
+ *    the record that failure was about. There is no "everything that ever
+ *    happened" recital.
+ *  - The presenter reset clears it EXPLICITLY — `resetLandedWrites()` in
+ *    `runPresenterReset` (layout.tsx) — and then hard-navigates, a real document
+ *    load which drops this module and the map with it.
+ *
+ * That second bullet used to read "the reset finishes with
+ * `window.location.assign`, so there is no path that wipes the ledger and leaves
+ * the journal behind", and it was FALSE. The reset route wipes the store as its
+ * first act and can still answer 502 (memory wiped, not fully re-seeded) or throw
+ * mid-sweep, and the old handler navigated on `res.ok` ALONE — so on exactly the
+ * paths where the ledger had gone back to seed, the journal survived and the next
+ * failure on one of those records recited writes the reset had taken away. Both
+ * halves are now unconditional (see `runPresenterReset`), and the explicit clear
+ * is what makes it true even if the navigation never lands.
+ *
+ * THE INVARIANT IT CAN CLAIM, precisely: a journal entry outlives the store only
+ * through a wipe THIS DOCUMENT NEVER SAW — a `curl`/Playwright POST to
+ * `dev/reset`, or a dev-server restart re-initialising the in-memory store. No
+ * client-side code can observe either, and neither is on a presenter's path.
+ */
+const landedWrites = new Map<string, string[]>();
+
+/** Every write `narrateWrite` saw land on `subject`, in the order they landed. */
+export const landedWritesOn = (subject: string): readonly string[] =>
+  landedWrites.get(subject) ?? [];
+
+/**
+ * Empty the journal.
+ *
+ * Two callers, and the first is production: `runPresenterReset` (layout.tsx)
+ * calls it on every path where the server store was — or may have been — wiped,
+ * because a journal entry whose record no longer exists is a recital of writes
+ * that were reset away.
+ *
+ * The second is tests: the map is module-level, so it outlives an individual
+ * `it` and one case's landed writes would otherwise be recited by the next
+ * case's failure.
+ */
+export const resetLandedWrites = (): void => landedWrites.clear();
+
+/** Opens every line `narrateWrite` emits for a write that did not complete. */
+export const WRITE_FAILED_PREFIX = "Could not complete ";
+
+/**
+ * Every opening this skin's write handlers use to say the write did NOT happen:
+ * the server refused it (`REFUSED…`), it was rejected on the wire
+ * (`WRITE_FAILED_PREFIX`, a subset of `Could not…`), the route answered non-2xx
+ * (`Could not hold the order (HTTP 500).`), or the record was never found at all
+ * (`No order matches "9999".`).
+ *
+ * A closed set matched by prefix, because these lines are also read by the agent
+ * and every one of them is written in this file's sibling `tools.tsx`. Adding a
+ * handler with a fifth phrasing means adding it here.
+ */
+const WRITE_FAILURE_OPENING = /^(REFUSED\b|Could not\b|No [a-z]+ matches\b)/;
+
+/**
+ * True when a write tool's result reports that the write did NOT happen.
+ *
+ * The receipts use it to pick their tone. A failure line rendered under a green
+ * tick is the same lie as showing no error at all: from the back of a room the
+ * tick is what registers, not the sentence.
+ */
+export function isWriteFailureLine(result: unknown): boolean {
+  return WRITE_FAILURE_OPENING.test(String(result ?? ""));
+}
+
+/**
+ * What already landed on this record, for a failure that landed nothing itself.
+ * Beat 5's value: "held the order, but could not post the note" is both more
+ * useful on stage and more honest than a bare failure — the ledger really is
+ * half-mutated, and nothing was rolled back.
+ *
+ * "and still stand" is an assertion about the SERVER, so it is only as true as
+ * the journal's lifetime rule above: nothing rolls a landed write back, and the
+ * presenter reset — the one thing that does take them away — empties this map
+ * before it navigates. Do not soften this line into a hedge; make the clearing
+ * hold instead. An unconditional "may or may not still stand" would gut the beat
+ * for the sake of a case (an out-of-band `dev/reset`) that no presenter path
+ * reaches.
+ */
+function priorWritesNote(subject: string | undefined): string {
+  const prior = subject ? landedWritesOn(subject) : [];
+  if (prior.length === 0) return "";
+  return ` Earlier steps on this record did land and still stand: ${prior.join(", ")}.`;
+}
+
+/**
+ * Run one write handler's body and ALWAYS resolve with a line the agent can
+ * narrate — on success, on a refusal, and on a transport failure.
+ *
+ * Every handler in `tools.tsx` checked `!res.ok` and stopped there, which covers
+ * a server that answered and nothing else. A `fetch` that REJECTS — offline
+ * browser, dev server restarted mid-call, connection dropped — threw straight out
+ * of the handler, so the agent got no result for that step at all. On beat 5's
+ * chain that is the worst available shape of failure: one write visibly landed,
+ * the next silently vanished, and nothing on screen or in the transcript says
+ * which.
+ *
+ * ONE wrapper rather than seven try/catches, because seven copies is how the
+ * eighth handler ships without one.
+ *
+ * @param attempt.action Noun phrase naming the write, completing "Could not
+ * complete …" — e.g. `"the note on order 4463"`.
+ * @param attempt.subject The record the write is against (an order id). Supply it
+ * only where a CHAIN of writes shares one record; that shared key is the whole
+ * reason the partial-progress recital means anything.
+ * @param run The handler body. It is handed `landed`, which it MUST call the
+ * moment the write is confirmed and MUST NOT call on a refusal: that call is the
+ * only thing separating "never happened" from "happened, then the follow-up
+ * broke", and the two get opposite receipts.
+ */
+export async function narrateWrite(
+  attempt: { action: string; subject?: string },
+  run: (landed: (what: string) => void) => Promise<string>,
+): Promise<string> {
+  // An object rather than a bare `let`: TypeScript narrows a variable that is
+  // only ever assigned inside a closure to its initializer at the read site,
+  // which would make the branch below unreachable in the type system.
+  const state = { landed: false };
+  const landed = (what: string) => {
+    state.landed = true;
+    if (!attempt.subject) return;
+    const prior = landedWrites.get(attempt.subject) ?? [];
+    // Re-running a step (the presenter repeats beat 5, or the agent retries)
+    // must not list it twice.
+    if (!prior.includes(what)) {
+      landedWrites.set(attempt.subject, [...prior, what]);
+    }
+  };
+
+  try {
+    return await run(landed);
+  } catch (error) {
+    console.error(`[commerce] ${attempt.action} did not complete`, error);
+    const reason = describeError(error);
+    if (state.landed) {
+      // The write itself is done and only what follows it broke. Reporting a
+      // failure here would be a receipt AGAINST a write that really landed — the
+      // mirror image of the replay bug `tools.tsx` calls out, and just as
+      // dishonest. Note this line deliberately does NOT match
+      // `isWriteFailureLine`.
+      return `Completed ${attempt.action}, but the follow-up failed: ${reason}. The change itself did land.`;
+    }
+    return (
+      `${WRITE_FAILED_PREFIX}${attempt.action}: ${reason}. Nothing came back, so treat it as not applied.` +
+      priorWritesNote(attempt.subject)
+    );
+  }
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/skin.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/skin.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import commerce from "@/skins/commerce/skin";
+import { OrdersPage } from "@/skins/commerce/pages/orders";
+import { CatalogPage } from "@/skins/commerce/pages/catalog";
+import { PromotionsPage } from "@/skins/commerce/pages/promotions";
+import { ReturnsPage } from "@/skins/commerce/pages/returns";
+
+/**
+ * `resolvePage` maps URL segments (untrusted caller input) to a page. A plain
+ * object indexed by the joined segments walks the prototype chain, so these keys
+ * all resolve to a truthy `Function` (or, for `__proto__`, `Object.prototype`)
+ * that slips past the shell's `if (!Page) notFound()` guard in
+ * `src/app/[skin]/[[...rest]]/page.tsx` and is rendered as a `ComponentType` —
+ * a 500 instead of a 404. The `Map`-backed lookup must return `null` for every
+ * one. Mirrors `src/skins/keel/skin.test.tsx`.
+ */
+const PROTOTYPE_CHAIN_KEYS = [
+  "constructor",
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "__proto__",
+  "__defineGetter__",
+];
+
+describe("commerce resolvePage", () => {
+  it("resolves every real page segment to its component", () => {
+    expect(commerce.resolvePage([])).toBe(OrdersPage);
+    expect(commerce.resolvePage(["orders"])).toBe(OrdersPage);
+    expect(commerce.resolvePage(["catalog"])).toBe(CatalogPage);
+    expect(commerce.resolvePage(["promotions"])).toBe(PromotionsPage);
+    expect(commerce.resolvePage(["returns"])).toBe(ReturnsPage);
+  });
+
+  it("covers every nav segment, so no nav entry can 404", () => {
+    for (const route of commerce.nav) {
+      expect(
+        commerce.resolvePage(route.segment ? [route.segment] : []),
+      ).not.toBeNull();
+    }
+  });
+
+  it("returns null (404) for an unknown segment", () => {
+    expect(commerce.resolvePage(["nope"])).toBeNull();
+    expect(commerce.resolvePage(["orders", "extra"])).toBeNull();
+  });
+
+  it.each(PROTOTYPE_CHAIN_KEYS)(
+    "returns null (404) for prototype-chain key %j, never a Function component",
+    (key) => {
+      expect(commerce.resolvePage([key])).toBeNull();
+    },
+  );
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/skin.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/skin.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import type { ComponentType } from "react";
+import {
+  ClipboardList,
+  Paperclip,
+  PackageSearch,
+  RotateCcw,
+  Tag,
+} from "lucide-react";
+import type { NavRoute, Skin, Suggestion } from "@/shell/skin-contract";
+import { commerceIdentity } from "./identity";
+import { CommerceLayout } from "./layout";
+import { CommerceTools } from "./tools";
+import { OrdersPage } from "./pages/orders";
+import { CatalogPage } from "./pages/catalog";
+import { PromotionsPage } from "./pages/promotions";
+import { ReturnsPage } from "./pages/returns";
+import { catalog } from "./catalog";
+import { CommerceCanvasSurface } from "./canvas-surface";
+import { commerceSuggestions, RESTOCK_PLAN_MESSAGE } from "./suggestions";
+import { BELLWETHER_DESIGN_SKILL } from "./design-skill";
+import { sandboxFunctions } from "./sandbox-functions";
+import {
+  CommerceProviders,
+  CommerceRuntimeProviders,
+  useCommerceRuntimeProperties,
+} from "./providers";
+import {
+  attachPriceSheetByHand,
+  reportPriceSheetFailure,
+  sendRestockRequestWithPriceSheet,
+} from "./attach-price-sheet";
+
+const nav: NavRoute[] = [
+  { segment: "", label: "Orders", icon: ClipboardList },
+  { segment: "catalog", label: "Catalog", icon: PackageSearch },
+  { segment: "promotions", label: "Promotions", icon: Tag },
+  { segment: "returns", label: "Returns", icon: RotateCcw },
+];
+
+/**
+ * `resolvePage` — not `nav` — is the single source of truth for which segments
+ * are valid. It accepts `orders` as an alias for the index that the nav never
+ * lists, so a deep link or a typed URL lands somewhere sensible instead of 404.
+ *
+ * A `Map` (not a plain object) is load-bearing for security, exactly as in
+ * `src/skins/keel/skin.tsx`: `segments` comes straight from the URL path after
+ * `/commerce`, so the lookup key is untrusted caller input. A plain-object
+ * lookup (`PAGES[key]`) walks the prototype chain, so `"constructor"`,
+ * `"toString"`, `"valueOf"`, `"hasOwnProperty"`, `"__proto__"`, … all resolve
+ * truthy and slip past the `?? null` 404 guard — handing the shell a `Function`
+ * (or `Object.prototype`) where a `ComponentType` is declared, so
+ * `/commerce/toString` 500s instead of showing a 404. `Map.get` only ever sees
+ * own entries, making that bad state unrepresentable rather than relying on a
+ * per-call-site guard. `Record<string, ComponentType>` could not catch this —
+ * the annotation was a lie about a plain object.
+ */
+const PAGES: Map<string, ComponentType> = new Map([
+  ["", OrdersPage],
+  ["orders", OrdersPage],
+  ["catalog", CatalogPage],
+  ["promotions", PromotionsPage],
+  ["returns", ReturnsPage],
+]);
+
+function resolvePage(segments: string[]): ComponentType | null {
+  const key = segments.length === 0 ? "" : segments.join("/");
+  return PAGES.get(key) ?? null;
+}
+
+/**
+ * Human labels for the tool-activity chips, so the transcript reads as phrases
+ * rather than as function names. "Optional" in the contract and mandatory in
+ * practice: `showMarginLadder` on a projector says "this is a demo of an API".
+ */
+const TOOL_LABELS: Record<string, string> = {
+  showMarginLadder: "Pulling up the margin ladder",
+  showProduct: "Looking a product up",
+  showOrderList: "Gathering the orders",
+  showMarginSummary: "Summarizing margin",
+  issueRefund: "Opening the refund",
+  showOrderQueue: "Setting up the queue view",
+  holdOrder: "Putting the order on hold",
+  notifyCustomer: "Messaging the customer",
+  postOrderNote: "Noting it on the order",
+  createRestockPlan: "Filing the restock plan",
+  approveMarkdown: "Approving the markdown",
+  openMarginWaiver: "Filing a margin waiver",
+  finalizeMarginWaiver: "Finalizing the margin waiver",
+  offerWorkflowRecording: "Asking to learn this one",
+  awaitDemonstration: "Watching you do it",
+  saveLearnedProcedure: "Writing down what it learned",
+  requestChargebackEvidence: "Pulling chargeback evidence",
+  scheduleCarrierPickup: "Booking a carrier pickup",
+  sendReviewRequest: "Queueing a review request",
+  openSupplierClaim: "Opening a supplier claim",
+  render_trade_brief: "Building the trading review",
+};
+
+// ── BEAT 3d: driving the real composer ──────────────────────────────────────
+// The framework's suggestion path DROPS attachments, so the pill that must carry
+// the price sheet cannot take it. Instead it is intercepted below and pushed
+// through the actual composer — stage the file into the hidden input, set the
+// textarea, click send — which is the path that correctly consumes an attachment
+// on submit. All of that (and its fail-loud contract) lives in
+// `./attach-price-sheet`; this module only routes the two entry points to it.
+
+/**
+ * Launch one of beat 3d's async actions from a DOM event handler.
+ *
+ * Event handlers cannot await, so the promise is not returned to the framework —
+ * but it is not DROPPED either. Both actions already report every expected
+ * failure and resolve `false`; this wrapper covers the remaining hole, an
+ * unexpected rejection, so no path through beat 3d can end in silence. A bare
+ * `void action()` here is what made the paperclip fail with nothing in the
+ * console, so do not reintroduce one.
+ */
+function launchBeat3d(action: () => Promise<boolean>): void {
+  action().catch((err: unknown) => {
+    reportPriceSheetFailure(
+      `Unexpected error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+}
+
+// NOTE: no `agent` field, and this module must NEVER import ./agent.ts. Agents
+// pull in @copilotkit/runtime, which must not reach the browser bundle; the
+// agent registers separately in src/shell/agent-registry.ts under this same id.
+const commerce: Skin = {
+  id: "commerce",
+  identity: commerceIdentity,
+  themeClass: "theme-commerce",
+  Layout: CommerceLayout,
+  nav,
+  resolvePage,
+  Tools: CommerceTools,
+  catalog,
+  suggestions: commerceSuggestions,
+  designSkill: BELLWETHER_DESIGN_SKILL,
+
+  // Above CopilotKitProvider — holds the ledger, which `useRuntimeProperties`
+  // reads for the signed-in operator.
+  RuntimeProviders: CommerceRuntimeProviders,
+  useRuntimeProperties: useCommerceRuntimeProperties,
+  // Below it — the teach-mode recording context and the sandbox data sync.
+  Providers: CommerceProviders,
+
+  CanvasSurface: CommerceCanvasSurface,
+  sandboxFunctions,
+  toolLabels: TOOL_LABELS,
+
+  // REST-backed like banking, logistics and people: components read the ledger
+  // through `useCommerceLedger()` directly, so nothing flows through
+  // `useSkinData` and `useData` is deliberately omitted.
+
+  chatHeaderActions: [
+    {
+      icon: Paperclip,
+      label: "Attach the vendor price sheet",
+      // A manual fallback for the presenter if the pill path misbehaves live.
+      // It is the fallback, so it must be the LOUDEST link in the chain: if this
+      // one fails quietly too, the presenter has nothing left to try.
+      onClick: () => launchBeat3d(attachPriceSheetByHand),
+    },
+  ],
+
+  onSuggestionSelect: (suggestion: Suggestion) => {
+    if (suggestion.message !== RESTOCK_PLAN_MESSAGE) {
+      return false; // every other pill takes the default "send the message" path
+    }
+    // `true` means "the shell must not run its default send", and that is
+    // unconditionally correct for this pill: the default path would send "read
+    // the attached price sheet" with the attachment DROPPED, which is the exact
+    // failure beat 3d cannot survive. So the click is claimed either way, and
+    // `sendRestockRequestWithPriceSheet` guarantees the only two outcomes are
+    // "sent with the sheet" or "aborted and the presenter was told why" — never
+    // the old third outcome of returning `true` and then doing nothing at all.
+    launchBeat3d(sendRestockRequestWithPriceSheet);
+    return true;
+  },
+};
+
+export default commerce;

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/streaming-args.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/streaming-args.test.tsx
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import * as store from "./data/store";
+import type { Operator } from "./data/types";
+
+/**
+ * ARGUMENTS STREAM, AND EVERY RENDER RUNS THROUGHOUT.
+ *
+ * CopilotKit hands a render `partialJSONParse(toolCall.function.arguments)`
+ * verbatim, which returns `{}` for the first frames of a call, so EVERY declared
+ * argument is `undefined` on the way to its value — a `.optional()` in the schema
+ * is not what makes that true, and a required field is not what makes it false.
+ * There is also nowhere to report a bad argument back from a display component
+ * (a render-only tool posts an empty tool result), so the render IS the
+ * enforcement.
+ *
+ * Two DIFFERENT failure modes come out of that, and they are treated differently
+ * here because a single guard fixes only one of them:
+ *
+ *  - it THROWS. `showOrderList` did `orderIds.map(…)` on an argument that had
+ *    not arrived, i.e. a TypeError inside React render, on BEAT 1 — the beat the
+ *    demo opens with. Unconditional: it happens on every call to that component.
+ *
+ *  - it LIES. `showProduct` flashed a red "Nothing in the range matches ''"
+ *    before the needle arrived, and `showMarginSummary` drew beat 4's rose "why"
+ *    band as an empty coloured bar while the `note` streamed. Both assert
+ *    something on screen — a miss, a recalled preference — that nobody has
+ *    established yet.
+ *
+ * The standard for the second mode is the one `order-queue-levers` already set
+ * for the Sort chip: a value that has not arrived gets NO confident rendering.
+ * And not silence either — the audience is watching generative UI appear, so an
+ * absent argument draws a visible arriving card rather than nothing at all.
+ *
+ * The `?? []` half of the fix is banking's established pattern for exactly this
+ * (`src/skins/banking/tools.tsx:793-794`, `showTable`'s `columns ?? []` /
+ * `rows ?? []`).
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+
+/** Only the parts of a registration these tests exercise. */
+interface ComponentRegistration {
+  name: string;
+  render: (props: Record<string, unknown>) => ReactNode;
+}
+
+const { components, handlers } = vi.hoisted(() => ({
+  components: new Map<string, ComponentRegistration>(),
+  handlers: new Map<string, (args: never) => Promise<string>>(),
+}));
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+  useComponent: (registration: ComponentRegistration) => {
+    components.set(registration.name, registration);
+  },
+  useFrontendTool: (config: {
+    name: string;
+    handler?: (args: never) => Promise<string>;
+  }) => {
+    if (config.handler) handlers.set(config.name, config.handler);
+  },
+  useHumanInTheLoop: () => {},
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: () => {}, replace: () => {} }),
+  usePathname: () => "/commerce",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("@/shell/skin-path", () => ({
+  useSkinHref: () => (path?: string) => path ?? "/commerce",
+}));
+
+vi.mock("./data/ledger-context", async () => {
+  const real = await import("./data/store");
+  return {
+    useCommerceLedger: () => ({
+      data: real.snapshot(),
+      refresh: async () => true,
+      operator: real.operators()[0] satisfies Operator,
+      setOperatorId: () => {},
+    }),
+  };
+});
+
+// Imported after the mocks so the module graph picks them up.
+const { CommerceTools } = await import("./tools");
+
+/** Render one registered display component exactly as a tool call would. */
+function draw(name: string, args: Record<string, unknown>) {
+  const registration = components.get(name);
+  if (!registration) throw new Error(`${name} was not registered`);
+  render(<>{registration.render(args)}</>);
+  return document.body.textContent ?? "";
+}
+
+function handler<A>(name: string): (args: A) => Promise<string> {
+  const found = handlers.get(name);
+  if (typeof found !== "function") {
+    throw new Error(`${name} did not register a handler`);
+  }
+  return found as (args: A) => Promise<string>;
+}
+
+beforeEach(() => {
+  store.reset();
+  components.clear();
+  handlers.clear();
+  render(<CommerceTools />);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("showOrderList while its arguments stream", () => {
+  it("does not throw when no ids have arrived at all", () => {
+    // `{}` is literally what `partialJSONParse` returns for the first frames.
+    expect(() => draw("showOrderList", {})).not.toThrow();
+  });
+
+  it("shows an arriving card rather than claiming no order matched", () => {
+    // The lie half of the same instance: `orderIds ?? []` alone makes the card
+    // render its red "No matching orders." on every call before the first id
+    // lands, which is a MISS asserted over an argument nobody has sent.
+    const text = draw("showOrderList", {});
+    expect(text).not.toContain("No matching orders");
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it("survives a half-streamed array holding a blank string", () => {
+    // `{"orderIds": ["` parses to a one-element array whose element is "".
+    expect(() => draw("showOrderList", { orderIds: [""] })).not.toThrow();
+    expect(document.body.textContent).not.toContain("No matching orders");
+  });
+
+  it("survives an element that is not a string yet", () => {
+    expect(() =>
+      draw("showOrderList", { orderIds: [null, 4471] }),
+    ).not.toThrow();
+  });
+
+  it("still says so when real ids arrived and matched nothing", () => {
+    const text = draw("showOrderList", { orderIds: ["ord-nope"] });
+    expect(text).toContain("No matching orders");
+  });
+
+  it("lists the orders once the ids are complete", () => {
+    const text = draw("showOrderList", {
+      orderIds: ["ord-4471", "#4409"],
+      caption: "The two oldest",
+    });
+    expect(text).toContain("Dorian Vale");
+    expect(text).toContain("The two oldest");
+  });
+});
+
+describe("showProduct while its argument streams", () => {
+  it("does not flash a miss before the needle has arrived", () => {
+    const text = draw("showProduct", {});
+    expect(text).not.toContain("Nothing in the range matches");
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it("does not flash a miss on a blank or whitespace needle", () => {
+    expect(draw("showProduct", { product: "" })).not.toContain(
+      "Nothing in the range matches",
+    );
+    cleanup();
+    expect(draw("showProduct", { product: "  " })).not.toContain(
+      "Nothing in the range matches",
+    );
+  });
+
+  it("does not throw when the needle is not a string yet", () => {
+    expect(() => draw("showProduct", { product: 41 })).not.toThrow();
+  });
+
+  it("resolves a partially streamed name through the substring match", () => {
+    expect(draw("showProduct", { product: "Cedar" })).toContain("Cedar Hoodie");
+  });
+
+  it("still reports a genuine miss once a real needle arrived", () => {
+    expect(draw("showProduct", { product: "Zeppelin" })).toContain(
+      "Nothing in the range matches",
+    );
+  });
+
+  it("renders the card once the name is complete", () => {
+    expect(draw("showProduct", { product: "Cedar Hoodie" })).toContain(
+      "Cedar Hoodie",
+    );
+  });
+});
+
+/** The rose "why" band — beat 4's visible proof that memory was recalled. */
+const whyBand = () => document.querySelector(".bg-brand-violet\\/10");
+
+describe("showMarginSummary while its arguments stream", () => {
+  it("draws no empty rose band before the note has arrived", () => {
+    draw("showMarginSummary", {});
+    expect(whyBand()).toBeNull();
+  });
+
+  it("draws no rose band for a blank note", () => {
+    draw("showMarginSummary", {
+      byCategory: true,
+      belowFloorFirst: true,
+      asMarginPercent: true,
+      note: "   ",
+    });
+    expect(whyBand()).toBeNull();
+  });
+
+  it("still renders the list itself while the flags stream", () => {
+    // Not silence: the audience is watching the card appear, so an absent flag
+    // draws the list in its plain shape rather than an empty card.
+    draw("showMarginSummary", {});
+    expect(document.querySelectorAll("ul li").length).toBeGreaterThan(0);
+  });
+
+  it("draws the band once the note is complete", () => {
+    const text = draw("showMarginSummary", {
+      byCategory: true,
+      belowFloorFirst: true,
+      asMarginPercent: true,
+      note: "You read these by category, below-floor first.",
+    });
+    expect(whyBand()?.textContent).toContain("by category");
+    expect(text).toContain("Harbor Parka");
+  });
+});
+
+describe("showMarginLadder while its argument streams", () => {
+  // Already guarded by `resolveCategoryScope` — pinned here so the sweep records
+  // the negative rather than leaving it to be re-derived.
+  it("draws the whole range for an absent category", () => {
+    expect(() => draw("showMarginLadder", {})).not.toThrow();
+    expect(document.querySelector("figure")).not.toBeNull();
+  });
+
+  it("draws the whole range for a prefix of a real category", () => {
+    draw("showMarginLadder", { category: "Foot" });
+    expect(document.querySelector("figure")).not.toBeNull();
+  });
+});
+
+describe("receipts that formatted an absent response field", () => {
+  const respondWith = (status: number, body: unknown) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: status < 400,
+      status,
+      json: async () => body,
+    } as Response);
+  };
+
+  it("omits the discount clause when the approval body carries no percent", async () => {
+    respondWith(200, { promotion: { name: "Cedar Hoodie autumn markdown" } });
+    const line = await handler<{ promotionId: string }>("approveMarkdown")({
+      promotionId: "promo-cedar",
+    });
+    // "goes live at % off" is a sentence with the number missing from it.
+    expect(line).not.toMatch(/at\s*% off/);
+    expect(line).toContain("Cedar Hoodie autumn markdown");
+  });
+
+  it("states the discount when the body does carry it", async () => {
+    respondWith(200, {
+      promotion: { name: "Cedar Hoodie autumn markdown", discountPercent: 30 },
+    });
+    const line = await handler<{ promotionId: string }>("approveMarkdown")({
+      promotionId: "promo-cedar",
+    });
+    expect(line).toContain("at 30% off");
+  });
+
+  it("does not report an undefined waiver id", async () => {
+    respondWith(200, {});
+    const line = await handler<{
+      promotionId: string;
+      code: string;
+      justification: string;
+    }>("openMarginWaiver")({
+      promotionId: "promo-cedar",
+      code: "MW-SEASON-EXIT",
+      justification: "End of season exit approved by merchandising.",
+    });
+    expect(line).not.toContain("undefined");
+    expect(line.toLowerCase()).toContain("waiver");
+  });
+
+  it("reports the waiver id when the body carries one", async () => {
+    // Beat 6's next step needs it, so the clause must survive the guard.
+    respondWith(200, { id: "mw-7" });
+    const line = await handler<{
+      promotionId: string;
+      code: string;
+      justification: string;
+    }>("openMarginWaiver")({
+      promotionId: "promo-cedar",
+      code: "MW-SEASON-EXIT",
+      justification: "End of season exit approved by merchandising.",
+    });
+    expect(line).toContain("Waiver id mw-7.");
+  });
+
+  it("does not describe a waiver by an absent code when finalizing", async () => {
+    respondWith(200, {});
+    const line = await handler<{ waiverId: string }>("finalizeMarginWaiver")({
+      waiverId: "mw-1",
+    });
+    // The `?? ""` left a gap where the code should have been: "Finalized the
+    // margin waiver." with two spaces in it.
+    expect(line).not.toMatch(/\s{2}/);
+    expect(line).toContain("Finalized the margin waiver.");
+  });
+
+  it("names the code when finalizing does carry one", async () => {
+    respondWith(200, { code: "MW-SEASON-EXIT" });
+    const line = await handler<{ waiverId: string }>("finalizeMarginWaiver")({
+      waiverId: "mw-1",
+    });
+    expect(line).toContain("Finalized the MW-SEASON-EXIT margin waiver.");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/suggestions.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/suggestions.ts
@@ -1,0 +1,92 @@
+import type { Suggestion } from "@/shell/skin-contract";
+
+/**
+ * THE PILLS ARE THE DEMO SCRIPT.
+ *
+ * The presenter should never have to type. That is half stagecraft and half
+ * correctness: free-typed phrasing routes to the wrong tool. Asking for the
+ * margin "report" instead of the margin "ladder" sends Bellwether to the canvas
+ * trading brief rather than the in-chat ladder, and the audience reads the
+ * hesitation as the product being unsure.
+ *
+ * ── BEAT MAP ────────────────────────────────────────────────────────────────
+ * | Beat              | Bellwether's step                       | Pill | Implemented by                                                  |
+ * | ----------------- | --------------------------------------- | ---- | --------------------------------------------------------------- |
+ * | 1 face            | The margin ladder                       | 1    | `showMarginLadder` useComponent → `components/margin-ladder.tsx` |
+ * | 2 rich thread     | Reload; ladder + receipts still there   | —    | every render keyed off `result`; `answeredRefunds` map           |
+ * | 3a drive the app  | Goodwill refund, figure typed in chat   | 2    | `issueRefund` HITL → POST …/returns/[id]/refund                  |
+ * | 3b sees my screen | Ask on Orders, then on Catalog          | 3    | route readable (layout) + per-page readables (all 4 pages)       |
+ * | 3c levers         | Oldest orders on exception, top 10      | 4    | `showOrderQueue` HITL → ?status&exception&sort&top, tinted       |
+ * | 3d multimodal     | Vendor price sheet → durable plan       | 5    | `onSuggestionSelect` + `attach-price-sheet` → POST /plans        |
+ * | 4 memory          | Margin summary in Nadia's saved format  | 6    | seeded topical memory + `showMarginSummary({ note })`            |
+ * | 5 stored skill    | "Order 4471 looks fraudulent — handle"  | 7    | seeded operational memory → 3 writes amid 4 distractors          |
+ * | 6 teach a skill   | Below-floor markdown approval           | 8    | 422 BELOW_MARGIN_FLOOR → offer → watch → save → replay on Slate  |
+ * | (canvas)          | The Trading Review brief                | 9    | server `render_trade_brief` → a2ui `CommerceCanvasSurface`       |
+ *
+ * Beat 2 has no pill on purpose — it is demonstrated by reloading the browser
+ * and reopening the thread, not by asking for anything.
+ *
+ * Beat 6 is taught on the **Cedar Hoodie** markdown and replayed unaided on the
+ * **Slate Chelsea Boot** markdown. Both are seeded below the margin floor, so
+ * the case taught on stage is never the case the replay lands on.
+ */
+
+/**
+ * Shared with `onSuggestionSelect` in skin.tsx by string equality, so the match
+ * can never drift out of sync with the pill. This is the pill that must carry a
+ * file, and the framework's suggestion path DROPS attachments — see
+ * `attach-price-sheet.ts`.
+ */
+export const RESTOCK_PLAN_MESSAGE =
+  "Here's the autumn price sheet from Kestrel Mills. Read it and file the restock plan.";
+
+export const commerceSuggestions: Suggestion[] = [
+  // 1 — lead with generative UI. The ladder is Bellwether's signature visual and
+  // the setup for beats 4 and 6.
+  {
+    title: "Show me the margin ladder",
+    message:
+      "Show me the margin ladder and tell me which products are sitting below their margin floor.",
+  },
+  // 3a — a mutation whose sensitive value never reaches the assistant.
+  {
+    title: "Refund Marguerite's return",
+    message:
+      "Marguerite Bell's Aspen Shell return is approved. Issue the goodwill refund.",
+  },
+  // 3b — click this on TWO different pages. The answers must differ.
+  {
+    title: "What's on my screen?",
+    message:
+      "Look at the page I'm on right now and tell me what's on screen — the key elements and the figures shown.",
+  },
+  // 3c — HITL confirm, then navigate + filter + sort, controls visibly tinted.
+  {
+    title: "Oldest orders on exception",
+    message: "Show me the ten oldest orders still stuck on an exception.",
+  },
+  // 3d — intercepted in skin.tsx; stages the generated vendor price sheet.
+  { title: "File the restock plan", message: RESTOCK_PLAN_MESSAGE },
+  // 4 — recalls the seeded preference AND names it in the note slot.
+  {
+    title: "Where does margin stand?",
+    message: "Give me a summary of where margin stands right now.",
+  },
+  // 5 — one vague sentence replays a seeded three-step procedure.
+  {
+    title: "Order 4471 looks wrong",
+    message: "Order 4471 looks fraudulent — handle it.",
+  },
+  // 6 — the gated action Bellwether does NOT know how to do yet. It must decline.
+  {
+    title: "Approve the Cedar markdown",
+    message:
+      "Sales put the Cedar Hoodie up for an autumn markdown. Approve the promotion.",
+  },
+  // The canvas artifact — a good closer, and the only pill that leaves chat.
+  {
+    title: "Prep the trading review",
+    message:
+      "Put together the trading review brief for Monday's leadership meeting on the canvas.",
+  },
+];

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/teach-mode-directives.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/teach-mode-directives.test.tsx
@@ -1,0 +1,278 @@
+import type { ReactNode } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CommerceStoreState, Operator } from "./data/types";
+import {
+  SAVE_PROCEDURE_CONFIRMED,
+  SAVE_PROCEDURE_DECLINED,
+  buildDemonstrationDirective,
+  classifySaveProcedureResult,
+  readDemonstratedStepCount,
+} from "./teach-mode-directives";
+
+/** The `{ args, status, result, respond }` render a HITL registration gets. */
+type ToolRender = (props: {
+  args?: Record<string, unknown>;
+  result?: unknown;
+  respond?: (value: string) => void;
+  toolCallId?: string;
+}) => ReactNode;
+
+// CommerceTools registers into CopilotKit and renders null, so the only way to
+// reach a card's render is to capture the registrations as they are made.
+const { renders } = vi.hoisted(() => ({
+  renders: new Map<string, unknown>(),
+}));
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+  useComponent: () => {},
+  useFrontendTool: (config: { name: string; render?: unknown }) => {
+    if (config.render) renders.set(config.name, config.render);
+  },
+  useHumanInTheLoop: (config: { name: string; render: unknown }) => {
+    renders.set(config.name, config.render);
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("@/shell/skin-path", () => ({
+  useSkinHref: () => (path: string) => path,
+}));
+
+const EMPTY_LEDGER: CommerceStoreState = {
+  products: [],
+  floors: [],
+  orders: [],
+  notifications: [],
+  returns: [],
+  promotions: [],
+  waivers: [],
+  plans: [],
+  operators: [],
+};
+
+const OPERATOR: Operator = {
+  id: "op-nadia",
+  name: "Nadia Okonjo",
+  role: "merch-lead",
+  team: "Merchandising",
+};
+
+vi.mock("./data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: EMPTY_LEDGER,
+    // `refresh` resolves a boolean: `true` = a fresh snapshot was committed.
+    refresh: async () => true,
+    operator: OPERATOR,
+    setOperatorId: () => {},
+  }),
+}));
+
+vi.mock("./components/recording-context", () => ({
+  useRecording: () => ({
+    isRecording: false,
+    steps: [],
+    beginRecording: () => {},
+    endRecording: () => {},
+    logStep: () => {},
+    getDemonstratedCode: () => null,
+    reset: () => {},
+  }),
+}));
+
+// Imported after the mocks so it binds the stubbed modules.
+import { CommerceTools } from "./tools";
+
+function cardRenderFor(name: string): ToolRender {
+  render(<CommerceTools />);
+  const found = renders.get(name);
+  if (typeof found !== "function") {
+    throw new Error(`${name} did not register a render`);
+  }
+  return found as ToolRender;
+}
+
+const saveProcedureRender = () => cardRenderFor("saveLearnedProcedure");
+
+describe("classifySaveProcedureResult", () => {
+  it("reports pending while the card is unanswered", () => {
+    expect(classifySaveProcedureResult(undefined)).toBe("pending");
+    expect(classifySaveProcedureResult(null)).toBe("pending");
+    expect(classifySaveProcedureResult({ ok: true })).toBe("pending");
+    expect(classifySaveProcedureResult("   ")).toBe("pending");
+  });
+
+  it("separates the two directives that both settle as strings", () => {
+    expect(classifySaveProcedureResult(SAVE_PROCEDURE_CONFIRMED)).toBe("saved");
+    expect(classifySaveProcedureResult(SAVE_PROCEDURE_DECLINED)).toBe(
+      "declined",
+    );
+  });
+
+  it("never guesses 'saved' for a string it cannot explain", () => {
+    expect(classifySaveProcedureResult("ok")).toBe("unknown");
+    expect(classifySaveProcedureResult("The user said no thanks.")).toBe(
+      "unknown",
+    );
+    expect(classifySaveProcedureResult("They declined.")).toBe("declined");
+  });
+});
+
+/**
+ * THREE real steps, two of whose labels carry a numeral-dot-space the old
+ * derivation scored as a step of its own ("1. " and "2. ") — five matches for
+ * three steps. Step labels interpolate free text from the ledger (promotion and
+ * product names), so a rename is all it takes to get there.
+ */
+const DECIMAL_STEPS = [
+  "Marked Cedar Hoodie down to $1. 50 under the floor",
+  "Filed a MARGIN-EXEC-OK margin waiver on Cedar Hoodie 2. 0 markdown",
+  "Approved the markdown on Cedar Hoodie autumn markdown",
+];
+
+/**
+ * The step count is REPORTED by the recorder, never recounted from the directive
+ * it wrote. The card used to count `/\d+\.\s/` matches in that prose, so a step
+ * label carrying a numeral-dot-space added a step that does not exist — and the
+ * count is the claim beat 6 rests on.
+ */
+describe("the demonstration directive (beat 6)", () => {
+  it("reports the true count when a step label contains a numeral-dot-space", () => {
+    const directive = buildDemonstrationDirective({
+      steps: DECIMAL_STEPS,
+      code: "MARGIN-EXEC-OK",
+    });
+
+    expect(readDemonstratedStepCount(directive)).toBe(3);
+    // The shape the old derivation read, proving the labels really do carry the
+    // numerals that inflated it: five matches for three steps.
+    expect((directive.match(/\d+\.\s/g) ?? []).length).toBe(5);
+  });
+
+  it("is unchanged for ordinary steps, and counts one step singular", () => {
+    expect(
+      readDemonstratedStepCount(
+        buildDemonstrationDirective({
+          steps: ["Opened Promotions", "Approved the markdown"],
+          code: null,
+        }),
+      ),
+    ).toBe(2);
+    const one = buildDemonstrationDirective({
+      steps: ["Approved the markdown"],
+      code: null,
+    });
+    expect(one).toContain("after 1 step.");
+    expect(readDemonstratedStepCount(one)).toBe(1);
+  });
+
+  it("reports zero rather than nothing when the recorder caught nothing", () => {
+    const empty = buildDemonstrationDirective({ steps: [], code: null });
+    expect(empty).toContain("(nothing captured)");
+    expect(readDemonstratedStepCount(empty)).toBe(0);
+  });
+
+  it("keeps the observed list and the waiver code the agent needs", () => {
+    const directive = buildDemonstrationDirective({
+      steps: ["Opened Promotions", "Filed a waiver"],
+      code: "MARGIN-EXEC-OK",
+    });
+
+    expect(directive).toContain("1. Opened Promotions");
+    expect(directive).toContain("2. Filed a waiver");
+    expect(directive).toContain(
+      "The waiver code they used was MARGIN-EXEC-OK.",
+    );
+    expect(buildDemonstrationDirective({ steps: ["x"], code: null })).toContain(
+      "No waiver code was captured.",
+    );
+  });
+
+  it("claims no count for a string that never reported one", () => {
+    // A thread recorded before this contract, and anything else that settles it.
+    expect(
+      readDemonstratedStepCount(
+        "The user finished. Observed steps:\n1. Opened",
+      ),
+    ).toBeNull();
+    expect(readDemonstratedStepCount(undefined)).toBeNull();
+    expect(readDemonstratedStepCount("1. one 2. two")).toBeNull();
+  });
+});
+
+describe("awaitDemonstration card (beat 6)", () => {
+  afterEach(() => {
+    cleanup();
+    renders.clear();
+  });
+
+  it("prints the reported count, not one recounted from the prose", () => {
+    const settled = buildDemonstrationDirective({
+      steps: DECIMAL_STEPS,
+      code: "MARGIN-EXEC-OK",
+    });
+    const demoRender = cardRenderFor("awaitDemonstration");
+    render(<>{demoRender({ result: settled })}</>);
+
+    expect(screen.getByText(/Recorded 3 steps\./)).toBeTruthy();
+    expect(screen.queryByText(/5 steps/)).toBeNull();
+  });
+
+  it("stays vague rather than guessing for a directive with no count", () => {
+    const demoRender = cardRenderFor("awaitDemonstration");
+    render(<>{demoRender({ result: "The user finished. Observed steps:" })}</>);
+
+    expect(screen.getByText(/Recorded the demonstration\./)).toBeTruthy();
+  });
+});
+
+describe("saveLearnedProcedure card (beat 6)", () => {
+  afterEach(() => {
+    cleanup();
+    renders.clear();
+  });
+
+  it("offers both choices while unanswered", () => {
+    const cardRender = saveProcedureRender();
+    render(<>{cardRender({ args: { procedure: "1. File a waiver" } })}</>);
+
+    expect(screen.getByText(/File a waiver/)).toBeTruthy();
+    expect(screen.getByText(/Remember it/)).toBeTruthy();
+    expect(screen.getByText(/Don’t save/)).toBeTruthy();
+  });
+
+  it("shows the saved receipt only when the user confirmed", () => {
+    const cardRender = saveProcedureRender();
+    render(<>{cardRender({ result: SAVE_PROCEDURE_CONFIRMED })}</>);
+
+    expect(screen.getByText(/Saved\./)).toBeTruthy();
+  });
+
+  // THE REGRESSION. Both buttons settle this tool with a string, so a render
+  // that branches on `typeof result === "string"` claims a durable write after
+  // "Don't save" — live, and again on every thread replay.
+  it("does NOT claim a durable write after the user declined", () => {
+    const cardRender = saveProcedureRender();
+    render(<>{cardRender({ result: SAVE_PROCEDURE_DECLINED })}</>);
+
+    expect(screen.queryByText(/Saved\./)).toBeNull();
+    expect(screen.queryByText(/use this next time/)).toBeNull();
+    expect(screen.getByText(/nothing was written to memory/)).toBeTruthy();
+  });
+
+  it("asserts neither outcome for a result it cannot explain", () => {
+    const cardRender = saveProcedureRender();
+    render(<>{cardRender({ result: "something else entirely" })}</>);
+
+    expect(screen.queryByText(/Saved\./)).toBeNull();
+    expect(screen.getByText(/already answered/)).toBeTruthy();
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/teach-mode-directives.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/teach-mode-directives.ts
@@ -1,0 +1,115 @@
+/**
+ * BEAT 6 — the strings the teach chain's cards settle with, and the rules that
+ * read them back: the demonstration directive (written by the recorder, read by
+ * the "Recorded N steps" card) and the two `respond()` directives for the "shall
+ * I remember it?" card with the rule that classifies which one came back.
+ *
+ * Server-safe and React-free on purpose: these readers are the pieces of those
+ * cards worth a unit test, and a pure module is testable without mounting a
+ * provider, a thread and an agent registration.
+ *
+ * The rule the whole file exists to hold: a card states only what its producer
+ * REPORTED. It never re-derives a fact by parsing the rendering — see each
+ * reader's note for the bug that rule was written after.
+ *
+ * Why a classifier at all. BOTH buttons settle the tool with a string — "save
+ * it" and "don't save" alike — so `typeof result === "string"` tells you the
+ * card was answered and NOTHING about the answer. Branching on mere presence
+ * printed the "Saved. I'll use this next time" receipt after a presenter clicked
+ * "Don't save", asserting a durable write that never happened, and it
+ * mis-rendered the same way on thread replay — which is exactly when beat 2 is
+ * on screen. This is the misclassification the `issueRefund` card in `tools.tsx`
+ * documents and forbids; the payoff of the teach-a-procedure beat is the one
+ * place it must not happen.
+ *
+ * The payloads live here beside the classifier so the two cannot drift apart:
+ * change a directive string and the matcher that reads it is in view.
+ */
+
+/**
+ * BEAT 6, the demonstration hand-off: the directive `awaitDemonstration` settles
+ * with, and the ONE way to read its step count back out.
+ *
+ * The recorder KNOWS how many steps it captured, so the directive REPORTS that
+ * number and the card prints the reported number. The card used to re-derive it
+ * by counting `/\d+\.\s/` matches in this very prose, which also counts any
+ * numeral-dot-space a step LABEL happens to contain: a recorded
+ * `Marked down Aurora Throw to 1. 50 under the floor` or
+ * `Filed waiver MARGIN-EXEC-OK at 12.5 % margin` each added a phantom step, so
+ * the card announced more steps than the list printed under it — in the one beat
+ * whose whole claim is that the recording is faithful.
+ *
+ * The count has to travel INSIDE the directive because that string is all the
+ * card has on thread replay: the recording context is live-session state and is
+ * empty by the time a reopened thread re-renders this card (rule 3 in
+ * `tools.tsx`). Builder and reader therefore sit together — the wording below and
+ * the pattern that reads it must never drift apart, and `teach-mode-directives.test`
+ * round-trips them so they cannot.
+ */
+export function buildDemonstrationDirective({
+  steps,
+  code,
+}: {
+  /** The observed step labels, in order, exactly as the recorder captured them. */
+  steps: string[];
+  /** The waiver code the human actually filed, or `null` if none was captured. */
+  code: string | null;
+}): string {
+  const observed = steps
+    .map((label, index) => `${index + 1}. ${label}`)
+    .join("\n");
+  return (
+    `The user finished after ${steps.length} ${steps.length === 1 ? "step" : "steps"}. ` +
+    `Observed steps:\n${observed || "(nothing captured)"}\n` +
+    (code
+      ? `The waiver code they used was ${code}.`
+      : "No waiver code was captured.")
+  );
+}
+
+/**
+ * The step count the directive above REPORTED, or `null` for any string that
+ * carries none — a directive recorded before this contract existed, or a
+ * paraphrase. `null` means "say nothing about a count", never "zero".
+ *
+ * Anchored at the START of the result on purpose: the count is read only from the
+ * sentence the recorder wrote, so nothing inside a free-text step label can be
+ * mistaken for it.
+ */
+export function readDemonstratedStepCount(result: unknown): number | null {
+  if (typeof result !== "string") return null;
+  const match = /^The user finished after (\d+) steps?\./.exec(result.trim());
+  return match ? Number(match[1]) : null;
+}
+
+/** Settles the card when the user confirms. Directs the agent to persist. */
+export const SAVE_PROCEDURE_CONFIRMED =
+  "The user confirmed. Persist this with save_memory now (scope 'user', kind 'operational'), then say in one sentence that you have it.";
+
+/** Settles the card when the user declines. Forbids the durable write. */
+export const SAVE_PROCEDURE_DECLINED =
+  "The user declined to save it. Do not call save_memory.";
+
+/**
+ * `pending` — not answered yet (render the live card).
+ * `saved` — the user confirmed; the procedure was persisted.
+ * `declined` — the user refused; NOTHING was written.
+ * `unknown` — settled with a string neither directive explains. Never rendered
+ * as a success: an unrecognized settle is not evidence of a write.
+ */
+export type SaveProcedureOutcome = "pending" | "saved" | "declined" | "unknown";
+
+export function classifySaveProcedureResult(
+  result: unknown,
+): SaveProcedureOutcome {
+  if (typeof result !== "string") return "pending";
+  const text = result.trim();
+  if (text.length === 0) return "pending";
+  if (text === SAVE_PROCEDURE_CONFIRMED) return "saved";
+  if (text === SAVE_PROCEDURE_DECLINED) return "declined";
+  // Tolerate a paraphrase, but never GUESS "saved": a decline reads as a
+  // decline, and only an explicit confirmation earns the receipt.
+  if (/declined|do not call save_memory/i.test(text)) return "declined";
+  if (/confirmed/i.test(text) && /save_memory/i.test(text)) return "saved";
+  return "unknown";
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/theme.css
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/theme.css
@@ -1,0 +1,212 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   Bellwether — commerce operations. Skin-scoped VALUES for the shell's shared
+   token vocabulary (names declared in src/app/globals.css; never invent new
+   ones).
+
+   PALETTE RATIONALE. The five shipped skins already own violet (banking 252),
+   cyan (airline 190), amber (logistics 32), teal (keel 170) and plum (people
+   315). Deep ink blue (206) is the remaining hue that reads as INFRASTRUCTURE
+   rather than as a consumer brand — which is the point: this is the back office
+   behind a storefront, not the storefront. It is dark and only moderately
+   saturated (206 72% 30%) so the one genuinely loud colour on any screen is the
+   markdown accent below.
+
+   `--brand-violet` is repurposed as Bellwether's MARKDOWN accent — a hot rose
+   (336 78% 44%) reserved for discounts, promotions and anything a merchandiser
+   is being asked to sign off on. That is the same move keel makes with amber and
+   people makes with gold. The shell only cares that the token resolves; what it
+   MEANS is the skin's business. Reserving it this narrowly is what lets a
+   markdown chip be spotted from the back of a room.
+
+   `--negative` is pulled to a warm red (4) and kept far from both the ink brand
+   and the rose accent in hue, so "below the margin floor" can never be mistaken
+   for "on promotion".
+   ────────────────────────────────────────────────────────────────────────── */
+.theme-commerce {
+  /* Crisper than people's 0.875rem: this is a trading console, and softened
+     corners on dense numeric tables read as a consumer app pretending to be
+     one. Still short of logistics' utilitarian 0.5rem. */
+  --radius: 0.625rem;
+
+  /* Dark-mode OPT-IN. src/hooks/use-theme.ts forces any skin WITHOUT this flag
+     to light and ignores the stored preference, which would make the layout's
+     ThemeToggle a dead control. The `.dark .theme-commerce` block below is only
+     live because this is set. */
+  --nw-dark-capable: 1;
+
+  --brand: 206 72% 30%;
+  --brand-indigo: 210 66% 21%;
+  /* 44%, not 50%. Both uses are small text — a `text-[0.74rem] font-medium`
+     figure in pages/promotions.tsx and a `text-[0.68rem]` chip in
+     components/primitives.tsx — so the bar is WCAG AA's 4.5:1, and the CHIP does
+     not sit on the bare card: the markdown Pill is `bg-brand-violet/12
+     text-brand-violet`, i.e. the rose reads against a 12% wash of ITSELF
+     composited over `--surface`. That ground is darker than the card, so the
+     card measurement flatters it. At 50% the figure cleared 4.52:1 on the card
+     while the chip was only 3.75:1 — a fail that a card-only measurement called
+     a pass. 44% buys 4.60:1 on the chip's real ground and 5.60:1 on the card,
+     hue and saturation untouched: the same hot rose, one step deeper.
+     `theme.test.ts` computes BOTH grounds. */
+  --brand-violet: 336 78% 44%;
+  --brand-foreground: 0 0% 100%;
+  --brand-soft: 206 62% 95%;
+
+  --background: 210 30% 99%;
+  --foreground: 212 32% 12%;
+  --canvas: 210 22% 95%;
+  --surface: 0 0% 100%;
+  --surface-muted: 210 26% 97%;
+  --ink: 212 32% 12%;
+  --ink-muted: 210 12% 44%;
+  --hairline: 210 20% 89%;
+
+  --positive: 162 58% 33%;
+  --positive-soft: 162 48% 94%;
+  --negative: 4 74% 48%;
+  --negative-soft: 4 84% 96%;
+}
+
+/* DARK. `.dark` lands on <html>, an ancestor of the `.theme-commerce` root, so
+   this re-values only what differs — surfaces, ink, hairline and the semantic
+   pairs — and lets `--radius` inherit from the light block. The ink brand has to
+   be lifted here: at 30% lightness it disappears against a dark surface, where
+   in light mode it is the anchor.
+
+   CONTRAST. A lifted `--brand` FLIPS the polarity of every pair it anchors, and
+   the two directions pull against each other, so both halves have to move here:
+
+   - `--brand` is a FILL under `--brand-foreground` (every primary button:
+     `bg-brand text-brand-foreground`). White on the lifted brand measures only
+     2.60:1 — the labels are small and semibold, so the applicable WCAG AA bar is
+     4.5:1, not 3:1. Darkening `--brand` back toward the light value is NOT the
+     fix: `--brand` is simultaneously TEXT on `--brand-soft` (nav active state,
+     brand pills, `activeSelectClass`), and at 40% lightness that pair collapses
+     to 2.70:1. So the brand stays lifted and `--brand-foreground` becomes a deep
+     ink in the brand's own hue — the move logistics already makes in light mode
+     for its bright amber (`--brand-foreground: 30 50% 10%`). 6.70:1.
+   - `--brand-violet` is TEXT on `--brand-soft` wherever the shared chrome opts
+     the rose accent into dark mode (`dark:focus:text-brand-violet` in
+     dropdown-menu / select, `dark:text-brand-violet` on avatar initials and the
+     secondary/ghost/link buttons). At 62% that measured 3.65:1. Lifting the rose
+     to 70% clears 4.5:1 (4.70:1) while leaving `--brand-soft` alone, so the nav
+     tint, pill fills and progress track are visually unchanged. Hue and
+     saturation are untouched: it is the same hot rose, one step brighter for a
+     dark ground.
+
+   `src/skins/commerce/theme.test.ts` computes these ratios from this file and
+   fails if either regresses — a contrast regression is invisible to typecheck,
+   lint and every other test. */
+.dark .theme-commerce {
+  color-scheme: dark;
+
+  --background: 212 26% 8%;
+  --foreground: 210 24% 94%;
+  --canvas: 212 26% 8%;
+  --surface: 212 22% 12%;
+  --surface-muted: 212 20% 15%;
+  --ink: 210 24% 94%;
+  --ink-muted: 210 10% 60%;
+  --hairline: 212 14% 22%;
+
+  --brand: 202 76% 58%;
+  --brand-indigo: 206 60% 44%;
+  --brand-foreground: 206 60% 10%;
+  --brand-soft: 206 40% 20%;
+
+  --brand-violet: 336 76% 70%;
+
+  --positive: 162 50% 48%;
+  --positive-soft: 162 32% 15%;
+  --negative: 4 78% 62%;
+  --negative-soft: 4 40% 18%;
+}
+
+/* ── Signature: the margin ladder ────────────────────────────────────────────
+   The one element this skin is meant to be remembered by. Each category is a
+   vertical rail running from that category's MARGIN FLOOR (bottom) to a shared
+   ceiling (top); every product is a dot at its real gross margin. Kept in CSS
+   rather than Tailwind because the gradient direction and the below-floor pulse
+   both need to follow the live tokens. */
+.bw-rail {
+  /* Ink only, deepening upward — healthy margin is "further up the rail". An
+     earlier version graded into the rose markdown accent at the top, which read
+     as though high margin were itself a promotion. The floor is now marked by a
+     discrete line instead, which says "this is the edge" without recolouring the
+     whole rail. */
+  background-image: linear-gradient(
+    to top,
+    hsl(var(--brand) / 0.07) 0%,
+    hsl(var(--brand) / 0.28) 100%
+  );
+}
+
+/* The margin floor. A short solid line in the negative tone, because crossing it
+   downward is the thing that makes a SKU actionable — this is the one place a
+   rail earns a warning colour. */
+.bw-rail-floor {
+  background-color: hsl(var(--negative) / 0.8);
+}
+
+/* The planned margin for the category. Quiet — it is a reference, not an alarm. */
+.bw-rail-target {
+  background-color: hsl(var(--ink-muted) / 0.35);
+}
+
+/* A product trading below its floor gets a ring that breathes twice on mount — a
+   visible affordance the audience can catch from the back of a room without it
+   animating forever. */
+@keyframes bw-flag-in {
+  0% {
+    box-shadow: 0 0 0 0 hsl(var(--negative) / 0.55);
+  }
+
+  70% {
+    box-shadow: 0 0 0 7px hsl(var(--negative) / 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 hsl(var(--negative) / 0);
+  }
+}
+
+.bw-flag {
+  animation: bw-flag-in 1.4s ease-out 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bw-flag {
+    animation: none;
+    outline: 2px solid hsl(var(--negative));
+    outline-offset: 2px;
+  }
+}
+
+/* BEAT 6 — the recording vignette. A slow breathe on the canvas edge so a room
+   can see that Bellwether is watching the demonstration, without a spinner or a
+   modal stealing focus from the thing being demonstrated. */
+@keyframes bw-record-breathe {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Keep the border — it carries the "recording" signal — drop the pulse. */
+  [style*="bw-record-breathe"] {
+    animation: none !important;
+    opacity: 0.85 !important;
+  }
+}
+
+/* Tabular figures everywhere a price, a margin, a unit count or a day-count is
+   shown, so columns of numbers line up and a changed digit is visible as a
+   change rather than as a reflow. */
+.bw-num {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/theme.test.ts
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/theme.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Contrast guard for Bellwether's token values.
+ *
+ * WHY THIS EXISTS. A skin owns only the VALUES behind the shell's shared token
+ * names, and the dark block re-values one side of a pair at a time. That is
+ * exactly how a foreground/background pair silently loses its contrast: lifting
+ * `--brand` for a dark ground FLIPS the polarity of every pair the brand
+ * anchors, and nothing else in this repo notices. A failing pair still
+ * type-checks, still lints, still renders, and still passes every other unit
+ * test — the button is simply unreadable. So the ratios are computed here,
+ * straight out of `theme.css`, and asserted.
+ *
+ * The file is parsed rather than imported because CSS custom properties are not
+ * a module: reading the real declarations is what makes this a guard on the
+ * shipped values and not a restatement of them.
+ *
+ * ── TWO WAYS THIS GUARD ITSELF WAS WRONG, both fixed here ────────────────────
+ *
+ * A contrast guard is only as good as the BACKGROUND it names, and a green check
+ * on the wrong ground actively suppresses investigation. Both of these shipped:
+ *
+ *  1. **It measured the wrong ground.** `--brand-violet` was asserted against
+ *     `--surface` and cited the markdown Pill as the thing that renders it — but
+ *     that Pill is `bg-brand-violet/12 text-brand-violet`, so the rose reads
+ *     against a 12% wash of ITSELF over the card, which is darker than the card.
+ *     The card said 4.52:1 (pass); the real ground said 3.75:1 (fail). Hence
+ *     `bg.alpha`/`bg.over` below: a tinted ground is COMPOSITED before measuring.
+ *  2. **Its citations rotted, so nothing could be checked.** Every `file:line`
+ *     was hand-written and every one of them was stale — the reader could not
+ *     find the site an assertion claimed to be about, which is how (1) survived.
+ *     Sites are now DERIVED: each pair carries the class-pair pattern that
+ *     renders it, the test greps for it, prints the line numbers it found, and
+ *     FAILS when a pattern finds nothing. A pair whose render site disappears can
+ *     no longer sit here looking like coverage.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const THEME_CSS = path.join(__dirname, "theme.css");
+/** `src/`, so a site can name a shell file as well as one of this skin's. */
+const SRC_ROOT = path.join(__dirname, "..", "..");
+
+/** An `H S% L%` token value, as `--brand: 202 76% 58%` declares it. */
+type Hsl = readonly [h: number, s: number, l: number];
+
+function hslToRgb([h, s, l]: Hsl): [number, number, number] {
+  const hue = ((h % 360) + 360) % 360;
+  const sat = s / 100;
+  const light = l / 100;
+  const c = (1 - Math.abs(2 * light - 1)) * sat;
+  const hp = hue / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  const [r, g, b] =
+    hp < 1
+      ? [c, x, 0]
+      : hp < 2
+        ? [x, c, 0]
+        : hp < 3
+          ? [0, c, x]
+          : hp < 4
+            ? [0, x, c]
+            : hp < 5
+              ? [x, 0, c]
+              : [c, 0, x];
+  const m = light - c / 2;
+  return [r + m, g + m, b + m];
+}
+
+/** An `r g b` triple in 0…1, which is what a composited ground is. */
+type Rgb = readonly [number, number, number];
+
+/** WCAG 2.x relative luminance. */
+function relativeLuminance(colour: Rgb): number {
+  const [r, g, b] = colour.map((channel) =>
+    channel <= 0.03928
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4),
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG 2.x contrast ratio between two opaque colours, 1:1 … 21:1. */
+function ratioRgb(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [lighter, darker] = la > lb ? [la, lb] : [lb, la];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** WCAG 2.x contrast ratio, 1:1 … 21:1. */
+export function contrastRatio(a: Hsl, b: Hsl): number {
+  return ratioRgb(hslToRgb(a), hslToRgb(b));
+}
+
+/**
+ * `hsl(var(--x) / a)` over an opaque ground, i.e. what the browser actually
+ * paints for a Tailwind `bg-<token>/<alpha>` utility. Text on a tinted chip reads
+ * against THIS, not against the card underneath it.
+ */
+export function composite(tint: Hsl, base: Hsl, alpha: number): Rgb {
+  const [tr, tg, tb] = hslToRgb(tint);
+  const [br, bg, bb] = hslToRgb(base);
+  const mix = (t: number, b: number) => alpha * t + (1 - alpha) * b;
+  return [mix(tr, br), mix(tg, bg), mix(tb, bb)];
+}
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Pull the `H S% L%` declarations out of one rule body. Only triplet-valued
+ * tokens are collected — `--radius`, `color-scheme` and the dark-capable flag
+ * are not colours and are deliberately skipped.
+ *
+ * The selector is anchored to the START OF A LINE and required to match EXACTLY
+ * once. An `indexOf(".theme-commerce {")` here used to find `.dark
+ * .theme-commerce {` as well, so reordering `theme.css` would silently retarget
+ * every light-mode assertion at the dark block — a guard that reports on a
+ * different rule than the one it names is worse than no guard.
+ */
+export function parseRule(css: string, selector: string): Record<string, Hsl> {
+  const opens = [
+    ...css.matchAll(new RegExp(`^${escapeRe(selector)}\\s*\\{`, "gm")),
+  ];
+  if (opens.length !== 1) {
+    throw new Error(
+      `theme.css must declare \`${selector}\` exactly once at the start of a line; found ${opens.length}`,
+    );
+  }
+  const open = css.indexOf("{", opens[0].index);
+  const close = css.indexOf("}", open);
+  const body = css.slice(open + 1, close);
+  if (body.includes("{")) {
+    throw new Error(
+      `\`${selector}\` has a nested block; this parser only reads flat rule bodies`,
+    );
+  }
+
+  const tokens: Record<string, Hsl> = {};
+  for (const [, name, value] of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    const hsl = value.trim().match(/^(-?[\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/);
+    if (hsl) tokens[name] = [Number(hsl[1]), Number(hsl[2]), Number(hsl[3])];
+  }
+  return tokens;
+}
+
+const css = readFileSync(THEME_CSS, "utf8");
+const lightTokens = parseRule(css, ".theme-commerce");
+const darkOverrides = parseRule(css, ".dark .theme-commerce");
+/** `.dark` is an ancestor of the theme root, so dark INHERITS what it omits. */
+const darkTokens = { ...lightTokens, ...darkOverrides };
+
+/**
+ * Where a pair is rendered, as the CLASS PAIR that renders it rather than a
+ * line number. Grepped at test time, so the citation cannot rot and an assertion
+ * whose render site disappears fails instead of quietly guarding nothing.
+ */
+type Site = { readonly file: string; readonly pattern: RegExp };
+
+const lineAt = (text: string, index: number) =>
+  text.slice(0, index).split("\n").length;
+
+/** `file:line` for every match of every pattern, in file order. */
+function findSites(sites: readonly Site[]): string[] {
+  return sites.flatMap(({ file, pattern }) => {
+    const text = readFileSync(path.join(SRC_ROOT, file), "utf8");
+    const re = new RegExp(
+      pattern.source,
+      pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+    );
+    return [...text.matchAll(re)].map(
+      (m) => `${file}:${lineAt(text, m.index)}`,
+    );
+  });
+}
+
+/**
+ * The pairs that carry TEXT in this skin. 4.5:1 is the bar for all of them: every
+ * label listed here is normal-size text (the primary buttons are
+ * `text-[0.75rem] font-semibold`, which is well under the 18.66px/bold cut-off
+ * that would let 3:1 apply).
+ *
+ * `bg` is the ground the text is actually PAINTED ON. When that ground is a
+ * Tailwind alpha tint (`bg-brand-violet/12`), give `alpha` + `over` so the ground
+ * is composited first — measuring against the card underneath a tint reports a
+ * ratio the user never sees, and reported it as a pass.
+ */
+type Pair = {
+  readonly fg: string;
+  readonly bg: {
+    readonly token: string;
+    /** Set together: `token` at `alpha` composited over `over`. */
+    readonly alpha?: number;
+    readonly over?: string;
+  };
+  /** What renders it, in prose. Line numbers come from `sites`, never from here. */
+  readonly label: string;
+  /** Class-pair patterns that locate the render sites. Omitted for diffuse pairs. */
+  readonly sites?: readonly Site[];
+  /** Omitted = asserted in both modes. Set when only one mode renders it. */
+  readonly modes?: ReadonlyArray<"light" | "dark">;
+};
+
+const COMMERCE = "skins/commerce";
+
+const TEXT_PAIRS: readonly Pair[] = [
+  {
+    fg: "--brand-foreground",
+    bg: { token: "--brand" },
+    label: "every primary button (`bg-brand text-brand-foreground`)",
+    sites: [
+      `${COMMERCE}/tools.tsx`,
+      `${COMMERCE}/pages/promotions.tsx`,
+      `${COMMERCE}/pages/returns.tsx`,
+    ].map((file) => ({
+      file,
+      pattern: /\bbg-brand\b[^"]*\btext-brand-foreground\b/,
+    })),
+  },
+  {
+    fg: "--brand",
+    bg: { token: "--brand-soft" },
+    label: "brand pills, the active nav item, agent-set filter/sort controls",
+    sites: [
+      `${COMMERCE}/components/primitives.tsx`,
+      `${COMMERCE}/layout.tsx`,
+      "shell/layout/selector-card.tsx",
+    ].map((file) => ({
+      file,
+      pattern: /\bbg-brand-soft\b[^"]*\btext-brand(?![\w-])/,
+    })),
+  },
+  {
+    // DARK ONLY — every one of these sites pairs brand-soft with
+    // `text-brand-indigo` in light mode and reaches for the rose exclusively
+    // behind a `dark:` variant, so a light-mode assertion here would guard a
+    // combination that never renders. The pattern encodes exactly that: a
+    // brand-soft ground and a `dark:`-gated rose label on the same element.
+    fg: "--brand-violet",
+    bg: { token: "--brand-soft" },
+    modes: ["dark"],
+    label:
+      "shared chrome's dark rose on brand-soft: dropdown/select focus rows, avatar initials, secondary + ghost button labels",
+    sites: [
+      "components/ui/dropdown-menu.tsx",
+      "components/ui/select.tsx",
+      "components/ui/avatar.tsx",
+      "components/ui/button.tsx",
+    ].map((file) => ({
+      file,
+      pattern: /\bbg-brand-soft\b[^"]*\bdark:(?:\w+:)?text-brand-violet\b/,
+    })),
+  },
+  {
+    // The markdown Pill. Its ground is a 12% wash of the rose over the card, NOT
+    // the card: this is the pair the old card-only assertion mis-measured as
+    // 4.52:1 when the rendered ratio was 3.75:1.
+    fg: "--brand-violet",
+    bg: { token: "--brand-violet", alpha: 0.12, over: "--surface" },
+    label:
+      "the markdown Pill — `bg-brand-violet/12 text-brand-violet` at text-[0.68rem], on a bg-surface Panel",
+    sites: [
+      {
+        file: `${COMMERCE}/components/primitives.tsx`,
+        pattern: /bg-brand-violet\/12[^"]*text-brand-violet\b/,
+      },
+    ],
+  },
+  {
+    // The rose on the bare card: the small markdown figure on a promotions row.
+    // (`Metric`'s markdown figure is `text-xl font-semibold`, i.e. WCAG large
+    // text at 3:1, so this 4.5:1 bar is set by this small use.)
+    fg: "--brand-violet",
+    bg: { token: "--surface" },
+    label: "the small markdown price figure on a promotions row",
+    sites: [
+      {
+        file: `${COMMERCE}/pages/promotions.tsx`,
+        pattern: /font-medium text-brand-violet\b/,
+      },
+    ],
+  },
+  {
+    // The "why" slot on the margin-summary tool card: ink on a 10% rose wash.
+    fg: "--ink",
+    bg: { token: "--brand-violet", alpha: 0.1, over: "--surface" },
+    label: "the rose `why` note on a tool card",
+    sites: [
+      {
+        file: `${COMMERCE}/tools.tsx`,
+        pattern: /bg-brand-violet\/10[^"]*text-ink\b/,
+      },
+    ],
+  },
+  // Diffuse pairs: no single render site to cite, so none is claimed.
+  { fg: "--ink", bg: { token: "--surface" }, label: "every card body" },
+  {
+    fg: "--ink-muted",
+    bg: { token: "--surface" },
+    label: "every label and hint",
+  },
+  { fg: "--ink", bg: { token: "--canvas" }, label: "page background" },
+  { fg: "--ink-muted", bg: { token: "--canvas" }, label: "page background" },
+  { fg: "--foreground", bg: { token: "--background" }, label: "document root" },
+];
+
+/*
+ * DELIBERATE EXCLUSIONS, so the list above is not read as "everything passes".
+ * Each of these was measured and each is a pre-existing, TWO-sided choice rather
+ * than the one-sided dark override this guard is about:
+ *
+ * - `--positive` on `--positive-soft`: 4.12:1 light, 5.47:1 dark.
+ * - `--negative` on `--negative-soft`: 4.41:1 light, 4.33:1 dark.
+ *   Both tone-chip pairs are short of 4.5:1 in LIGHT mode too, i.e. they are not
+ *   a dark-mode regression, and the same treatment is short in all six skins.
+ *   Moving them is a palette decision across the set, not a fix to this file.
+ * - `--brand-indigo` on `--brand-soft`: 11.10:1 light, 2.70:1 dark. Fails in
+ *   dark in EVERY dark-capable skin (banking 2.75, keel 1.21, logistics 2.43,
+ *   people 2.62), which is why the shared chrome MOSTLY pairs brand-soft with a
+ *   `dark:`-gated `--brand-violet` ink instead — the pair asserted above. It does
+ *   NOT do so everywhere, and the un-overridden remainder INCLUDES REAL TEXT:
+ *   `button.tsx`'s `outline` variant re-inks its LABEL to `--brand-indigo` on
+ *   hover with no dark counterpart. An earlier version of this note claimed the
+ *   override was applied "at every text site" and that the sole holdout was a
+ *   non-text icon hover; both halves were false, and the wrong half was the
+ *   reassuring one. The holdouts are therefore no longer described in prose:
+ *   `UN_OVERRIDDEN_BRAND_SOFT_INK` below names them, and a test derives the real
+ *   set from the shared chrome and fails if it grows OR if a listed one is fixed.
+ *   Correcting them is still shell-wide work (five skins paint these) and out of
+ *   this skin's reach — but the gap is now recorded rather than denied.
+ * - `Metric`'s markdown figure (`text-xl font-semibold text-brand-violet` on
+ *   `--surface-muted`) is WCAG LARGE text, so its bar is 3:1. It measures 5.42:1
+ *   light / 6.02:1 dark, i.e. it also clears the stricter bar — it is listed here
+ *   rather than asserted because the bar that applies to it is not this file's.
+ * - The markdown Pill is only ever mounted inside a `bg-surface` Panel
+ *   (pages/promotions.tsx, catalog/renderers.tsx). Its wash over the two other
+ *   grounds would be 4.31:1 (`--surface-muted`) and 4.13:1 (`--canvas`), so
+ *   moving it onto a muted panel WOULD need the rose deepened again. There is no
+ *   static way to assert where a component is mounted; this note is the record.
+ */
+
+/*
+ * ── The un-overridden `--brand-indigo` on `--brand-soft` holdouts ────────────
+ *
+ * The exclusion note above used to assert a completeness claim by hand ("at every
+ * text site", "the one remaining un-overridden site"), and both halves were
+ * wrong. Hand-written coverage claims in this file have now been wrong twice —
+ * the rotted `file:line` citations were the first time — so this one is DERIVED
+ * the same way the render sites are: the scan below finds the real holdouts and
+ * the list is only allowed to say which ones are known.
+ *
+ * NOT a contrast assertion. These pairs deliberately do not clear 4.5:1 in dark,
+ * the fix is shell-wide, and this skin may not make it. What is asserted is that
+ * the KNOWN SET IS THE REAL SET, in both directions: a new holdout fails, and a
+ * holdout somebody fixes fails too, so nobody has to trust the prose.
+ */
+
+/** Shared chrome: every non-test source file under `src/` outside `src/skins/`. */
+function sharedChromeFiles(): string[] {
+  return readdirSync(SRC_ROOT, { recursive: true, encoding: "utf8" })
+    .map((rel) => rel.split(path.sep).join("/"))
+    .filter((rel) => /\.tsx?$/.test(rel) && !/\.(test|spec)\./.test(rel))
+    .filter((rel) => !rel.startsWith("skins/"))
+    .sort();
+}
+
+/**
+ * `file:line` for every shared-chrome class string that inks `--brand-indigo` on
+ * a `--brand-soft` ground and does NOT re-ink it behind a `dark:` variant.
+ *
+ * Line-scoped because every such class string in this tree is written on one
+ * line; a multi-line `cn()` argument would escape the scan, which is why the
+ * declared list below is checked to still MATCH rather than merely be believed.
+ */
+function unOverriddenBrandSoftInk(): string[] {
+  const overridden = /\bdark:[^\s"'`]*text-brand-violet\b/;
+  return sharedChromeFiles().flatMap((file) =>
+    readFileSync(path.join(SRC_ROOT, file), "utf8")
+      .split("\n")
+      .flatMap((text, index) =>
+        /\btext-brand-indigo\b/.test(text) &&
+        /\bbg-brand-soft\b/.test(text) &&
+        !overridden.test(text)
+          ? [`${file}:${index + 1}`]
+          : [],
+      ),
+  );
+}
+
+/**
+ * The holdouts as of this commit, each with what it costs. Both are shell chrome
+ * shared by five skins, so neither is this file's to fix; both are on the
+ * follow-up list. Kept as `Site` patterns rather than line numbers for the reason
+ * the header gives: hand-written line numbers in this file rotted once already.
+ */
+const UN_OVERRIDDEN_BRAND_SOFT_INK: readonly (Site & { cost: string })[] = [
+  {
+    file: "components/ui/button.tsx",
+    pattern:
+      /border border-hairline bg-surface text-ink[^"]*hover:text-brand-indigo\b/,
+    // The `outline` variant's hovered LABEL — real text, and the half of the old
+    // claim that mattered. 2.75:1 in banking dark, 1.21:1 in keel dark.
+    cost: "an unreadable button label on hover, in dark, in five skins",
+  },
+  {
+    file: "components/ui/theme-toggle.tsx",
+    pattern: /text-ink-muted hover:bg-brand-soft hover:text-brand-indigo\b/,
+    // The theme toggle's hovered ICON. Non-text, so WCAG 1.4.3 does not reach it
+    // (1.4.11 would, at 3:1) — the lesser of the two, and the only one the old
+    // note admitted to.
+    cost: "a low-contrast icon on hover, in dark",
+  },
+];
+
+const AA_NORMAL_TEXT = 4.5;
+
+/** Resolve a pair's ground in one mode, compositing an alpha tint if declared. */
+function groundOf(pair: Pair, tokens: Record<string, Hsl>): Rgb | undefined {
+  const { token, alpha, over } = pair.bg;
+  const tint = tokens[token];
+  if (!tint) return undefined;
+  if (alpha === undefined || over === undefined) return hslToRgb(tint);
+  const base = tokens[over];
+  return base ? composite(tint, base, alpha) : undefined;
+}
+
+/** How the ground reads in a test name and a failure message. */
+const groundName = ({ bg }: Pair) =>
+  bg.alpha === undefined
+    ? bg.token
+    : `${bg.token}/${Math.round(bg.alpha * 100)} over ${bg.over}`;
+
+describe("Bellwether theme.css contrast", () => {
+  for (const [mode, tokens] of [
+    ["light", lightTokens],
+    ["dark", darkTokens],
+  ] as const) {
+    describe(mode, () => {
+      for (const pair of TEXT_PAIRS) {
+        const { fg, modes, label } = pair;
+        if (modes && !modes.includes(mode)) continue;
+        const bg = groundName(pair);
+        it(`${fg} on ${bg} clears WCAG AA for normal text (${label})`, () => {
+          const foreground = tokens[fg];
+          expect(foreground, `${fg} is not declared`).toBeDefined();
+          const background = groundOf(pair, tokens);
+          expect(background, `${bg} is not declared`).toBeDefined();
+
+          const ratio = ratioRgb(hslToRgb(foreground), background!);
+          expect(
+            ratio,
+            `${mode}: ${fg} (${foreground.join(" ")}) on ${bg} is ` +
+              `${ratio.toFixed(2)}:1, below ${AA_NORMAL_TEXT}:1`,
+          ).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+        });
+      }
+    });
+  }
+
+  describe("the pairs are the pairs that render", () => {
+    // The half of this guard that the hand-written `file:line` citations were
+    // supposed to be and were not: a pair whose class pair no longer appears
+    // anywhere is guarding a combination the app does not paint, and must fail
+    // rather than keep passing. The located lines are printed so the next reader
+    // can go and look — the thing the stale citations made impossible.
+    for (const pair of TEXT_PAIRS) {
+      if (!pair.sites) continue;
+      it(`still renders ${pair.fg} on ${groundName(pair)} somewhere`, () => {
+        const found = findSites(pair.sites!);
+        expect(
+          found,
+          `no source matches the class pair for ${pair.fg} on ${groundName(pair)} — ` +
+            `either the pattern is wrong or this pair no longer renders`,
+        ).not.toEqual([]);
+        console.info(`${pair.fg} on ${groundName(pair)}: ${found.join(", ")}`);
+      });
+    }
+  });
+
+  describe("the brand-soft ink holdouts are the holdouts we know about", () => {
+    // Guards the DELIBERATE EXCLUSIONS note, which twice claimed coverage it did
+    // not have. Nothing here asserts a ratio: the fix is shell-wide and out of
+    // this skin's reach. It asserts only that the note cannot understate the gap.
+
+    it("still finds each declared holdout where it says it is", () => {
+      for (const site of UN_OVERRIDDEN_BRAND_SOFT_INK) {
+        const found = findSites([site]);
+        expect(
+          found,
+          `${site.file} no longer matches the declared holdout pattern — either ` +
+            `it was restyled (drop it from UN_OVERRIDDEN_BRAND_SOFT_INK) or the ` +
+            `pattern rotted`,
+        ).not.toEqual([]);
+        console.info(
+          `brand-soft ink holdout: ${found.join(", ")} — ${site.cost}`,
+        );
+      }
+    });
+
+    it("finds no shared-chrome holdout the list does not name", () => {
+      const declared = new Set(
+        UN_OVERRIDDEN_BRAND_SOFT_INK.flatMap((site) => findSites([site])),
+      );
+      const undeclared = unOverriddenBrandSoftInk().filter(
+        (id) => !declared.has(id),
+      );
+      expect(
+        undeclared,
+        `shared chrome inks --brand-indigo on --brand-soft with no dark override ` +
+          `at a site the exclusion note does not admit to: ${undeclared.join(", ")}. ` +
+          `Add it to UN_OVERRIDDEN_BRAND_SOFT_INK (with what it costs) or give it ` +
+          `a dark:text-brand-violet counterpart.`,
+      ).toEqual([]);
+    });
+
+    it("keeps no holdout on the list after it is fixed", () => {
+      // The dead-exemption half. A list that only ever grows drifts back into
+      // overstating the gap the other way round, and a reader who checks one
+      // entry and finds it already fixed stops trusting the rest.
+      const live = new Set(unOverriddenBrandSoftInk());
+      const stale = UN_OVERRIDDEN_BRAND_SOFT_INK.flatMap((site) =>
+        findSites([site]).filter((id) => !live.has(id)),
+      );
+      expect(
+        stale,
+        `these are listed as un-overridden but now carry a dark override (or no ` +
+          `longer sit on brand-soft): ${stale.join(", ")}. Remove them.`,
+      ).toEqual([]);
+    });
+  });
+
+  it("reads the light block even if theme.css is reordered", () => {
+    // `indexOf(".theme-commerce {")` also matches inside `.dark .theme-commerce
+    // {`, so with the dark rule first every light assertion silently moved to the
+    // dark block. Anchoring to a line start is what makes the lookup positional-
+    // independent; this proves it on a reordered file rather than on ours.
+    const reordered = [
+      ".dark .theme-commerce {",
+      "  --brand: 1 1% 1%;",
+      "}",
+      ".theme-commerce {",
+      "  --brand: 2 2% 2%;",
+      "}",
+    ].join("\n");
+    expect(parseRule(reordered, ".theme-commerce")["--brand"]).toEqual([
+      2, 2, 2,
+    ]);
+    expect(parseRule(reordered, ".dark .theme-commerce")["--brand"]).toEqual([
+      1, 1, 1,
+    ]);
+  });
+
+  it("composites an alpha tint the way a browser paints it", () => {
+    // Fully opaque and fully transparent are the two ends the compositor must
+    // agree with, or every tinted ground above is measured against the wrong
+    // colour — which is exactly the bug this mechanism was added for.
+    const rose: Hsl = [336, 78, 44];
+    const white: Hsl = [0, 0, 100];
+    expect(composite(rose, white, 1)).toEqual(hslToRgb(rose));
+    expect(composite(rose, white, 0)).toEqual(hslToRgb(white));
+    // A tint of a colour over a LIGHTER base always reduces that colour's own
+    // contrast against the ground it sits on.
+    expect(ratioRgb(hslToRgb(rose), composite(rose, white, 0.12))).toBeLessThan(
+      contrastRatio(rose, white),
+    );
+  });
+
+  it("re-values --brand-foreground in dark, because dark lifts --brand", () => {
+    // The regression this whole file exists for: a dark block that lifts the
+    // brand fill and leaves the label colour behind. Asserting the OVERRIDE is
+    // present (not merely that the ratio happens to pass) is what stops the
+    // pairing from silently drifting apart again.
+    expect(darkOverrides["--brand"]).toBeDefined();
+    expect(darkOverrides["--brand-foreground"]).toBeDefined();
+  });
+
+  it("keeps the calculator honest against known WCAG values", () => {
+    // Black on white is exactly 21:1; a colour against itself is exactly 1:1.
+    expect(contrastRatio([0, 0, 0], [0, 0, 100])).toBeCloseTo(21, 5);
+    expect(contrastRatio([206, 72, 30], [206, 72, 30])).toBeCloseTo(1, 5);
+    // #767676 on white is the canonical 4.54:1 AA boundary grey.
+    expect(contrastRatio([0, 0, 46.3], [0, 0, 100])).toBeCloseTo(4.54, 1);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/tools-blank-needle.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/tools-blank-needle.test.tsx
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { CommerceStoreState, Operator } from "./data/types";
+import { CommerceTools } from "./tools";
+import { RecordingProvider } from "./components/recording-context";
+
+/**
+ * The write tools must REFUSE a blank record reference rather than mutate the
+ * first row in the ledger.
+ *
+ * `findOrder` / `findProduct` / `findReturn` each end in a substring match, and
+ * `"anything".includes("")` is true, so a blank needle used to resolve to
+ * `rows[0]`. The model supplies these needles from conversation, so blank is
+ * ordinary input — and `holdOrder`, `notifyCustomer` and `postOrderNote` are
+ * WRITE paths. The wrong-record write then came back as a success receipt naming
+ * a customer nobody had mentioned.
+ *
+ * The pure matching is covered in `data/find-record.test.ts`; this file pins the
+ * consequence at the tool boundary — no fetch, and a refusal in the result.
+ *
+ * `rows[0]` in the fixture below is Priya Raghavan, so "did not fall through to
+ * row 0" is assertable by name.
+ */
+
+const { LEDGER, OPERATOR, refresh, TOOLS } = vi.hoisted(() => {
+  const operator: Operator = {
+    id: "op-nadia",
+    name: "Nadia Okonjo",
+    role: "merch-lead",
+    team: "Merchandising",
+  };
+  const ledger: CommerceStoreState = {
+    products: [
+      {
+        id: "bw-1",
+        sku: "BW-CDR-HDY",
+        name: "Cedar Hoodie",
+        category: "Knitwear",
+        listPrice: 120,
+        unitCost: 70,
+        inventory: 400,
+        trailing30Units: 90,
+        status: "live",
+        vendor: "Cedar Mills",
+      },
+      {
+        id: "bw-2",
+        sku: "BW-ALD-THR",
+        name: "Alder Throw",
+        category: "Home",
+        listPrice: 90,
+        unitCost: 40,
+        inventory: 120,
+        trailing30Units: 30,
+        status: "live",
+        vendor: "Alder Co",
+      },
+    ],
+    floors: [],
+    orders: [
+      {
+        id: "ord-first",
+        number: "4412",
+        customerName: "Priya Raghavan",
+        customerEmail: "priya@example.com",
+        channel: "web",
+        destination: "Lisbon, PT",
+        placedAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+        status: "open",
+        exception: "none",
+        lines: [{ productId: "bw-1", quantity: 2, unitPrice: 40 }],
+        total: 80,
+        notes: [],
+      },
+      {
+        id: "ord-held",
+        number: "4463",
+        customerName: "Dana Reyes",
+        customerEmail: "dana@example.com",
+        channel: "retail",
+        destination: "Porto, PT",
+        placedAt: new Date(Date.now() - 5 * 86_400_000).toISOString(),
+        status: "open",
+        exception: "none",
+        lines: [{ productId: "bw-2", quantity: 1, unitPrice: 90 }],
+        total: 90,
+        notes: [],
+      },
+    ],
+    notifications: [],
+    returns: [],
+    promotions: [],
+    waivers: [],
+    plans: [],
+    operators: [operator],
+  };
+  return {
+    OPERATOR: operator,
+    LEDGER: ledger,
+    refresh: vi.fn(async () => true),
+    /** Every tool `CommerceTools` registers, captured by the mocked hooks. */
+    TOOLS: new Map<string, RegisteredTool>(),
+  };
+});
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+interface RegisteredTool {
+  name: string;
+  handler?: ToolHandler;
+}
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+  useComponent: () => {},
+  useFrontendTool: (config: RegisteredTool) => TOOLS.set(config.name, config),
+  useHumanInTheLoop: (config: RegisteredTool) => TOOLS.set(config.name, config),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("@/shell/skin-path", () => ({
+  useSkinHref: () => (path?: string) => path ?? "/",
+}));
+
+vi.mock("./data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: LEDGER,
+    refresh,
+    operator: OPERATOR,
+    setOperatorId: () => {},
+  }),
+}));
+
+const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+
+function handlerFor(name: string): ToolHandler {
+  const handler = TOOLS.get(name)?.handler;
+  if (!handler) throw new Error(`"${name}" registered no handler`);
+  return handler;
+}
+
+beforeEach(() => {
+  TOOLS.clear();
+  fetchMock.mockClear();
+  refresh.mockClear();
+  vi.stubGlobal("fetch", fetchMock);
+  render(
+    <RecordingProvider>
+      <CommerceTools />
+    </RecordingProvider>,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+/** Blank in every shape a model actually emits. */
+const BLANK = ["", "   ", "#"];
+
+describe("holdOrder — a blank order reference", () => {
+  it.each(BLANK)("refuses %j instead of holding row 0", async (order) => {
+    const result = await handlerFor("holdOrder")({
+      order,
+      reason: "fraud-review",
+    });
+    expect(String(result)).toMatch(/^No order matches/);
+    // The finding itself: nothing was written.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(String(result)).not.toContain("4412");
+    expect(String(result)).not.toContain("Priya");
+  });
+
+  it("still holds the order it was actually given", async () => {
+    const result = await handlerFor("holdOrder")({
+      order: "4463",
+      reason: "oversell",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("/api/commerce/v1/orders/ord-held");
+    expect(init.method).toBe("PATCH");
+    expect(String(result)).toContain("4463");
+  });
+});
+
+describe("notifyCustomer — a blank order reference", () => {
+  it.each(BLANK)("refuses %j instead of messaging row 0", async (order) => {
+    const result = await handlerFor("notifyCustomer")({
+      order,
+      template: "verification-required",
+    });
+    expect(String(result)).toMatch(/^No order matches/);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(String(result)).not.toContain("Priya");
+  });
+
+  it("still messages the customer it was actually given", async () => {
+    await handlerFor("notifyCustomer")({
+      order: "Dana",
+      template: "delay-apology",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toBe("/api/commerce/v1/orders/ord-held/notify");
+  });
+});
+
+describe("postOrderNote — a blank order reference", () => {
+  it.each(BLANK)("refuses %j instead of annotating row 0", async (order) => {
+    const result = await handlerFor("postOrderNote")({
+      order,
+      text: "Held pending verification.",
+    });
+    expect(String(result)).toMatch(/^No order matches/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still annotates the order it was actually given", async () => {
+    await handlerFor("postOrderNote")({ order: "#4463", text: "Looked at." });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toBe("/api/commerce/v1/orders/ord-held/notes");
+  });
+});
+
+describe("the read-only distractors", () => {
+  it.each(BLANK)(
+    "sendReviewRequest(%j) names no customer at all",
+    async (order) => {
+      const result = await handlerFor("sendReviewRequest")({ order });
+      expect(String(result)).not.toContain("Priya");
+      expect(String(result)).not.toContain("Dana");
+    },
+  );
+
+  it.each(BLANK)(
+    "openSupplierClaim(%j) names no product at all",
+    async (product) => {
+      const result = await handlerFor("openSupplierClaim")({
+        product,
+        detail: "Short-shipped.",
+      });
+      expect(String(result)).not.toContain("Cedar Hoodie");
+      expect(String(result)).not.toContain("Alder Throw");
+    },
+  );
+
+  it("still resolves a real product reference", async () => {
+    const result = await handlerFor("openSupplierClaim")({
+      product: "alder",
+      detail: "Short-shipped.",
+    });
+    expect(String(result)).toContain("Alder Throw");
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/tools.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/tools.test.tsx
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { DemonstrationCard, RefundCard } from "./tools";
+import { RecordingProvider } from "./components/recording-context";
+import type { ReturnRequest } from "./data/types";
+
+/**
+ * BEAT 3a's card, under failure. The original version did `setSaving(true)` and
+ * then awaited `onDone` bare: a rejected handler left the button reading
+ * "Issuing…" forever, with the human-in-the-loop interrupt unresolved and the
+ * agent run blocked behind it — and nothing on screen or in the console said so.
+ * The card is the last line of defence, so it is tested independently of whether
+ * its handlers keep their side of the bargain.
+ *
+ * No `@testing-library/jest-dom` in this app, so assertions are plain DOM.
+ */
+const request: ReturnRequest = {
+  id: "ret-1",
+  orderId: "ord-1",
+  orderNumber: "BW-1041",
+  customerName: "Dana Reyes",
+  productId: "sku-1",
+  reason: "damaged",
+  detail: "Arrived scuffed.",
+  requestedAt: new Date().toISOString(),
+  status: "requested",
+  itemValue: 120,
+  refundAmount: null,
+};
+
+type OnDone = (r: ReturnRequest, amount: number) => Promise<string | null>;
+
+function renderCard(
+  overrides: {
+    onDone?: OnDone;
+    onCancel?: () => Promise<string | null>;
+    find?: (needle: string) => ReturnRequest | undefined;
+  } = {},
+) {
+  const onDone: OnDone = overrides.onDone ?? vi.fn(async () => null);
+  const onCancel = overrides.onCancel ?? vi.fn(async () => null);
+  render(
+    <RefundCard
+      query="Dana"
+      find={overrides.find ?? (() => request)}
+      productName={() => "Alder Throw"}
+      onDone={onDone}
+      onCancel={onCancel}
+    />,
+  );
+  return { onDone, onCancel };
+}
+
+const button = (name: RegExp) =>
+  screen.getByRole("button", { name }) as HTMLButtonElement;
+const issueButton = () => button(/issue refund|issuing/i);
+const alertText = () => screen.queryByRole("alert")?.textContent ?? null;
+/** Every money figure in a string, so two renderings can be compared. */
+const moneyIn = (text: string) => text.match(/\$[\d,.]+/g) ?? [];
+
+/** Enter a valid goodwill figure so the submit button un-disables. */
+function typeAmount(amount: string) {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: amount } });
+}
+
+/** Click and let the handler's microtasks drain, so state settles inside act(). */
+async function clickAndSettle(el: HTMLElement) {
+  await act(async () => {
+    fireEvent.click(el);
+  });
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("RefundCard failure handling", () => {
+  it("leaves its saving state and surfaces the reason when onDone REJECTS", async () => {
+    const onDone = vi.fn(async () => {
+      throw new Error("Failed to fetch");
+    });
+    renderCard({ onDone });
+    typeAmount("40");
+    expect(issueButton().disabled).toBe(false);
+
+    await clickAndSettle(issueButton());
+
+    // (a) the button came back — it is not stuck on "Issuing…"
+    expect(issueButton().textContent).toBe("Issue refund");
+    expect(issueButton().disabled).toBe(false);
+    // (b) the failure is on screen rather than swallowed
+    expect(alertText()).toContain("Failed to fetch");
+    // (c) and it is retryable — the run is still waiting, so this is the user's
+    //     only way forward
+    await clickAndSettle(issueButton());
+    expect(onDone).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the sentence a handler returns when the interrupt could not be settled", async () => {
+    // What `settleInterrupt` hands back when `respond` is unavailable — a missing
+    // respond must never be a silent no-op.
+    const onDone: OnDone = vi.fn(
+      async () => "I couldn't hand that back to the assistant. Try again.",
+    );
+    renderCard({ onDone });
+    typeAmount("40");
+    await clickAndSettle(issueButton());
+
+    expect(alertText()).toContain("I couldn't hand that back to the assistant");
+    expect(issueButton().disabled).toBe(false);
+    expect(issueButton().textContent).toBe("Issue refund");
+  });
+
+  it("clears a previous failure on the next attempt", async () => {
+    const onDone = vi
+      .fn<OnDone>()
+      .mockResolvedValueOnce("first attempt failed")
+      .mockResolvedValueOnce(null);
+    renderCard({ onDone });
+    typeAmount("40");
+
+    await clickAndSettle(issueButton());
+    expect(alertText()).toContain("first attempt failed");
+
+    await clickAndSettle(issueButton());
+    expect(alertText()).toBeNull();
+  });
+
+  it("passes the typed figure through and shows nothing on success", async () => {
+    const { onDone } = renderCard();
+    typeAmount("$40.25");
+    await clickAndSettle(issueButton());
+
+    expect(onDone).toHaveBeenCalledWith(request, 40.25);
+    expect(alertText()).toBeNull();
+  });
+
+  it("disables both buttons while a refund is in flight", async () => {
+    let release: (() => void) | undefined;
+    const onDone: OnDone = () =>
+      new Promise<string | null>((resolve) => {
+        release = () => resolve(null);
+      });
+    renderCard({ onDone });
+    typeAmount("40");
+
+    await clickAndSettle(issueButton());
+    expect(issueButton().textContent).toBe("Issuing…");
+    expect(issueButton().disabled).toBe(true);
+    expect(button(/cancel/i).disabled).toBe(true);
+
+    await act(async () => release?.());
+    expect(issueButton().disabled).toBe(false);
+  });
+
+  it("surfaces a cancel that could not be settled, on both cancel paths", async () => {
+    const onCancel = vi.fn(async () => "cancel never reached the assistant");
+    renderCard({ onCancel });
+    await clickAndSettle(button(/cancel/i));
+    expect(alertText()).toContain("cancel never reached the assistant");
+
+    cleanup();
+    // The "no matching return" branch settles the interrupt too, and carries the
+    // same obligation to say when it could not.
+    renderCard({ onCancel, find: () => undefined });
+    await clickAndSettle(button(/close/i));
+    expect(alertText()).toContain("cancel never reached the assistant");
+  });
+});
+
+/**
+ * BEAT 6's waiting card had the same shape of bug: "I'm done" handed the observed
+ * steps to `respond?.(…)` and returned. With `respond` unavailable that is a
+ * no-op, so the teach chain stalled mid-recording with the button still inviting
+ * a click that could not work.
+ */
+describe("DemonstrationCard failure handling", () => {
+  const renderDemo = (onDone: (summary: string) => Promise<string | null>) =>
+    render(
+      <RecordingProvider>
+        <DemonstrationCard onDone={onDone} />
+      </RecordingProvider>,
+    );
+  const doneButton = () => button(/i.m done|saving/i);
+
+  it("leaves its saving state and surfaces the reason when onDone REJECTS", async () => {
+    const onDone = vi.fn(async () => {
+      throw new Error("stream closed");
+    });
+    renderDemo(onDone);
+
+    await clickAndSettle(doneButton());
+
+    expect(doneButton().disabled).toBe(false);
+    expect(doneButton().textContent).toBe("I’m done");
+    expect(alertText()).toContain("stream closed");
+    // Retryable: the teach chain can still be completed.
+    await clickAndSettle(doneButton());
+    expect(onDone).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows the sentence returned when the interrupt could not be settled", async () => {
+    renderDemo(async () => "I couldn't hand that back to the assistant.");
+    await clickAndSettle(doneButton());
+
+    expect(alertText()).toContain("I couldn't hand that back to the assistant");
+    expect(doneButton().disabled).toBe(false);
+  });
+
+  it("reports the observed steps and stays quiet on success", async () => {
+    const onDone = vi.fn<(summary: string) => Promise<string | null>>(
+      async () => null,
+    );
+    renderDemo(onDone);
+    await clickAndSettle(doneButton());
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    // The directive REPORTS the recorder's own count — nothing was logged in
+    // this render, so it says so rather than leaving the card to count prose.
+    expect(onDone.mock.calls[0][0]).toContain(
+      "The user finished after 0 steps.",
+    );
+    expect(onDone.mock.calls[0][0]).toContain("(nothing captured)");
+    expect(alertText()).toBeNull();
+  });
+});
+
+/**
+ * BEAT 3a's card, where its own INSTRUCTION meets its own rule.
+ *
+ * The bug: the placeholder printed `formatMoney(itemValue)` — rounded to whole
+ * dollars — while the button compared the typed amount EXACTLY against
+ * `itemValue`. A return charged $152.50 invited "up to $153", and typing 153 left
+ * the button silently disabled. Worse than a wrong number: the operator follows
+ * the app's own guidance on stage and the app refuses without saying why.
+ *
+ * No seeded return carries cents today (340, 96, 152, 96, 290), so this is the
+ * coverage that keeps a latent defect from becoming a live one.
+ */
+describe("RefundCard guidance and validation agree", () => {
+  const CENTS: ReturnRequest = { ...request, itemValue: 152.5 };
+  const amountInput = () => screen.getByRole("textbox") as HTMLInputElement;
+
+  it("accepts the figure its own placeholder invites", async () => {
+    const { onDone } = renderCard({ find: () => CENTS });
+    expect(amountInput().placeholder).toBe("up to $152.50");
+
+    // Exactly what an operator reading that placeholder would type.
+    typeAmount(amountInput().placeholder.replace(/[^0-9.]/g, ""));
+    expect(issueButton().disabled).toBe(false);
+
+    await clickAndSettle(issueButton());
+    expect(onDone).toHaveBeenCalledWith(CENTS, 152.5);
+    expect(alertText()).toBeNull();
+  });
+
+  it("prints ONE charged figure, and it is the placeholder's", () => {
+    renderCard({ find: () => CENTS });
+    const charged = screen.getByText(/^Charged/).textContent ?? "";
+    expect(moneyIn(charged)).toEqual(["$152.50"]);
+    expect(moneyIn(amountInput().placeholder)).toEqual(moneyIn(charged));
+  });
+
+  it("still refuses a cent over the exact ceiling", () => {
+    renderCard({ find: () => CENTS });
+    typeAmount("152.51");
+    expect(issueButton().disabled).toBe(true);
+  });
+});

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/tools.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/tools.tsx
@@ -1,0 +1,1974 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import {
+  useAgentContext,
+  useComponent,
+  useFrontendTool,
+  useHumanInTheLoop,
+} from "@copilotkit/react-core/v2";
+import { CheckCircle2, CircleAlert, Radio, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useSkin } from "@/shell/skin-provider";
+import { useSkinHref } from "@/shell/skin-path";
+import { useCommerceLedger } from "./data/ledger-context";
+import {
+  CATEGORY_VOCABULARY,
+  categoryParameter,
+  resolveCategoryScope,
+} from "./category-argument";
+import {
+  EXCEPTION_FILTERS,
+  HOLD_REASONS,
+  ORDER_EXCEPTION_LABEL,
+  ORDER_SORTS,
+  ORDER_STATUS_FILTERS,
+  RETURN_REASON_LABEL,
+  ageInDays,
+  formatMargin,
+  formatMoney,
+  isOnException,
+  nullableBelowFloor,
+  orderUnits,
+  productFloorStatus,
+  productMargin,
+  promotionFloorStatus,
+  promotionMargin,
+  refundGuidance,
+  weeksOfCover,
+} from "./data/derive";
+import {
+  JUSTIFICATION_MAX_LENGTH,
+  JUSTIFICATION_MIN_LENGTH,
+} from "./data/waiver-codes";
+import * as records from "./data/find-record";
+import type {
+  CommerceStoreState,
+  MarginFloor,
+  Order,
+  Product,
+  ReturnRequest,
+} from "./data/types";
+import { NOTIFICATION_TEMPLATES } from "./data/types";
+import { selectSummaryRows } from "./margin-summary";
+import {
+  normalizeQueueLevers,
+  queueLeverChips,
+  queueLeverQuery,
+} from "./order-queue-levers";
+import { readRefundedCustomer, submitRefund } from "./refund";
+import {
+  describeError,
+  isWriteFailureLine,
+  narrateWrite,
+  settleInterrupt,
+  staleNote,
+} from "./settle";
+import { MarginLadder } from "./components/margin-ladder";
+import { SkuTile } from "./components/sku-tile";
+import { Pill } from "./components/primitives";
+import { useRecording } from "./components/recording-context";
+import {
+  SAVE_PROCEDURE_CONFIRMED,
+  SAVE_PROCEDURE_DECLINED,
+  buildDemonstrationDirective,
+  classifySaveProcedureResult,
+  readDemonstratedStepCount,
+} from "./teach-mode-directives";
+
+/**
+ * Every frontend tool, HITL card, gen-UI component and global readable
+ * Bellwether ships. Renders null. Registered at the SKIN level rather than per
+ * page, so the teach-mode chain survives the navigation it is recording.
+ *
+ * Six rules run through this whole file; each fails SILENTLY if broken.
+ *
+ *  1. EVERY registration closes with a deps array. Omit it and the closure
+ *     captures whatever the data was at registration time — for a REST-backed
+ *     skin, the EMPTY ledger from before the first fetch — forever. It compiles,
+ *     it lints, it passes tests, and the agent narrates confidently over a
+ *     component rendering its "not found" branch.
+ *
+ *  2. A parameterized `useComponent` render receives the schema output DIRECTLY
+ *     (`render: ({ category }) => …`). Only `useFrontendTool` and
+ *     `useHumanInTheLoop` renders get `{ args, status, result, respond }`.
+ *
+ *  3. Renders are REPLAY-SAFE: keyed off `result`, never off `status`. Reopen a
+ *     thread and you get the recorded result with no live status transition, so
+ *     a status-keyed render is perfect during the demo and blank the moment
+ *     anyone revisits — which is exactly when beat 2 is being shown.
+ *
+ *  4. Nothing sensitive goes into a tool result. Whatever a handler returns is
+ *     stored in the thread forever (beat 3a).
+ *
+ *  5. A HITL card NEVER calls `respond` directly — it goes through
+ *     `settleInterrupt` from `./settle`, and a card that awaits anything must
+ *     restore its own controls in a `finally`. `respond` is `undefined` while
+ *     arguments stream and its promise can reject, so `respond?.(…)` silently
+ *     drops the response and WEDGES the run: the card waits, the agent waits,
+ *     and nothing is logged. Read the header of `./settle` before touching any
+ *     card's buttons.
+ *
+ *  6. EVERY write handler's body goes through `narrateWrite` from `./settle`, and
+ *     `!res.ok` is only HALF of the failures. A `fetch` REJECTS when the browser
+ *     is offline or the dev server restarts mid-call, and an uncaught rejection
+ *     throws out of the handler, so the agent gets no result for that step at
+ *     all. Beat 5 is a three-write chain against one order, so that is not one
+ *     missing sentence — it is a half-mutated ledger with one visible receipt,
+ *     one vanished write, and no error anywhere.
+ */
+
+/**
+ * BEAT 2 + 3a — replay memory for the refund card.
+ *
+ * On thread reopen a HITL call replays as in-progress with no live state, so the
+ * card needs somewhere to recover what happened. This map holds ONLY the
+ * customer's name and the product label — never the figure the merchant typed.
+ * That omission is the beat: the amount exists in the REST call and the ledger,
+ * and nowhere the assistant or the transcript can reach.
+ */
+const answeredRefunds = new Map<string, { customer: string }>();
+
+/** Same idea for the navigate-confirm card. */
+const answeredNavigations = new Map<string, { confirmed: boolean }>();
+
+function ToolCard({
+  tone = "brand",
+  children,
+}: {
+  tone?: "brand" | "positive" | "negative";
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "my-1 rounded-lg border bg-surface p-3 text-ink shadow-soft",
+        tone === "brand" && "border-brand/25",
+        tone === "positive" && "border-positive/30",
+        tone === "negative" && "border-negative/30",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The card a render draws while its arguments are STILL STREAMING.
+ *
+ * Every render in this file runs from the FIRST frame of its tool call, holding
+ * `partialJSONParse(toolCall.function.arguments)` — which is `{}` until the first
+ * field closes. So an argument that the schema declares REQUIRED is `undefined`
+ * for some of the renders it appears in, and a render either guards for that or
+ * ships one of two bugs: it dereferences the absent value and THROWS inside React
+ * render, or it formats the absent value into a confident label and asserts
+ * something nobody has established.
+ *
+ * The honest state is neither a default nor an empty return: a default asserts a
+ * choice the agent has not made (the precedent is the Sort chip in
+ * `./order-queue-levers`, which printed "oldest first" over an unset lever), and
+ * rendering nothing at all is worse television than a placeholder — beat 1 leads
+ * with generative UI and the room is watching it appear. So: a visible, muted
+ * card that claims only what is known.
+ */
+function ArrivingCard({ children }: { children: React.ReactNode }) {
+  return (
+    <ToolCard>
+      <p className="text-[0.78rem] text-ink-muted">{children}</p>
+    </ToolCard>
+  );
+}
+
+/**
+ * The trimmed string an argument holds once it has ARRIVED, or `null` while it
+ * has not.
+ *
+ * `null` covers all three shapes an unarrived argument takes: absent, blank (the
+ * `{"product": "` frame parses to `""`), and not-a-string-yet — a render is
+ * handed unvalidated JSON, so `typeof` is part of the guard rather than a
+ * formality.
+ */
+function arrivedText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** A one-line "this happened" receipt. Every mutation gets one. */
+function Receipt({
+  tone = "positive",
+  icon,
+  children,
+}: {
+  tone?: "positive" | "negative";
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "my-1 flex items-start gap-2 rounded-lg border px-3 py-2 text-[0.8rem]",
+        tone === "positive"
+          ? "border-positive/30 bg-positive-soft text-ink"
+          : "border-negative/30 bg-negative-soft text-ink",
+      )}
+    >
+      <span className={tone === "positive" ? "text-positive" : "text-negative"}>
+        {/* The icon FOLLOWS the tone by default. A negative receipt that had to
+            be handed a CircleAlert explicitly is a receipt that reads as a green
+            tick the one time somebody forgets — and on a failure line the tick is
+            what the room believes, not the sentence. */}
+        {icon ??
+          (tone === "negative" ? (
+            <CircleAlert className="mt-0.5 h-4 w-4" />
+          ) : (
+            <CheckCircle2 className="mt-0.5 h-4 w-4" />
+          ))}
+      </span>
+      <span className="min-w-0 flex-1">{children}</span>
+    </div>
+  );
+}
+
+/**
+ * The receipt for a write tool's result — the ONE renderer every write handler
+ * uses, so tone can never drift from what the line actually says.
+ *
+ * `isWriteFailureLine` covers both halves of "it didn't happen": the server
+ * refused it (`REFUSED…`) or it never completed (`narrateWrite`'s prefix). The
+ * `REFUSED` marker itself is stripped — it is an internal convention the renders
+ * branch on, not something to put in front of an audience.
+ */
+function WriteReceipt({ result }: { result: unknown }) {
+  const failed = isWriteFailureLine(result);
+  return (
+    <Receipt tone={failed ? "negative" : "positive"}>
+      {String(result).replace(/^REFUSED(?: \([^)]*\))?:\s*/, "")}
+    </Receipt>
+  );
+}
+
+export function CommerceTools() {
+  const { data, refresh, operator } = useCommerceLedger();
+  const router = useRouter();
+  const skin = useSkin();
+  const skinHref = useSkinHref(skin.id);
+  const recording = useRecording();
+
+  /**
+   * Handlers read the ledger through a ref, not through the closure.
+   *
+   * `useFrontendTool` / `useHumanInTheLoop` TEAR DOWN and re-register whenever
+   * their deps change. A `[data]` dep on a tool that itself mutates the ledger
+   * therefore unregisters the tool in the middle of its own call — the write
+   * lands, the tool disappears, and the agent gets no result. Banking hit this
+   * exact bug with its PIN tool. So: `[]` deps on write tools plus this ref, and
+   * real deps on the read-only display components below.
+   */
+  const ledgerRef = useRef<CommerceStoreState>(data);
+  useEffect(() => {
+    ledgerRef.current = data;
+  }, [data]);
+  const operatorRef = useRef(operator);
+  useEffect(() => {
+    operatorRef.current = operator;
+  }, [operator]);
+
+  /**
+   * Resolving an agent-supplied reference to a row. The matching itself is pure
+   * and lives in `./data/find-record` — including the guard that makes a BLANK
+   * needle resolve to nothing instead of to `rows[0]` (read that file's header
+   * before touching any of the three). These are only the ledgerRef bindings.
+   */
+  const findOrder = (needle: string): Order | undefined =>
+    records.findOrder(ledgerRef.current.orders, needle);
+
+  const findProduct = (needle: string): Product | undefined =>
+    records.findProduct(ledgerRef.current.products, needle);
+
+  const findReturn = (needle: string): ReturnRequest | undefined =>
+    records.findReturn(ledgerRef.current.returns, needle);
+
+  // ── Global readables ──────────────────────────────────────────────────────
+  // The page-scoped readables (in each page component) say what is ON SCREEN.
+  // This one says what EXISTS, so tools callable from anywhere — hold an order,
+  // approve a markdown — can resolve a name to an id without the user having to
+  // be on the right page first.
+  useAgentContext({
+    description:
+      "The Bellwether commerce ledger: the whole product range with each " +
+      "item's margin against its category floor, the category margin policy, " +
+      "the whole order book — cancelled orders included — with each row's " +
+      "exception and whether it still counts as queue work (`onException`), " +
+      "the returns desk, the pending markdowns, and the restock plans on file. " +
+      "Use this to resolve a product, order, return or markdown to an id " +
+      "before calling any tool.",
+    value: JSON.stringify({
+      marginFloors: data.floors,
+      products: data.products.map((p) => ({
+        id: p.id,
+        sku: p.sku,
+        name: p.name,
+        category: p.category,
+        vendor: p.vendor,
+        listPrice: p.listPrice,
+        unitCost: p.unitCost,
+        margin: formatMargin(productMargin(p)),
+        // `null`, never `false`, when the category has no floor on file — the
+        // agent must not be able to report an unchecked SKU as compliant.
+        belowFloor: nullableBelowFloor(productFloorStatus(data.floors, p)),
+        inventory: p.inventory,
+        weeksOfCover: weeksOfCover(p),
+        status: p.status,
+      })),
+      // The WHOLE order book, cancelled rows included. This used to filter them
+      // out, which made `cancelled` the one status `showOrderQueue` could set and
+      // the agent could not then talk about: the page has that control, renders
+      // those rows and describes them in its own readable, and the OGUI sandbox's
+      // `getOrders` returns them — so the exclusion also put a page readable
+      // listing rows next to a ledger readable denying they exist.
+      //
+      // What a cancelled order is NOT is queue work, and that is said HERE with
+      // the one shared predicate rather than by dropping the row: `onException`
+      // is `isOnException`, the same clause behind every count, figure and queue
+      // list in the skin.
+      orders: data.orders.map((o) => ({
+        id: o.id,
+        number: o.number,
+        customer: o.customerName,
+        status: o.status,
+        exception: ORDER_EXCEPTION_LABEL[o.exception],
+        onException: isOnException(o),
+        total: o.total,
+        units: orderUnits(o),
+        ageDays: ageInDays(o.placedAt),
+      })),
+      returns: data.returns.map((r) => ({
+        id: r.id,
+        orderNumber: r.orderNumber,
+        customer: r.customerName,
+        product: data.products.find((p) => p.id === r.productId)?.name,
+        reason: RETURN_REASON_LABEL[r.reason],
+        status: r.status,
+        itemValue: r.itemValue,
+      })),
+      pendingMarkdowns: data.promotions
+        .filter((p) => p.status === "pending")
+        .map((promo) => {
+          const item = data.products.find((p) => p.id === promo.productId);
+          const floor = data.floors.find(
+            (f) => f.category === item?.category,
+          )?.floor;
+          const margin = promotionMargin(item, promo);
+          return {
+            id: promo.id,
+            name: promo.name,
+            product: item?.name,
+            discountPercent: promo.discountPercent,
+            margin: margin === null ? null : formatMargin(margin),
+            floor: floor === undefined ? null : formatMargin(floor),
+            // Same rule as the products above: `null` when it could not be
+            // checked. Beat 6 turns on this flag, so a false `false` here would
+            // have the agent claim a gated markdown is clear to approve.
+            belowFloor: nullableBelowFloor(
+              promotionFloorStatus(data.floors, item, promo),
+            ),
+          };
+        }),
+      restockPlans: data.plans.map((plan) => ({
+        id: plan.id,
+        vendor: plan.vendor,
+        season: plan.season,
+      })),
+    }),
+  });
+
+  // ══ BEAT 1 — GIVE THE AGENT A FACE ═══════════════════════════════════════
+  // Lead with generative UI, never a wall of text. The margin ladder is
+  // Bellwether's signature visual and its first answer.
+
+  useComponent(
+    {
+      name: "showMarginLadder",
+      description:
+        "Display the margin ladder: every product plotted at its gross margin " +
+        "against its own category floor, with anything below its floor flagged " +
+        "in red beneath the line. Use this for any question about margin, " +
+        "which products are below floor, or how the range is trading. Render " +
+        "the ladder AND answer in one or two sentences — never one without the " +
+        "other.",
+      // ENUMERATED, not `z.string()`. The category is the one closed-set value
+      // the model fills here, and the enum is what puts the five accepted names
+      // in the tool definition it reads. See `./category-argument` — the same
+      // parameter the OGUI sandbox advertises.
+      parameters: z.object({
+        category: categoryParameter
+          .optional()
+          .describe(
+            `Restrict the ladder to one category, spelled exactly — one of: ${CATEGORY_VOCABULARY}. Omit for the whole range.`,
+          ),
+      }),
+      // Parameterized `useComponent` → the render receives the schema output
+      // DIRECTLY. This is NOT the `{ args }` shape a HITL render gets.
+      render: ({ category }) => {
+        // …and the schema above is NOT enforced before this runs. A render is
+        // handed `partialJSONParse(toolCall.function.arguments)` verbatim, and a
+        // render-only tool posts an EMPTY tool result, so there is nowhere to
+        // report a bad argument back to either. `resolveCategoryScope` is the
+        // enforcement; read its module header before loosening anything here.
+        const scope = resolveCategoryScope(category);
+        if (scope.kind === "unknown") {
+          // NOT a ladder. An off-vocabulary category used to draw all five rails
+          // with no dots on them, which is the worst outcome available: it looks
+          // like an answer.
+          return (
+            <ToolCard tone="negative">
+              <p className="text-[0.8rem] text-ink-muted">
+                There is no “{scope.value}” category in the range, so there is
+                nothing to plot. Bellwether trades {CATEGORY_VOCABULARY} — ask
+                again with one of those.
+              </p>
+            </ToolCard>
+          );
+        }
+        // `arriving` — a prefix of a real category, i.e. still streaming — draws
+        // the whole range exactly as an omitted category does.
+        const only = scope.kind === "one" ? scope.category : null;
+        // No floors fallback. The old `floors.length ? floors : data.floors` was
+        // the other half of the empty ladder: it re-broadened the RAILS while
+        // leaving the products filtered. A real category with no floor on file
+        // now draws no rail and `ladderCaption` says why.
+        const floors = only
+          ? data.floors.filter((f) => f.category === only)
+          : data.floors;
+        const items = only
+          ? data.products.filter((p) => p.category === only)
+          : data.products;
+        return (
+          <ToolCard>
+            <MarginLadder floors={floors} products={items} compact />
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  useComponent(
+    {
+      name: "showProduct",
+      description:
+        "Display one product's card: price, landed cost, margin against its " +
+        "category floor, inventory and weeks of cover. Use when the user asks " +
+        "about a specific SKU.",
+      parameters: z.object({
+        product: z.string().describe("The product's name, SKU code or id."),
+      }),
+      render: ({ product }) => {
+        // The needle STREAMS, so the first renders of every call to this card
+        // hold no needle at all. It used to go straight into the matcher, and a
+        // miss on nothing drew the red "Nothing in the range matches “”" — a
+        // refusal flashed over an argument the agent had not finished sending, on
+        // every SKU the demo looks up. An arriving card instead; the red one is
+        // for a needle that arrived and matched nothing, which is a real answer.
+        const needle = arrivedText(product);
+        if (needle === null) {
+          return <ArrivingCard>Looking up the product…</ArrivingCard>;
+        }
+        // Reads `data`, not ledgerRef — this is a display component with a
+        // `[data]` dep, so the closure is live. Same pure matcher as the tools,
+        // so a blank argument renders the "nothing matches" branch rather than
+        // presenting the first SKU in the range as the one that was asked for.
+        const item = records.findProduct(data.products, needle);
+        if (!item) {
+          return (
+            <ToolCard tone="negative">
+              <p className="text-[0.8rem] text-ink-muted">
+                Nothing in the range matches “{needle}”.
+              </p>
+            </ToolCard>
+          );
+        }
+        const margin = productMargin(item);
+        const floor = data.floors.find(
+          (f) => f.category === item.category,
+        )?.floor;
+        const status = productFloorStatus(data.floors, item);
+        const below = status === "below";
+        const cover = weeksOfCover(item);
+        return (
+          <ToolCard>
+            <div className="flex items-start gap-3">
+              <SkuTile
+                name={item.name}
+                size="lg"
+                ring={below ? "negative" : "brand"}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold">{item.name}</p>
+                <p className="bw-num text-[0.75rem] text-ink-muted">
+                  {item.sku} · {item.vendor}
+                </p>
+                <div className="mt-1.5 flex flex-wrap gap-1">
+                  <Pill tone="brand">{item.category}</Pill>
+                  <Pill>{formatMoney(item.listPrice)}</Pill>
+                  <Pill>cost {formatMoney(item.unitCost)}</Pill>
+                  {/* Three states, because the green pill is an assertion. A
+                      SKU whose category has no floor on file gets a NEUTRAL
+                      pill saying so — it has not been cleared, it has not been
+                      checked. */}
+                  {below ? (
+                    <Pill tone="negative">
+                      {formatMargin(margin)} · below floor
+                    </Pill>
+                  ) : status === "unknown" ? (
+                    <Pill tone="neutral">
+                      {formatMargin(margin)} · no floor on file
+                    </Pill>
+                  ) : (
+                    <Pill tone="positive">{formatMargin(margin)} margin</Pill>
+                  )}
+                  {floor !== undefined ? (
+                    <Pill>floor {formatMargin(floor)}</Pill>
+                  ) : null}
+                </div>
+                <p className="bw-num mt-2 text-[0.72rem] text-ink-muted">
+                  {item.inventory.toLocaleString("en-US")} on hand ·{" "}
+                  {item.trailing30Units.toLocaleString("en-US")} sold in 30 days
+                  {cover === null ? "" : ` · ${cover} weeks of cover`}
+                </p>
+              </div>
+            </div>
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  useComponent(
+    {
+      name: "showOrderList",
+      description:
+        "Display a list of orders by id or order number. Use this instead of " +
+        "writing a markdown table whenever you are showing more than one order.",
+      parameters: z.object({
+        orderIds: z
+          .array(z.string())
+          .describe("Order ids or numbers, in the order to show."),
+        caption: z.string().optional(),
+      }),
+      render: ({ orderIds, caption }) => {
+        // BEAT 1 CRASHED HERE. `orderIds` is declared required, which is not the
+        // same as PRESENT: this render ran `orderIds.map(…)` from the first frame
+        // of the call, before any id had streamed, so it threw a TypeError inside
+        // React render on the beat the demo opens with. `?? []` is banking's
+        // established guard for the identical shape (`showTable`'s
+        // `columns ?? []` / `rows ?? []`, src/skins/banking/tools.tsx:793-794);
+        // the array's CONTENTS need the same treatment, because a half-streamed
+        // `["` parses to `[""]` and `id.replace` throws on anything unstringy.
+        const ids = (Array.isArray(orderIds) ? orderIds : [])
+          .map((id) => arrivedText(id))
+          .filter((id): id is string => id !== null);
+        // No ids yet is NOT "no order matched" — that red card is an answer, and
+        // asserting it before the argument arrives makes every order list the
+        // demo draws open on a refusal.
+        if (ids.length === 0) {
+          return <ArrivingCard>Pulling the orders…</ArrivingCard>;
+        }
+        const rows = ids
+          .map(
+            (id) =>
+              data.orders.find((o) => o.id === id) ??
+              data.orders.find((o) => o.number === id.replace(/^#/, "")),
+          )
+          .filter((o): o is Order => Boolean(o));
+        if (rows.length === 0) {
+          return (
+            <ToolCard tone="negative">
+              <p className="text-[0.8rem] text-ink-muted">
+                No matching orders.
+              </p>
+            </ToolCard>
+          );
+        }
+        return (
+          <ToolCard>
+            {caption ? (
+              <p className="mb-2 text-[0.75rem] font-medium text-ink-muted">
+                {caption}
+              </p>
+            ) : null}
+            <ul className="divide-y divide-hairline">
+              {rows.map((order) => (
+                <li key={order.id} className="flex items-center gap-2 py-1.5">
+                  <SkuTile
+                    name={order.customerName}
+                    size="xs"
+                    shape="round"
+                    ring={order.exception !== "none" ? "negative" : null}
+                  />
+                  <span className="bw-num shrink-0 text-[0.72rem] text-ink-muted">
+                    #{order.number}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[0.78rem]">
+                    {order.customerName}
+                    {order.exception !== "none" ? (
+                      <span className="ml-1.5 text-negative">
+                        {ORDER_EXCEPTION_LABEL[order.exception]}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="bw-num shrink-0 text-[0.7rem] text-ink-muted">
+                    {ageInDays(order.placedAt)}d
+                  </span>
+                  <span className="bw-num shrink-0 text-[0.72rem] font-medium">
+                    {formatMoney(order.total)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </ToolCard>
+        );
+      },
+    },
+    [data],
+  );
+
+  // ══ BEAT 4 — LONG-TERM MEMORY ════════════════════════════════════════════
+  // `note` is the slot where the agent NAMES the preference it recalled. Without
+  // a visible "why", recall looks like a normal answer and the beat is invisible
+  // to the room even when it worked perfectly.
+  useComponent(
+    {
+      name: "showMarginSummary",
+      description:
+        "Summarize where margin stands across the range. Before calling this, " +
+        "recall the user's saved formatting preference and pass it through the " +
+        "flags. ALWAYS fill `note` with the preference you applied, in your own " +
+        "words — that is how the user knows you remembered.",
+      parameters: z.object({
+        byCategory: z
+          .boolean()
+          .describe("Group by category rather than by vendor."),
+        belowFloorFirst: z
+          .boolean()
+          .describe("Put anything under its category floor at the top."),
+        asMarginPercent: z
+          .boolean()
+          .describe(
+            "Show each product as its gross margin percent instead of its price.",
+          ),
+        note: z
+          .string()
+          .describe(
+            "Name the saved preference you applied, e.g. 'You read these by category, below-floor first.'",
+          ),
+      }),
+      render: ({ byCategory, belowFloorFirst, asMarginPercent, note }) => (
+        <MarginSummaryList
+          products={data.products}
+          floors={data.floors}
+          byCategory={byCategory}
+          belowFloorFirst={belowFloorFirst}
+          asMarginPercent={asMarginPercent}
+          note={note}
+        />
+      ),
+    },
+    [data],
+  );
+
+  // ══ BEAT 3a — DRIVE THE APP, SECRET WITHHELD ═════════════════════════════
+  useHumanInTheLoop(
+    {
+      name: "issueRefund",
+      description:
+        "Open the refund card for one return so the user can enter the " +
+        "goodwill amount themselves. NEVER ask for the figure and never ask " +
+        "which return first — call this immediately with your best match.",
+      parameters: z.object({
+        returnRef: z
+          .string()
+          .describe("The return id, the customer's name, or the order number."),
+      }),
+      render: ({ args, respond, result, toolCallId }) => {
+        // REPLAY-SAFE. Consult the answered map first (a thread reopened in the
+        // same session), then the recorded `result` (a reload). Only fall
+        // through to the live editor when neither exists. Nothing here reads
+        // `status`, which does not replay.
+        //
+        // The result must be CLASSIFIED, not merely detected. An earlier version
+        // of the equivalent card in the people skin branched on "is there a
+        // result at all" and rendered the success receipt for every settled
+        // call — so a CANCELLED refund replayed as "Refund issued", claiming a
+        // mutation that never happened. A replayed card asserting a write that
+        // did not occur is worse than a blank one, and only shows up when
+        // someone reopens the thread — which is exactly when beat 2 is being
+        // demonstrated.
+        const remembered = toolCallId
+          ? answeredRefunds.get(toolCallId)
+          : undefined;
+        const settled = typeof result === "string" ? result : null;
+        // The name comes back through `readRefundedCustomer`, which lives beside
+        // the line `submitRefund` writes — the card does not carry its own idea
+        // of how that sentence is worded.
+        const refundedCustomer =
+          remembered?.customer ??
+          (settled ? readRefundedCustomer(settled) : null);
+
+        if (refundedCustomer) {
+          return (
+            <Receipt>
+              Refund issued on <strong>{refundedCustomer}</strong>&rsquo;s
+              return. The amount stayed in this card — it was never sent to the
+              assistant.
+            </Receipt>
+          );
+        }
+        if (settled) {
+          // Cancelled, or the REST call was refused. Say which, plainly.
+          const cancelled = /cancelled/i.test(settled);
+          return (
+            <Receipt
+              tone="negative"
+              icon={<CircleAlert className="mt-0.5 h-4 w-4" />}
+            >
+              {cancelled
+                ? "The refund was cancelled — nothing was issued."
+                : settled}
+            </Receipt>
+          );
+        }
+        return (
+          <RefundCard
+            query={args?.returnRef ?? ""}
+            find={findReturn}
+            productName={(id) =>
+              ledgerRef.current.products.find((p) => p.id === id)?.name ??
+              "the item"
+            }
+            // `submitRefund` is TOTAL: every path through it settles the
+            // interrupt and it never throws, resolving with `null` on success or
+            // the sentence the card must show. It lives in `./refund` so that
+            // guarantee is directly testable rather than asserted in a comment.
+            onDone={(request, amount) =>
+              submitRefund({
+                request,
+                amount,
+                respond,
+                refresh,
+                onIssued: () => {
+                  if (toolCallId) {
+                    answeredRefunds.set(toolCallId, {
+                      customer: request.customerName,
+                    });
+                  }
+                },
+              })
+            }
+            onCancel={() =>
+              settleInterrupt(respond, "The user cancelled the refund.")
+            }
+          />
+        );
+      },
+    },
+    // `[]` + ledgerRef: this tool writes, and a data dep would tear it down
+    // mid-write. See the note on ledgerRef above.
+    [],
+  );
+
+  // ══ BEAT 3c — NAVIGATE WITH LEVERS ═══════════════════════════════════════
+  useHumanInTheLoop(
+    {
+      name: "showOrderQueue",
+      description:
+        "Take the user to the Orders page with a specific status filter, " +
+        "exception filter, sort order and top-N limit applied. Confirm the " +
+        "levers with them first. Use for any 'show me the oldest / biggest / " +
+        "stuck orders' question. For anything about orders being STUCK or " +
+        "WAITING, filter on the exception and leave status as 'all' — an " +
+        "exception filter already excludes clean orders, and pinning the " +
+        "status as well means any order you later put on hold drops straight " +
+        "out of the view you just built.",
+      // Every lever's advertised values come from the page's OWN control
+      // vocabularies, so the tool cannot offer a value the Orders page has no
+      // control for. `top` is `.int().positive()` because that is precisely what
+      // `parseTopLever` will honour — a fractional or zero limit is not a limit.
+      parameters: z.object({
+        status: z.enum(ORDER_STATUS_FILTERS),
+        exception: z
+          .enum(EXCEPTION_FILTERS)
+          .describe("'any' means every order still carrying an exception."),
+        sort: z.enum(ORDER_SORTS),
+        top: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Limit to the first N rows."),
+        reason: z.string().describe("One short line on why this view."),
+      }),
+      render: ({ args, respond, result, toolCallId }) => {
+        const remembered = toolCallId
+          ? answeredNavigations.get(toolCallId)
+          : undefined;
+        const settled = remembered !== undefined || typeof result === "string";
+        const confirmed =
+          remembered?.confirmed ?? String(result ?? "").startsWith("Opened");
+
+        // ONE normalized record behind both the chips and the URL — see the
+        // header of `./order-queue-levers`. A lever that was not set (arguments
+        // stream, so mid-render that is every lever) draws NO chip rather than a
+        // default the agent never chose.
+        const levers = normalizeQueueLevers(args);
+        const chips = queueLeverChips(levers);
+
+        return (
+          <ToolCard tone={settled && !confirmed ? "negative" : "brand"}>
+            {/* The headline promises a list only when there is one — no chips
+                means no levers have arrived yet, and "with these controls set:"
+                over an empty strip is the same false claim in prose. */}
+            <p className="text-[0.8rem] font-medium">
+              {settled
+                ? confirmed
+                  ? chips.length
+                    ? "Opened the Orders page with these controls set:"
+                    : "Opened the Orders page."
+                  : "Stayed on this page."
+                : chips.length
+                  ? "I can open the Orders page with these controls set:"
+                  : "I can open the Orders page for you."}
+            </p>
+            {chips.length ? (
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {chips.map((chip) => (
+                  <li key={chip}>
+                    <Pill tone="brand">{chip}</Pill>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {args?.reason ? (
+              <p className="mt-2 text-[0.74rem] text-ink-muted">
+                {args.reason}
+              </p>
+            ) : null}
+            {!settled ? (
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={async () => {
+                    // The same `levers` the chips above were drawn from, so the
+                    // view this opens is the view the card just promised. Built
+                    // from the ONE normalized record rather than re-read off
+                    // `args` here: a second reading is how the chips and the URL
+                    // drifted apart in the first place.
+                    const query = queueLeverQuery(levers);
+                    // The nav is attempted inside a try for the same reason every
+                    // write handler now runs inside `narrateWrite`: a throw here
+                    // used to escape this async onClick, which means the interrupt
+                    // is never settled and the RUN WEDGES — the one failure worse
+                    // than not navigating. Whatever `router.push` does, the report
+                    // below still goes back.
+                    let navigated = true;
+                    try {
+                      // The Orders page IS the skin index, so this is skinHref()
+                      // with no segment — `/commerce` unlocked, `/` under a lock.
+                      router.push(`${skinHref()}${query ? `?${query}` : ""}`);
+                    } catch (error) {
+                      navigated = false;
+                      console.error(
+                        "[commerce] could not open the Orders view",
+                        error,
+                      );
+                    }
+                    // Same rule as the refund card: remember the answer only once
+                    // the interrupt is really settled, and never drop the failure
+                    // silently — `settleInterrupt` logs one. This card keeps no
+                    // state to show it in, so an undelivered response simply
+                    // leaves both buttons live and the user clicks again.
+                    const failure = await settleInterrupt(
+                      respond,
+                      navigated
+                        ? "Opened the Orders page with the filters and sort applied. The controls are highlighted on screen."
+                        : "Could not open the Orders page — the navigation failed, so the user is still where they were.",
+                    );
+                    if (!failure && toolCallId && navigated) {
+                      answeredNavigations.set(toolCallId, { confirmed: true });
+                    }
+                  }}
+                  className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+                >
+                  Open it
+                </button>
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const failure = await settleInterrupt(
+                      respond,
+                      "The user chose to stay on the current page.",
+                    );
+                    if (!failure && toolCallId) {
+                      answeredNavigations.set(toolCallId, { confirmed: false });
+                    }
+                  }}
+                  className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+                >
+                  Stay here
+                </button>
+              </div>
+            ) : null}
+          </ToolCard>
+        );
+      },
+    },
+    [],
+  );
+
+  // ══ BEAT 5 — THE STORED PROCEDURE'S THREE WRITES ═════════════════════════
+  // Registered globally so the procedure can run from any page. Each produces a
+  // change the audience can SEE on the Orders page.
+
+  useFrontendTool(
+    {
+      name: "holdOrder",
+      description:
+        "Put an order on hold so fulfillment stops, and record which exception " +
+        "caused it.",
+      parameters: z.object({
+        order: z.string().describe("The order number or id."),
+        // Built FROM `ORDER_EXCEPTIONS` (see `HOLD_REASONS` in `data/derive`),
+        // not hand-copied — same rule as `notifyCustomer`'s templates below and
+        // `showOrderQueue`'s levers above.
+        reason: z
+          .enum(HOLD_REASONS)
+          .describe("Which exception is stopping the order."),
+      }),
+      handler: async ({ order, reason }) => {
+        const target = findOrder(order);
+        if (!target) return `No order matches "${order}".`;
+        // `subject` is the ORDER, shared with the two writes below: that is what
+        // lets whichever of the three fails recite what the other two landed.
+        return narrateWrite(
+          { action: `the hold on order ${target.number}`, subject: target.id },
+          async (landed) => {
+            const res = await fetch(`/api/commerce/v1/orders/${target.id}`, {
+              method: "PATCH",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ status: "on-hold", exception: reason }),
+            });
+            if (!res.ok)
+              return `Could not hold the order (HTTP ${res.status}).`;
+            landed("put on hold");
+            const refreshed = await refresh();
+            recording.logStep(
+              `Put order ${target.number} on hold for ${ORDER_EXCEPTION_LABEL[reason]}`,
+            );
+            return (
+              `Order ${target.number} is on hold — ${ORDER_EXCEPTION_LABEL[reason]}.` +
+              staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result, args }) => {
+        if (result) return <WriteReceipt result={result} />;
+        // `args.order` streams too. "Holding order …" with the number missing is
+        // the same absent-value formatting as the cards above, so the in-flight
+        // line names the order only once it has one.
+        const order = arrivedText(args?.order);
+        return (
+          <ArrivingCard>
+            {order ? `Holding order ${order}…` : "Holding the order…"}
+          </ArrivingCard>
+        );
+      },
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "notifyCustomer",
+      description:
+        "Send the customer on an order a templated message. Use " +
+        "'verification-required' when an order is being held for fraud review.",
+      parameters: z.object({
+        order: z.string().describe("The order number or id."),
+        // Built FROM the store's closed set, not hand-copied: the route
+        // validates against the same list, so a template the tool offers and the
+        // wire refuses (or the reverse) is unrepresentable.
+        template: z
+          .enum(NOTIFICATION_TEMPLATES)
+          .describe("Which templated message to send."),
+      }),
+      handler: async ({ order, template }) => {
+        const target = findOrder(order);
+        if (!target) return `No order matches "${order}".`;
+        return narrateWrite(
+          {
+            action: `the message to ${target.customerName} on order ${target.number}`,
+            subject: target.id,
+          },
+          async (landed) => {
+            const res = await fetch(
+              `/api/commerce/v1/orders/${target.id}/notify`,
+              {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  template,
+                  sentBy: operatorRef.current.name,
+                }),
+              },
+            );
+            if (!res.ok)
+              return `Could not notify the customer (HTTP ${res.status}).`;
+            landed("notified the customer");
+            const refreshed = await refresh();
+            recording.logStep(
+              `Sent ${target.customerName} the ${template} message`,
+            );
+            return (
+              `Sent ${target.customerName} the ${template.replace(/-/g, " ")} message.` +
+              staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result }) =>
+        result ? <WriteReceipt result={result} /> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "postOrderNote",
+      description:
+        "Post a short note on an order's record saying what was done and why. " +
+        "Keep it to one sentence.",
+      parameters: z.object({
+        order: z.string().describe("The order number or id."),
+        text: z.string().describe("The note, one sentence."),
+      }),
+      handler: async ({ order, text }) => {
+        const target = findOrder(order);
+        if (!target) return `No order matches "${order}".`;
+        // Force the marker. "Use a light or a bell or whatever so people can see
+        // that it changed" — a note that reads like every other note is
+        // invisible from the back of a room, so the emoji is prepended here
+        // rather than left to the model's discretion.
+        const marked = text.trim().startsWith("🚨")
+          ? text.trim()
+          : `🚨 ${text.trim()}`;
+        return narrateWrite(
+          { action: `the note on order ${target.number}`, subject: target.id },
+          async (landed) => {
+            const res = await fetch(
+              `/api/commerce/v1/orders/${target.id}/notes`,
+              {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  text: marked,
+                  author: operatorRef.current.name,
+                }),
+              },
+            );
+            if (!res.ok) return `Could not post the note (HTTP ${res.status}).`;
+            landed("posted a note");
+            const refreshed = await refresh();
+            recording.logStep(`Posted a note on order ${target.number}`);
+            return (
+              `Posted the note on order ${target.number}.` +
+              staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result }) =>
+        result ? <WriteReceipt result={result} /> : null,
+    },
+    [],
+  );
+
+  // ── Distractors ──────────────────────────────────────────────────────────
+  // Plausible, real, and useless for both the stored procedure and the gate.
+  // They are what make "it picked the right three" and "it cleared the gate"
+  // mean something rather than being the only options available.
+  useFrontendTool(
+    {
+      name: "requestChargebackEvidence",
+      description:
+        "Pull the evidence packet a payment processor needs to fight a chargeback.",
+      parameters: z.object({ order: z.string() }),
+      handler: async ({ order }) =>
+        `Chargeback evidence packet requested for order ${findOrder(order)?.number ?? order}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "scheduleCarrierPickup",
+      description:
+        "Book a carrier pickup slot for an order that is ready to go.",
+      parameters: z.object({ order: z.string() }),
+      handler: async ({ order }) =>
+        `Carrier pickup scheduled for order ${findOrder(order)?.number ?? order}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "sendReviewRequest",
+      description: "Ask a customer to review what they bought.",
+      parameters: z.object({ order: z.string() }),
+      handler: async ({ order }) =>
+        `Review request queued for ${findOrder(order)?.customerName ?? order}.`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "openSupplierClaim",
+      description:
+        "Open a claim against a supplier for damaged or short-shipped goods.",
+      parameters: z.object({ product: z.string(), detail: z.string() }),
+      handler: async ({ product, detail }) =>
+        `Supplier claim opened on ${findProduct(product)?.name ?? product}: ${detail}`,
+      render: ({ result }) =>
+        result ? <Receipt>{String(result)}</Receipt> : null,
+    },
+    [],
+  );
+
+  // ══ BEAT 3d — MULTIMODAL IN, DURABLE ARTIFACT OUT ════════════════════════
+  useFrontendTool(
+    {
+      name: "createRestockPlan",
+      description:
+        "File a restock plan into the app. When the user has attached a vendor " +
+        "price sheet, read it and carry its REAL details — the quoted landed " +
+        "costs, the minimum order quantities, the freight terms and the ship " +
+        "schedule — into this call rather than inventing plausible ones.",
+      parameters: z.object({
+        vendor: z.string().describe("The supplier the sheet came from."),
+        season: z
+          .string()
+          .describe('What the plan covers, e.g. "Autumn knitwear".'),
+        summary: z
+          .string()
+          .describe("Two sentences on what is being bought and why."),
+        highlights: z
+          .array(z.string())
+          .max(3)
+          .describe("At most three short facts worth surfacing."),
+        // `landedCost` and `units` are bounded to what a PO can mean, because
+        // `POST /plans` refuses anything else field by field (`requireNumber`,
+        // with `integer: true` on units) and a 422 the schema could have
+        // prevented is a round trip spent on a row the model already had. The
+        // ROW COUNT is deliberately not repeated here: that cap is a layout
+        // budget owned by the route, which names it in its refusal, and a third
+        // copy of the number is a third thing to drift.
+        lines: z
+          .array(
+            z.object({
+              sku: z.string(),
+              name: z.string(),
+              landedCost: z
+                .number()
+                .nonnegative()
+                .describe("Quoted landed cost per unit, in dollars."),
+              units: z
+                .number()
+                .int()
+                .nonnegative()
+                .describe("Whole units being bought."),
+            }),
+          )
+          .describe("The SKUs the plan covers, at the QUOTED landed cost."),
+        schedule: z
+          .array(z.object({ week: z.string(), item: z.string() }))
+          .describe(
+            'The ship schedule, e.g. [{ week: "Week 1", item: "PO countersigned" }].',
+          ),
+      }),
+      handler: async ({
+        vendor,
+        season,
+        summary,
+        highlights,
+        lines,
+        schedule,
+      }) => {
+        // No `subject`: a plan is filed in ONE write, so there is no sibling
+        // write on the same record for a failure here to recite.
+        return narrateWrite(
+          { action: `the ${season} restock plan for ${vendor}` },
+          async (landed) => {
+            const res = await fetch("/api/commerce/v1/plans", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                vendor,
+                season,
+                summary,
+                highlights,
+                lines,
+                schedule,
+                filedBy: operatorRef.current.name,
+              }),
+            });
+            if (!res.ok) {
+              // Surface the route's message, not just the status. `POST /plans`
+              // REFUSES a plan that would not fit the card or whose rows it
+              // cannot read (it no longer trims or coerces them into a quietly
+              // wrong artifact), and the refusal names the offending field —
+              // which is only actionable if the agent can see it.
+              const body = await res.json().catch(() => ({}));
+              return `Could not file the plan: ${body?.message ?? `HTTP ${res.status}`}`;
+            }
+            landed("filed the plan");
+            const refreshed = await refresh();
+            return (
+              `Filed the ${season} restock plan for ${vendor}. It is on the Catalog page under Restock plans.` +
+              staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result, args }) =>
+        result ? (
+          // Not `WriteReceipt`: this one carries the durability line that IS
+          // beat 3d, and it must not be promised over a plan that never filed.
+          isWriteFailureLine(result) ? (
+            <WriteReceipt result={result} />
+          ) : (
+            <Receipt>
+              {String(result)}{" "}
+              <span className="text-ink-muted">
+                It belongs to the app, so deleting this conversation will not
+                remove it.
+              </span>
+            </Receipt>
+          )
+        ) : (
+          <ArrivingCard>
+            {arrivedText(args?.vendor)
+              ? `Filing the plan for ${arrivedText(args?.vendor)}…`
+              : "Filing the restock plan…"}
+          </ArrivingCard>
+        ),
+    },
+    [],
+  );
+
+  // ══ BEAT 6 — THE GATE, THE UNLOCK, AND THE TEACH CHAIN ═══════════════════
+
+  useFrontendTool(
+    {
+      name: "approveMarkdown",
+      description:
+        "Approve a pending markdown so it goes live at the discounted price.",
+      parameters: z.object({
+        promotionId: z
+          .string()
+          .describe("The markdown's id, e.g. promo-cedar."),
+      }),
+      handler: async ({ promotionId }) => {
+        // No `subject`: beat 6's chain spans a promotion AND a waiver id, so no
+        // single record key would cover it. A half-applied unlock is also benign
+        // — a draft waiver that was never finalized changes nothing — which is
+        // exactly what beat 5's chain is not.
+        return narrateWrite(
+          { action: `the approval of ${promotionId}` },
+          async (landed) => {
+            const res = await fetch(
+              `/api/commerce/v1/promotions/${promotionId}/approve`,
+              { method: "POST" },
+            );
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok) {
+              recording.logStep("Approve refused");
+              // The refusal is passed through VERBATIM and is symptom-only. Do
+              // not append a hint here — the agent must not be able to derive the
+              // unlock from the error, or beat 6 stops proving that it learned.
+              return `REFUSED (${body?.error ?? res.status}): ${body?.message ?? "Approval refused."}`;
+            }
+            landed("approved the markdown");
+            const refreshed = await refresh();
+            const name = body?.promotion?.name ?? "the markdown";
+            recording.logStep(`Approved ${name}`);
+            // The DISCOUNT clause is dropped rather than filled with `""`. The
+            // old line read "goes live at % off" whenever the route's body did
+            // not carry the percent — a receipt stating a figure with the figure
+            // missing from it, kept in the thread forever (beat 2). Same rule as
+            // the streaming renders above: an absent value gets no sentence, not
+            // an empty slot in one.
+            const discount = body?.promotion?.discountPercent;
+            const atDiscount =
+              typeof discount === "number" && Number.isFinite(discount)
+                ? ` at ${discount}% off`
+                : "";
+            return (
+              `Approved. ${name} goes live${atDiscount}.` + staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result, args }) => {
+        if (!result) {
+          const promotionId = arrivedText(args?.promotionId);
+          return (
+            <ArrivingCard>
+              {promotionId
+                ? `Approving ${promotionId}…`
+                : "Approving the markdown…"}
+            </ArrivingCard>
+          );
+        }
+        return <WriteReceipt result={result} />;
+      },
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "openMarginWaiver",
+      description:
+        "File a margin waiver against a markdown under a given code.",
+      parameters: z.object({
+        promotionId: z.string(),
+        // DELIBERATELY a free string, and the one parameter in this file that
+        // must stay one. `MARGIN_WAIVER_CODES` is a closed set, but enumerating
+        // it here would hand the agent the whole catalogue in the tool
+        // definition — and beat 6 turns on the agent NOT knowing it and having
+        // to watch a merchandiser file one. The store refuses an unknown code
+        // without listing the valid ones for exactly the same reason; see the
+        // header of `data/waiver-codes.ts`.
+        code: z.string().describe("The waiver code to file under."),
+        // The API refuses an empty or placeholder justification, so say so here
+        // rather than spending a round-trip on a 422 the model has to read.
+        justification: z
+          .string()
+          .min(JUSTIFICATION_MIN_LENGTH)
+          .max(JUSTIFICATION_MAX_LENGTH)
+          .describe(
+            `Why the waiver is being filed — what is on file. At least ${JUSTIFICATION_MIN_LENGTH} characters; never blank.`,
+          ),
+      }),
+      handler: async ({ promotionId, code, justification }) => {
+        return narrateWrite(
+          { action: `the margin waiver on ${promotionId}` },
+          async (landed) => {
+            const res = await fetch("/api/commerce/v1/margin-waivers", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ promotionId, code, justification }),
+            });
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok) return `REFUSED: ${body?.message ?? res.status}`;
+            landed("filed a margin waiver");
+            const refreshed = await refresh();
+            // Beat 6's next step is `finalizeMarginWaiver`, which needs this id —
+            // so "Waiver id undefined" was worse than saying nothing: the agent
+            // reads this line and would go on to finalize the string
+            // "undefined". Say it only when it is there.
+            const waiverId = arrivedText(body?.id);
+            return (
+              `Filed a margin waiver (${code}).` +
+              (waiverId ? ` Waiver id ${waiverId}.` : "") +
+              " It still needs finalizing." +
+              staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result }) =>
+        result ? <WriteReceipt result={result} /> : null,
+    },
+    [],
+  );
+
+  useFrontendTool(
+    {
+      name: "finalizeMarginWaiver",
+      description: "Finalize a draft margin waiver so it takes effect.",
+      parameters: z.object({ waiverId: z.string() }),
+      handler: async ({ waiverId }) => {
+        return narrateWrite(
+          { action: `the finalizing of waiver ${waiverId}` },
+          async (landed) => {
+            const res = await fetch(
+              `/api/commerce/v1/margin-waivers/${waiverId}/finalize`,
+              { method: "POST" },
+            );
+            const body = await res.json().catch(() => ({}));
+            if (!res.ok) return `REFUSED: ${body?.message ?? res.status}`;
+            landed("finalized the margin waiver");
+            const refreshed = await refresh();
+            const code = arrivedText(body?.code);
+            return (
+              `Finalized the${code ? ` ${code}` : ""} margin waiver.` +
+              staleNote(refreshed)
+            );
+          },
+        );
+      },
+      render: ({ result }) =>
+        result ? <WriteReceipt result={result} /> : null,
+    },
+    [],
+  );
+
+  // ── The teach chain: offer → watch → save ────────────────────────────────
+  useHumanInTheLoop(
+    {
+      followUp: true,
+      name: "offerWorkflowRecording",
+      description:
+        "Call this when you have hit a refusal you have no saved procedure " +
+        "for. Say plainly that you do not know this one and offer to watch the " +
+        "user do it. Never guess a workaround instead of calling this.",
+      parameters: z.object({
+        situation: z
+          .string()
+          .describe("What you were blocked on, in one line."),
+      }),
+      render: ({ args, respond, result }) => {
+        // Settled. Render a HUMAN line, never `result` — that string is an
+        // internal directive addressed to the agent ("Call awaitDemonstration
+        // now and wait…") and printing it verbatim puts the demo's own wiring on
+        // screen in front of the audience.
+        if (typeof result === "string") {
+          const agreed = /agreed to demonstrate/i.test(result);
+          return (
+            <ToolCard>
+              <p className="text-[0.78rem] text-ink-muted">
+                {agreed
+                  ? "Watching you do it once."
+                  : "Left it for now — nothing was recorded."}
+              </p>
+            </ToolCard>
+          );
+        }
+        return (
+          <ToolCard>
+            <p className="text-[0.8rem]">
+              I don&rsquo;t have a saved way to do this yet
+              {args?.situation
+                ? ` — ${args.situation.replace(/\.+$/, "")}`
+                : ""}
+              . Want to show me once, and I&rsquo;ll remember it?
+            </p>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  void settleInterrupt(
+                    respond,
+                    "The user agreed to demonstrate. Call awaitDemonstration now and wait — do not guess any steps.",
+                  )
+                }
+                className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+              >
+                Show me
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  void settleInterrupt(
+                    respond,
+                    "The user declined to demonstrate. Stop here.",
+                  )
+                }
+                className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+              >
+                Not now
+              </button>
+            </div>
+          </ToolCard>
+        );
+      },
+    },
+    [],
+  );
+
+  useHumanInTheLoop(
+    {
+      followUp: true,
+      name: "awaitDemonstration",
+      description:
+        "Hold the conversation while the user demonstrates. Do NOT list steps " +
+        "or suggest what they should do — you do not know yet. That is the point.",
+      parameters: z.object({}),
+      render: ({ respond, result }) => {
+        // Same rule as above: `result` is the raw observed-steps directive
+        // written for the agent. Summarize it for the human instead.
+        if (typeof result === "string") {
+          // The figure the RECORDER reported, never one re-counted out of this
+          // prose: a step label containing "1. 50" or "12.5 %" used to be
+          // counted as a step of its own. `null` = the directive carries no
+          // count (an older thread), so claim no number at all.
+          const count = readDemonstratedStepCount(result);
+          return (
+            <ToolCard tone="positive">
+              <p className="text-[0.78rem]">
+                Recorded{" "}
+                {count === null
+                  ? "the demonstration"
+                  : `${count} ${count === 1 ? "step" : "steps"}`}
+                .
+              </p>
+            </ToolCard>
+          );
+        }
+        return (
+          <DemonstrationCard
+            onDone={(summary) => settleInterrupt(respond, summary)}
+          />
+        );
+      },
+    },
+    [],
+  );
+
+  useHumanInTheLoop(
+    {
+      followUp: true,
+      name: "saveLearnedProcedure",
+      description:
+        "Summarize what you just watched as a numbered procedure and show it " +
+        "for confirmation. After the user confirms, persist it with save_memory " +
+        "(scope 'user', kind 'operational'). Save it AT MOST ONCE.",
+      parameters: z.object({
+        procedure: z
+          .string()
+          .describe(
+            "The numbered procedure, naming the exact waiver code that worked.",
+          ),
+      }),
+      render: ({ args, respond, result }) => {
+        // CLASSIFIED, not merely detected — see `teach-mode-directives.ts`. Both
+        // buttons below settle this tool with a string, so "is there a result at
+        // all" would print the saved receipt over a decline and claim a durable
+        // write that never happened. Same rule the refund card above states.
+        const outcome = classifySaveProcedureResult(result);
+        if (outcome === "saved") {
+          return (
+            <Receipt>
+              Saved. I&rsquo;ll use this next time without being asked.
+            </Receipt>
+          );
+        }
+        if (outcome === "declined") {
+          return (
+            <ToolCard>
+              <p className="text-[0.78rem] text-ink-muted">
+                Left it unsaved — nothing was written to memory.
+              </p>
+            </ToolCard>
+          );
+        }
+        if (outcome === "unknown") {
+          return (
+            <ToolCard>
+              <p className="text-[0.78rem] text-ink-muted">
+                This card was already answered.
+              </p>
+            </ToolCard>
+          );
+        }
+        return (
+          <ToolCard>
+            <p className="text-[0.78rem] font-medium">
+              Here&rsquo;s what I picked up — shall I remember it?
+            </p>
+            <pre className="mt-2 whitespace-pre-wrap rounded-md bg-surface-muted p-2.5 text-[0.73rem] leading-relaxed text-ink">
+              {args?.procedure}
+            </pre>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  void settleInterrupt(respond, SAVE_PROCEDURE_CONFIRMED)
+                }
+                className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground"
+              >
+                Remember it
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  void settleInterrupt(respond, SAVE_PROCEDURE_DECLINED)
+                }
+                className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink"
+              >
+                Don&rsquo;t save
+              </button>
+            </div>
+          </ToolCard>
+        );
+      },
+    },
+    [],
+  );
+
+  return null;
+}
+
+/**
+ * BEAT 4's list. Split out of the `showMarginSummary` render so the ordering and
+ * the truncation can be tested without a provider stack — the selection itself is
+ * pure and lives in `./margin-summary`.
+ *
+ * The list is CAPPED and says so. It used to render `rows.slice(0, 12)` and
+ * nothing else, against a fourteen-SKU seeded range: two rows vanished with no
+ * mark, and under `byCategory` — where the ranked order is alphabetical by
+ * category — the two that vanished were both Outerwear SKUs, one of them below
+ * its floor. A category missing entirely is indistinguishable from a category
+ * with nothing to report, so the omission read as an all-clear in the one skin
+ * whose whole claim is that margin is comparable across categories. The caption
+ * `selectSummaryRows` returns names the count, the below-floor and unchecked
+ * rows among them, and any category that disappeared.
+ */
+export function MarginSummaryList({
+  products,
+  floors,
+  byCategory,
+  belowFloorFirst,
+  asMarginPercent,
+  note,
+}: {
+  products: Product[];
+  floors: MarginFloor[];
+  // OPTIONAL, all four, even though the tool schema declares them required. The
+  // render is handed streaming arguments, so this component is called with
+  // `undefined` in every slot on the way to the real values, and the types said
+  // otherwise while the runtime did not — which is how the empty band below
+  // shipped.
+  byCategory?: boolean;
+  belowFloorFirst?: boolean;
+  asMarginPercent?: boolean;
+  note?: string;
+}) {
+  // A presentation flag that has not arrived reads as its plain shape (by vendor,
+  // in money) — the same defaulting banking does for `showSpendSummary`'s
+  // remembered flags. Safe here only because nothing in this card LABELS the
+  // flags: the list shows what it shows and claims nothing about why.
+  const { visible, caption } = selectSummaryRows(products, floors, {
+    byCategory: byCategory ?? false,
+    belowFloorFirst: belowFloorFirst ?? false,
+  });
+  // The `note`, by contrast, is a CLAIM — and it streams last of the four. An
+  // absent one used to draw the rose band as an empty coloured bar: beat 4's one
+  // visible piece of evidence that memory was recalled, rendered as decoration
+  // with nothing in it. No note, no band, exactly as the caption below already
+  // does it.
+  const why = arrivedText(note);
+
+  return (
+    <ToolCard>
+      {/* The "why" slot. Rose, because in Bellwether rose marks the thing
+          a merchandiser is being asked to notice — and being remembered
+          is one. */}
+      {why ? (
+        <p className="mb-2 flex items-start gap-1.5 rounded-md border border-brand-violet/30 bg-brand-violet/10 px-2.5 py-1.5 text-[0.74rem] text-ink">
+          <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-brand-violet" />
+          <span>{why}</span>
+        </p>
+      ) : null}
+      <ul className="divide-y divide-hairline">
+        {visible.map((item) => {
+          const status = productFloorStatus(floors, item);
+          const below = status === "below";
+          return (
+            <li key={item.id} className="flex items-center gap-2 py-1.5">
+              <SkuTile name={item.name} size="xs" />
+              <span className="min-w-0 flex-1 truncate text-[0.78rem]">
+                {item.name}
+              </span>
+              {byCategory ? (
+                <Pill tone="brand">{item.category}</Pill>
+              ) : (
+                <Pill>{item.vendor}</Pill>
+              )}
+              <span
+                className={cn(
+                  "bw-num w-24 shrink-0 text-right text-[0.74rem] font-medium",
+                  below && "text-negative",
+                )}
+              >
+                {asMarginPercent
+                  ? `${formatMargin(productMargin(item))}${below ? " ↓" : status === "unknown" ? " ?" : ""}`
+                  : formatMoney(item.listPrice)}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      {caption ? (
+        <p className="mt-2 flex items-start gap-1.5 text-[0.72rem] text-ink-muted">
+          <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{caption}</span>
+        </p>
+      ) : null}
+    </ToolCard>
+  );
+}
+
+/**
+ * BEAT 3a's card. The figure lives in local state and goes straight to REST; it
+ * is never lifted into a tool argument, a respond() string, or the transcript.
+ * What the item was originally charged at IS shown, so the merchant can see the
+ * ceiling they are working under — the same rule the store enforces, surfaced
+ * rather than hidden.
+ *
+ * Both handlers are contracted to SETTLE the interrupt and resolve — never to
+ * throw — returning `null` on success or a sentence this card must show. See
+ * `./settle`. The card still wraps them in try/finally: an earlier version awaited
+ * `onDone` bare, so one rejected fetch left the button reading "Issuing…" forever
+ * with the run wedged behind it and nothing logged anywhere.
+ */
+export function RefundCard({
+  query,
+  find,
+  productName,
+  onDone,
+  onCancel,
+}: {
+  query: string;
+  find: (needle: string) => ReturnRequest | undefined;
+  productName: (productId: string) => string;
+  onDone: (request: ReturnRequest, amount: number) => Promise<string | null>;
+  onCancel: () => Promise<string | null>;
+}) {
+  const request = find(query);
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  /**
+   * The single path out of this card. Whatever happens, `saving` comes back down
+   * and either the interrupt is settled or the user is told why it is not.
+   */
+  const run = async (action: () => Promise<string | null>) => {
+    setFailure(null);
+    setSaving(true);
+    try {
+      setFailure(await action());
+    } catch (error) {
+      // Unreachable via the handlers this card is given, which settle and return
+      // instead of throwing. Kept so a future edit to a call site cannot put the
+      // stuck-spinner bug back: catching here is what guarantees the button
+      // recovers no matter what the caller does.
+      setFailure(describeError(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const failureNote = failure ? (
+    <p
+      role="alert"
+      className="mt-2 flex items-start gap-1.5 text-[0.72rem] text-negative"
+    >
+      <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      {failure}
+    </p>
+  ) : null;
+
+  if (!request) {
+    return (
+      <ToolCard tone="negative">
+        <p className="text-[0.8rem] text-ink-muted">
+          I couldn&rsquo;t find a return matching “{query}”.
+        </p>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void run(onCancel)}
+          className="mt-2 rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] disabled:opacity-40"
+        >
+          Close
+        </button>
+        {failureNote}
+      </ToolCard>
+    );
+  }
+
+  // The placeholder and the button's rule come out of ONE call, so the figure
+  // the card invites is always a figure the card accepts. See `refundGuidance`.
+  const {
+    placeholder,
+    ceiling,
+    amount: parsed,
+    valid,
+  } = refundGuidance(request.itemValue, value);
+
+  return (
+    <ToolCard>
+      <div className="flex items-center gap-2.5">
+        <SkuTile name={productName(request.productId)} size="md" />
+        <div className="min-w-0">
+          <p className="text-[0.82rem] font-semibold">
+            {productName(request.productId)}
+          </p>
+          <p className="bw-num text-[0.72rem] text-ink-muted">
+            {request.customerName} · #{request.orderNumber} ·{" "}
+            {RETURN_REASON_LABEL[request.reason]}
+          </p>
+        </div>
+      </div>
+
+      <label className="mt-3 block">
+        <span className="mb-1 block text-[0.7rem] font-medium text-ink-muted">
+          Goodwill refund
+        </span>
+        <input
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          inputMode="decimal"
+          autoComplete="off"
+          placeholder={placeholder}
+          className="bw-num w-full rounded-md border border-hairline bg-surface px-2.5 py-1.5 text-[0.85rem] text-ink outline-none focus:border-brand/50"
+        />
+        <span className="bw-num mt-1 block text-[0.68rem] text-ink-muted">
+          Charged {ceiling} · {ageInDays(request.requestedAt)} days open
+        </span>
+      </label>
+
+      <p className="mt-2 text-[0.68rem] text-ink-muted">
+        This figure goes straight to the payment processor. The assistant never
+        sees it.
+      </p>
+
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          disabled={!valid || saving}
+          onClick={() => void run(() => onDone(request, parsed))}
+          className="rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground disabled:opacity-40"
+        >
+          {saving ? "Issuing…" : "Issue refund"}
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void run(onCancel)}
+          className="rounded-md border border-hairline px-3 py-1.5 text-[0.75rem] text-ink-muted hover:text-ink disabled:opacity-40"
+        >
+          Cancel
+        </button>
+      </div>
+      {failureNote}
+    </ToolCard>
+  );
+}
+
+/**
+ * BEAT 6's waiting card. Deliberately NON-DIRECTIONAL: it never lists steps or
+ * hints at what to do, because the whole premise is that the agent does not know
+ * them. It shows a live "Rec" badge and narrates the steps it observes, so the
+ * room can see that watching is really happening.
+ *
+ * `onDone` settles the interrupt and resolves with `null`, or with a sentence
+ * this card shows. Same contract, and same reason, as `RefundCard`: "I'm done"
+ * handing off to an unavailable `respond` used to be a silent no-op that stranded
+ * the whole teach-mode chain mid-recording.
+ */
+export function DemonstrationCard({
+  onDone,
+}: {
+  onDone: (summary: string) => Promise<string | null>;
+}) {
+  const { beginRecording, endRecording, steps, getDemonstratedCode, reset } =
+    useRecording();
+  const [sending, setSending] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  useEffect(() => {
+    reset();
+    beginRecording();
+    return () => endRecording();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <ToolCard>
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-negative-soft px-2 py-0.5 text-[0.68rem] font-semibold text-negative">
+          <Radio className="h-3 w-3 animate-pulse" />
+          Rec
+        </span>
+        <p className="text-[0.8rem]">Watching — go ahead and show me.</p>
+      </div>
+
+      {steps.length > 0 ? (
+        <ol className="mt-2.5 space-y-1 border-l-2 border-brand/30 pl-3">
+          {steps.map((step, index) => (
+            <li key={step.id} className="text-[0.74rem] text-ink">
+              <span className="bw-num mr-1.5 text-ink-muted">{index + 1}.</span>
+              {step.label}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className="mt-2 text-[0.72rem] text-ink-muted">
+          Nothing captured yet.
+        </p>
+      )}
+
+      <button
+        type="button"
+        disabled={sending}
+        onClick={async () => {
+          // The recorder is the only thing that KNOWS how many steps it caught,
+          // so the directive it hands over reports that number — the card that
+          // renders the settled result reads it rather than recounting the
+          // prose. Both halves live in `./teach-mode-directives`.
+          const directive = buildDemonstrationDirective({
+            steps: steps.map((s) => s.label),
+            code: getDemonstratedCode(),
+          });
+          setFailure(null);
+          setSending(true);
+          try {
+            setFailure(await onDone(directive));
+          } catch (error) {
+            setFailure(describeError(error));
+          } finally {
+            setSending(false);
+          }
+        }}
+        className="mt-3 rounded-md bg-brand px-3 py-1.5 text-[0.75rem] font-semibold text-brand-foreground disabled:opacity-40"
+      >
+        {sending ? "Saving…" : "I’m done"}
+      </button>
+      {failure ? (
+        <p
+          role="alert"
+          className="mt-2 flex items-start gap-1.5 text-[0.72rem] text-negative"
+        >
+          <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          {failure}
+        </p>
+      ) : null}
+    </ToolCard>
+  );
+}

--- a/examples/showcases/reskinnable-demo/src/skins/commerce/write-failures.test.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/commerce/write-failures.test.tsx
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { CommerceStoreState, Operator, Order } from "./data/types";
+import { isWriteFailureLine, narrateWrite, resetLandedWrites } from "./settle";
+
+/**
+ * A write handler must END IN A RESULT on every path — success, refusal, AND a
+ * fetch that never completed.
+ *
+ * The bug this pins: all seven `useFrontendTool` write handlers checked
+ * `!res.ok` and nothing else, so an offline browser or a dev server restarted
+ * mid-call threw straight out of the handler. The agent then gets no result for
+ * that step at all, which on beat 5 — a THREE-write chain against one order —
+ * is the worst available shape of failure: one write visibly landed, the next
+ * silently vanished, and nothing on screen or in the transcript says which.
+ *
+ * Covered at both boundaries, because either alone leaves the bug reachable:
+ * the WRAPPER (`narrateWrite` must resolve, and must distinguish a write that
+ * landed from one that did not) and the HANDLERS (a handler that skipped the
+ * wrapper would pass every wrapper assertion below).
+ *
+ * No `@testing-library/jest-dom` in this app, so nothing here touches matchers.
+ */
+
+// ── The handler half. `CommerceTools` registers into CopilotKit and renders
+// null, so the only way to reach a handler is to capture the registrations as
+// they are made. Hoisted because `vi.mock` is lifted above the imports.
+const { handlers } = vi.hoisted(() => ({
+  handlers: new Map<string, (args: never) => Promise<string>>(),
+}));
+
+vi.mock("@copilotkit/react-core/v2", () => ({
+  useAgentContext: () => {},
+  useComponent: () => {},
+  useHumanInTheLoop: () => {},
+  useFrontendTool: (config: {
+    name: string;
+    handler?: (args: never) => Promise<string>;
+  }) => {
+    if (config.handler) handlers.set(config.name, config.handler);
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("@/shell/skin-provider", () => ({
+  useSkin: () => ({ id: "commerce" }),
+}));
+
+vi.mock("@/shell/skin-path", () => ({
+  useSkinHref: () => (path?: string) => path ?? "/commerce",
+}));
+
+const ORDER: Order = {
+  id: "ord-4463",
+  number: "4463",
+  customerName: "Priya Raghavan",
+  customerEmail: "priya@example.com",
+  channel: "web",
+  destination: "Lisbon, PT",
+  placedAt: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+  status: "open",
+  exception: "none",
+  lines: [{ productId: "bw-1", quantity: 2, unitPrice: 40 }],
+  total: 80,
+  notes: [],
+};
+
+const OPERATOR: Operator = {
+  id: "op-nadia",
+  name: "Nadia Okonjo",
+  role: "merch-lead",
+  team: "Merchandising",
+};
+
+const LEDGER: CommerceStoreState = {
+  products: [],
+  floors: [],
+  orders: [ORDER],
+  notifications: [],
+  returns: [],
+  promotions: [],
+  waivers: [],
+  plans: [],
+  operators: [OPERATOR],
+};
+
+vi.mock("./data/ledger-context", () => ({
+  useCommerceLedger: () => ({
+    data: LEDGER,
+    refresh: async () => true,
+    operator: OPERATOR,
+    setOperatorId: () => {},
+  }),
+}));
+
+vi.mock("./components/recording-context", () => ({
+  useRecording: () => ({
+    isRecording: false,
+    steps: [],
+    beginRecording: () => {},
+    endRecording: () => {},
+    logStep: () => {},
+    getDemonstratedCode: () => null,
+    reset: () => {},
+  }),
+}));
+
+// Imported after the mocks so it binds the stubbed modules.
+import { CommerceTools } from "./tools";
+
+/** Mount the registrations and hand back one handler by tool name. */
+function handler<A>(name: string): (args: A) => Promise<string> {
+  render(<CommerceTools />);
+  const found = handlers.get(name);
+  if (typeof found !== "function") {
+    throw new Error(`${name} did not register a handler`);
+  }
+  return found as unknown as (args: A) => Promise<string>;
+}
+
+const ok = () =>
+  ({ ok: true, status: 200, json: async () => ({}) }) as unknown as Response;
+
+const setFetch = (impl: (url: string) => Promise<Response>) => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => impl(String(input))),
+  );
+};
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  resetLandedWrites();
+});
+
+afterEach(() => {
+  cleanup();
+  handlers.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("write handlers under a REJECTED fetch", () => {
+  it("holdOrder resolves with a narratable failure instead of throwing", async () => {
+    setFetch(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const holdOrder = handler<{ order: string; reason: string }>("holdOrder");
+
+    // The assertion that matters: it RESOLVES. Before the fix this rejected, and
+    // the agent received nothing at all for the step.
+    const result = await holdOrder({ order: "4463", reason: "fraud-review" });
+
+    expect(isWriteFailureLine(result)).toBe(true);
+    expect(result).toContain("the hold on order 4463");
+    expect(result).toContain("Failed to fetch");
+    // Honest about what it does NOT know: a rejected fetch cannot tell whether
+    // the server saw the request, so it must not claim the ledger is untouched.
+    expect(result).toMatch(/not applied/i);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("postOrderNote resolves with a narratable failure instead of throwing", async () => {
+    setFetch(async () => {
+      throw new Error("socket hang up");
+    });
+    const postOrderNote = handler<{ order: string; text: string }>(
+      "postOrderNote",
+    );
+
+    const result = await postOrderNote({
+      order: "4463",
+      text: "Held for fraud review.",
+    });
+
+    expect(isWriteFailureLine(result)).toBe(true);
+    expect(result).toContain("the note on order 4463");
+    expect(result).toContain("socket hang up");
+  });
+
+  it("approveMarkdown resolves rather than throwing, so beat 6 still narrates", async () => {
+    setFetch(async () => {
+      throw new Error("Failed to fetch");
+    });
+    const approveMarkdown = handler<{ promotionId: string }>("approveMarkdown");
+
+    const result = await approveMarkdown({ promotionId: "promo-cedar" });
+
+    expect(isWriteFailureLine(result)).toBe(true);
+    expect(result).toContain("the approval of promo-cedar");
+  });
+});
+
+/**
+ * THE REGRESSION THIS FIX IS FOR. Beat 5 puts the order on hold, posts the note,
+ * then notifies the customer. A throw on the SECOND write left the ledger
+ * half-mutated with no receipt saying so: the room sees the hold land and the
+ * note simply disappear.
+ */
+describe("beat 5's three-write chain, failing mid-chain", () => {
+  it("reports what already landed on the order when write #2 fails", async () => {
+    let calls = 0;
+    setFetch(async (url) => {
+      calls += 1;
+      if (url.includes("/notes")) throw new Error("Failed to fetch");
+      return ok();
+    });
+
+    const holdOrder = handler<{ order: string; reason: string }>("holdOrder");
+    const postOrderNote = handler<{ order: string; text: string }>(
+      "postOrderNote",
+    );
+
+    const held = await holdOrder({ order: "4463", reason: "fraud-review" });
+    expect(isWriteFailureLine(held)).toBe(false);
+    expect(held).toContain("on hold");
+
+    const noted = await postOrderNote({
+      order: "4463",
+      text: "Held for fraud review.",
+    });
+
+    expect(calls).toBe(2);
+    // (a) it failed, narratably
+    expect(isWriteFailureLine(noted)).toBe(true);
+    // (b) and it says the hold DID land — "held the order, but could not post the
+    //     note" is the sentence the presenter needs, and the honest one: nothing
+    //     was rolled back.
+    expect(noted).toContain("still stand");
+    expect(noted).toContain("put on hold");
+  });
+
+  it("keeps the recital to the order it is about", async () => {
+    setFetch(async (url) => {
+      if (url.includes("/notes")) throw new Error("Failed to fetch");
+      return ok();
+    });
+    const holdOrder = handler<{ order: string; reason: string }>("holdOrder");
+    await holdOrder({ order: "4463", reason: "fraud-review" });
+
+    // A different record's failure must not inherit order 4463's history.
+    const failure = await narrateWrite(
+      { action: "the approval of promo-cedar" },
+      async () => {
+        throw new Error("Failed to fetch");
+      },
+    );
+    expect(failure).not.toContain("still stand");
+  });
+});
+
+describe("narrateWrite", () => {
+  it("passes a successful body's line through untouched", async () => {
+    await expect(
+      narrateWrite({ action: "the hold on order 4463" }, async (landed) => {
+        landed("put on hold");
+        return "Order 4463 is on hold — Fraud review.";
+      }),
+    ).resolves.toBe("Order 4463 is on hold — Fraud review.");
+  });
+
+  it("passes a refusal through and does NOT journal it as landed", async () => {
+    const refusal = await narrateWrite(
+      { action: "the hold on order 4463", subject: "ord-4463" },
+      async () => "Could not hold the order (HTTP 500).",
+    );
+    expect(refusal).toBe("Could not hold the order (HTTP 500).");
+
+    // Nothing landed, so a later failure on the same order has nothing to recite.
+    const next = await narrateWrite(
+      { action: "the note on order 4463", subject: "ord-4463" },
+      async () => {
+        throw new Error("Failed to fetch");
+      },
+    );
+    expect(next).not.toContain("still stand");
+  });
+
+  it("does not report a failure for a write that landed before the throw", async () => {
+    const line = await narrateWrite(
+      { action: "the hold on order 4463", subject: "ord-4463" },
+      async (landed) => {
+        landed("put on hold");
+        // e.g. the follow-up ledger re-read blowing up after the PATCH committed.
+        throw new Error("ledger unreachable");
+      },
+    );
+    // A "could not" line here would be a receipt AGAINST a write that really
+    // happened, which is the mirror image of the bug above and just as dishonest.
+    expect(isWriteFailureLine(line)).toBe(false);
+    expect(line).toContain("did land");
+    expect(line).toContain("ledger unreachable");
+  });
+
+  it("never lists a repeated step twice", async () => {
+    const run = () =>
+      narrateWrite(
+        { action: "the hold on order 4463", subject: "ord-4463" },
+        async (landed) => {
+          landed("put on hold");
+          return "Order 4463 is on hold.";
+        },
+      );
+    await run();
+    await run();
+
+    const failure = await narrateWrite(
+      { action: "the note on order 4463", subject: "ord-4463" },
+      async () => {
+        throw new Error("Failed to fetch");
+      },
+    );
+    expect(failure.match(/put on hold/g)?.length).toBe(1);
+  });
+
+  it("never throws, whatever the body throws", async () => {
+    await expect(
+      narrateWrite({ action: "the plan" }, () =>
+        Promise.reject("not an Error at all"),
+      ),
+    ).resolves.toContain("not an Error at all");
+  });
+});
+
+describe("isWriteFailureLine", () => {
+  it("recognises every way this skin says a write did not happen", () => {
+    expect(isWriteFailureLine("REFUSED (BELOW_MARGIN_FLOOR): nope")).toBe(true);
+    expect(
+      isWriteFailureLine("Could not complete the note: Failed to fetch."),
+    ).toBe(true);
+    expect(isWriteFailureLine("Could not hold the order (HTTP 500).")).toBe(
+      true,
+    );
+    expect(isWriteFailureLine('No order matches "9999".')).toBe(true);
+  });
+
+  it("does not read a success receipt as a failure", () => {
+    expect(isWriteFailureLine("Order 4463 is on hold — Fraud review.")).toBe(
+      false,
+    );
+    expect(
+      isWriteFailureLine("Approved. Cedar Hoodie goes live at 30% off."),
+    ).toBe(false);
+    expect(isWriteFailureLine(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds a sixth skin to the reskinnable demo: **`commerce` / "Bellwether"**, a storefront operations console for a DTC retail brand. REST-backed over `/api/commerce/v1/*`, and demo-complete against all nine demo beats plus the presenter-reset requirement — which puts it alongside `banking` and `people` rather than the earlier wiring-only skins.

Its teachable gate is approving a markdown that would trade **below the category margin floor** (422 `BELOW_MARGIN_FLOOR`), unlocked by a margin waiver filed under a justifying code. Two below-floor markdowns are seeded, so the case taught on stage and the unaided replay are different products.

## The signature visual: the margin ladder

One rail per category, each anchored to that category's own margin floor, so *"how far from the line I may not cross"* is comparable across categories at a glance.

The decisions inside it are all recorded in the commit bodies, because all of them were wrong first:

- Every floor line sits at **one** rail height, so the rails read as a set — the per-category floor is encoded by dot position, not by moving the line.
- A dot that overflows its rail is **never hidden**. Hiding it lent the dot to the *next* rail, silently misattributing a below-floor product to a compliant category.
- An **empty** ladder renders as "nothing plotted", not as an all-clear.
- A category with **no margin floor on file** renders as visibly *unchecked* — not green, not red, and not a bare figure in neutral ink, which reads as "checked, fine" on the exact question the ladder exists to answer.

## Also the reference for a four-lever view (beat 3c)

Status, exception class, sort and top-N all arrive from the query string and **all four controls tint**. The queue count is computed against the filters actually applied rather than the unfiltered set, and an unusable top-N lever is ignored instead of collapsing the view to one row.

## Review

This branch went through an unusually long review: **95 findings** fixed in the first cycle, then a **24-agent unbiased confirmation round** (all seven slot types, verbatim prompt) which returned ~233 more. Those resolved into **11 recurring defect classes**, closed by class sweeps rather than per-instance fixes.

**Every sweep found more instances than the finding that triggered it** — which is the argument for the approach, as data rather than opinion:

| Class | Named | Found |
| ----- | ----- | ----- |
| Secret redaction covering the URL but not the key | 2 secrets | **5** (the API key appeared verbatim 5× in one response body) |
| Beat 3d attachment reporting success it never verified | 6 | 6 |
| Silent input coercion on the refund path | 2 | **9 of 22 probed inputs became issuable figures** |
| Gen-UI renderers dereferencing streaming args | 4 | **9**, from enumerating all 19 renders |
| Guards whose premise was wrong | 4 | **8** |
| Unchecked-floor claims | 5 | **9**, from 33 consumers enumerated |
| Write controls that could fire twice or latch | 4 | 6, across three pages |
| Doc fixes that had falsified their neighbours | 4 | 4 + 21 verified sound |

Four post-convergence audits (2 → 2 → 1 → 0) then caught a class no diff-scoped reviewer could: **claims this PR made about code outside the diff.** That is how the two most valuable findings in the whole review surfaced — see below.

Tests: **372 → 1130**. Full evidence, per-finding, in the review ledger.

## Two live defects in *other* skins, found by this review

Neither is in scope here; both are on the follow-up list and worth prioritising:

1. **`people`'s offer letter generates a structurally corrupt PDF today.** Same `/Length`-from-string-length byte math commerce's price sheet had, but with **no ASCII fold at all** — live-reachable for the seeded employees `Inés Vidal`, `Sasha Bergström` and the city `Montréal`. Commerce's fix here is the template. (Commerce's own guard was found to work only by accident: with `toAscii` neutered, **8 pre-existing tests stayed green on a structurally corrupt document**. The invariant is now pinned.)
2. **`banking` and `people` leak more secrets than commerce did** — an unredacted `memoryError` plus `apiUrl` echoed into a presenter-facing reset body, where commerce leaked one API key. `src/lib/redact-secrets.ts` added here is skin-agnostic and adoptable as-is.

Also: `banking/attach-invoice.ts` and `people/attach-offer-letter.ts` carry beat 3d's identical unverified-attachment defect — **wiring `onUploadFailed` in `chat-panel.tsx` would close it for all three skins at once.**

## Shipping with a known, documented parked list

This is deliberate and recorded, not an oversight. The parked items are in-subject and real but not demo-blocking — a conditional cross-skin memory deletion (needs a pinned `INTELLIGENCE_USER_ID`), a latent ladder-rail inversion (unreachable at current seed floors), two prototype-chain lookups needing a hostile URL, 500-vs-400 on malformed request bodies, an unguarded presenter Reset, and ~20 test-hygiene items that belong in a test-hygiene PR of their own.

## Skill-staleness rule

`CLAUDE.md` requires every change to existing code to answer whether it leaves `.claude/skills/reskin/` wrong, incomplete or misleading. **Answered in full in the final commit body: yes, in many places, and that commit is the fix.**

The skill gained a new `failure-modes.md` encoding the cross-cutting lessons — chiefly that **a demo skin's characteristic bug is not a crash but a confident falsehood**, and that a skin publishes facts to three audiences (the screen, an agent readable, generated UI) with three different obligations. Existing files were corrected throughout: a demo-complete skin scores out of nine beats not six, the required pill count is now derived from the beat map, the Reset link no longer teaches an href the app's own lint bans, and the `theme.css` scaffold is written so prettier cannot mangle its selector.

## History

109 commits reorganised into 12 by area of concern. The tree was proven identical to the pre-rewrite state three ways — empty diff, identical root tree object, and nothing staged after the move — and all 109 original SHAs are cited across the 12 bodies, so the per-fix reasoning stays reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
