### PR TITLE
chore: release python sdk 0.1.95

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "copilotkit"
-version = "0.1.94"
+version = "0.1.95"
 description = "CopilotKit python SDK"
 authors = ["Markus Ecker <markus.ecker@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Closes #6231.

## Why

`copilotkit` on PyPI is stuck at **0.1.94 (2026-06-04)**. The newest upload of any kind is the **0.1.95a4** prerelease from **2026-06-19**, and four merged sdk-python fixes postdate it — so none of them exist in any installable artifact. Consuming them today requires a VCS pin.

The version in `sdk-python/pyproject.toml` was never bumped, which is why nothing published: the Python lane in `publish-release.yml` fires on a merged PR that changes that version and no-ops otherwise. `sdk-python` is not one of the `release / create-pr` scopes (`monorepo | angular | channels`), so it never gets swept along with the JS releases. This PR is the bump.

## What ships

Eleven commits since 0.1.94, including the two fixes the issue is blocked on:

| commit | landed on main | |
|---|---|---|
| `44c43e477` | Jul 3 | fold app context into the system prompt — fixes `langchain-anthropic` rejecting a second, non-consecutive system message |
| `bb32138e1` | Jul 24 | read copilotkit context from config when state is empty |
| `fee7ec237` | Jul 24 | bridge copilotkit context into LangGraph subgraphs |
| `a76d59ae0` | Jul 26 | capture subgraph context from run input (#3886) |

Plus `ag-ui-langgraph >=0.0.42`, the ag-ui state-channel declaration with the `a2ui_params` host override, and the A2UI single-arg `A2UIToolParams` work.

## Testing

- **Confirmed the fixes are genuinely unpublished.** Downloaded the `0.1.95a4` sdist from PyPI and grepped it: `_get_copilotkit_context` and the config-fallback docstring introduced by `bb32138e1` are absent. The reporter's containment analysis is correct.
- **Reconciled the one date that looked wrong.** `bb32138e1` carries an author date of Jun 10, before the Jun 19 prerelease, which would suggest it should have been included. Its committer date is Jul 24 — it landed on main after the prerelease was cut. All four fixes genuinely postdate every published artifact.
- **Verified all four commits are ancestors of `origin/main`** and touch `sdk-python/`.
- **Python unit CI green on main** — `test_unit-python-sdk.yml` succeeded on Jul 27 at `e9148b305`, which is after the last sdk-python change (`a76d59ae0`, Jul 26).
- **Matched the precedent.** The previous release, `2b5d2e0113` ("chore: release python sdk 0.1.94"), was a one-line change to the same file. `sdk-python/uv.lock` has no root `copilotkit` entry and `poetry.lock` records only dependency versions, so neither needs to move; there is no `sdk-python/CHANGELOG.md` and no `__version__` in `__init__.py`. `pyproject.toml` is the single source.
- `0.1.95` sorts above the existing `0.1.95a4` prerelease, so the publish lane's version-delta detection will fire.

## Follow-up, deliberately not in this PR

Seven files pin the old version and should move once 0.1.95 is actually on PyPI — pinning ahead of the publish would break them:

- `examples/integrations/{claude-sdk-python,langgraph-fastapi,langgraph-python,strands-python}/agent/pyproject.toml`
- `showcase/integrations/{langgraph-fastapi,langgraph-python,strands}/requirements.txt`

Two showcase files (`_header_forwarding_middleware.py` in langgraph-fastapi and langgraph-python) also carry comments describing a workaround vendored against "copilotkit 0.1.94's copilotkit_lg_middleware module" — worth rechecking whether the subgraph fixes make that vendoring unnecessary.

Keeping the bump minimal so the publish lane cannot be held up by an unrelated example failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
