### PR TITLE
fix(shell-docs): restore docs runtime packaging

### DIFF
--- a/showcase/shell-docs/Dockerfile
+++ b/showcase/shell-docs/Dockerfile
@@ -43,7 +43,7 @@ RUN cd scripts && node node_modules/tsx/dist/cli.mjs generate-registry.ts \
     && cd ../shell-docs && npx next build
 
 FROM node:20-slim AS runner
-WORKDIR /app
+WORKDIR /app/shell-docs
 ARG COMMIT_SHA=unknown
 ARG BRANCH=unknown
 ENV NODE_ENV=production
@@ -56,6 +56,12 @@ COPY --from=builder /app/shell-docs/node_modules ./node_modules
 COPY --from=builder /app/shell-docs/package.json ./
 COPY --from=builder /app/shell-docs/public ./public
 COPY --from=builder /app/shell-docs/src/content ./src/content
+
+# Turbopack can emit hashed package aliases under `.next/node_modules` as
+# relative symlinks back to `shell-docs/node_modules`. Keep the builder's
+# directory layout in the runtime image, and fail the image build if a future
+# Next.js change leaves any runtime alias dangling.
+RUN node -e 'const fs = require("node:fs"); const root = ".next/node_modules"; const broken = fs.readdirSync(root).map((name) => `${root}/${name}`).filter((path) => fs.lstatSync(path).isSymbolicLink() && !fs.existsSync(path)); if (broken.length) { console.error(`Broken Next.js runtime symlink(s):\n${broken.join("\n")}`); process.exit(1); }'
 
 EXPOSE 10000
 CMD ["npx", "next", "start", "-p", "10000"]


### PR DESCRIPTION
## Why

The staging docs site currently returns HTTP 500 for normal content pages, so the production promotion guard correctly refuses to promote it. This began after the AEO contract change expanded Turbopack's root to `showcase/`. Next now emits hashed runtime package aliases under `.next/node_modules` as relative symlinks back to `shell-docs/node_modules`; the Docker runner relocated `.next` to `/app/.next`, breaking those aliases at runtime.

This is unrelated to the earlier canonical-host lock. That change had multiple green staging deploy checks afterward, and machine routes such as `/robots.txt` continue to render.

## What changed

- preserve the builder's `/app/shell-docs` directory layout in the runner image
- fail the image build if any Next runtime package alias is dangling

## Evidence

- old runner layout: `/` returns 500 with `ERR_MODULE_NOT_FOUND` for `next-mdx-remote-53ad903680e5eefa/rsc`; `/robots.txt` returns 200
- corrected runner layout from the same built artifact: `/`, `/quickstart`, `/aeo`, `/robots.txt`, `/sitemap.xml`, `/llms.txt`, and `/.well-known/copilotkit-capabilities/v1.json` all return 200 with expected content types
- standalone shell-docs production build passed
- shell-docs typecheck passed
- shell-docs lint passed with existing warnings only
- repo commit hooks passed

## Local Docker note

The full local image build completed the app build and reached the corrected runner stage. The constrained Colima disk filled while exporting the 764 MB `node_modules` layer; the PR's Depot build is the decisive full-image check.