### PR TITLE
chore: remove unreferenced root assets

### DIFF
--- a/assets/animated-banner.gif
+++ b/assets/animated-banner.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e64bcbd50b9b8685342cc012c1f79659d7c9966714b4fcb6b0c625e5f9f52265
-size 26159308

--- a/assets/demo.gif
+++ b/assets/demo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c351040b050fafc8b6d11030d7e9505fff055d3f6fa42238f717cc25fb0abcd2
-size 17436012

--- a/assets/proejct-perplexity-clone.png
+++ b/assets/proejct-perplexity-clone.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efdc87f029a8f166cebf0aa88dae6cb133f10ad6f580fc6c8b4be5531ceaaaf3
-size 173304

--- a/assets/travel-planner-gif.gif
+++ b/assets/travel-planner-gif.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a9bf75be94981f314162f6055cdb8c793857cf1c2242b17a05d4460752107c23
-size 12567423


### PR DESCRIPTION
Removes four files under `assets/` that nothing in the repo references. Together they are ~56 MB of git-LFS payload that every fresh clone pays for.

| File | Size | Status |
| --- | --- | --- |
| `assets/demo.gif` | 17.4 MB | Last referenced by `README.md` until `446ad06afc` (2023-11-29) removed the `<img src="./assets/demo.gif">` tag |
| `assets/animated-banner.gif` | 26.2 MB | No reference in the tree |
| `assets/travel-planner-gif.gif` | 12.6 MB | No reference in the tree |
| `assets/proejct-perplexity-clone.png` | 173 KB | No reference in the tree; filename also carries a `proejct` typo |

`assets/license-badge.svg` is the only remaining asset referenced from the repo (`README.md:30`) and is untouched.

Credit to @VZBYang, who identified `assets/demo.gif` in #4314. That PR carried 746 commits not in `main` (234 merges plus 512 commits whose subjects are absent from `main`), and with squash and rebase both disabled on this repo there is no way to land it without grafting all of them onto `main` for a file deletion — so the deletion is being taken directly here instead.

## Testing

Every claim below was checked against this branch's base (`758e7dcb10`).

**1. Each file is unreferenced.** Grepped the full tree for each basename and for the path-qualified form:

```
$ git grep -l animated-banner.gif -- .          → 0 files
$ git grep -l travel-planner-gif.gif -- .       → 0 files
$ git grep -l proejct-perplexity-clone.png -- . → 0 files
$ git grep -n "assets/demo.gif" -- .            → (no references to assets/demo.gif)
```

`demo.gif` returns 4 bare-basename matches, all of which are different files with their own relative paths, none resolving to `assets/`:

```
examples/integrations/agent-spec/README.md:5:![Demo](demo.gif)
examples/showcases/chatkit-studio/apps/playground/README.md:5:![Demo Gif](docs/demo.gif)
examples/showcases/chatkit-studio/apps/world/README.md:5:![Gif Demo](copilotkit-world-demo.gif)
examples/showcases/multi-agent-canvas/README.md:63:![mcp-demo](./agent/demo/mcp-demo.gif)
```

**2. Nothing builds or copies the root `assets/` dir.** Grepped `*.json`, `*.yml`, `*.yaml`, `*.ts`, `*.mjs` for `assets` path references — the only hits are per-package `assets` fields (Angular examples, `packages/angular/ng-package.json`, `packages/web-inspector/src/assets/`), none of which reach the root directory.

**3. No CI check depends on them.** `.github/workflows/static_check-binaries.yml:94` explicitly allow-lists `assets/*` from the binary-size gate, so removing files there cannot trip it.

**4. Sizes confirmed from the LFS pointers** at base:

```
demo.gif                           17436012 bytes
animated-banner.gif                26159308 bytes
travel-planner-gif.gif             12567423 bytes
proejct-perplexity-clone.png         173304 bytes
```

**5. `license-badge.svg` still resolves** — `README.md:30` is the sole reference into `assets/` and that file is not part of this change.

## Known limitation

These are git-LFS objects, so deleting them from `HEAD` does not reclaim history — it cuts the LFS payload a fresh clone fetches, not the repo's stored size. Anyone who hand-built an absolute `raw.githubusercontent.com/.../main/assets/<file>` link will 404 afterward; the only reference the repo ever published was the relative `./assets/demo.gif` path in the README, dereferenced in 2023.

