### PR TITLE
fix(showcase/harness): re-auth on 403 from an expired PocketBase token

### DIFF
--- a/showcase/harness/src/storage/pb-client.test.ts
+++ b/showcase/harness/src/storage/pb-client.test.ts
@@ -266,6 +266,63 @@ describe("pb-client", () => {
     expect(writeCount).toBe(1);
   });
 
+  it("drains the failed response body on the 401 re-auth path (F2.3 socket reuse)", async () => {
+    // The 429 and 5xx retry branches drain the failed response body before
+    // continuing so the runtime's HTTP agent can reuse the socket. The
+    // re-auth (401/403) branch must do the same — otherwise every token
+    // refresh leaves a half-consumed socket. Observe drain via bodyUsed on
+    // the exact Response object returned for the failing attempt.
+    const failed401 = new Response("stale-token", { status: 401 });
+    let getCount = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response(JSON.stringify({ token: "tok" }), { status: 200 });
+      }
+      getCount += 1;
+      if (getCount === 1) return failed401;
+      return new Response(JSON.stringify({ id: "r1" }), { status: 200 });
+    });
+    const pb = createPbClient({
+      url: "http://pb",
+      email: "e",
+      password: "p",
+      logger,
+      fetchImpl,
+    });
+    await pb.getOne("status", "r1");
+    // Body of the 401 response must have been consumed (drained).
+    expect(failed401.bodyUsed).toBe(true);
+  });
+
+  it("stays within the maxAttempts envelope when a token expires on the final attempt", async () => {
+    // A token that expires on the LAST attempt must not enter the re-auth
+    // branch and fire a 4th fetch beyond the documented maxAttempts=3
+    // envelope. Attempts 1 and 2 are consumed by 5xx backoff; attempt 3
+    // returns 401. The re-auth gate must honor attempts < maxAttempts like
+    // the 429/5xx gates and NOT retry.
+    let writeCount = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        return new Response(JSON.stringify({ token: "tok" }), { status: 200 });
+      }
+      writeCount += 1;
+      if (writeCount < 3) return new Response("", { status: 503 });
+      return new Response("", { status: 401 });
+    });
+    const pb = createPbClient({
+      url: "http://pb",
+      email: "e",
+      password: "p",
+      logger,
+      fetchImpl,
+    });
+    await expect(pb.getOne("status", "x")).rejects.toThrow(
+      /pb getOne failed: 401/,
+    );
+    // Exactly maxAttempts requests to the records endpoint — no 4th call.
+    expect(writeCount).toBe(3);
+  });
+
   it("retries when fetchImpl throws (network error) with same envelope as 5xx", async () => {
     let attempts = 0;
     const fetchImpl = makeFetch(() => {

--- a/showcase/harness/src/storage/pb-client.test.ts
+++ b/showcase/harness/src/storage/pb-client.test.ts
@@ -144,6 +144,128 @@ describe("pb-client", () => {
     expect(authCount).toBe(2);
   });
 
+  it("re-auths on 403 (expired superuser token treated as guest) then retries the write", async () => {
+    // Root cause of the 46h dashboard blackout: PocketBase treats an
+    // Authorization token whose ~14-day TTL has expired as an
+    // unauthenticated (guest) request, so a guest write to a
+    // superuser-gated collection returns 403 "Only admins can perform this
+    // action" — NOT 401. The client must recognize that a 403 on a request
+    // that DID carry a token means the session went stale, refresh the
+    // token, and retry the write once.
+    let authCount = 0;
+    let writeCount = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        authCount += 1;
+        return new Response(JSON.stringify({ token: "t" + authCount }), {
+          status: 200,
+        });
+      }
+      writeCount += 1;
+      // First write carries the (now-expired) cached token -> PB 403 guest.
+      if (writeCount === 1) {
+        return new Response(
+          JSON.stringify({
+            code: 403,
+            message: "Only admins can perform this action.",
+            data: {},
+          }),
+          { status: 403 },
+        );
+      }
+      // Retry after re-auth carries a fresh, valid token -> success.
+      return new Response(JSON.stringify({ id: "created" }), { status: 200 });
+    });
+    const pb = createPbClient({
+      url: "http://pb",
+      email: "e",
+      password: "p",
+      logger,
+      fetchImpl,
+    });
+    const out = await pb.create<{ id: string }>("status", {
+      key: "k",
+      state: "green",
+    });
+    expect(out.id).toBe("created");
+    // Initial auth + exactly one re-auth.
+    expect(authCount).toBe(2);
+    // Original 403'd write + the successful retry.
+    expect(writeCount).toBe(2);
+  });
+
+  it("caps 403 re-auth at 1 — a 403 that persists after a fresh auth surfaces (no infinite loop)", async () => {
+    // A 403 that is STILL returned after a fresh, successful re-auth is a
+    // genuine permission error, not an expired session. It must surface to
+    // the caller (classified `pb_permission`) rather than spin the re-auth
+    // path forever.
+    let authCount = 0;
+    let writeCount = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        authCount += 1;
+        return new Response(JSON.stringify({ token: "t" + authCount }), {
+          status: 200,
+        });
+      }
+      writeCount += 1;
+      return new Response(
+        JSON.stringify({
+          code: 403,
+          message: "Only admins can perform this action.",
+          data: {},
+        }),
+        { status: 403 },
+      );
+    });
+    const pb = createPbClient({
+      url: "http://pb",
+      email: "e",
+      password: "p",
+      logger,
+      fetchImpl,
+    });
+    await expect(pb.create("status", { key: "k" })).rejects.toThrow(
+      /pb create failed: 403/,
+    );
+    // Initial auth + exactly one re-auth, then the persistent 403 surfaces.
+    expect(authCount).toBe(2);
+    // Original write + one retry; no third attempt.
+    expect(writeCount).toBe(2);
+  });
+
+  it("does NOT re-auth on 403 when no credentials were sent (genuine guest-forbidden)", async () => {
+    // Guard against masking real authz errors: a 403 on a request that
+    // carried NO Authorization header (creds unset) can never be fixed by
+    // re-auth, so the client must surface it directly without burning a
+    // re-auth attempt.
+    let authCount = 0;
+    let writeCount = 0;
+    const fetchImpl = makeFetch((url) => {
+      if (url.includes("auth-with-password")) {
+        authCount += 1;
+        return new Response(JSON.stringify({ token: "t" }), { status: 200 });
+      }
+      writeCount += 1;
+      return new Response(
+        JSON.stringify({
+          code: 403,
+          message: "Only admins can perform this action.",
+          data: {},
+        }),
+        { status: 403 },
+      );
+    });
+    // No email/password -> ensureAuth never mints a token -> no header sent.
+    const pb = createPbClient({ url: "http://pb", logger, fetchImpl });
+    await expect(pb.create("status", { key: "k" })).rejects.toThrow(
+      /pb create failed: 403/,
+    );
+    // Never attempted auth, and never retried the write.
+    expect(authCount).toBe(0);
+    expect(writeCount).toBe(1);
+  });
+
   it("retries when fetchImpl throws (network error) with same envelope as 5xx", async () => {
     let attempts = 0;
     const fetchImpl = makeFetch(() => {

--- a/showcase/harness/src/storage/pb-client.ts
+++ b/showcase/harness/src/storage/pb-client.ts
@@ -88,8 +88,11 @@ export interface PbClient {
 // unbounded loops if PB ever returns a full page indefinitely.
 const DELETE_BY_FILTER_MAX_ITERATIONS = 100;
 
-// Cap 401 re-auth retries at 1. A persistent 401 means creds are bad or
-// the server will never accept us; retrying forever just pins the CPU.
+// Cap 401/403 re-auth retries at 1. A persistent 401 (bad token) or a 403
+// that survives a fresh, successful re-auth (genuine permission denial)
+// means the server will never accept the write; retrying forever just pins
+// the CPU and, worse, could mask a real authz error as an endless re-auth
+// loop.
 const MAX_AUTH_RETRIES = 1;
 
 // Floor for 429 Retry-After honoring — if header is absent or unparseable,
@@ -304,12 +307,32 @@ export function createPbClient(config: PbClientConfig): PbClient {
         }
         throw err;
       }
-      if (res.status === 401 && authRetries < MAX_AUTH_RETRIES) {
+      // Re-auth trigger. PB returns 401 when the Authorization token is
+      // malformed/absent — but a superuser/admin token whose ~14-day TTL
+      // has EXPIRED is treated as an unauthenticated (guest) request, and a
+      // guest write to a superuser-gated collection comes back as 403 "Only
+      // admins can perform this action", NOT 401. Historically only 401
+      // re-triggered auth, so an expired token was never refreshed and every
+      // status write failed permanently until the process restarted — the
+      // root cause of the 46h dashboard blackout. Treat a 403 as the same
+      // stale-session signal, but ONLY when we actually sent a token
+      // (`sentAuth`): a 403 on a request that carried no Authorization
+      // header is a genuine guest-forbidden result that re-auth can't fix,
+      // and re-authing it would just burn an attempt. The retry is bounded
+      // by MAX_AUTH_RETRIES, so a 403 that PERSISTS after a fresh, successful
+      // auth is a real permission error that falls through to the caller
+      // (classified `pb_permission`), never an infinite re-auth loop.
+      const sentAuth = headers.has("authorization");
+      if (
+        (res.status === 401 || (res.status === 403 && sentAuth)) &&
+        authRetries < MAX_AUTH_RETRIES
+      ) {
         // Note: the outer `attempts += 1` fired before entering this
-        // branch, so a single 401-re-auth chain consumes 2 of 3
-        // attempts, leaving 1 slot for a subsequent 5xx/429. Defensive
-        // but intentional — we prefer to fail fast on pathological
-        // 401→429 loops rather than burn the full envelope.
+        // branch, so a single re-auth chain consumes 2 of 3 attempts,
+        // leaving 1 slot for a subsequent 5xx/429. Defensive but
+        // intentional — we prefer to fail fast on pathological
+        // 401/403→429 loops rather than burn the full envelope.
+        const authFailStatus = res.status;
         authRetries += 1;
         authToken = null;
         try {
@@ -337,7 +360,7 @@ export function createPbClient(config: PbClientConfig): PbClient {
             });
           }
           throw new Error(
-            `pb-client: re-auth failed on ${path} (status 401): ${String(err)}`,
+            `pb-client: re-auth failed on ${path} (status ${authFailStatus}): ${String(err)}`,
             { cause: err },
           );
         }

--- a/showcase/harness/src/storage/pb-client.ts
+++ b/showcase/harness/src/storage/pb-client.ts
@@ -307,6 +307,22 @@ export function createPbClient(config: PbClientConfig): PbClient {
         }
         throw err;
       }
+      // Helper: drain the body so the underlying connection can be
+      // reused by the runtime's HTTP agent — otherwise some fetch
+      // implementations will leave the socket half-consumed and open a
+      // fresh one on every retry. Log drain errors at debug so
+      // ECONNRESET / ERR_STREAM_PREMATURE_CLOSE evidence isn't lost
+      // (F2.3) — callers rarely need this, but it's invaluable when
+      // diagnosing socket-level flakiness.
+      const drainBody = async (): Promise<void> => {
+        await res.text().catch((drainErr: unknown) => {
+          logger.debug("pb-client.body-drain-failed", {
+            path,
+            status: res.status,
+            err: String(drainErr),
+          });
+        });
+      };
       // Re-auth trigger. PB returns 401 when the Authorization token is
       // malformed/absent — but a superuser/admin token whose ~14-day TTL
       // has EXPIRED is treated as an unauthenticated (guest) request, and a
@@ -325,13 +341,16 @@ export function createPbClient(config: PbClientConfig): PbClient {
       const sentAuth = headers.has("authorization");
       if (
         (res.status === 401 || (res.status === 403 && sentAuth)) &&
-        authRetries < MAX_AUTH_RETRIES
+        authRetries < MAX_AUTH_RETRIES &&
+        attempts < maxAttempts
       ) {
-        // Note: the outer `attempts += 1` fired before entering this
-        // branch, so a single re-auth chain consumes 2 of 3 attempts,
-        // leaving 1 slot for a subsequent 5xx/429. Defensive but
-        // intentional — we prefer to fail fast on pathological
-        // 401/403→429 loops rather than burn the full envelope.
+        // Bounded like the 429/5xx branches by `attempts < maxAttempts`:
+        // the outer `attempts += 1` already fired for this attempt, so a
+        // token that expires on the final attempt does NOT re-auth-and-
+        // retry past the maxAttempts envelope — it falls through and the
+        // 401/403 is returned to the caller. A single re-auth chain thus
+        // consumes 2 of 3 attempts, leaving 1 slot for a subsequent
+        // 5xx/429.
         const authFailStatus = res.status;
         authRetries += 1;
         authToken = null;
@@ -365,24 +384,12 @@ export function createPbClient(config: PbClientConfig): PbClient {
           );
         }
         if (authToken) headers.set("authorization", authToken);
+        // Drain the failed (401/403) response before retrying, same as the
+        // 429/5xx branches, so the runtime's HTTP agent can reuse the
+        // socket instead of leaving it half-consumed on every refresh (F2.3).
+        await drainBody();
         continue;
       }
-      // Helper: drain the body so the underlying connection can be
-      // reused by the runtime's HTTP agent — otherwise some fetch
-      // implementations will leave the socket half-consumed and open a
-      // fresh one on every retry. Log drain errors at debug so
-      // ECONNRESET / ERR_STREAM_PREMATURE_CLOSE evidence isn't lost
-      // (F2.3) — callers rarely need this, but it's invaluable when
-      // diagnosing socket-level flakiness.
-      const drainBody = async (): Promise<void> => {
-        await res.text().catch((drainErr: unknown) => {
-          logger.debug("pb-client.body-drain-failed", {
-            path,
-            status: res.status,
-            err: String(drainErr),
-          });
-        });
-      };
       // HF13-B1: read the body text once, returning "" on any error
       // (premature-close, already-drained, network blip). Used BEFORE
       // drain on the terminal-failure paths so we can surface the


### PR DESCRIPTION
## Root cause

The harness's PocketBase client (`showcase/harness/src/storage/pb-client.ts`) re-authenticated its superuser token **only on HTTP 401**. But when the superuser/admin auth token's ~14-day TTL expires, PocketBase does **not** return 401 — it treats the request as an unauthenticated *guest* and returns:

```
HTTP 403 {"code":403,"message":"Only admins can perform this action.","data":{}}
```

on every write. Because 403 was never treated as an auth-expiry signal, the expired token was never refreshed, so **all `status` writes failed permanently** until the process restarted. `classifyWriterError` maps 403 → `pb_permission` (a terminal reason), so the failure looked like a permission problem rather than an expired session. This is what blanked the dashboard for ~46h.

## The fix

In `request()`, treat a 403 as the same stale-session signal as a 401 — **but only when the request actually carried an `Authorization` header** (`sentAuth`). A 403 on a request that sent no token is a genuine guest-forbidden result that re-auth cannot fix, so it is left to surface.

- The retry stays bounded by `MAX_AUTH_RETRIES` (1). A 403 that **persists after a fresh, successful re-auth** is a real permission error and falls through to the caller (still classified `pb_permission`) — never an infinite re-auth loop.
- No change to the 401 path, the retry envelope, or any other status class.

```
(res.status === 401 || (res.status === 403 && sentAuth)) &&
authRetries < MAX_AUTH_RETRIES && attempts < maxAttempts
```

## Local red-green proof (real PocketBase, real client — not a fake)

Stood up a live **PocketBase v0.22.21** (the pinned version) locally, created an admin + a superuser-gated `status` collection, and set `adminAuthToken.duration = 5` (5s — the server's minimum). A temporary driver drove the **real `createPbClient`** against it: write #1 caches a token, sleep 6.5s so the cached token **genuinely expires**, then write #2.

First confirmed the raw failure surface — an expired admin token on a write:

```
EXPIRED-token write status + body:
{"code":403,"message":"Only admins can perform this action.","data":{}}
HTTP 403
```

### RED (unmodified code)

```
[driver] write#1 OK id=setjh0ca1s09s14 — token now cached
[driver] sleeping 6.5s for the cached admin token to expire...
CVDIAG component=pb-client:create:status ... status=error error=status=403 {"code":403,"message":"Only admins can perform this action.","data":{}}
[driver] RED: write#2 FAILED after expiry: Error: pb create failed: 403 {"code":403,"message":"Only admins can perform this action.","data":{}}
EXIT=1
```

The expired token 403s, **no re-auth occurs**, the write stays failed.

### GREEN (with this fix)

```
[driver] write#1 OK id=tkl59dt5d3xt11g — token now cached
[driver] sleeping 6.5s for the cached admin token to expire...
[driver] GREEN: write#2 SUCCEEDED after expiry id=uns9y2dgysynpwz
EXIT=0
```

Same repro, same expired token: the 403 now triggers re-auth, the write is retried once and **succeeds**.

## Regression tests

Added three tests to `pb-client.test.ts`:

1. `re-auths on 403 (expired superuser token treated as guest) then retries the write` — 403-with-token → re-auth → retry succeeds (2 auths, 2 writes).
2. `caps 403 re-auth at 1 — a 403 that persists after a fresh auth surfaces (no infinite loop)` — bounded; the persistent 403 surfaces (2 auths, 2 writes, then throws).
3. `does NOT re-auth on 403 when no credentials were sent (genuine guest-forbidden)` — no token → no re-auth, no retry (0 auths, 1 write).

**Mutation check:** reverting the fix (403 branch removed) makes tests 1 and 2 fail while test 3 still passes — the tests are structurally able to detect the fix.

## Code-review hardening (Tier-3 cr-loop)

A full-breadth review of the re-auth branch surfaced two additional load-bearing issues in the exact code this PR modifies; both fixed here with their own red-green + individual mutation checks:

- **Drain the response body on the re-auth path.** The 401/403 re-auth branch did `continue` without draining the prior failed response — unlike the 429/5xx branches, which call `drainBody()` — leaking a half-consumed socket on every token refresh (F2.3 socket-reuse discipline). `drainBody` was hoisted above the branch and invoked before the retry.
  - RED: `failed401.bodyUsed` = `false` (undrained). GREEN: body drained after the fix.
- **Bound the re-auth gate by `attempts < maxAttempts`.** The re-auth gate checked only `authRetries`, not `attempts` (the 429/5xx gates check both), so a token expiring on the final attempt could fire a 4th `fetchImpl`, exceeding the documented `maxAttempts = 3` envelope. Added the guard for consistency.
  - RED: `expected 4 to be 3` (4th fetch fired). GREEN: `writeCount === 3`.

Full `pb-client.test.ts` suite: **35 passed**. CI green.

## Follow-ups (out of scope for this PR — pre-existing, tracked separately)

The review confirmed the fix is sound and found no defect in it, but flagged pre-existing issues in the same file that predate this change and belong in their own PRs:

- **Observability regression (HF13-B1):** `create()`'s CVDIAG "every record write failure is greppable" log is unreachable for retry-exhausted 429/5xx writes, because `request()` now throws `PbHttpError` before `create()`'s `!res.ok` block runs. (403 writes are unaffected — they reach the log.)
- **Auth re-auth stampede:** `ensureAuth()` has no single-flight guard, so at token expiry every concurrent writer re-auths independently. Fixing this (coalesce concurrent re-auths behind one shared in-flight promise) benefits both the 401 and 403 paths.
- **401 `sentAuth` symmetry (trivial):** the 401 re-auth path lacks the `sentAuth` guard the new 403 path has, wasting one bounded attempt when no credentials are configured.
- **`deleteByFilter` off-by-one:** the iteration cap throws on a fully-successful delete of exactly a multiple-of-200 ≥ 20000 rows.
- **Inert `RETRY_AFTER_MAX_MS` cap + its mutation-blind test.**
