### PR TITLE
docs(shell-docs): prefix vendored ag-ui links with /ag-ui

### DIFF
--- a/showcase/shell-docs/src/content/ag-ui/concepts/events.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/concepts/events.mdx
@@ -568,7 +568,7 @@ and
 for the underlying concept of encrypted reasoning items, which inspired this
 design.
 
-See [Reasoning](/concepts/reasoning) for comprehensive documentation including
+See [Reasoning](/ag-ui/concepts/reasoning) for comprehensive documentation including
 privacy considerations, compliance guidance, and implementation examples.
 
 ```mermaid
@@ -706,7 +706,7 @@ The `THINKING_*` events have been replaced by `REASONING_*` events:
 | `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
 | `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
 
-See [Reasoning Migration](/concepts/reasoning#migration-from-thinking-events)
+See [Reasoning Migration](/ag-ui/concepts/reasoning#migration-from-thinking-events)
 for detailed migration guidance.
 
 ## Draft Events
@@ -729,7 +729,7 @@ development and discussion.
 >
   DRAFT
 </span>
-[View Proposal](/drafts/meta-events)
+[View Proposal](/ag-ui/drafts/meta-events)
 
 Meta events provide annotations and signals independent of agent runs, such as
 user feedback or external system events.
@@ -757,7 +757,7 @@ A side-band annotation event that can occur anywhere in the stream.
 >
   DRAFT
 </span>
-[View Proposal](/drafts/interrupts)
+[View Proposal](/ag-ui/drafts/interrupts)
 
 Extensions to existing lifecycle events to support interrupts and branching.
 
@@ -770,7 +770,7 @@ The `RunFinished` event gains new fields to support interrupt-aware workflows.
 | `outcome`   | Optional: "success" or "interrupt"               |
 | `interrupt` | Optional: Contains interrupt details when paused |
 
-See [Serialization](/concepts/serialization) for lineage and input capture.
+See [Serialization](/ag-ui/concepts/serialization) for lineage and input capture.
 
 #### RunStarted (Extended)
 

--- a/showcase/shell-docs/src/content/ag-ui/concepts/messages.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/concepts/messages.mdx
@@ -236,7 +236,7 @@ Key points:
 - **Separate from assistant messages:** Reasoning is kept distinct from final
   responses to avoid polluting the conversation history.
 
-See [Reasoning Events](/concepts/events#reasoning-events) for the streaming
+See [Reasoning Events](/ag-ui/concepts/events#reasoning-events) for the streaming
 event lifecycle.
 
 ## Vendor Neutrality

--- a/showcase/shell-docs/src/content/ag-ui/concepts/middleware.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/concepts/middleware.mdx
@@ -123,7 +123,7 @@ agent.use(allowedFilter);
 
 ## Middleware Patterns
 
-Common patterns include logging, auth via `forwardedProps`, and rate limiting. See the [JS middleware reference](/sdk/js/client/middleware) for concrete implementations.
+Common patterns include logging, auth via `forwardedProps`, and rate limiting. See the [JS middleware reference](/ag-ui/sdk/js/client/middleware) for concrete implementations.
 
 ## Combining Middleware
 
@@ -186,7 +186,7 @@ const conditionalMiddleware: MiddlewareFunction = (input, next) => {
 };
 ```
 
-For event transformation and stream-control variants, see the [JS middleware reference](/sdk/js/client/middleware).
+For event transformation and stream-control variants, see the [JS middleware reference](/ag-ui/sdk/js/client/middleware).
 
 ## Conclusion
 

--- a/showcase/shell-docs/src/content/ag-ui/concepts/reasoning.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/concepts/reasoning.mdx
@@ -59,7 +59,7 @@ Key characteristics:
 ## Reasoning Events
 
 Reasoning events manage the lifecycle of reasoning messages. See
