### PR TITLE
fix(core): refresh Intelligence delegate headers before every join

### DIFF
--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -1964,6 +1964,37 @@ describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
       expect(joinHeaders(1)).toMatchObject({ "X-Tenant": "tenant-b" });
     });
 
+    // The report names both endpoints. `/run` reaches the delegate through
+    // `#runViaDelegate`, which shares `resolveDelegate` with the connect path —
+    // pin that rather than infer it from the shared call site.
+    it("sends a changed header on the run path too", async () => {
+      const agent = new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: "http://localhost:4000/api/copilotkit",
+        agentId: "default",
+        runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+        intelligence: { wsUrl: "ws://localhost:4401/client" },
+        headers: { "X-Tenant": "tenant-a" },
+      });
+      agent.threadId = "thread-1";
+
+      // First connect builds and caches the delegate under tenant A.
+      await completeConnect(agent, "run-1", "event-1");
+
+      agent.headers = { "X-Tenant": "tenant-b" };
+
+      // `run` is protected on AbstractAgent; concrete agents expose it.
+      (agent as unknown as { run(input: RunAgentInput): Observable<BaseEvent> })
+        .run({ ...defaultInput, runId: "run-2" })
+        .subscribe({ next: () => {}, error: () => {} });
+      await flushAsyncWork();
+
+      const runCall = mockFetch.mock.calls.find((call) =>
+        String(call[0]).includes("/run"),
+      );
+      expect(runCall).toBeDefined();
+      expect(runCall![1].headers).toMatchObject({ "X-Tenant": "tenant-b" });
+    });
+
     it("sends credentials changed after the delegate was created", async () => {
       const agent = new ProxiedCopilotRuntimeAgent({
         runtimeUrl: "http://localhost:4000/api/copilotkit",

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -1908,4 +1908,123 @@ describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
 
     expect(agent.state).toEqual(finalSnapshot);
   });
+
+  // The delegate is created once and cached for the lifetime of the proxy, so
+  // anything it copied out of the proxy at construction time goes stale the
+  // moment the proxy is updated. `CopilotKitCore.setHeaders` /
+  // `applyHeadersToAgent` write the proxy's `headers`; the Intelligence join
+  // request must read that live value, not the construction-time copy.
+  describe("delegate reads live proxy headers", () => {
+    /** Drive one full connect cycle to resolution. */
+    async function completeConnect(
+      agent: InstanceType<typeof ProxiedCopilotRuntimeAgent>,
+      runId: string,
+      eventId: string,
+    ) {
+      const promise = agent.connectAgent({ runId });
+      await flushAsyncWork();
+      const delegate = (
+        agent as unknown as { delegate: IntelligenceAgentInstance }
+      ).delegate;
+      await waitForConnection(delegate);
+      const channel = getChannel(delegate)!;
+      channel.triggerJoin("ok");
+      channel.serverPush("replay_complete", { latestEventId: eventId });
+      channel.serverPush("stream_idle", { latestEventId: eventId });
+      await promise;
+    }
+
+    function joinHeaders(callIndex: number) {
+      return mockFetch.mock.calls[callIndex]![1].headers as Record<
+        string,
+        string
+      >;
+    }
+
+    it("sends a header changed after the delegate was created", async () => {
+      const agent = new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: "http://localhost:4000/api/copilotkit",
+        agentId: "default",
+        runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+        intelligence: { wsUrl: "ws://localhost:4401/client" },
+        headers: { "X-Tenant": "tenant-a" },
+      });
+      agent.threadId = "thread-1";
+
+      // First connect: builds and caches the delegate under tenant A.
+      await completeConnect(agent, "run-1", "event-1");
+      expect(joinHeaders(0)).toMatchObject({ "X-Tenant": "tenant-a" });
+
+      // Tenant switch — this is exactly what applyHeadersToAgent does to the
+      // proxy when the `headers` prop changes.
+      agent.headers = { "X-Tenant": "tenant-b" };
+
+      await completeConnect(agent, "run-2", "event-2");
+
+      expect(joinHeaders(1)).toMatchObject({ "X-Tenant": "tenant-b" });
+    });
+
+    it("sends credentials changed after the delegate was created", async () => {
+      const agent = new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: "http://localhost:4000/api/copilotkit",
+        agentId: "default",
+        runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+        intelligence: { wsUrl: "ws://localhost:4401/client" },
+      });
+      agent.threadId = "thread-1";
+
+      await completeConnect(agent, "run-1", "event-1");
+
+      agent.credentials = "include";
+
+      await completeConnect(agent, "run-2", "event-2");
+
+      expect(mockFetch.mock.calls[1]![1].credentials).toBe("include");
+    });
+
+    // `IntelligenceAgent.clone()` hands the copy the same config object, so the
+    // headers setter must replace that object rather than write through it.
+    // The join path alone would mask an in-place write (syncDelegate rewrites
+    // headers just before every join), but the credential re-acquisition inside
+    // a running pipeline does not re-sync — so a clone's tenant could ride out
+    // on the original's refresh. This pins the invariant directly.
+    it("does not let a clone's header update reach the original", () => {
+      const original = new IntelligenceAgent({
+        url: "ws://localhost:4401/client",
+        runtimeUrl: "http://localhost:4000",
+        agentId: "default",
+        headers: { "X-Tenant": "tenant-a" },
+      });
+
+      const copy = original.clone();
+      copy.headers = { "X-Tenant": "tenant-b" };
+
+      expect(copy.headers).toEqual({ "X-Tenant": "tenant-b" });
+      expect(original.headers).toEqual({ "X-Tenant": "tenant-a" });
+    });
+
+    it("keeps a per-thread clone's headers independent of the original", async () => {
+      const agent = new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: "http://localhost:4000/api/copilotkit",
+        agentId: "default",
+        runtimeMode: RUNTIME_MODE_INTELLIGENCE,
+        intelligence: { wsUrl: "ws://localhost:4401/client" },
+        headers: { "X-Tenant": "tenant-a" },
+      });
+      agent.threadId = "thread-1";
+
+      await completeConnect(agent, "run-1", "event-1");
+
+      // clone() copies the delegate; updating the clone must not retroactively
+      // rewrite the original's header source.
+      const clone = agent.clone();
+      clone.headers = { "X-Tenant": "tenant-b" };
+      await completeConnect(clone, "run-2", "event-2");
+
+      await completeConnect(agent, "run-3", "event-3");
+
+      expect(joinHeaders(1)).toMatchObject({ "X-Tenant": "tenant-b" });
+      expect(joinHeaders(2)).toMatchObject({ "X-Tenant": "tenant-a" });
+    });
+  });
 });

