### PR TITLE
feat(channels-slack): render table cells as rich_text when they carry markup

### DIFF
--- a/packages/channels-slack/src/__tests__/markdown-to-rich-text.test.ts
+++ b/packages/channels-slack/src/__tests__/markdown-to-rich-text.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  markdownToRichTextRuns,
+  needsRichText,
+  truncateRuns,
+} from "../markdown-to-rich-text.js";
+
+const ISSUE_URL = "https://linear.app/copilotkit/issue/CPK-1234";
+
+describe("markdownToRichTextRuns", () => {
+  it("returns a single plain run for plain text", () => {
+    const runs = markdownToRichTextRuns("🟡 In Progress");
+    expect(runs).toEqual([{ type: "text", text: "🟡 In Progress" }]);
+    expect(needsRichText(runs)).toBe(false);
+  });
+
+  it("returns no runs for empty input", () => {
+    expect(markdownToRichTextRuns("")).toEqual([]);
+    expect(needsRichText([])).toBe(false);
+  });
+
+  it("converts a bold markdown link into a styled link run", () => {
+    const runs = markdownToRichTextRuns(`[**CPK-1234**](${ISSUE_URL})`);
+    expect(runs).toEqual([
+      {
+        type: "link",
+        url: ISSUE_URL,
+        text: "CPK-1234",
+        style: { bold: true },
+      },
+    ]);
+    expect(needsRichText(runs)).toBe(true);
+  });
+
+  it("converts mixed inline markup into one run per span", () => {
+    expect(
+      markdownToRichTextRuns(
+        `**bold** plain \`code\` — [unstyled link](${ISSUE_URL})`,
+      ),
+    ).toEqual([
+      { type: "text", text: "bold", style: { bold: true } },
+      { type: "text", text: " plain " },
+      { type: "text", text: "code", style: { code: true } },
+      { type: "text", text: " — " },
+      { type: "link", url: ISSUE_URL, text: "unstyled link" },
+    ]);
+  });
+
+  it("carries italic and strikethrough", () => {
+    expect(markdownToRichTextRuns("*soft* and ~~gone~~")).toEqual([
+      { type: "text", text: "soft", style: { italic: true } },
+      { type: "text", text: " and " },
+      { type: "text", text: "gone", style: { strike: true } },
+    ]);
+  });
+
+  it("leaves word-internal markers alone", () => {
+    const runs = markdownToRichTextRuns("provider_file_id and 2 * 3 * 4");
+    expect(runs).toEqual([
+      { type: "text", text: "provider_file_id and 2 * 3 * 4" },
+    ]);
+    expect(needsRichText(runs)).toBe(false);
+  });
+
+  it("treats a bare URL as plain text (Slack does not linkify it either)", () => {
+    expect(needsRichText(markdownToRichTextRuns(ISSUE_URL))).toBe(false);
+  });
+});
+
+describe("truncateRuns", () => {
+  it("leaves runs within budget untouched", () => {
+    const runs = markdownToRichTextRuns(`[**CPK-1234**](${ISSUE_URL})`);
+    expect(truncateRuns(runs, 2000)).toEqual(runs);
+  });
+
+  it("cuts the straddling run and drops the rest, landing on the budget", () => {
+    const runs = truncateRuns(
+      [
+        { type: "text", text: "abcde", style: { bold: true } },
+        { type: "link", url: ISSUE_URL, text: "dropped" },
+      ],
+      3,
+    );
+    expect(runs).toEqual([
+      { type: "text", text: "ab…", style: { bold: true } },
+    ]);
+  });
+
+  it("does not count link URLs against the visible-text budget", () => {
+    const runs: Parameters<typeof truncateRuns>[0] = [
+      { type: "link", url: `${ISSUE_URL}?very=long&query=string`, text: "ok" },
+    ];
+    expect(truncateRuns(runs, 5)).toEqual(runs);
+  });
+});

