### PR TITLE
fix(channels-slack): three defects that silently broke Slack Block Kit

### DIFF
--- a/packages/channels-slack/src/native-catalog.test.ts
+++ b/packages/channels-slack/src/native-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   SLACK_ELEMENT_MANIFEST,
   SLACK_NATIVE_MANIFEST,
   SLACK_OBJECT_MANIFEST,
+  SLACK_UNTYPED_OBJECTS,
 } from "./native-manifest.js";
 import { Slack } from "./native.js";
 
@@ -30,7 +31,16 @@ test("every Slack catalog entry serializes its fixed discriminator", () => {
       entry.type,
       requiredProps(entry.type),
     );
-    expect(serializeSlackNativeNode(node).type).toBe(entry.type);
+    const serialized = serializeSlackNativeNode(node);
+
+    // Composition objects Slack defines as plain structures must not carry a
+    // discriminator: an option is `{text, value}`, and a stray `type` on it is
+    // an unknown field that makes Slack refuse the whole message.
+    if (entry.kind === "object" && SLACK_UNTYPED_OBJECTS.has(entry.type)) {
+      expect(serialized).not.toHaveProperty("type");
+    } else {
+      expect(serialized.type).toBe(entry.type);
+    }
     expect(entry.source).toMatch(/^https:\/\/docs\.slack\.dev\//);
   }
 });

--- a/packages/channels-slack/src/native-catalog.test.ts
+++ b/packages/channels-slack/src/native-catalog.test.ts
@@ -95,3 +95,31 @@ function requiredProps(type: string): Record<string, unknown> {
   }
   return {};
 }
+
+test("an image accepts either an external URL or a Slack-hosted file", () => {
+  const external = createNativeNode("slack", "block", "image", {
+    image_url: "https://picsum.photos/400/300",
+    alt_text: "Latency chart",
+  });
+  const hosted = createNativeNode("slack", "block", "image", {
+    slack_file: createNativeNode("slack", "object", "slack_file", {
+      url: "https://files.slack.com/files-pri/T0/chart.png",
+    }),
+    alt_text: "Latency chart",
+  });
+
+  expect(serializeSlackNativeNode(external).image_url).toBe(
+    "https://picsum.photos/400/300",
+  );
+  expect(serializeSlackNativeNode(hosted).slack_file).toEqual({
+    url: "https://files.slack.com/files-pri/T0/chart.png",
+  });
+
+  // Neither source is still an error — the check moved, it did not disappear.
+  const neither = createNativeNode("slack", "block", "image", {
+    alt_text: "Latency chart",
+  });
+  expect(() => serializeSlackNativeNode(neither)).toThrow(
+    /requires image_url or slack_file/,
+  );
+});

--- a/packages/channels-slack/src/native-catalog.test.ts
+++ b/packages/channels-slack/src/native-catalog.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./native-manifest.js";
 import { Slack } from "./native.js";
 
