### PR TITLE
fix(core): prevent duplicate interrupt tool results (#6201)

### DIFF
--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -109,8 +109,8 @@ describe("InterruptController", () => {
   it("accumulates multiple decisions, persists tool results, and resumes once", async () => {
     const { agent, controller, run, startResume } = setup();
     finalizeStandard(agent, [
-      makeInterrupt("one", { toolCallId: "tool-one" }),
-      makeInterrupt("two", { toolCallId: "tool-two" }),
+      makeInterrupt("one", { reason: "tool_call", toolCallId: "tool-one" }),
+      makeInterrupt("two", { reason: "tool_call", toolCallId: "tool-two" }),
     ]);
 
     await controller.cancel("two");
@@ -143,6 +143,22 @@ describe("InterruptController", () => {
     startResume();
     await Promise.all([resumePromise, duplicatePromise]);
     expect(controller.hasInterrupt()).toBe(false);
+  });
+
+  it("does not add tool messages for backend-owned interrupts", async () => {
+    const { agent, controller, startResume } = setup();
+    finalizeStandard(agent, [
+      makeInterrupt("mastra-run::tool-one", {
+        reason: "human_approval",
+        toolCallId: "tool-one",
+      }),
+    ]);
+
+    const resume = controller.resolve("approved");
+    startResume();
+    await resume;
+
+    expect(agent.addMessage).not.toHaveBeenCalled();
   });
 
   it("resumes legacy events with forwarded command data", async () => {

--- a/packages/core/src/__tests__/interrupt-state.test.ts
+++ b/packages/core/src/__tests__/interrupt-state.test.ts
@@ -3,10 +3,14 @@ import { describe, expect, it } from "vitest";
 
 import { ɵInterruptState } from "../interrupt-state";
 
-function interrupt(id: string, toolCallId?: string): Interrupt {
+function interrupt(
+  id: string,
+  toolCallId?: string,
+  reason: string = id,
+): Interrupt {
   return {
     id,
-    reason: id,
+    reason,
     ...(toolCallId ? { toolCallId } : {}),
   };
 }
@@ -14,7 +18,10 @@ function interrupt(id: string, toolCallId?: string): Interrupt {
 describe("ɵInterruptState", () => {
   it("waits for every interrupt and emits one resume decision", () => {
     const state = new ɵInterruptState();
-    state.setStandard([interrupt("one", "call-one"), interrupt("two")]);
+    state.setStandard([
+      interrupt("one", "call-one", "tool_call"),
+      interrupt("two"),
+    ]);
 
     expect(state.resolve({ approved: true }, "one")).toEqual({
       kind: "waiting",
@@ -35,6 +42,18 @@ describe("ɵInterruptState", () => {
           content: JSON.stringify({ approved: true }),
         },
       ],
+    });
+  });
+
+  it("does not create tool results for backend-owned interrupts", () => {
+    const state = new ɵInterruptState();
+    state.setStandard([
+      interrupt("mastra-run::tool-one", "tool-one", "human_approval"),
+    ]);
+
+    expect(state.resolve("approved")).toMatchObject({
+      kind: "resume",
+      toolResults: [],
     });
   });
 

--- a/packages/core/src/interrupt-state.ts
+++ b/packages/core/src/interrupt-state.ts
@@ -145,7 +145,7 @@ export class ɵInterruptState<TValue = unknown> {
     const mutableInterrupts = [...interrupts];
     const resume = buildResumeArray(mutableInterrupts, this.#responses);
     const toolResults = mutableInterrupts.flatMap((interrupt) => {
-      if (!interrupt.toolCallId) return [];
+      if (!interrupt.toolCallId || interrupt.reason !== "tool_call") return [];
       return [
         {
           toolCallId: interrupt.toolCallId,

--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -898,7 +898,7 @@ describe("useInterrupt", () => {
       runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
       const TOOL_INT: Interrupt = {
         id: "int-1",
-        reason: "tool_approval",
+        reason: "tool_call",
         toolCallId: "tc-1",
       };
       const calls: any[] = [];
@@ -939,6 +939,25 @@ describe("useInterrupt", () => {
       });
     });
 
+    it("does not persist a tool-result message for backend-owned interrupts", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const renderSpy = vi.fn();
+      render(<StandardHarness renderSpy={renderSpy} />);
+      fireStandardInterrupt([
+        {
+          id: "mastra-run::int-1",
+          reason: "human_approval",
+          toolCallId: "int-1",
+        },
+      ]);
+
+      await act(async () => {
+        screen.getByTestId("resolve").click();
+      });
+
+      expect(mockAgent.addMessage).not.toHaveBeenCalled();
+    });
+
     it("forwards the interrupting runId and suppresses duplicate resolves", async () => {
       const events: string[] = [];
       runAgentMock.mockImplementation(async () => {
@@ -947,7 +966,7 @@ describe("useInterrupt", () => {
       });
       const TOOL_INT: Interrupt = {
         id: "int-run-id",
-        reason: "tool_approval",
+        reason: "tool_call",
         toolCallId: "tc-run-id",
       };
       const resolves: Array<


### PR DESCRIPTION
## Summary

Only create client-side tool results for `tool_call` interrupts. Backend-owned interrupts now resume without synthetic tool messages, preventing duplicate results.

Includes Core, Angular, and React test coverage.

## References

- Fixes #6201
- Related: #6270
- [AG-UI interrupts](https://docs.ag-ui.com/concepts/interrupts)

## Validation

- [x] Core, Angular, and React tests
- [x] Full workspace test suite
- [x] Type checks