### PR TITLE
fix(react, vue): preserve popup rounded corners

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import CopilotChatView, {
+import type {
   CopilotChatViewProps,
   WelcomeScreenProps,
 } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
 import CopilotChatToggleButton from "./CopilotChatToggleButton";
 import { CopilotModalHeader } from "./CopilotModalHeader";
 import { cn } from "../../lib/utils";
-import { renderSlot, SlotValue } from "../../lib/slots";
+import type { SlotValue } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 import {
   CopilotChatConfigurationProvider,
   CopilotChatDefaultLabels,
@@ -209,7 +211,7 @@ function CopilotPopupViewInternal({
     <div
       data-copilotkit
       className={cn(
-        "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch",
+        "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent",
         "cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4",
       )}
     >

--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -233,7 +233,7 @@ function CopilotPopupViewInternal({
     <div
       data-copilotkit
       className={cn(
-        "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch",
+        "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent",
         "cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4",
       )}
     >

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.tsx
@@ -448,6 +448,22 @@ describe("CopilotPopupView Slot System E2E Tests", () => {
   // 8. INTEGRATION TESTS
   // ============================================================================
   describe("8. Integration Tests", () => {
+    it("keeps the positioning wrapper transparent so rounded corners remain visible", () => {
+      const { container } = render(
+        <TestWrapper>
+          <CopilotPopupView messages={sampleMessages} defaultOpen={true} />
+        </TestWrapper>,
+      );
+
+      const popup = container.querySelector("[data-copilot-popup]");
+      const positioningWrapper = popup?.parentElement;
+
+      expect(positioningWrapper?.hasAttribute("data-copilotkit")).toBe(true);
+      expect(positioningWrapper?.classList.contains("cpk:bg-transparent")).toBe(
+        true,
+      );
+    });
+
     it("should render popup with all default components when open", () => {
       const { container } = render(
         <TestWrapper>

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.tsx
@@ -448,7 +448,7 @@ describe("CopilotPopupView Slot System E2E Tests", () => {
   // 8. INTEGRATION TESTS
   // ============================================================================
   describe("8. Integration Tests", () => {
-    it("keeps the positioning wrapper transparent so rounded corners remain visible", () => {
+    it("keeps the transparent-background utility on the positioning wrapper", () => {
       const { container } = render(
         <TestWrapper>
           <CopilotPopupView messages={sampleMessages} defaultOpen={true} />
@@ -459,6 +459,7 @@ describe("CopilotPopupView Slot System E2E Tests", () => {
       const positioningWrapper = popup?.parentElement;
 
       expect(positioningWrapper?.hasAttribute("data-copilotkit")).toBe(true);
+      // jsdom does not load the generated stylesheet; this guards the utility-class contract only.
       expect(positioningWrapper?.classList.contains("cpk:bg-transparent")).toBe(
         true,
       );

--- a/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
+++ b/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
@@ -366,7 +366,7 @@ onBeforeUnmount(() => {
   <div
     v-if="isRendered"
     data-copilotkit
-    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
+    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
   >
     <div
       ref="containerRef"

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.ts
@@ -540,6 +540,25 @@ describe("CopilotPopupView Slot System E2E Tests", () => {
   });
 
   describe("8. Integration Tests", () => {
+    it("keeps the positioning wrapper transparent so rounded corners remain visible", () => {
+      const Host = defineComponent({
+        components: { CopilotPopupView },
+        setup() {
+          return { sampleMessages };
+        },
+        template: `<CopilotPopupView :messages="sampleMessages" :default-open="true" />`,
+      });
+
+      const { container } = renderInWrapper(Host);
+      const popup = container.querySelector("[data-copilot-popup]");
+      const positioningWrapper = popup?.parentElement;
+
+      expect(positioningWrapper?.hasAttribute("data-copilotkit")).toBe(true);
+      expect(positioningWrapper?.classList.contains("cpk:bg-transparent")).toBe(
+        true,
+      );
+    });
+
     it("should render popup with all default components when open", () => {
       const Host = defineComponent({
         components: { CopilotPopupView },

--- a/packages/vue/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.ts
+++ b/packages/vue/src/v2/components/chat/__tests__/CopilotPopupView.slots.e2e.test.ts
@@ -540,7 +540,7 @@ describe("CopilotPopupView Slot System E2E Tests", () => {
   });
 
   describe("8. Integration Tests", () => {
-    it("keeps the positioning wrapper transparent so rounded corners remain visible", () => {
+    it("keeps the transparent-background utility on the positioning wrapper", () => {
       const Host = defineComponent({
         components: { CopilotPopupView },
         setup() {
@@ -554,6 +554,7 @@ describe("CopilotPopupView Slot System E2E Tests", () => {
       const positioningWrapper = popup?.parentElement;
 
       expect(positioningWrapper?.hasAttribute("data-copilotkit")).toBe(true);
+      // jsdom does not load the generated stylesheet; this guards the utility-class contract only.
       expect(positioningWrapper?.classList.contains("cpk:bg-transparent")).toBe(
         true,
       );


### PR DESCRIPTION
## What does this PR do?

Fixes the v2 popup wrapper background in both React and Vue.

The outer fixed positioning wrapper keeps `data-copilotkit` for theme scoping, but now explicitly applies `cpk:bg-transparent`. This prevents the default theme background from showing around the inner popup's 16px rounded corners.

Regression tests verify that the positioning wrapper remains theme-scoped and carries the transparent background utility in both implementations.

## Related PRs and Issues

- Fixes https://github.com/CopilotKit/CopilotKit/issues/6472

## Testing

- `pnpm nx run @copilotkit/react-core:test --skip-nx-cache --excludeTaskDependencies --outputStyle=static`
- `pnpm nx run @copilotkit/vue:test --skip-nx-cache --excludeTaskDependencies --outputStyle=static`
- `pnpm nx run-many -t build:css -p @copilotkit/react-core @copilotkit/vue --parallel=2 --skip-nx-cache --outputStyle=static`
- Direct type checks for `@copilotkit/react-core` and `@copilotkit/vue`
- Pre-commit affected package tests, publint, and attw checks

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] Documentation is not required for this focused bug fix
- [x] "Allow edits by maintainers" is checked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved popup layout behavior so its contents stretch appropriately within the container.
  * Updated popup styling to maintain a transparent background across React and Vue implementations.

* **Tests**
  * Added integration coverage verifying popup wrapper attributes and styling classes when the popup is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->