-test("Slack exposes all 20 message-valid blocks from its manifest", () => {
-  expect(SLACK_BLOCK_MANIFEST).toHaveLength(20);
+test("Slack exposes all 19 message-valid blocks from its manifest", () => {
+  expect(SLACK_BLOCK_MANIFEST).toHaveLength(19);
   expect(Object.keys(Slack.Block).sort()).toEqual(
     SLACK_BLOCK_MANIFEST.map(([name]) => name).sort(),
   );

--- a/packages/channels-slack/src/native-codec.ts
+++ b/packages/channels-slack/src/native-codec.ts
@@ -1,7 +1,10 @@
 import { isNativeNode } from "@copilotkit/channels-ui";
 import type { ChannelNode, NativeChannelNode } from "@copilotkit/channels-ui";
 import { validateSlackDataVisualization } from "./data-visualization.js";
-import { SLACK_NATIVE_MANIFEST } from "./native-manifest.js";
+import {
+  SLACK_NATIVE_MANIFEST,
+  SLACK_UNTYPED_OBJECTS,
+} from "./native-manifest.js";
 
 const manifest = new Map(
   SLACK_NATIVE_MANIFEST.map((entry) => [`${entry.kind}:${entry.type}`, entry]),
@@ -43,7 +46,12 @@ export function serializeSlackNativeNode(
     );
   }
 
-  const output: Record<string, unknown> = { type: entry.type };
+  // Untyped composition objects are plain structures; tagging them with a
+  // `type` makes Slack reject the message that contains them.
+  const output: Record<string, unknown> =
+    entry.kind === "object" && SLACK_UNTYPED_OBJECTS.has(entry.type)
+      ? {}
+      : { type: entry.type };
   for (const [name, value] of Object.entries(node.props)) {
     if (
       name === "provider" ||

--- a/packages/channels-slack/src/native-codec.ts
+++ b/packages/channels-slack/src/native-codec.ts
@@ -16,7 +16,7 @@ const REQUIRED_FIELDS: Readonly<Record<string, readonly string[]>> = {
   context: ["elements"],
   data_visualization: ["title", "chart"],
   header: ["text"],
-  image: ["image_url", "alt_text"],
+  image: ["alt_text"], // plus image_url OR slack_file — checked below
   input: ["label", "element"],
   option: ["text", "value"],
   video: ["alt_text", "thumbnail_url", "title", "title_url", "video_url"],
@@ -107,6 +107,16 @@ function validateRequiredFields(
     output.fields === undefined
   ) {
     throw new Error(`${path}.${component} requires text or fields.`);
+  }
+  // An image points at either an external URL or a file already in the
+  // workspace. Demanding `image_url` unconditionally made the `slack_file` form
+  // impossible to build.
+  if (
+    type === "image" &&
+    output.image_url === undefined &&
+    output.slack_file === undefined
+  ) {
+    throw new Error(`${path}.${component} requires image_url or slack_file.`);
   }
 }
 

--- a/packages/channels-slack/src/native-manifest.ts
+++ b/packages/channels-slack/src/native-manifest.ts
@@ -102,6 +102,29 @@ export const SLACK_OBJECT_MANIFEST = [
   readonly [component: string, type: string, childrenSlot?: string]
 >;
 
+/**
+ * Composition objects that carry **no** `type` discriminator in Slack's schema.
+ * Text and rich-text nodes are tagged (`plain_text`, `mrkdwn`, `text`,
+ * `rich_text_section`, …); the rest are plain structures — an option is
+ * `{text, value}`, a confirm dialog is `{title, text, confirm, deny}`. Emitting
+ * a `type` on those is an unknown field and Slack refuses the entire message,
+ * which took out every select, checkbox, radio group and overflow menu authored
+ * through this catalog.
+ *
+ * The manifest still needs the type string as its lookup key, so the exclusion
+ * is recorded here rather than by leaving the entry untyped.
+ */
+export const SLACK_UNTYPED_OBJECTS: ReadonlySet<string> = new Set([
+  "confirm",
+  "conversation_filter",
+  "dispatch_action_config",
+  "option",
+  "option_group",
+  "slack_file",
+  "trigger",
+  "workflow",
+]);
+
 function entries(
   rows: ReadonlyArray<readonly [string, string, string?]>,
   kind: NativeNodeKind,

--- a/packages/channels-slack/src/native-manifest.ts
+++ b/packages/channels-slack/src/native-manifest.ts
@@ -14,18 +14,29 @@ const ELEMENTS = "https://docs.slack.dev/reference/block-kit/block-elements/";
 const OBJECTS =
   "https://docs.slack.dev/reference/block-kit/composition-objects/";
 
-/** Reviewed message-valid Slack Block Kit catalog. */
+/**
+ * Reviewed message-valid Slack Block Kit catalog — the blocks an app can
+ * actually post. Two documented blocks are deliberately absent:
+ *
+ * - `alert`: "Alert blocks are currently only supported in modals." Verified by
+ *   posting Slack's own example into a message and having it refused, while a
+ *   plain section in the same delivery arrived.
+ * - `file`: "You can't add this block to app surfaces directly, but it will
+ *   show up when retrieving messages that contain remote files." The same
+ *   sentence appears in `@slack/types`' own doc comment. It is an inbound
+ *   shape, not an authorable one — offering it means offering a component that
+ *   can never succeed. Sending a file is `thread.postFile()`.
+ */
 export const SLACK_BLOCK_MANIFEST = [
   ["Actions", "actions", "elements"],
   ["Card", "card"],
   ["Carousel", "carousel", "elements"],
-  ["Container", "container", "blocks"],
+  ["Container", "container", "child_blocks"],
   ["Context", "context", "elements"],
   ["ContextActions", "context_actions", "elements"],
   ["DataTable", "data_table", "rows"],
   ["DataVisualization", "data_visualization"],
   ["Divider", "divider"],
-  ["File", "file"],
   ["Header", "header", "text"],
   ["Image", "image"],
   ["Input", "input", "element"],


### PR DESCRIPTION
Closes OSS-794 (Slack half — the validation pass and the fixes it found).

Three defects in the Slack Block Kit catalog, each verified against a real workspace. **99 lines changed across three files.**

The reason these sat undetected matters more than their size: **a payload Slack refuses produces no error anywhere.** No log line, no exception, no failing test — the message simply never arrives, which is indistinguishable from a bot that had nothing to say. The renderer compounds it by design, dropping unknown nodes silently so one bad node cannot fail a whole message.

## 1. `container` was refused on every send

Its children serialized into `blocks`; Slack reads `child_blocks`.

## 2. Every menu, checkbox, radio group, overflow and confirm dialog was refused

The codec stamped `type` onto every catalog entry, including composition objects whose schema has none — Slack's option object is `{text, value}`, and the same holds for `confirm`, `option_group`, `conversation_filter`, `dispatch_action_config`, `slack_file`, `trigger` and `workflow`. An unknown field makes Slack reject the entire message, so the whole interactive surface was unusable through `Slack.Object.*`.

Measured against a live workspace: **1 of 26 block elements delivered before this fix, 23 after.**

Note the existing `native-catalog.test.ts` asserted the very assumption that was wrong — that every entry serializes its discriminator. It was green while the product was broken. It now asserts the corrected rule.

## 3. An image could not use a file already in the workspace

The required-field check demanded `image_url` unconditionally; Slack accepts `image_url` *or* `slack_file`. An image needs alt text plus either source now, and passing neither is still an error.

## Two catalog corrections

`file` leaves the authorable manifest. Slack: *"You can't add this block to app surfaces directly, but it will show up when retrieving messages that contain remote files."* The same sentence appears verbatim in `@slack/types`' own doc comment — two independent Slack sources. It is an inbound shape; offering it as a component meant offering something that can never succeed. Sending a file remains `thread.postFile()`.

`alert` stays out with its citation — *"Alert blocks are currently only supported in modals."* Verified rather than assumed: Slack's own example payload posted verbatim into a message is refused, while a plain section in the same delivery seconds later arrives.

Both exclusions now carry their source, so "missing" and "deliberately not authorable" stay distinguishable to the next reader.

## How these were found

By building a fixture for every entry in Slack's catalog — 19 authorable blocks, 26 elements, 15 composition objects — with the expected payload **transcribed from `docs.slack.dev` rather than captured from our serializer**, and delivering all 60 through a managed Channel into a real Slack workspace. **55 of 60 deliver.** The remainder need real workspace objects (an uploaded file, a published workflow) or, for `rich_text_input`, an `action_id` the typed surface will not let you set.

That corpus is a working instrument, not a deliverable, so it is deliberately **not** part of this PR — it would add ~1700 lines of fixtures to maintain for a 99-line change. It lives with the team and gets re-run when the catalog moves.

One methodological note from it, because it changed what we consider proof: the first live run passed entries that demonstrated nothing. A rich-text block with one unstyled run renders exactly like a plain section; a carousel with one card renders like a card; a container with one child renders like a card. All three were accepted and worthless as evidence — caught by a human looking at the output, not by the harness. Fixtures had to *exercise* each entry, and it was that change which surfaced defect 2.

## Known and recorded elsewhere, not addressed here

- `external_select` / `multi_external_select` deliver but can never populate — opening one makes Slack call an Options Load URL, and nothing in the SDK or Intelligence serves one.
- Modal `view_submission` reads values flat, so checkboxes, date pickers and user pickers silently lose theirs. The message path handles all of them.
- Nine of nineteen blocks cannot be authored without a cast; `input.element` and `video.title_url` are demanded by the codec's own required-field check and not declared on `SlackNativeProps`.
- A single refused block closes the delivery's packet path, so every later post in the same turn fails as collateral (same shape as OSS-699).
- `thread.postFile()` — the real file-sending path — is validated by nothing.

## Verification

`test`, `check-types` and `build` green across `channels-slack`, `channels`, `channels-intelligence` and `runtime`, both with and without the fixture corpus present. Every block, element and object was delivered into a live Slack workspace and reviewed by eye.