### PR TITLE
feat: negotiate compact thread restore

### DIFF
--- a/.claude/plans/2026-08-12-reliable-thread-restore-v2.md
+++ b/.claude/plans/2026-08-12-reliable-thread-restore-v2.md
@@ -4,7 +4,7 @@
 
 **Goal:** Negotiate compact full restore by default while giving apps with mutating subscribers one stable opt-out.
 
-**Architecture:** Core owns a `compactRestore` preference, captures it per connection attempt, and includes the supported reducer/version tuple in the phase-1 restore capability. Clones and proxied agents inherit the setting. Development warns when a mutation-capable subscriber is added while compact restore remains enabled.
+**Architecture:** Core owns a normalized `compactRestore` preference, captures it per connection attempt, and includes the supported projection tuple as an optional extension of the phase-1 restore capability only for null-cursor connect restores. The shared gateway contract pins the tuple fields before either repository implements them; `restore.version` remains `1`. Core, discovered/provisional proxies, clones, and Intelligence delegates all inherit the setting. Development warns once at the public-agent subscription boundary when a subscriber can mutate events while compact restore remains enabled.
 
 **Tech Stack:** TypeScript, Vitest, RxJS, Nx, MDX.
 
@@ -16,23 +16,33 @@
 
 - Modify: `packages/core/src/agent.ts`
 - Modify: `packages/core/src/intelligence-agent.ts`
+- Modify: `packages/core/src/core/core.ts`
+- Modify: `packages/core/src/core/agent-registry.ts`
 - Modify: `packages/core/src/__tests__/intelligence-agent.test.ts`
+- Modify: `packages/react-core/src/v2/hooks/use-agent.tsx`
+- Modify: `packages/angular/src/lib/agent.ts`
+- Modify: `packages/vue/src/v2/hooks/use-agent.ts`
 
-- [ ] Test default enabled, explicit opt-out, attempt capture, clone propagation, proxied-agent propagation, old-gateway fallback, and valid-cursor legacy behavior.
+- [ ] Pin one additive shared contract with `schemaVersion`, `reducerVersion`, `sanitizerVersion`, and `compactorVersion`; preserve `restore: { version: 1, sdkVersion }` for old gateways.
+- [ ] Test Core default enabled and explicit opt-out across registered, discovered, and provisional React/Angular/Vue proxies, both clone paths, and Intelligence delegate creation.
+- [ ] Test attempt capture through delayed credentials, invalid-cursor retry, and socket credential refresh.
+- [ ] Test that compact support is advertised only for connect mode with a null cursor; run mode, valid-cursor reconnect, and explicit opt-out retain legacy behavior.
+- [ ] Assert old acknowledgement, unknown acknowledgement, and a new gateway selecting legacy all complete without client failure.
 - [ ] Confirm the negotiation assertions fail before implementation.
-- [ ] Add the smallest public configuration surface and join capability tuple.
+- [ ] Add `compactRestore?: boolean` to Core, Intelligence agent, and proxied-agent configuration, normalized to `true`, and thread the captured attempt value explicitly to channel parameter creation.
 - [ ] Run core tests, typecheck, lint, and build.
 
 ### Task 2: Mutation warning
 
 **Files:**
 
-- Modify: `packages/core/src/intelligence-agent.ts`
-- Modify: `packages/core/src/__tests__/intelligence-agent.test.ts`
+- Modify: `packages/core/src/agent.ts`
+- Modify: `packages/core/src/__tests__/agent.test.ts`
 
-- [ ] Test one development warning for mutation-capable subscribers with compact restore enabled, no claim that mutation is certain, no production warning, and no warning when opted out.
+- [ ] Test one development warning per public agent for subscribers whose event callbacks can return an `AgentStateMutation`; exclude notification-only callbacks.
+- [ ] Test no production warning, no opt-out warning, no duplicate during proxy-to-delegate forwarding, and no behavior change to `super.subscribe()`.
 - [ ] Confirm warning tests fail before implementation.
-- [ ] Implement warning dedupe at subscriber registration without changing subscriber behavior.
+- [ ] Implement advisory wording at public subscriber registration without claiming mutation is certain.
 - [ ] Run focused and full core tests.
 
 ### Task 3: Public docs and release note
@@ -41,7 +51,8 @@
 
 - Modify: `showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx`
 - Modify: `showcase/shell-docs/src/content/docs/premium/self-hosting.mdx`
-- Modify: `packages/core/CHANGELOG.md`
 
-- [ ] Document default compact full restore, opt-out, clone/proxy propagation, callback-count and `RAW` differences, version fallback, valid-cursor legacy behavior, and the development warning.
+- [ ] Document default compact full restore, public Core/provider opt-out, clone/proxy propagation, callback-count and `RAW` differences, version fallback, valid-cursor legacy behavior, and the development warning.
+- [ ] Keep browser callback semantics with the Core/provider docs; use self-hosting docs only for gateway compatibility and deployment configuration.
+- [ ] Use the conventional commit subject for release tooling; do not edit generated package changelogs.
 - [ ] Run docs checks and package verification.

--- a/.claude/plans/2026-08-12-reliable-thread-restore-v2.md
+++ b/.claude/plans/2026-08-12-reliable-thread-restore-v2.md
@@ -1,0 +1,47 @@
+# CopilotKit Reliable Thread Restore V2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Negotiate compact full restore by default while giving apps with mutating subscribers one stable opt-out.
+
+**Architecture:** Core owns a `compactRestore` preference, captures it per connection attempt, and includes the supported reducer/version tuple in the phase-1 restore capability. Clones and proxied agents inherit the setting. Development warns when a mutation-capable subscriber is added while compact restore remains enabled.
+
+**Tech Stack:** TypeScript, Vitest, RxJS, Nx, MDX.
+
+---
+
+### Task 1: Core contract and propagation
+
+**Files:**
+
+- Modify: `packages/core/src/agent.ts`
+- Modify: `packages/core/src/intelligence-agent.ts`
+- Modify: `packages/core/src/__tests__/intelligence-agent.test.ts`
+
+- [ ] Test default enabled, explicit opt-out, attempt capture, clone propagation, proxied-agent propagation, old-gateway fallback, and valid-cursor legacy behavior.
+- [ ] Confirm the negotiation assertions fail before implementation.
+- [ ] Add the smallest public configuration surface and join capability tuple.
+- [ ] Run core tests, typecheck, lint, and build.
+
+### Task 2: Mutation warning
+
+**Files:**
+
+- Modify: `packages/core/src/intelligence-agent.ts`
+- Modify: `packages/core/src/__tests__/intelligence-agent.test.ts`
+
+- [ ] Test one development warning for mutation-capable subscribers with compact restore enabled, no claim that mutation is certain, no production warning, and no warning when opted out.
+- [ ] Confirm warning tests fail before implementation.
+- [ ] Implement warning dedupe at subscriber registration without changing subscriber behavior.
+- [ ] Run focused and full core tests.
+
+### Task 3: Public docs and release note
+
+**Files:**
+
+- Modify: `showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx`
+- Modify: `showcase/shell-docs/src/content/docs/premium/self-hosting.mdx`
+- Modify: `packages/core/CHANGELOG.md`
+
+- [ ] Document default compact full restore, opt-out, clone/proxy propagation, callback-count and `RAW` differences, version fallback, valid-cursor legacy behavior, and the development warning.
+- [ ] Run docs checks and package verification.

--- a/packages/angular/src/lib/agent.spec.ts
+++ b/packages/angular/src/lib/agent.spec.ts
@@ -31,6 +31,7 @@ type StubCore = Pick<
   | "runtimeTransport"
   | "runtimeConnectionStatus"
   | "headers"
+  | "compactRestore"
   | "subscribeToAgentWithOptions"
 > & {
   agents?: Record<string, AbstractAgent>;
@@ -163,6 +164,7 @@ class CopilotKitStub {
     runtimeTransport: "auto",
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus.Disconnected,
     headers: {},
+    compactRestore: true,
     subscribeToAgentWithOptions:
       this.#coreInstance.subscribeToAgentWithOptions.bind(this.#coreInstance),
   };
@@ -190,6 +192,10 @@ class CopilotKitStub {
   setRuntimeTransport(value: "rest" | "single" | "auto") {
     this.#runtimeTransport.set(value);
     this.core = { ...this.core, runtimeTransport: value };
+  }
+
+  setCompactRestore(value: boolean) {
+    this.core = { ...this.core, compactRestore: value };
   }
 }
 
@@ -325,6 +331,28 @@ describe("injectAgentStore", () => {
     const proxiedAgent = proxied as ProxiedCopilotRuntimeAgent;
     expect(proxiedAgent.agentId).toBe("missing");
     expect(proxiedAgent.headers).toEqual({ "x-test": "1" });
+  });
+
+  it("propagates the core compact restore opt-out to a provisional agent", () => {
+    copilotKitStub.setAgents({});
+    copilotKitStub.setRuntimeUrl("https://runtime.local");
+    copilotKitStub.setCompactRestore(false);
+    copilotKitStub.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+
+    @Component({ standalone: true, template: "" })
+    class MissingAgentHost {
+      store = injectAgentStore("missing");
+    }
+
+    const fixture = TestBed.createComponent(MissingAgentHost);
+    fixture.detectChanges();
+
+    expect(
+      (fixture.componentInstance.store().agent as ProxiedCopilotRuntimeAgent)
+        .compactRestore,
+    ).toBe(false);
   });
 
   it("shares a provisional runtime agent across same-id consumers", () => {

--- a/packages/angular/src/lib/agent.ts
+++ b/packages/angular/src/lib/agent.ts
@@ -156,6 +156,7 @@ export class CopilotkitAgentFactory {
           runtimeUrl,
           agentId: resolvedAgentId,
           transport: this.#copilotkit.runtimeTransport(),
+          compactRestore: this.#copilotkit.core.compactRestore,
         });
         if (hasAgentHeaders(provisional)) {
           provisional.headers = { ...headers };

--- a/packages/angular/src/lib/config.ts
+++ b/packages/angular/src/lib/config.ts
@@ -39,6 +39,8 @@ export interface CopilotKitConfig {
   headers?: Record<string, string>;
   licenseKey?: string;
   properties?: Record<string, unknown>;
+  /** Advertise compact full-thread restore support. Defaults to true. */
+  compactRestore?: boolean;
   agents?: Record<string, AbstractAgent>;
   selfManagedAgents?: Record<string, AbstractAgent>;
   tools?: ClientTool[];

--- a/packages/angular/src/lib/copilotkit.spec.ts
+++ b/packages/angular/src/lib/copilotkit.spec.ts
@@ -102,6 +102,22 @@ describe("CopilotKit", () => {
     (globalThis as any).__copilotkitAngularLicenseWatermarkLogged = undefined;
   });
 
+  it("threads the compact restore opt-out into the core", () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideCopilotKit({
+          runtimeUrl: "https://runtime.local",
+          licenseKey,
+          compactRestore: false,
+        }),
+      ],
+    });
+
+    TestBed.inject(CopilotKit);
+
+    expect(lastCoreConfig.compactRestore).toBe(false);
+  });
+
   it("initialises core with transformed tool and renderer config", () => {
     @Component({
       selector: "dummy-tool",

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -150,6 +150,7 @@ export class CopilotKit {
       this.#config.properties,
       this.#config.a2ui?.catalog !== undefined,
     ),
+    compactRestore: this.#config.compactRestore,
   });
 
   readonly #toolCallRenderConfigs: WritableSignal<RenderToolCallConfig[]> =

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -1,0 +1,109 @@
+import type { AgentSubscriber } from "@ag-ui/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+
+function createAgent(compactRestore = true): ProxiedCopilotRuntimeAgent {
+  return new ProxiedCopilotRuntimeAgent({
+    runtimeUrl: "https://runtime.example",
+    agentId: "default",
+    compactRestore,
+  });
+}
+
+describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "onEvent",
+    "onToolCallStartEvent",
+    "onRunInitialized",
+    "onRunFailed",
+    "onRunFinalized",
+  ] as const)("warns for the mutation-capable %s callback", (callbackName) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = createAgent();
+
+    agent.subscribe({
+      [callbackName]: () => ({ state: { replaced: true } }),
+    } as AgentSubscriber);
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0]?.[0]).toMatch(/compact restore/i);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/immutable/i);
+    expect(warn.mock.calls[0]?.[0]).toContain("compactRestore: false");
+  });
+
+  it("warns only once per public agent", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = createAgent();
+
+    agent.subscribe({ onEvent: () => ({ state: {} }) });
+    agent.subscribe({ onStateDeltaEvent: () => ({ state: {} }) });
+
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("does not warn for notification-only callbacks", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = createAgent();
+
+    agent.subscribe({
+      onMessagesChanged: () => {},
+      onStateChanged: () => {},
+      onNewMessage: () => {},
+      onNewToolCall: () => {},
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn outside development", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    createAgent().subscribe({ onEvent: () => ({ state: {} }) });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when compact restore is disabled", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    createAgent(false).subscribe({ onEvent: () => ({ state: {} }) });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("preserves the base subscription and unsubscription behavior", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = createAgent();
+    const subscriber: AgentSubscriber = {
+      onEvent: () => ({ state: {} }),
+    };
+
+    const subscription = agent.subscribe(subscriber);
+    expect(agent.subscribers).toContain(subscriber);
+
+    subscription.unsubscribe();
+    expect(agent.subscribers).not.toContain(subscriber);
+  });
+
+  it("warns independently for a cloned public agent without forwarding a duplicate", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = createAgent();
+    const clone = agent.clone();
+
+    agent.subscribe({ onEvent: () => ({ state: {} }) });
+    clone.subscribe({ onEvent: () => ({ state: {} }) });
+    clone.subscribe({ onRawEvent: () => ({ state: {} }) });
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -92,7 +92,9 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0]?.[0]).toMatch(/compact restore/i);
     expect(warn.mock.calls[0]?.[0]).toMatch(/immutable/i);
-    expect(warn.mock.calls[0]?.[0]).toMatch(/returned messages.*state mutations/i);
+    expect(warn.mock.calls[0]?.[0]).toMatch(
+      /returned messages.*state mutations/i,
+    );
     expect(warn.mock.calls[0]?.[0]).toContain("compactRestore: false");
   });
 
@@ -226,10 +228,7 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
         agent.run = () => EMPTY;
       }
 
-      await agent.runAgent(
-        { runId: "run-1" },
-        { onRunInitialized },
-      );
+      await agent.runAgent({ runId: "run-1" }, { onRunInitialized });
 
       expect(onRunInitialized).toHaveBeenCalledOnce();
       expect(warn).toHaveBeenCalledOnce();
@@ -243,10 +242,7 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     agent.threadId = "thread-1";
     agent.connect = () => EMPTY;
 
-    await agent.connectAgent(
-      { runId: "connect-1" },
-      { onRunInitialized },
-    );
+    await agent.connectAgent({ runId: "connect-1" }, { onRunInitialized });
 
     expect(onRunInitialized).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledOnce();

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -2,6 +2,7 @@ import type {
   AbstractAgent as AbstractAgentType,
   AgentSubscriber,
 } from "@ag-ui/client";
+import { EMPTY } from "rxjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProxiedCopilotRuntimeAgent } from "../agent";
 
@@ -55,6 +56,15 @@ function createAgent(compactRestore = true): ProxiedCopilotRuntimeAgent {
   });
 }
 
+function createIntelligenceAgent(): ProxiedCopilotRuntimeAgent {
+  return new ProxiedCopilotRuntimeAgent({
+    runtimeUrl: "https://runtime.example",
+    agentId: "default",
+    runtimeMode: "intelligence",
+    intelligence: { wsUrl: "wss://runtime.example/client" },
+  });
+}
+
 describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
   beforeEach(() => {
     vi.stubEnv("NODE_ENV", "development");
@@ -82,7 +92,21 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0]?.[0]).toMatch(/compact restore/i);
     expect(warn.mock.calls[0]?.[0]).toMatch(/immutable/i);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/returned messages.*state mutations/i);
     expect(warn.mock.calls[0]?.[0]).toContain("compactRestore: false");
+  });
+
+  it("recognizes mutation-capable callbacks declared as class methods", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    class ClassSubscriber implements AgentSubscriber {
+      onEvent() {
+        return { state: { replaced: true } };
+      }
+    }
+
+    createAgent().subscribe(new ClassSubscriber());
+
+    expect(warn).toHaveBeenCalledOnce();
   });
 
   it("warns only once per public agent", () => {
@@ -126,6 +150,24 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("does not throw in a browser-like environment without global process", () => {
+    const processDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "process",
+    );
+    Reflect.deleteProperty(globalThis, "process");
+
+    try {
+      expect(() =>
+        createAgent().subscribe({ onEvent: () => ({ state: {} }) }),
+      ).not.toThrow();
+    } finally {
+      if (processDescriptor) {
+        Object.defineProperty(globalThis, "process", processDescriptor);
+      }
+    }
+  });
+
   it("preserves the base subscription and unsubscription behavior", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const agent = createAgent();
@@ -152,21 +194,61 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     expect(warn).toHaveBeenCalledTimes(2);
   });
 
