### PR TITLE
docs: clarify managed organization onboarding

### DIFF
--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -14,7 +14,7 @@ For a product-level map of features and hosting options, start with the [Enterpr
   variant="inline"
   title="Start with Cloud-Hosted Enterprise Intelligence"
   body="Create a hosted project, get a project API key, and inspect persistent threads before deciding whether self-hosting is required."
-  ctaLabel="Create a free account"
+  ctaLabel="Start managed onboarding"
   surface="docs_premium_intelligence_architecture_intro"
 />
 

--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -15,6 +15,7 @@ For a product-level map of features and hosting options, start with the [Enterpr
   title="Start with Cloud-Hosted Enterprise Intelligence"
   body="Create a hosted project, get a project API key, and inspect persistent threads before deciding whether self-hosting is required."
   ctaLabel="Start managed onboarding"
+  href="https://dashboard.operations.copilotkit.ai/"
   surface="docs_premium_intelligence_architecture_intro"
 />
 

--- a/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
@@ -12,9 +12,9 @@ Cloud-Hosted Enterprise Intelligence is the CopilotKit-operated deployment of th
 
 <OpsPlatformCTA
   variant="inline"
-  title="Create hosted projects and API keys"
-  body="Create a free Enterprise Intelligence account, then use the CLI or dashboard to connect your first app."
-  ctaLabel="Create a free account"
+  title="Start hosted onboarding"
+  body="Sign up or sign in, select an organization and project, then return to the flow that brought you here."
+  ctaLabel="Start managed onboarding"
   surface="docs_premium_managed_intelligence_platform_intro"
 />
 
@@ -26,12 +26,38 @@ The hosted web app is the control surface for developers and administrators. End
 
 Use Cloud-Hosted Enterprise Intelligence when you want the fastest path to production. Use [Self-Hosting Enterprise Intelligence](/premium/self-hosting) when your organization needs the platform inside its own VPC, cluster, or data boundary.
 
-## Login and workspace flow
+## Hosted onboarding
 
-You sign in at [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai). After login, choose or create the organization workspace you want to operate in. The ready page gives you two common paths:
+Start at [dashboard.operations.copilotkit.ai](https://dashboard.operations.copilotkit.ai) or in the CopilotKit CLI.
 
-- `npx copilotkit@latest create` for a new app.
-- `npx copilotkit@latest skills onboard` for adding CopilotKit to an existing app with agent-assisted onboarding.
+<Steps>
+  <Step>
+    ### Sign up or sign in
+
+    During Clerk signup, new users accept the CopilotKit Self-Service Agreement. Existing accounts do not re-consent.
+  </Step>
+
+  <Step>
+    ### Select or create an organization
+
+    Select or create an organization in the browser. Existing hosted organizations created before the rollout cutoff continue without a plan prompt. Every new hosted organization created at or after the rollout cutoff must explicitly choose Developer or a paid plan. Developer is the no-cost choice; signup does not select it automatically.
+  </Step>
+
+  <Step>
+    ### Select or create a project
+
+    Choose the project that will hold your app's threads, events, runtime connection metadata, and API keys, or create a new one.
+  </Step>
+
+  <Step>
+    ### Continue where you started
+
+    Onboarding resumes the exact CLI or managed-app destination that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue. In the dashboard, the ready page offers two common paths:
+
+    - `npx copilotkit@latest create` for a new app.
+    - `npx copilotkit@latest skills onboard` for adding CopilotKit to an existing app with agent-assisted onboarding.
+  </Step>
+</Steps>
 
 The [CopilotKit CLI](/cli) uses the same sign-in system. When the CLI needs dashboard access, it opens a browser login flow and then stores a local CLI session so project selection can happen from your terminal.
 
@@ -78,6 +104,10 @@ Some capabilities may appear in the dashboard as early access. Those capabilitie
 
 ## Cloud-hosted vs. self-hosted
 
+<Callout type="info" title="Team Self-hosted is a plan, not a deployment login">
+  A Team Self-hosted purchase uses a Clerk-backed hosted organization. A customer-run self-hosted deployment uses the customer's identity provider and never sees the Clerk admission flow or hosted organization plan gate.
+</Callout>
+
 | Choose this | When |
 |---|---|
 | Cloud-Hosted Enterprise Intelligence | You want hosted projects, managed API keys, conversation history, thread inspection, and plan management without running platform infrastructure. |
@@ -86,8 +116,9 @@ Some capabilities may appear in the dashboard as early access. Those capabilitie
 Your application code should stay focused on the CopilotKit frontend SDK and
 runtime. The deployment mode changes which platform endpoint and credentials
 your runtime uses, not how the frontend lists threads or renders chat. Moving
-from cloud-hosted projects to self-hosting is available on the Team self-hosted
-plan or a custom Enterprise plan.
+from cloud-hosted projects to self-hosting requires the Team Self-hosted plan
+or a custom Enterprise plan. That purchase does not replace the identity system
+in a customer-run deployment.
 
 ## Next steps
 

--- a/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
@@ -15,6 +15,7 @@ Cloud-Hosted Enterprise Intelligence is the CopilotKit-operated deployment of th
   title="Start hosted onboarding"
   body="Sign up or sign in, finish organization onboarding, then return to the CLI or hosted app to select a project."
   ctaLabel="Start managed onboarding"
+  href="https://dashboard.operations.copilotkit.ai/"
   surface="docs_premium_managed_intelligence_platform_intro"
 />
 

--- a/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
@@ -13,7 +13,7 @@ Cloud-Hosted Enterprise Intelligence is the CopilotKit-operated deployment of th
 <OpsPlatformCTA
   variant="inline"
   title="Start hosted onboarding"
-  body="Sign up or sign in, select an organization and project, then return to the flow that brought you here."
+  body="Sign up or sign in, finish organization onboarding, then return to the CLI or hosted app to select a project."
   ctaLabel="Start managed onboarding"
   surface="docs_premium_managed_intelligence_platform_intro"
 />
@@ -44,15 +44,15 @@ Start at [dashboard.operations.copilotkit.ai](https://dashboard.operations.copil
   </Step>
 
   <Step>
-    ### Select or create a project
+    ### Continue where you started
 
-    Choose the project that will hold your app's threads, events, runtime connection metadata, and API keys, or create a new one.
+    After organization onboarding, the browser resumes the exact CLI or hosted-app destination that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue.
   </Step>
 
   <Step>
-    ### Continue where you started
+    ### Select or create a project
 
-    Onboarding resumes the exact CLI or managed-app destination that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue. In the dashboard, the ready page offers two common paths:
+    The resumed CLI or hosted app asks you to choose the project that will hold your app's threads, events, runtime connection metadata, and API keys, or create a new one. In the dashboard, the ready page offers two common paths:
 
     - `npx copilotkit@latest create` for a new app.
     - `npx copilotkit@latest skills onboard` for adding CopilotKit to an existing app with agent-assisted onboarding.

--- a/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/managed-intelligence-platform.mdx
@@ -40,7 +40,7 @@ Start at [dashboard.operations.copilotkit.ai](https://dashboard.operations.copil
   <Step>
     ### Select or create an organization
 
-    Select or create an organization in the browser. Existing hosted organizations created before the rollout cutoff continue without a plan prompt. Every new hosted organization created at or after the rollout cutoff must explicitly choose Developer or a paid plan. Developer is the no-cost choice; signup does not select it automatically.
+    Select or create an organization in the browser. Existing hosted organizations created before the rollout cutoff continue without a plan prompt. Every new hosted organization created at or after the rollout cutoff must explicitly choose Developer or a paid plan. Developer is the no-cost choice. Clerk's automatic Free assignment does not count as the required Developer-or-paid choice.
   </Step>
 
   <Step>

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -11,6 +11,7 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
   title="Start managed Intelligence onboarding"
   body="Sign up or sign in, finish organization onboarding when required, then return to the CLI to select a project and connect your app."
   ctaLabel="Start managed onboarding"
+  href="https://dashboard.operations.copilotkit.ai/"
   surface="docs_cli_intro_signup"
 />
 

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -9,7 +9,7 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
 <OpsPlatformCTA
   variant="inline"
   title="Start managed Intelligence onboarding"
-  body="Sign up or sign in, finish organization onboarding when required, then return to the CLI to connect your app."
+  body="Sign up or sign in, finish organization onboarding when required, then return to the CLI to select a project and connect your app."
   ctaLabel="Start managed onboarding"
   surface="docs_cli_intro_signup"
 />
@@ -56,11 +56,15 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
   </Step>
 
   <Step>
+    ### Return to the terminal
+
+    After organization onboarding, return to the terminal. The original CLI command resumes and prompts you to select or create a project.
+  </Step>
+
+  <Step>
     ### Select or create a project
 
     Choose an existing cloud-hosted project or create a new one. A project is where your app's threads, messages, and platform metadata are stored.
-
-    Onboarding resumes the exact CLI or managed-app destination that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue.
 
     The CLI writes the selected project to `.copilotkit/project.json`:
 

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -8,9 +8,9 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
 
 <OpsPlatformCTA
   variant="inline"
-  title="Start with a hosted Enterprise Intelligence project"
-  body="Create a free account, then copy the create command below to scaffold a connected app."
-  ctaLabel="Create a free account"
+  title="Start managed Intelligence onboarding"
+  body="Sign up or sign in, finish organization onboarding when required, then return to the CLI to connect your app."
+  ctaLabel="Start managed onboarding"
   surface="docs_cli_intro_signup"
 />
 
@@ -19,6 +19,10 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
 - Node.js 20+
 - A CopilotKit account for Cloud-Hosted Enterprise Intelligence
 - An OpenAI API key or another model provider key for the starter app you choose
+
+<Callout type="info" title="Team Self-hosted is a plan, not a deployment login">
+  A Team Self-hosted purchase uses a Clerk-backed hosted organization. A customer-run self-hosted deployment uses the customer's identity provider and never sees the Clerk admission flow or hosted organization plan gate.
+</Callout>
 
 ## Start a new app
 
@@ -38,17 +42,25 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
   </Step>
 
   <Step>
-    ### Sign in
+    ### Sign up or sign in
 
-    If you are not already signed in, the CLI opens a browser login flow. Complete login in the browser, then return to the terminal.
+    If you are not already signed in, the CLI opens a browser login flow. During Clerk signup, new users accept the CopilotKit Self-Service Agreement. Existing accounts do not re-consent.
 
     If the browser does not open, the CLI prints a login URL and supports a manual paste fallback.
   </Step>
 
   <Step>
-    ### Select a project
+    ### Select or create an organization
+
+    Select or create an organization in the browser. Existing hosted organizations created before the rollout cutoff continue without a plan prompt. Every new hosted organization created at or after the rollout cutoff must explicitly choose Developer or a paid plan. Developer is the no-cost choice; signup does not select it automatically.
+  </Step>
+
+  <Step>
+    ### Select or create a project
 
     Choose an existing cloud-hosted project or create a new one. A project is where your app's threads, messages, and platform metadata are stored.
+
+    Onboarding resumes the exact CLI or managed-app destination that sent you there. If the CLI opened the browser, return to the terminal and let the original command continue.
 
     The CLI writes the selected project to `.copilotkit/project.json`:
 

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -52,7 +52,7 @@ Use the CLI when you want to start a new app, import historical ADK or LangGraph
   <Step>
     ### Select or create an organization
 
-    Select or create an organization in the browser. Existing hosted organizations created before the rollout cutoff continue without a plan prompt. Every new hosted organization created at or after the rollout cutoff must explicitly choose Developer or a paid plan. Developer is the no-cost choice; signup does not select it automatically.
+    Select or create an organization in the browser. Existing hosted organizations created before the rollout cutoff continue without a plan prompt. Every new hosted organization created at or after the rollout cutoff must explicitly choose Developer or a paid plan. Developer is the no-cost choice. Clerk's automatic Free assignment does not count as the required Developer-or-paid choice.
   </Step>
 
   <Step>

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -43,7 +43,7 @@ function expectPatternsInOrder(
 
 test("documents the conditional managed onboarding journey", () => {
   const sequence = [
-    /new (?:users|accounts)[^.]*Self-Service Agreement[^.]*Clerk|Clerk[^.]*new (?:users|accounts)[^.]*Self-Service Agreement/i,
+    /Clerk signup,[^.]*\b(?:new users accept|a new user accepts)\b[^.]*CopilotKit Self-Service Agreement/i,
     /select or create an organization/i,
     /every new hosted organization created at or after[^.]*cutoff[^.]*explicitly choose[^.]*Developer[^.]*paid plan/i,
     /select or create a project/i,
@@ -67,10 +67,20 @@ test("documents grandfathering, consent, and self-hosted admission boundaries", 
   }
 });
 
+test("does not count Clerk automatic Free as the required organization choice", () => {
+  for (const source of readSources(MANAGED_ONBOARDING_GUIDES)) {
+    expect(source).toMatch(
+      /Clerk(?:'s|’s) automatic Free assignment does not (?:satisfy|count as) the required Developer-or-paid choice/i,
+    );
+    expect(source).not.toMatch(
+      /Clerk(?:'s|’s) automatic Free assignment (?:satisfies|counts as) the required Developer-or-paid choice/i,
+    );
+  }
+});
+
 test("removes automatic-Free promises from managed onboarding calls to action", () => {
   for (const source of readSources(MANAGED_CTA_SOURCES)) {
     expect(source).not.toMatch(/Create a free account/i);
-    expect(source).not.toMatch(/automatically[^.]*Free/i);
     expect(source).toContain('ctaLabel="Start managed onboarding"');
   }
 });

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -46,8 +46,8 @@ test("documents the conditional managed onboarding journey", () => {
     /Clerk signup,[^.]*\b(?:new users accept|a new user accepts)\b[^.]*CopilotKit Self-Service Agreement/i,
     /select or create an organization/i,
     /every new hosted organization created at or after[^.]*cutoff[^.]*explicitly choose[^.]*Developer[^.]*paid plan/i,
+    /(?:resumes? the exact[^.]*(?:CLI[^.]*(?:managed|hosted)|(?:managed|hosted)[^.]*CLI)[^.]*destination|return to the terminal)/i,
     /select or create a project/i,
-    /resumes? the exact[^.]*(?:CLI[^.]*managed|managed[^.]*CLI)[^.]*destination/i,
   ];
 
   for (const source of readSources(MANAGED_ONBOARDING_GUIDES)) {

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "vitest";
+
+const CONTENT_DIR = path.resolve(import.meta.dirname, "../../content");
+const MANAGED_ONBOARDING_GUIDES = [
+  "docs/premium/managed-intelligence-platform.mdx",
+  "snippets/shared/cli/cli.mdx",
+];
+const MANAGED_CTA_SOURCES = [
+  ...MANAGED_ONBOARDING_GUIDES,
+  "docs/premium/intelligence-platform.mdx",
+];
+
+/** Reads managed-onboarding docs as whitespace-normalized contract fixtures. */
+function readSources(relativePaths: readonly string[]): string[] {
+  return relativePaths.map((relativePath) =>
+    fs
+      .readFileSync(path.join(CONTENT_DIR, relativePath), "utf8")
+      .replace(/\s+/g, " "),
+  );
+}
+
+/** Asserts that a guide presents onboarding requirements in journey order. */
+function expectPatternsInOrder(
+  source: string,
+  patterns: readonly RegExp[],
+): void {
+  let previousIndex = -1;
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(source);
+    if (!match) throw new Error(`Missing onboarding step: ${pattern}`);
+
+    expect(
+      match.index,
+      `Onboarding step is out of order: ${pattern}`,
+    ).toBeGreaterThan(previousIndex);
+    previousIndex = match.index;
+  }
+}
+
+test("documents the conditional managed onboarding journey", () => {
+  const sequence = [
+    /new (?:users|accounts)[^.]*Self-Service Agreement[^.]*Clerk|Clerk[^.]*new (?:users|accounts)[^.]*Self-Service Agreement/i,
+    /select or create an organization/i,
+    /every new hosted organization created at or after[^.]*cutoff[^.]*explicitly choose[^.]*Developer[^.]*paid plan/i,
+    /select or create a project/i,
+    /resumes? the exact[^.]*(?:CLI[^.]*managed|managed[^.]*CLI)[^.]*destination/i,
+  ];
+
+  for (const source of readSources(MANAGED_ONBOARDING_GUIDES)) {
+    expectPatternsInOrder(source, sequence);
+  }
+});
+
+test("documents grandfathering, consent, and self-hosted admission boundaries", () => {
+  for (const source of readSources(MANAGED_ONBOARDING_GUIDES)) {
+    expect(source).toMatch(
+      /(?:existing )?hosted organizations created before[^.]*cutoff[^.]*continue without a plan prompt/i,
+    );
+    expect(source).toMatch(/existing accounts do not re-consent/i);
+    expect(source).toMatch(
+      /customer-run self-hosted deployment[^.]*customer[^.]*identity provider[^.]*never sees[^.]*Clerk admission/i,
+    );
+  }
+});
+
+test("removes automatic-Free promises from managed onboarding calls to action", () => {
+  for (const source of readSources(MANAGED_CTA_SOURCES)) {
+    expect(source).not.toMatch(/Create a free account/i);
+    expect(source).not.toMatch(/automatically[^.]*Free/i);
+    expect(source).toContain('ctaLabel="Start managed onboarding"');
+  }
+});

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -12,6 +12,7 @@ const MANAGED_CTA_SOURCES = [
   ...MANAGED_ONBOARDING_GUIDES,
   "docs/premium/intelligence-platform.mdx",
 ];
+const MANAGED_DASHBOARD_URL = "https://dashboard.operations.copilotkit.ai/";
 
 /** Reads managed-onboarding docs as whitespace-normalized contract fixtures. */
 function readSources(relativePaths: readonly string[]): string[] {
@@ -82,5 +83,15 @@ test("removes automatic-Free promises from managed onboarding calls to action", 
   for (const source of readSources(MANAGED_CTA_SOURCES)) {
     expect(source).not.toMatch(/Create a free account/i);
     expect(source).toContain('ctaLabel="Start managed onboarding"');
+  }
+});
+
+test("points managed onboarding calls to action at the hosted dashboard", () => {
+  for (const source of readSources(MANAGED_CTA_SOURCES)) {
+    const managedCta = source.match(
+      /<OpsPlatformCTA[^>]*ctaLabel="Start managed onboarding"[^>]*\/>/,
+    )?.[0];
+
+    expect(managedCta).toContain(`href="${MANAGED_DASHBOARD_URL}"`);
   }
 });

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -46,8 +46,8 @@ test("documents the conditional managed onboarding journey", () => {
     /Clerk signup,[^.]*\b(?:new users accept|a new user accepts)\b[^.]*CopilotKit Self-Service Agreement/i,
     /select or create an organization/i,
     /every new hosted organization created at or after[^.]*cutoff[^.]*explicitly choose[^.]*Developer[^.]*paid plan/i,
-    /(?:resumes? the exact[^.]*(?:CLI[^.]*(?:managed|hosted)|(?:managed|hosted)[^.]*CLI)[^.]*destination|return to the terminal)/i,
-    /select or create a project/i,
+    /### (?:Return to the terminal|Continue where you started)/i,
+    /### Select or create a project/i,
   ];
 
   for (const source of readSources(MANAGED_ONBOARDING_GUIDES)) {


### PR DESCRIPTION
## What changed

- replace the managed “Create a free account” wording with the hosted organization admission flow
- state that Clerk's automatic Free subscription does not count as an explicit Developer choice
- document Clerk-native Self-Service Agreement consent for new accounts and no re-consent for existing accounts
- explain that old organizations continue while new hosted organizations choose Developer or a paid plan
- make the browser return to the CLI or hosted destination explicit before that destination performs project selection
- keep customer-run self-hosted setup outside Clerk and this admission gate

## Why

Managed onboarding docs must describe the same flow users see in the hosted app and CLI without changing starters, runtime packages, or self-hosted setup.

Plan: [New-Organization Admission, Clerk Consent, and Monthly Seat Pricing](https://app.notion.com/p/3b83aa381852818a868acee473e1a07c?pvs=204)

## Clean replacement

This PR targets `main` directly and supersedes #6441. It does not depend on #6188 and changes only two managed-onboarding pages, one architecture CTA, and their standalone contract test.

## Validation

- managed onboarding contract test: passed
- TypeScript: passed
- lint: passed with inherited warnings
- production docs build: passed; 222 pages rendered
- formatting and `git diff --check`: passed

The repository-wide test command still has four unrelated baseline failures: three Git LFS PNG pointer checks and one Channels dark-image expectation. This PR does not change those files or checks.
