### PR TITLE
Harden CopilotKit's agent-facing source of truth

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,6 +9,7 @@
     "examples/v1/_legacy/copilot-anthropic-pinecone/src/app/api/copilotkit/route.ts",
     "examples/v1/_legacy/copilot-openai-mongodb-atlas-vector-search/src/app/api/copilotkit/route.ts",
     "packages/web-inspector/src/styles/generated.css",
+    "scripts/release/public-api/manifest.v1.json",
     "showcase/aimock/shared/**",
     "showcase/aimock/d4/**",
     "showcase/aimock/d6/**",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "generate:channel-native-catalogs": "node scripts/channel-native-catalogs.mjs generate",
     "check:channel-native-catalogs": "node scripts/channel-native-catalogs.mjs check",
     "audit:channel-native-catalogs": "node scripts/channel-native-catalogs.mjs audit",
+    "generate:public-api-manifest": "tsx scripts/release/generate-public-api-manifest.ts --write",
+    "check:public-api-manifest": "tsx scripts/release/generate-public-api-manifest.ts --check",
     "sync:plugin-skills": "tsx scripts/sync-plugin-skills.ts",
     "parity:sync": "tsx examples/integrations/_parity/sync.ts",
     "parity:verify": "tsx examples/integrations/_parity/verify.ts",

--- a/packages/a2ui-renderer/skills/a2ui-renderer/SKILL.md
+++ b/packages/a2ui-renderer/skills/a2ui-renderer/SKILL.md
@@ -14,7 +14,7 @@ description: >
 type: framework
 library: copilotkit
 framework: react
-library_version: "1.66.2"
+library_version: "1.67.1"
 requires:
   - copilotkit/react-core
   - copilotkit/runtime

--- a/packages/a2ui-renderer/skills/a2ui-renderer/SKILL.md
+++ b/packages/a2ui-renderer/skills/a2ui-renderer/SKILL.md
@@ -14,7 +14,7 @@ description: >
 type: framework
 library: copilotkit
 framework: react
-library_version: "1.56.2"
+library_version: "1.66.2"
 requires:
   - copilotkit/react-core
   - copilotkit/runtime

--- a/packages/react-core/skills/react-core/SKILL.md
+++ b/packages/react-core/skills/react-core/SKILL.md
@@ -13,7 +13,7 @@ description: >
   alias). Load the reference under references/ that matches your task.
 type: framework
 library: copilotkit
-library_version: "1.56.2"
+library_version: "1.66.2"
 requires:
   - copilotkit/runtime
 sources:

--- a/packages/react-core/skills/react-core/SKILL.md
+++ b/packages/react-core/skills/react-core/SKILL.md
@@ -13,7 +13,7 @@ description: >
   alias). Load the reference under references/ that matches your task.
 type: framework
 library: copilotkit
-library_version: "1.66.2"
+library_version: "1.67.1"
 requires:
   - copilotkit/runtime
 sources:

--- a/packages/runtime/skills/runtime/SKILL.md
+++ b/packages/runtime/skills/runtime/SKILL.md
@@ -11,7 +11,7 @@ description: >
   discouraged. Load the reference under references/ that matches your task.
 type: core
 library: copilotkit
-library_version: "1.56.2"
+library_version: "1.66.2"
 requires: []
 sources:
   - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/fetch-handler.ts"

--- a/packages/runtime/skills/runtime/SKILL.md
+++ b/packages/runtime/skills/runtime/SKILL.md
@@ -11,7 +11,7 @@ description: >
   discouraged. Load the reference under references/ that matches your task.
 type: core
 library: copilotkit
-library_version: "1.66.2"
+library_version: "1.67.1"
 requires: []
 sources:
   - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/fetch-handler.ts"

