### PR TITLE
fix(reskinnable-demo): guard the page-level HITL approval renders

### DIFF
--- a/examples/showcases/reskinnable-demo/src/skins/banking/pages/cards.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/pages/cards.tsx
@@ -129,7 +129,7 @@ export default function Page() {
         .string()
         .describe("The pin code of the card (set by user), 4 digits"),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { type, color, pin } = args;
 
       if (status === "inProgress") {
@@ -181,6 +181,7 @@ export default function Page() {
             </div>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               await addNewCard({ type, color, pin } as NewCardRequest);
               respond?.("Card created successfully");
@@ -205,7 +206,7 @@ export default function Page() {
           .describe("The card (from existing) to assign policy to"),
         policyType: z.string().describe("The type of the policy to use"),
       }),
-      render: ({ args, respond, status }) => {
+      render: ({ args, respond, status, result }) => {
         const { cardId, policyType } = args;
 
         if (status === "inProgress") {
@@ -234,6 +235,7 @@ export default function Page() {
               </p>
             </div>
             <ApprovalButtons
+              resolved={status === "complete" || !!result}
               onApprove={async () => {
                 const policyId = policy?.id;
                 if (!cardId || !policyId) {

--- a/examples/showcases/reskinnable-demo/src/skins/banking/pages/team.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/pages/team.tsx
@@ -83,7 +83,7 @@ export default function Team() {
           "The ID of the member to remove (provided by copilot, ask questions to figure out the member)",
         ),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { id } = args;
       if (status === "inProgress")
         return (
@@ -105,6 +105,7 @@ export default function Team() {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!id) {
                 respond?.("Missing member information");
@@ -129,7 +130,7 @@ export default function Team() {
       id: z.string().describe("The ID of the member to change the role of"),
       role: z.string().describe("The new role of the member"),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { id, role } = args;
       if (status === "inProgress")
         return (
@@ -155,6 +156,7 @@ export default function Team() {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!id || !role) {
                 respond?.("Missing member or role information");
@@ -179,7 +181,7 @@ export default function Team() {
       id: z.string().describe("The ID of the member to change the team of"),
       team: z.string().describe("The new team of the member"),
     }),
-    render: ({ args, respond, status }) => {
+    render: ({ args, respond, status, result }) => {
       const { id, team: newTeam } = args;
       if (status === "inProgress")
         return (
@@ -205,6 +207,7 @@ export default function Team() {
             </p>
           </div>
           <ApprovalButtons
+            resolved={status === "complete" || !!result}
             onApprove={async () => {
               if (!id || !newTeam) {
                 respond?.("Missing member or team information");


### PR DESCRIPTION
## What

`0a9b99aae3` added the durable `resolved` prop to `ApprovalButtons` and wired the three call sites in `tools.tsx` that need it. The five `useHumanInTheLoop` renders that live on the pages were missed:

| File | Actions |
|---|---|
| `pages/team.tsx` | `removeMember`, `changeMemberRole`, `changeMemberTeam` |
| `pages/cards.tsx` | `addNewCard`, `assignPolicyToCard` |

All five guarded only on `status === "inProgress"` and then fell through to `ApprovalButtons`, whose local `responded` state dies with the component. Each now destructures `result` and passes the same signal the three wired renders use:

```tsx
resolved={status === "complete" || !!result}
```

## Why it matters

Reload a thread containing an already-answered `removeMember` and the local state is gone, so live Approve/Deny buttons come back on a settled call. A second click fires a duplicate write. This is reachable without the multi-step chain that motivated the original fix.

The other three renders in `tools.tsx` still need nothing — they return a terminal card when complete, so they never reach the buttons.

## Correctness

The render props are a discriminated union: `result` is `undefined` while `Executing` and a `string` once `Complete`, so the buttons stay live in exactly the one state where the user should act.

`ToolCallStatus` is a string enum, so the `status === "complete"` comparison deserved a check rather than an assumption. Verified against the repo's tsc 5.9.2 in isolation: it compiles clean, and a negative control (`status === "definitelyNotAMember"`) errors with TS2367, so the check isn't vacuous.

`|| !!result` is redundant given the union, but kept for consistency with the three existing call sites.

## Verification

- `nx run reskinnable-demo:lint` — clean
- `nx run reskinnable-demo:test:unit` — 1130 tests across 99 files pass
- lefthook pre-commit + commitlint — passed, no `--no-verify`

Two things I did not do, stated plainly:

- **Not exercised in a browser.** The original three were verified live; these five are structurally identical renders extended by inspection.
- **`nx run reskinnable-demo:build` fails locally**, on `Module not found: Can't resolve '@copilotkit/shared'` from `packages/web-inspector/dist`. It fails identically on clean `main`, so it is a stale local workspace link and not a regression from this change — but it does mean CI is the first real type-check of this diff.

## Out of scope

Only the banking skin's `ApprovalButtons` sites were audited. The other skins (commerce, keel, logistics, people, airline) were not checked for their own approval UIs carrying the same local-state-only pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)