### PR TITLE
fix(angular): prevent duplicate OpenGenerativeUI sandboxes

### DIFF
--- a/packages/angular/src/lib/components/open-generative-ui/__tests__/open-generative-ui-activity-renderer.spec.ts
+++ b/packages/angular/src/lib/components/open-generative-ui/__tests__/open-generative-ui-activity-renderer.spec.ts
@@ -192,6 +192,85 @@ describe("CopilotOpenGenerativeUIRenderer", () => {
     ).not.toBeNull();
   });
 
+  it("does not duplicate the final sandbox while its loader is pending", async () => {
+    let resolveLoader!: (value: { create: typeof mockCreate }) => void;
+    mockLoadWebsandbox.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoader = resolve;
+      }),
+    );
+    const content: OpenGenerativeUIContent = {
+      css: ".metric { color: blue; }",
+      cssComplete: true,
+      html: ['<body><div class="metric">Revenue</div></body>'],
+      htmlComplete: true,
+    };
+
+    setContent(fixture, content);
+    await flushSandboxImport(fixture);
+    setContent(fixture, { ...content });
+    await flushSandboxImport(fixture);
+
+    resolveLoader({ create: mockCreate });
+    await flushSandboxImport(fixture);
+
+    expect({
+      createCount: mockCreate.mock.calls.length,
+      destroyCount: mockDestroy.mock.calls.length,
+      iframeCount: fixture.nativeElement.querySelectorAll(
+        '[data-testid="open-generative-ui-final-sandbox"]',
+      ).length,
+      loaderCount: mockLoadWebsandbox.mock.calls.length,
+    }).toEqual({
+      createCount: 1,
+      destroyCount: 0,
+      iframeCount: 1,
+      loaderCount: 1,
+    });
+  });
+
+  it("cancels stale final sandbox effects when content changes A to B to A", async () => {
+    let resolveLoader!: (value: { create: typeof mockCreate }) => void;
+    mockLoadWebsandbox.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoader = resolve;
+      }),
+    );
+    const contentA: OpenGenerativeUIContent = {
+      html: ["<body><p>A</p></body>"],
+      htmlComplete: true,
+    };
+    const contentB: OpenGenerativeUIContent = {
+      html: ["<body><p>B</p></body>"],
+      htmlComplete: true,
+    };
+
+    setContent(fixture, contentA);
+    await flushSandboxImport(fixture);
+    setContent(fixture, contentB);
+    await flushSandboxImport(fixture);
+    setContent(fixture, contentA);
+    await flushSandboxImport(fixture);
+
+    resolveLoader({ create: mockCreate });
+    await flushSandboxImport(fixture);
+
+    expect({
+      createCount: mockCreate.mock.calls.length,
+      destroyCount: mockDestroy.mock.calls.length,
+      iframeCount: fixture.nativeElement.querySelectorAll(
+        '[data-testid="open-generative-ui-final-sandbox"]',
+      ).length,
+      loaderCount: mockLoadWebsandbox.mock.calls.length,
+    }).toEqual({
+      createCount: 1,
+      destroyCount: 0,
+      iframeCount: 1,
+      loaderCount: 3,
+    });
+    expect(mockCreate.mock.calls[0][1].frameContent).toContain("<p>A</p>");
+  });
+
   it("destroys the preview sandbox when final HTML arrives", async () => {
     setContent(fixture, {
       css: ".metric { color: red; }",

--- a/packages/angular/src/lib/components/open-generative-ui/open-generative-ui-activity-renderer.ts
+++ b/packages/angular/src/lib/components/open-generative-ui/open-generative-ui-activity-renderer.ts
@@ -9,6 +9,7 @@ import {
   inject,
   input,
   signal,
+  untracked,
   viewChild,
   InjectionToken,
 } from "@angular/core";
@@ -183,7 +184,6 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
   private previewSandbox: WebsandboxInstance | undefined;
   private sandboxReady = false;
   private previewReady = false;
-  private finalSandboxKey: string | undefined;
   private executedExpressionIndex = 0;
   private pendingQueue: string[] = [];
   private jsFunctionsInjected = false;
@@ -256,6 +256,35 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
       this.clearThrottle();
       this.destroyPreviewSandbox();
       this.destroyFinalSandbox();
+    });
+
+    afterRenderEffect({
+      write: (onCleanup) => {
+        const fullHtml = this.fullHtml();
+        const css = this.css();
+        const container = this.containerRef()?.nativeElement;
+
+        untracked(() => {
+          let cancelled = false;
+
+          onCleanup(() => {
+            cancelled = true;
+            this.destroyFinalSandbox();
+          });
+
+          this.resetFinalRuntimeState();
+          this.autoHeight.set(undefined);
+          if (!container || !fullHtml) return;
+
+          this.destroyPreviewSandbox();
+          void this.createFinalSandbox(
+            fullHtml,
+            css,
+            container,
+            () => cancelled,
+          );
+        });
+      },
     });
 
     afterRenderEffect({
@@ -413,10 +442,6 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
 
   private reconcileSandboxState(state: OpenGenerativeUIRenderState): void {
     if (!state.fullHtml) {
-      this.destroyFinalSandbox();
-      this.resetFinalRuntimeState();
-      this.autoHeight.set(undefined);
-
       if (!state.hasPreview) {
         this.destroyPreviewSandbox();
         return;
@@ -428,43 +453,21 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
     }
 
     this.destroyPreviewSandbox();
-    const finalSandboxKey = this.getFinalSandboxKey(state.fullHtml, state.css);
-    if (!this.sandbox || this.finalSandboxKey !== finalSandboxKey) {
-      void this.createFinalSandbox(state.fullHtml, state.css, finalSandboxKey);
-    }
-
     this.injectJsFunctions(state.jsFunctions);
     void this.executeNewExpressions(state.jsExpressions);
-  }
-
-  private getFinalSandboxKey(
-    fullHtml: string,
-    css: string | undefined,
-  ): string {
-    return JSON.stringify([fullHtml, css ?? ""]);
   }
 
   private async createFinalSandbox(
     fullHtml: string,
     css: string | undefined,
-    finalSandboxKey: string,
+    container: HTMLDivElement,
+    isCancelled: () => boolean,
   ): Promise<void> {
-    const container = this.containerRef()?.nativeElement;
-    if (!container || !fullHtml) return;
-
-    this.destroyPreviewSandbox();
-    this.destroyFinalSandbox();
-    this.finalSandboxKey = finalSandboxKey;
-    this.resetFinalRuntimeState();
-    this.autoHeight.set(undefined);
-
     const htmlContent = css ? injectCssIntoHtml(fullHtml, css) : fullHtml;
 
     try {
       const Websandbox = await this.loadWebsandbox();
-      if (!this.containerRef() || this.finalSandboxKey !== finalSandboxKey) {
-        return;
-      }
+      if (isCancelled()) return;
 
       const sandbox = Websandbox.create(this.createLocalApi(), {
         frameContainer: container,
@@ -479,7 +482,7 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
       this.styleIframe(sandbox.iframe);
 
       sandbox.promise.then(() => {
-        if (this.sandbox !== sandbox) return;
+        if (isCancelled() || this.sandbox !== sandbox) return;
         this.sandboxReady = true;
         void sandbox.run(`
           var s = document.createElement('style');
@@ -491,9 +494,6 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
         for (const code of queue) void sandbox.run(code);
       });
     } catch (error) {
-      if (this.finalSandboxKey === finalSandboxKey) {
-        this.finalSandboxKey = undefined;
-      }
       console.error("[OpenGenerativeUI] Failed to load sandbox module:", error);
     }
   }
@@ -598,7 +598,6 @@ export class CopilotOpenGenerativeUIRenderer implements OnChanges {
     }
     this.sandboxReady = false;
     this.heightMeasured = false;
-    this.finalSandboxKey = undefined;
   }
 }
 


### PR DESCRIPTION
Prevents stale async loaders from creating duplicate OpenGenerativeUI sandbox iframes by tying final sandbox creation to `afterRenderEffect` cleanup.

Adds regression tests for identical content and A → B → A races.

### Testing

- Angular tests
- Type checking
- Angular package build