-  it("does not warn again when a public subscriber is forwarded to an Intelligence delegate", async () => {
+  it("does not warn again when public and direct subscribers reach an Intelligence delegate", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const onEvent = vi.fn(() => ({ state: { fromSubscriber: true } }));
-    const agent = new ProxiedCopilotRuntimeAgent({
-      runtimeUrl: "https://runtime.example",
-      agentId: "default",
-      runtimeMode: "intelligence",
-      intelligence: { wsUrl: "wss://runtime.example/client" },
-    });
+    const registeredOnEvent = vi.fn(() => ({ state: { registered: true } }));
+    const directOnEvent = vi.fn(() => ({ state: { direct: true } }));
+    const agent = createIntelligenceAgent();
     agent.threadId = "thread-1";
-    agent.subscribe({ onEvent });
+    agent.subscribe({ onEvent: registeredOnEvent });
 
-    await agent.connectAgent({ runId: "connect-1" });
+    await agent.connectAgent(
+      { runId: "connect-1" },
+      { onEvent: directOnEvent },
+    );
 
-    expect(onEvent).toHaveBeenCalledOnce();
+    expect(registeredOnEvent).toHaveBeenCalledOnce();
+    expect(directOnEvent).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it.each(["sse", "intelligence"] as const)(
+    "warns for a direct mutation-capable runAgent subscriber in %s mode",
+    async (runtimeMode) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const onRunInitialized = vi.fn(() => ({ state: { direct: true } }));
+      const agent =
+        runtimeMode === "intelligence"
+          ? createIntelligenceAgent()
+          : createAgent();
+      agent.threadId = "thread-1";
+      if (runtimeMode === "sse") {
+        agent.run = () => EMPTY;
+      }
+
+      await agent.runAgent(
+        { runId: "run-1" },
+        { onRunInitialized },
+      );
+
+      expect(onRunInitialized).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("warns for a direct mutation-capable non-Intelligence connectAgent subscriber", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onRunInitialized = vi.fn(() => ({ state: { direct: true } }));
+    const agent = createAgent();
+    agent.threadId = "thread-1";
+    agent.connect = () => EMPTY;
+
+    await agent.connectAgent(
+      { runId: "connect-1" },
+      { onRunInitialized },
+    );
+
+    expect(onRunInitialized).toHaveBeenCalledOnce();
     expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -2,7 +2,7 @@ import type {
   AbstractAgent as AbstractAgentType,
   AgentSubscriber,
 } from "@ag-ui/client";
-import { EMPTY } from "rxjs";
+import { EMPTY as emptyObservable } from "rxjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProxiedCopilotRuntimeAgent } from "../agent";
 
@@ -225,7 +225,7 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
           : createAgent();
       agent.threadId = "thread-1";
       if (runtimeMode === "sse") {
-        agent.run = () => EMPTY;
+        agent.run = () => emptyObservable;
       }
 
       await agent.runAgent({ runId: "run-1" }, { onRunInitialized });
@@ -240,7 +240,7 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     const onRunInitialized = vi.fn(() => ({ state: { direct: true } }));
     const agent = createAgent();
     agent.threadId = "thread-1";
-    agent.connect = () => EMPTY;
+    agent.connect = () => emptyObservable;
 
     await agent.connectAgent({ runId: "connect-1" }, { onRunInitialized });
 

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -2,6 +2,48 @@ import type { AgentSubscriber } from "@ag-ui/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProxiedCopilotRuntimeAgent } from "../agent";
 
+vi.mock("../intelligence-agent", async () => {
+  const { AbstractAgent, EventType } = await import("@ag-ui/client");
+  const { EMPTY } = await import("rxjs");
+
+  class ForwardingTestIntelligenceAgent extends AbstractAgent {
+    run() {
+      return EMPTY;
+    }
+
+    override async connectAgent(
+      _parameters?: Parameters<AbstractAgent["connectAgent"]>[0],
+      subscriber?: AgentSubscriber,
+    ) {
+      const input = {
+        threadId: this.threadId,
+        runId: "delegate-run",
+        messages: this.messages,
+        state: this.state,
+        tools: [],
+        context: [],
+        forwardedProps: {},
+      };
+      for (const current of [...this.subscribers, subscriber ?? {}]) {
+        await current.onEvent?.({
+          event: {
+            type: EventType.CUSTOM,
+            name: "forwarding-test",
+            value: null,
+          },
+          input,
+          messages: this.messages,
+          state: this.state,
+          agent: this,
+        });
+      }
+      return { result: undefined, newMessages: [] };
+    }
+  }
+
+  return { IntelligenceAgent: ForwardingTestIntelligenceAgent };
+});
+
 function createAgent(compactRestore = true): ProxiedCopilotRuntimeAgent {
   return new ProxiedCopilotRuntimeAgent({
     runtimeUrl: "https://runtime.example",
@@ -105,5 +147,23 @@ describe("ProxiedCopilotRuntimeAgent compact restore mutation warning", () => {
     clone.subscribe({ onRawEvent: () => ({ state: {} }) });
 
     expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not warn again when a public subscriber is forwarded to an Intelligence delegate", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onEvent = vi.fn(() => ({ state: { fromSubscriber: true } }));
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "default",
+      runtimeMode: "intelligence",
+      intelligence: { wsUrl: "wss://runtime.example/client" },
+    });
+    agent.threadId = "thread-1";
+    agent.subscribe({ onEvent });
+
+    await agent.connectAgent({ runId: "connect-1" });
+
+    expect(onEvent).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -1,4 +1,7 @@
-import type { AgentSubscriber } from "@ag-ui/client";
+import type {
+  AbstractAgent as AbstractAgentType,
+  AgentSubscriber,
+} from "@ag-ui/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProxiedCopilotRuntimeAgent } from "../agent";
 
@@ -12,7 +15,7 @@ vi.mock("../intelligence-agent", async () => {
     }
 
     override async connectAgent(
-      _parameters?: Parameters<AbstractAgent["connectAgent"]>[0],
+      _parameters?: Parameters<AbstractAgentType["connectAgent"]>[0],
       subscriber?: AgentSubscriber,
     ) {
       const input = {

--- a/packages/core/src/__tests__/compact-restore-config.test.ts
+++ b/packages/core/src/__tests__/compact-restore-config.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+import { CopilotKitCore } from "../core";
+import { waitForCondition } from "./test-utils";
+
+describe("compact restore configuration", () => {
+  const originalFetch = global.fetch;
+  const originalWindow = (globalThis as { window?: unknown }).window;
+
+  beforeEach(() => {
+    (globalThis as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it("defaults on and propagates an opt-out to registered proxies", () => {
+    expect(new CopilotKitCore({}).compactRestore).toBe(true);
+
+    const core = new CopilotKitCore({
+      runtimeUrl: "https://runtime.example",
+      compactRestore: false,
+    });
+    const { agent } = core.registerProxiedAgent({
+      agentId: "chat-1",
+      runtimeAgentId: "default",
+    });
+
+    expect(core.compactRestore).toBe(false);
+    expect(agent.compactRestore).toBe(false);
+  });
+
+  it("propagates an opt-out to runtime-discovered proxies", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        version: "1.0.0",
+        mode: "intelligence",
+        intelligence: { wsUrl: "wss://runtime.example/client" },
+        agents: { default: { description: "assistant", capabilities: {} } },
+      }),
+    }) as unknown as typeof fetch;
+
+    const core = new CopilotKitCore({
+      runtimeUrl: "https://runtime.example",
+      runtimeTransport: "rest",
+      compactRestore: false,
+    });
+    await waitForCondition(() => core.getAgent("default") !== undefined);
+
+    const discovered = core.getAgent("default");
+    expect(discovered).toBeInstanceOf(ProxiedCopilotRuntimeAgent);
+    expect((discovered as ProxiedCopilotRuntimeAgent).compactRestore).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/src/__tests__/compact-restore-config.test.ts
+++ b/packages/core/src/__tests__/compact-restore-config.test.ts
@@ -25,7 +25,6 @@ describe("compact restore configuration", () => {
     expect(new CopilotKitCore({}).compactRestore).toBe(true);
 
     const core = new CopilotKitCore({
-      runtimeUrl: "https://runtime.example",
       compactRestore: false,
     });
     const { agent } = core.registerProxiedAgent({

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -437,6 +437,38 @@ describe("IntelligenceAgent", () => {
       expect(result.events).toContainEqual(finishedEvent);
     });
 
+    it("does not let a terminal event from an older run complete the current run", async () => {
+      const agent = createAgent();
+      const promise = collectEvents(agent);
+      let settled = false;
+      void promise.then(() => {
+        settled = true;
+      });
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      channel.triggerJoin("ok");
+      channel.serverPush("ag_ui_event", {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-old",
+      } as BaseEvent);
+
+      await flushAsyncWork();
+      expect(settled).toBe(false);
+
+      const currentRunFinished = {
+        type: EventType.RUN_FINISHED,
+        threadId: "thread-1",
+        runId: "run-1",
+      } as BaseEvent;
+      channel.serverPush("ag_ui_event", currentRunFinished);
+
+      const result = await promise;
+      expect(result.completed).toBe(true);
+      expect(result.events).toEqual([currentRunFinished]);
+    });
+
     it("errors the observable on RUN_ERROR", async () => {
       const agent = createAgent();
       const promise = collectEvents(agent);
@@ -447,6 +479,7 @@ describe("IntelligenceAgent", () => {
 
       const errorEvent = {
         type: EventType.RUN_ERROR,
+        runId: "run-1",
         message: "something went wrong",
       } as BaseEvent;
       channel.serverPush("ag_ui_event", errorEvent);

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -107,13 +107,16 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function createAgent() {
+function createAgent(
+  overrides: Partial<ConstructorParameters<typeof IntelligenceAgent>[0]> = {},
+) {
   return new IntelligenceAgent({
     url: "ws://localhost:4000/client",
     runtimeUrl: "http://localhost:4000",
     agentId: "my-agent",
     socketParams: { token: "test-token" },
     headers: { Authorization: "Bearer abc" },
+    ...overrides,
   });
 }
 
@@ -127,10 +130,19 @@ const defaultInput: RunAgentInput = {
   forwardedProps: {},
 };
 
+const COMPACT_RESTORE_CAPABILITY = {
+  schemaVersion: 1,
+  reducerVersion: 1,
+  sanitizerVersion: 1,
+  compactorVersion: 1,
+} as const;
+
 interface IntelligenceAgentTestAccess {
   activeChannel: MockChannel | null;
   canonicalRunId: string | null;
-  config: unknown;
+  config: ConstructorParameters<typeof IntelligenceAgent>[0] & {
+    compactRestore: boolean;
+  };
   connect(input: RunAgentInput): Observable<BaseEvent>;
   messages: RunAgentInput["messages"];
   socket: MockSocket | null;
@@ -213,7 +225,9 @@ function getCanonicalRunIdForTest(
   return getAgentTestAccess(agent).canonicalRunId;
 }
 
-function getConfigForTest(agent: IntelligenceAgentInstance): unknown {
+function getConfigForTest(
+  agent: IntelligenceAgentInstance,
+): IntelligenceAgentTestAccess["config"] {
   return getAgentTestAccess(agent).config;
 }
 
@@ -342,6 +356,18 @@ describe("IntelligenceAgent", () => {
         stream_mode: "run",
         run_id: "run-1",
       });
+      expect(channel.params).toMatchObject({
+        capabilities: {
+          restore: {
+            version: 1,
+            sdkVersion: expect.any(String),
+          },
+        },
+      });
+      expect(
+        (channel.params.capabilities as { restore: Record<string, unknown> })
+          .restore,
+      ).not.toHaveProperty("compact");
     });
   });
 
@@ -548,7 +574,7 @@ describe("IntelligenceAgent", () => {
       expect(error).toBeNull();
     });
 
-    it("reacquires connect credentials after MAX_CONSECUTIVE_ERRORS socket errors", async () => {
+    it("never advertises compact restore when a run refreshes socket credentials", async () => {
       mockFetch
         .mockResolvedValueOnce(
           await jsonResponse(runtimeCredentials({ joinToken: "jt-1" })),
@@ -586,6 +612,13 @@ describe("IntelligenceAgent", () => {
         stream_mode: "connect",
         last_seen_event_id: "event-2",
       });
+      expect(
+        (
+          getChannel(agent)!.params.capabilities as {
+            restore: Record<string, unknown>;
+          }
+        ).restore,
+      ).not.toHaveProperty("compact");
     });
 
     it("cleans up stale socket and channel before joining with refreshed credentials", async () => {
@@ -903,7 +936,11 @@ describe("IntelligenceAgent", () => {
       const channel = getChannel(agent)!;
       expect(channel.params).toMatchObject({
         capabilities: {
-          restore: { version: 1, sdkVersion: expect.any(String) },
+          restore: {
+            version: 1,
+            sdkVersion: expect.any(String),
+            compact: COMPACT_RESTORE_CAPABILITY,
+          },
         },
       });
       channel.triggerJoin("ok", {
@@ -950,6 +987,10 @@ describe("IntelligenceAgent", () => {
     it.each([
       ["an old gateway acknowledgement", {}],
       ["an unrecognized acknowledgement", { restore: { mode: "future" } }],
+      [
+        "a compact-aware gateway selecting legacy replay",
+        { restore: { mode: "legacy", reason: "projection_miss" } },
+      ],
     ])(
       "preserves legacy completion for %s",
       async (_label, acknowledgement) => {
@@ -970,6 +1011,51 @@ describe("IntelligenceAgent", () => {
         });
       },
     );
+
+    it("does not advertise compact restore when explicitly disabled", async () => {
+      const agent = createAgent({ compactRestore: false });
+      setThreadIdForTest(agent, "thread-1");
+
+      const promise = agent.connectAgent({ runId: "run-1" });
+      await waitForConnection(agent);
+      const channel = getChannel(agent)!;
+
+      expect(
+        (channel.params.capabilities as { restore: Record<string, unknown> })
+          .restore,
+      ).not.toHaveProperty("compact");
+      channel.triggerJoin("ok", {});
+      channel.serverPush("replay_complete", { latestEventId: "event-1" });
+      channel.serverPush("stream_idle", { latestEventId: "event-1" });
+      await expect(promise).resolves.toBeDefined();
+    });
+
+    it("captures compact preference before delayed connect credentials resolve", async () => {
+      let resolveCredentials!: (response: Response) => void;
+      mockFetch.mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveCredentials = resolve;
+        }),
+      );
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+
+      const promise = agent.connectAgent({ runId: "run-1" });
+      getConfigForTest(agent).compactRestore = false;
+      resolveCredentials(await jsonResponse(runtimeCredentials()));
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      expect(channel.params).toMatchObject({
+        capabilities: {
+          restore: { compact: COMPACT_RESTORE_CAPABILITY },
+        },
+      });
+      channel.triggerJoin("ok", {});
+      channel.serverPush("replay_complete", { latestEventId: "event-1" });
+      channel.serverPush("stream_idle", { latestEventId: "event-1" });
+      await expect(promise).resolves.toBeDefined();
+    });
 
     it("automatically retries an invalid cursor once with a full restore", async () => {
       mockFetch
@@ -995,6 +1081,7 @@ describe("IntelligenceAgent", () => {
           restoreAttemptId: "ra_invalid",
         },
       });
+      getConfigForTest(agent).compactRestore = false;
       firstChannel.serverPush("restore_failed", {
         restoreAttemptId: "ra_invalid",
         code: "invalid_cursor",
@@ -1011,6 +1098,9 @@ describe("IntelligenceAgent", () => {
       });
       expect(secondChannel.params).toMatchObject({
         last_seen_event_id: null,
+        capabilities: {
+          restore: { compact: COMPACT_RESTORE_CAPABILITY },
+        },
       });
 
       secondChannel.triggerJoin("ok", {
@@ -1286,6 +1376,13 @@ describe("IntelligenceAgent", () => {
         stream_mode: "connect",
         last_seen_event_id: "event-1",
       });
+      expect(
+        (
+          connectChannel.params.capabilities as {
+            restore: Record<string, unknown>;
+          }
+        ).restore,
+      ).not.toHaveProperty("compact");
     });
 
     it("clearReconnectCursor() empties the cursor for the next connect", async () => {
@@ -2084,7 +2181,7 @@ describe("IntelligenceAgent", () => {
       expect(error).toBeNull();
     });
 
-    it("reacquires connect credentials after MAX_CONSECUTIVE_ERRORS socket errors", async () => {
+    it("reacquires credentials with the attempt's compact preference after socket exhaustion", async () => {
       mockFetch.mockResolvedValueOnce(
         await jsonResponse(runtimeCredentials({ joinToken: "jt-1" })),
       );
@@ -2100,6 +2197,7 @@ describe("IntelligenceAgent", () => {
       await waitForConnection(agent);
 
       getChannel(agent)!.triggerJoin("ok");
+      getConfigForTest(agent).compactRestore = false;
 
       for (let i = 0; i < 5; i++) {
         getSocket(agent)!.triggerError(new Error("network failure"));
@@ -2110,6 +2208,12 @@ describe("IntelligenceAgent", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(getSocket(agent)!.opts.params).toMatchObject({
         join_token: "jt-2",
+      });
+      expect(getChannel(agent)!.params).toMatchObject({
+        last_seen_event_id: null,
+        capabilities: {
+          restore: { compact: COMPACT_RESTORE_CAPABILITY },
+        },
       });
     });
 
@@ -2165,6 +2269,13 @@ describe("IntelligenceAgent", () => {
         stream_mode: "connect",
         last_seen_event_id: "event-before-refresh",
       });
+      expect(
+        (
+          getChannel(agent)!.params.capabilities as {
+            restore: Record<string, unknown>;
+          }
+        ).restore,
+      ).not.toHaveProperty("compact");
     });
 
     it("does not treat a synthetic connect run id as abortable run identity", async () => {
@@ -2195,13 +2306,20 @@ describe("IntelligenceAgent", () => {
   });
 
   describe("clone", () => {
-    it("returns a new IntelligenceAgent with the same config", () => {
+    it("returns a new IntelligenceAgent with the normalized compact config", () => {
       const agent = createAgent();
       const cloned = agent.clone();
 
       expect(cloned).toBeInstanceOf(IntelligenceAgent);
       expect(cloned).not.toBe(agent);
       expect(getConfigForTest(cloned)).toEqual(getConfigForTest(agent));
+      expect(getConfigForTest(cloned).compactRestore).toBe(true);
+    });
+
+    it("preserves a compact restore opt-out across clones", () => {
+      const agent = createAgent({ compactRestore: false });
+
+      expect(getConfigForTest(agent.clone()).compactRestore).toBe(false);
     });
 
     it("shares the replay cursor across clones (clearing on one clears for both)", async () => {
@@ -2289,6 +2407,42 @@ describe("IntelligenceAgent", () => {
 });
 
 describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
+  it("defaults compact restore on and preserves an opt-out through proxy clones and delegates", async () => {
+    const defaultAgent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "http://localhost:4000/api/copilotkit",
+      agentId: "default",
+    });
+    expect(defaultAgent.compactRestore).toBe(true);
+
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "http://localhost:4000/api/copilotkit",
+      agentId: "default",
+      runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+      intelligence: { wsUrl: "ws://localhost:4401/client" },
+      compactRestore: false,
+    });
+    expect(agent.clone().compactRestore).toBe(false);
+
+    agent.threadId = "thread-1";
+    const promise = agent.connectAgent({ runId: "run-1" });
+    await flushAsyncWork();
+    const delegate = (
+      agent as unknown as { delegate: IntelligenceAgentInstance }
+    ).delegate;
+    expect(getConfigForTest(delegate).compactRestore).toBe(false);
+
+    await waitForConnection(delegate);
+    const channel = getChannel(delegate)!;
+    expect(
+      (channel.params.capabilities as { restore: Record<string, unknown> })
+        .restore,
+    ).not.toHaveProperty("compact");
+    channel.triggerJoin("ok", {});
+    channel.serverPush("replay_complete", { latestEventId: "event-1" });
+    channel.serverPush("stream_idle", { latestEventId: "event-1" });
+    await promise;
+  });
+
   it("forwards the thread restore store and force-full action to its delegate", async () => {
     mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
     const agent = new ProxiedCopilotRuntimeAgent({

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -324,6 +324,10 @@ describe("IntelligenceAgent", () => {
           restoreAttemptId: "ra_run",
         },
       });
+      expect(
+        (channel.params.capabilities as { restore: Record<string, unknown> })
+          .restore,
+      ).not.toHaveProperty("compact");
       channel.serverPush("restore_failed", {
         restoreAttemptId: "ra_run",
         code: "dependency_failure",
@@ -943,6 +947,15 @@ describe("IntelligenceAgent", () => {
           },
         },
       });
+      expect(
+        Object.keys(
+          (
+            channel.params.capabilities as {
+              restore: { compact: Record<string, number> };
+            }
+          ).restore.compact,
+        ).sort(),
+      ).toEqual(Object.keys(COMPACT_RESTORE_CAPABILITY).sort());
       channel.triggerJoin("ok", {
         restore: {
           mode: "failure_reporting",

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -1610,6 +1610,40 @@ describe("IntelligenceAgent", () => {
       expect(socket.disconnected).toBe(true);
     });
 
+    it("never applies the legacy stream_idle fallback after reliable restore is negotiated", async () => {
+      mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
+
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+
+      let resolved = false;
+      const promise = agent.connectAgent({ runId: "run-1" }).then((result) => {
+        resolved = true;
+        return result;
+      });
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      channel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_aware",
+        },
+      });
+      channel.serverPush("stream_idle", {});
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      await flushAsyncWork();
+
+      expect(resolved).toBe(false);
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "restoring",
+        restoreAttemptId: "ra_aware",
+      });
+
+      channel.serverPush("replay_complete", { latestEventId: "event-2" });
+      await expect(promise).resolves.toBeDefined();
+    });
+
     it("uses snake_case latest_event_id control cursors for subsequent reconnects", async () => {
       mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
       mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -84,6 +84,20 @@ async function waitForConnection(
   }
 }
 
+async function expectConnectAgentToResolve(
+  promise: Promise<RunAgentResult>,
+): Promise<RunAgentResult> {
+  return await Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      setTimeout(
+        () => reject(new Error("connectAgent did not resolve")),
+        1_000,
+      );
+    }),
+  ]);
+}
+
 beforeEach(() => {
   mockFetch = vi.fn().mockResolvedValue(jsonResponse(runtimeCredentials()));
   vi.stubGlobal("fetch", mockFetch);
@@ -120,6 +134,9 @@ interface IntelligenceAgentTestAccess {
   connect(input: RunAgentInput): Observable<BaseEvent>;
   messages: RunAgentInput["messages"];
   socket: MockSocket | null;
+  sharedState: {
+    lastSeenEventIds: Map<string, string>;
+  };
   threadId: string | undefined;
 }
 
@@ -239,7 +256,7 @@ describe("IntelligenceAgent", () => {
 
       const channel = getChannel(agent)!;
       expect(channel.topic).toBe("thread:thread-1");
-      expect(channel.params).toEqual({
+      expect(channel.params).toMatchObject({
         stream_mode: "run",
         run_id: "run-1",
       });
@@ -281,6 +298,39 @@ describe("IntelligenceAgent", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it("surfaces typed restore failures on run-mode channel joins", async () => {
+      const agent = createAgent();
+      const result = collectEvents(agent);
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      channel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_run",
+        },
+      });
+      channel.serverPush("restore_failed", {
+        restoreAttemptId: "ra_run",
+        code: "dependency_failure",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+
+      await expect(result).resolves.toMatchObject({
+        completed: false,
+        error: {
+          name: "ThreadRestoreError",
+          code: "dependency_failure",
+          restoreAttemptId: "ra_run",
+        },
+      });
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "failed",
+        restoreAttemptId: "ra_run",
+      });
+    });
+
     it("joins with a null replay cursor when the thread has no prior events", async () => {
       const agent = createAgent();
       agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });
@@ -288,7 +338,7 @@ describe("IntelligenceAgent", () => {
 
       const channel = getChannel(agent)!;
 
-      expect(channel.params).toEqual({
+      expect(channel.params).toMatchObject({
         stream_mode: "run",
         run_id: "run-1",
       });
@@ -499,7 +549,7 @@ describe("IntelligenceAgent", () => {
       expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
         lastSeenEventId: "event-2",
       });
-      expect(getChannel(agent)!.params).toEqual({
+      expect(getChannel(agent)!.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: "event-2",
       });
@@ -808,19 +858,335 @@ describe("IntelligenceAgent", () => {
       });
     }
 
-    async function expectConnectAgentToResolve(
-      promise: Promise<RunAgentResult>,
-    ): Promise<RunAgentResult> {
-      return await Promise.race([
-        promise,
-        new Promise<never>((_, reject) => {
-          setTimeout(
-            () => reject(new Error("connectAgent did not resolve")),
-            1_000,
-          );
-        }),
-      ]);
-    }
+    it("negotiates failure reporting and exposes typed restore progress and failure", async () => {
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+      const listener = vi.fn();
+      const unsubscribe = agent.subscribeToThreadRestore(listener);
+
+      const promise = agent.connectAgent({ runId: "run-1" });
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      expect(channel.params).toMatchObject({
+        capabilities: {
+          restore: { version: 1, sdkVersion: expect.any(String) },
+        },
+      });
+      channel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_1",
+        },
+      });
+      channel.serverPush("restore_progress", {
+        restoreAttemptId: "ra_1",
+        status: "restoring",
+        elapsedMs: 42,
+      });
+
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "restoring",
+        threadId: "thread-1",
+        restoreAttemptId: "ra_1",
+        elapsedMs: 42,
+      });
+
+      channel.serverPush("restore_failed", {
+        restoreAttemptId: "ra_1",
+        code: "timeout",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        name: "ThreadRestoreError",
+        code: "timeout",
+        retryable: true,
+        retryAction: "reload_conversation",
+        restoreAttemptId: "ra_1",
+      });
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "failed",
+        restoreAttemptId: "ra_1",
+      });
+      expect(listener).toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it.each([
+      ["an old gateway acknowledgement", {}],
+      ["an unrecognized acknowledgement", { restore: { mode: "future" } }],
+    ])(
+      "preserves legacy completion for %s",
+      async (_label, acknowledgement) => {
+        const agent = createAgent();
+        setThreadIdForTest(agent, "thread-1");
+
+        const promise = agent.connectAgent({ runId: "run-1" });
+        await waitForConnection(agent);
+        const channel = getChannel(agent)!;
+        channel.triggerJoin("ok", acknowledgement);
+        channel.serverPush("replay_complete", { latestEventId: "event-1" });
+        channel.serverPush("stream_idle", { latestEventId: "event-1" });
+
+        await expect(promise).resolves.toBeDefined();
+        expect(agent.getThreadRestoreState()).toEqual({
+          status: "ready",
+          threadId: "thread-1",
+        });
+      },
+    );
+
+    it("automatically retries an invalid cursor once with a full restore", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          await jsonResponse(runtimeCredentials({ joinToken: "jt-1" })),
+        )
+        .mockResolvedValueOnce(
+          await jsonResponse(runtimeCredentials({ joinToken: "jt-2" })),
+        );
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+      getAgentTestAccess(agent).sharedState.lastSeenEventIds.set(
+        "thread-1",
+        "unknown-event",
+      );
+
+      const promise = agent.connectAgent({ runId: "run-1" });
+      await waitForConnection(agent);
+      const firstChannel = getChannel(agent)!;
+      firstChannel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_invalid",
+        },
+      });
+      firstChannel.serverPush("restore_failed", {
+        restoreAttemptId: "ra_invalid",
+        code: "invalid_cursor",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+      await waitForConnection(agent);
+
+      const secondChannel = getChannel(agent)!;
+      expect(secondChannel).not.toBe(firstChannel);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
+        lastSeenEventId: null,
+      });
+      expect(secondChannel.params).toMatchObject({
+        last_seen_event_id: null,
+      });
+
+      secondChannel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_full",
+        },
+      });
+      secondChannel.serverPush("replay_complete", {
+        latestEventId: "event-2",
+      });
+      secondChannel.serverPush("stream_idle", { latestEventId: "event-2" });
+
+      await expect(promise).resolves.toBeDefined();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("collapses duplicate force-full restores and ignores stale attempt frames", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          await jsonResponse(runtimeCredentials({ joinToken: "jt-1" })),
+        )
+        .mockResolvedValueOnce(
+          await jsonResponse(runtimeCredentials({ joinToken: "jt-2" })),
+        );
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+
+      const failedConnect = agent.connectAgent({ runId: "run-1" });
+      await waitForConnection(agent);
+      const failedChannel = getChannel(agent)!;
+      failedChannel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_failed",
+        },
+      });
+      failedChannel.serverPush("restore_failed", {
+        restoreAttemptId: "ra_failed",
+        code: "timeout",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+      await expect(failedConnect).rejects.toMatchObject({ code: "timeout" });
+
+      const firstReload = agent.forceFullRestore();
+      const secondReload = agent.forceFullRestore();
+      expect(secondReload).toBe(firstReload);
+      await waitForConnection(agent);
+
+      const reloadChannel = getChannel(agent)!;
+      expect(reloadChannel).not.toBe(failedChannel);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
+        lastSeenEventId: null,
+      });
+
+      reloadChannel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_reload",
+        },
+      });
+      failedChannel.serverPush("restore_progress", {
+        restoreAttemptId: "ra_failed",
+        status: "restoring",
+        elapsedMs: 999,
+      });
+      failedChannel.serverPush("restore_failed", {
+        restoreAttemptId: "ra_failed",
+        code: "internal_failure",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+      failedChannel.triggerClose({ reason: "normal" });
+
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "restoring",
+        restoreAttemptId: "ra_reload",
+      });
+
+      reloadChannel.serverPush("replay_complete", {
+        latestEventId: "event-full",
+      });
+      reloadChannel.serverPush("stream_idle", {
+        latestEventId: "event-full",
+      });
+      await expect(firstReload).resolves.toBeUndefined();
+      expect(agent.getThreadRestoreState()).toEqual({
+        status: "ready",
+        threadId: "thread-1",
+        restoreAttemptId: "ra_reload",
+      });
+    });
+
+    it("does not retry a failed force-full restore a second time", async () => {
+      mockFetch
+        .mockResolvedValueOnce(await jsonResponse(runtimeCredentials()))
+        .mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+
+      const failedConnect = agent.connectAgent({ runId: "run-1" });
+      await waitForConnection(agent);
+      getChannel(agent)!.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_failed",
+        },
+      });
+      getChannel(agent)!.serverPush("restore_failed", {
+        restoreAttemptId: "ra_failed",
+        code: "timeout",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+      await expect(failedConnect).rejects.toMatchObject({ code: "timeout" });
+
+      const reload = agent.forceFullRestore();
+      await waitForConnection(agent);
+      getChannel(agent)!.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_full_failed",
+        },
+      });
+      getChannel(agent)!.serverPush("restore_failed", {
+        restoreAttemptId: "ra_full_failed",
+        code: "invalid_cursor",
+        retryable: true,
+        retryAction: "reload_conversation",
+      });
+
+      await expect(reload).rejects.toMatchObject({ code: "invalid_cursor" });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("settles an acknowledged restore when the channel closes before a terminal frame", async () => {
+      const agent = createAgent();
+      setThreadIdForTest(agent, "thread-1");
+      const promise = agent.connectAgent({ runId: "run-1" });
+      await waitForConnection(agent);
+
+      const channel = getChannel(agent)!;
+      channel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_closed",
+        },
+      });
+      channel.triggerClose({ reason: "normal" });
+
+      await expect(promise).rejects.toMatchObject({
+        name: "ThreadRestoreError",
+        code: "internal_failure",
+        restoreAttemptId: "ra_closed",
+      });
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "failed",
+        restoreAttemptId: "ra_closed",
+      });
+    });
+
+    it("does not let delayed credentials from an older generation replace the active channel", async () => {
+      let resolveOldCredentials!: (response: Response) => void;
+      mockFetch
+        .mockReturnValueOnce(
+          new Promise<Response>((resolve) => {
+            resolveOldCredentials = resolve;
+          }),
+        )
+        .mockResolvedValueOnce(
+          await jsonResponse(runtimeCredentials({ joinToken: "jt-new" })),
+        );
+      const agent = createAgent();
+
+      connectWithTestAccess(agent, defaultInput).subscribe({ error: () => {} });
+      await flushAsyncWork();
+      connectWithTestAccess(agent, defaultInput).subscribe({ error: () => {} });
+      await waitForConnection(agent);
+
+      const currentChannel = getChannel(agent)!;
+      currentChannel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "ra_new",
+        },
+      });
+      currentChannel.serverPush("restore_progress", {
+        restoreAttemptId: "ra_new",
+        status: "restoring",
+        elapsedMs: 8,
+      });
+
+      resolveOldCredentials(
+        await jsonResponse(runtimeCredentials({ joinToken: "jt-old" })),
+      );
+      await flushAsyncWork();
+
+      expect(getChannel(agent)).toBe(currentChannel);
+      expect(getSocket(agent)!.opts.params).toMatchObject({
+        join_token: "jt-new",
+      });
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "restoring",
+        restoreAttemptId: "ra_new",
+        elapsedMs: 8,
+      });
+    });
 
     it("fetches a live connect plan and joins the thread topic without pushing connect", async () => {
       mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
@@ -844,7 +1210,7 @@ describe("IntelligenceAgent", () => {
 
       const channel = getChannel(agent)!;
       expect(channel.topic).toBe("thread:thread-1");
-      expect(channel.params).toEqual({
+      expect(channel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: null,
       });
@@ -883,7 +1249,7 @@ describe("IntelligenceAgent", () => {
       await waitForConnection(agent);
 
       const connectChannel = getChannel(agent)!;
-      expect(connectChannel.params).toEqual({
+      expect(connectChannel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: "event-1",
       });
@@ -917,7 +1283,7 @@ describe("IntelligenceAgent", () => {
       await waitForConnection(agent);
 
       const connectChannel = getChannel(agent)!;
-      expect(connectChannel.params).toEqual({
+      expect(connectChannel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: null,
       });
@@ -1008,7 +1374,7 @@ describe("IntelligenceAgent", () => {
       expect(JSON.parse(mockFetch.mock.calls[2]![1].body)).toMatchObject({
         lastSeenEventId: null,
       });
-      expect(secondThreadAChannel.params).toEqual({
+      expect(secondThreadAChannel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: null,
       });
@@ -1271,7 +1637,7 @@ describe("IntelligenceAgent", () => {
       expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
         lastSeenEventId: "event-snake",
       });
-      expect(secondChannel.params).toEqual({
+      expect(secondChannel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: "event-snake",
       });
@@ -1480,7 +1846,7 @@ describe("IntelligenceAgent", () => {
       expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
         lastSeenEventId: "event-3",
       });
-      expect(getChannel(agent)!.params).toEqual({
+      expect(getChannel(agent)!.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: "event-3",
       });
@@ -1532,7 +1898,7 @@ describe("IntelligenceAgent", () => {
       expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
         lastSeenEventId: "zzzz-runner-event",
       });
-      expect(getChannel(agent)!.params).toEqual({
+      expect(getChannel(agent)!.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: "zzzz-runner-event",
       });
@@ -1579,7 +1945,7 @@ describe("IntelligenceAgent", () => {
       expect(JSON.parse(mockFetch.mock.calls[1]![1].body)).toMatchObject({
         lastSeenEventId: null,
       });
-      expect(getChannel(agent)!.params).toEqual({
+      expect(getChannel(agent)!.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: null,
       });
@@ -1605,6 +1971,15 @@ describe("IntelligenceAgent", () => {
 
       expect(result.error).toBeInstanceOf(Error);
       expect(result.error!.message).toContain("REST connect request failed");
+      expect(result.error).toMatchObject({
+        name: "ThreadRestoreError",
+        code: "dependency_failure",
+        retryAction: "reload_conversation",
+      });
+      expect(agent.getThreadRestoreState()).toMatchObject({
+        status: "failed",
+        error: result.error,
+      });
       expect(getSocket(agent)).toBeNull();
     });
 
@@ -1672,7 +2047,7 @@ describe("IntelligenceAgent", () => {
     });
 
     it("uses one captured replay cursor for REST refresh and Phoenix rejoin after socket exhaustion", async () => {
-      let resolveRefreshCredentials: (response: Response) => void = () => {};
+      let resolveRefreshCredentials!: (response: Response) => void;
       const refreshCredentials = new Promise<Response>((resolve) => {
         resolveRefreshCredentials = resolve;
       });
@@ -1802,7 +2177,7 @@ describe("IntelligenceAgent", () => {
       await waitForConnection(cloned);
 
       const connectChannel = getChannel(cloned)!;
-      expect(connectChannel.params).toEqual({
+      expect(connectChannel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: null,
       });
@@ -1838,7 +2213,7 @@ describe("IntelligenceAgent", () => {
       });
 
       const connectChannel = getChannel(cloned)!;
-      expect(connectChannel.params).toEqual({
+      expect(connectChannel.params).toMatchObject({
         stream_mode: "connect",
         last_seen_event_id: "event-2",
       });
@@ -1847,6 +2222,55 @@ describe("IntelligenceAgent", () => {
 });
 
 describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
+  it("forwards the thread restore store and force-full action to its delegate", async () => {
+    mockFetch.mockResolvedValueOnce(await jsonResponse(runtimeCredentials()));
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "http://localhost:4000/api/copilotkit",
+      agentId: "default",
+      runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+      intelligence: { wsUrl: "ws://localhost:4401/client" },
+    });
+    agent.threadId = "thread-1";
+    const listener = vi.fn();
+    const unsubscribe = agent.subscribeToThreadRestore(listener);
+
+    const promise = agent.connectAgent({ runId: "run-1" });
+    await flushAsyncWork();
+    const delegate = (
+      agent as unknown as { delegate: IntelligenceAgentInstance }
+    ).delegate;
+    await waitForConnection(delegate);
+    const channel = getChannel(delegate)!;
+    channel.triggerJoin("ok", {
+      restore: {
+        mode: "failure_reporting",
+        restoreAttemptId: "ra_proxy",
+      },
+    });
+    channel.serverPush("restore_progress", {
+      restoreAttemptId: "ra_proxy",
+      status: "restoring",
+      elapsedMs: 7,
+    });
+
+    expect(agent.getThreadRestoreState()).toMatchObject({
+      status: "restoring",
+      restoreAttemptId: "ra_proxy",
+    });
+    expect(listener).toHaveBeenCalled();
+
+    channel.serverPush("replay_complete", { latestEventId: "event-1" });
+    channel.serverPush("stream_idle", { latestEventId: "event-1" });
+    await promise;
+
+    const forceFullRestore = vi
+      .spyOn(delegate, "forceFullRestore")
+      .mockResolvedValue(undefined);
+    await agent.forceFullRestore();
+    expect(forceFullRestore).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
   // Mirrors the real demo wiring: Vite app → BFF runtime that exposes a
   // ProxiedCopilotRuntimeAgent in intelligence mode → IntelligenceAgent delegate
   // talking to the realtime gateway. On thread resume, gateway replay emits

--- a/packages/core/src/__tests__/phoenix-observable.test.ts
+++ b/packages/core/src/__tests__/phoenix-observable.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { Subject } from "rxjs";
+import { lastValueFrom, Subject } from "rxjs";
 import { MockSocket } from "./test-utils";
+import type {
+  ɵPhoenixChannelSession as PhoenixChannelSession,
+  ɵPhoenixSocketSession as PhoenixSocketSession,
+} from "../utils/phoenix-observable";
 
 const phoenix = vi.hoisted(() => ({
   sockets: [] as MockSocket[],
@@ -22,9 +26,6 @@ const {
   ɵphoenixChannel$,
   ɵphoenixSocket$,
 } = await import("../utils/phoenix-observable");
-
-type PhoenixSocketSession =
-  import("../utils/phoenix-observable").ɵPhoenixSocketSession;
 
 describe("phoenix observable utilities", () => {
   it("connects on subscribe and disconnects on teardown", () => {
@@ -81,6 +82,56 @@ describe("phoenix observable utilities", () => {
 
     expect(channel!.left).toBe(true);
     expect(phoenix.sockets[0]!.disconnected).toBe(true);
+  });
+
+  it("exposes the successful join acknowledgement", () => {
+    phoenix.sockets.splice(0);
+    const channel$ = ɵphoenixChannel$({
+      socket$: ɵphoenixSocket$({ url: "ws://localhost:4000/client" }),
+      topic: "room:lobby",
+    });
+
+    let joinOutcome: unknown;
+    const subscription = channel$.subscribe((session) => {
+      session.joinOutcome$.subscribe((outcome) => {
+        joinOutcome = outcome;
+      });
+    });
+    const channel = phoenix.sockets[0]!.channels[0]!;
+
+    channel.triggerJoin("ok", {
+      restore: { mode: "failure_reporting", restoreAttemptId: "ra_1" },
+    });
+
+    expect(joinOutcome).toEqual({
+      type: "joined",
+      response: {
+        restore: { mode: "failure_reporting", restoreAttemptId: "ra_1" },
+      },
+    });
+    subscription.unsubscribe();
+  });
+
+  it("exposes channel close as a shared one-shot session signal", async () => {
+    phoenix.sockets.splice(0);
+    const channel$ = ɵphoenixChannel$({
+      socket$: ɵphoenixSocket$({ url: "ws://localhost:4000/client" }),
+      topic: "room:lobby",
+    });
+
+    let session: PhoenixChannelSession | undefined;
+    const subscription = channel$.subscribe((value) => {
+      session = value;
+    });
+    const channel = phoenix.sockets[0]!.channels[0]!;
+    const firstClose = lastValueFrom(session!.close$);
+    const secondClose = lastValueFrom(session!.close$);
+
+    channel.triggerClose({ reason: "normal" });
+
+    await expect(firstClose).resolves.toEqual({ reason: "normal" });
+    await expect(secondClose).resolves.toEqual({ reason: "normal" });
+    subscription.unsubscribe();
   });
 
   it("removes channel event listeners on unsubscribe", () => {

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -139,7 +139,7 @@ export class MockAgent {
 
 export function createMessage(overrides: MessageOverrides = {}): Message {
   return {
-    id: `msg-${Math.random().toString(36).substr(2, 9)}`,
+    id: `msg-${Math.random().toString(36).slice(2, 11)}`,
     role: "user",
     content: "Test message",
     ...overrides,
@@ -161,7 +161,7 @@ export function createToolCallMessage(
   args: any = {},
   overrides: MessageOverrides = {},
 ): Message {
-  const toolCallId = `tool-call-${Math.random().toString(36).substr(2, 9)}`;
+  const toolCallId = `tool-call-${Math.random().toString(36).slice(2, 11)}`;
   return createAssistantMessage({
     content: "",
     toolCalls: [
@@ -215,7 +215,7 @@ export function createTool<T extends Record<string, unknown>>(
   overrides: Partial<FrontendTool<T>> = {},
 ): FrontendTool<T> {
   return {
-    name: `tool-${Math.random().toString(36).substr(2, 9)}`,
+    name: `tool-${Math.random().toString(36).slice(2, 11)}`,
     description: "Test tool",
     handler: vi.fn(async () => "Tool result"),
     followUp: false, // Default to false to avoid unexpected recursion in tests
@@ -230,7 +230,7 @@ export function createMultipleToolCallsMessage(
   return createAssistantMessage({
     content: "",
     toolCalls: toolCalls.map((tc) => ({
-      id: `tool-call-${Math.random().toString(36).substr(2, 9)}`,
+      id: `tool-call-${Math.random().toString(36).slice(2, 11)}`,
       type: "function",
       function: {
         name: tc.name,
@@ -279,7 +279,7 @@ export function createSuggestionToolCall(
   suggestions: Array<{ title: string; message: string }>,
   overrides: MessageOverrides = {},
 ): Message {
-  const toolCallId = `suggest-call-${Math.random().toString(36).substr(2, 9)}`;
+  const toolCallId = `suggest-call-${Math.random().toString(36).slice(2, 11)}`;
   return createAssistantMessage({
     content: "",
     toolCalls: [
@@ -339,6 +339,10 @@ export class MockChannel {
   >();
   private joinPush = new MockPush();
   private errorHandlers: Array<(reason?: any) => void> = [];
+  private closeHandlers: Array<{
+    ref: number;
+    callback: (reason?: any) => void;
+  }> = [];
   private nextRef = 1;
 
   constructor(topic: string = "", params: Record<string, any> = {}) {
@@ -356,6 +360,12 @@ export class MockChannel {
   }
 
   off(event: string, ref?: number): void {
+    if (event === "phx_close") {
+      this.closeHandlers = this.closeHandlers.filter(
+        (handler) => ref !== undefined && handler.ref !== ref,
+      );
+      return;
+    }
     if (!this.handlers.has(event)) return;
     if (ref === undefined) {
       this.handlers.delete(event);
@@ -367,6 +377,12 @@ export class MockChannel {
 
   onError(callback: (reason?: any) => void): void {
     this.errorHandlers.push(callback);
+  }
+
+  onClose(callback: (reason?: any) => void): number {
+    const ref = this.nextRef++;
+    this.closeHandlers.push({ ref, callback });
+    return ref;
   }
 
   join(payload?: Record<string, any>): MockPush {
@@ -400,6 +416,11 @@ export class MockChannel {
   /** Test helper — simulate the channel crashing server-side. */
   triggerError(reason?: string): void {
     for (const handler of this.errorHandlers) handler(reason);
+  }
+
+  /** Test helper — simulate the channel closing server-side. */
+  triggerClose(reason?: unknown): void {
+    for (const { callback } of this.closeHandlers) callback(reason);
   }
 }
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -33,18 +33,51 @@ import type { CopilotRuntimeTransport } from "./types";
 
 type ResolvedRuntimeMode = RuntimeMode | "pending";
 
-const MUTATION_CAPABLE_LIFECYCLE_CALLBACKS: ReadonlySet<keyof AgentSubscriber> =
-  new Set(["onRunInitialized", "onRunFailed", "onRunFinalized"]);
+const MUTATION_CAPABLE_SUBSCRIBER_CALLBACKS = [
+  "onRunInitialized",
+  "onRunFailed",
+  "onRunFinalized",
+  "onEvent",
+  "onRunStartedEvent",
+  "onRunFinishedEvent",
+  "onRunErrorEvent",
+  "onStepStartedEvent",
+  "onStepFinishedEvent",
+  "onTextMessageStartEvent",
+  "onTextMessageContentEvent",
+  "onTextMessageEndEvent",
+  "onToolCallStartEvent",
+  "onToolCallArgsEvent",
+  "onToolCallEndEvent",
+  "onToolCallResultEvent",
+  "onStateSnapshotEvent",
+  "onStateDeltaEvent",
+  "onMessagesSnapshotEvent",
+  "onActivitySnapshotEvent",
+  "onActivityDeltaEvent",
+  "onRawEvent",
+  "onCustomEvent",
+  "onReasoningStartEvent",
+  "onReasoningMessageStartEvent",
+  "onReasoningMessageContentEvent",
+  "onReasoningMessageEndEvent",
+  "onReasoningEndEvent",
+  "onReasoningEncryptedValueEvent",
+] as const satisfies ReadonlyArray<keyof AgentSubscriber>;
 
 function canSubscriberMutateAgentState(subscriber: AgentSubscriber): boolean {
-  return Object.entries(subscriber).some(
-    ([callbackName, callback]) =>
-      typeof callback === "function" &&
-      (callbackName === "onEvent" ||
-        callbackName.endsWith("Event") ||
-        MUTATION_CAPABLE_LIFECYCLE_CALLBACKS.has(
-          callbackName as keyof AgentSubscriber,
-        )),
+  return MUTATION_CAPABLE_SUBSCRIBER_CALLBACKS.some(
+    (callbackName) => typeof subscriber[callbackName] === "function",
+  );
+}
+
+function isDevelopmentEnvironment(): boolean {
+  return (
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: { NODE_ENV?: string } };
+      }
+    ).process?.env?.NODE_ENV === "development"
   );
 }
 
@@ -202,19 +235,32 @@ export class ProxiedCopilotRuntimeAgent
   override subscribe(subscriber: AgentSubscriber): {
     unsubscribe: () => void;
   } {
+    this.warnAboutCompactRestoreMutation(subscriber);
+
+    return super.subscribe(subscriber);
+  }
+
+  private warnAboutCompactRestoreMutation(subscriber?: AgentSubscriber): void {
     if (
-      process.env.NODE_ENV === "development" &&
+      subscriber &&
+      isDevelopmentEnvironment() &&
       this.compactRestore &&
       !this.didWarnAboutCompactRestoreMutation &&
       canSubscriberMutateAgentState(subscriber)
     ) {
       this.didWarnAboutCompactRestoreMutation = true;
       console.warn(
-        "CopilotKit: compact restore is enabled for an agent with a mutation-capable event subscriber. Treat event payloads as immutable under compact restore. If the subscriber intentionally transforms replayed events, configure { compactRestore: false } for this agent.",
+        "CopilotKit: compact restore is enabled for an agent with a mutation-capable event subscriber. Returned messages or state mutations may produce different restore results because compact projections reduce the event stream; treat event payloads as immutable. If the subscriber intentionally transforms replayed events, configure { compactRestore: false } for this agent.",
       );
     }
+  }
 
-    return super.subscribe(subscriber);
+  override runAgent(
+    parameters?: Parameters<HttpAgent["runAgent"]>[0],
+    subscriber?: AgentSubscriber,
+  ): Promise<RunAgentResult> {
+    this.warnAboutCompactRestoreMutation(subscriber);
+    return super.runAgent(parameters, subscriber);
   }
 
   override requestInit(input: RunAgentInput): RequestInit {
@@ -343,6 +389,8 @@ export class ProxiedCopilotRuntimeAgent
     parameters?: RunAgentParameters,
     subscriber?: AgentSubscriber,
   ): Promise<RunAgentResult> {
+    this.warnAboutCompactRestoreMutation(subscriber);
+
     if (this.runtimeMode !== RUNTIME_MODE_INTELLIGENCE) {
       return super.connectAgent(parameters, subscriber);
     }

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -33,6 +33,21 @@ import type { CopilotRuntimeTransport } from "./types";
 
 type ResolvedRuntimeMode = RuntimeMode | "pending";
 
+const MUTATION_CAPABLE_LIFECYCLE_CALLBACKS: ReadonlySet<keyof AgentSubscriber> =
+  new Set(["onRunInitialized", "onRunFailed", "onRunFinalized"]);
+
+function canSubscriberMutateAgentState(subscriber: AgentSubscriber): boolean {
+  return Object.entries(subscriber).some(
+    ([callbackName, callback]) =>
+      typeof callback === "function" &&
+      (callbackName === "onEvent" ||
+        callbackName.endsWith("Event") ||
+        MUTATION_CAPABLE_LIFECYCLE_CALLBACKS.has(
+          callbackName as keyof AgentSubscriber,
+        )),
+  );
+}
+
 interface RunnableAgent {
   connect(input: RunAgentInput): Observable<BaseEvent>;
   run(input: RunAgentInput): Observable<BaseEvent>;
@@ -121,6 +136,7 @@ export class ProxiedCopilotRuntimeAgent
   private delegate?: AbstractAgent;
   private runtimeInfoPromise?: Promise<void>;
   private restoreListeners = new Map<() => void, () => void>();
+  private didWarnAboutCompactRestoreMutation = false;
 
   constructor(config: ProxiedCopilotRuntimeAgentConfig) {
     const normalizedRuntimeUrl = config.runtimeUrl
@@ -181,6 +197,24 @@ export class ProxiedCopilotRuntimeAgent
 
   get capabilities(): AgentCapabilities | undefined {
     return this._capabilities;
+  }
+
+  override subscribe(subscriber: AgentSubscriber): {
+    unsubscribe: () => void;
+  } {
+    if (
+      process.env.NODE_ENV === "development" &&
+      this.compactRestore &&
+      !this.didWarnAboutCompactRestoreMutation &&
+      canSubscriberMutateAgentState(subscriber)
+    ) {
+      this.didWarnAboutCompactRestoreMutation = true;
+      console.warn(
+        "CopilotKit: compact restore is enabled for an agent with a mutation-capable event subscriber. Treat event payloads as immutable under compact restore. If the subscriber intentionally transforms replayed events, configure { compactRestore: false } for this agent.",
+      );
+    }
+
+    return super.subscribe(subscriber);
   }
 
   override requestInit(input: RunAgentInput): RequestInit {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -97,6 +97,8 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
    * bookkeeping; only outbound routing is overridden.
    */
   runtimeAgentId?: string;
+  /** Advertise compact full-thread restore support. Defaults to true. */
+  compactRestore?: boolean;
 }
 
 export class ProxiedCopilotRuntimeAgent
@@ -110,6 +112,7 @@ export class ProxiedCopilotRuntimeAgent
   // (already captured) from `routedAgentId()` (consulted per-call by
   // stop/connect/single-route paths).
   readonly runtimeAgentId?: string;
+  readonly compactRestore: boolean;
   private transport: CopilotRuntimeTransport;
   private singleEndpointUrl?: string;
   private runtimeMode: ResolvedRuntimeMode;
@@ -143,6 +146,7 @@ export class ProxiedCopilotRuntimeAgent
     this.runtimeUrl = normalizedRuntimeUrl ?? config.runtimeUrl;
     this.credentials = config.credentials;
     this.runtimeAgentId = config.runtimeAgentId;
+    this.compactRestore = config.compactRestore ?? true;
     this.transport = transport;
     this.runtimeMode = config.runtimeMode ?? RUNTIME_MODE_SSE;
     this.intelligence = config.intelligence;
@@ -489,6 +493,7 @@ export class ProxiedCopilotRuntimeAgent
       intelligence: this.intelligence,
       capabilities: this._capabilities,
       debug: this.debug,
+      compactRestore: this.compactRestore,
     });
     cloned.threadId = this.threadId;
     cloned.setState(this.state);
@@ -713,6 +718,7 @@ export class ProxiedCopilotRuntimeAgent
       agentId: routedId,
       headers: { ...this.headers },
       credentials: this.credentials,
+      compactRestore: this.compactRestore,
     });
   }
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -27,6 +27,8 @@ import type {
   ResolvedDebugConfig,
 } from "@copilotkit/shared";
 import { IntelligenceAgent } from "./intelligence-agent";
+import { isThreadRestoreAware } from "./thread-restore";
+import type { ThreadRestoreAware, ThreadRestoreState } from "./thread-restore";
 import type { CopilotRuntimeTransport } from "./types";
 
 type ResolvedRuntimeMode = RuntimeMode | "pending";
@@ -97,7 +99,10 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
   runtimeAgentId?: string;
 }
 
-export class ProxiedCopilotRuntimeAgent extends HttpAgent {
+export class ProxiedCopilotRuntimeAgent
+  extends HttpAgent
+  implements ThreadRestoreAware
+{
   runtimeUrl?: string;
   credentials?: RequestCredentials;
   // `readonly` because `super.url` is baked at construction; mutating
@@ -112,6 +117,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   private _capabilities?: AgentCapabilities;
   private delegate?: AbstractAgent;
   private runtimeInfoPromise?: Promise<void>;
+  private restoreListeners = new Map<() => void, () => void>();
 
   constructor(config: ProxiedCopilotRuntimeAgentConfig) {
     const normalizedRuntimeUrl = config.runtimeUrl
@@ -183,6 +189,38 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
 
   async getCapabilities(): Promise<AgentCapabilities> {
     return this._capabilities ?? {};
+  }
+
+  getThreadRestoreState(): ThreadRestoreState {
+    return isThreadRestoreAware(this.delegate)
+      ? this.delegate.getThreadRestoreState()
+      : {
+          status: "ready",
+          threadId: this.threadId ?? "",
+        };
+  }
+
+  subscribeToThreadRestore(listener: () => void): () => void {
+    if (!this.restoreListeners.has(listener)) {
+      this.restoreListeners.set(listener, () => {});
+      this.bindThreadRestoreListener(listener);
+    }
+
+    return () => {
+      this.restoreListeners.get(listener)?.();
+      this.restoreListeners.delete(listener);
+    };
+  }
+
+  forceFullRestore(): Promise<void> {
+    return this.resolveDelegate().then(() => {
+      if (!isThreadRestoreAware(this.delegate)) {
+        throw new Error(
+          "Thread restore is only available for Intelligence agents",
+        );
+      }
+      return this.delegate.forceFullRestore();
+    });
   }
 
   override async detachActiveRun(): Promise<void> {
@@ -492,6 +530,9 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
         throw new Error("A delegate is only created for Intelligence mode");
       }
       this.delegate = this.createIntelligenceDelegate();
+      for (const listener of this.restoreListeners.keys()) {
+        this.bindThreadRestoreListener(listener);
+      }
     }
 
     this.syncDelegate(this.delegate);
@@ -691,5 +732,17 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     if (hasCredentials(delegate)) {
       delegate.credentials = this.credentials;
     }
+  }
+
+  private bindThreadRestoreListener(listener: () => void): void {
+    if (!isThreadRestoreAware(this.delegate)) {
+      return;
+    }
+
+    this.restoreListeners.get(listener)?.();
+    this.restoreListeners.set(
+      listener,
+      this.delegate.subscribeToThreadRestore(listener),
+    );
   }
 }

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -361,6 +361,7 @@ export class AgentRegistry {
         : RUNTIME_MODE_SSE,
       intelligence: this._intelligence,
       debug: debug ? resolveDebugConfig(debug) : undefined,
+      compactRestore: friends.compactRestore,
     });
     this.applyHeadersToAgent(agent);
 
@@ -771,6 +772,9 @@ export class AgentRegistry {
         .credentials;
       const rawDebug = (this.core as unknown as CopilotKitCoreFriendsAccess)
         .debug;
+      const compactRestore = (
+        this.core as unknown as CopilotKitCoreFriendsAccess
+      ).compactRestore;
       const agents: Record<string, AbstractAgent> = Object.fromEntries(
         Object.entries(runtimeInfo.agents).map(
           ([id, { description, capabilities }]) => {
@@ -805,6 +809,7 @@ export class AgentRegistry {
               intelligence: runtimeInfoResponse.intelligence,
               capabilities,
               debug: rawDebug ? resolveDebugConfig(rawDebug) : undefined,
+              compactRestore,
             });
             this.applyHeadersToAgent(agent);
             return [id, agent];

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -71,6 +71,8 @@ export interface CopilotKitCoreConfig {
   suggestionsConfig?: SuggestionsConfig[];
   /** Enable debug logging for the client-side event pipeline. */
   debug?: DebugConfig;
+  /** Advertise compact full-thread restore support. Defaults to true. */
+  compactRestore?: boolean;
 }
 
 export type {
@@ -347,6 +349,7 @@ export interface CopilotKitCoreFriendsAccess {
   readonly properties: Readonly<Record<string, unknown>>;
   readonly context: Readonly<Record<string, Context>>;
   readonly debug?: DebugConfig;
+  readonly compactRestore: boolean;
 
   // Internal methods
   buildFrontendTools(agentId?: string): import("@ag-ui/client").Tool[];
@@ -402,6 +405,7 @@ export class CopilotKitCore {
   private _properties: Record<string, unknown>;
   private _defaultThrottleMs?: number;
   private _debug?: DebugConfig;
+  private readonly _compactRestore: boolean;
 
   private subscribers: Set<CopilotKitCoreSubscriber> = new Set();
 
@@ -438,11 +442,13 @@ export class CopilotKitCore {
     tools = [],
     suggestionsConfig = [],
     debug,
+    compactRestore = true,
   }: CopilotKitCoreConfig) {
     this._headers = normalizeHeaders(headers);
     this._credentials = credentials;
     this._properties = properties;
     this._debug = debug;
+    this._compactRestore = compactRestore;
 
     // Initialize delegate classes
     this.agentRegistry = new AgentRegistry(this);
@@ -704,6 +710,10 @@ export class CopilotKitCore {
 
   get debug(): DebugConfig | undefined {
     return this._debug;
+  }
+
+  get compactRestore(): boolean {
+    return this._compactRestore;
   }
 
   setDebug(debug: DebugConfig | undefined): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,4 @@ export * from "./threads";
 export * from "./memory";
 export * from "./features";
 export * from "./interrupt-state";
+export * from "./thread-restore";

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -41,15 +41,25 @@ import {
   takeUntil,
   tap,
 } from "rxjs/operators";
-import { phoenixExponentialBackoff } from "@copilotkit/shared";
+import {
+  COPILOTKIT_VERSION,
+  phoenixExponentialBackoff,
+} from "@copilotkit/shared";
 import {
   ɵphoenixChannel$,
   ɵphoenixSocket$,
-  ɵjoinPhoenixChannel$,
+  ɵobservePhoenixJoinOutcome$,
   ɵobservePhoenixSocketSignals$,
   ɵobservePhoenixSocketHealth$,
   ɵobservePhoenixEvent$,
 } from "./utils/phoenix-observable";
+import {
+  ThreadRestoreError,
+  parseThreadRestoreFailure,
+  parseThreadRestoreJoinAcknowledgement,
+  parseThreadRestoreProgress,
+} from "./thread-restore";
+import type { ThreadRestoreAware, ThreadRestoreState } from "./thread-restore";
 import type {
   ɵPhoenixChannelLike,
   ɵPhoenixChannelSession,
@@ -71,11 +81,15 @@ interface Channel extends ɵPhoenixChannelLike {
 const CLIENT_AG_UI_EVENT = "ag_ui_event";
 const REPLAY_COMPLETE_EVENT = "replay_complete";
 const STREAM_IDLE_EVENT = "stream_idle";
+const RESTORE_PROGRESS_EVENT = "restore_progress";
+const RESTORE_FAILED_EVENT = "restore_failed";
 const STOP_RUN_EVENT = "stop_run";
 const CONNECT_STREAM_IDLE_REPLAY_FALLBACK_MS = 100;
 
 interface IntelligenceAgentSharedState {
   lastSeenEventIds: Map<string, string>;
+  latestConnectInputs: Map<string, RunAgentInput>;
+  forceFullRestorePromises: Map<string, Promise<void>>;
 }
 
 interface RealtimeConnectionInfo {
@@ -151,17 +165,29 @@ export interface IntelligenceAgentConfig {
   credentials?: RequestCredentials;
 }
 
-export class IntelligenceAgent extends AbstractAgent {
+export class IntelligenceAgent
+  extends AbstractAgent
+  implements ThreadRestoreAware
+{
   private config: IntelligenceAgentConfig;
   private socket: Socket | null = null;
   private activeChannel: Channel | null = null;
   private canonicalRunId: string | null = null;
   private sharedState: IntelligenceAgentSharedState;
+  private restoreGeneration = 0;
+  private restoreState: ThreadRestoreState = {
+    status: "ready",
+    threadId: "",
+  };
+  private restoreListeners = new Set<() => void>();
+  private forceFullConnectThreads = new Set<string>();
 
   constructor(
     config: IntelligenceAgentConfig,
     sharedState: IntelligenceAgentSharedState = {
       lastSeenEventIds: new Map<string, string>(),
+      latestConnectInputs: new Map<string, RunAgentInput>(),
+      forceFullRestorePromises: new Map<string, Promise<void>>(),
     },
   ) {
     super();
@@ -171,6 +197,62 @@ export class IntelligenceAgent extends AbstractAgent {
 
   clone(): IntelligenceAgent {
     return new IntelligenceAgent(this.config, this.sharedState);
+  }
+
+  getThreadRestoreState(): ThreadRestoreState {
+    return this.restoreState;
+  }
+
+  subscribeToThreadRestore(listener: () => void): () => void {
+    this.restoreListeners.add(listener);
+    return () => {
+      this.restoreListeners.delete(listener);
+    };
+  }
+
+  forceFullRestore(): Promise<void> {
+    const threadId = this.restoreState.threadId || this.threadId;
+    if (!threadId) {
+      return Promise.reject(
+        new Error("Cannot reload a conversation before a thread is selected"),
+      );
+    }
+
+    const active = this.sharedState.forceFullRestorePromises.get(threadId);
+    if (active) {
+      return active;
+    }
+
+    const input = this.sharedState.latestConnectInputs.get(threadId);
+    if (!input) {
+      return Promise.reject(
+        new Error("Cannot reload a conversation before it has been connected"),
+      );
+    }
+
+    this.restoreGeneration += 1;
+    this.setThreadRestoreState({
+      status: "restoring",
+      threadId,
+      elapsedMs: 0,
+    });
+
+    const reload = (async () => {
+      await this.detachActiveRun();
+      this.clearReconnectCursor(threadId);
+      this.forceFullConnectThreads.add(threadId);
+      this.setMessages([]);
+      this.setState({});
+      await this.connectAgent({ runId: input.runId });
+    })();
+    const tracked = reload.finally(() => {
+      if (this.sharedState.forceFullRestorePromises.get(threadId) === tracked) {
+        this.sharedState.forceFullRestorePromises.delete(threadId);
+      }
+      this.forceFullConnectThreads.delete(threadId);
+    });
+    this.sharedState.forceFullRestorePromises.set(threadId, tracked);
+    return tracked;
   }
 
   /**
@@ -312,9 +394,17 @@ export class IntelligenceAgent extends AbstractAgent {
   run(input: RunAgentInput): Observable<BaseEvent> {
     this.threadId = input.threadId;
     this.canonicalRunId = input.runId;
+    this.sharedState.latestConnectInputs.set(input.threadId, input);
+    const restoreGeneration = this.beginThreadRestore(input.threadId);
 
     return defer(() => this.requestJoinCredentials$("run", input)).pipe(
       switchMap((credentials) => {
+        if (
+          !this.isCurrentRestoreGeneration(restoreGeneration, input.threadId)
+        ) {
+          return EMPTY;
+        }
+
         if (credentials === null) {
           return throwError(
             () => new Error("REST run request returned no credentials"),
@@ -330,7 +420,18 @@ export class IntelligenceAgent extends AbstractAgent {
         return this.observeThread$(canonicalInput, credentials, {
           completeOnRunError: false,
           streamMode: "run",
+          restoreGeneration,
         });
+      }),
+      catchError((error) => {
+        if (error instanceof AgentThreadLockedError) {
+          this.markThreadRestoreReady(restoreGeneration, input.threadId);
+          return throwError(() => error);
+        }
+
+        return throwError(() =>
+          this.toThreadRestoreError(restoreGeneration, input.threadId, error),
+        );
       }),
     );
   }
@@ -355,13 +456,35 @@ export class IntelligenceAgent extends AbstractAgent {
   protected connect(input: RunAgentInput): Observable<BaseEvent> {
     this.threadId = input.threadId;
     this.canonicalRunId = null;
-    const replayCursor = this.getReconnectCursor(input);
+    this.sharedState.latestConnectInputs.set(input.threadId, input);
+    const forceFull = this.forceFullConnectThreads.delete(input.threadId);
+    const replayCursor = forceFull ? null : this.getReconnectCursor(input);
+    const generation = this.beginThreadRestore(input.threadId);
 
+    return this.connectRestoreAttempt$(
+      input,
+      replayCursor,
+      generation,
+      !forceFull,
+    );
+  }
+
+  private connectRestoreAttempt$(
+    input: RunAgentInput,
+    replayCursor: string | null,
+    generation: number,
+    allowInvalidCursorRetry: boolean,
+  ): Observable<BaseEvent> {
     return defer(() =>
       this.requestJoinCredentials$("connect", input, replayCursor),
     ).pipe(
       switchMap((credentials) => {
+        if (!this.isCurrentRestoreGeneration(generation, input.threadId)) {
+          return EMPTY;
+        }
+
         if (credentials === null) {
+          this.markThreadRestoreReady(generation, input.threadId);
           return EMPTY;
         }
 
@@ -375,7 +498,30 @@ export class IntelligenceAgent extends AbstractAgent {
           completeOnRunError: false,
           streamMode: "connect",
           replayCursor,
+          restoreGeneration: generation,
         });
+      }),
+      catchError((error) => {
+        if (
+          allowInvalidCursorRetry &&
+          replayCursor !== null &&
+          error instanceof ThreadRestoreError &&
+          error.code === "invalid_cursor" &&
+          this.isCurrentRestoreGeneration(generation, input.threadId)
+        ) {
+          this.clearReconnectCursor(input.threadId);
+          const retryGeneration = this.beginThreadRestore(input.threadId);
+          return this.connectRestoreAttempt$(
+            input,
+            null,
+            retryGeneration,
+            false,
+          );
+        }
+
+        return throwError(() =>
+          this.toThreadRestoreError(generation, input.threadId, error),
+        );
       }),
     );
   }
@@ -389,19 +535,24 @@ export class IntelligenceAgent extends AbstractAgent {
     ownChannel: Channel | null,
     ownSocket: Socket | null,
   ): void {
+    let clearedOwnedResource = false;
     if (ownChannel) {
       ownChannel.leave();
       if (this.activeChannel === ownChannel) {
         this.activeChannel = null;
+        clearedOwnedResource = true;
       }
     }
     if (ownSocket) {
       ownSocket.disconnect();
       if (this.socket === ownSocket) {
         this.socket = null;
+        clearedOwnedResource = true;
       }
     }
-    this.canonicalRunId = null;
+    if (clearedOwnedResource) {
+      this.canonicalRunId = null;
+    }
   }
 
   private cleanup(): void {
@@ -521,12 +672,23 @@ export class IntelligenceAgent extends AbstractAgent {
       streamMode: "run" | "connect";
       channelMode?: "run" | "connect";
       replayCursor?: string | null;
+      restoreGeneration?: number;
     },
   ): Observable<BaseEvent> {
     return this.observeThreadSession$(input, credentials, options).pipe(
       catchError((error) => {
         if (!this.isSocketReconnectExhaustedError(error)) {
           return throwError(() => error);
+        }
+
+        if (
+          options.restoreGeneration !== undefined &&
+          !this.isCurrentRestoreGeneration(
+            options.restoreGeneration,
+            input.threadId,
+          )
+        ) {
+          return EMPTY;
         }
 
         const replayCursor = this.getReconnectCursor(input);
@@ -536,7 +698,12 @@ export class IntelligenceAgent extends AbstractAgent {
           replayCursor,
         ).pipe(
           switchMap((refreshedCredentials) =>
-            refreshedCredentials === null
+            refreshedCredentials === null ||
+            (options.restoreGeneration !== undefined &&
+              !this.isCurrentRestoreGeneration(
+                options.restoreGeneration,
+                input.threadId,
+              ))
               ? EMPTY
               : this.observeThread$(
                   this.applyCanonicalRunIdentity(input, refreshedCredentials, {
@@ -563,6 +730,7 @@ export class IntelligenceAgent extends AbstractAgent {
       streamMode: "run" | "connect";
       channelMode?: "run" | "connect";
       replayCursor?: string | null;
+      restoreGeneration?: number;
     },
   ): Observable<BaseEvent> {
     return defer(() => {
@@ -612,6 +780,8 @@ export class IntelligenceAgent extends AbstractAgent {
       const reconnectCursor = this.readDurableEventId(
         options.replayCursor ?? this.getReconnectCursor(input),
       );
+      const restoreGeneration = options.restoreGeneration;
+      let recognizedRestoreAttemptId: string | null = null;
       let latestObservedReplayCursor: string | null = null;
       const threadEvents$ = this.observeThreadEvents$(
         input.threadId,
@@ -628,11 +798,24 @@ export class IntelligenceAgent extends AbstractAgent {
         input.threadId,
         channel$,
         REPLAY_COMPLETE_EVENT,
-      ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+        restoreGeneration,
+      ).pipe(
+        tap(() => {
+          if (restoreGeneration !== undefined) {
+            this.markThreadRestoreReady(
+              restoreGeneration,
+              input.threadId,
+              recognizedRestoreAttemptId ?? undefined,
+            );
+          }
+        }),
+        shareReplay({ bufferSize: 1, refCount: true }),
+      );
       const streamIdle$ = this.observeControlEvent$(
         input.threadId,
         channel$,
         STREAM_IDLE_EVENT,
+        restoreGeneration,
       ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
       const streamIdleCompletion$ =
         options.streamMode === "connect"
@@ -652,7 +835,18 @@ export class IntelligenceAgent extends AbstractAgent {
                 ),
                 delay(CONNECT_STREAM_IDLE_REPLAY_FALLBACK_MS),
               ),
-            ).pipe(take(1))
+            ).pipe(
+              take(1),
+              tap(() => {
+                if (restoreGeneration !== undefined) {
+                  this.markThreadRestoreReady(
+                    restoreGeneration,
+                    input.threadId,
+                    recognizedRestoreAttemptId ?? undefined,
+                  );
+                }
+              }),
+            )
           : EMPTY;
       const threadCompleted$ = threadEvents$.pipe(
         ignoreElements(),
@@ -660,9 +854,128 @@ export class IntelligenceAgent extends AbstractAgent {
         take(1),
       );
       const terminal$ = merge(threadCompleted$, streamIdleCompletion$);
+      const restoreProgress$ =
+        restoreGeneration === undefined
+          ? EMPTY
+          : channel$.pipe(
+              switchMapOperator(({ channel }) =>
+                this.observeChannelEvent$<unknown>(
+                  channel,
+                  RESTORE_PROGRESS_EVENT,
+                ),
+              ),
+              tap((payload) => {
+                const progress = parseThreadRestoreProgress(payload);
+                if (
+                  progress &&
+                  recognizedRestoreAttemptId === progress.restoreAttemptId &&
+                  this.isCurrentRestoreGeneration(
+                    restoreGeneration,
+                    input.threadId,
+                  )
+                ) {
+                  this.setThreadRestoreState({
+                    status: "restoring",
+                    threadId: input.threadId,
+                    restoreAttemptId: progress.restoreAttemptId,
+                    elapsedMs: progress.elapsedMs,
+                  });
+                }
+              }),
+              ignoreElements(),
+              takeUntil(terminal$),
+            );
+      const restoreFailure$ =
+        restoreGeneration === undefined
+          ? EMPTY
+          : channel$.pipe(
+              switchMapOperator(({ channel }) =>
+                this.observeChannelEvent$<unknown>(
+                  channel,
+                  RESTORE_FAILED_EVENT,
+                ),
+              ),
+              mergeMap((payload) => {
+                const failure = parseThreadRestoreFailure(payload);
+                if (
+                  !failure ||
+                  recognizedRestoreAttemptId !== failure.restoreAttemptId ||
+                  !this.isCurrentRestoreGeneration(
+                    restoreGeneration,
+                    input.threadId,
+                  )
+                ) {
+                  return EMPTY;
+                }
+
+                const error = new ThreadRestoreError(failure);
+                this.setThreadRestoreState({
+                  status: "failed",
+                  threadId: input.threadId,
+                  restoreAttemptId: failure.restoreAttemptId,
+                  error,
+                });
+                return throwError(() => error);
+              }),
+              takeUntil(terminal$),
+            );
+      const restoreClose$ =
+        restoreGeneration === undefined
+          ? EMPTY
+          : channel$.pipe(
+              switchMapOperator((session) => session.close$.pipe(take(1))),
+              mergeMap(() => {
+                if (
+                  !recognizedRestoreAttemptId ||
+                  !this.isCurrentRestoreGeneration(
+                    restoreGeneration,
+                    input.threadId,
+                  ) ||
+                  this.restoreState.status === "ready" ||
+                  this.restoreState.status === "failed"
+                ) {
+                  return EMPTY;
+                }
+
+                const error = new ThreadRestoreError({
+                  restoreAttemptId: recognizedRestoreAttemptId,
+                  code: "internal_failure",
+                  retryable: true,
+                  retryAction: "reload_conversation",
+                });
+                this.setThreadRestoreState({
+                  status: "failed",
+                  threadId: input.threadId,
+                  restoreAttemptId: recognizedRestoreAttemptId,
+                  error,
+                });
+                return throwError(() => error);
+              }),
+              takeUntil(terminal$),
+            );
 
       return merge(
-        this.joinThreadChannel$(channel$),
+        this.joinThreadChannel$(channel$, (response) => {
+          if (
+            restoreGeneration === undefined ||
+            !this.isCurrentRestoreGeneration(restoreGeneration, input.threadId)
+          ) {
+            return;
+          }
+
+          const acknowledgement =
+            parseThreadRestoreJoinAcknowledgement(response);
+          recognizedRestoreAttemptId =
+            acknowledgement?.restoreAttemptId ?? null;
+          if (acknowledgement) {
+            this.setThreadRestoreState({
+              status: "restoring",
+              threadId: input.threadId,
+              restoreAttemptId: acknowledgement.restoreAttemptId,
+              elapsedMs: 0,
+            });
+          }
+        }),
         this.observeSocketHealth$(socket$).pipe(takeUntil(terminal$)),
         threadEvents$.pipe(takeUntil(streamIdleCompletion$)),
         replayComplete$.pipe(ignoreElements(), takeUntil(terminal$)),
@@ -670,14 +983,34 @@ export class IntelligenceAgent extends AbstractAgent {
           ignoreElements(),
           takeUntil(threadCompleted$),
         ),
+        restoreProgress$,
+        restoreFailure$,
+        restoreClose$,
       ).pipe(finalize(() => this.cleanupOwned(ownChannel, ownSocket)));
     });
   }
 
   private joinThreadChannel$(
     channel$: Observable<ɵPhoenixChannelSession>,
+    onJoined: (response?: unknown) => void = () => {},
   ): Observable<never> {
-    return ɵjoinPhoenixChannel$(channel$);
+    return ɵobservePhoenixJoinOutcome$(channel$).pipe(
+      take(1),
+      mergeMap((outcome) => {
+        if (outcome.type === "joined") {
+          onJoined(outcome.response);
+          return EMPTY;
+        }
+
+        return throwError(() =>
+          outcome.type === "timeout"
+            ? new Error("Timed out joining channel")
+            : new Error(
+                `Failed to join channel: ${JSON.stringify(outcome.response)}`,
+              ),
+        );
+      }),
+    );
   }
 
   private observeSocketHealth$(
@@ -692,11 +1025,20 @@ export class IntelligenceAgent extends AbstractAgent {
   private observeThreadEvents$(
     threadId: string,
     channel$: Observable<ɵPhoenixChannelSession>,
-    options: { completeOnRunError: boolean; streamMode: "run" | "connect" },
+    options: {
+      completeOnRunError: boolean;
+      streamMode: "run" | "connect";
+      restoreGeneration?: number;
+    },
   ): Observable<BaseEvent> {
     return channel$.pipe(
       switchMapOperator(({ channel }) =>
         this.observeChannelEvent$<BaseEvent>(channel, CLIENT_AG_UI_EVENT),
+      ),
+      filter(
+        () =>
+          options.restoreGeneration === undefined ||
+          this.isCurrentRestoreGeneration(options.restoreGeneration, threadId),
       ),
       tap((payload) => {
         this.updateLastSeenEventId(threadId, payload);
@@ -717,10 +1059,16 @@ export class IntelligenceAgent extends AbstractAgent {
     threadId: string,
     channel$: Observable<ɵPhoenixChannelSession>,
     eventName: string,
+    restoreGeneration?: number,
   ): Observable<unknown> {
     return channel$.pipe(
       switchMapOperator(({ channel }) =>
         this.observeChannelEvent$<unknown>(channel, eventName),
+      ),
+      filter(
+        () =>
+          restoreGeneration === undefined ||
+          this.isCurrentRestoreGeneration(restoreGeneration, threadId),
       ),
       tap((payload) =>
         this.updateLastSeenEventIdFromControl(threadId, payload),
@@ -781,10 +1129,18 @@ export class IntelligenceAgent extends AbstractAgent {
     streamMode: "run" | "connect",
     replayCursor?: string | null,
   ): Record<string, unknown> {
+    const capabilities = {
+      restore: {
+        version: 1,
+        sdkVersion: COPILOTKIT_VERSION,
+      },
+    };
+
     return streamMode === "run"
       ? {
           stream_mode: "run",
           run_id: input.runId,
+          capabilities,
         }
       : {
           stream_mode: "connect",
@@ -792,7 +1148,89 @@ export class IntelligenceAgent extends AbstractAgent {
             replayCursor === undefined
               ? this.getReconnectCursor(input)
               : replayCursor,
+          capabilities,
         };
+  }
+
+  private beginThreadRestore(threadId: string): number {
+    const generation = ++this.restoreGeneration;
+    this.setThreadRestoreState({
+      status: "restoring",
+      threadId,
+      elapsedMs: 0,
+    });
+    return generation;
+  }
+
+  private isCurrentRestoreGeneration(
+    generation: number,
+    threadId: string,
+  ): boolean {
+    return (
+      generation === this.restoreGeneration &&
+      this.restoreState.threadId === threadId
+    );
+  }
+
+  private markThreadRestoreReady(
+    generation: number,
+    threadId: string,
+    restoreAttemptId?: string,
+  ): void {
+    if (!this.isCurrentRestoreGeneration(generation, threadId)) {
+      return;
+    }
+
+    this.setThreadRestoreState({
+      status: "ready",
+      threadId,
+      ...(restoreAttemptId ? { restoreAttemptId } : {}),
+    });
+  }
+
+  private setThreadRestoreState(state: ThreadRestoreState): void {
+    this.restoreState = state;
+    for (const listener of this.restoreListeners) {
+      listener();
+    }
+  }
+
+  private toThreadRestoreError(
+    generation: number,
+    threadId: string,
+    cause: unknown,
+  ): unknown {
+    if (
+      cause instanceof ThreadRestoreError ||
+      !this.isCurrentRestoreGeneration(generation, threadId)
+    ) {
+      return cause;
+    }
+
+    const restoreAttemptId =
+      this.restoreState.status === "restoring" &&
+      this.restoreState.restoreAttemptId
+        ? this.restoreState.restoreAttemptId
+        : `ra_client_${randomUUID()}`;
+    const message = cause instanceof Error ? cause.message : String(cause);
+    const error = new ThreadRestoreError(
+      {
+        restoreAttemptId,
+        code: message.startsWith("REST ")
+          ? "dependency_failure"
+          : "internal_failure",
+        retryable: true,
+        retryAction: "reload_conversation",
+      },
+      { message, cause },
+    );
+    this.setThreadRestoreState({
+      status: "failed",
+      threadId,
+      restoreAttemptId,
+      error,
+    });
+    return error;
   }
 
   private getLastSeenEventId(threadId: string): string | null {

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -85,6 +85,12 @@ const RESTORE_PROGRESS_EVENT = "restore_progress";
 const RESTORE_FAILED_EVENT = "restore_failed";
 const STOP_RUN_EVENT = "stop_run";
 const CONNECT_STREAM_IDLE_REPLAY_FALLBACK_MS = 100;
+const COMPACT_RESTORE_CAPABILITY = Object.freeze({
+  schemaVersion: 1,
+  reducerVersion: 1,
+  sanitizerVersion: 1,
+  compactorVersion: 1,
+});
 
 interface IntelligenceAgentSharedState {
   lastSeenEventIds: Map<string, string>;
@@ -163,6 +169,8 @@ export interface IntelligenceAgentConfig {
   headers?: Record<string, string>;
   /** Optional credentials mode for fetch requests */
   credentials?: RequestCredentials;
+  /** Advertise compact full-thread restore support. Defaults to true. */
+  compactRestore?: boolean;
 }
 
 export class IntelligenceAgent
@@ -191,7 +199,10 @@ export class IntelligenceAgent
     },
   ) {
     super();
-    this.config = config;
+    this.config = {
+      ...config,
+      compactRestore: config.compactRestore ?? true,
+    };
     this.sharedState = sharedState;
   }
 
@@ -282,6 +293,7 @@ export class IntelligenceAgent
     parameters?: RunAgentParameters,
     subscriber?: AgentSubscriber,
   ): Promise<RunAgentResult> {
+    const compactRestore = this.config.compactRestore ?? true;
     // Access private fields through a type escape hatch — these are set/read
     // by the base class and must be managed identically to the original.
     // Using `any` because these fields are private in AbstractAgent, and
@@ -323,7 +335,7 @@ export class IntelligenceAgent
         resolveCompletion = resolve;
       });
 
-      const source$ = defer(() => this.connect(input)).pipe(
+      const source$ = defer(() => this.connect(input, compactRestore)).pipe(
         // transformChunks reassembles partial/streamed messages — still needed.
         transformChunks(this.debugLogger),
         // NOTE: verifyEvents is intentionally omitted here. See JSDoc above.
@@ -453,7 +465,10 @@ export class IntelligenceAgent
    * gateway only streams events past it instead of replaying the
    * entire history every time the chat re-opens a socket.
    */
-  protected connect(input: RunAgentInput): Observable<BaseEvent> {
+  protected connect(
+    input: RunAgentInput,
+    compactRestore = this.config.compactRestore ?? true,
+  ): Observable<BaseEvent> {
     this.threadId = input.threadId;
     this.canonicalRunId = null;
     this.sharedState.latestConnectInputs.set(input.threadId, input);
@@ -466,6 +481,7 @@ export class IntelligenceAgent
       replayCursor,
       generation,
       !forceFull,
+      compactRestore,
     );
   }
 
@@ -474,6 +490,7 @@ export class IntelligenceAgent
     replayCursor: string | null,
     generation: number,
     allowInvalidCursorRetry: boolean,
+    compactRestore: boolean,
   ): Observable<BaseEvent> {
     return defer(() =>
       this.requestJoinCredentials$("connect", input, replayCursor),
@@ -499,6 +516,7 @@ export class IntelligenceAgent
           streamMode: "connect",
           replayCursor,
           restoreGeneration: generation,
+          compactRestore,
         });
       }),
       catchError((error) => {
@@ -516,6 +534,7 @@ export class IntelligenceAgent
             null,
             retryGeneration,
             false,
+            compactRestore,
           );
         }
 
@@ -673,6 +692,7 @@ export class IntelligenceAgent
       channelMode?: "run" | "connect";
       replayCursor?: string | null;
       restoreGeneration?: number;
+      compactRestore?: boolean;
     },
   ): Observable<BaseEvent> {
     return this.observeThreadSession$(input, credentials, options).pipe(
@@ -731,6 +751,7 @@ export class IntelligenceAgent
       channelMode?: "run" | "connect";
       replayCursor?: string | null;
       restoreGeneration?: number;
+      compactRestore?: boolean;
     },
   ): Observable<BaseEvent> {
     return defer(() => {
@@ -765,6 +786,7 @@ export class IntelligenceAgent
         input,
         options.channelMode ?? options.streamMode,
         options.replayCursor,
+        options.streamMode === "connect" && options.compactRestore === true,
       );
       const channel$ = ɵphoenixChannel$({
         socket$,
@@ -1138,11 +1160,21 @@ export class IntelligenceAgent
     input: RunAgentInput,
     streamMode: "run" | "connect",
     replayCursor?: string | null,
+    compactRestore = false,
   ): Record<string, unknown> {
+    const lastSeenEventId =
+      replayCursor === undefined
+        ? this.getReconnectCursor(input)
+        : replayCursor;
     const capabilities = {
       restore: {
         version: 1,
         sdkVersion: COPILOTKIT_VERSION,
+        ...(streamMode === "connect" &&
+        lastSeenEventId === null &&
+        compactRestore
+          ? { compact: COMPACT_RESTORE_CAPABILITY }
+          : {}),
       },
     };
 
@@ -1154,10 +1186,7 @@ export class IntelligenceAgent
         }
       : {
           stream_mode: "connect",
-          last_seen_event_id:
-            replayCursor === undefined
-              ? this.getReconnectCursor(input)
-              : replayCursor,
+          last_seen_event_id: lastSeenEventId,
           capabilities,
         };
   }

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -826,12 +826,14 @@ export class IntelligenceAgent
               ]),
               streamIdle$.pipe(
                 take(1),
-                filter((payload) =>
-                  this.canFallbackCompleteConnect(
-                    payload,
-                    reconnectCursor,
-                    latestObservedReplayCursor,
-                  ),
+                filter(
+                  (payload) =>
+                    recognizedRestoreAttemptId === null &&
+                    this.canFallbackCompleteConnect(
+                      payload,
+                      reconnectCursor,
+                      latestObservedReplayCursor,
+                    ),
                 ),
                 delay(CONNECT_STREAM_IDLE_REPLAY_FALLBACK_MS),
               ),

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -786,7 +786,7 @@ export class IntelligenceAgent
       const threadEvents$ = this.observeThreadEvents$(
         input.threadId,
         channel$,
-        options,
+        { ...options, runId: input.runId },
       ).pipe(
         tap((payload) => {
           latestObservedReplayCursor =
@@ -1030,6 +1030,7 @@ export class IntelligenceAgent
     options: {
       completeOnRunError: boolean;
       streamMode: "run" | "connect";
+      runId: string;
       restoreGeneration?: number;
     },
   ): Observable<BaseEvent> {
@@ -1041,6 +1042,13 @@ export class IntelligenceAgent
         () =>
           options.restoreGeneration === undefined ||
           this.isCurrentRestoreGeneration(options.restoreGeneration, threadId),
+      ),
+      filter(
+        (payload) =>
+          options.streamMode !== "run" ||
+          (payload.type !== EventType.RUN_FINISHED &&
+            payload.type !== EventType.RUN_ERROR) ||
+          payload.runId === options.runId,
       ),
       tap((payload) => {
         this.updateLastSeenEventId(threadId, payload);

--- a/packages/core/src/thread-restore.ts
+++ b/packages/core/src/thread-restore.ts
@@ -1,0 +1,161 @@
+export const THREAD_RESTORE_FAILURE_CODES = [
+  "timeout",
+  "dependency_failure",
+  "decode_failure",
+  "partial_window",
+  "invalid_cursor",
+  "buffer_overflow",
+  "scope_violation",
+  "internal_failure",
+] as const;
+
+export type ThreadRestoreFailureCode =
+  (typeof THREAD_RESTORE_FAILURE_CODES)[number];
+
+export type ThreadRestoreRetryAction = "reload_conversation" | "none";
+
+export interface ThreadRestoreProgress {
+  restoreAttemptId: string;
+  status: "restoring";
+  elapsedMs: number;
+}
+
+export interface ThreadRestoreFailure {
+  restoreAttemptId: string;
+  code: ThreadRestoreFailureCode;
+  retryable: boolean;
+  retryAction: ThreadRestoreRetryAction;
+}
+
+export type ThreadRestoreState =
+  | {
+      status: "ready";
+      threadId: string;
+      restoreAttemptId?: string;
+    }
+  | {
+      status: "restoring";
+      threadId: string;
+      restoreAttemptId?: string;
+      elapsedMs: number;
+    }
+  | {
+      status: "failed";
+      threadId: string;
+      restoreAttemptId: string;
+      error: ThreadRestoreError;
+    };
+
+export interface ThreadRestoreAware {
+  getThreadRestoreState(): ThreadRestoreState;
+  subscribeToThreadRestore(listener: () => void): () => void;
+  forceFullRestore(): Promise<void>;
+}
+
+export class ThreadRestoreError extends Error {
+  readonly code: ThreadRestoreFailureCode;
+  readonly retryable: boolean;
+  readonly retryAction: ThreadRestoreRetryAction;
+  readonly restoreAttemptId: string;
+
+  constructor(
+    failure: ThreadRestoreFailure,
+    options?: { message?: string; cause?: unknown },
+  ) {
+    super(options?.message ?? `Thread restore failed (${failure.code})`, {
+      cause: options?.cause,
+    });
+    this.name = "ThreadRestoreError";
+    this.code = failure.code;
+    this.retryable = failure.retryable;
+    this.retryAction = failure.retryAction;
+    this.restoreAttemptId = failure.restoreAttemptId;
+  }
+}
+
+export function isThreadRestoreAware(
+  agent: unknown,
+): agent is ThreadRestoreAware {
+  if (typeof agent !== "object" || agent === null) {
+    return false;
+  }
+
+  const candidate = agent as Partial<ThreadRestoreAware>;
+  return (
+    typeof candidate.getThreadRestoreState === "function" &&
+    typeof candidate.subscribeToThreadRestore === "function" &&
+    typeof candidate.forceFullRestore === "function"
+  );
+}
+
+export function parseThreadRestoreJoinAcknowledgement(
+  payload: unknown,
+): { restoreAttemptId: string } | null {
+  const envelope = asRecord(payload);
+  const restore = asRecord(envelope?.restore);
+  return restore?.mode === "failure_reporting" &&
+    isNonEmptyString(restore.restoreAttemptId)
+    ? { restoreAttemptId: restore.restoreAttemptId }
+    : null;
+}
+
+export function parseThreadRestoreProgress(
+  payload: unknown,
+): ThreadRestoreProgress | null {
+  const progress = asRecord(payload);
+  return progress &&
+    isNonEmptyString(progress.restoreAttemptId) &&
+    progress.status === "restoring" &&
+    typeof progress.elapsedMs === "number" &&
+    Number.isFinite(progress.elapsedMs) &&
+    progress.elapsedMs >= 0
+    ? {
+        restoreAttemptId: progress.restoreAttemptId,
+        status: "restoring",
+        elapsedMs: progress.elapsedMs,
+      }
+    : null;
+}
+
+export function parseThreadRestoreFailure(
+  payload: unknown,
+): ThreadRestoreFailure | null {
+  const failure = asRecord(payload);
+  return failure &&
+    isNonEmptyString(failure.restoreAttemptId) &&
+    isThreadRestoreFailureCode(failure.code) &&
+    typeof failure.retryable === "boolean" &&
+    isThreadRestoreRetryAction(failure.retryAction)
+    ? {
+        restoreAttemptId: failure.restoreAttemptId,
+        code: failure.code,
+        retryable: failure.retryable,
+        retryAction: failure.retryAction,
+      }
+    : null;
+}
+
+function isThreadRestoreFailureCode(
+  value: unknown,
+): value is ThreadRestoreFailureCode {
+  return (
+    typeof value === "string" &&
+    (THREAD_RESTORE_FAILURE_CODES as readonly string[]).includes(value)
+  );
+}
+
+function isThreadRestoreRetryAction(
+  value: unknown,
+): value is ThreadRestoreRetryAction {
+  return value === "reload_conversation" || value === "none";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/packages/core/src/utils/phoenix-observable.ts
+++ b/packages/core/src/utils/phoenix-observable.ts
@@ -27,6 +27,7 @@ export interface ɵPhoenixChannelLike {
   on(event: string, callback: (payload: unknown) => void): number;
   off(event: string, ref?: number): void;
   onError?(callback: (reason?: unknown) => void): unknown;
+  onClose?(callback: (reason?: unknown) => void): unknown;
   join(params?: Record<string, unknown>): ɵPhoenixPushLike;
   push?(event: string, payload: unknown): ɵPhoenixPushLike;
   leave(): void;
@@ -54,7 +55,7 @@ export type ɵPhoenixSocketSignal =
  * Terminal outcomes of a Phoenix channel join attempt.
  */
 export type ɵPhoenixJoinOutcome =
-  | { type: "joined" }
+  | { type: "joined"; response?: unknown }
   | { type: "error"; response?: unknown }
   | { type: "timeout" };
 
@@ -72,6 +73,7 @@ export interface ɵPhoenixSocketSession {
 export interface ɵPhoenixChannelSession {
   channel: ɵPhoenixChannelLike;
   joinOutcome$: Observable<ɵPhoenixJoinOutcome>;
+  close$: Observable<unknown>;
 }
 
 /**
@@ -116,8 +118,8 @@ function ɵcreatePhoenixJoinOutcome$(
   return new Observable<ɵPhoenixJoinOutcome>((observer) => {
     channel
       .join()
-      .receive("ok", () => {
-        observer.next({ type: "joined" });
+      .receive("ok", (response?: unknown) => {
+        observer.next({ type: "joined", response });
         observer.complete();
       })
       .receive("error", (response?: unknown) => {
@@ -129,6 +131,30 @@ function ɵcreatePhoenixJoinOutcome$(
         observer.complete();
       });
   });
+}
+
+/**
+ * Adapt a Phoenix channel close callback into a single-outcome observable.
+ */
+function ɵcreatePhoenixChannelClose$(
+  channel: ɵPhoenixChannelLike,
+): Observable<unknown> {
+  if (!channel.onClose) {
+    return NEVER;
+  }
+
+  return new Observable<unknown>((observer) => {
+    const ref = channel.onClose!((reason?: unknown) => {
+      observer.next(reason);
+      observer.complete();
+    });
+
+    return () => {
+      if (typeof ref === "number") {
+        channel.off("phx_close", ref);
+      }
+    };
+  }).pipe(take(1), shareReplay({ bufferSize: 1, refCount: true }));
 }
 
 /**
@@ -178,11 +204,13 @@ export function ɵphoenixChannel$(
         const joinOutcome$ = ɵcreatePhoenixJoinOutcome$(channel).pipe(
           shareReplay({ bufferSize: 1, refCount: true }),
         );
+        const close$ = ɵcreatePhoenixChannelClose$(channel);
 
         return concat(
           of({
             channel,
             joinOutcome$,
+            close$,
           }),
           NEVER,
         ).pipe(

--- a/packages/react-core/src/v2/__tests__/headless-exports.test.ts
+++ b/packages/react-core/src/v2/__tests__/headless-exports.test.ts
@@ -14,6 +14,7 @@ describe("@copilotkit/react-core/v2/headless runtime exports", () => {
     const hooks: (keyof typeof headless)[] = [
       "useCopilotKit",
       "useAgent",
+      "useThreadRestore",
       "useFrontendTool",
       "useComponent",
       "useHumanInTheLoop",

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -19,6 +19,7 @@ import type { Suggestion, CopilotKitCoreErrorCode } from "@copilotkit/core";
 import {
   CopilotKitCoreRuntimeConnectionStatus,
   isRunCompletionAware,
+  isThreadRestoreAware,
   ɵcreateThreadStore,
 } from "@copilotkit/core";
 import type { ɵThreadRuntimeContext, ɵThreadStore } from "@copilotkit/core";
@@ -41,6 +42,8 @@ import {
 } from "../../lib/transcription-client";
 import { LastUserMessageContext } from "./last-user-message-context";
 import type { LastUserMessageState } from "./last-user-message-context";
+import { useThreadRestoreForAgent } from "../../hooks/use-thread-restore";
+import type { UseThreadRestoreResult } from "../../hooks/use-thread-restore";
 
 export type CopilotChatProps = Omit<
   CopilotChatViewProps,
@@ -57,6 +60,7 @@ export type CopilotChatProps = Omit<
   | "onDragOver"
   | "onDragLeave"
   | "onDrop"
+  | "threadRestore"
 > & {
   agentId?: string;
   threadId?: string;
@@ -124,6 +128,7 @@ export function CopilotChat({
     agentId: resolvedAgentId,
     throttleMs,
   });
+  const observedThreadRestore = useThreadRestoreForAgent(agent);
   const { copilotkit } = useCopilotKit();
   const { suggestions: autoSuggestions } = useSuggestions({
     agentId: resolvedAgentId,
@@ -227,6 +232,24 @@ export function CopilotChat({
   >(null);
   const isConnecting =
     hasExplicitThreadId && lastConnectedThreadId !== resolvedThreadId;
+  // connectAgent begins in an effect, one paint after the first render. Treat
+  // that known pre-connect window as restoring so an explicit thread never
+  // flashes a usable composer before the core restore store advances.
+  const threadRestore = useMemo<UseThreadRestoreResult>(() => {
+    if (
+      isConnecting &&
+      isThreadRestoreAware(agent) &&
+      observedThreadRestore.status === "ready"
+    ) {
+      return {
+        status: "restoring",
+        threadId: resolvedThreadId,
+        elapsedMs: 0,
+        reloadConversation: observedThreadRestore.reloadConversation,
+      };
+    }
+    return observedThreadRestore;
+  }, [agent, isConnecting, observedThreadRestore, resolvedThreadId]);
   const activeConnectCountRef = useRef(0);
   const pendingRunActivityReconnectRef = useRef(false);
   const runActivityReconnectGenerationRef = useRef(0);
@@ -458,6 +481,7 @@ export function CopilotChat({
     let detached = false;
     let wakeReconnectActive = false;
     let pendingAgentIdleDrain: ReturnType<typeof setTimeout> | null = null;
+    const activeWakeRunIds = activeWakeRunIdsRef.current;
     const hasActiveAgentRun = () =>
       activeLocalRunIdsRef.current.size > 0 || agent.isRunning;
     const scheduleAgentIdleDrain = () => {
@@ -576,7 +600,7 @@ export function CopilotChat({
       if (wakeReconnectActive) {
         agent.detachActiveRun().catch(() => {});
       }
-      activeWakeRunIdsRef.current.clear();
+      activeWakeRunIds.clear();
       subscription.unsubscribe();
       if (ownsStandaloneStore) {
         threadStore.setContext(null);
@@ -945,7 +969,7 @@ export function CopilotChat({
     setTimeout(() => {
       fileInputRef.current?.click();
     }, 100);
-  }, []);
+  }, [fileInputRef]);
 
   // Use shallow spread instead of ts-deepmerge. ts-deepmerge deep-clones plain
   // objects even from a single source, which would defeat the reference
@@ -1069,6 +1093,7 @@ export function CopilotChat({
     onDrop: handleDrop,
     isConnecting,
     hasExplicitThreadId,
+    threadRestore,
   };
 
   // Always create a provider with merged values

--- a/packages/react-core/src/v2/components/chat/CopilotChatRestoreView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatRestoreView.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback, useRef, useState } from "react";
+import type { UseThreadRestoreResult } from "../../hooks/use-thread-restore";
+import {
+  CopilotChatDefaultLabels,
+  useCopilotChatConfiguration,
+} from "../../providers/CopilotChatConfigurationProvider";
+import { Button } from "../ui/button";
+import { cn } from "../../lib/utils";
+
+export interface CopilotChatRestoreViewProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  threadRestore: UseThreadRestoreResult;
+}
+
+/** Default full-chat gate shown while a conversation is restoring or failed. */
+export function CopilotChatRestoreView({
+  threadRestore,
+  className,
+  ...props
+}: CopilotChatRestoreViewProps) {
+  const labels =
+    useCopilotChatConfiguration()?.labels ?? CopilotChatDefaultLabels;
+  const reloadConversation = threadRestore.reloadConversation;
+  const reloadInFlightRef = useRef(false);
+  const [isReloading, setIsReloading] = useState(false);
+
+  const handleReload = useCallback(async () => {
+    if (reloadInFlightRef.current) return;
+    reloadInFlightRef.current = true;
+    setIsReloading(true);
+    try {
+      await reloadConversation();
+    } finally {
+      reloadInFlightRef.current = false;
+      setIsReloading(false);
+    }
+  }, [reloadConversation]);
+
+  if (threadRestore.status === "ready") return null;
+
+  return (
+    <div
+      data-copilotkit
+      data-testid="copilot-chat-restore"
+      className={cn(
+        "copilotKitChat cpk:h-full cpk:flex cpk:items-center cpk:justify-center cpk:px-6 cpk:text-center",
+        className,
+      )}
+      {...props}
+    >
+      {threadRestore.status === "restoring" ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="cpk:text-sm cpk:text-muted-foreground"
+        >
+          {labels.restoreLoadingText}
+        </div>
+      ) : (
+        <div
+          role="alert"
+          className="cpk:flex cpk:max-w-sm cpk:flex-col cpk:items-center cpk:gap-3"
+        >
+          <p className="cpk:m-0 cpk:text-sm cpk:font-medium cpk:text-foreground">
+            {labels.restoreFailedText}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleReload}
+            disabled={isReloading}
+          >
+            {labels.restoreReloadButtonLabel}
+          </Button>
+          <p className="cpk:m-0 cpk:text-xs cpk:text-muted-foreground">
+            {labels.restoreSupportIdLabel}: {threadRestore.restoreAttemptId}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CopilotChatRestoreView;

--- a/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatView.tsx
@@ -8,26 +8,20 @@ import React, {
 import { ScrollElementContext } from "./scroll-element-context";
 import type { WithSlots, SlotValue } from "../../lib/slots";
 import { renderSlot } from "../../lib/slots";
-import CopilotChatMessageView from "./CopilotChatMessageView";
+import { CopilotChatMessageView } from "./CopilotChatMessageView";
 import type { IntelligenceIndicatorView } from "../intelligence-indicator";
 import type {
   CopilotChatInputProps,
   CopilotChatInputMode,
 } from "./CopilotChatInput";
-import CopilotChatInput from "./CopilotChatInput";
-import CopilotChatSuggestionView, {
-  CopilotChatSuggestionViewProps,
-} from "./CopilotChatSuggestionView";
+import { CopilotChatInput } from "./CopilotChatInput";
+import { CopilotChatSuggestionView } from "./CopilotChatSuggestionView";
 import type { Suggestion } from "@copilotkit/core";
 import type { Message } from "@ag-ui/core";
 import type { Attachment } from "@copilotkit/shared";
 import { CopilotChatAttachmentQueue } from "./CopilotChatAttachmentQueue";
 import { twMerge } from "tailwind-merge";
-import {
-  StickToBottom,
-  useStickToBottom,
-  useStickToBottomContext,
-} from "use-stick-to-bottom";
+import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { ChevronDown, Upload } from "lucide-react";
 import { Button } from "../../components/ui/button";
 import { cn } from "../../lib/utils";
@@ -39,6 +33,8 @@ import { useKeyboardHeight } from "../../hooks/use-keyboard-height";
 import { normalizeAutoScroll } from "./normalize-auto-scroll";
 import type { AutoScrollMode } from "./normalize-auto-scroll";
 import { usePinToSend } from "../../hooks/use-pin-to-send";
+import type { UseThreadRestoreResult } from "../../hooks/use-thread-restore";
+import { CopilotChatRestoreView } from "./CopilotChatRestoreView";
 
 // Vertical gap between the scroll-to-bottom button and the input container.
 const SCROLL_BUTTON_OFFSET = 16;
@@ -60,6 +56,7 @@ export type CopilotChatViewProps = WithSlots<
     scrollView: typeof CopilotChatView.ScrollView;
     input: typeof CopilotChatInput;
     suggestionView: typeof CopilotChatSuggestionView;
+    restoreView: typeof CopilotChatRestoreView;
   },
   {
     messages?: Message[];
@@ -102,6 +99,11 @@ export type CopilotChatViewProps = WithSlots<
      * connect) rather than a generic "start a new chat" greeting.
      */
     hasExplicitThreadId?: boolean;
+    /**
+     * Explicit restore lifecycle for custom/headless composition. Any state
+     * other than `ready` replaces the normal message and input surfaces.
+     */
+    threadRestore?: UseThreadRestoreResult;
     /**
      * @deprecated Use the `input` slot's `disclaimer` prop instead:
      * ```tsx
@@ -168,6 +170,8 @@ export function CopilotChatView({
   onDrop,
   isConnecting = false,
   hasExplicitThreadId = false,
+  threadRestore,
+  restoreView,
   // Deprecated — forwarded to input slot
   disclaimer,
   // Pass-through to CopilotChatMessageView's intelligenceIndicator slot
@@ -192,8 +196,7 @@ export function CopilotChatView({
   const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Track keyboard state for mobile
-  const { isKeyboardOpen, keyboardHeight, availableHeight } =
-    useKeyboardHeight();
+  const { isKeyboardOpen, keyboardHeight } = useKeyboardHeight();
 
   // Track input container height changes
   useEffect(() => {
@@ -314,6 +317,18 @@ export function CopilotChatView({
       </div>
     ),
   });
+  const BoundRestoreView = threadRestore
+    ? renderSlot(restoreView, CopilotChatRestoreView, { threadRestore })
+    : null;
+
+  // Restoration is a full-surface gate: partially restored messages and a
+  // usable composer would imply the conversation is ready when it is not.
+  // Keep this after the component's hooks so transitions do not change hook
+  // ordering, but before every normal-chat render branch (welcome, children,
+  // and default view).
+  if (threadRestore && threadRestore.status !== "ready") {
+    return BoundRestoreView;
+  }
 
   // Welcome screen logic
   const isEmpty = messages.length === 0;
@@ -401,6 +416,7 @@ export function CopilotChatView({
           input: BoundInput,
           scrollView: BoundScrollView,
           suggestionView: BoundSuggestionView ?? <></>,
+          restoreView: BoundRestoreView ?? <></>,
         })}
       </div>
     );

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -564,7 +564,7 @@ describe("CopilotChat activity message rendering", () => {
         capabilities: {
           restore: {
             version: 1,
-            sdkVersion: "1.67.0",
+            sdkVersion: "1.67.1",
           },
         },
       });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -565,6 +565,12 @@ describe("CopilotChat activity message rendering", () => {
           restore: {
             version: 1,
             sdkVersion: "1.67.1",
+            compact: {
+              schemaVersion: 1,
+              reducerVersion: 1,
+              sanitizerVersion: 1,
+              compactorVersion: 1,
+            },
           },
         },
       });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.tsx
@@ -36,7 +36,7 @@ const {
     run: vi.fn().mockResolvedValue(undefined),
     destroy: mockDestroy,
   }));
-  const mockSockets: MockPhoenixSocket[] = [];
+  const mockSockets: MockPhoenixSocketImpl[] = [];
 
   class MockPhoenixPush {
     private callbacks = new Map<string, (response?: unknown) => void>();
@@ -113,7 +113,7 @@ const {
     }
   }
 
-  class MockPhoenixSocket {
+  class MockPhoenixSocketImpl {
     public channels: MockPhoenixChannel[] = [];
 
     constructor(
@@ -145,7 +145,7 @@ const {
     mockWebsandboxCreate: mockCreate,
     mockWebsandboxDestroy: mockDestroy,
     mockPhoenixSockets: mockSockets,
-    MockPhoenixSocket,
+    MockPhoenixSocket: MockPhoenixSocketImpl,
   };
 });
 
@@ -561,11 +561,23 @@ describe("CopilotChat activity message rendering", () => {
       expect(channel.params).toEqual({
         stream_mode: "connect",
         last_seen_event_id: null,
+        capabilities: {
+          restore: {
+            version: 1,
+            sdkVersion: "1.67.0",
+          },
+        },
       });
 
-      channel.triggerJoin("ok");
+      channel.triggerJoin("ok", {
+        restore: {
+          mode: "failure_reporting",
+          restoreAttemptId: "restore-connect-1",
+        },
+      });
       channel.serverPush("ag_ui_event", {
         type: EventType.RUN_STARTED,
+        eventId: "event-1",
         threadId,
         run_id: "backend-run-1",
         input: {
@@ -580,6 +592,7 @@ describe("CopilotChat activity message rendering", () => {
       });
       channel.serverPush("ag_ui_event", {
         type: EventType.ACTIVITY_SNAPSHOT,
+        eventId: "event-2",
         messageId: testId("connect-a2ui-activity"),
         activityType: "a2ui-surface",
         content: {
@@ -611,7 +624,9 @@ describe("CopilotChat activity message rendering", () => {
       });
       channel.serverPush("ag_ui_event", {
         type: EventType.RUN_FINISHED,
+        eventId: "event-3",
       });
+      channel.serverPush("replay_complete", { latestEventId: "event-3" });
       channel.serverPush("stream_idle", { latestEventId: "event-3" });
 
       await waitFor(() => {

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatRestoreView.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatRestoreView.test.tsx
@@ -1,0 +1,65 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ThreadRestoreError } from "@copilotkit/core";
+import { CopilotChatRestoreView } from "../CopilotChatRestoreView";
+
+describe("CopilotChatRestoreView", () => {
+  it("renders an accessible restoring status", () => {
+    render(
+      <CopilotChatRestoreView
+        threadRestore={{
+          status: "restoring",
+          threadId: "thread-1",
+          restoreAttemptId: "restore-1",
+          elapsedMs: 5_000,
+          reloadConversation: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Restoring conversation…",
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders exact failure copy, support ID, and collapses duplicate reloads", async () => {
+    let resolveReload!: () => void;
+    const reloadConversation = vi.fn(
+      () => new Promise<void>((resolve) => (resolveReload = resolve)),
+    );
+    const error = new ThreadRestoreError({
+      restoreAttemptId: "restore-support-123",
+      code: "timeout",
+      retryable: true,
+      retryAction: "reload_conversation",
+    });
+
+    render(
+      <CopilotChatRestoreView
+        threadRestore={{
+          status: "failed",
+          threadId: "thread-1",
+          restoreAttemptId: error.restoreAttemptId,
+          error,
+          reloadConversation,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "This conversation couldn’t be restored.",
+    );
+    expect(screen.getByText("Support ID: restore-support-123")).not.toBeNull();
+
+    const button = screen.getByRole("button", {
+      name: "Reload conversation",
+    });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(reloadConversation).toHaveBeenCalledTimes(1);
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    await act(async () => resolveReload());
+  });
+});

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.connectingGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatView.connectingGate.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect } from "vitest";
 import { CopilotChatView } from "../CopilotChatView";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
+import { vi } from "vitest";
 
 // Minimal provider wrapper. No agent registry is required because these tests
 // only exercise local render decisions (welcome-screen suppression) that
@@ -17,6 +18,53 @@ const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
 );
 
 describe("CopilotChatView connect-gating", () => {
+  it("renders only the restore gate while restoration is in progress", () => {
+    render(
+      <TestWrapper>
+        <CopilotChatView
+          messages={[]}
+          threadRestore={{
+            status: "restoring",
+            threadId: "test-thread",
+            elapsedMs: 0,
+            reloadConversation: vi.fn(),
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Restoring conversation…",
+    );
+    expect(screen.queryByPlaceholderText("Type a message...")).toBeNull();
+  });
+
+  it("passes restore state and actions to a replacement restoreView slot", () => {
+    const RestoreView = vi.fn(
+      ({ threadRestore }: { threadRestore: { status: string } }) => (
+        <div>Custom {threadRestore.status}</div>
+      ),
+    );
+
+    render(
+      <TestWrapper>
+        <CopilotChatView
+          messages={[]}
+          restoreView={RestoreView}
+          threadRestore={{
+            status: "restoring",
+            threadId: "test-thread",
+            elapsedMs: 0,
+            reloadConversation: vi.fn(),
+          }}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText("Custom restoring")).not.toBeNull();
+    expect(RestoreView).toHaveBeenCalled();
+  });
+
   it("suppresses the welcome screen while isConnecting=true", () => {
     render(
       <TestWrapper>

--- a/packages/react-core/src/v2/components/chat/index.ts
+++ b/packages/react-core/src/v2/components/chat/index.ts
@@ -53,6 +53,11 @@ export {
 export { CopilotChat, type CopilotChatProps } from "./CopilotChat";
 
 export {
+  CopilotChatRestoreView,
+  type CopilotChatRestoreViewProps,
+} from "./CopilotChatRestoreView";
+
+export {
   CopilotChatToggleButton,
   type CopilotChatToggleButtonProps,
   CopilotChatToggleButtonOpenIcon,

--- a/packages/react-core/src/v2/headless.ts
+++ b/packages/react-core/src/v2/headless.ts
@@ -40,6 +40,11 @@ export {
 // option), so it must be a value export — `export type` would strip its runtime
 // binding from this entry under isolatedModules, breaking consumers.
 export { useAgent, UseAgentUpdate } from "./hooks/use-agent";
+export {
+  useThreadRestore,
+  type UseThreadRestoreOptions,
+  type UseThreadRestoreResult,
+} from "./hooks/use-thread-restore";
 export { useFrontendTool } from "./hooks/use-frontend-tool";
 export { useComponent } from "./hooks/use-component";
 export { useHumanInTheLoop } from "./hooks/use-human-in-the-loop";

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -30,6 +30,7 @@ describe("useAgent stability during runtime connection", () => {
     runtimeUrl: string | undefined;
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
     runtimeTransport: string;
+    compactRestore: boolean;
     credentials: RequestCredentials | undefined;
     headers: Record<string, string>;
     agents: Record<string, AbstractAgent>;
@@ -47,6 +48,7 @@ describe("useAgent stability during runtime connection", () => {
       runtimeConnectionStatus:
         CopilotKitCoreRuntimeConnectionStatus.Disconnected,
       runtimeTransport: "rest",
+      compactRestore: false,
       credentials: undefined,
       headers: {},
       agents: {},
@@ -72,6 +74,20 @@ describe("useAgent stability during runtime connection", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("propagates the core compact restore opt-out to a provisional agent", () => {
+    let provisional: ProxiedCopilotRuntimeAgent | undefined;
+
+    function AgentTracker() {
+      const { agent } = useAgent({ agentId: "test-agent" });
+      provisional = agent as ProxiedCopilotRuntimeAgent;
+      return null;
+    }
+
+    render(<AgentTracker />);
+
+    expect(provisional?.compactRestore).toBe(false);
   });
 
   it("should reuse the same provisional agent across re-renders during Disconnected→Connecting", () => {

--- a/packages/react-core/src/v2/hooks/__tests__/use-thread-restore.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-thread-restore.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadRestoreError } from "@copilotkit/core";
+import type { ThreadRestoreState } from "@copilotkit/core";
+import { useThreadRestore } from "../use-thread-restore";
+
+const useAgent = vi.fn();
+
+vi.mock("../use-agent", () => ({
+  useAgent: (...args: unknown[]) => useAgent(...args),
+}));
+
+function createRestoreAwareAgent(initialState: ThreadRestoreState) {
+  let state = initialState;
+  const listeners = new Set<() => void>();
+  const forceFullRestore = vi.fn(async () => {});
+
+  return {
+    getThreadRestoreState: () => state,
+    subscribeToThreadRestore: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    forceFullRestore,
+    setState(nextState: ThreadRestoreState) {
+      state = nextState;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}
+
+describe("useThreadRestore", () => {
+  beforeEach(() => {
+    useAgent.mockReset();
+  });
+
+  it("subscribes to the agent restore store and exposes progress", () => {
+    const agent = createRestoreAwareAgent({
+      status: "ready",
+      threadId: "thread-1",
+    });
+    useAgent.mockReturnValue({ agent, isReady: true });
+
+    const { result } = renderHook(() =>
+      useThreadRestore({ agentId: "research" }),
+    );
+
+    expect(useAgent).toHaveBeenCalledWith({ agentId: "research", updates: [] });
+    expect(result.current).toMatchObject({
+      status: "ready",
+      threadId: "thread-1",
+    });
+
+    act(() => {
+      agent.setState({
+        status: "restoring",
+        threadId: "thread-1",
+        restoreAttemptId: "restore-1",
+        elapsedMs: 5_000,
+      });
+    });
+
+    expect(result.current).toMatchObject({
+      status: "restoring",
+      restoreAttemptId: "restore-1",
+      elapsedMs: 5_000,
+    });
+  });
+
+  it("exposes a typed failed state and delegates reloadConversation", async () => {
+    const error = new ThreadRestoreError({
+      restoreAttemptId: "restore-support-123",
+      code: "timeout",
+      retryable: true,
+      retryAction: "reload_conversation",
+    });
+    const agent = createRestoreAwareAgent({
+      status: "failed",
+      threadId: "thread-1",
+      restoreAttemptId: error.restoreAttemptId,
+      error,
+    });
+    useAgent.mockReturnValue({ agent, isReady: true });
+
+    const { result } = renderHook(() => useThreadRestore());
+
+    expect(result.current).toMatchObject({ status: "failed", error });
+    await act(() => result.current.reloadConversation());
+    expect(agent.forceFullRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats agents without restore support as ready", () => {
+    useAgent.mockReturnValue({
+      agent: { threadId: "legacy-thread" },
+      isReady: true,
+    });
+
+    const { result } = renderHook(() => useThreadRestore());
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      threadId: "legacy-thread",
+    });
+  });
+
+  it("stabilizes equivalent snapshots from pre-delegate proxy agents", () => {
+    useAgent.mockReturnValue({
+      agent: {
+        threadId: "proxy-thread",
+        getThreadRestoreState: () => ({
+          status: "ready" as const,
+          threadId: "proxy-thread",
+        }),
+        subscribeToThreadRestore: () => () => {},
+        forceFullRestore: vi.fn(),
+      },
+      isReady: false,
+    });
+
+    const { result } = renderHook(() => useThreadRestore());
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      threadId: "proxy-thread",
+    });
+  });
+});

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -8,6 +8,11 @@ export { useRenderTool } from "./use-render-tool";
 export { useDefaultRenderTool } from "./use-default-render-tool";
 export { useHumanInTheLoop } from "./use-human-in-the-loop";
 export { useAgent, UseAgentUpdate } from "./use-agent";
+export { useThreadRestore } from "./use-thread-restore";
+export type {
+  UseThreadRestoreOptions,
+  UseThreadRestoreResult,
+} from "./use-thread-restore";
 export { useCapabilities } from "./use-capabilities";
 export { useAgentContext } from "./use-agent-context";
 export type { AgentContextInput, JsonSerializable } from "./use-agent-context";

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -276,6 +276,7 @@ export function useAgent({
         runtimeAgentId,
         transport: copilotkit.runtimeTransport,
         runtimeMode: "pending",
+        compactRestore: copilotkit.compactRestore,
       });
       copilotkit.applyHeadersToAgent(provisional);
       provisionalAgentCache.current.set(resolvedAgentId, provisional);
@@ -310,6 +311,7 @@ export function useAgent({
         transport: copilotkit.runtimeTransport,
         credentials: copilotkit.credentials,
         runtimeMode: "pending",
+        compactRestore: copilotkit.compactRestore,
       });
       // Apply current headers so runs/connects inherit them
       copilotkit.applyHeadersToAgent(provisional);
@@ -336,6 +338,7 @@ export function useAgent({
         transport: copilotkit.runtimeTransport,
         credentials: copilotkit.credentials,
         runtimeMode: "pending",
+        compactRestore: copilotkit.compactRestore,
       });
       copilotkit.applyHeadersToAgent(provisional);
       provisionalAgentCache.current.set(resolvedAgentId, provisional);

--- a/packages/react-core/src/v2/hooks/use-thread-restore.ts
+++ b/packages/react-core/src/v2/hooks/use-thread-restore.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import { isThreadRestoreAware } from "@copilotkit/core";
+import type { ThreadRestoreState } from "@copilotkit/core";
+import type { AbstractAgent } from "@ag-ui/client";
+import { useAgent } from "./use-agent";
+
+export type UseThreadRestoreResult = ThreadRestoreState & {
+  /**
+   * Clears the failed restore cursor, requests a fresh credential, and
+   * reconnects the current conversation from its complete retained history.
+   * Concurrent calls share the same in-flight recovery in core.
+   */
+  reloadConversation: () => Promise<void>;
+};
+
+export interface UseThreadRestoreOptions {
+  /** Agent to observe. Falls back to the surrounding chat configuration. */
+  agentId?: string;
+}
+
+/**
+ * Observes the current agent's thread-restore lifecycle.
+ *
+ * Agents that do not implement reliable restore are reported as `ready`, so
+ * custom interfaces remain compatible with older runtimes and non-Intelligence
+ * agents.
+ */
+export function useThreadRestore(
+  options: UseThreadRestoreOptions = {},
+): UseThreadRestoreResult {
+  const { agent } = useAgent({ agentId: options.agentId, updates: [] });
+  return useThreadRestoreForAgent(agent);
+}
+
+/** @internal Reuses an agent already resolved by a composed component. */
+export function useThreadRestoreForAgent(
+  agent: AbstractAgent,
+): UseThreadRestoreResult {
+  const legacyReadyState = useMemo<ThreadRestoreState>(
+    () => ({ status: "ready", threadId: agent.threadId }),
+    [agent],
+  );
+  const snapshotCacheRef = useRef<{
+    agent: typeof agent;
+    state: ThreadRestoreState;
+  } | null>(null);
+
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      isThreadRestoreAware(agent)
+        ? agent.subscribeToThreadRestore(listener)
+        : () => {},
+    [agent],
+  );
+  const getSnapshot = useCallback(() => {
+    const nextState = isThreadRestoreAware(agent)
+      ? agent.getThreadRestoreState()
+      : legacyReadyState;
+    const cached = snapshotCacheRef.current;
+    if (
+      cached?.agent === agent &&
+      threadRestoreStatesEqual(cached.state, nextState)
+    ) {
+      return cached.state;
+    }
+    snapshotCacheRef.current = { agent, state: nextState };
+    return nextState;
+  }, [agent, legacyReadyState]);
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const reloadConversation = useCallback(async () => {
+    if (isThreadRestoreAware(agent)) {
+      await agent.forceFullRestore();
+    }
+  }, [agent]);
+
+  return useMemo(
+    () => ({ ...state, reloadConversation }),
+    [state, reloadConversation],
+  );
+}
+
+function threadRestoreStatesEqual(
+  left: ThreadRestoreState,
+  right: ThreadRestoreState,
+): boolean {
+  if (
+    left.status !== right.status ||
+    left.threadId !== right.threadId ||
+    left.restoreAttemptId !== right.restoreAttemptId
+  ) {
+    return false;
+  }
+  if (left.status === "restoring" && right.status === "restoring") {
+    return left.elapsedMs === right.elapsedMs;
+  }
+  if (left.status === "failed" && right.status === "failed") {
+    return left.error === right.error;
+  }
+  return left.status === "ready" && right.status === "ready";
+}

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -36,6 +36,10 @@ export const CopilotChatDefaultLabels = {
   chatToggleCloseLabel: "Close chat",
   modalHeaderTitle: "CopilotKit Chat",
   welcomeMessageText: "How can I help you today?",
+  restoreLoadingText: "Restoring conversation…",
+  restoreFailedText: "This conversation couldn’t be restored.",
+  restoreReloadButtonLabel: "Reload conversation",
+  restoreSupportIdLabel: "Support ID",
 };
 
 export type CopilotChatLabels = typeof CopilotChatDefaultLabels;

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -119,6 +119,8 @@ export interface CopilotKitProviderProps {
    * Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies in cross-origin requests).
    */
   credentials?: RequestCredentials;
+  /** Advertise compact full-thread restore support. Defaults to true. */
+  compactRestore?: boolean;
   /** Your CopilotKit public license key. */
   publicApiKey?: string;
   /** Your public license key for accessing Enterprise Intelligence Platform features. */
@@ -273,6 +275,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   runtimeUrl,
   headers: headersProp = EMPTY_HEADERS,
   credentials,
+  compactRestore,
   publicApiKey,
   publicLicenseKey,
   licenseToken,
@@ -620,6 +623,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
             : "auto",
       headers: mergedHeaders,
       credentials,
+      compactRestore,
       properties,
       agents__unsafe_dev_only: mergedAgents,
       tools: allTools,

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferWiring.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.deferWiring.test.tsx
@@ -79,4 +79,17 @@ describe("CopilotKitProvider — deferral wiring (mocked core, #5801)", () => {
     // ...and the provider started the connection from a commit-phase effect.
     await waitFor(() => expect(connectCalls.length).toBeGreaterThanOrEqual(1));
   });
+
+  it("threads the compact restore opt-out into the core", () => {
+    render(
+      <CopilotKitProvider
+        runtimeUrl="https://runtime.example/rest"
+        compactRestore={false}
+      >
+        <div>child</div>
+      </CopilotKitProvider>,
+    );
+
+    expect(ctorConfigs[0]?.compactRestore).toBe(false);
+  });
 });

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.ts
@@ -509,6 +509,12 @@ describe("CopilotChat activity message rendering", () => {
       expect(channel.params).toEqual({
         stream_mode: "connect",
         last_seen_event_id: null,
+        capabilities: {
+          restore: {
+            version: 1,
+            sdkVersion: "1.67.1",
+          },
+        },
       });
 
       channel.triggerJoin("ok");

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotChatActivityRendering.e2e.test.ts
@@ -513,6 +513,12 @@ describe("CopilotChat activity message rendering", () => {
           restore: {
             version: 1,
             sdkVersion: "1.67.1",
+            compact: {
+              schemaVersion: 1,
+              reducerVersion: 1,
+              sanitizerVersion: 1,
+              compactorVersion: 1,
+            },
           },
         },
       });

--- a/packages/vue/src/v2/hooks/__tests__/use-agent-stability.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-agent-stability.test.ts
@@ -6,7 +6,10 @@ import type { AbstractAgent } from "@ag-ui/client";
 import { useCopilotKit } from "../../providers/useCopilotKit";
 import { MockStepwiseAgent } from "../../__tests__/utils/test-helpers";
 import { useAgent } from "../use-agent";
-import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  ProxiedCopilotRuntimeAgent,
+} from "@copilotkit/core";
 
 // Mock the CopilotKitProvider to control copilotkit state directly
 vi.mock("../../providers/useCopilotKit", () => ({
@@ -28,6 +31,7 @@ describe("useAgent stability during runtime connection", () => {
     runtimeUrl: string | undefined;
     runtimeConnectionStatus: CopilotKitCoreRuntimeConnectionStatus;
     runtimeTransport: string;
+    compactRestore: boolean;
     headers: Record<string, string>;
     agents: Record<string, AbstractAgent>;
     // Added after the hook moved to consume the shared core API. Mocks only
@@ -46,6 +50,7 @@ describe("useAgent stability during runtime connection", () => {
       runtimeConnectionStatus:
         CopilotKitCoreRuntimeConnectionStatus.Disconnected,
       runtimeTransport: "rest",
+      compactRestore: false,
       headers: {},
       agents: {},
       subscribeToAgentWithOptions: vi.fn(() => ({ unsubscribe: vi.fn() })),
@@ -61,6 +66,27 @@ describe("useAgent stability during runtime connection", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it("propagates the core compact restore opt-out to a provisional agent", async () => {
+    let provisional: AbstractAgent | null = null;
+    const AgentTracker = defineComponent({
+      setup() {
+        const { agent } = useAgent({ agentId: "test-agent" });
+        watchEffect(() => {
+          provisional = agent.value;
+        });
+        return () => null;
+      },
+    });
+
+    render(AgentTracker);
+    await nextTick();
+
+    expect(provisional).toBeInstanceOf(ProxiedCopilotRuntimeAgent);
+    expect((provisional as ProxiedCopilotRuntimeAgent).compactRestore).toBe(
+      false,
+    );
   });
 
   it("should reuse the same provisional agent across re-renders during Disconnected→Connecting", async () => {

--- a/packages/vue/src/v2/hooks/use-agent.ts
+++ b/packages/vue/src/v2/hooks/use-agent.ts
@@ -160,6 +160,7 @@ export function useAgent(props: UseAgentProps = {}) {
       agentId: id,
       transport,
       runtimeMode: "pending",
+      compactRestore: copilotkit.value.compactRestore,
     });
     provisional.headers = { ...headers };
     return provisional;

--- a/packages/vue/src/v2/providers/CopilotKitProvider.types.ts
+++ b/packages/vue/src/v2/providers/CopilotKitProvider.types.ts
@@ -16,6 +16,8 @@ export interface CopilotKitProviderProps {
   runtimeUrl?: string;
   headers?: Record<string, string> | (() => Record<string, string>);
   credentials?: RequestCredentials;
+  /** Advertise compact full-thread restore support. Defaults to true. */
+  compactRestore?: boolean;
   defaultThrottleMs?: number;
   publicApiKey?: string;
   publicLicenseKey?: string;

--- a/packages/vue/src/v2/providers/CopilotKitProvider.vue
+++ b/packages/vue/src/v2/providers/CopilotKitProvider.vue
@@ -399,6 +399,7 @@ const createCopilotKit = () => {
           : "auto",
     headers: mergedHeaders.value,
     credentials: props.credentials,
+    compactRestore: props.compactRestore,
     properties: resolvedProperties.value,
     agents__unsafe_dev_only: mergedAgents.value,
     tools: allTools.value,

--- a/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.debug.test.ts
+++ b/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.debug.test.ts
@@ -19,6 +19,7 @@ function renderProvider(args: {
   properties?: Record<string, unknown>;
   agents__unsafe_dev_only?: Record<string, unknown>;
   defaultThrottleMs?: number;
+  compactRestore?: boolean;
 }) {
   const Host = defineComponent({
     components: {
@@ -57,6 +58,11 @@ function renderProvider(args: {
         required: false,
         default: undefined,
       },
+      compactRestore: {
+        type: Boolean,
+        required: false,
+        default: undefined,
+      },
     },
     template: `
       <CopilotKitProvider
@@ -67,6 +73,7 @@ function renderProvider(args: {
         :properties="properties"
         :agents__unsafe_dev_only="agents__unsafe_dev_only"
         :default-throttle-ms="defaultThrottleMs"
+        :compact-restore="compactRestore"
       >
         <ChildComponent />
       </CopilotKitProvider>
@@ -82,6 +89,7 @@ function renderProvider(args: {
       properties: args.properties,
       agents__unsafe_dev_only: args.agents__unsafe_dev_only,
       defaultThrottleMs: args.defaultThrottleMs,
+      compactRestore: args.compactRestore,
     },
   });
 }
@@ -124,6 +132,14 @@ describe("CopilotKitProvider debug", () => {
   });
 
   describe("initial threading", () => {
+    it("threads the compact restore opt-out into the core", () => {
+      const { child, getCore } = createCoreCollector();
+
+      renderProvider({ child, compactRestore: false });
+
+      expect(getCore().compactRestore).toBe(false);
+    });
+
     it("threads debug=true through to copilotkit.debug on mount", async () => {
       const { child, getCore } = createCoreCollector();
 

--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -53,6 +53,51 @@ Realtime sync keeps thread metadata and active conversation state aligned across
 
 The important application-level contract is simple: your app uses the same frontend APIs, while the runtime points at the platform endpoint for the selected deployment.
 
+### Reliable conversation restore
+
+When a restore-aware frontend reconnects to a durable thread, the realtime
+gateway does not present a partial replay as a successful conversation. The
+client declares one versioned restore capability on the Phoenix channel join.
+If the gateway recognizes it, the join acknowledgement includes an opaque
+restore attempt ID, progress begins immediately and repeats at least every five
+seconds, and the attempt settles as either `ready` or one typed failure.
+
+The default full-restore deadline is 60 seconds. Self-hosted deployments may
+set it inclusively from 1,000 through 300,000 milliseconds. Live events that
+arrive during replay are sanitized before accounting and buffered up to both
+10,000 events and 16 MiB. Crossing either limit fails closed with
+`buffer_overflow`; the cursor is not advanced. Successful handoff emits the
+proven replay window before buffered live events in durable order. V1 does not
+compact replay, so retained history size still determines full-restore work.
+
+The browser exposes the same `ready | restoring | failed` model through the
+built-in chat, the `restoreView` slot, and
+[`useThreadRestore`](/reference/v2/hooks/useThreadRestore). A failed restore can
+be retried with **Reload conversation**, which clears the cursor, remints one
+credential, and performs one force-full reconnect. The opaque support ID may be
+shared with an operator; thread, project, user, and attempt identifiers are not
+metric dimensions.
+
+#### Version compatibility
+
+Reliable restore is capability-negotiated, so the frontend and gateway can be
+deployed in either order.
+
+| Frontend | Gateway | Behavior |
+|---|---|---|
+| Existing | Existing | Existing join and replay behavior. |
+| Existing | Restore-aware | Existing wire controls remain in use; the gateway applies the configured 60-second default deadline. |
+| Restore-aware | Existing | The gateway ignores the unknown capability; the frontend accepts existing replay controls. |
+| Restore-aware | Restore-aware | Typed progress and failure reporting, bounded buffering, and force-full recovery are enabled. |
+
+Malformed or unrecognized capability data never rejects a join. It falls back
+to existing behavior and is recorded only in protected diagnostics, without
+customer identifiers in metric labels.
+
+Terminal telemetry records restore duration, post-sanitization payload bytes,
+and event count. Its dimensions are closed to `outcome` (`ready` or one of the
+eight failure codes) and `failure_reporting` (`supported` or `legacy`).
+
 ## Inspection and operational history
 
 The platform also gives teams operational visibility into agent behavior. The cloud-hosted web app exposes project history, thread detail pages, event timelines, API key management, and plan management.

--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -67,7 +67,11 @@ set it inclusively from 1,000 through 300,000 milliseconds. Live events that
 arrive during replay are sanitized before accounting and buffered up to both
 10,000 events and 16 MiB. Crossing either limit fails closed with
 `buffer_overflow`; the cursor is not advanced. Successful handoff emits the
-proven replay window before buffered live events in durable order. V1 does not
+proven replay window before buffered live events in durable order. The gateway
+captures a Redis acceptance barrier after subscribing and waits until the
+PostgreSQL replay projection proves it. Run-follow joins scope replay, live
+events, and terminal completion to the requested run; the core client also
+ignores a mismatched run terminal defensively. V1 does not
 compact replay, so retained history size still determines full-restore work.
 
 The browser exposes the same `ready | restoring | failed` model through the
@@ -95,8 +99,10 @@ to existing behavior and is recorded only in protected diagnostics, without
 customer identifiers in metric labels.
 
 Terminal telemetry records restore duration, post-sanitization payload bytes,
-and event count. Its dimensions are closed to `outcome` (`ready` or one of the
-eight failure codes) and `failure_reporting` (`supported` or `legacy`).
+event count, and buffer event/byte high-water marks. Its dimensions are closed
+to `outcome` (`ready` or one of the eight failure codes), `failure_reporting`
+(`supported` or `legacy`), replay `source`, and whether an invalid-cursor
+full-read fallback occurred.
 
 ## Inspection and operational history
 

--- a/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/intelligence-platform.mdx
@@ -57,10 +57,23 @@ The important application-level contract is simple: your app uses the same front
 
 When a restore-aware frontend reconnects to a durable thread, the realtime
 gateway does not present a partial replay as a successful conversation. The
-client declares one versioned restore capability on the Phoenix channel join.
-If the gateway recognizes it, the join acknowledgement includes an opaque
+client declares versioned restore capabilities on the Phoenix channel join. If
+the gateway recognizes them, the join acknowledgement includes an opaque
 restore attempt ID, progress begins immediately and repeats at least every five
 seconds, and the attempt settles as either `ready` or one typed failure.
+
+For a connect restore with no cursor, compact full restore is enabled by
+default. The gateway may replace the retained event-by-event history with a
+smaller projection that reconstructs the same final messages and state. This
+also applies after an invalid cursor is cleared for a full-read retry. A normal
+run, a reconnect with a valid cursor, or a gateway that does not support the
+advertised projection versions continues to use the legacy event stream.
+
+Compact restore is negotiated as one compatible set of schema, reducer,
+sanitizer, and compactor versions. The gateway selects compaction only when it
+supports that complete set. Older gateways, unknown acknowledgements, and a
+gateway that selects legacy behavior remain compatible; they do not make the
+client fail the restore.
 
 The default full-restore deadline is 60 seconds. Self-hosted deployments may
 set it inclusively from 1,000 through 300,000 milliseconds. Live events that
@@ -71,8 +84,104 @@ proven replay window before buffered live events in durable order. The gateway
 captures a Redis acceptance barrier after subscribing and waits until the
 PostgreSQL replay projection proves it. Run-follow joins scope replay, live
 events, and terminal completion to the requested run; the core client also
-ignores a mismatched run terminal defensively. V1 does not
-compact replay, so retained history size still determines full-restore work.
+ignores a mismatched run terminal defensively.
+
+#### Configure compact restore
+
+Most applications should keep the default. Use `compactRestore: false` only
+when existing subscriber behavior depends on every retained event being
+replayed.
+
+##### Core
+
+```ts
+import { CopilotKitCore } from "@copilotkit/core";
+
+const copilotkit = new CopilotKitCore({
+  runtimeUrl: "/api/copilotkit",
+  compactRestore: false,
+});
+```
+
+<FrontendOnly frontend="react">
+
+##### React
+
+```tsx
+import { CopilotKitProvider } from "@copilotkit/react-core/v2";
+
+<CopilotKitProvider
+  runtimeUrl="/api/copilotkit"
+  compactRestore={false}
+>
+  {children}
+</CopilotKitProvider>;
+```
+
+</FrontendOnly>
+
+<FrontendOnly frontend="vue">
+
+##### Vue
+
+```vue
+<script setup lang="ts">
+import { CopilotKitProvider } from "@copilotkit/vue/v2";
+</script>
+
+<template>
+  <CopilotKitProvider
+    runtime-url="/api/copilotkit"
+    :compact-restore="false"
+  >
+    <RouterView />
+  </CopilotKitProvider>
+</template>
+```
+
+</FrontendOnly>
+
+<FrontendOnly frontend="angular">
+
+##### Angular
+
+```ts
+import type { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      runtimeUrl: "/api/copilotkit",
+      compactRestore: false,
+    }),
+  ],
+};
+```
+
+</FrontendOnly>
+
+The Core or provider setting propagates to registered, discovered, and
+provisional runtime proxies. Agent clones preserve the originating setting, and
+an Intelligence proxy passes it to its delegate. You do not need to configure
+each generated agent separately.
+
+#### Subscriber compatibility
+
+A compact projection preserves the restored conversation, not the original
+number of replay callbacks. Event callbacks can run fewer times, and retained
+`RAW` events that are unnecessary to reconstruct messages and state may not be
+replayed. Do not use replay callback counts or the presence of every historical
+`RAW` event as a durable side-effect mechanism.
+
+Subscriber event payloads are immutable. In development, CopilotKit warns once
+per public agent when a subscriber has a callback that _can_ return replacement
+messages or state mutations while compact restore is enabled. The warning is
+advisory: callback capability does not prove that the subscriber mutates a
+restore. If its returned messages or state mutations depend on the complete
+legacy event stream, make the callback independent of replay granularity or set
+`compactRestore: false`. Notification-only callbacks do not trigger the
+warning.
 
 The browser exposes the same `ready | restoring | failed` model through the
 built-in chat, the `restoreView` slot, and
@@ -91,8 +200,8 @@ deployed in either order.
 |---|---|---|
 | Existing | Existing | Existing join and replay behavior. |
 | Existing | Restore-aware | Existing wire controls remain in use; the gateway applies the configured 60-second default deadline. |
-| Restore-aware | Existing | The gateway ignores the unknown capability; the frontend accepts existing replay controls. |
-| Restore-aware | Restore-aware | Typed progress and failure reporting, bounded buffering, and force-full recovery are enabled. |
+| Restore-aware | Existing | The gateway ignores unknown restore and compact-projection capabilities; the frontend accepts existing replay controls. |
+| Restore-aware | Restore-aware | Typed progress and failure reporting, bounded buffering, force-full recovery, and compact null-cursor full restore are enabled when the advertised projection versions match. |
 
 Malformed or unrecognized capability data never rejects a join. It falls back
 to existing behavior and is recorded only in protected diagnostics, without

--- a/showcase/shell-docs/src/content/docs/premium/self-hosting.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/self-hosting.mdx
@@ -6,3 +6,42 @@ doc_type: how-to
 premium: true
 ---
 <SelfHosting />
+
+## Reliable restore controls
+
+The realtime gateway defaults to a 60-second full-restore deadline and buffers
+live events that arrive during replay up to 10,000 events or 16 MiB after
+sanitization. The event and byte caps are independent; crossing either cap
+fails closed and does not advance the client's cursor. V1 replays retained
+events without compaction.
+
+Set the controls under `realtimeGateway.restore` in your values overlay:
+
+```yaml title="my-values.yaml"
+realtimeGateway:
+  enabled: true
+  restore:
+    # Inclusive range: 1,000–300,000 milliseconds.
+    fullDeadlineMs: 60000
+    # Both buffer values must be positive integers.
+    bufferMaxEvents: 10000
+    bufferMaxBytes: 16777216
+```
+
+The chart maps these values to `RESTORE_FULL_DEADLINE_MS`,
+`RESTORE_BUFFER_MAX_EVENTS`, and `RESTORE_BUFFER_MAX_BYTES` on every gateway
+pod. Invalid deadlines or non-positive buffer limits stop the gateway at
+startup instead of silently accepting unsafe bounds.
+
+Capacity planning must account for the per-active-restore upper bound. With
+the defaults, `N` concurrent full restores can retain at most approximately
+`N × 16 MiB` of serialized live-event payload, plus BEAM/process and message
+overhead. Size gateway memory and autoscaling from your expected concurrent
+restore count, not only steady-state socket count. If long restores regularly
+approach a cap, investigate retained-history size and dependency latency before
+raising the limits.
+
+Cloud-hosted and self-hosted deployments use the same negotiation, failure
+codes, ordering, recovery action, and bounded telemetry. Only this Helm wiring
+differs. See [Enterprise Intelligence Architecture](/premium/intelligence-platform#reliable-conversation-restore)
+for the protocol and compatibility matrix.

--- a/showcase/shell-docs/src/content/docs/premium/self-hosting.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/self-hosting.mdx
@@ -12,8 +12,9 @@ premium: true
 The realtime gateway defaults to a 60-second full-restore deadline and buffers
 live events that arrive during replay up to 10,000 events or 16 MiB after
 sanitization. The event and byte caps are independent; crossing either cap
-fails closed and does not advance the client's cursor. V1 replays retained
-events without compaction.
+fails closed and does not advance the client's cursor. Compatible frontend,
+realtime-gateway, and app-api releases negotiate compact null-cursor full
+restore by default; version skew falls back to the legacy retained-event replay.
 
 Set the controls under `realtimeGateway.restore` in your values overlay:
 
@@ -40,6 +41,20 @@ overhead. Size gateway memory and autoscaling from your expected concurrent
 restore count, not only steady-state socket count. If long restores regularly
 approach a cap, investigate retained-history size and dependency latency before
 raising the limits.
+
+### Deploy compatible service versions
+
+Deploy the realtime gateway and app-api versions pinned by the same
+`copilot-intelligence` chart release. If you manage their images separately,
+verify that both releases support the same compact-restore projection versions
+before enabling them in production. Upgrade the pair before relying on compact
+restore for capacity planning.
+
+Rolling upgrades remain safe: capability negotiation makes a mixed or older
+service pair use legacy replay instead of rejecting the connection. During that
+window, retained history size still determines full-restore work, so keep
+legacy replay capacity until every gateway and app-api replica runs a compatible
+release.
 
 Cloud-hosted and self-hosted deployments use the same negotiation, failure
 codes, ordering, recovery action, and bounded telemetry. Only this Helm wiring

--- a/showcase/shell-docs/src/content/reference/hooks/useThreadRestore.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useThreadRestore.mdx
@@ -1,0 +1,166 @@
+---
+title: "useThreadRestore"
+description: "Observe and recover the reliable thread-restore lifecycle"
+---
+
+## Overview
+
+`useThreadRestore` exposes the restore lifecycle for a durable conversation as
+`ready`, `restoring`, or `failed`. Use it when you build a custom chat surface
+or need restore status outside the built-in `CopilotChat` UI.
+
+`CopilotChat` already uses this lifecycle. While a restore-aware agent is
+restoring, it replaces the normal messages and composer with an accessible
+status. If restoration fails, it shows a recovery action and an opaque support
+ID. The composer is rendered only after the conversation is ready.
+
+Agents and gateways that do not support reliable restore are treated as
+`ready`, preserving compatibility with existing AG-UI integrations.
+
+## Signature
+
+```tsx
+import { useThreadRestore } from "@copilotkit/react-core/v2";
+
+function useThreadRestore(options?: {
+  agentId?: string;
+}): UseThreadRestoreResult;
+```
+
+The hook is also available from the UI-free entry:
+
+```tsx
+import { useThreadRestore } from "@copilotkit/react-core/v2/headless";
+```
+
+## Parameters
+
+<PropertyReference name="options" type="UseThreadRestoreOptions">
+  Optional agent selection.
+
+  <PropertyReference name="agentId" type="string" default='"default"'>
+    Agent to observe. If omitted, the hook uses the agent from the surrounding
+    chat configuration, then the default agent.
+  </PropertyReference>
+</PropertyReference>
+
+## Return value
+
+Every state includes `threadId` and `reloadConversation()`.
+
+| `status` | Additional fields | Meaning |
+|---|---|---|
+| `ready` | `restoreAttemptId?` | The retained history is complete and normal conversation UI may render. |
+| `restoring` | `restoreAttemptId?`, `elapsedMs` | Replay is still in progress. Do not present partial history as ready. |
+| `failed` | `restoreAttemptId`, `error` | Restore settled with a typed failure. `restoreAttemptId` is safe to show as a support ID. |
+
+`error` is a `ThreadRestoreError` with a bounded `code`, `retryable` flag,
+`retryAction`, and the opaque `restoreAttemptId`. Failure codes are
+`timeout`, `dependency_failure`, `decode_failure`, `partial_window`,
+`invalid_cursor`, `buffer_overflow`, `scope_violation`, and
+`internal_failure`.
+
+`reloadConversation()` clears the failed cursor, obtains a new one-use join
+credential, and reconnects once from the complete retained history. Concurrent
+calls share the same in-flight recovery.
+
+## Default UI
+
+No extra wiring is required for the built-in chat:
+
+```tsx title="Conversation.tsx"
+import { CopilotChat } from "@copilotkit/react-core/v2";
+
+export function Conversation({ threadId }: { threadId: string }) {
+  return <CopilotChat threadId={threadId} />;
+}
+```
+
+You can customize the four restore labels with the normal `labels` prop:
+
+```tsx
+<CopilotChat
+  threadId={threadId}
+  labels={{
+    restoreLoadingText: "Loading retained history…",
+    restoreFailedText: "This conversation couldn’t be restored.",
+    restoreReloadButtonLabel: "Reload conversation",
+    restoreSupportIdLabel: "Support ID",
+  }}
+/>
+```
+
+## Replace the restore view
+
+The `restoreView` slot receives the same state and recovery action. It replaces
+the default full-chat restore surface while status is `restoring` or `failed`.
+
+```tsx title="Conversation.tsx"
+import {
+  CopilotChat,
+  type CopilotChatRestoreViewProps,
+} from "@copilotkit/react-core/v2";
+
+function BrandedRestoreView({
+  threadRestore,
+}: CopilotChatRestoreViewProps) {
+  if (threadRestore.status === "restoring") {
+    return <p role="status">Restoring conversation…</p>;
+  }
+
+  if (threadRestore.status === "failed") {
+    return (
+      <div role="alert">
+        <p>This conversation couldn’t be restored.</p>
+        <button onClick={threadRestore.reloadConversation}>
+          Reload conversation
+        </button>
+        <small>Support ID: {threadRestore.restoreAttemptId}</small>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export function Conversation({ threadId }: { threadId: string }) {
+  return <CopilotChat threadId={threadId} restoreView={BrandedRestoreView} />;
+}
+```
+
+## Headless UI
+
+Gate both the transcript and composer on `ready`. This prevents users from
+reading or replying to a history window that has not been proven complete.
+
+```tsx title="HeadlessConversation.tsx"
+import { useThreadRestore } from "@copilotkit/react-core/v2/headless";
+
+export function HeadlessConversation() {
+  const restore = useThreadRestore({ agentId: "default" });
+
+  if (restore.status === "restoring") {
+    return <p role="status">Restoring conversation…</p>;
+  }
+
+  if (restore.status === "failed") {
+    return (
+      <div role="alert">
+        <p>This conversation couldn’t be restored.</p>
+        <button onClick={restore.reloadConversation}>
+          Reload conversation
+        </button>
+        <small>Support ID: {restore.restoreAttemptId}</small>
+      </div>
+    );
+  }
+
+  return <YourConversationAndComposer />;
+}
+```
+
+## Related
+
+- [`useAgent`](/reference/v2/hooks/useAgent) — access the underlying AG-UI agent
+- [Enterprise Intelligence Architecture](/premium/intelligence-platform) — reliable restore protocol, limits, and compatibility
+- [Self-Hosting Enterprise Intelligence](/premium/self-hosting) — configure restore deadlines and buffer bounds


### PR DESCRIPTION
## Summary

Adds the SDK-side Reliable Thread Restore V2 negotiation, default-on compact preference, mutating-subscriber opt-out, clone/proxy propagation, and public docs.

## Blocked by

- #6450
- ag-ui-protocol/ag-ui#2379
- CopilotKit/Intelligence#830

## Status

Implementation in progress. The branch starts from the exact #6450 head and the PR targets main.