--- a/packages/channels-slack/src/markdown-to-rich-text.ts
+++ b/packages/channels-slack/src/markdown-to-rich-text.ts
@@ -1,0 +1,215 @@
+import { markdownToMrkdwn } from "./markdown-to-mrkdwn.js";
+
+/**
+ * Inline character styles Slack's `rich_text` elements can carry. Omitted
+ * entirely (rather than set to `false`) when a run is unstyled, matching the
+ * payload shape Slack itself emits.
+ */
+export interface RichTextStyle {
+  bold?: true;
+  italic?: true;
+  strike?: true;
+  code?: true;
+}
+
+/** A literal text run inside a `rich_text_section`. */
+export interface RichTextTextRun {
+  type: "text";
+  text: string;
+  style?: RichTextStyle;
+}
+
+/** A link run inside a `rich_text_section`. Renders clickable in Slack. */
+export interface RichTextLinkRun {
+  type: "link";
+  url: string;
+  text?: string;
+  style?: RichTextStyle;
+}
+
+export type RichTextRun = RichTextTextRun | RichTextLinkRun;
+
+/**
+ * One pass over Slack's inline `mrkdwn` markup. Alternatives, in order:
+ *
+ *   1/2 `<url|label>` or `<url>`   → link
+ *   3   `` `code` ``               → code run (contents are literal)
+ *   4   `*bold*`
+ *   5   `~strike~`
+ *   6   `_italic_`
+ *
+ * The style markers require a non-word boundary outside and non-whitespace
+ * inside, mirroring the italic rule in {@link markdownToMrkdwn} and Slack's
+ * own behaviour, so `snake_case_names` and `2 * 3 * 4` are left alone.
+ */
+const INLINE_MRKDWN_SOURCE =
+  /<([^<>|\n]+)(?:\|([^<>\n]*))?>|`([^`\n]+)`|(?<![\w*])\*(\S(?:[^*\n]*\S)?)\*(?![\w*])|(?<![\w~])~(\S(?:[^~\n]*\S)?)~(?![\w~])|(?<![\w_])_(\S(?:[^_\n]*\S)?)_(?![\w_])/
+    .source;
+
+/**
+ * A fresh matcher per scan: `tokenize` recurses into nested markup, and a
+ * shared sticky/global regex would have its `lastIndex` clobbered by the
+ * inner scan.
+ */
+const inlineMatcher = () => new RegExp(INLINE_MRKDWN_SOURCE, "g");
+
+/**
+ * Convert the portable Markdown dialect into Slack `rich_text` runs.
+ *
+ * This deliberately routes through {@link markdownToMrkdwn} — the package's
+ * single source of truth for what the portable dialect means — and then
+ * tokenizes its output, which is Slack's own well-specified inline `mrkdwn`
+ * syntax. That keeps one Markdown parser in the package instead of two
+ * divergent ones; the step added here is a `mrkdwn` tokenizer, not a second
+ * Markdown dialect.
+ *
+ * A side effect of going through `mrkdwn` is that inline markup a caller wrote
+ * in Slack's syntax directly (`<https://x|y>`, `*bold*`) is honoured too,
+ * which is what a caller writing it plainly wants.
+ */
+export function markdownToRichTextRuns(markdown: string): RichTextRun[] {
+  if (!markdown) return [];
+  return mergeAdjacent(tokenize(markdownToMrkdwn(markdown), {}));
+}
+
+/**
+ * True when the runs need a `rich_text` cell to render faithfully — i.e. they
+ * contain a link or any styled run. Plain runs render identically as
+ * `raw_text`, so callers keep emitting that for them.
+ */
+export function needsRichText(runs: readonly RichTextRun[]): boolean {
+  return runs.some(
+    (run) => run.type === "link" || Object.keys(run.style ?? {}).length > 0,
+  );
+}
+
+/**
+ * Clamp the runs to `max` characters of *visible* text, mirroring
+ * {@link truncateText}: an ellipsis replaces the last kept character only when
+ * something was actually dropped.
+ *
+ * Link URLs are not counted — only the text a reader sees — and a link whose
+ * label gets cut stays a link. Slack documents the cell budget as a text
+ * length, and applying it to visible text is the reading that keeps a rich
+ * cell and the equivalent plain cell truncating at the same place.
+ */
+export function truncateRuns(
+  runs: readonly RichTextRun[],
+  max: number,
+): RichTextRun[] {
+  const total = runs.reduce((sum, run) => sum + visibleText(run).length, 0);
+  if (total <= max) return [...runs];
+
+  const out: RichTextRun[] = [];
+  let budget = max;
+  for (const run of runs) {
+    if (budget <= 0) break;
+    const text = visibleText(run);
+    if (text.length <= budget) {
+      out.push(run);
+      budget -= text.length;
+      continue;
+    }
+    // This run straddles the limit: keep budget-1 chars plus the ellipsis so
+    // the cell lands at exactly `max`, then stop.
+    out.push(withText(run, text.slice(0, Math.max(0, budget - 1)) + "…"));
+    budget = 0;
+  }
+  return out;
+}
+
+function visibleText(run: RichTextRun): string {
+  return run.text ?? "";
+}
+
+function withText(run: RichTextRun, text: string): RichTextRun {
+  return { ...run, text };
+}
+
+function tokenize(input: string, inherited: RichTextStyle): RichTextRun[] {
+  const runs: RichTextRun[] = [];
+  const pushText = (text: string) => {
+    if (text.length > 0) runs.push(styled({ type: "text", text }, inherited));
+  };
+
+  let last = 0;
+  const re = inlineMatcher();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(input)) !== null) {
+    pushText(input.slice(last, match.index));
+    last = match.index + match[0].length;
+
+    const [, url, label, code, bold, strike, italic] = match;
+    if (url !== undefined) {
+      const inner =
+        label === undefined || label === ""
+          ? undefined
+          : tokenize(label, inherited);
+      const link: RichTextLinkRun = { type: "link", url };
+      if (inner) {
+        link.text = inner.map(visibleText).join("");
+        // A Slack link element carries one style, so per-run styling inside a
+        // label collapses to the union of the styles found in it.
+        const style = unionStyle(inner);
+        if (Object.keys(style).length > 0) link.style = style;
+      }
+      runs.push(link);
+    } else if (code !== undefined) {
+      // Code spans are literal: no nested markup.
+      runs.push(
+        styled({ type: "text", text: code }, { ...inherited, code: true }),
+      );
+    } else if (bold !== undefined) {
+      runs.push(...tokenize(bold, { ...inherited, bold: true }));
+    } else if (strike !== undefined) {
+      runs.push(...tokenize(strike, { ...inherited, strike: true }));
+    } else if (italic !== undefined) {
+      runs.push(...tokenize(italic, { ...inherited, italic: true }));
+    }
+  }
+  pushText(input.slice(last));
+  return runs;
+}
+
+function styled(run: RichTextTextRun, style: RichTextStyle): RichTextTextRun {
+  return Object.keys(style).length > 0 ? { ...run, style: { ...style } } : run;
+}
+
+function unionStyle(runs: readonly RichTextRun[]): RichTextStyle {
+  const style: RichTextStyle = {};
+  for (const run of runs) {
+    if (run.style?.bold) style.bold = true;
+    if (run.style?.italic) style.italic = true;
+    if (run.style?.strike) style.strike = true;
+    if (run.style?.code) style.code = true;
+  }
+  return style;
+}
+
+/** Collapse neighbouring text runs that share a style into one run. */
+function mergeAdjacent(runs: readonly RichTextRun[]): RichTextRun[] {
+  const out: RichTextRun[] = [];
+  for (const run of runs) {
+    const prev = out[out.length - 1];
+    if (
+      prev !== undefined &&
+      prev.type === "text" &&
+      run.type === "text" &&
+      sameStyle(prev.style, run.style)
+    ) {
+      out[out.length - 1] = { ...prev, text: prev.text + run.text };
+      continue;
+    }
+    out.push(run);
+  }
+  return out;
+}
+
+function sameStyle(a: RichTextStyle | undefined, b: RichTextStyle | undefined) {
+  return (
+    !!a?.bold === !!b?.bold &&
+    !!a?.italic === !!b?.italic &&
+    !!a?.strike === !!b?.strike &&
+    !!a?.code === !!b?.code
+  );
+}

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -3,6 +3,33 @@ import type { ChannelNode } from "@copilotkit/channels-ui";
 import { describe, expect, it } from "vitest";
 import { renderBlockKit, renderSlackMessage } from "./block-kit.js";
 