--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -2005,6 +2005,7 @@ describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
       agent.threadId = "thread-1";
 
       await completeConnect(agent, "run-1", "event-1");
+      expect(mockFetch.mock.calls[0]![1].credentials).toBeUndefined();
 
       agent.credentials = "include";
 
@@ -2046,8 +2047,10 @@ describe("ProxiedCopilotRuntimeAgent (intelligence mode)", () => {
 
       await completeConnect(agent, "run-1", "event-1");
 
-      // clone() copies the delegate; updating the clone must not retroactively
-      // rewrite the original's header source.
+      // End-to-end companion to the invariant test above: each proxy's joins
+      // carry its own tenant. This does NOT guard the copy-on-write setter —
+      // syncDelegate rewrites headers before every join, so it passes even with
+      // an in-place write. The test above is what pins that.
       const clone = agent.clone();
       clone.headers = { "X-Tenant": "tenant-b" };
       await completeConnect(clone, "run-2", "event-2");

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -169,6 +169,43 @@ export class IntelligenceAgent extends AbstractAgent {
     this.sharedState = sharedState;
   }
 
+  /**
+   * Headers sent with the REST join requests (`/connect`, `/run`).
+   *
+   * Deliberately a public accessor pair rather than a plain read of `config`.
+   * `ProxiedCopilotRuntimeAgent` builds its delegate once and caches it for the
+   * proxy's lifetime, so a header that changes later (a tenant switch, a
+   * rotated bearer) would otherwise never reach the gateway. The accessor is
+   * what closes that gap: `syncDelegate` refreshes the delegate before every
+   * join, and its `hasHeaders` probe is an `"headers" in agent` check — which a
+   * prototype accessor satisfies but a `private config` does not.
+   *
+   * The setter replaces the config object instead of mutating it because
+   * `clone()` hands the same config reference to the copy. An in-place write
+   * would therefore have a per-thread clone's headers land on the original's
+   * config too. The join path itself would survive that (`syncDelegate`
+   * rewrites the headers just before every join), but the re-acquisition inside
+   * an already-running pipeline does not go through `syncDelegate` — so a
+   * clone's tenant could ride out on the original's socket-error refresh. That
+   * is the same cross-tenant leak this accessor exists to prevent.
+   */
+  get headers(): Record<string, string> | undefined {
+    return this.config.headers;
+  }
+
+  set headers(headers: Record<string, string> | undefined) {
+    this.config = { ...this.config, headers };
+  }
+
+  /** Credentials mode for the REST join requests. Live for the same reason as {@link headers}. */
+  get credentials(): RequestCredentials | undefined {
+    return this.config.credentials;
+  }
+
+  set credentials(credentials: RequestCredentials | undefined) {
+    this.config = { ...this.config, credentials };
+  }
+
   clone(): IntelligenceAgent {
     return new IntelligenceAgent(this.config, this.sharedState);
   }
@@ -419,7 +456,7 @@ export class IntelligenceAgent extends AbstractAgent {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            ...this.config.headers,
+            ...this.headers,
           },
           body: JSON.stringify({
             threadId: input.threadId,
@@ -438,9 +475,7 @@ export class IntelligenceAgent extends AbstractAgent {
                 }
               : {}),
           }),
-          ...(this.config.credentials
-            ? { credentials: this.config.credentials }
-            : {}),
+          ...(this.credentials ? { credentials: this.credentials } : {}),
         });
 
         if (response.status === 204 && mode === "connect") {


### PR DESCRIPTION
## Summary

`ProxiedCopilotRuntimeAgent` builds its `IntelligenceAgent` delegate **once** and caches it for the proxy's lifetime, copying `headers` into the delegate's constructor config. Nothing ever refreshed that copy, so **a header that changed after the delegate was created never reached `/connect` or `/run`** — for the life of the agent.

For a multi-tenant app carrying the active tenant in a header, the join was attempted under the *previous* tenant's identity with the *new* tenant's thread id, and the platform correctly answered `THREAD_NOT_FOUND`. Only a full page reload cleared it, because that rebuilds the delegate. A rotated or refreshed `Authorization` bearer has the same exposure.

Reported by Sameday against 1.67.1 with a deterministic staging repro:

```
19:45:23.554 | /copilotkit/runtime/threads            | hdr=<tenant B> | 200
19:45:23.886 | /copilotkit/runtime/threads/subscribe  | hdr=<tenant B> | 200
19:45:23.893 | /copilotkit/runtime/agent/<id>/connect | hdr=<tenant A> | body.companyId=<tenant B> | 404
```

`/threads` carries **B** while `/connect` carries **A**, ~340ms apart in the same switch. Not a race — a stale copy with no refresh path.

## Root cause

`setHeaders` / `applyHeadersToAgent` could not fix this: they write an agent's `.headers`, and `IntelligenceAgent` exposed only `private config`. `syncDelegate` *looks* like the refresh path, but its `hasHeaders` probe is `"headers" in agent` — false for the delegate, since `headers` is declared on `HttpAgent`, not on `AbstractAgent`. So `config.headers` was the sole header source for Intelligence REST calls, with no refresh path at all.

## The fix

Expose `headers` as a public accessor pair backed by `config`, and read it in `requestJoinCredentials$`.

**The accessor is the entire fix**: it makes `hasHeaders` true, so `syncDelegate` — which already runs on every `resolveDelegate()`, and is preceded by `applyHeadersToAgent` in `RunHandler.connectAgent` — starts actually refreshing the delegate before each join. No new plumbing.

Two things worth flagging for reviewers:

1. **The originally-suggested fix ("make `requestJoinCredentials$` read live headers") does not work on its own** — and is actively harmful. There was no live header source on the class to read: without the accessor, `this.headers` is `undefined` and **every header is dropped** (verified: only `Content-Type` survives). The read here goes through the accessor for a single source of truth, not because that read carries the fix.

2. **The setter replaces the config object rather than mutating it**, because `clone()` shares the config reference. The join path alone would mask an in-place write (`syncDelegate` rewrites headers just before every join), but the credential re-acquisition inside a running pipeline (`intelligence-agent.ts:563`) does not re-sync — so a clone's tenant could ride out on the original's socket-error refresh. That's the same cross-tenant leak this accessor exists to prevent.

`credentials` had the identical defect via `config.credentials` (`hasCredentials` was false too) and gets the same treatment.

## Testing

**Unit tests (5 new, each written first and watched fail).** The pre-fix failure is the staging symptom reproduced:

```
FAIL > sends a header changed after the delegate was created
AssertionError: expected { …(2) } to match object { 'X-Tenant': 'tenant-b' }
-   "X-Tenant": "tenant-b",
+   "X-Tenant": "tenant-a",
```

Coverage: a header changed post-construction reaches `/connect`; the same on the `/run` path (which was independently verified broken pre-fix, sending tenant A where B was expected); credentials likewise; a clone's header update must not reach the original (`IntelligenceAgent.clone()` invariant — this one fails under in-place config mutation); and a per-thread clone and its original each send their own tenant.

**Verified beyond the unit tests.** Because the mocked-harness result alone doesn't prove the production wiring, I drove the real chain — `CopilotKitCore.setHeaders` → registry → proxy → delegate → outbound POST — in a plain Node process with no vitest and no `vi.mock`, stubbing only `fetch` at the network boundary. Same script against the unfixed file, then the fix:

```
BEFORE (origin/main)                      AFTER (this PR)
"headers" in delegate: false              "headers" in delegate: true
delegate.headers: undefined               delegate.headers: { X-Tenant: tenant-b }
proxy.headers after setHeaders(B):        proxy.headers after setHeaders(B):
  { X-Tenant: tenant-b }                    { X-Tenant: tenant-b }

0: POST /connect  X-Tenant=tenant-a       0: POST /connect  X-Tenant=tenant-a
1: POST /connect  X-Tenant=tenant-a  <--  1: POST /connect  X-Tenant=tenant-b  credentials=include
FAIL (stale headers)                      PASS (live headers reach /connect)
```

The "before" column reproduces the report's tell exactly: `proxy.headers` correct at tenant B while `/connect` still sends tenant A, through the very API the report found ineffective.

**Gates** (run in a worktree with a freshly built `@copilotkit/shared`, since a stale dist otherwise produces 20 unrelated `core-inspector-metadata` failures and 4 `tsc` errors):

| Gate | Result |
| --- | --- |
| `@copilotkit/core` vitest | **654 passed / 654**, 59/59 files |
| `tsc --noEmit` | clean |
| `oxlint` | 0 errors (2 warnings, both pre-existing test helpers) |
| `oxfmt` | no reformatting needed |

**Not covered:** `fetch` is stubbed, so this does not exercise a live Intelligence gateway or a browser tenant switch — it proves the outbound header is correct, not the platform's response to it.

## Note for whoever merges

#6450 and #6468 also touch `intelligence-agent.ts` (thread-restore work) but neither goes near the header path, so conflicts should be textual at worst.

## Follow-up left out of scope

Two separate pre-existing defects surfaced while verifying this one. Neither is touched here.

**1. `credentials` passed to a `ProxiedCopilotRuntimeAgent` constructor are dropped at registration.** `applyCredentialsToAgent` overwrites `agent.credentials` from core unconditionally, with no per-agent baseline — unlike `applyHeadersToAgent`, which merges over the `agentOwnHeaders` baseline captured for exactly this reason (#5635). Probed in a real process: an agent constructed with `credentials: "include"` in a core with none configured reports `undefined` immediately after registration, and every join goes out without credentials. Identical before and after this PR, so it is not a regression from this change — but the headers/credentials asymmetry looks unintended, given #5433 was specifically about preserving proxied runtime credentials.

**2. `buildRuntimeUrl` reads `config.agentId` (`intelligence-agent.ts:770`), (`intelligence-agent.ts:770`), so `syncDelegate`'s `delegate.agentId = routedAgentId()` is cosmetic for the REST URL. Same root-cause class as this bug, but latent rather than live (routing is fixed per proxy instance).

Happy to file both separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
