### PR TITLE
feat(runtime): add MiniMax built-in models

### DIFF
--- a/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
+++ b/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
@@ -37,6 +37,8 @@ describe("resolveModel — custom baseURL via env", () => {
     process.env.OPENAI_API_KEY = "test-openai-key";
     process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
     process.env.GOOGLE_API_KEY = "test-google-key";
+    process.env.MINIMAX_API_KEY = "test-minimax-key";
+    delete process.env.MINIMAX_BASE_URL;
   });
 
   afterEach(() => {
@@ -73,6 +75,30 @@ describe("resolveModel — custom baseURL via env", () => {
     resolveModel("openai/gpt-4o");
     expect(createOpenAI).toHaveBeenCalledWith(
       expect.objectContaining({ baseURL: undefined }),
+    );
+  });
+
+  it.each(["MiniMax-M3", "MiniMax-M2.7"])(
+    "resolves MiniMax model %s with the global endpoint",
+    (modelId) => {
+      const model = resolveModel(`minimax/${modelId}`);
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        name: "minimax",
+        apiKey: "test-minimax-key",
+        baseURL: "https://api.minimax.io/v1",
+      });
+      expect(model).toMatchObject({ modelId });
+    },
+  );
+
+  it("passes MINIMAX_BASE_URL to the MiniMax provider", () => {
+    process.env.MINIMAX_BASE_URL = "https://api.minimaxi.com/v1";
+
+    resolveModel("minimax:MiniMax-M3");
+
+    expect(createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://api.minimaxi.com/v1" }),
     );
   });
 });

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -102,6 +102,9 @@ export type BuiltInAgentModel =
   | "google/gemini-2.5-pro"
   | "google/gemini-2.5-flash"
   | "google/gemini-2.5-flash-lite"
+  // MiniMax models
+  | "minimax/MiniMax-M3"
+  | "minimax/MiniMax-M2.7"
   // Allow any LanguageModel instance
   | (string & {});
 
@@ -233,6 +236,15 @@ export function resolveModel(
       });
       // Accepts any Gemini id, e.g. "gemini-2.5-pro", "gemini-2.5-flash"
       return google(model);
+    }
+
+    case "minimax": {
+      const minimax = createOpenAI({
+        name: "minimax",
+        apiKey: apiKey || process.env.MINIMAX_API_KEY!,
+        baseURL: process.env.MINIMAX_BASE_URL || "https://api.minimax.io/v1",
+      });
+      return minimax(model);
     }
 
     case "vertex": {
@@ -815,6 +827,7 @@ export interface BuiltInAgentClassicConfig {
    * - OPENAI_API_KEY for OpenAI models
    * - ANTHROPIC_API_KEY for Anthropic models
    * - GOOGLE_API_KEY for Google models
+   * - MINIMAX_API_KEY for MiniMax models
    */
   apiKey?: string;
   /**

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -5,7 +5,7 @@ description: "Choose and configure models for your Built-in Agent."
 ---
 
 The Built-in Agent uses the [Vercel AI SDK](https://sdk.vercel.ai), so you can use
-models from OpenAI, Anthropic, and Google, or pass any custom AI SDK model.
+built-in model strings or pass any custom AI SDK model.
 
 ## Supported Models
 
@@ -63,6 +63,19 @@ const agent = new BuiltInAgent({
 });
 ```
 
+### MiniMax
+
+| Model        | Specifier              |
+| ------------ | ---------------------- |
+| MiniMax M3   | `minimax:MiniMax-M3`   |
+| MiniMax M2.7 | `minimax:MiniMax-M2.7` |
+
+```typescript
+const agent = new BuiltInAgent({
+  model: "minimax:MiniMax-M3",
+});
+```
+
 ## Environment Variables
 
 Set the API key for your chosen provider:
@@ -76,6 +89,12 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # Google
 GOOGLE_API_KEY=...
+
+# MiniMax
+MINIMAX_API_KEY=...
+
+# Optional: use the China endpoint
+MINIMAX_BASE_URL=https://api.minimaxi.com/v1
 ```
 
 Alternatively, pass the API key directly in your configuration:


### PR DESCRIPTION
Reason: Add the current MiniMax text models to BuiltInAgent model resolution.

- Register MiniMax-M3 and MiniMax-M2.7 as built-in model identifiers.
- Resolve MiniMax model strings through the global endpoint with API key and regional base URL configuration.
- Document both model specifiers and cover global and China endpoint selection.

Checks:
- `node_modules/.bin/nx run @copilotkit/runtime:test -- src/agent/__tests__/resolve-model-baseurl.test.ts`
- `node_modules/.bin/nx run @copilotkit/runtime:check-types`
- `pnpm validate:model-names`
- `node_modules/.bin/nx format:check --files=packages/runtime/src/agent/index.ts,packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts`
- `git diff --check`