+const ISSUE_URL = "https://linear.app/copilotkit/issue/CPK-1234";
+
+/** One-row table IR with the given header + cell texts. */
+const table = (headers: string[], cells: string[]): ChannelNode[] => [
+  {
+    type: "table",
+    props: {
+      columns: headers.map((header) => ({ header })),
+      children: [
+        {
+          type: "row",
+          props: {
+            children: cells.map((value) => ({
+              type: "cell",
+              props: { children: [{ type: "text", props: { value } }] },
+            })),
+          },
+        },
+      ],
+    },
+  },
+];
+
+/** The rendered `rows` of the single table block produced by `ir`. */
+const cellsOf = (ir: ChannelNode[]): unknown[][] =>
+  (renderBlockKit(ir)[0] as unknown as { rows: unknown[][] }).rows;
+
 describe("renderBlockKit", () => {
   it("flattens a message into header + section blocks (markdown → mrkdwn)", () => {
     const ir = renderToIR(
@@ -161,6 +188,98 @@ describe("renderBlockKit", () => {
         column_settings: [{ align: "left" }, { align: "center" }],
       },
     ]);
+  });
+
+  describe("table cells", () => {
+    it("keeps plain content as raw_text, byte for byte", () => {
+      const [, body] = cellsOf(table(["Status"], ["🟡 In Progress"]));
+      expect(body).toEqual([{ type: "raw_text", text: "🟡 In Progress" }]);
+    });
+
+    it("promotes a markdown link with bold label to a rich_text cell", () => {
+      const [, body] = cellsOf(
+        table(["Issue"], [`[**CPK-1234**](${ISSUE_URL})`]),
+      );
+      expect(body).toEqual([
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                {
+                  type: "link",
+                  url: ISSUE_URL,
+                  text: "CPK-1234",
+                  style: { bold: true },
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("renders mixed runs in one cell", () => {
+      const [, body] = cellsOf(
+        table(
+          ["Mixed"],
+          [`**bold** plain \`code\` — [unstyled link](${ISSUE_URL})`],
+        ),
+      );
+      expect(body).toEqual([
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                { type: "text", text: "bold", style: { bold: true } },
+                { type: "text", text: " plain " },
+                { type: "text", text: "code", style: { code: true } },
+                { type: "text", text: " — " },
+                { type: "link", url: ISSUE_URL, text: "unstyled link" },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("never promotes a header cell, even with markdown in it", () => {
+      const [header] = cellsOf(table([`[**Issue**](${ISSUE_URL})`], ["plain"]));
+      expect(header).toEqual([
+        { type: "raw_text", text: `[**Issue**](${ISSUE_URL})` },
+      ]);
+    });
+
+    it("truncates a plain cell at 2000 chars", () => {
+      const [, body] = cellsOf(table(["Long"], ["a".repeat(2500)]));
+      expect(body).toEqual([
+        { type: "raw_text", text: "a".repeat(1999) + "…" },
+      ]);
+    });
+
+    it("truncates a rich cell on visible text, keeping the styling", () => {
+      const [, body] = cellsOf(table(["Long"], [`**${"a".repeat(2500)}**`]));
+      expect(body).toEqual([
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [
+                {
+                  type: "text",
+                  text: "a".repeat(1999) + "…",
+                  style: { bold: true },
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   it("passes raw native Block Kit through unchanged", () => {

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -2,6 +2,12 @@ import { isNativeNode } from "@copilotkit/channels-ui";
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import type { ContextActionsBlock, KnownBlock } from "@slack/types";
 import { markdownToMrkdwn } from "../markdown-to-mrkdwn.js";
+import {
+  markdownToRichTextRuns,
+  needsRichText,
+  truncateRuns,
+} from "../markdown-to-rich-text.js";
+import type { RichTextRun } from "../markdown-to-rich-text.js";
 import { SLACK_LIMITS, clampArray, truncateText } from "./budget.js";
 import { serializeSlackNativeNode } from "../native-codec.js";
 import { validateSlackBlockKit } from "../block-kit-validation.js";
@@ -305,14 +311,9 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       return;
     }
     case "table": {
-      // Native Slack Table block: rows of `{ type: "raw_text", text }` cells.
-      // Header row from `columns`, data rows from `row`/`cell` children.
-      // Not yet in `@slack/types`, so the block is built plain and cast.
-      const cellOf = (text: string): { type: "raw_text"; text: string } => ({
-        type: "raw_text",
-        text: truncateText(text, SLACK_LIMITS.cellText),
-      });
-
+      // Native Slack Table block. Header row from `columns`, data rows from
+      // `row`/`cell` children. Not yet in `@slack/types`, so the block is
+      // built plain and cast.
       const columnsProp = props.columns as
         | { header: string; align?: "left" | "center" | "right" }[]
         | undefined;
@@ -320,16 +321,18 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
         ? clampArray(columnsProp, SLACK_LIMITS.tableColumns).items
         : undefined;
 
-      const rows: { type: "raw_text"; text: string }[][] = [];
+      const rows: TableCell[][] = [];
       if (columns && columns.length > 0) {
-        rows.push(columns.map((c) => cellOf(c.header)));
+        // Header cells stay `raw_text`: Slack already renders them bold, and
+        // `rich_text` is not allowed in a `data_table` header cell.
+        rows.push(columns.map((c) => rawTextCell(c.header)));
       }
 
       const rowNodes = childNodes(node).filter((c) => c.type === "row");
       const { items: dataRows } = clampArray(rowNodes, SLACK_LIMITS.tableRows);
       for (const rowNode of dataRows) {
         const cells = childNodes(rowNode).filter((c) => c.type === "cell");
-        rows.push(cells.map((cell) => cellOf(collectText(cell))));
+        rows.push(cells.map((cell) => bodyCell(collectText(cell))));
       }
 
       const block: Record<string, unknown> = { type: "table", rows };
@@ -496,6 +499,47 @@ function fieldMrkdwn(node: ChannelNode): string {
 }
 
 /** Concatenate the `value` of all descendant `text` nodes (depth-first). */
+/**
+ * A cell of a Slack `table` block. `raw_text` is literal — Markdown, Slack
+ * link syntax and bare URLs all render as plain characters — so cell content
+ * that carries inline markup is promoted to `rich_text` instead.
+ *
+ * Only the portable `<Table>` vocabulary funnels through here; a `data_table`
+ * only ever reaches Slack via the native passthrough (`Slack.Block.DataTable`
+ * → `native-codec.ts`), which is untouched. `rich_text` body cells were
+ * verified to render in both block types.
+ */
+type TableCell =
+  | { type: "raw_text"; text: string }
+  | {
+      type: "rich_text";
+      elements: [{ type: "rich_text_section"; elements: RichTextRun[] }];
+    };
+
+function rawTextCell(text: string): TableCell {
+  return { type: "raw_text", text: truncateText(text, SLACK_LIMITS.cellText) };
+}
+
+/**
+ * Render a body cell: `rich_text` when the content actually needs it (link,
+ * bold, italic, strikethrough or inline code), otherwise the byte-identical
+ * `raw_text` payload it has always produced — plain content, emoji glyphs
+ * included, passes through untouched.
+ */
+function bodyCell(text: string): TableCell {
+  const runs = markdownToRichTextRuns(text);
+  if (!needsRichText(runs)) return rawTextCell(text);
+  return {
+    type: "rich_text",
+    elements: [
+      {
+        type: "rich_text_section",
+        elements: truncateRuns(runs, SLACK_LIMITS.cellText),
+      },
+    ],
+  };
+}
+
 function collectText(node: ChannelNode): string {
   if (typeof node.type === "string" && node.type === "text") {
     return String(node.props?.value ?? "");


### PR DESCRIPTION
## Problem

Portable `<Table>` / `<Row>` / `<Cell>` cells were always emitted as Slack `raw_text`, which is literal. Measured in a real Slack workspace:

- `[**CPK-1234**](https://linear.app/...)` renders as literal text
- Slack's own `<https://…|CPK-1234>` renders as literal text
- a bare URL is not auto-linkified

So there was **no way** to get a clickable link or bold text into a table cell through the portable vocabulary. This blocks moving an OpenTag issue list from one-text-section-per-row to a real Slack `table`, since its identifiers are markdown links to Linear.

## Change

`<Cell>` body content is now emitted as a `rich_text` cell **when, and only when, it carries markup** — a link, bold, italic, strikethrough or inline code. Plain content still produces the byte-identical `raw_text` payload it always did (emoji glyphs and everything else pass through untouched), so no existing fixture or snapshot changes.

- New `src/markdown-to-rich-text.ts` converts the portable dialect into `rich_text` runs. It routes through the existing `markdownToMrkdwn` — the package's single source of truth for what the portable dialect means — and tokenizes its `mrkdwn` output. The package keeps one markdown parser; what is added is an `mrkdwn` tokenizer, not a second dialect.
- Header cells always stay `raw_text`: Slack already renders them bold (verified — no visual difference), and `rich_text` is not allowed in a `data_table` header cell, so promoting one risks a refusal.
- Truncation: the 2000-char cell budget now applies to the **visible text** of a rich cell, mirroring `truncateText` (ellipsis only when something was actually dropped). Link URLs are not counted, and a link whose label is cut stays a link — this keeps a rich cell and the equivalent plain cell truncating at the same place.
- Only the portable `table` path is touched. A `data_table` reaches Slack solely through the native passthrough (`Slack.Block.DataTable` → `native-codec.ts`), which is untouched; `rich_text` body cells were verified to render in both block types.

## Verification

Both target payload shapes were **verified live in a real Slack workspace** (delivered through the managed transport, clickable/bold confirmed by eye) and are asserted exactly in the tests:

```json
{"type":"link","url":"https://linear.app/copilotkit/issue/CPK-1234","text":"CPK-1234","style":{"bold":true}}
```

```json
[{"type":"text","text":"bold","style":{"bold":true}},
 {"type":"text","text":" plain "},
 {"type":"text","text":"code","style":{"code":true}},
 {"type":"text","text":" — "},
 {"type":"link","url":"https://linear.app/copilotkit/issue/CPK-1234","text":"unstyled link"}]
```

New tests cover plain text (unchanged `raw_text`), the bold link, mixed runs in one cell, a header cell with markdown in it, both truncation paths, and that word-internal markers (`provider_file_id`, `2 * 3 * 4`) are left alone.

`nx run @copilotkit/channels-slack:{check-types,test,build}` all pass (405 tests), `oxfmt --check` clean, `oxlint` warning count unchanged. No existing test needed changing.

Linear: OSS-794