-[Events](/concepts/events#reasoning-events) for the complete event reference.
+[Events](/ag-ui/concepts/events#reasoning-events) for the complete event reference.
 
 ### Event Flow
 
@@ -471,6 +471,6 @@ yield { type: "REASONING_END", messageId: "reasoning-001" }
 
 ## Related Documentation
 
-- [Events](/concepts/events#reasoning-events) - Complete event type reference
-- [Messages](/concepts/messages#reasoning-messages) - Message type documentation
-- [Serialization](/concepts/serialization) - State continuity and lineage
+- [Events](/ag-ui/concepts/events#reasoning-events) - Complete event type reference
+- [Messages](/ag-ui/concepts/messages#reasoning-messages) - Message type documentation
+- [Serialization](/ag-ui/concepts/serialization) - State continuity and lineage

--- a/showcase/shell-docs/src/content/ag-ui/concepts/serialization.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/concepts/serialization.mdx
@@ -183,5 +183,5 @@ After:
 
 ## See Also
 
-- Concepts: [Events](/concepts/events), [State Management](/concepts/state)
+- Concepts: [Events](/ag-ui/concepts/events), [State Management](/ag-ui/concepts/state)
 - SDKs: TypeScript encoder and core event types

--- a/showcase/shell-docs/src/content/ag-ui/drafts/generative-ui.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/drafts/generative-ui.mdx
@@ -355,7 +355,7 @@ Generate different UI layouts based on user preferences or device capabilities.
 
 ## References
 
-- [AG-UI Tools Documentation](/concepts/tools)
+- [AG-UI Tools Documentation](/ag-ui/concepts/tools)
 - [JSON Schema](https://json-schema.org/)
 - [React Hook Form](https://react-hook-form.com/)
 - [JSON Forms](https://jsonforms.io/)

--- a/showcase/shell-docs/src/content/ag-ui/drafts/interrupts.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/drafts/interrupts.mdx
@@ -245,5 +245,5 @@ Python SDK:
 
 ## References
 
-- [AG-UI Events Documentation](/concepts/events)
-- [AG-UI State Management](/concepts/state)
+- [AG-UI Events Documentation](/ag-ui/concepts/events)
+- [AG-UI State Management](/ag-ui/concepts/state)

--- a/showcase/shell-docs/src/content/ag-ui/drafts/meta-events.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/drafts/meta-events.mdx
@@ -237,6 +237,6 @@ Python SDK:
 
 ## References
 
-- [AG-UI Events Documentation](/concepts/events)
+- [AG-UI Events Documentation](/ag-ui/concepts/events)
 - [Event Sourcing](https://martinfowler.com/eaaDev/EventSourcing.html)
 - [CQRS Pattern](https://martinfowler.com/bliki/CQRS.html)

--- a/showcase/shell-docs/src/content/ag-ui/introduction.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/introduction.mdx
@@ -663,7 +663,7 @@ development workflows to debugging techniques.
 ## Contributing
 
 Want to contribute? Check out our
-[Contributing Guide](/development/contributing) to learn how you can help
+[Contributing Guide](/ag-ui/development/contributing) to learn how you can help
 improve AG-UI.
 
 ## Support and Feedback

--- a/showcase/shell-docs/src/content/ag-ui/quickstart/applications.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/quickstart/applications.mdx
@@ -11,7 +11,7 @@ any client.
 
 A client is defined as any system that can receieve, display, and respond to
 AG-UI events. For more information on existing clients and integrations, see
-the [integrations](/integrations) page.
+the [integrations](/ag-ui/integrations) page.
 
 # Automatic Setup
 

--- a/showcase/shell-docs/src/content/ag-ui/quickstart/introduction.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/quickstart/introduction.mdx
@@ -23,13 +23,13 @@ Agents integrating with AG-UI can:
 - **Call client-side tools** - Your agent can use functions and services defined by clients
 - **Share state** - Your agent's state is bidirectional shared state
 - **Execute universally** - Integrate with any AG-UI compatible client application
-- **And much more!** - Check out the full specification [here](/concepts/events).
+- **And much more!** - Check out the full specification [here](/ag-ui/concepts/events).
 
 ### When should I make any integration?
 
-If the integration you're looking for is not listed on our [integrations page](/integrations), you'll need to make an integration. We've got a few guides on this below!
+If the integration you're looking for is not listed on our [integrations page](/ag-ui/integrations), you'll need to make an integration. We've got a few guides on this below!
 
-However, if you're looking to utilize an existing integration (like LangGraph, CrewAI, Mastra, etc.), you can skip this step and go straight to [building an application](/quickstart/applications).
+However, if you're looking to utilize an existing integration (like LangGraph, CrewAI, Mastra, etc.), you can skip this step and go straight to [building an application](/ag-ui/quickstart/applications).
 
 # Types of Integrations
 

--- a/showcase/shell-docs/src/content/ag-ui/sdk/dart/core/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/dart/core/overview.mdx
@@ -19,11 +19,11 @@ The Agent User Interaction Protocol Dart SDK uses a streaming event-based archit
 
 Core data structures that represent the building blocks of the system:
 
-- [RunAgentInput](/sdk/dart/core/types#runagentinput) - Input parameters for running agents
-- [Message](/sdk/dart/core/types#message-types) - User-assistant communication and tool usage
-- [Context](/sdk/dart/core/types#context) - Contextual information provided to agents
-- [Tool](/sdk/dart/core/types#tool) - Defines functions that agents can call
-- [State](/sdk/dart/core/types#state) - Agent state management
+- [RunAgentInput](/ag-ui/sdk/dart/core/types#runagentinput) - Input parameters for running agents
+- [Message](/ag-ui/sdk/dart/core/types#message-types) - User-assistant communication and tool usage
+- [Context](/ag-ui/sdk/dart/core/types#context) - Contextual information provided to agents
+- [Tool](/ag-ui/sdk/dart/core/types#tool) - Defines functions that agents can call
+- [State](/ag-ui/sdk/dart/core/types#state) - Agent state management
 
 <Card
   title="Types Reference"
@@ -39,11 +39,11 @@ Core data structures that represent the building blocks of the system:
 
 Events that power communication between agents and frontends:
 
-- [Lifecycle Events](/sdk/dart/core/events#lifecycle-events) - Run and step tracking
-- [Text Message Events](/sdk/dart/core/events#text-message-events) - Assistant message streaming
-- [Tool Call Events](/sdk/dart/core/events#tool-call-events) - Function call lifecycle
-- [State Management Events](/sdk/dart/core/events#state-management-events) - Agent state updates
-- [Special Events](/sdk/dart/core/events#special-events) - Raw and custom events
+- [Lifecycle Events](/ag-ui/sdk/dart/core/events#lifecycle-events) - Run and step tracking
+- [Text Message Events](/ag-ui/sdk/dart/core/events#text-message-events) - Assistant message streaming
+- [Tool Call Events](/ag-ui/sdk/dart/core/events#tool-call-events) - Function call lifecycle
+- [State Management Events](/ag-ui/sdk/dart/core/events#state-management-events) - Agent state updates
+- [Special Events](/ag-ui/sdk/dart/core/events#special-events) - Raw and custom events
 
 <Card
   title="Events Reference"

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/client/abstract-agent.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/client/abstract-agent.mdx
@@ -71,7 +71,7 @@ interface RunAgentParameters {
 ```
 
 The optional `subscriber` parameter allows you to provide an
-[AgentSubscriber](/sdk/js/client/subscriber) for handling events during this
+[AgentSubscriber](/ag-ui/sdk/js/client/subscriber) for handling events during this
 specific run.
 
 #### Return Value
@@ -85,7 +85,7 @@ interface RunAgentResult {
 
 ### subscribe()
 
-Adds an [AgentSubscriber](/sdk/js/client/subscriber) to handle events across
+Adds an [AgentSubscriber](/ag-ui/sdk/js/client/subscriber) to handle events across
 multiple agent runs.
 
 ```typescript
@@ -126,7 +126,7 @@ agent.use(
 agent.use(loggingMiddleware, authMiddleware, filterMiddleware);
 ```
 
-Middleware executes in the order added, with each wrapping the next. Middleware is applied in `runAgent()`; `connectAgent()` currently calls `connect()` directly. See the [Middleware documentation](/sdk/js/client/middleware) for more details.
+Middleware executes in the order added, with each wrapping the next. Middleware is applied in `runAgent()`; `connectAgent()` currently calls `connect()` directly. See the [Middleware documentation](/ag-ui/sdk/js/client/middleware) for more details.
 
 ### getCapabilities()
 
@@ -137,7 +137,7 @@ to advertise what they support. Returns `undefined` if not implemented.
 getCapabilities?(): Promise<AgentCapabilities>
 ```
 
-See [Capabilities](/concepts/capabilities) for the full `AgentCapabilities`
+See [Capabilities](/ag-ui/concepts/capabilities) for the full `AgentCapabilities`
 type definition and usage patterns.
 
 ### abortRun()

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/client/compaction.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/client/compaction.mdx
@@ -74,4 +74,4 @@ Tool call compaction works analogously for `TOOL_CALL_ARGS` chunks.
 - This utility focuses on message and tool‑call streams. It does not modify
   state events (`STATE_SNAPSHOT`/`STATE_DELTA`) or generate message snapshots.
 - For background and broader patterns (branching, normalization), see
-  [Serialization](/concepts/serialization).
+  [Serialization](/ag-ui/concepts/serialization).

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/client/http-agent.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/client/http-agent.mdx
@@ -49,7 +49,7 @@ runAgent(parameters?: RunAgentParameters, subscriber?: AgentSubscriber): Promise
 
 The `parameters` argument follows the standard `RunAgentParameters` interface.
 The optional `subscriber` parameter allows you to provide an
-[AgentSubscriber](/sdk/js/client/subscriber) for handling events during this
+[AgentSubscriber](/ag-ui/sdk/js/client/subscriber) for handling events during this
 specific run.
 
 #### Return Value
@@ -63,7 +63,7 @@ interface RunAgentResult {
 
 ### subscribe()
 
-Adds an [AgentSubscriber](/sdk/js/client/subscriber) to handle events across
+Adds an [AgentSubscriber](/ag-ui/sdk/js/client/subscriber) to handle events across
 multiple agent runs.
 
 ```typescript

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/client/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/client/overview.mdx
@@ -19,13 +19,13 @@ npm install @ag-ui/client
 connectivity. Extending this class and implementing `run()` lets you bridge your
 own service or agent implementation to AG-UI.
 
-- [Configuration](/sdk/js/client/abstract-agent#configuration) - Setup with
+- [Configuration](/ag-ui/sdk/js/client/abstract-agent#configuration) - Setup with
   agent ID, messages, and state
-- [Core Methods](/sdk/js/client/abstract-agent#core-methods) - Run, abort, and
+- [Core Methods](/ag-ui/sdk/js/client/abstract-agent#core-methods) - Run, abort, and
   clone functionality
-- [Protected Methods](/sdk/js/client/abstract-agent#protected-methods) -
+- [Protected Methods](/ag-ui/sdk/js/client/abstract-agent#protected-methods) -
   Extensible hooks for custom implementations
-- [Properties](/sdk/js/client/abstract-agent#properties) - State and message
+- [Properties](/ag-ui/sdk/js/client/abstract-agent#properties) - State and message
   tracking
 
 <Card
@@ -42,13 +42,13 @@ own service or agent implementation to AG-UI.
 
 Concrete implementation for HTTP-based agent connectivity:
 
-- [Configuration](/sdk/js/client/http-agent#configuration) - URL and header
+- [Configuration](/ag-ui/sdk/js/client/http-agent#configuration) - URL and header
   setup
-- [Methods](/sdk/js/client/http-agent#methods) - HTTP-specific execution and
+- [Methods](/ag-ui/sdk/js/client/http-agent#methods) - HTTP-specific execution and
   cancellation
-- [Protected Methods](/sdk/js/client/http-agent#protected-methods) -
+- [Protected Methods](/ag-ui/sdk/js/client/http-agent#protected-methods) -
   Customizable HTTP request handling
-- [Properties](/sdk/js/client/http-agent#properties) - Connection management
+- [Properties](/ag-ui/sdk/js/client/http-agent#properties) - Connection management
 
 <Card
   title="HttpAgent Reference"
@@ -66,13 +66,13 @@ Concrete implementation for HTTP-based agent connectivity:
 Transform and intercept event streams flowing through agents with a flexible
 middleware system:
 
-- [Function Middleware](/sdk/js/client/middleware#function-based-middleware) - Simple
+- [Function Middleware](/ag-ui/sdk/js/client/middleware#function-based-middleware) - Simple
   transformations with plain functions
-- [Class Middleware](/sdk/js/client/middleware#class-based-middleware) - Stateful
+- [Class Middleware](/ag-ui/sdk/js/client/middleware#class-based-middleware) - Stateful
   middleware with configuration
-- [Built-in Middleware](/sdk/js/client/middleware#built-in-middleware) -
+- [Built-in Middleware](/ag-ui/sdk/js/client/middleware#built-in-middleware) -
   FilterToolCallsMiddleware and more
-- [Middleware Patterns](/sdk/js/client/middleware#middleware-patterns) - Common
+- [Middleware Patterns](/ag-ui/sdk/js/client/middleware#middleware-patterns) - Common
   use cases and examples
 
 <Card
@@ -90,13 +90,13 @@ middleware system:
 Event-driven subscriber system for handling agent lifecycle events and state
 mutations during agent execution:
 
-- [Event Handlers](/sdk/js/client/subscriber#event-handlers) - Lifecycle,
+- [Event Handlers](/ag-ui/sdk/js/client/subscriber#event-handlers) - Lifecycle,
   message, tool call, and state events
-- [State Management](/sdk/js/client/subscriber#state-management) - Mutation
+- [State Management](/ag-ui/sdk/js/client/subscriber#state-management) - Mutation
   control and propagation handling
-- [Usage Examples](/sdk/js/client/subscriber#usage-examples) - Logging,
+- [Usage Examples](/ag-ui/sdk/js/client/subscriber#usage-examples) - Logging,
   persistence, and error handling patterns
-- [Integration](/sdk/js/client/subscriber#integration-with-agents) - Registering
+- [Integration](/ag-ui/sdk/js/client/subscriber#integration-with-agents) - Registering
   and using subscribers with agents
 
 <Card

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/core/events.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/core/events.mdx
@@ -585,7 +585,7 @@ The following event types are deprecated:
 | `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
 | `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
 
-See [Reasoning Migration](/concepts/reasoning#migration-from-thinking-events)
+See [Reasoning Migration](/ag-ui/concepts/reasoning#migration-from-thinking-events)
 for detailed migration guidance.
 
 ## Event Schemas

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/core/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/core/overview.mdx
@@ -17,14 +17,14 @@ npm install @ag-ui/core
 
 Core data structures that represent the building blocks of the system:
 
-- [RunAgentInput](/sdk/js/core/types#runagentinput) - Input parameters for
+- [RunAgentInput](/ag-ui/sdk/js/core/types#runagentinput) - Input parameters for
   running agents
-- [Message](/sdk/js/core/types#message-types) - User assistant communication and
+- [Message](/ag-ui/sdk/js/core/types#message-types) - User assistant communication and
   tool usage
-- [Context](/sdk/js/core/types#context) - Contextual information provided to
+- [Context](/ag-ui/sdk/js/core/types#context) - Contextual information provided to
   agents
-- [Tool](/sdk/js/core/types#tool) - Defines functions that agents can call
-- [State](/sdk/js/core/types#state) - Agent state management
+- [Tool](/ag-ui/sdk/js/core/types#tool) - Defines functions that agents can call
+- [State](/ag-ui/sdk/js/core/types#state) - Agent state management
 
 <Card
   title="Types Reference"
@@ -40,15 +40,15 @@ Core data structures that represent the building blocks of the system:
 
 Events that power communication between agents and frontends:
 
-- [Lifecycle Events](/sdk/js/core/events#lifecycle-events) - Run and step
+- [Lifecycle Events](/ag-ui/sdk/js/core/events#lifecycle-events) - Run and step
   tracking
-- [Text Message Events](/sdk/js/core/events#text-message-events) - Assistant
+- [Text Message Events](/ag-ui/sdk/js/core/events#text-message-events) - Assistant
   message streaming
-- [Tool Call Events](/sdk/js/core/events#tool-call-events) - Function call
+- [Tool Call Events](/ag-ui/sdk/js/core/events#tool-call-events) - Function call
   lifecycle
-- [State Management Events](/sdk/js/core/events#state-management-events) - Agent
+- [State Management Events](/ag-ui/sdk/js/core/events#state-management-events) - Agent
   state updates
-- [Special Events](/sdk/js/core/events#special-events) - Raw and custom events
+- [Special Events](/ag-ui/sdk/js/core/events#special-events) - Raw and custom events
 
 <Card
   title="Events Reference"

--- a/showcase/shell-docs/src/content/ag-ui/sdk/js/core/types.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/js/core/types.mdx
@@ -418,5 +418,5 @@ interface AgentCapabilities {
 | `humanInTheLoop` | `HumanInTheLoopCapabilities` | Human-in-the-loop support                    |
 | `custom`         | `Record<string, unknown>`    | Integration-specific capabilities            |
 
-See [Capabilities](/concepts/capabilities) for the full category type
+See [Capabilities](/ag-ui/concepts/capabilities) for the full category type
 definitions and usage patterns.

--- a/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/client/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/client/overview.mdx
@@ -27,7 +27,7 @@ Stateless client for cases where no ongoing context is needed or the agent manag
 - Agent handles state management
 - Minimal client-side memory usage
 
-[Learn more about AgUiAgent →](/docs/sdk/kotlin/client/agui-agent)
+[Learn more about AgUiAgent →](/ag-ui/sdk/kotlin/client/agui-agent)
 
 ### StatefulAgUiAgent
 
@@ -37,7 +37,7 @@ Stateful client that maintains conversation history and sends it with each reque
 - Full conversation history sent with each request
 - Suitable for complex conversational workflows
 
-[Learn more about StatefulAgUiAgent →](/docs/sdk/kotlin/client/stateful-agui-agent)
+[Learn more about StatefulAgUiAgent →](/ag-ui/sdk/kotlin/client/stateful-agui-agent)
 
 ### HttpAgent
 
@@ -47,7 +47,7 @@ Low-level HTTP transport implementation providing direct protocol access.
 - Custom request/response handling
 - Foundation for higher-level agents
 
-[Learn more about HttpAgent →](/docs/sdk/kotlin/client/http-agent)
+[Learn more about HttpAgent →](/ag-ui/sdk/kotlin/client/http-agent)
 
 ### AbstractAgent
 
@@ -57,7 +57,7 @@ Base class for implementing custom agent connectivity patterns.
 - Standardized lifecycle methods
 - Event handling framework
 
-[Learn more about AbstractAgent →](/docs/sdk/kotlin/client/abstract-agent)
+[Learn more about AbstractAgent →](/ag-ui/sdk/kotlin/client/abstract-agent)
 
 ## Features
 

--- a/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/core/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/core/overview.mdx
@@ -29,7 +29,7 @@ Complete set of AG-UI protocol events with automatic serialization.
 - State management events
 - Error handling events
 
-[Learn more about Events →](/docs/sdk/kotlin/core/events)
+[Learn more about Events →](/ag-ui/sdk/kotlin/core/events)
 
 ### Types
 
@@ -40,7 +40,7 @@ Protocol message types and data structures.
 - State management types
 - Request/response structures
 
-[Learn more about Types →](/docs/sdk/kotlin/core/types)
+[Learn more about Types →](/ag-ui/sdk/kotlin/core/types)
 
 ## Features
 

--- a/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/overview.mdx
@@ -46,7 +46,7 @@ High-level agent implementations and client infrastructure.
 - **HttpAgent**: Low-level HTTP transport implementation
 - **AbstractAgent**: Base class for custom agent implementations
 
-[Learn more about the Client module →](/docs/sdk/kotlin/client/overview)
+[Learn more about the Client module →](/ag-ui/sdk/kotlin/client/overview)
 
 ### kotlin-core
 
@@ -56,7 +56,7 @@ Protocol types, events, and message definitions.
 - **Types**: Protocol message types and state management
 - **Serialization**: JSON handling with kotlinx.serialization
 
-[Learn more about the Core module →](/docs/sdk/kotlin/core/overview)
+[Learn more about the Core module →](/ag-ui/sdk/kotlin/core/overview)
 
 ### kotlin-tools
 
@@ -66,7 +66,7 @@ Tool execution framework for extending agent capabilities.
 - **ToolRegistry**: Tool registration and management
 - **ToolExecutionManager**: Tool execution with circuit breaker patterns
 
-[Learn more about the Tools module →](/docs/sdk/kotlin/tools/overview)
+[Learn more about the Tools module →](/ag-ui/sdk/kotlin/tools/overview)
 
 ## Supported Platforms
 

--- a/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/tools/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/kotlin/tools/overview.mdx
@@ -27,7 +27,7 @@ Interface for implementing custom tools that agents can call.
 - Handles validation and error handling
 - Provides timeout configuration
 
-[Learn more about ToolExecutor →](/docs/sdk/kotlin/tools/tool-executor)
+[Learn more about ToolExecutor →](/ag-ui/sdk/kotlin/tools/tool-executor)
 
 ### ToolRegistry
 
@@ -38,7 +38,7 @@ Manages and executes registered tools.
 - Statistics and monitoring
 - Thread-safe concurrent access
 
-[Learn more about ToolRegistry →](/docs/sdk/kotlin/tools/tool-registry)
+[Learn more about ToolRegistry →](/ag-ui/sdk/kotlin/tools/tool-registry)
 
 ## Key Concepts
 

--- a/showcase/shell-docs/src/content/ag-ui/sdk/python/core/events.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/python/core/events.mdx
@@ -595,7 +595,7 @@ The following event types are deprecated:
 | `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
 | `THINKING_TEXT_MESSAGE_END`     | `REASONING_MESSAGE_END`     |
 
-See [Reasoning Migration](/concepts/reasoning#migration-from-thinking-events)
+See [Reasoning Migration](/ag-ui/concepts/reasoning#migration-from-thinking-events)
 for detailed migration guidance.
 
 ## Event Discrimination

--- a/showcase/shell-docs/src/content/ag-ui/sdk/python/core/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/python/core/overview.mdx
@@ -21,14 +21,14 @@ from ag_ui.core import ...
 
 Core data structures that represent the building blocks of the system:
 
-- [RunAgentInput](/sdk/python/core/types#runagentinput) - Input parameters for
+- [RunAgentInput](/ag-ui/sdk/python/core/types#runagentinput) - Input parameters for
   running agents
-- [Message](/sdk/python/core/types#message-types) - User assistant communication
+- [Message](/ag-ui/sdk/python/core/types#message-types) - User assistant communication
   and tool usage
-- [Context](/sdk/python/core/types#context) - Contextual information provided to
+- [Context](/ag-ui/sdk/python/core/types#context) - Contextual information provided to
   agents
-- [Tool](/sdk/python/core/types#tool) - Defines functions that agents can call
-- [State](/sdk/python/core/types#state) - Agent state management
+- [Tool](/ag-ui/sdk/python/core/types#tool) - Defines functions that agents can call
+- [State](/ag-ui/sdk/python/core/types#state) - Agent state management
 
 <Card
   title="Types Reference"
@@ -44,15 +44,15 @@ Core data structures that represent the building blocks of the system:
 
 Events that power communication between agents and frontends:
 
-- [Lifecycle Events](/sdk/python/core/events#lifecycle-events) - Run and step
+- [Lifecycle Events](/ag-ui/sdk/python/core/events#lifecycle-events) - Run and step
   tracking
-- [Text Message Events](/sdk/python/core/events#text-message-events) - Assistant
+- [Text Message Events](/ag-ui/sdk/python/core/events#text-message-events) - Assistant
   message streaming
-- [Tool Call Events](/sdk/python/core/events#tool-call-events) - Function call
+- [Tool Call Events](/ag-ui/sdk/python/core/events#tool-call-events) - Function call
   lifecycle
-- [State Management Events](/sdk/python/core/events#state-management-events) -
+- [State Management Events](/ag-ui/sdk/python/core/events#state-management-events) -
   Agent state updates
-- [Special Events](/sdk/python/core/events#special-events) - Raw and custom
+- [Special Events](/ag-ui/sdk/python/core/events#special-events) - Raw and custom
   events
 
 <Card

--- a/showcase/shell-docs/src/content/ag-ui/sdk/ruby/core/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/ruby/core/overview.mdx
@@ -21,11 +21,11 @@ require "ag_ui_protocol"
 
 Core data structures that represent the building blocks of the system:
 
-- [RunAgentInput](/sdk/ruby/core/types#runagentinput) - Input parameters for running agents
-- [Message types](/sdk/ruby/core/types#message-types) - User assistant communication and tool usage
-- [Context](/sdk/ruby/core/types#context) - Contextual information provided to agents
-- [Tool](/sdk/ruby/core/types#tool) - Defines functions that agents can call
-- [State](/sdk/ruby/core/types#state) - Agent state management
+- [RunAgentInput](/ag-ui/sdk/ruby/core/types#runagentinput) - Input parameters for running agents
+- [Message types](/ag-ui/sdk/ruby/core/types#message-types) - User assistant communication and tool usage
+- [Context](/ag-ui/sdk/ruby/core/types#context) - Contextual information provided to agents
+- [Tool](/ag-ui/sdk/ruby/core/types#tool) - Defines functions that agents can call
+- [State](/ag-ui/sdk/ruby/core/types#state) - Agent state management
 
 <Card
   title="Types Reference"
@@ -41,11 +41,11 @@ Core data structures that represent the building blocks of the system:
 
 Events that power communication between agents and frontends:
 
-- [Lifecycle Events](/sdk/ruby/core/events#lifecycle-events) - Run and step tracking
-- [Text Message Events](/sdk/ruby/core/events#text-message-events) - Assistant message streaming
-- [Tool Call Events](/sdk/ruby/core/events#tool-call-events) - Function call lifecycle
-- [State Management Events](/sdk/ruby/core/events#state-management-events) - Agent state updates
-- [Special Events](/sdk/ruby/core/events#special-events) - Raw and custom events
+- [Lifecycle Events](/ag-ui/sdk/ruby/core/events#lifecycle-events) - Run and step tracking
+- [Text Message Events](/ag-ui/sdk/ruby/core/events#text-message-events) - Assistant message streaming
+- [Tool Call Events](/ag-ui/sdk/ruby/core/events#tool-call-events) - Function call lifecycle
+- [State Management Events](/ag-ui/sdk/ruby/core/events#state-management-events) - Agent state updates
+- [Special Events](/ag-ui/sdk/ruby/core/events#special-events) - Raw and custom events
 
 <Card
   title="Events Reference"

--- a/showcase/shell-docs/src/content/ag-ui/sdk/rust/client/overview.mdx
+++ b/showcase/shell-docs/src/content/ag-ui/sdk/rust/client/overview.mdx
@@ -19,13 +19,13 @@ cargo add ag-ui-client
 connectivity. Implementing `run()` lets you bridge your
 own service or agent implementation to AG-UI.
 
-- [Configuration](/sdk/rust/client/agent-trait#configuration) - Setup with
+- [Configuration](/ag-ui/sdk/rust/client/agent-trait#configuration) - Setup with
   agent ID, messages, and state
-- [Core Methods](/sdk/rust/client/agent-trait#core-methods) - Run, abort, and
+- [Core Methods](/ag-ui/sdk/rust/client/agent-trait#core-methods) - Run, abort, and
   clone functionality
-- [Protected Methods](/sdk/rust/client/agent-trait#protected-methods) -
+- [Protected Methods](/ag-ui/sdk/rust/client/agent-trait#protected-methods) -
   Extensible hooks for custom implementations
-- [Properties](/sdk/rust/client/agent-trait#properties) - State and message
+- [Properties](/ag-ui/sdk/rust/client/agent-trait#properties) - State and message
   tracking
 
 <Card
@@ -42,13 +42,13 @@ own service or agent implementation to AG-UI.
 
 Agent implementation for HTTP-based agent connectivity:
 
-- [Configuration](/sdk/rust/client/http-agent#configuration) - URL and header
+- [Configuration](/ag-ui/sdk/rust/client/http-agent#configuration) - URL and header
   setup
-- [Methods](/sdk/rust/client/http-agent#methods) - HTTP-specific execution and
+- [Methods](/ag-ui/sdk/rust/client/http-agent#methods) - HTTP-specific execution and
   cancellation
-- [Protected Methods](/sdk/rust/client/http-agent#protected-methods) -
+- [Protected Methods](/ag-ui/sdk/rust/client/http-agent#protected-methods) -
   Customizable HTTP request handling
-- [Properties](/sdk/rust/client/http-agent#properties) - Connection management
+- [Properties](/ag-ui/sdk/rust/client/http-agent#properties) - Connection management
 
 <Card
   title="HttpAgent Reference"
@@ -66,13 +66,13 @@ Agent implementation for HTTP-based agent connectivity:
 Event-driven subscriber system for handling agent lifecycle events and state
 mutations during agent execution:
 
-- [Event Handlers](/sdk/rust/client/subscriber#event-handlers) - Lifecycle,
+- [Event Handlers](/ag-ui/sdk/rust/client/subscriber#event-handlers) - Lifecycle,
   message, tool call, and state events
-- [State Management](/sdk/rust/client/subscriber#state-management) - Mutation
+- [State Management](/ag-ui/sdk/rust/client/subscriber#state-management) - Mutation
   control and propagation handling
-- [Usage Examples](/sdk/rust/client/subscriber#usage-examples) - Logging,
+- [Usage Examples](/ag-ui/sdk/rust/client/subscriber#usage-examples) - Logging,
   persistence, and error handling patterns
-- [Integration](/sdk/rust/client/subscriber#integration-with-agents) - Registering
+- [Integration](/ag-ui/sdk/rust/client/subscriber#integration-with-agents) - Registering
   and using subscribers with agents
 
 <Card

--- a/showcase/shell-docs/src/lib/__tests__/ag-ui-content-links.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/ag-ui-content-links.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+// The `ag-ui` content tree is vendored from ag-ui-protocol/ag-ui, where the
+// docs are served at the site root (`docs.ag-ui.com/concepts/events`). Here the
+// same pages live one level down (`/ag-ui/concepts/events`), so a root-relative
+// link copied over verbatim 404s. These tests pin the two forms that break so a
+// future re-vendor cannot silently reintroduce them.
+
+const AG_UI_ROOT = join(process.cwd(), "src/content/ag-ui");
+
+function markdownFiles(path: string): string[] {
+  return readdirSync(path, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(path, entry.name);
+    if (entry.isDirectory()) return markdownFiles(entryPath);
+    return entry.name.endsWith(".mdx") ? [entryPath] : [];
+  });
+}
+
+interface AuthoredLink {
+  file: string;
+  href: string;
+}
+
+function authoredLinks(): AuthoredLink[] {
+  return markdownFiles(AG_UI_ROOT).flatMap((file) => {
+    const body = readFileSync(file, "utf8");
+    const matches = body.matchAll(/\]\((\/[^)\s]*)\)/g);
+    return [...matches].map((match) => ({
+      file: file.slice(process.cwd().length + 1),
+      href: match[1] as string,
+    }));
+  });
+}
+
+function pagePath(href: string): string {
+  const slug = href.replace(/[?#].*$/, "").replace(/^\/+|\/+$/g, "");
+  return join(AG_UI_ROOT, `${slug}.mdx`);
+}
+
+describe("vendored ag-ui docs links", () => {
+  test("root-relative links that name an ag-ui page carry the /ag-ui prefix", () => {
+    const unprefixed = authoredLinks().filter(
+      ({ href }) => !href.startsWith("/ag-ui") && existsSync(pagePath(href)),
+    );
+
+    expect(
+      unprefixed.map(({ file, href }) => `${file}: ${href}`),
+    ).toStrictEqual([]);
+  });
+
+  test("no links use the upstream /docs/ path prefix", () => {
+    const upstreamDocsLinks = authoredLinks().filter(({ href }) =>
+      href.startsWith("/docs/"),
+    );
+
+    expect(
+      upstreamDocsLinks.map(({ file, href }) => `${file}: ${href}`),
+    ).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes 112 broken doc links in the vendored `ag-ui` content tree.

That tree is vendored from `ag-ui-protocol/ag-ui`, where those docs are served at the **site root** (`docs.ag-ui.com/concepts/events` → 200). On `docs.copilotkit.ai` the same pages live one level down under `/ag-ui`, so every root-relative link copied over verbatim 404s:

```
404  https://docs.copilotkit.ai/concepts/events
200  https://docs.copilotkit.ai/ag-ui/concepts/events
```

This is the same class of breakage as the `/concepts/copilot-runtime` link reported in #2082 and fixed in #5296 — I found the rest while verifying that PR.

**What changed:** each link that names a real vendored ag-ui page is repointed at its actual URL — `/concepts/*`, `/sdk/*`, `/drafts/*`, `/development/contributing`, `/quickstart/applications`, and the bare `/integrations` (which in these pages means AG-UI's integrations page, not CopilotKit's). The Kotlin SDK links additionally carried an upstream `/docs/` prefix (`/docs/sdk/kotlin/core/types`), which is dropped.

**What deliberately did not change:** links that resolve to CopilotKit's own pages — `/`, `/quickstart`, `/frontend-tools`, `/integrations/<framework>` — all return 200 today and have no ag-ui counterpart, so a blanket prefix sweep would have broken them. Each of the 52 distinct link targets in the tree was checked individually rather than rewritten by pattern.

Also adds a regression test, because there is no automated sync for this tree: a future re-vendor from upstream would otherwise silently reintroduce the same 404s.

## Why not fix this upstream or in the renderer?

- **Not upstream:** these links are *correct* in `ag-ui-protocol/ag-ui` — that site serves at the root. The breakage is introduced purely by vendoring under a subpath, so the fix belongs in this copy only.
- **Not in `resolveDocsHref`:** a render-time `/ag-ui` prefix rule would rewrite the 13 links that legitimately point at CopilotKit pages, turning working links into 404s. The mapping is not mechanical, so it is pinned in content and enforced by test.

## Testing

- **New test fails before the change, passes after.** Written first, run against unfixed content: 112 violations across 27 files. After the fix:
  ```
  ✓ src/lib/__tests__/ag-ui-content-links.test.ts (2 tests) 71ms
    ✓ root-relative links that name an ag-ui page carry the /ag-ui prefix
    ✓ no links use the upstream /docs/ path prefix
  Test Files  1 passed (1)
  ```
- **Every one of the 38 unique new link targets was fetched against production:** 35 return 200. The 3 exceptions are pre-existing page errors, unrelated to link paths (see below).
- **Residue check** — the only root-absolute links left in the tree are the intended CopilotKit-owned ones:
  ```
  6 /   2 /quickstart   2 /integrations   2 /frontend-tools   11 /integrations/<framework>
  ```
  and no `](/ag-ui/ag-ui` double prefixes or leftover `](/docs/sdk/` remain.
- `oxfmt --write` + `oxlint` clean on the new test file. No changesets (docs/test only).
- Pre-existing, unrelated: `src/lib/__tests__/docs-link-rewrite.test.ts` cannot collect in a fresh worktree because `@/data/setup-content.json` is generated at build time and untracked. Unaffected by this change.

## Separately: 6 of 8 AG-UI Rust SDK pages return 500 in production

Found while verifying link targets — **not** a link problem and **not** fixed here; the URLs below are correct and the MDX files exist:

```
500  /ag-ui/sdk/rust/client/agent-trait     500  /ag-ui/sdk/rust/core/types
500  /ag-ui/sdk/rust/client/http-agent      500  /ag-ui/sdk/rust/core/events
500  /ag-ui/sdk/rust/client/subscriber      500  /ag-ui/sdk/rust/core/overview
200  /ag-ui/sdk/rust/client/overview        200  /ag-ui/sdk/rust/overview
```

Only the two `overview` pages render. I ruled out the obvious MDX hazards (bare `<Generic>` brackets, braces outside code fences, frontmatter shape, missing `meta.json`) — none correlate with the failures, so the cause is elsewhere in the page pipeline. Happy to open a separate issue for it.

## Related PRs and Issues

- Follows #5296 / #2082 (same breakage class, CopilotKit-authored side)