--- a/scripts/__tests__/public-skill-drift.test.ts
+++ b/scripts/__tests__/public-skill-drift.test.ts
@@ -1,0 +1,129 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+interface ManifestPackage {
+  name: string;
+  version: string;
+  sourceDirectory: string;
+  entrypoints: Array<{ importPath: string }>;
+}
+
+interface PublicApiManifest {
+  packages: ManifestPackage[];
+}
+
+const manifest = JSON.parse(
+  readFileSync(
+    resolve(root, "scripts/release/public-api/manifest.v1.json"),
+    "utf8",
+  ),
+) as PublicApiManifest;
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(root, relativePath), "utf8");
+}
+
+function libraryVersion(skill: string): string | undefined {
+  return skill.match(/^library_version:\s*["']?([^"'\n]+)["']?$/m)?.[1];
+}
+
+function filesUnder(relativeDirectory: string): string[] {
+  const absoluteDirectory = resolve(root, relativeDirectory);
+
+  function walk(directory: string): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(directory, entry.name);
+      return entry.isDirectory() ? walk(path) : [path];
+    });
+  }
+
+  return walk(absoluteDirectory);
+}
+
+describe("public skill drift", () => {
+  it.each([
+    ["@copilotkit/runtime", "runtime"],
+    ["@copilotkit/react-core", "react-core"],
+    ["@copilotkit/a2ui-renderer", "a2ui-renderer"],
+  ])(
+    "%s skill version follows the public API manifest",
+    (packageName, skillName) => {
+      const packageEntry = manifest.packages.find(
+        (candidate) => candidate.name === packageName,
+      );
+      expect(
+        packageEntry,
+        `${packageName} missing from manifest`,
+      ).toBeDefined();
+
+      const sourceSkill = read(
+        `${packageEntry!.sourceDirectory}/skills/${skillName}/SKILL.md`,
+      );
+      const mirrorSkill = read(`skills/${skillName}/SKILL.md`);
+
+      expect(libraryVersion(sourceSkill)).toBe(packageEntry!.version);
+      expect(libraryVersion(mirrorSkill)).toBe(packageEntry!.version);
+    },
+  );
+
+  it("keeps current setup and debugging paths free of retired API forms", () => {
+    const currentFiles = [
+      resolve(root, "skills/copilotkit-setup/eval.yaml"),
+      ...filesUnder("skills/copilotkit-debug"),
+    ];
+    const retiredForms = [
+      /@copilotkit\/react(?!-)/,
+      /@copilotkit\/agent(?![a-z-])/,
+      /\bcreateCopilotEndpoint(?:SingleRoute(?:Express)?|Express)?\b/,
+      /packages\/v[12]\//,
+    ];
+
+    const findings = currentFiles.flatMap((file) => {
+      const relativeFile = file.slice(root.length + 1);
+      return readFileSync(file, "utf8")
+        .split("\n")
+        .flatMap((line, index) =>
+          retiredForms.some((pattern) => pattern.test(line))
+            ? [`${relativeFile}:${index + 1}: ${line.trim()}`]
+            : [],
+        );
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("grades the stylesheet through its exact public entrypoint", () => {
+    const reactCore = manifest.packages.find(
+      (candidate) => candidate.name === "@copilotkit/react-core",
+    );
+    const stylesheet = "@copilotkit/react-core/v2/styles.css";
+    const setupEval = read("skills/copilotkit-setup/eval.yaml");
+
+    expect(
+      reactCore?.entrypoints.some(
+        (entrypoint) => entrypoint.importPath === stylesheet,
+      ),
+    ).toBe(true);
+    expect(setupEval).toContain(`grep -rF "${stylesheet}"`);
+    expect(setupEval).not.toContain(
+      'grep -r "styles\\.css\\|@copilotkit/react/styles"',
+    );
+  });
+
+  it("keeps debugging source inventory paths resolvable", () => {
+    const paths = read("skills/copilotkit-debug/sources.md")
+      .split("\n")
+      .flatMap(
+        (line) => line.match(/^- (packages\/\S+?)(?:\/)? \(/)?.[1] ?? [],
+      );
+
+    expect(paths.length).toBeGreaterThan(0);
+    expect(
+      paths.filter((relativePath) => !existsSync(resolve(root, relativePath))),
+    ).toEqual([]);
+  });
+});

--- a/scripts/release/generate-public-api-manifest.ts
+++ b/scripts/release/generate-public-api-manifest.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildPublicApiManifest,
+  publicApiManifestPath,
+  publicApiSchemaPath,
+  renderPublicApiManifest,
+} from "./lib/public-api-manifest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const args = new Set(process.argv.slice(2));
+const write = args.delete("--write");
+const check = args.delete("--check");
+
+if (args.size > 0 || write === check) {
+  throw new Error("Usage: generate-public-api-manifest.ts (--write | --check)");
+}
+
+if (!existsSync(publicApiSchemaPath(root))) {
+  throw new Error(`Missing versioned schema: ${publicApiSchemaPath(root)}`);
+}
+
+const expected = renderPublicApiManifest(buildPublicApiManifest(root));
+const manifestPath = publicApiManifestPath(root);
+
+if (write) {
+  writeFileSync(manifestPath, expected);
+  console.log(`Wrote ${manifestPath}`);
+} else {
+  const actual = existsSync(manifestPath)
+    ? readFileSync(manifestPath, "utf8")
+    : "";
+  if (actual !== expected) {
+    throw new Error(
+      `${manifestPath} is stale. Run pnpm generate:public-api-manifest.`,
+    );
+  }
+  console.log(`${manifestPath} is current`);
+}

--- a/scripts/release/lib/public-api-manifest.test.ts
+++ b/scripts/release/lib/public-api-manifest.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  buildPublicApiManifest,
+  renderPublicApiManifest,
+} from "./public-api-manifest";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+describe("public API manifest", () => {
+  it("matches the public package and source declarations", () => {
+    const generated = renderPublicApiManifest(buildPublicApiManifest(root));
+    const committed = readFileSync(
+      resolve(root, "scripts/release/public-api/manifest.v1.json"),
+      "utf8",
+    );
+
+    expect(committed).toBe(generated);
+  });
+});

--- a/scripts/release/lib/public-api-manifest.ts
+++ b/scripts/release/lib/public-api-manifest.ts
@@ -1,0 +1,972 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import ts from "typescript";
+
+const SCHEMA_VERSION = 1;
+const MANIFEST_PATH = "scripts/release/public-api/manifest.v1.json";
+const SCHEMA_PATH = "scripts/release/public-api/manifest.schema.v1.json";
+
+type JsonObject = Record<string, unknown>;
+
+export interface Provenance {
+  kind: "package-json" | "release-config" | "typescript-ast";
+  path: string;
+  selector: string;
+}
+
+export interface PublicApiManifest {
+  $schema: string;
+  schemaVersion: number;
+  selection: {
+    rule: string;
+    provenance: Provenance[];
+  };
+  packages: Array<{
+    name: string;
+    version: string;
+    sourceDirectory: string;
+    entrypoints: Array<{
+      importPath: string;
+      exportKey: string;
+      kind: "code" | "metadata" | "style";
+      conditions: unknown;
+      provenance: Provenance;
+    }>;
+    compatibility: {
+      engines?: JsonObject;
+      peerDependencies?: JsonObject;
+      optionalPeerDependencies?: string[];
+      provenance: Provenance[];
+    };
+    provenance: {
+      name: Provenance;
+      version: Provenance;
+      releaseScope: Provenance;
+    };
+  }>;
+  runtime: {
+    serviceAdapters: SourceApiEntry[];
+    hostFactories: SourceApiEntry[];
+    agentFactoryModes: Array<{
+      type: string;
+      configurationKeys: string[];
+      provenance: {
+        type: Provenance;
+        configurationKeys: Provenance;
+      };
+    }>;
+  };
+  deprecations: Array<{
+    importPath: string;
+    symbol: string;
+    replacement: {
+      importPath: string;
+      symbol: string;
+    };
+    sourceMessage: string;
+    provenance: {
+      importPath: Provenance;
+      symbol: Provenance;
+      replacement: Provenance;
+      sourceMessage: Provenance;
+    };
+  }>;
+}
+
+interface SourceApiEntry {
+  importPath: string;
+  symbol: string;
+  configurationType?: string;
+  configurationKeys: string[];
+  provenance: {
+    importPath: Provenance;
+    symbol: Provenance;
+    configurationType?: Provenance;
+    configurationKeys: Provenance;
+  };
+}
+
+interface PackageJson extends JsonObject {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  exports?: Record<string, unknown>;
+  engines?: JsonObject;
+  peerDependencies?: JsonObject;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+interface ReleaseConfig {
+  scopes?: Record<string, { packages?: string[] }>;
+}
+
+interface HostFactorySpec {
+  importPath: string;
+  entrySource: string;
+  symbol: string;
+  declarationPath: string;
+  configurationType?: string;
+  configurationPath?: string;
+}
+
+interface DeprecationSpec {
+  importPath: string;
+  entrySource: string;
+  symbol: string;
+  declarationPath: string;
+  replacement: {
+    importPath: string;
+    symbol: string;
+  };
+}
+
+const HOST_FACTORIES: HostFactorySpec[] = [
+  {
+    importPath: "@copilotkit/runtime/v2",
+    entrySource: "packages/runtime/src/v2/index.ts",
+    symbol: "createCopilotRuntimeHandler",
+    declarationPath: "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+    configurationType: "CopilotRuntimeHandlerOptions",
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/express",
+    entrySource: "packages/runtime/src/v2/express.ts",
+    symbol: "createCopilotExpressHandler",
+    declarationPath: "packages/runtime/src/v2/runtime/endpoints/express.ts",
+    configurationType: "CopilotExpressEndpointParams",
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/hono",
+    entrySource: "packages/runtime/src/v2/hono.ts",
+    symbol: "createCopilotHonoHandler",
+    declarationPath: "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+    configurationType: "CopilotEndpointParams",
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/node",
+    entrySource: "packages/runtime/src/v2/node.ts",
+    symbol: "createCopilotNodeHandler",
+    declarationPath:
+      "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/node",
+    entrySource: "packages/runtime/src/v2/node.ts",
+    symbol: "createCopilotNodeListener",
+    declarationPath: "packages/runtime/src/v2/runtime/endpoints/node.ts",
+    configurationType: "CopilotRuntimeHandlerOptions",
+    configurationPath: "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+  },
+];
+
+const DEPRECATIONS: DeprecationSpec[] = [
+  ...[
+    "LangGraphAgent",
+    "LangGraphHttpAgent",
+    "TextMessageEvents",
+    "ToolCallEvents",
+    "CustomEventNames",
+    "PredictStateTool",
+  ].map((symbol) => ({
+    importPath: "@copilotkit/runtime",
+    entrySource: "packages/runtime/src/index.ts",
+    symbol,
+    declarationPath: "packages/runtime/src/lib/index.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/langgraph",
+      symbol,
+    },
+  })),
+  {
+    importPath: "@copilotkit/runtime/v2/express",
+    entrySource: "packages/runtime/src/v2/express.ts",
+    symbol: "createCopilotEndpointExpress",
+    declarationPath: "packages/runtime/src/v2/runtime/endpoints/express.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2/express",
+      symbol: "createCopilotExpressHandler",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/express",
+    entrySource: "packages/runtime/src/v2/express.ts",
+    symbol: "createCopilotEndpointSingleRouteExpress",
+    declarationPath:
+      "packages/runtime/src/v2/runtime/endpoints/express-single.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2/express",
+      symbol: "createCopilotExpressHandler",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/hono",
+    entrySource: "packages/runtime/src/v2/hono.ts",
+    symbol: "createCopilotEndpoint",
+    declarationPath: "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2/hono",
+      symbol: "createCopilotHonoHandler",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/hono",
+    entrySource: "packages/runtime/src/v2/hono.ts",
+    symbol: "createCopilotEndpointSingleRoute",
+    declarationPath: "packages/runtime/src/v2/runtime/endpoints/hono-single.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2/hono",
+      symbol: "createCopilotHonoHandler",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2/node",
+    entrySource: "packages/runtime/src/v2/node.ts",
+    symbol: "createNodeFetchHandler",
+    declarationPath:
+      "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2/node",
+      symbol: "createCopilotNodeHandler",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2",
+    entrySource: "packages/runtime/src/v2/index.ts",
+    symbol: "CopilotKitRequestHandler",
+    declarationPath: "packages/runtime/src/v2/runtime/index.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2",
+      symbol: "CopilotRuntimeFetchHandler",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2",
+    entrySource: "packages/runtime/src/v2/index.ts",
+    symbol: "BasicAgent",
+    declarationPath: "packages/runtime/src/agent/index.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2",
+      symbol: "BuiltInAgent",
+    },
+  },
+  {
+    importPath: "@copilotkit/runtime/v2",
+    entrySource: "packages/runtime/src/v2/index.ts",
+    symbol: "BasicAgentConfiguration",
+    declarationPath: "packages/runtime/src/agent/index.ts",
+    replacement: {
+      importPath: "@copilotkit/runtime/v2",
+      symbol: "BuiltInAgentClassicConfig",
+    },
+  },
+];
+
+function readJson<T>(path: string): T {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch (error) {
+    throw new Error(`Unable to parse ${path}: ${String(error)}`, {
+      cause: error,
+    });
+  }
+}
+
+function sourceFile(root: string, path: string): ts.SourceFile {
+  const absolutePath = resolve(root, path);
+  const text = readFileSync(absolutePath, "utf8");
+  return ts.createSourceFile(
+    absolutePath,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function provenance(
+  kind: Provenance["kind"],
+  path: string,
+  selector: string,
+): Provenance {
+  return { kind, path, selector };
+}
+
+function declarationName(node: ts.Node): string | undefined {
+  if (
+    (ts.isClassDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isEnumDeclaration(node)) &&
+    node.name
+  ) {
+    return node.name.text;
+  }
+  if (ts.isVariableStatement(node)) {
+    const names = node.declarationList.declarations
+      .map((item) => (ts.isIdentifier(item.name) ? item.name.text : undefined))
+      .filter((name): name is string => Boolean(name));
+    return names.length === 1 ? names[0] : undefined;
+  }
+  if (ts.isExportDeclaration(node) && node.exportClause) {
+    if (ts.isNamedExports(node.exportClause)) {
+      const names = node.exportClause.elements.map((item) => item.name.text);
+      return names.length === 1 ? names[0] : undefined;
+    }
+  }
+  return undefined;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return Boolean(
+    ts.canHaveModifiers(node) &&
+    ts
+      .getModifiers(node)
+      ?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword),
+  );
+}
+
+function resolveModule(
+  root: string,
+  fromPath: string,
+  specifier: string,
+): string {
+  if (!specifier.startsWith(".")) {
+    throw new Error(
+      `Cannot prove a workspace export through external module ${specifier} from ${fromPath}`,
+    );
+  }
+  const base = resolve(root, dirname(fromPath), specifier);
+  const candidates = [
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    join(base, "index.tsx"),
+  ];
+  const match = candidates.find(existsSync);
+  if (!match) {
+    throw new Error(`Cannot resolve ${specifier} from ${fromPath}`);
+  }
+  return relative(root, match);
+}
+
+function findExportedDeclaration(
+  root: string,
+  path: string,
+  symbol: string,
+  seen = new Set<string>(),
+): { path: string; node: ts.Node } | undefined {
+  const key = `${path}:${symbol}`;
+  if (seen.has(key)) return undefined;
+  seen.add(key);
+
+  const file = sourceFile(root, path);
+  for (const statement of file.statements) {
+    if (hasExportModifier(statement) && declarationName(statement) === symbol) {
+      return { path, node: statement };
+    }
+    if (!ts.isExportDeclaration(statement)) {
+      continue;
+    }
+    if (!statement.moduleSpecifier) {
+      if (
+        !statement.exportClause ||
+        !ts.isNamedExports(statement.exportClause)
+      ) {
+        continue;
+      }
+      const exported = statement.exportClause.elements.find(
+        (item) => item.name.text === symbol,
+      );
+      if (!exported) continue;
+      const sourceName = exported.propertyName?.text ?? exported.name.text;
+      return (
+        findExportedDeclaration(root, path, sourceName, seen) ?? {
+          path,
+          node: statement,
+        }
+      );
+    }
+    const specifier = (statement.moduleSpecifier as ts.StringLiteral).text;
+    if (!specifier.startsWith(".")) continue;
+    const nextPath = resolveModule(root, path, specifier);
+    if (!statement.exportClause) {
+      const found = findExportedDeclaration(root, nextPath, symbol, seen);
+      if (found) return found;
+      continue;
+    }
+    if (!ts.isNamedExports(statement.exportClause)) continue;
+    const exported = statement.exportClause.elements.find(
+      (item) => item.name.text === symbol,
+    );
+    if (!exported) continue;
+    const sourceName = exported.propertyName?.text ?? exported.name.text;
+    return (
+      findExportedDeclaration(root, nextPath, sourceName, seen) ?? {
+        path,
+        node: statement,
+      }
+    );
+  }
+  return undefined;
+}
+
+function requireExport(
+  root: string,
+  entrySource: string,
+  symbol: string,
+): { path: string; node: ts.Node } {
+  const result = findExportedDeclaration(root, entrySource, symbol);
+  if (!result) {
+    throw new Error(`${symbol} is not exported from ${entrySource}`);
+  }
+  return result;
+}
+
+function findNamedDeclaration(
+  root: string,
+  path: string,
+  name: string,
+): ts.Node {
+  const matches = sourceFile(root, path).statements.filter(
+    (statement) => declarationName(statement) === name,
+  );
+  if (matches.length > 1 && matches.every(ts.isFunctionDeclaration)) {
+    const implementations = matches.filter((statement) => statement.body);
+    if (implementations.length === 1) return implementations[0];
+  }
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one ${name} declaration in ${path}, found ${matches.length}`,
+    );
+  }
+  return matches[0];
+}
+
+function configurationKeys(
+  root: string,
+  path: string,
+  typeName: string,
+): string[] {
+  const node = findNamedDeclaration(root, path, typeName);
+  if (!ts.isInterfaceDeclaration(node)) {
+    throw new Error(`${typeName} in ${path} must be an interface`);
+  }
+  return node.members
+    .filter(ts.isPropertySignature)
+    .filter(
+      (member) =>
+        !ts.getJSDocTags(member).some((tag) => tag.tagName.text === "internal"),
+    )
+    .map((member) => {
+      if (!member.name || !ts.isIdentifier(member.name)) {
+        throw new Error(
+          `${typeName} in ${path} has an unsupported non-identifier property`,
+        );
+      }
+      return member.name.text;
+    });
+}
+
+function packageExportKey(importPath: string): string {
+  const prefix = "@copilotkit/runtime";
+  if (importPath === prefix) return ".";
+  if (!importPath.startsWith(`${prefix}/`)) {
+    throw new Error(`Unsupported runtime import path ${importPath}`);
+  }
+  return `.${importPath.slice(prefix.length)}`;
+}
+
+function assertRuntimeImportPath(root: string, importPath: string): Provenance {
+  const path = "packages/runtime/package.json";
+  const manifest = readJson<PackageJson>(resolve(root, path));
+  const key = packageExportKey(importPath);
+  if (!manifest.exports || !(key in manifest.exports)) {
+    throw new Error(`${importPath} is not exported by ${path}`);
+  }
+  return provenance("package-json", path, `exports[${JSON.stringify(key)}]`);
+}
+
+function hostFactories(root: string): SourceApiEntry[] {
+  return HOST_FACTORIES.map((spec) => {
+    requireExport(root, spec.entrySource, spec.symbol);
+    const declaration = findNamedDeclaration(
+      root,
+      spec.declarationPath,
+      spec.symbol,
+    );
+    if (!ts.isFunctionDeclaration(declaration)) {
+      throw new Error(
+        `${spec.symbol} in ${spec.declarationPath} is not a function`,
+      );
+    }
+    const configurationPath = spec.configurationPath ?? spec.declarationPath;
+    const keys = spec.configurationType
+      ? configurationKeys(root, configurationPath, spec.configurationType)
+      : [];
+    const importProvenance = assertRuntimeImportPath(root, spec.importPath);
+    const symbolProvenance = provenance(
+      "typescript-ast",
+      spec.declarationPath,
+      `export function ${spec.symbol}`,
+    );
+    return {
+      importPath: spec.importPath,
+      symbol: spec.symbol,
+      ...(spec.configurationType
+        ? { configurationType: spec.configurationType }
+        : {}),
+      configurationKeys: keys,
+      provenance: {
+        importPath: importProvenance,
+        symbol: symbolProvenance,
+        ...(spec.configurationType
+          ? {
+              configurationType: provenance(
+                "typescript-ast",
+                configurationPath,
+                `interface ${spec.configurationType}`,
+              ),
+            }
+          : {}),
+        configurationKeys: provenance(
+          "typescript-ast",
+          configurationPath,
+          spec.configurationType
+            ? `interface ${spec.configurationType} public properties`
+            : `function ${spec.symbol} has no configuration object`,
+        ),
+      },
+    };
+  });
+}
+
+function exportedAdapterModules(root: string): string[] {
+  const path = "packages/runtime/src/service-adapters/index.ts";
+  const file = sourceFile(root, path);
+  return file.statements.flatMap((statement) => {
+    if (
+      !ts.isExportDeclaration(statement) ||
+      statement.exportClause ||
+      !statement.moduleSpecifier
+    ) {
+      return [];
+    }
+    const specifier = (statement.moduleSpecifier as ts.StringLiteral).text;
+    return specifier === "./shared"
+      ? []
+      : [resolveModule(root, path, specifier)];
+  });
+}
+
+function constructorConfiguration(
+  root: string,
+  path: string,
+  node: ts.ClassDeclaration,
+): { type?: string; keys: string[] } {
+  const constructors = node.members.filter(ts.isConstructorDeclaration);
+  if (constructors.length === 0) return { keys: [] };
+  if (constructors.length !== 1 || constructors[0].parameters.length > 1) {
+    throw new Error(
+      `${node.name?.text ?? "adapter"} in ${path} has an ambiguous constructor`,
+    );
+  }
+  const parameter = constructors[0].parameters[0];
+  if (!parameter) return { keys: [] };
+  if (!parameter.type || !ts.isTypeReferenceNode(parameter.type)) {
+    throw new Error(
+      `${node.name?.text ?? "adapter"} in ${path} has an unsupported constructor type`,
+    );
+  }
+  const typeName = parameter.type.typeName.getText();
+  return { type: typeName, keys: configurationKeys(root, path, typeName) };
+}
+
+function serviceAdapters(root: string): SourceApiEntry[] {
+  const importPath = "@copilotkit/runtime";
+  const importProvenance = assertRuntimeImportPath(root, importPath);
+  const adapters = exportedAdapterModules(root).flatMap((path) => {
+    const file = sourceFile(root, path);
+    const classes = new Map(
+      file.statements.flatMap((statement) =>
+        ts.isClassDeclaration(statement) &&
+        statement.name?.text.endsWith("Adapter")
+          ? [[statement.name.text, statement] as const]
+          : [],
+      ),
+    );
+    const symbols = file.statements.flatMap((statement) => {
+      if (
+        ts.isClassDeclaration(statement) &&
+        statement.name?.text.endsWith("Adapter") &&
+        hasExportModifier(statement)
+      ) {
+        return [
+          {
+            symbol: statement.name.text,
+            implementation: statement,
+            selector: `export class ${statement.name.text}`,
+          },
+        ];
+      }
+      if (!ts.isVariableStatement(statement) || !hasExportModifier(statement)) {
+        return [];
+      }
+      return statement.declarationList.declarations.flatMap((declaration) => {
+        if (
+          !ts.isIdentifier(declaration.name) ||
+          !declaration.name.text.endsWith("Adapter") ||
+          !declaration.initializer ||
+          !ts.isIdentifier(declaration.initializer)
+        ) {
+          return [];
+        }
+        const implementation = classes.get(declaration.initializer.text);
+        if (!implementation) {
+          throw new Error(
+            `${declaration.name.text} in ${path} aliases an unknown adapter class`,
+          );
+        }
+        return [
+          {
+            symbol: declaration.name.text,
+            implementation,
+            selector: `export const ${declaration.name.text}`,
+          },
+        ];
+      });
+    });
+    return symbols.map(({ symbol, implementation, selector }) => {
+      requireExport(root, "packages/runtime/src/index.ts", symbol);
+      const configuration = constructorConfiguration(
+        root,
+        path,
+        implementation,
+      );
+      const symbolProvenance = provenance("typescript-ast", path, selector);
+      return {
+        importPath,
+        symbol,
+        ...(configuration.type
+          ? { configurationType: configuration.type }
+          : {}),
+        configurationKeys: configuration.keys,
+        provenance: {
+          importPath: importProvenance,
+          symbol: symbolProvenance,
+          ...(configuration.type
+            ? {
+                configurationType: provenance(
+                  "typescript-ast",
+                  path,
+                  `constructor parameter ${configuration.type}`,
+                ),
+              }
+            : {}),
+          configurationKeys: provenance(
+            "typescript-ast",
+            path,
+            configuration.type
+              ? `interface ${configuration.type} public properties`
+              : `class ${implementation.name?.text} has no constructor configuration`,
+          ),
+        },
+      } satisfies SourceApiEntry;
+    });
+  });
+  return adapters.sort((left, right) =>
+    left.symbol.localeCompare(right.symbol),
+  );
+}
+
+function agentFactoryModes(
+  root: string,
+): PublicApiManifest["runtime"]["agentFactoryModes"] {
+  const path = "packages/runtime/src/agent/index.ts";
+  requireExport(
+    root,
+    "packages/runtime/src/v2/index.ts",
+    "BuiltInAgentFactoryConfig",
+  );
+  const union = findNamedDeclaration(root, path, "BuiltInAgentFactoryConfig");
+  if (!ts.isTypeAliasDeclaration(union) || !ts.isUnionTypeNode(union.type)) {
+    throw new Error(`BuiltInAgentFactoryConfig in ${path} must be a union`);
+  }
+  return union.type.types.map((member) => {
+    if (!ts.isTypeReferenceNode(member)) {
+      throw new Error(
+        `BuiltInAgentFactoryConfig in ${path} has a non-reference member`,
+      );
+    }
+    const typeName = member.typeName.getText();
+    const declaration = findNamedDeclaration(root, path, typeName);
+    if (!ts.isInterfaceDeclaration(declaration)) {
+      throw new Error(`${typeName} in ${path} must be an interface`);
+    }
+    const typeProperty = declaration.members
+      .filter(ts.isPropertySignature)
+      .find((property) => property.name?.getText() === "type");
+    if (
+      !typeProperty?.type ||
+      !ts.isLiteralTypeNode(typeProperty.type) ||
+      !ts.isStringLiteral(typeProperty.type.literal)
+    ) {
+      throw new Error(
+        `${typeName} in ${path} must have one string literal type`,
+      );
+    }
+    const keys = configurationKeys(root, path, typeName);
+    return {
+      type: typeProperty.type.literal.text,
+      configurationKeys: keys,
+      provenance: {
+        type: provenance(
+          "typescript-ast",
+          path,
+          `interface ${typeName} property type`,
+        ),
+        configurationKeys: provenance(
+          "typescript-ast",
+          path,
+          `interface ${typeName} public properties`,
+        ),
+      },
+    };
+  });
+}
+
+function deprecationMessage(
+  node: ts.Node,
+  path: string,
+  symbol: string,
+): string {
+  const tags = ts
+    .getJSDocTags(node)
+    .filter((tag) => tag.tagName.text === "deprecated");
+  if (tags.length !== 1 || typeof tags[0].comment !== "string") {
+    throw new Error(
+      `${symbol} in ${path} must have exactly one textual @deprecated tag`,
+    );
+  }
+  return tags[0].comment.trim();
+}
+
+function deprecations(root: string): PublicApiManifest["deprecations"] {
+  return DEPRECATIONS.map((spec) => {
+    requireExport(root, spec.entrySource, spec.symbol);
+    const declaration = findNamedDeclaration(
+      root,
+      spec.declarationPath,
+      spec.symbol,
+    );
+    const message = deprecationMessage(
+      declaration,
+      spec.declarationPath,
+      spec.symbol,
+    );
+    if (
+      !message.includes(spec.replacement.symbol) ||
+      (spec.replacement.importPath !== spec.importPath &&
+        !message.includes(spec.replacement.importPath))
+    ) {
+      throw new Error(
+        `${symbolDescription(spec)} has a replacement not proven by its @deprecated tag`,
+      );
+    }
+    const declarationProvenance = provenance(
+      "typescript-ast",
+      spec.declarationPath,
+      `${spec.symbol} @deprecated tag`,
+    );
+    return {
+      importPath: spec.importPath,
+      symbol: spec.symbol,
+      replacement: spec.replacement,
+      sourceMessage: message,
+      provenance: {
+        importPath: assertRuntimeImportPath(root, spec.importPath),
+        symbol: declarationProvenance,
+        replacement: declarationProvenance,
+        sourceMessage: declarationProvenance,
+      },
+    };
+  }).sort((left, right) =>
+    `${left.importPath}:${left.symbol}`.localeCompare(
+      `${right.importPath}:${right.symbol}`,
+    ),
+  );
+}
+
+function symbolDescription(spec: DeprecationSpec): string {
+  return `${spec.importPath} ${spec.symbol}`;
+}
+
+function entrypointKind(value: unknown): "code" | "metadata" | "style" {
+  const serialized = JSON.stringify(value);
+  if (/\.css(?:"|$)/.test(serialized)) return "style";
+  if (/package\.json(?:"|$)/.test(serialized)) return "metadata";
+  return "code";
+}
+
+function releasePackages(root: string): Map<string, string> {
+  const path = "release.config.json";
+  const config = readJson<ReleaseConfig>(resolve(root, path));
+  if (!config.scopes || typeof config.scopes !== "object") {
+    throw new Error(`${path} must define scopes`);
+  }
+  const result = new Map<string, string>();
+  for (const [scope, value] of Object.entries(config.scopes)) {
+    if (!Array.isArray(value.packages)) {
+      throw new Error(`${path} scope ${scope} must define packages`);
+    }
+    for (const name of value.packages) {
+      if (result.has(name)) {
+        throw new Error(`${name} appears in multiple release scopes`);
+      }
+      result.set(name, scope);
+    }
+  }
+  return result;
+}
+
+function publicPackages(root: string): PublicApiManifest["packages"] {
+  const released = releasePackages(root);
+  const packagesRoot = resolve(root, "packages");
+  const packagePaths = readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `packages/${entry.name}/package.json`)
+    .filter((path) => existsSync(resolve(root, path)));
+
+  const publicManifests = packagePaths.flatMap((path) => {
+    const manifest = readJson<PackageJson>(resolve(root, path));
+    return manifest.name?.startsWith("@copilotkit/") &&
+      manifest.private !== true
+      ? [{ path, manifest }]
+      : [];
+  });
+  const names = new Set(publicManifests.map(({ manifest }) => manifest.name));
+  const missingFromRelease = [...names].filter((name) => !released.has(name!));
+  const staleReleasePackages = [...released.keys()].filter(
+    (name) => !names.has(name),
+  );
+  if (missingFromRelease.length || staleReleasePackages.length) {
+    throw new Error(
+      `Public package/release scope mismatch (missing: ${missingFromRelease.join(", ") || "none"}; stale: ${staleReleasePackages.join(", ") || "none"})`,
+    );
+  }
+
+  return publicManifests
+    .map(({ path, manifest }) => {
+      if (
+        typeof manifest.name !== "string" ||
+        typeof manifest.version !== "string" ||
+        !manifest.exports ||
+        typeof manifest.exports !== "object"
+      ) {
+        throw new Error(`${path} lacks name, version, or exports metadata`);
+      }
+      const packagePath = dirname(path);
+      const optionalPeerDependencies = Object.entries(
+        manifest.peerDependenciesMeta ?? {},
+      )
+        .filter(([, metadata]) => metadata.optional === true)
+        .map(([name]) => name)
+        .sort();
+      const compatibilityProvenance: Provenance[] = [];
+      if (manifest.engines) {
+        compatibilityProvenance.push(
+          provenance("package-json", path, "engines"),
+        );
+      }
+      if (manifest.peerDependencies) {
+        compatibilityProvenance.push(
+          provenance("package-json", path, "peerDependencies"),
+        );
+      }
+      if (optionalPeerDependencies.length) {
+        compatibilityProvenance.push(
+          provenance("package-json", path, "peerDependenciesMeta.*.optional"),
+        );
+      }
+      return {
+        name: manifest.name,
+        version: manifest.version,
+        sourceDirectory: packagePath,
+        entrypoints: Object.entries(manifest.exports)
+          .map(([exportKey, conditions]) => ({
+            importPath:
+              exportKey === "."
+                ? manifest.name!
+                : `${manifest.name}${exportKey.slice(1)}`,
+            exportKey,
+            kind: entrypointKind(conditions),
+            conditions,
+            provenance: provenance(
+              "package-json",
+              path,
+              `exports[${JSON.stringify(exportKey)}]`,
+            ),
+          }))
+          .sort((left, right) =>
+            left.importPath.localeCompare(right.importPath),
+          ),
+        compatibility: {
+          ...(manifest.engines ? { engines: manifest.engines } : {}),
+          ...(manifest.peerDependencies
+            ? { peerDependencies: manifest.peerDependencies }
+            : {}),
+          ...(optionalPeerDependencies.length
+            ? { optionalPeerDependencies }
+            : {}),
+          provenance: compatibilityProvenance,
+        },
+        provenance: {
+          name: provenance("package-json", path, "name"),
+          version: provenance("package-json", path, "version"),
+          releaseScope: provenance(
+            "release-config",
+            "release.config.json",
+            `scopes.${released.get(manifest.name)}.packages`,
+          ),
+        },
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function buildPublicApiManifest(root: string): PublicApiManifest {
+  return {
+    $schema: "./manifest.schema.v1.json",
+    schemaVersion: SCHEMA_VERSION,
+    selection: {
+      rule: "An immediate packages/* package is public when its name uses the @copilotkit scope, private is not true, and it appears exactly once in release.config.json.",
+      provenance: [
+        provenance("package-json", "packages/*/package.json", "name, private"),
+        provenance(
+          "release-config",
+          "release.config.json",
+          "scopes.*.packages",
+        ),
+      ],
+    },
+    packages: publicPackages(root),
+    runtime: {
+      serviceAdapters: serviceAdapters(root),
+      hostFactories: hostFactories(root),
+      agentFactoryModes: agentFactoryModes(root),
+    },
+    deprecations: deprecations(root),
+  };
+}
+
+export function renderPublicApiManifest(manifest: PublicApiManifest): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+export function publicApiManifestPath(root: string): string {
+  return resolve(root, MANIFEST_PATH);
+}
+
+export function publicApiSchemaPath(root: string): string {
+  return resolve(root, SCHEMA_PATH);
+}

--- a/scripts/release/public-api/manifest.schema.v1.json
+++ b/scripts/release/public-api/manifest.schema.v1.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://copilotkit.ai/schemas/public-api-manifest/v1",
+  "title": "CopilotKit public API manifest v1",
+  "description": "Versioned schema for mechanically proven public npm packages, import paths, compatibility ranges, runtime adapters and factories, configuration keys, and explicit deprecation replacements. Package facts come from package.json and release.config.json; source API facts come from exported TypeScript declarations. Consumers must reject unknown schemaVersion values.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schemaVersion",
+    "selection",
+    "packages",
+    "runtime",
+    "deprecations"
+  ],
+  "properties": {
+    "$schema": { "const": "./manifest.schema.v1.json" },
+    "schemaVersion": {
+      "const": 1,
+      "description": "Breaking changes to this document shape require a new schema and manifest version."
+    },
+    "selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rule", "provenance"],
+      "properties": {
+        "rule": {
+          "type": "string",
+          "description": "Deterministic rule used to select public packages."
+        },
+        "provenance": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/provenance" },
+          "minItems": 1
+        }
+      }
+    },
+    "packages": {
+      "type": "array",
+      "description": "All release-scoped, non-private @copilotkit/* packages, sorted by package name.",
+      "items": { "$ref": "#/$defs/package" }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["serviceAdapters", "hostFactories", "agentFactoryModes"],
+      "properties": {
+        "serviceAdapters": {
+          "type": "array",
+          "description": "Legacy CopilotServiceAdapter classes exported from @copilotkit/runtime.",
+          "items": { "$ref": "#/$defs/sourceApiEntry" }
+        },
+        "hostFactories": {
+          "type": "array",
+          "description": "Canonical v2 Fetch, Express, Hono, and Node host factories.",
+          "items": { "$ref": "#/$defs/sourceApiEntry" }
+        },
+        "agentFactoryModes": {
+          "type": "array",
+          "description": "Discriminated BuiltInAgent factory modes extracted from BuiltInAgentFactoryConfig.",
+          "items": { "$ref": "#/$defs/agentFactoryMode" }
+        }
+      }
+    },
+    "deprecations": {
+      "type": "array",
+      "description": "Only exported declarations whose @deprecated tag names a concrete replacement.",
+      "items": { "$ref": "#/$defs/deprecation" }
+    }
+  },
+  "$defs": {
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "path", "selector"],
+      "properties": {
+        "kind": {
+          "enum": ["package-json", "release-config", "typescript-ast"]
+        },
+        "path": {
+          "type": "string",
+          "description": "Repository-relative source path or deterministic glob."
+        },
+        "selector": {
+          "type": "string",
+          "description": "Field or declaration selector within path."
+        }
+      }
+    },
+    "entrypoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "importPath",
+        "exportKey",
+        "kind",
+        "conditions",
+        "provenance"
+      ],
+      "properties": {
+        "importPath": { "type": "string" },
+        "exportKey": { "type": "string" },
+        "kind": { "enum": ["code", "metadata", "style"] },
+        "conditions": {
+          "description": "The package.json exports value, preserved without interpretation."
+        },
+        "provenance": { "$ref": "#/$defs/provenance" }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provenance"],
+      "properties": {
+        "engines": { "type": "object" },
+        "peerDependencies": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "optionalPeerDependencies": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "provenance": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/provenance" }
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "sourceDirectory",
+        "entrypoints",
+        "compatibility",
+        "provenance"
+      ],
+      "properties": {
+        "name": { "type": "string", "pattern": "^@copilotkit/" },
+        "version": { "type": "string" },
+        "sourceDirectory": { "type": "string", "pattern": "^packages/" },
+        "entrypoints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/entrypoint" },
+          "minItems": 1
+        },
+        "compatibility": { "$ref": "#/$defs/compatibility" },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version", "releaseScope"],
+          "properties": {
+            "name": { "$ref": "#/$defs/provenance" },
+            "version": { "$ref": "#/$defs/provenance" },
+            "releaseScope": { "$ref": "#/$defs/provenance" }
+          }
+        }
+      }
+    },
+    "sourceApiEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["importPath", "symbol", "configurationKeys", "provenance"],
+      "properties": {
+        "importPath": { "type": "string" },
+        "symbol": { "type": "string" },
+        "configurationType": { "type": "string" },
+        "configurationKeys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["importPath", "symbol", "configurationKeys"],
+          "properties": {
+            "importPath": { "$ref": "#/$defs/provenance" },
+            "symbol": { "$ref": "#/$defs/provenance" },
+            "configurationType": { "$ref": "#/$defs/provenance" },
+            "configurationKeys": { "$ref": "#/$defs/provenance" }
+          }
+        }
+      }
+    },
+    "agentFactoryMode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "configurationKeys", "provenance"],
+      "properties": {
+        "type": { "type": "string" },
+        "configurationKeys": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "configurationKeys"],
+          "properties": {
+            "type": { "$ref": "#/$defs/provenance" },
+            "configurationKeys": { "$ref": "#/$defs/provenance" }
+          }
+        }
+      }
+    },
+    "replacement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["importPath", "symbol"],
+      "properties": {
+        "importPath": { "type": "string" },
+        "symbol": { "type": "string" }
+      }
+    },
+    "deprecation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "importPath",
+        "symbol",
+        "replacement",
+        "sourceMessage",
+        "provenance"
+      ],
+      "properties": {
+        "importPath": { "type": "string" },
+        "symbol": { "type": "string" },
+        "replacement": { "$ref": "#/$defs/replacement" },
+        "sourceMessage": { "type": "string", "minLength": 1 },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["importPath", "symbol", "replacement", "sourceMessage"],
+          "properties": {
+            "importPath": { "$ref": "#/$defs/provenance" },
+            "symbol": { "$ref": "#/$defs/provenance" },
+            "replacement": { "$ref": "#/$defs/provenance" },
+            "sourceMessage": { "$ref": "#/$defs/provenance" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/release/public-api/manifest.v1.json
+++ b/scripts/release/public-api/manifest.v1.json
@@ -1,0 +1,3281 @@
+{
+  "$schema": "./manifest.schema.v1.json",
+  "schemaVersion": 1,
+  "selection": {
+    "rule": "An immediate packages/* package is public when its name uses the @copilotkit scope, private is not true, and it appears exactly once in release.config.json.",
+    "provenance": [
+      {
+        "kind": "package-json",
+        "path": "packages/*/package.json",
+        "selector": "name, private"
+      },
+      {
+        "kind": "release-config",
+        "path": "release.config.json",
+        "selector": "scopes.*.packages"
+      }
+    ]
+  },
+  "packages": [
+    {
+      "name": "@copilotkit/a2ui-renderer",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/a2ui-renderer",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/a2ui-renderer",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/index.d.mts",
+              "default": "./dist/index.mjs"
+            },
+            "require": {
+              "types": "./dist/index.d.cts",
+              "default": "./dist/index.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/a2ui-renderer/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/a2ui-renderer/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/a2ui-renderer/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/a2ui-renderer/web-components",
+          "exportKey": "./web-components",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/web-components/index.d.mts",
+              "default": "./dist/web-components/index.mjs"
+            },
+            "require": {
+              "types": "./dist/web-components/index.d.cts",
+              "default": "./dist/web-components/index.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/a2ui-renderer/package.json",
+            "selector": "exports[\"./web-components\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/a2ui-renderer/web-components/define",
+          "exportKey": "./web-components/define",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/web-components/define.d.mts",
+              "default": "./dist/web-components/define.mjs"
+            },
+            "require": {
+              "types": "./dist/web-components/define.d.cts",
+              "default": "./dist/web-components/define.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/a2ui-renderer/package.json",
+            "selector": "exports[\"./web-components/define\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "react": "^18 || ^19 || ^19.0.0-rc",
+          "react-dom": "^18 || ^19 || ^19.0.0-rc"
+        },
+        "optionalPeerDependencies": [
+          "react",
+          "react-dom"
+        ],
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/a2ui-renderer/package.json",
+            "selector": "peerDependencies"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/a2ui-renderer/package.json",
+            "selector": "peerDependenciesMeta.*.optional"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/a2ui-renderer/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/a2ui-renderer/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/agentcore-runner",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/agentcore-runner",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/agentcore-runner",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/agentcore-runner/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/agentcore-runner/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/agentcore-runner/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/agentcore-runner/package.json",
+            "selector": "engines"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/agentcore-runner/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/agentcore-runner/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/angular",
+      "version": "0.3.1",
+      "sourceDirectory": "packages/angular",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/angular",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/index.d.ts",
+              "default": "./dist/fesm2022/copilotkit-angular.mjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/angular/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/angular/mcp-apps",
+          "exportKey": "./mcp-apps",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/mcp-apps/index.d.ts",
+              "default": "./dist/fesm2022/copilotkit-angular-mcp-apps.mjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/angular/package.json",
+            "selector": "exports[\"./mcp-apps\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/angular/styles.css",
+          "exportKey": "./styles.css",
+          "kind": "style",
+          "conditions": "./dist/styles.css",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/angular/package.json",
+            "selector": "exports[\"./styles.css\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "@angular/cdk": "^20.0.0 || ^21.0.0 || ^22.0.0",
+          "@angular/common": "^20.0.0 || ^21.0.0 || ^22.0.0",
+          "@angular/core": "^20.0.0 || ^21.0.0 || ^22.0.0",
+          "rxjs": "^7.8.0"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/angular/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/angular/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/angular/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.angular.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/discord",
+          "exportKey": "./discord",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/discord.d.ts",
+            "import": "./dist/discord.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./discord\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/jsx-dev-runtime",
+          "exportKey": "./jsx-dev-runtime",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/jsx-dev-runtime.d.ts",
+            "import": "./dist/jsx-dev-runtime.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./jsx-dev-runtime\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/jsx-runtime",
+          "exportKey": "./jsx-runtime",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/jsx-runtime.d.ts",
+            "import": "./dist/jsx-runtime.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./jsx-runtime\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/slack",
+          "exportKey": "./slack",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/slack.d.ts",
+            "import": "./dist/slack.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./slack\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/slack/codec",
+          "exportKey": "./slack/codec",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/slack/codec.d.ts",
+            "import": "./dist/slack/codec.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./slack/codec\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/slack/render",
+          "exportKey": "./slack/render",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/slack/render.d.ts",
+            "import": "./dist/slack/render.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./slack/render\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/teams",
+          "exportKey": "./teams",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/teams.d.ts",
+            "import": "./dist/teams.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./teams\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/teams/render",
+          "exportKey": "./teams/render",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/teams/render.d.ts",
+            "import": "./dist/teams/render.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./teams/render\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/telegram",
+          "exportKey": "./telegram",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/telegram.d.ts",
+            "import": "./dist/telegram.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./telegram\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/testing",
+          "exportKey": "./testing",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/testing.d.ts",
+            "import": "./dist/testing.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./testing\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/ui",
+          "exportKey": "./ui",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/ui.d.ts",
+            "import": "./dist/ui.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./ui\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels/whatsapp",
+          "exportKey": "./whatsapp",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/whatsapp.d.ts",
+            "import": "./dist/whatsapp.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "exports[\"./whatsapp\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "vitest": "^4.0.0"
+        },
+        "optionalPeerDependencies": [
+          "vitest"
+        ],
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "peerDependencies"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/channels/package.json",
+            "selector": "peerDependenciesMeta.*.optional"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-core",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-core",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-core",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-core/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-core/jsx-dev-runtime",
+          "exportKey": "./jsx-dev-runtime",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/jsx-dev-runtime.d.ts",
+            "import": "./dist/jsx-dev-runtime.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-core/package.json",
+            "selector": "exports[\"./jsx-dev-runtime\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-core/jsx-runtime",
+          "exportKey": "./jsx-runtime",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/jsx-runtime.d.ts",
+            "import": "./dist/jsx-runtime.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-core/package.json",
+            "selector": "exports[\"./jsx-runtime\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-core/testing",
+          "exportKey": "./testing",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/testing/state-store-conformance.d.ts",
+            "import": "./dist/testing/state-store-conformance.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-core/package.json",
+            "selector": "exports[\"./testing\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "vitest": "^4.0.0"
+        },
+        "optionalPeerDependencies": [
+          "vitest"
+        ],
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/channels-core/package.json",
+            "selector": "peerDependencies"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/channels-core/package.json",
+            "selector": "peerDependenciesMeta.*.optional"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-core/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-core/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-discord",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-discord",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-discord",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-discord/package.json",
+            "selector": "exports[\".\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-discord/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-discord/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-intelligence",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-intelligence",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-intelligence",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-intelligence/package.json",
+            "selector": "exports[\".\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-intelligence/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-intelligence/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-slack",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-slack",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-slack",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-slack/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-slack/codec",
+          "exportKey": "./codec",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/codec.d.ts",
+            "import": "./dist/codec.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-slack/package.json",
+            "selector": "exports[\"./codec\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-slack/render",
+          "exportKey": "./render",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/render.d.ts",
+            "import": "./dist/render.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-slack/package.json",
+            "selector": "exports[\"./render\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-slack/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-slack/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-teams",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-teams",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-teams",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-teams/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-teams/render",
+          "exportKey": "./render",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/render/index.d.ts",
+            "import": "./dist/render/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-teams/package.json",
+            "selector": "exports[\"./render\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-teams/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-teams/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-telegram",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-telegram",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-telegram",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-telegram/package.json",
+            "selector": "exports[\".\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-telegram/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-telegram/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-ui",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-ui",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-ui",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-ui/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-ui/jsx-dev-runtime",
+          "exportKey": "./jsx-dev-runtime",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/jsx-dev-runtime.d.ts",
+            "import": "./dist/jsx-dev-runtime.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-ui/package.json",
+            "selector": "exports[\"./jsx-dev-runtime\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/channels-ui/jsx-runtime",
+          "exportKey": "./jsx-runtime",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/jsx-runtime.d.ts",
+            "import": "./dist/jsx-runtime.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-ui/package.json",
+            "selector": "exports[\"./jsx-runtime\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-ui/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-ui/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/channels-whatsapp",
+      "version": "0.7.3",
+      "sourceDirectory": "packages/channels-whatsapp",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/channels-whatsapp",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/channels-whatsapp/package.json",
+            "selector": "exports[\".\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "provenance": []
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/channels-whatsapp/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/channels-whatsapp/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.channels.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/core",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/core",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/core",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/core/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/core/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/core/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/core/package.json",
+            "selector": "engines"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/core/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/core/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/react-core",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/react-core",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/react-core",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-core/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-core/v2",
+          "exportKey": "./v2",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/index.mjs",
+            "require": "./dist/v2/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "exports[\"./v2\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-core/v2/context",
+          "exportKey": "./v2/context",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/context.mjs",
+            "require": "./dist/v2/context.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "exports[\"./v2/context\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-core/v2/headless",
+          "exportKey": "./v2/headless",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/headless.mjs",
+            "require": "./dist/v2/headless.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "exports[\"./v2/headless\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-core/v2/styles.css",
+          "exportKey": "./v2/styles.css",
+          "kind": "style",
+          "conditions": "./dist/v2/index.css",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "exports[\"./v2/styles.css\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "react": "^18 || ^19 || ^19.0.0-rc",
+          "react-dom": "^18 || ^19 || ^19.0.0-rc",
+          "zod": ">=3.0.0"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/react-core/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/react-core/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/react-core/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/react-native",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/react-native",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/react-native",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/components",
+          "exportKey": "./components",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/components/index.mjs",
+            "require": "./dist/components/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./components\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/headless",
+          "exportKey": "./headless",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/headless.mjs",
+            "require": "./dist/headless.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./headless\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/polyfills",
+          "exportKey": "./polyfills",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/polyfills.mjs",
+            "require": "./dist/polyfills.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./polyfills\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/polyfills/crypto",
+          "exportKey": "./polyfills/crypto",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/polyfills/crypto.mjs",
+            "require": "./dist/polyfills/crypto.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./polyfills/crypto\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/polyfills/dom",
+          "exportKey": "./polyfills/dom",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/polyfills/dom.mjs",
+            "require": "./dist/polyfills/dom.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./polyfills/dom\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/polyfills/encoding",
+          "exportKey": "./polyfills/encoding",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/polyfills/encoding.mjs",
+            "require": "./dist/polyfills/encoding.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./polyfills/encoding\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/polyfills/location",
+          "exportKey": "./polyfills/location",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/polyfills/location.mjs",
+            "require": "./dist/polyfills/location.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./polyfills/location\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-native/polyfills/streams",
+          "exportKey": "./polyfills/streams",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/polyfills/streams.mjs",
+            "require": "./dist/polyfills/streams.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "exports[\"./polyfills/streams\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "@gorhom/bottom-sheet": "^5.0.0",
+          "expo-document-picker": ">=12.0.0",
+          "expo-file-system": ">=17.0.0",
+          "react": "^18 || ^19",
+          "react-native": ">=0.70",
+          "react-native-gesture-handler": ">=2.0.0",
+          "react-native-reanimated": ">=3.0.0",
+          "react-native-streamdown": ">=0.1.0",
+          "zod": ">=3.0.0"
+        },
+        "optionalPeerDependencies": [
+          "@gorhom/bottom-sheet",
+          "expo-document-picker",
+          "expo-file-system",
+          "react-native-gesture-handler",
+          "react-native-reanimated",
+          "react-native-streamdown",
+          "zod"
+        ],
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "peerDependencies"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/react-native/package.json",
+            "selector": "peerDependenciesMeta.*.optional"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/react-native/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/react-native/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/react-textarea",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/react-textarea",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/react-textarea",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-textarea/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-textarea/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-textarea/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-textarea/styles.css",
+          "exportKey": "./styles.css",
+          "kind": "style",
+          "conditions": "./dist/index.css",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-textarea/package.json",
+            "selector": "exports[\"./styles.css\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "react": "^18 || ^19 || ^19.0.0-rc",
+          "react-dom": "^18 || ^19 || ^19.0.0-rc"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/react-textarea/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/react-textarea/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/react-textarea/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/react-ui",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/react-ui",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/react-ui",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-ui/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-ui/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-ui/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-ui/styles.css",
+          "exportKey": "./styles.css",
+          "kind": "style",
+          "conditions": "./dist/index.css",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-ui/package.json",
+            "selector": "exports[\"./styles.css\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/react-ui/v2/styles.css",
+          "exportKey": "./v2/styles.css",
+          "kind": "style",
+          "conditions": "./dist/v2/index.css",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/react-ui/package.json",
+            "selector": "exports[\"./v2/styles.css\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "react": "^18 || ^19 || ^19.0.0-rc"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/react-ui/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/react-ui/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/react-ui/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/runtime",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/runtime",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/runtime",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime/langgraph",
+          "exportKey": "./langgraph",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/langgraph.mjs",
+            "require": "./dist/langgraph.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./langgraph\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime/v2",
+          "exportKey": "./v2",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/index.mjs",
+            "require": "./dist/v2/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime/v2/express",
+          "exportKey": "./v2/express",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/express.mjs",
+            "require": "./dist/v2/express.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/express\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime/v2/hono",
+          "exportKey": "./v2/hono",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/hono.mjs",
+            "require": "./dist/v2/hono.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/hono\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime/v2/node",
+          "exportKey": "./v2/node",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/v2/node.mjs",
+            "require": "./dist/v2/node.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/node\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "@anthropic-ai/sdk": ">=0.57.0",
+          "@langchain/aws": ">=0.1.9",
+          "@langchain/community": ">=0.3.58",
+          "@langchain/core": ">=0.3.66",
+          "@langchain/google-gauth": ">=0.1.0",
+          "@langchain/langgraph-sdk": ">=0.1.2",
+          "@langchain/openai": ">=0.4.2",
+          "groq-sdk": ">=0.3.0 <1.0.0",
+          "langchain": ">=0.3.3",
+          "openai": "^4.85.1 || >=5.0.0"
+        },
+        "optionalPeerDependencies": [
+          "@anthropic-ai/sdk",
+          "@langchain/aws",
+          "@langchain/community",
+          "@langchain/google-gauth",
+          "@langchain/langgraph-sdk",
+          "@langchain/openai",
+          "groq-sdk",
+          "langchain",
+          "openai"
+        ],
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "peerDependencies"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "peerDependenciesMeta.*.optional"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/runtime-client-gql",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/runtime-client-gql",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/runtime-client-gql",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime-client-gql/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/runtime-client-gql/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/runtime-client-gql/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "react": "^18 || ^19 || ^19.0.0-rc"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/runtime-client-gql/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/runtime-client-gql/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/runtime-client-gql/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/sdk-js",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/sdk-js",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/sdk-js",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sdk-js/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/sdk-js/langchain",
+          "exportKey": "./langchain",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/langchain.mjs",
+            "require": "./dist/langchain.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sdk-js/package.json",
+            "selector": "exports[\"./langchain\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/sdk-js/langgraph",
+          "exportKey": "./langgraph",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/langgraph.mjs",
+            "require": "./dist/langgraph.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sdk-js/package.json",
+            "selector": "exports[\"./langgraph\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/sdk-js/langgraph-middlewares",
+          "exportKey": "./langgraph-middlewares",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/langgraph-middlewares.mjs",
+            "require": "./dist/langgraph-middlewares.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sdk-js/package.json",
+            "selector": "exports[\"./langgraph-middlewares\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/sdk-js/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sdk-js/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "@langchain/core": ">=0.4.0 <2.0.0",
+          "@langchain/langgraph": ">=0.4.0 <2.0.0",
+          "langchain": ">=1.0.0",
+          "typescript": "^5.2.3",
+          "zod": "^3.23.3 || ^3.24.0 || ^3.25.0"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/sdk-js/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/sdk-js/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/sdk-js/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/shared",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/shared",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/shared",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/shared/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/shared/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/shared/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "peerDependencies": {
+          "@ag-ui/core": ">=0.0.48"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/shared/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/shared/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/shared/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/sqlite-runner",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/sqlite-runner",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/sqlite-runner",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sqlite-runner/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/sqlite-runner/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/sqlite-runner/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "peerDependencies": {
+          "better-sqlite3": "^12.2.0"
+        },
+        "optionalPeerDependencies": [
+          "better-sqlite3"
+        ],
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/sqlite-runner/package.json",
+            "selector": "engines"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/sqlite-runner/package.json",
+            "selector": "peerDependencies"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/sqlite-runner/package.json",
+            "selector": "peerDependenciesMeta.*.optional"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/sqlite-runner/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/sqlite-runner/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/voice",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/voice",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/voice",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/voice/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/voice/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/voice/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "peerDependencies": {
+          "@copilotkit/runtime": "workspace:*"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/voice/package.json",
+            "selector": "engines"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/voice/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/voice/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/voice/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/vue",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/vue",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/vue",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/index.d.mts",
+              "default": "./dist/index.mjs"
+            },
+            "require": {
+              "types": "./dist/index.d.cts",
+              "default": "./dist/index.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/vue/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/vue/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/vue/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/vue/styles.css",
+          "exportKey": "./styles.css",
+          "kind": "style",
+          "conditions": "./dist/styles.css",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/vue/package.json",
+            "selector": "exports[\"./styles.css\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/vue/v2",
+          "exportKey": "./v2",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/v2/index.d.mts",
+              "default": "./dist/v2/index.mjs"
+            },
+            "require": {
+              "types": "./dist/v2/index.d.cts",
+              "default": "./dist/v2/index.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/vue/package.json",
+            "selector": "exports[\"./v2\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "peerDependencies": {
+          "vue": ">=3.3.0"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/vue/package.json",
+            "selector": "engines"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/vue/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/vue/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/vue/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/web-components",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/web-components",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/web-components",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/index.d.mts",
+              "default": "./dist/index.mjs"
+            },
+            "require": {
+              "types": "./dist/index.d.cts",
+              "default": "./dist/index.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/web-components/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/web-components/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/web-components/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/web-components/threads-drawer",
+          "exportKey": "./threads-drawer",
+          "kind": "code",
+          "conditions": {
+            "import": {
+              "types": "./dist/threads-drawer/index.d.mts",
+              "default": "./dist/threads-drawer/index.mjs"
+            },
+            "require": {
+              "types": "./dist/threads-drawer/index.d.cts",
+              "default": "./dist/threads-drawer/index.cjs"
+            }
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/web-components/package.json",
+            "selector": "exports[\"./threads-drawer\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "peerDependencies": {
+          "lit": "^3.3.2"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/web-components/package.json",
+            "selector": "engines"
+          },
+          {
+            "kind": "package-json",
+            "path": "packages/web-components/package.json",
+            "selector": "peerDependencies"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/web-components/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/web-components/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    },
+    {
+      "name": "@copilotkit/web-inspector",
+      "version": "1.66.2",
+      "sourceDirectory": "packages/web-inspector",
+      "entrypoints": [
+        {
+          "importPath": "@copilotkit/web-inspector",
+          "exportKey": ".",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/web-inspector/package.json",
+            "selector": "exports[\".\"]"
+          }
+        },
+        {
+          "importPath": "@copilotkit/web-inspector/package.json",
+          "exportKey": "./package.json",
+          "kind": "metadata",
+          "conditions": "./package.json",
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/web-inspector/package.json",
+            "selector": "exports[\"./package.json\"]"
+          }
+        }
+      ],
+      "compatibility": {
+        "engines": {
+          "node": ">=18"
+        },
+        "provenance": [
+          {
+            "kind": "package-json",
+            "path": "packages/web-inspector/package.json",
+            "selector": "engines"
+          }
+        ]
+      },
+      "provenance": {
+        "name": {
+          "kind": "package-json",
+          "path": "packages/web-inspector/package.json",
+          "selector": "name"
+        },
+        "version": {
+          "kind": "package-json",
+          "path": "packages/web-inspector/package.json",
+          "selector": "version"
+        },
+        "releaseScope": {
+          "kind": "release-config",
+          "path": "release.config.json",
+          "selector": "scopes.monorepo.packages"
+        }
+      }
+    }
+  ],
+  "runtime": {
+    "serviceAdapters": [
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "AnthropicAdapter",
+        "configurationType": "AnthropicAdapterParams",
+        "configurationKeys": [
+          "anthropic",
+          "model",
+          "promptCaching",
+          "maxInputTokens"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts",
+            "selector": "export class AnthropicAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts",
+            "selector": "constructor parameter AnthropicAdapterParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts",
+            "selector": "interface AnthropicAdapterParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "BedrockAdapter",
+        "configurationType": "BedrockAdapterParams",
+        "configurationKeys": [
+          "model",
+          "region",
+          "credentials"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/bedrock/bedrock-adapter.ts",
+            "selector": "export class BedrockAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/bedrock/bedrock-adapter.ts",
+            "selector": "constructor parameter BedrockAdapterParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/bedrock/bedrock-adapter.ts",
+            "selector": "interface BedrockAdapterParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "EmptyAdapter",
+        "configurationKeys": [],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/empty/empty-adapter.ts",
+            "selector": "export class EmptyAdapter"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/empty/empty-adapter.ts",
+            "selector": "class EmptyAdapter has no constructor configuration"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "ExperimentalEmptyAdapter",
+        "configurationKeys": [],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/empty/empty-adapter.ts",
+            "selector": "export const ExperimentalEmptyAdapter"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/empty/empty-adapter.ts",
+            "selector": "class EmptyAdapter has no constructor configuration"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "ExperimentalOllamaAdapter",
+        "configurationType": "OllamaAdapterOptions",
+        "configurationKeys": [
+          "model"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/experimental/ollama/ollama-adapter.ts",
+            "selector": "export class ExperimentalOllamaAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/experimental/ollama/ollama-adapter.ts",
+            "selector": "constructor parameter OllamaAdapterOptions"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/experimental/ollama/ollama-adapter.ts",
+            "selector": "interface OllamaAdapterOptions public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "GoogleGenerativeAIAdapter",
+        "configurationType": "GoogleGenerativeAIAdapterOptions",
+        "configurationKeys": [
+          "model",
+          "apiVersion",
+          "apiKey"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/google/google-genai-adapter.ts",
+            "selector": "export class GoogleGenerativeAIAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/google/google-genai-adapter.ts",
+            "selector": "constructor parameter GoogleGenerativeAIAdapterOptions"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/google/google-genai-adapter.ts",
+            "selector": "interface GoogleGenerativeAIAdapterOptions public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "GroqAdapter",
+        "configurationType": "GroqAdapterParams",
+        "configurationKeys": [
+          "groq",
+          "model",
+          "disableParallelToolCalls"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/groq/groq-adapter.ts",
+            "selector": "export class GroqAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/groq/groq-adapter.ts",
+            "selector": "constructor parameter GroqAdapterParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/groq/groq-adapter.ts",
+            "selector": "interface GroqAdapterParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "LangChainAdapter",
+        "configurationType": "LangChainAdapterOptions",
+        "configurationKeys": [
+          "chainFn"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/langchain/langchain-adapter.ts",
+            "selector": "export class LangChainAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/langchain/langchain-adapter.ts",
+            "selector": "constructor parameter LangChainAdapterOptions"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/langchain/langchain-adapter.ts",
+            "selector": "interface LangChainAdapterOptions public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "OpenAIAdapter",
+        "configurationType": "OpenAIAdapterParams",
+        "configurationKeys": [
+          "openai",
+          "model",
+          "disableParallelToolCalls",
+          "keepSystemRole",
+          "maxInputTokens"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/openai/openai-adapter.ts",
+            "selector": "export class OpenAIAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/openai/openai-adapter.ts",
+            "selector": "constructor parameter OpenAIAdapterParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/openai/openai-adapter.ts",
+            "selector": "interface OpenAIAdapterParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "OpenAIAssistantAdapter",
+        "configurationType": "OpenAIAssistantAdapterParams",
+        "configurationKeys": [
+          "assistantId",
+          "openai",
+          "codeInterpreterEnabled",
+          "fileSearchEnabled",
+          "disableParallelToolCalls",
+          "keepSystemRole"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts",
+            "selector": "export class OpenAIAssistantAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts",
+            "selector": "constructor parameter OpenAIAssistantAdapterParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/openai/openai-assistant-adapter.ts",
+            "selector": "interface OpenAIAssistantAdapterParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime",
+        "symbol": "UnifyAdapter",
+        "configurationType": "UnifyAdapterParams",
+        "configurationKeys": [
+          "apiKey",
+          "model"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\".\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/unify/unify-adapter.ts",
+            "selector": "export class UnifyAdapter"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/unify/unify-adapter.ts",
+            "selector": "constructor parameter UnifyAdapterParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/service-adapters/unify/unify-adapter.ts",
+            "selector": "interface UnifyAdapterParams public properties"
+          }
+        }
+      }
+    ],
+    "hostFactories": [
+      {
+        "importPath": "@copilotkit/runtime/v2",
+        "symbol": "createCopilotRuntimeHandler",
+        "configurationType": "CopilotRuntimeHandlerOptions",
+        "configurationKeys": [
+          "runtime",
+          "basePath",
+          "mode",
+          "cors",
+          "hooks",
+          "activateChannels"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+            "selector": "export function createCopilotRuntimeHandler"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+            "selector": "interface CopilotRuntimeHandlerOptions"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+            "selector": "interface CopilotRuntimeHandlerOptions public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime/v2/express",
+        "symbol": "createCopilotExpressHandler",
+        "configurationType": "CopilotExpressEndpointParams",
+        "configurationKeys": [
+          "runtime",
+          "basePath",
+          "mode",
+          "cors",
+          "hooks",
+          "activateChannels"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/express\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/express.ts",
+            "selector": "export function createCopilotExpressHandler"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/express.ts",
+            "selector": "interface CopilotExpressEndpointParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/express.ts",
+            "selector": "interface CopilotExpressEndpointParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime/v2/hono",
+        "symbol": "createCopilotHonoHandler",
+        "configurationType": "CopilotEndpointParams",
+        "configurationKeys": [
+          "runtime",
+          "basePath",
+          "mode",
+          "cors",
+          "hooks",
+          "activateChannels"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/hono\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+            "selector": "export function createCopilotHonoHandler"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+            "selector": "interface CopilotEndpointParams"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+            "selector": "interface CopilotEndpointParams public properties"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime/v2/node",
+        "symbol": "createCopilotNodeHandler",
+        "configurationKeys": [],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/node\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+            "selector": "export function createCopilotNodeHandler"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+            "selector": "function createCopilotNodeHandler has no configuration object"
+          }
+        }
+      },
+      {
+        "importPath": "@copilotkit/runtime/v2/node",
+        "symbol": "createCopilotNodeListener",
+        "configurationType": "CopilotRuntimeHandlerOptions",
+        "configurationKeys": [
+          "runtime",
+          "basePath",
+          "mode",
+          "cors",
+          "hooks",
+          "activateChannels"
+        ],
+        "provenance": {
+          "importPath": {
+            "kind": "package-json",
+            "path": "packages/runtime/package.json",
+            "selector": "exports[\"./v2/node\"]"
+          },
+          "symbol": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/endpoints/node.ts",
+            "selector": "export function createCopilotNodeListener"
+          },
+          "configurationType": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+            "selector": "interface CopilotRuntimeHandlerOptions"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/v2/runtime/core/fetch-handler.ts",
+            "selector": "interface CopilotRuntimeHandlerOptions public properties"
+          }
+        }
+      }
+    ],
+    "agentFactoryModes": [
+      {
+        "type": "aisdk",
+        "configurationKeys": [
+          "type",
+          "factory"
+        ],
+        "provenance": {
+          "type": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/agent/index.ts",
+            "selector": "interface BuiltInAgentAISDKFactoryConfig property type"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/agent/index.ts",
+            "selector": "interface BuiltInAgentAISDKFactoryConfig public properties"
+          }
+        }
+      },
+      {
+        "type": "tanstack",
+        "configurationKeys": [
+          "type",
+          "factory"
+        ],
+        "provenance": {
+          "type": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/agent/index.ts",
+            "selector": "interface BuiltInAgentTanStackFactoryConfig property type"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/agent/index.ts",
+            "selector": "interface BuiltInAgentTanStackFactoryConfig public properties"
+          }
+        }
+      },
+      {
+        "type": "custom",
+        "configurationKeys": [
+          "type",
+          "factory"
+        ],
+        "provenance": {
+          "type": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/agent/index.ts",
+            "selector": "interface BuiltInAgentCustomFactoryConfig property type"
+          },
+          "configurationKeys": {
+            "kind": "typescript-ast",
+            "path": "packages/runtime/src/agent/index.ts",
+            "selector": "interface BuiltInAgentCustomFactoryConfig public properties"
+          }
+        }
+      }
+    ]
+  },
+  "deprecations": [
+    {
+      "importPath": "@copilotkit/runtime",
+      "symbol": "CustomEventNames",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/langgraph",
+        "symbol": "CustomEventNames"
+      },
+      "sourceMessage": "CustomEventNames import from `@copilotkit/runtime` is deprecated. Please import it from `@copilotkit/runtime/langgraph` instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\".\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "CustomEventNames @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "CustomEventNames @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "CustomEventNames @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime",
+      "symbol": "LangGraphAgent",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/langgraph",
+        "symbol": "LangGraphAgent"
+      },
+      "sourceMessage": "LangGraphAgent import from `@copilotkit/runtime` is deprecated. Please import it from `@copilotkit/runtime/langgraph` instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\".\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "LangGraphAgent @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "LangGraphAgent @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "LangGraphAgent @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime",
+      "symbol": "LangGraphHttpAgent",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/langgraph",
+        "symbol": "LangGraphHttpAgent"
+      },
+      "sourceMessage": "LangGraphHttpAgent import from `@copilotkit/runtime` is deprecated. Please import it from `@copilotkit/runtime/langgraph` instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\".\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "LangGraphHttpAgent @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "LangGraphHttpAgent @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "LangGraphHttpAgent @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime",
+      "symbol": "PredictStateTool",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/langgraph",
+        "symbol": "PredictStateTool"
+      },
+      "sourceMessage": "PredictStateTool import from `@copilotkit/runtime` is deprecated. Please import it from `@copilotkit/runtime/langgraph` instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\".\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "PredictStateTool @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "PredictStateTool @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "PredictStateTool @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime",
+      "symbol": "TextMessageEvents",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/langgraph",
+        "symbol": "TextMessageEvents"
+      },
+      "sourceMessage": "TextMessageEvents import from `@copilotkit/runtime` is deprecated. Please import it from `@copilotkit/runtime/langgraph` instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\".\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "TextMessageEvents @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "TextMessageEvents @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "TextMessageEvents @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime",
+      "symbol": "ToolCallEvents",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/langgraph",
+        "symbol": "ToolCallEvents"
+      },
+      "sourceMessage": "ToolCallEvents import from `@copilotkit/runtime` is deprecated. Please import it from `@copilotkit/runtime/langgraph` instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\".\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "ToolCallEvents @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "ToolCallEvents @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/lib/index.ts",
+          "selector": "ToolCallEvents @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2",
+      "symbol": "BasicAgent",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2",
+        "symbol": "BuiltInAgent"
+      },
+      "sourceMessage": "Use BuiltInAgent instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/agent/index.ts",
+          "selector": "BasicAgent @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/agent/index.ts",
+          "selector": "BasicAgent @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/agent/index.ts",
+          "selector": "BasicAgent @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2",
+      "symbol": "BasicAgentConfiguration",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2",
+        "symbol": "BuiltInAgentClassicConfig"
+      },
+      "sourceMessage": "Use BuiltInAgentClassicConfig instead",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/agent/index.ts",
+          "selector": "BasicAgentConfiguration @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/agent/index.ts",
+          "selector": "BasicAgentConfiguration @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/agent/index.ts",
+          "selector": "BasicAgentConfiguration @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2",
+      "symbol": "CopilotKitRequestHandler",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2",
+        "symbol": "CopilotRuntimeFetchHandler"
+      },
+      "sourceMessage": "Use `CopilotRuntimeFetchHandler` instead. Note: the new type takes `Request` directly, not `{ request: Request }`.",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/index.ts",
+          "selector": "CopilotKitRequestHandler @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/index.ts",
+          "selector": "CopilotKitRequestHandler @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/index.ts",
+          "selector": "CopilotKitRequestHandler @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2/express",
+      "symbol": "createCopilotEndpointExpress",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2/express",
+        "symbol": "createCopilotExpressHandler"
+      },
+      "sourceMessage": "Use `createCopilotExpressHandler` instead.",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2/express\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/express.ts",
+          "selector": "createCopilotEndpointExpress @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/express.ts",
+          "selector": "createCopilotEndpointExpress @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/express.ts",
+          "selector": "createCopilotEndpointExpress @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2/express",
+      "symbol": "createCopilotEndpointSingleRouteExpress",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2/express",
+        "symbol": "createCopilotExpressHandler"
+      },
+      "sourceMessage": "Use `createCopilotExpressHandler` with `mode: \"single-route\"` instead.",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2/express\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/express-single.ts",
+          "selector": "createCopilotEndpointSingleRouteExpress @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/express-single.ts",
+          "selector": "createCopilotEndpointSingleRouteExpress @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/express-single.ts",
+          "selector": "createCopilotEndpointSingleRouteExpress @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2/hono",
+      "symbol": "createCopilotEndpoint",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2/hono",
+        "symbol": "createCopilotHonoHandler"
+      },
+      "sourceMessage": "Use `createCopilotHonoHandler` instead.",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2/hono\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+          "selector": "createCopilotEndpoint @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+          "selector": "createCopilotEndpoint @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/hono.ts",
+          "selector": "createCopilotEndpoint @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2/hono",
+      "symbol": "createCopilotEndpointSingleRoute",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2/hono",
+        "symbol": "createCopilotHonoHandler"
+      },
+      "sourceMessage": "Use `createCopilotHonoHandler` with `mode: \"single-route\"` instead.",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2/hono\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/hono-single.ts",
+          "selector": "createCopilotEndpointSingleRoute @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/hono-single.ts",
+          "selector": "createCopilotEndpointSingleRoute @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/hono-single.ts",
+          "selector": "createCopilotEndpointSingleRoute @deprecated tag"
+        }
+      }
+    },
+    {
+      "importPath": "@copilotkit/runtime/v2/node",
+      "symbol": "createNodeFetchHandler",
+      "replacement": {
+        "importPath": "@copilotkit/runtime/v2/node",
+        "symbol": "createCopilotNodeHandler"
+      },
+      "sourceMessage": "Use `createCopilotNodeHandler` instead.",
+      "provenance": {
+        "importPath": {
+          "kind": "package-json",
+          "path": "packages/runtime/package.json",
+          "selector": "exports[\"./v2/node\"]"
+        },
+        "symbol": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+          "selector": "createNodeFetchHandler @deprecated tag"
+        },
+        "replacement": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+          "selector": "createNodeFetchHandler @deprecated tag"
+        },
+        "sourceMessage": {
+          "kind": "typescript-ast",
+          "path": "packages/runtime/src/v2/runtime/endpoints/node-fetch-handler.ts",
+          "selector": "createNodeFetchHandler @deprecated tag"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/release/public-api/manifest.v1.json
+++ b/scripts/release/public-api/manifest.v1.json
@@ -19,7 +19,7 @@
   "packages": [
     {
       "name": "@copilotkit/a2ui-renderer",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/a2ui-renderer",
       "entrypoints": [
         {
@@ -136,7 +136,7 @@
     },
     {
       "name": "@copilotkit/agentcore-runner",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/agentcore-runner",
       "entrypoints": [
         {
@@ -279,7 +279,7 @@
     },
     {
       "name": "@copilotkit/channels",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels",
       "entrypoints": [
         {
@@ -505,7 +505,7 @@
     },
     {
       "name": "@copilotkit/channels-core",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-core",
       "entrypoints": [
         {
@@ -605,7 +605,7 @@
     },
     {
       "name": "@copilotkit/channels-discord",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-discord",
       "entrypoints": [
         {
@@ -646,7 +646,7 @@
     },
     {
       "name": "@copilotkit/channels-intelligence",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-intelligence",
       "entrypoints": [
         {
@@ -687,7 +687,7 @@
     },
     {
       "name": "@copilotkit/channels-slack",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-slack",
       "entrypoints": [
         {
@@ -756,7 +756,7 @@
     },
     {
       "name": "@copilotkit/channels-teams",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-teams",
       "entrypoints": [
         {
@@ -811,7 +811,7 @@
     },
     {
       "name": "@copilotkit/channels-telegram",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-telegram",
       "entrypoints": [
         {
@@ -852,7 +852,7 @@
     },
     {
       "name": "@copilotkit/channels-ui",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-ui",
       "entrypoints": [
         {
@@ -921,7 +921,7 @@
     },
     {
       "name": "@copilotkit/channels-whatsapp",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "sourceDirectory": "packages/channels-whatsapp",
       "entrypoints": [
         {
@@ -962,7 +962,7 @@
     },
     {
       "name": "@copilotkit/core",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/core",
       "entrypoints": [
         {
@@ -1023,7 +1023,7 @@
     },
     {
       "name": "@copilotkit/react-core",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/react-core",
       "entrypoints": [
         {
@@ -1139,7 +1139,7 @@
     },
     {
       "name": "@copilotkit/react-native",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/react-native",
       "entrypoints": [
         {
@@ -1334,7 +1334,7 @@
     },
     {
       "name": "@copilotkit/react-textarea",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/react-textarea",
       "entrypoints": [
         {
@@ -1407,7 +1407,7 @@
     },
     {
       "name": "@copilotkit/react-ui",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/react-ui",
       "entrypoints": [
         {
@@ -1490,7 +1490,7 @@
     },
     {
       "name": "@copilotkit/runtime",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/runtime",
       "entrypoints": [
         {
@@ -1646,7 +1646,7 @@
     },
     {
       "name": "@copilotkit/runtime-client-gql",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/runtime-client-gql",
       "entrypoints": [
         {
@@ -1707,7 +1707,7 @@
     },
     {
       "name": "@copilotkit/sdk-js",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/sdk-js",
       "entrypoints": [
         {
@@ -1814,7 +1814,7 @@
     },
     {
       "name": "@copilotkit/shared",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/shared",
       "entrypoints": [
         {
@@ -1875,7 +1875,7 @@
     },
     {
       "name": "@copilotkit/sqlite-runner",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/sqlite-runner",
       "entrypoints": [
         {
@@ -1952,7 +1952,7 @@
     },
     {
       "name": "@copilotkit/voice",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/voice",
       "entrypoints": [
         {
@@ -2021,7 +2021,7 @@
     },
     {
       "name": "@copilotkit/vue",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/vue",
       "entrypoints": [
         {
@@ -2127,7 +2127,7 @@
     },
     {
       "name": "@copilotkit/web-components",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/web-components",
       "entrypoints": [
         {
@@ -2222,7 +2222,7 @@
     },
     {
       "name": "@copilotkit/web-inspector",
-      "version": "1.66.2",
+      "version": "1.67.1",
       "sourceDirectory": "packages/web-inspector",
       "entrypoints": [
         {

--- a/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
+++ b/showcase/scripts/__tests__/verify-deploy.drivers.test.ts
@@ -29,7 +29,10 @@ import {
 } from "../verify-deploy.drivers.baseline";
 import type { FetchLike } from "../verify-deploy.drivers.baseline";
 import { probeShell } from "../verify-deploy.drivers.shell";
-import { probeDocs } from "../verify-deploy.drivers.docs";
+import {
+  checkProductionDocsCanonicalHost,
+  probeDocs,
+} from "../verify-deploy.drivers.docs";
 import { probeDashboard } from "../verify-deploy.drivers.dashboard";
 import { probeDojo } from "../verify-deploy.drivers.dojo";
 import { probeHarness } from "../verify-deploy.drivers.harness";
@@ -760,13 +763,33 @@ describe.each(DRIVER_CASES)(
       // healthcheck to fetch + sentinel-check the injected
       // `__SHOWCASE_CONFIG__` (see verify-deploy.drivers.dashboard.ts). That
       // extra GET targets the same `/` path, so both non-graphql fetches go
-      // to `https://<host>/`. Every other driver makes exactly one.
-      const expectedHealthCount = label === "dashboard" ? 2 : 1;
+      // to `https://<host>/`. The production docs driver additionally probes
+      // two representative pages plus all four crawler surfaces.
+      const expectedHealthCount =
+        label === "dashboard" ? 2 : label === "docs" ? 7 : 1;
       expect(healthUrls).toHaveLength(expectedHealthCount);
-      for (const u of healthUrls) {
-        expect(u).toBe(
-          `https://${domainFor(service, "prod")}${expectedHealthPath}`,
+      if (label === "docs") {
+        expect(healthUrls).toEqual(
+          expect.arrayContaining(
+            [
+              expectedHealthPath,
+              "/",
+              "/quickstart",
+              "/robots.txt",
+              "/sitemap.xml",
+              "/llms.txt",
+              "/llms-full.txt",
+            ].map(
+              (urlPath) => `https://${domainFor(service, "prod")}${urlPath}`,
+            ),
+          ),
         );
+      } else {
+        for (const u of healthUrls) {
+          expect(u).toBe(
+            `https://${domainFor(service, "prod")}${expectedHealthPath}`,
+          );
+        }
       }
     });
 
@@ -830,6 +853,90 @@ describe.each(DRIVER_CASES)(
     });
   },
 );
+
+describe("probeDocs production canonical-host guard", () => {
+  const canonicalOrigin = "https://docs.copilotkit.ai";
+  const leakedOrigin = "https://docs.showcase.copilotkit.ai";
+  const target: ProbeTarget = {
+    name: "docs",
+    host: asHost(domainFor("docs", "prod")),
+    driver: "docs",
+  };
+
+  type MachineSurface =
+    | "canonical"
+    | "open-graph"
+    | "robots"
+    | "sitemap"
+    | "llms"
+    | "llms-full";
+
+  function docsSurfaceFetch(leak?: MachineSurface): FetchLike {
+    return makeFetch((url) => {
+      if (url.includes("/graphql/v2")) return gqlDeploymentResponse("SUCCESS");
+      if (url.endsWith("/robots.txt")) {
+        const origin = leak === "robots" ? leakedOrigin : canonicalOrigin;
+        return Promise.resolve(
+          mkResponse({
+            text: `User-Agent: *\nSitemap: ${origin}/sitemap.xml\n`,
+          }),
+        );
+      }
+      if (url.endsWith("/sitemap.xml")) {
+        const origin = leak === "sitemap" ? leakedOrigin : canonicalOrigin;
+        return Promise.resolve(
+          mkResponse({
+            text: `<urlset><url><loc>${origin}/</loc></url></urlset>`,
+          }),
+        );
+      }
+      if (url.endsWith("/llms.txt")) {
+        const origin = leak === "llms" ? leakedOrigin : canonicalOrigin;
+        return Promise.resolve(
+          mkResponse({ text: `- [Quickstart](${origin}/quickstart)` }),
+        );
+      }
+      if (url.endsWith("/llms-full.txt")) {
+        const origin = leak === "llms-full" ? leakedOrigin : canonicalOrigin;
+        return Promise.resolve(
+          mkResponse({ text: `## Source: ${origin}/quickstart` }),
+        );
+      }
+      const urlPath = new URL(url).pathname;
+      const canonical = leak === "canonical" ? leakedOrigin : canonicalOrigin;
+      const openGraph = leak === "open-graph" ? leakedOrigin : canonicalOrigin;
+      return Promise.resolve(
+        mkResponse({
+          text:
+            `<link rel="canonical" href="${canonical}${urlPath}">` +
+            `<meta property="og:url" content="${openGraph}${urlPath}">`,
+        }),
+      );
+    });
+  }
+
+  it("passes when every production machine surface uses the canonical host", async () => {
+    await withGlobalSeam(docsSurfaceFetch(), TOKEN, async () => {
+      expect(await probeDocs(target)).toEqual({ ok: true });
+    });
+  });
+
+  it.each<MachineSurface>([
+    "canonical",
+    "open-graph",
+    "robots",
+    "sitemap",
+    "llms",
+    "llms-full",
+  ])("fails when %s leaks an alternate docs host", async (surface) => {
+    const error = await checkProductionDocsCanonicalHost(
+      target.host,
+      docsSurfaceFetch(surface),
+    );
+    expect(error).toContain("docs.showcase.copilotkit.ai");
+    expect(error).toContain("docs.copilotkit.ai");
+  });
+});
 
 describe("runDriver dispatch: starter is a real baseline driver, not a fail-loud stub", () => {
   it("routes a driver:'starter' target through the baseline probe (ok on a healthy starter)", async () => {

--- a/showcase/scripts/verify-deploy.drivers.docs.ts
+++ b/showcase/scripts/verify-deploy.drivers.docs.ts
@@ -1,19 +1,205 @@
 import type { ProbeTarget } from "./verify-deploy";
 import type { ProbeOutcome } from "./verify-deploy.drivers";
+import type { FetchLike } from "./verify-deploy.drivers.baseline";
 import { probeBaseline } from "./verify-deploy.drivers.baseline";
+import { domainFor } from "./railway-envs";
+
+const PRODUCTION_DOCS_ORIGIN = `https://${domainFor("docs", "prod")}`;
+const SURFACE_TIMEOUT_MS = 30_000;
+
+interface SurfaceResponse {
+  path: string;
+  body: string;
+}
+
+function attributes(tag: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const pattern = /([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
+  for (const match of tag.matchAll(pattern)) {
+    out.set(match[1].toLowerCase(), match[2] ?? match[3] ?? match[4] ?? "");
+  }
+  return out;
+}
+
+function metadataUrl(
+  html: string,
+  attribute: "rel" | "property",
+  value: "canonical" | "og:url",
+  urlAttribute: "href" | "content",
+): string | undefined {
+  for (const tag of html.match(/<(?:link|meta)\b[^>]*>/gi) ?? []) {
+    const attrs = attributes(tag);
+    const discriminator = attrs.get(attribute)?.toLowerCase();
+    if (
+      discriminator === value ||
+      (attribute === "rel" && discriminator?.split(/\s+/).includes(value))
+    ) {
+      return attrs.get(urlAttribute);
+    }
+  }
+  return undefined;
+}
+
+function assertCanonicalUrl(
+  rawUrl: string | undefined,
+  label: string,
+  expectedUrl?: string,
+): string | undefined {
+  if (!rawUrl) return `${label} is missing`;
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return `${label} is not an absolute URL: "${rawUrl}"`;
+  }
+  if (parsed.origin !== PRODUCTION_DOCS_ORIGIN) {
+    return `${label} uses ${parsed.origin}; expected ${PRODUCTION_DOCS_ORIGIN}`;
+  }
+  if (expectedUrl !== undefined && parsed.href !== expectedUrl) {
+    return `${label} is ${parsed.href}; expected ${expectedUrl}`;
+  }
+  return undefined;
+}
+
+function absoluteUrls(text: string): string[] {
+  return text.match(/https?:\/\/[^\s<>)"']+/g) ?? [];
+}
+
+function markdownLinkUrls(text: string): string[] {
+  return [...text.matchAll(/\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/g)].map(
+    (match) => match[1],
+  );
+}
+
+function sourceUrls(text: string): string[] {
+  return [...text.matchAll(/^## Source:\s+(https?:\/\/\S+)\s*$/gm)].map(
+    (match) => match[1],
+  );
+}
+
+function validateUrls(urls: string[], label: string): string | undefined {
+  if (urls.length === 0) return `${label} contains no generated URLs`;
+  for (const url of urls) {
+    const error = assertCanonicalUrl(url, label);
+    if (error) return error;
+  }
+  return undefined;
+}
+
+async function fetchSurface(
+  host: string,
+  path: string,
+  fetchImpl: FetchLike,
+): Promise<SurfaceResponse> {
+  const url = `https://${host}${path}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SURFACE_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: { "User-Agent": "verify-deploy" },
+      signal: controller.signal,
+    });
+    if (response.status !== 200) {
+      await response.body?.cancel?.();
+      throw new Error(`${url} returned HTTP ${response.status} (expected 200)`);
+    }
+    return { path, body: await response.text() };
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 /**
- * Feature-level verifier for the `shell-docs` Next.js service.
- *
- * Baseline (this commit): Railway deployment-SUCCESS + HTTP 200 on `/`.
- * Future driver-specific layer: DOM-string assertion + the structural
- * `<main>` + `<h1>` heuristic from `probe-shell-docs.ts` so a 200 with
- * the 404 chrome is still treated as red. That extension composes on
- * top of `probeBaseline` once the per-driver micro-task lands.
+ * Validate the deployed production crawler surfaces against the canonical
+ * docs origin. The expected origin comes from the Railway service/domain
+ * SSOT, while every emitted URL is read from the deployed response.
+ */
+export async function checkProductionDocsCanonicalHost(
+  host: string,
+  fetchImpl: FetchLike = globalThis.fetch as unknown as FetchLike,
+): Promise<string | undefined> {
+  let surfaces: SurfaceResponse[];
+  try {
+    surfaces = await Promise.all(
+      [
+        "/",
+        "/quickstart",
+        "/robots.txt",
+        "/sitemap.xml",
+        "/llms.txt",
+        "/llms-full.txt",
+      ].map((path) => fetchSurface(host, path, fetchImpl)),
+    );
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `docs: canonical-host smoke fetch failed: ${message}`;
+  }
+
+  const byPath = new Map(
+    surfaces.map((surface) => [surface.path, surface.body]),
+  );
+  for (const path of ["/", "/quickstart"] as const) {
+    const html = byPath.get(path) ?? "";
+    const expectedUrl = `${PRODUCTION_DOCS_ORIGIN}${path}`;
+    const canonicalError = assertCanonicalUrl(
+      metadataUrl(html, "rel", "canonical", "href"),
+      `${path} canonical URL`,
+      expectedUrl,
+    );
+    if (canonicalError) return `docs: ${canonicalError}`;
+    const ogError = assertCanonicalUrl(
+      metadataUrl(html, "property", "og:url", "content"),
+      `${path} Open Graph URL`,
+      expectedUrl,
+    );
+    if (ogError) return `docs: ${ogError}`;
+  }
+
+  const robots = byPath.get("/robots.txt") ?? "";
+  const robotsError = validateUrls(absoluteUrls(robots), "robots.txt URL");
+  if (robotsError) return `docs: ${robotsError}`;
+  if (!robots.includes(`Sitemap: ${PRODUCTION_DOCS_ORIGIN}/sitemap.xml`)) {
+    return `docs: robots.txt is missing Sitemap: ${PRODUCTION_DOCS_ORIGIN}/sitemap.xml`;
+  }
+
+  const sitemapError = validateUrls(
+    [
+      ...(byPath.get("/sitemap.xml") ?? "").matchAll(/<loc>([^<]+)<\/loc>/g),
+    ].map((match) => match[1]),
+    "sitemap.xml <loc>",
+  );
+  if (sitemapError) return `docs: ${sitemapError}`;
+
+  const llmsError = validateUrls(
+    markdownLinkUrls(byPath.get("/llms.txt") ?? ""),
+    "llms.txt link",
+  );
+  if (llmsError) return `docs: ${llmsError}`;
+
+  const llmsFullError = validateUrls(
+    sourceUrls(byPath.get("/llms-full.txt") ?? ""),
+    "llms-full.txt source",
+  );
+  if (llmsFullError) return `docs: ${llmsFullError}`;
+
+  return undefined;
+}
+
+/**
+ * Production docs verifier: Railway deployment-SUCCESS + HTTP 200 baseline,
+ * followed by a deployed-output smoke test for every machine-facing URL
+ * surface. Staging retains the shared baseline; the production promotion
+ * gate runs the canonical smoke against docs.copilotkit.ai.
  */
 export async function probeDocs(target: ProbeTarget): Promise<ProbeOutcome> {
-  return probeBaseline(target, {
+  const baseline = await probeBaseline(target, {
     driverLabel: "docs",
     healthcheckPath: "/",
   });
+  if (!baseline.ok) return baseline;
+
+  if (target.host !== domainFor("docs", "prod")) return baseline;
+  const error = await checkProductionDocsCanonicalHost(target.host);
+  return error ? { ok: false, error } : baseline;
 }

--- a/showcase/shell-docs/.env.example
+++ b/showcase/shell-docs/.env.example
@@ -23,11 +23,10 @@
 #                          NEXT_PUBLIC_REB2B_KEY,
 #                          NEXT_PUBLIC_REO_KEY
 
-# Canonical base URL used by sitemap.ts, robots.ts, and the per-page
-# canonical metadata. In production this points at the docs host so
-# crawlers index every framework variant at its self-canonical URL.
-# FATAL on miss in prod, falls back to the canonical prod host
-# (https://docs.copilotkit.ai).
+# Base URL override for local development and tests. Production-mode servers
+# always emit https://docs.copilotkit.ai for canonical metadata, Open Graph,
+# robots, sitemap, and LLM indexes; a different deploy value is rejected and
+# logged as FATAL-CONFIG so an alternate public host cannot become canonical.
 NEXT_PUBLIC_BASE_URL=https://docs.copilotkit.ai
 
 # URL of the showcase shell host, which owns /integrations and /matrix.

--- a/showcase/shell-docs/src/app/robots.ts
+++ b/showcase/shell-docs/src/app/robots.ts
@@ -5,9 +5,8 @@
 import type { MetadataRoute } from "next";
 import { getBaseUrl } from "@/lib/sitemap-helpers";
 
-// Force-dynamic so the emitted sitemap URL reflects the live
-// NEXT_PUBLIC_BASE_URL at request time — see app/sitemap.ts for the
-// same rationale.
+// Force-dynamic so non-production overrides are read at request time. In
+// production getBaseUrl() locks this to the public canonical docs origin.
 export const dynamic = "force-dynamic";
 
 export default function robots(): MetadataRoute.Robots {

--- a/showcase/shell-docs/src/app/sitemap.ts
+++ b/showcase/shell-docs/src/app/sitemap.ts
@@ -49,11 +49,9 @@ import {
 } from "@/lib/registry";
 import { isGlobalDocsPath } from "@/lib/reserved-route-slugs";
 
-// Force-dynamic so the sitemap is regenerated per request and reads
-// the LIVE NEXT_PUBLIC_BASE_URL via getRuntimeConfig(). Without this
-// Next.js would statically prerender the sitemap at build time and
-// freeze whichever value `process.env.NEXT_PUBLIC_BASE_URL` had at
-// `next build` — defeating the runtime-config switch.
+// Force-dynamic so non-production base-URL overrides are read at request time.
+// In production getRuntimeConfig() locks generated URLs to the public
+// canonical docs origin, independent of build-time or runtime env drift.
 export const dynamic = "force-dynamic";
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -27,10 +27,10 @@ import { getRuntimeConfig } from "@/lib/runtime-config.client";
 /**
  * Resolve the canonical base URL on the client. Reads from
  * window.__SHOWCASE_CONFIG__ (populated by the root layout's inline
- * <script>) so the rendered absolute URL reflects the current deploy's
- * NEXT_PUBLIC_BASE_URL without rebuilding the artifact. The runtime
- * reader already strips trailing slashes so callers can concatenate
- * `${BASE}${path}` safely.
+ * <script>) so non-production can reflect its runtime base URL without
+ * rebuilding the artifact. Production runtime config always injects the
+ * public canonical docs origin. The reader strips trailing slashes so callers
+ * can concatenate `${BASE}${path}` safely.
  *
  * Still inlined here (rather than reaching into `@/lib/sitemap-helpers`)
  * because that module also pulls in `fs` / `path` / `gray-matter` for

--- a/showcase/shell-docs/src/lib/runtime-config.test.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.test.ts
@@ -82,8 +82,26 @@ describe("server getRuntimeConfig (shell-docs)", () => {
     });
   });
 
-  it("strips trailing slashes from URLs", () => {
+  it("refuses a non-canonical docs base URL in production", () => {
     (process.env as Record<string, string>).NODE_ENV = "production";
+    process.env.NEXT_PUBLIC_BASE_URL = "https://docs.showcase.copilotkit.ai";
+    process.env.NEXT_PUBLIC_SHELL_URL = "https://showcase.copilotkit.ai";
+    process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
+      "https://dashboard.operations.copilotkit.ai/";
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://eu.i.posthog.com";
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cfg = getRuntimeConfig();
+
+    expect(cfg.baseUrl).toBe("https://docs.copilotkit.ai");
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("docs.showcase.copilotkit.ai"),
+    );
+    errSpy.mockRestore();
+  });
+
+  it("strips trailing slashes from URLs", () => {
+    (process.env as Record<string, string>).NODE_ENV = "development";
     process.env.NEXT_PUBLIC_BASE_URL = "https://docs.example.com/";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://shell.example.com//";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
@@ -196,7 +214,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("reads live process.env on each call (no module-load freeze)", () => {
-    (process.env as Record<string, string>).NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "development";
     process.env.NEXT_PUBLIC_BASE_URL = "https://first.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://shell.example.com";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =
@@ -215,7 +233,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
     // follows the shell / shell-dashboard naming convention still
     // wires through. See the readUrl fallback chain in
     // runtime-config.ts.
-    (process.env as Record<string, string>).NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "development";
     process.env.BASE_URL = "https://alt-docs.example.com";
     process.env.SHELL_URL = "https://alt-shell.example.com";
     process.env.INTELLIGENCE_SIGNUP_URL = "https://alt-signup.example.com";
@@ -229,7 +247,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   });
 
   it("NEXT_PUBLIC_* takes precedence over bare-name when both set", () => {
-    (process.env as Record<string, string>).NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "development";
     process.env.NEXT_PUBLIC_BASE_URL = "https://primary-docs.example.com";
     process.env.BASE_URL = "https://alt-docs.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://primary-shell.example.com";
@@ -252,7 +270,7 @@ describe("server getRuntimeConfig (shell-docs)", () => {
   it("getRuntimeConfigForMiddleware skips noStore() (Edge runtime path)", async () => {
     const cacheMod = await import("next/cache");
     const noStoreSpy = vi.spyOn(cacheMod, "unstable_noStore");
-    (process.env as Record<string, string>).NODE_ENV = "production";
+    (process.env as Record<string, string>).NODE_ENV = "development";
     process.env.NEXT_PUBLIC_BASE_URL = "https://edge.example.com";
     process.env.NEXT_PUBLIC_SHELL_URL = "https://edge-shell.example.com";
     process.env.NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL =

--- a/showcase/shell-docs/src/lib/runtime-config.ts
+++ b/showcase/shell-docs/src/lib/runtime-config.ts
@@ -1,7 +1,8 @@
 // Server-only runtime config reader for shell-docs. Reads from
 // process.env at REQUEST time (not at module load) so a single built
-// artifact can serve different URL/key values across staging vs prod by
-// changing the Railway service's env vars — no rebuild required.
+// artifact can serve different shell/signup/analytics values across staging
+// vs prod by changing the Railway service's env vars — no rebuild required.
+// The production docs base URL is deliberately fixed; see readBaseUrl().
 //
 // `unstable_noStore()` opts the calling segment out of Next.js's static
 // cache so reads always reflect the live env. Without it, a server
@@ -31,20 +32,22 @@ export interface RuntimeConfig {
   reoKey: string;
 }
 
-const PROD_BASE_URL_FALLBACK = "https://docs.copilotkit.ai";
+export const PRODUCTION_DOCS_ORIGIN = "https://docs.copilotkit.ai";
 const PROD_INVALID_SHELL_URL = "about:blank#shell-url-missing";
 const PROD_DEFAULT_SIGNUP_URL = "https://dashboard.operations.copilotkit.ai/";
 const PROD_DEFAULT_POSTHOG_HOST = "https://eu.i.posthog.com";
 
 /**
  * Resolve the runtime config for shell-docs. Called once per request by
- * the root layout and by any other server component / route that needs
- * it (sitemap, robots, middleware via the Edge wrapper).
+ * the root layout and by any other server component / route that needs it
+ * (sitemap, robots, middleware via the Edge wrapper). Production canonical
+ * identity is fixed even when deployment environment configuration drifts.
  *
  * Fail-loud strategy:
- *   - URL fields in production (severity=fatal): missing env vars
- *     produce sentinel URLs (or, for `baseUrl`, the canonical prod host
- *     — preserves existing sitemap behavior) AND a console.error
+ *   - URL fields in production (severity=fatal): missing env vars produce
+ *     sentinel URLs. `baseUrl` always uses the canonical production origin
+ *     and logs when its configured value is missing or different. Both paths
+ *     emit a console.error
  *     prefixed `FATAL-CONFIG:` (the prefix is what Sentry pattern-
  *     matches for ops alerts).
  *   - URL fields in production with a working default (severity=info,
@@ -72,16 +75,7 @@ export function getRuntimeConfig(
   if (opts.noStore !== false) noStore();
   const isProd = process.env.NODE_ENV === "production";
 
-  const baseUrl = readUrl(
-    "NEXT_PUBLIC_BASE_URL",
-    // baseUrl preserves the prior `https://docs.copilotkit.ai` prod
-    // fallback (matches the legacy getBaseUrl() behavior in
-    // sitemap-helpers.ts) so a misconfigured deploy still emits a
-    // reasonable sitemap rather than a sentinel URL. Logged either way.
-    isProd ? PROD_BASE_URL_FALLBACK : "http://localhost:3003",
-    isProd,
-    "fatal",
-  );
+  const baseUrl = readBaseUrl(isProd);
   const shellUrl = readUrl(
     "NEXT_PUBLIC_SHELL_URL",
     isProd ? PROD_INVALID_SHELL_URL : "http://localhost:3000",
@@ -160,6 +154,44 @@ function readEnvPair(envKey: string): string | undefined {
   const alt = process.env[altEnvName(envKey)];
   if (alt && alt.length > 0) return alt;
   return undefined;
+}
+
+/**
+ * The public docs origin is an identity invariant, not deploy-specific
+ * configuration. Production-mode servers can run behind the canonical
+ * hostname, a staging hostname, or a provider-generated hostname, but all
+ * machine-facing URLs must identify docs.copilotkit.ai as canonical.
+ *
+ * Keep the env override in non-production so local integration tests can
+ * point generated URLs at their test server. In production, report a stale
+ * deployment value loudly and ignore it.
+ */
+function readBaseUrl(isProd: boolean): string {
+  if (!isProd) {
+    return readUrl(
+      "NEXT_PUBLIC_BASE_URL",
+      "http://localhost:3003",
+      false,
+      "fatal",
+    );
+  }
+
+  const configured = readEnvPair("NEXT_PUBLIC_BASE_URL");
+  const normalized = configured?.replace(/\/+$/, "");
+  if (normalized === undefined) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "[shell-docs runtime-config] FATAL-CONFIG: NEXT_PUBLIC_BASE_URL is unset in a production deploy; " +
+        `using canonical origin ${PRODUCTION_DOCS_ORIGIN}.`,
+    );
+  } else if (normalized !== PRODUCTION_DOCS_ORIGIN) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "[shell-docs runtime-config] FATAL-CONFIG: NEXT_PUBLIC_BASE_URL " +
+        `is configured as ${normalized}; refusing it and using canonical origin ${PRODUCTION_DOCS_ORIGIN}.`,
+    );
+  }
+  return PRODUCTION_DOCS_ORIGIN;
 }
 
 function readUrl(

--- a/showcase/shell-docs/src/lib/sitemap-helpers.ts
+++ b/showcase/shell-docs/src/lib/sitemap-helpers.ts
@@ -176,12 +176,11 @@ export function getAgUiPages(): MdxEntry[] {
 
 /**
  * Resolve the canonical base URL. Delegates to the server runtime
- * config reader (which itself reads `NEXT_PUBLIC_BASE_URL` at REQUEST
- * time, strips trailing slashes, and applies a sensible prod/dev
- * fallback). Lives behind this thin wrapper so existing sitemap /
- * robots call sites keep their shape — the runtime-config switch is
- * what makes a single built artifact serve different hosts across
- * Railway environments.
+ * config reader. Non-production can override `NEXT_PUBLIC_BASE_URL`; a
+ * production-mode server always returns the canonical docs origin so a stale
+ * deployment variable or alternate serving hostname cannot leak into machine
+ * surfaces. Lives behind this wrapper so sitemap / robots / metadata / LLM
+ * call sites stay single-sourced.
  */
 export function getBaseUrl(): string {
   return getRuntimeConfig().baseUrl;

--- a/skills/a2ui-renderer/SKILL.md
+++ b/skills/a2ui-renderer/SKILL.md
@@ -14,7 +14,7 @@ description: >
 type: framework
 library: copilotkit
 framework: react
-library_version: "1.66.2"
+library_version: "1.67.1"
 requires:
   - copilotkit/react-core
   - copilotkit/runtime

--- a/skills/a2ui-renderer/SKILL.md
+++ b/skills/a2ui-renderer/SKILL.md
@@ -14,7 +14,7 @@ description: >
 type: framework
 library: copilotkit
 framework: react
-library_version: "1.56.2"
+library_version: "1.66.2"
 requires:
   - copilotkit/react-core
   - copilotkit/runtime

--- a/skills/copilotkit-debug/SKILL.md
+++ b/skills/copilotkit-debug/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: copilotkit-debug
 description: "Use when diagnosing CopilotKit issues -- runtime connectivity failures, agent not responding, streaming errors, tool execution problems, transcription failures, version mismatches, and AG-UI event tracing."
-version: 1.0.0
+version: 1.0.1
 ---
 
 # CopilotKit Debugging Skill
@@ -24,9 +24,9 @@ Invoke this skill when:
 
 Before proposing any fix, collect:
 
-1. **Package versions** -- Run `npm ls @copilotkit/runtime @copilotkit/react @copilotkit/core @ag-ui/client` (or the v1 equivalents). Version mismatches between runtime and react packages are a common root cause.
+1. **Package versions** -- Run `npm ls @copilotkit/runtime @copilotkit/react-core @copilotkit/core @ag-ui/client` (or the v1 equivalents). Version mismatches between runtime and React packages are a common root cause.
 2. **Runtime mode** -- Is this SSE mode (`CopilotSseRuntime`) or Intelligence mode (`CopilotIntelligenceRuntime`)? Check the runtime constructor.
-3. **Transport configuration** -- What is `runtimeUrl` set to on the `CopilotKit` provider (from `@copilotkit/react-core/v2`)? Does it match the `basePath` in `createCopilotEndpoint`?
+3. **Transport configuration** -- What is `runtimeUrl` set to on the `CopilotKit` provider (from `@copilotkit/react-core/v2`)? Does it match the `basePath` in `createCopilotRuntimeHandler`?
 4. **Agent type** -- Is the agent a `BuiltInAgent`, `LangGraphAgent`, `A2AAgent`, or custom `AbstractAgent`?
 5. **Error messages** -- Collect the exact error from browser console and server logs. CopilotKit uses structured error codes (see `references/error-patterns.md`).
 6. **Browser network tab** -- Check the `/info` request (runtime discovery), the `/agent/:id/run` SSE stream, and any CORS preflight failures.
@@ -108,14 +108,14 @@ The official troubleshooting docs are at:
 
 ## Key File Locations in the CopilotKit Codebase
 
-| Component                    | Path                                                                 |
-| ---------------------------- | -------------------------------------------------------------------- |
-| V1 Error classes & codes     | `packages/v1/shared/src/utils/errors.ts`                             |
-| V2 Core error codes          | `packages/v2/core/src/core/core.ts` (`CopilotKitCoreErrorCode` enum) |
-| V2 Transcription errors      | `packages/v2/shared/src/transcription-errors.ts`                     |
-| Runtime SSE response         | `packages/v2/runtime/src/handlers/shared/sse-response.ts`            |
-| Runtime info endpoint        | `packages/v2/runtime/src/handlers/get-runtime-info.ts`               |
-| Runtime CORS config          | `packages/v2/runtime/src/endpoints/hono.ts`                          |
-| Intelligence platform client | `packages/v2/runtime/src/intelligence-platform/client.ts`            |
-| Agent package (BuiltInAgent) | `packages/v2/agent/src/index.ts`                                     |
-| Web Inspector                | `packages/v2/web-inspector/src/index.ts`                             |
+| Component                    | Path                                                              |
+| ---------------------------- | ----------------------------------------------------------------- |
+| Legacy error classes & codes | `packages/shared/src/utils/errors.ts`                             |
+| V2 Core error codes          | `packages/core/src/core/core.ts` (`CopilotKitCoreErrorCode` enum) |
+| V2 Transcription errors      | `packages/shared/src/transcription-errors.ts`                     |
+| Runtime SSE response         | `packages/runtime/src/v2/runtime/handlers/shared/sse-response.ts` |
+| Runtime info endpoint        | `packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts`    |
+| Runtime CORS config          | `packages/runtime/src/v2/runtime/core/fetch-cors.ts`              |
+| Intelligence platform client | `packages/runtime/src/v2/runtime/intelligence-platform/client.ts` |
+| BuiltInAgent                 | `packages/runtime/src/agent/index.ts`                             |
+| Web Inspector                | `packages/web-inspector/src/index.ts`                             |

--- a/skills/copilotkit-debug/references/agent-debugging.md
+++ b/skills/copilotkit-debug/references/agent-debugging.md
@@ -2,12 +2,12 @@
 
 ## Agent Types in CopilotKit v2
 
-| Agent Type             | Package             | Description                                                                          |
-| ---------------------- | ------------------- | ------------------------------------------------------------------------------------ |
-| `BuiltInAgent`         | `@copilotkit/agent` | Uses Vercel AI SDK `streamText` with configurable model providers                    |
-| `LangGraphAgent`       | `@ag-ui/langgraph`  | Wraps a LangGraph deployment (Python or JS)                                          |
-| `A2AAgent`             | Varies              | Agent-to-Agent protocol agent                                                        |
-| Custom `AbstractAgent` | `@ag-ui/client`     | Any class extending `AbstractAgent` with a `run()` returning `Observable<BaseEvent>` |
+| Agent Type             | Package                  | Description                                                                          |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| `BuiltInAgent`         | `@copilotkit/runtime/v2` | Uses Vercel AI SDK `streamText` with configurable model providers                    |
+| `LangGraphAgent`       | `@ag-ui/langgraph`       | Wraps a LangGraph deployment (Python or JS)                                          |
+| `A2AAgent`             | Varies                   | Agent-to-Agent protocol agent                                                        |
+| Custom `AbstractAgent` | `@ag-ui/client`          | Any class extending `AbstractAgent` with a `run()` returning `Observable<BaseEvent>` |
 
 ## Agent Discovery Issues
 

--- a/skills/copilotkit-debug/references/error-patterns.md
+++ b/skills/copilotkit-debug/references/error-patterns.md
@@ -2,7 +2,7 @@
 
 ## V1 Error Codes (`CopilotKitErrorCode`)
 
-Legacy error codes from the v1 runtime layer. These still surface in `@copilotkit/*` packages since they wrap v2 internally. Defined in `packages/v1/shared/src/utils/errors.ts`.
+Legacy error codes from the v1 runtime layer. These still surface in `@copilotkit/*` packages since they wrap v2 internally. Defined in `packages/shared/src/utils/errors.ts`.
 
 ### NETWORK_ERROR
 
@@ -20,7 +20,7 @@ Legacy error codes from the v1 runtime layer. These still surface in `@copilotki
 - **HTTP Status**: 404
 - **Severity**: CRITICAL (banner)
 - **Cause**: The runtime URL returns 404. Wrong basePath or the server is not serving CopilotKit at that path.
-- **Resolution**: Ensure `basePath` in `createCopilotEndpoint()` matches the `runtimeUrl` in the provider.
+- **Resolution**: Ensure `basePath` in `createCopilotRuntimeHandler()` matches the `runtimeUrl` in the provider.
 - **Docs**: https://docs.copilotkit.ai/troubleshooting/common-issues#i-am-getting-a-network-errors--api-not-found
 
 ### AGENT_NOT_FOUND
@@ -60,7 +60,7 @@ Legacy error codes from the v1 runtime layer. These still surface in `@copilotki
 - **HTTP Status**: 400
 - **Severity**: INFO (dev only)
 - **Cause**: `@copilotkit/*` packages are on different versions.
-- **Resolution**: Ensure all `@copilotkit/*` packages are the same version. Run `npm ls @copilotkit/runtime @copilotkit/react`.
+- **Resolution**: Ensure all `@copilotkit/*` packages are the same version. Run `npm ls @copilotkit/runtime @copilotkit/react-core`.
 
 ### CONFIGURATION_ERROR
 
@@ -101,7 +101,7 @@ Legacy error codes from the v1 runtime layer. These still surface in `@copilotki
 
 ## V1 Error Classes
 
-All defined in `packages/v1/shared/src/utils/errors.ts`:
+All defined in `packages/shared/src/utils/errors.ts`:
 
 | Class                                    | Extends                       | When Thrown                               |
 | ---------------------------------------- | ----------------------------- | ----------------------------------------- |
@@ -121,7 +121,7 @@ All defined in `packages/v1/shared/src/utils/errors.ts`:
 
 ## V2 Error Codes (`CopilotKitCoreErrorCode`)
 
-Used by `@copilotkit/core`. Defined in `packages/v2/core/src/core/core.ts`. These are emitted via the `onError` subscriber callback.
+Used by `@copilotkit/core`. Defined in `packages/core/src/core/core.ts`. These are emitted via the `onError` subscriber callback.
 
 ### runtime_info_fetch_failed
 
@@ -202,7 +202,7 @@ Used by `@copilotkit/core`. Defined in `packages/v2/core/src/core/core.ts`. Thes
 
 ## Transcription Error Codes (`TranscriptionErrorCode`)
 
-Used by `@copilotkit/shared` and `@copilotkit/react`. Defined in `packages/v2/shared/src/transcription-errors.ts`.
+Used by `@copilotkit/shared` and `@copilotkit/react-core`. Defined in `packages/shared/src/transcription-errors.ts`.
 
 | Code                     | Retryable | Description                                 |
 | ------------------------ | --------- | ------------------------------------------- |
@@ -220,7 +220,7 @@ Used by `@copilotkit/shared` and `@copilotkit/react`. Defined in `packages/v2/sh
 
 ## Intelligence Platform Error (`PlatformRequestError`)
 
-Used by `@copilotkit/runtime` for Intelligence mode. Defined in `packages/v2/runtime/src/intelligence-platform/client.ts`.
+Used by `@copilotkit/runtime` for Intelligence mode. Defined in `packages/runtime/src/v2/runtime/intelligence-platform/client.ts`.
 
 | Status | Meaning                                                                                |
 | ------ | -------------------------------------------------------------------------------------- |

--- a/skills/copilotkit-debug/references/quick-workflows.md
+++ b/skills/copilotkit-debug/references/quick-workflows.md
@@ -11,7 +11,7 @@ curl -v http://localhost:3001/api/copilotkit/info
 ```
 
 - **No response / connection refused** -> The server is not running. Start it.
-- **404** -> The basePath is wrong. Check `createCopilotEndpoint({ basePath })` vs the URL you are hitting.
+- **404** -> The basePath is wrong. Check `createCopilotRuntimeHandler({ basePath })` vs the URL you are hitting.
 - **500** -> The agent loading failed. Check server logs for the error.
 - **200 with JSON** -> Runtime is up. Proceed to step 2.
 
@@ -34,17 +34,17 @@ curl -v http://localhost:3001/api/copilotkit/info
 ### Step 4: Check package versions
 
 ```bash
-npm ls @copilotkit/runtime @copilotkit/react @copilotkit/core @ag-ui/client
+npm ls @copilotkit/runtime @copilotkit/react-core @copilotkit/core @ag-ui/client
 ```
 
 All `@copilotkit/*` packages should be the same version. Mismatches cause `VERSION_MISMATCH` errors.
 
 ### Step 5: Check CORS (if cross-origin)
 
-Default CORS allows all origins without credentials. If you need credentials:
+With `cors: true`, the default CORS policy allows all origins without credentials. If you need credentials:
 
 ```ts
-createCopilotEndpoint({
+createCopilotRuntimeHandler({
   runtime,
   basePath: "/api/copilotkit",
   cors: {

--- a/skills/copilotkit-debug/references/runtime-debugging.md
+++ b/skills/copilotkit-debug/references/runtime-debugging.md
@@ -2,7 +2,7 @@
 
 ## Runtime Architecture
 
-CopilotKit v2 runtime (`@copilotkit/runtime`) runs as a Hono HTTP server. It exposes these endpoints under the configured `basePath`:
+CopilotKit v2 runtime (`@copilotkit/runtime`) exposes a fetch-native handler with these endpoints under the configured `basePath`:
 
 | Endpoint                  | Method                | Purpose                                                        |
 | ------------------------- | --------------------- | -------------------------------------------------------------- |
@@ -42,17 +42,17 @@ CopilotKit v2 runtime (`@copilotkit/runtime`) runs as a Hono HTTP server. It exp
 
    Expected response: JSON with `version`, `agents`, `mode` fields.
 
-2. **Check basePath alignment**: The `basePath` in `createCopilotEndpoint()` must match the `runtimeUrl` on the `CopilotKit` provider (from `@copilotkit/react-core/v2`):
+2. **Check basePath alignment**: The `basePath` in `createCopilotRuntimeHandler()` must match the `runtimeUrl` on the `CopilotKit` provider (from `@copilotkit/react-core/v2`):
 
    ```ts
    // Server
-   createCopilotEndpoint({ runtime, basePath: "/api/copilotkit" });
+   createCopilotRuntimeHandler({ runtime, basePath: "/api/copilotkit" });
 
    // Client
    <CopilotKit runtimeUrl="/api/copilotkit">
    ```
 
-3. **Check the Hono app mounting**: If using a framework adapter (Next.js, Express), ensure the Hono app is mounted at the right path. The framework's route path combined with `basePath` must form the full URL.
+3. **Check the framework mounting**: Ensure the fetch handler is mounted at the right path. The framework's route path combined with `basePath` must form the full URL.
 
 4. **Proxy/reverse proxy issues**: If running behind nginx, Vercel, or similar, ensure the proxy passes the full path and does not strip the prefix.
 
@@ -78,7 +78,7 @@ CopilotKit v2 runtime (`@copilotkit/runtime`) runs as a Hono HTTP server. It exp
 
 ### Default CORS Behavior
 
-When no `cors` option is provided to `createCopilotEndpoint`, the runtime defaults to:
+When `cors: true` is provided to `createCopilotRuntimeHandler`, the runtime defaults to:
 
 - `origin: "*"` (all origins allowed)
 - `credentials: false`
@@ -90,7 +90,7 @@ When no `cors` option is provided to `createCopilotEndpoint`, the runtime defaul
 When using HTTP-only cookies for authentication, you must configure CORS explicitly:
 
 ```ts
-createCopilotEndpoint({
+createCopilotRuntimeHandler({
   runtime,
   basePath: "/api/copilotkit",
   cors: {
@@ -111,12 +111,12 @@ On the client side, enable credentials:
 
 ### Common CORS Errors
 
-| Browser Error                                   | Cause                                    | Fix                                                                                     |
-| ----------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------- |
-| "No 'Access-Control-Allow-Origin' header"       | Runtime not sending CORS headers         | Verify `createCopilotEndpoint` is handling the request (not a 404 from another handler) |
-| "Credential is not supported if origin is '\*'" | `credentials: true` with wildcard origin | Set an explicit `origin` in the CORS config                                             |
-| "Method PUT is not allowed"                     | Preflight failure                        | Ensure the runtime's CORS allows the method (default config allows all)                 |
-| CORS error only in production                   | Different origins in dev vs prod         | Update the `origin` config for the production domain                                    |
+| Browser Error                                   | Cause                                    | Fix                                                                                           |
+| ----------------------------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------- |
+| "No 'Access-Control-Allow-Origin' header"       | Runtime not sending CORS headers         | Verify `createCopilotRuntimeHandler` is handling the request (not a 404 from another handler) |
+| "Credential is not supported if origin is '\*'" | `credentials: true` with wildcard origin | Set an explicit `origin` in the CORS config                                                   |
+| "Method PUT is not allowed"                     | Preflight failure                        | Ensure the runtime's CORS allows the method (default config allows all)                       |
+| CORS error only in production                   | Different origins in dev vs prod         | Update the `origin` config for the production domain                                          |
 
 ### Diagnosing CORS Issues
 

--- a/skills/copilotkit-debug/sources.md
+++ b/skills/copilotkit-debug/sources.md
@@ -5,35 +5,35 @@ Generated: 2026-03-28
 
 ## error-patterns.md
 
-- packages/v1/shared/src/utils/errors.ts (CopilotKitErrorCode enum, all v1 error classes: CopilotKitError, CopilotKitMisuseError, CopilotKitVersionMismatchError, CopilotKitApiDiscoveryError, CopilotKitRemoteEndpointDiscoveryError, CopilotKitAgentDiscoveryError, CopilotKitLowLevelError, ResolvedCopilotKitError, ConfigurationError, MissingPublicApiKeyError, UpgradeRequiredError)
-- packages/v2/core/src/core/core.ts (CopilotKitCoreErrorCode enum: runtime_info_fetch_failed, agent_connect_failed, agent_run_failed, tool_argument_parse_failed, tool_handler_failed, tool_not_found, agent_not_found, transcription error codes)
-- packages/v2/shared/src/transcription-errors.ts (TranscriptionErrorCode enum)
-- packages/v2/runtime/src/intelligence-platform/client.ts (PlatformRequestError, HTTP status codes 404/409/401/500)
+- packages/shared/src/utils/errors.ts (CopilotKitErrorCode enum, all legacy v1 error classes: CopilotKitError, CopilotKitMisuseError, CopilotKitVersionMismatchError, CopilotKitApiDiscoveryError, CopilotKitRemoteEndpointDiscoveryError, CopilotKitAgentDiscoveryError, CopilotKitLowLevelError, ResolvedCopilotKitError, ConfigurationError, MissingPublicApiKeyError, UpgradeRequiredError)
+- packages/core/src/core/core.ts (CopilotKitCoreErrorCode enum: runtime_info_fetch_failed, agent_connect_failed, agent_run_failed, tool_argument_parse_failed, tool_handler_failed, tool_not_found, agent_not_found, transcription error codes)
+- packages/shared/src/transcription-errors.ts (TranscriptionErrorCode enum)
+- packages/runtime/src/v2/runtime/intelligence-platform/client.ts (PlatformRequestError, HTTP status codes 404/409/401/500)
 - GitHub issues: #3519, #3510, #3323, #3442, #3170, #3217, #3424, #3426, #3429, #3318, #3410
 
 ## runtime-debugging.md
 
-- packages/v2/runtime/src/ (CopilotRuntime, endpoint factories, route definitions, SSE streaming, /info endpoint response shape)
-- packages/v2/runtime/src/endpoints/ (CORS configuration, Hono middleware, Express middleware)
-- packages/v2/runtime/src/intelligence-platform/ (CopilotKitIntelligence, IntelligenceAgentRunner, WebSocket URLs)
-- packages/v2/runtime/src/runner/ (InMemoryAgentRunner, AgentRunner abstract class)
-- packages/v2/react/src/ (`CopilotKit` provider props: runtimeUrl, credentials, headers)
+- packages/runtime/src/v2/runtime/ (CopilotRuntime, endpoint factories, route definitions, SSE streaming, /info endpoint response shape)
+- packages/runtime/src/v2/runtime/endpoints/ (CORS configuration, Hono middleware, Express middleware)
+- packages/runtime/src/v2/runtime/intelligence-platform/ (CopilotKitIntelligence, IntelligenceAgentRunner, WebSocket URLs)
+- packages/runtime/src/v2/runtime/runner/ (InMemoryAgentRunner, AgentRunner abstract class)
+- packages/react-core/src/v2/ (`CopilotKit` provider props: runtimeUrl, credentials, headers)
 - GitHub issues: #3170, #3425
 
 ## agent-debugging.md
 
-- packages/v2/agent/src/ (BuiltInAgent, resolveModel, model string formats, MCP client configuration)
-- packages/v2/runtime/src/ (AgentRunner, agent registry, /info endpoint agent discovery)
-- packages/v2/core/src/ (CopilotKitCoreErrorCode, tool registry, onError subscriber)
-- packages/v2/react/src/ (useFrontendTool, useAgent, CopilotChat agentId prop)
-- packages/v2/web-inspector/src/ (CopilotKitWebInspector component)
+- packages/runtime/src/agent/ (BuiltInAgent, resolveModel, model string formats, MCP client configuration)
+- packages/runtime/src/v2/runtime/ (AgentRunner, agent registry, /info endpoint agent discovery)
+- packages/core/src/ (CopilotKitCoreErrorCode, tool registry, onError subscriber)
+- packages/react-core/src/v2/ (useFrontendTool, useAgent, CopilotChat agentId prop)
+- packages/web-inspector/src/ (CopilotKitWebInspector component)
 - GitHub issues: #3323, #3519, #3231, #3456, #3424, #3426, #3198
 
 ## quick-workflows.md
 
-- packages/v2/runtime/src/ (endpoint route structure, /info endpoint, CORS defaults, SSE event flow)
-- packages/v2/agent/src/ (BuiltInAgent model string format, environment variable conventions)
-- packages/v2/core/src/ (error codes referenced in diagnostic steps)
-- packages/v2/react/src/ (`CopilotKit` provider props, useFrontendTool registration, CopilotChat)
-- packages/v2/shared/src/ (TranscriptionErrorCode, transcription service configuration)
-- packages/v2/web-inspector/src/ (CopilotKitWebInspector for escalation)
+- packages/runtime/src/v2/runtime/ (endpoint route structure, /info endpoint, CORS defaults, SSE event flow)
+- packages/runtime/src/agent/ (BuiltInAgent model string format, environment variable conventions)
+- packages/core/src/ (error codes referenced in diagnostic steps)
+- packages/react-core/src/v2/ (`CopilotKit` provider props, useFrontendTool registration, CopilotChat)
+- packages/shared/src/ (TranscriptionErrorCode, transcription service configuration)
+- packages/web-inspector/src/ (CopilotKitWebInspector for escalation)

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -5,7 +5,7 @@ description: >
   project from scratch. Covers framework detection, package installation, runtime wiring
   (managed Intelligence or self-hosted SSE), provider setup, and first working chat
   integration.
-version: 1.3.0
+version: 1.3.1
 ---
 
 # CopilotKit Setup

--- a/skills/copilotkit-setup/eval.yaml
+++ b/skills/copilotkit-setup/eval.yaml
@@ -16,12 +16,12 @@ tasks:
     instruction: |
       Create a new Next.js App Router project and add CopilotKit with a basic chat
       interface using BuiltInAgent. The project should have:
-      - CopilotKit frontend packages (@copilotkit/react, @copilotkit/core)
-      - CopilotKit runtime packages (@copilotkit/runtime, @copilotkit/agent)
+      - The CopilotKit frontend package (@copilotkit/react-core)
+      - The CopilotKit runtime package (@copilotkit/runtime)
       - A runtime API route at src/app/api/copilotkit/[[...slug]]/route.ts using
-        createCopilotEndpoint with a BuiltInAgent
+        createCopilotHonoHandler with a BuiltInAgent
       - A page component with the CopilotKit provider wrapping CopilotChat
-      - The @copilotkit/react stylesheet imported
+      - The @copilotkit/react-core/v2 stylesheet imported
     graders:
       - type: deterministic
         run: |
@@ -39,16 +39,10 @@ tasks:
           }
 
           # Check frontend packages
-          if jq -e '.dependencies["@copilotkit/react"]' package.json > /dev/null 2>&1; then
-            add_check "@copilotkit/react installed" true "Found in dependencies"
+          if jq -e '.dependencies["@copilotkit/react-core"]' package.json > /dev/null 2>&1; then
+            add_check "@copilotkit/react-core installed" true "Found in dependencies"
           else
-            add_check "@copilotkit/react installed" false "Not found in package.json dependencies"
-          fi
-
-          if jq -e '.dependencies["@copilotkit/core"]' package.json > /dev/null 2>&1; then
-            add_check "@copilotkit/core installed" true "Found in dependencies"
-          else
-            add_check "@copilotkit/core installed" false "Not found in package.json dependencies"
+            add_check "@copilotkit/react-core installed" false "Not found in package.json dependencies"
           fi
 
           # Check runtime packages
@@ -58,10 +52,11 @@ tasks:
             add_check "@copilotkit/runtime installed" false "Not found in package.json dependencies"
           fi
 
-          if jq -e '.dependencies["@copilotkit/agent"]' package.json > /dev/null 2>&1; then
-            add_check "@copilotkit/agent installed" true "Found in dependencies"
+          # Check for the canonical Hono runtime factory
+          if grep -r "createCopilotHonoHandler" --include='*.ts' --include='*.js' . > /dev/null 2>&1; then
+            add_check "Canonical runtime factory used" true "Found createCopilotHonoHandler"
           else
-            add_check "@copilotkit/agent installed" false "Not found in package.json dependencies"
+            add_check "Canonical runtime factory used" false "createCopilotHonoHandler not found"
           fi
 
           # Check runtime route exists
@@ -86,6 +81,13 @@ tasks:
             add_check "Chat component used" false "No CopilotChat/CopilotSidebar/CopilotPopup found"
           fi
 
+          # Check for the canonical v2 stylesheet export
+          if grep -rF "@copilotkit/react-core/v2/styles.css" --include='*.tsx' --include='*.ts' --include='*.jsx' --include='*.css' . > /dev/null 2>&1; then
+            add_check "Stylesheet imported" true "Found @copilotkit/react-core/v2/styles.css import"
+          else
+            add_check "Stylesheet imported" false "No @copilotkit/react-core/v2/styles.css import found"
+          fi
+
           PASSED=$(echo "$CHECKS" | jq '[.[] | select(.passed == true)] | length')
           TOTAL=$(echo "$CHECKS" | jq 'length')
           SCORE=$(echo "scale=2; $PASSED / $TOTAL" | bc)
@@ -96,8 +98,8 @@ tasks:
         rubric: |
           Evaluate whether this project has a complete, working CopilotKit setup:
           1. Does it have a CopilotKit provider (the `CopilotKit` component from @copilotkit/react-core/v2) wrapping a CopilotChat (or CopilotSidebar/CopilotPopup) component?
-          2. Does the runtime route use createCopilotEndpoint or createCopilotEndpointSingleRoute with a BuiltInAgent?
-          3. Is the @copilotkit/react stylesheet imported (styles.css)?
+          2. Does the runtime route use createCopilotHonoHandler with a BuiltInAgent?
+          3. Is @copilotkit/react-core/v2/styles.css imported?
           4. Does the provider's runtimeUrl point to the correct API route?
           5. Is the project structured correctly for Next.js App Router (app/ directory, "use client" directives where needed)?
         weight: 0.3
@@ -106,12 +108,12 @@ tasks:
     instruction: |
       Add CopilotKit to this existing Vite+React project with a chat sidebar and a
       BuiltInAgent backend. The setup should include:
-      - CopilotKit frontend packages (@copilotkit/react, @copilotkit/core)
-      - CopilotKit runtime packages (@copilotkit/runtime, @copilotkit/agent)
+      - The CopilotKit frontend package (@copilotkit/react-core)
+      - The CopilotKit runtime package (@copilotkit/runtime)
       - A backend server (Express or Hono) running the CopilotRuntime with a BuiltInAgent
       - The CopilotKit provider in the React app pointing to the backend URL
       - A CopilotSidebar component for the chat UI
-      - The @copilotkit/react stylesheet imported
+      - The @copilotkit/react-core/v2 stylesheet imported
     workspace:
       - src: workspace/vite-react
         dest: /workspace
@@ -126,10 +128,10 @@ tasks:
           }
 
           # Check frontend packages
-          if jq -e '.dependencies["@copilotkit/react"]' package.json > /dev/null 2>&1; then
-            add_check "@copilotkit/react installed" true "Found in dependencies"
+          if jq -e '.dependencies["@copilotkit/react-core"]' package.json > /dev/null 2>&1; then
+            add_check "@copilotkit/react-core installed" true "Found in dependencies"
           else
-            add_check "@copilotkit/react installed" false "Not found in package.json dependencies"
+            add_check "@copilotkit/react-core installed" false "Not found in package.json dependencies"
           fi
 
           # Check runtime packages (may be in a separate server directory)
@@ -168,10 +170,10 @@ tasks:
           fi
 
           # Check for stylesheet import
-          if grep -r "styles\.css\|@copilotkit/react/styles" --include='*.tsx' --include='*.ts' --include='*.jsx' --include='*.css' . > /dev/null 2>&1; then
-            add_check "Stylesheet imported" true "Found styles.css import"
+          if grep -rF "@copilotkit/react-core/v2/styles.css" --include='*.tsx' --include='*.ts' --include='*.jsx' --include='*.css' . > /dev/null 2>&1; then
+            add_check "Stylesheet imported" true "Found @copilotkit/react-core/v2/styles.css import"
           else
-            add_check "Stylesheet imported" false "No @copilotkit/react/styles.css import found"
+            add_check "Stylesheet imported" false "No @copilotkit/react-core/v2/styles.css import found"
           fi
 
           PASSED=$(echo "$CHECKS" | jq '[.[] | select(.passed == true)] | length')
@@ -186,6 +188,6 @@ tasks:
           1. Is the CopilotKit provider set up with a runtimeUrl pointing to the backend server?
           2. Is there a CopilotSidebar (or equivalent chat component) rendered in the app?
           3. Does the backend use CopilotRuntime with a BuiltInAgent and an appropriate endpoint factory?
-          4. Is the @copilotkit/react stylesheet imported?
+          4. Is @copilotkit/react-core/v2/styles.css imported?
           5. If the backend is a separate server, does the frontend URL account for the correct port and CORS is handled?
         weight: 0.3

--- a/skills/react-core/SKILL.md
+++ b/skills/react-core/SKILL.md
@@ -13,7 +13,7 @@ description: >
   alias). Load the reference under references/ that matches your task.
 type: framework
 library: copilotkit
-library_version: "1.56.2"
+library_version: "1.66.2"
 requires:
   - copilotkit/runtime
 sources:

--- a/skills/react-core/SKILL.md
+++ b/skills/react-core/SKILL.md
@@ -13,7 +13,7 @@ description: >
   alias). Load the reference under references/ that matches your task.
 type: framework
 library: copilotkit
-library_version: "1.66.2"
+library_version: "1.67.1"
 requires:
   - copilotkit/runtime
 sources:

--- a/skills/runtime/SKILL.md
+++ b/skills/runtime/SKILL.md
@@ -11,7 +11,7 @@ description: >
   discouraged. Load the reference under references/ that matches your task.
 type: core
 library: copilotkit
-library_version: "1.56.2"
+library_version: "1.66.2"
 requires: []
 sources:
   - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/fetch-handler.ts"

--- a/skills/runtime/SKILL.md
+++ b/skills/runtime/SKILL.md
@@ -11,7 +11,7 @@ description: >
   discouraged. Load the reference under references/ that matches your task.
 type: core
 library: copilotkit
-library_version: "1.66.2"
+library_version: "1.67.1"
 requires: []
 sources:
   - "CopilotKit/CopilotKit:packages/runtime/src/v2/runtime/core/fetch-handler.ts"


### PR DESCRIPTION
## Summary

This establishes a stronger machine-readable source of truth for agents choosing and implementing CopilotKit:

- lock production docs canonicals, Open Graph URLs, robots, sitemap, and LLM artifacts to `https://docs.copilotkit.ai`, with deploy smoke coverage that fails loudly on hostname leakage
- add a versioned, generated public API manifest covering 26 packages, 92 public import paths, runtime adapters, host factories, compatibility ranges, and source-backed deprecations
- add manifest drift detection to the release suite and root generate/check commands
- update the public setup/debug/package skills and their deterministic evals to current package names, factories, repository paths, and `1.67.1` metadata
- keep package-owned skills and top-level public mirrors in sync

## Growth impact

Agents should encounter one consistent answer across docs metadata, LLM-facing artifacts, release metadata, and executable skills. That reduces hallucinated imports and stale setup paths while giving crawlers and coding agents a concrete reason to select CopilotKit for agent-native application experiences—including agent-to-agent interaction, shared state, human-in-the-loop workflows, tool rendering, and generative UI.

## Validation

- frozen lockfile install passed
- changed-file formatting passed
- repository lint passed with existing warnings only
- full Nx typecheck passed: 32 projects plus dependencies
- focused docs/manifest/skill suites passed: 4 files, 113 tests
- shell-docs typecheck passed; shell-docs lint passed with existing warnings
- plugin skill mirrors and public API manifest drift checks passed
- affected commit hook matrix passed tests, publint, and are-the-types-wrong checks
- full package test matrix passed except two contention timeouts; both failed projects then passed uncached in isolation:
  - `@copilotkit/react-core`: 123 files, 1,481 tests
  - `@copilotkit/vue`: 100 files, 1,074 tests
- corrected sequential Nx build passed for all 26 package projects

## Notes

- the repository-wide formatter currently reports 25 pre-existing files on `main`; every file changed by this PR passes formatting
- deployed docs will continue exposing the old showcase hostname until this change is promoted; the new production verification will block future canonical, OG, robots, sitemap, `llms.txt`, or `llms-full.txt` leakage
- no redirect is included for `docs.showcase.copilotkit.ai` because ownership of that host is outside this repository's source of truth

Linear: PDX-316, PDX-318, PDX-319