### PR TITLE
docs(README): Channels is live — add per-channel status

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 Build **agent-native applications** — on any framework, on any surface.
 
-Generative UI, shared state, and human-in-the-loop workflows for React, Angular, Vue, React Native — and beyond the browser.
+Generative UI, shared state, and human-in-the-loop workflows for React, Angular, Vue, React Native — and in Slack and Microsoft Teams.
 
 </div>
 
@@ -55,7 +55,7 @@ Generative UI, shared state, and human-in-the-loop workflows for React, Angular,
 
 CopilotKit is a best-in-class SDK for building full-stack agentic applications, Generative UI, and chat applications.
 
-What started as a React library is now a **multi-platform agentic framework**: the same agent can power your web app, your mobile app, and your team's Slack workspace.
+What started as a React library is now the **horizontal layer between your agents and your users**: the same agent can power your web app, your mobile app, and your team's Slack or Microsoft Teams workspace.
 
 We are the company behind the **[AG-UI Protocol](https://github.com/ag-ui-protocol/ag-ui)** - adopted by Google, LangChain, AWS, Microsoft, Mastra, PydanticAI, and more!
 
@@ -104,10 +104,12 @@ One agent backend. Every frontend.
 | 🅰️ Angular                                  | ✅ Supported | [Source Code & Quickstart](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular) |
 | 💚 Vue                                      | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue)     |
 | 📱 React Native                             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native)                                                       |
-| 💬 Slack / MS Teams / Discord / WhatsApp / Google Chat / iMessage / Telegram / SMS | ✅ Supported      | [Quickstart](https://docs.copilotkit.ai/slack)                                        |
+| 💬 Slack / Microsoft Teams                  | ✅ Supported | [Channels](https://www.copilotkit.ai/channels) · [Quickstart](https://docs.copilotkit.ai/slack)             |
+| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [See the Channels roadmap](https://www.copilotkit.ai/channels)                          |
 
+Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework and channel.
 
-## 💬 Beyond the Browser: Slack & Microsoft Teams (Discord, Google Chat, Telegram, iMessage, SMS, WhatsApp)
+## 💬 Beyond the Browser: Agents in Slack and Microsoft Teams
 
 <img width="1920" height="1080" alt="Write it once, run every channel" src="https://github.com/user-attachments/assets/883e5ede-0387-4ae8-a361-48da3adf8f22" />
 
@@ -119,9 +121,9 @@ CopilotKit now lets you deploy the **same agent** to the places your users alrea
 - **Slack** – Agents as first-class Slack apps: threads, tool calls, and human-in-the-loop approvals right in the channel.
 - **Microsoft Teams** – Bring agentic workflows to the enterprise, where your org already lives.
 
-🔒 **Early access:** We're onboarding teams now.
+Discord, WhatsApp, Telegram, Google Chat, iMessage, and SMS are on the way.
 
-👉 **[Request early access →](https://go.copilotkit.ai/beyond-the-web-form)**
+👉 **[Explore Channels →](https://www.copilotkit.ai/channels)**
 
 ## 🧠 Self-Learning Agents
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ One agent backend. Every frontend.
 | 💚 Vue                                                          | ✅ Supported   | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) |
 | 📱 React Native                                                 | ✅ Supported   | [Quickstart](https://docs.copilotkit.ai/react-native)                                                   |
 | 💬 Slack / Microsoft Teams                                      | ✅ Supported   | [Channels](https://www.copilotkit.ai/channels) · [Quickstart](https://docs.copilotkit.ai/slack)         |
-| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [Channels SDK](#-channels-one-agent-every-chat-app)                                                     |
+| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [Channels](https://www.copilotkit.ai/channels)                                                          |
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework and channel.
 
@@ -117,17 +117,6 @@ The **Channels SDK** takes the agent you already built and drops it into the cha
 
 - **Slack** – Agents as first-class Slack apps: threads, tool calls, and human-in-the-loop approvals right in the channel.
 - **Microsoft Teams** – Bring agentic workflows to the enterprise, where your org already lives.
-
-| Channel         | Status         |
-| --------------- | -------------- |
-| Slack           | ✅ Supported   |
-| Microsoft Teams | ✅ Supported   |
-| WhatsApp        | 🟡 Coming soon |
-| Discord         | 🟡 Coming soon |
-| Telegram        | 🟡 Coming soon |
-| Google Chat     | 🟡 Coming soon |
-| iMessage        | 🟡 Coming soon |
-| SMS             | 🟡 Coming soon |
 
 👉 **[Explore Channels →](https://www.copilotkit.ai/channels)**
 

--- a/README.md
+++ b/README.md
@@ -98,21 +98,20 @@ https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3
 
 One agent backend. Every frontend.
 
-| Platform                                    | Status       | Get Started                                                                                                 |
-| ------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
-| ⚛️ React / Next.js                          | ✅ GA        | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart)                                          |
-| 🅰️ Angular                                  | ✅ Supported | [Source Code & Quickstart](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular) |
-| 💚 Vue                                      | ✅ Supported | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue)     |
-| 📱 React Native                             | ✅ Supported | [Quickstart](https://docs.copilotkit.ai/react-native)                                                       |
-| 💬 Slack / Microsoft Teams                  | ✅ Supported | [Channels](https://www.copilotkit.ai/channels) · [Quickstart](https://docs.copilotkit.ai/slack)             |
-| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [See the Channels roadmap](https://www.copilotkit.ai/channels)                          |
+| Platform                                                        | Status         | Get Started                                                                                             |
+| --------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------- |
+| ⚛️ React / Next.js                                              | ✅ GA          | [Quickstart](https://docs.copilotkit.ai/built-in-agent/quickstart)                                      |
+| 🅰️ Angular                                                      | ✅ Supported   | [Source Code & Quickstart](https://github.com/CopilotKit/CopilotKit/tree/main/packages/angular)         |
+| 💚 Vue                                                          | ✅ Supported   | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) |
+| 📱 React Native                                                 | ✅ Supported   | [Quickstart](https://docs.copilotkit.ai/react-native)                                                   |
+| 💬 Slack / Microsoft Teams                                      | ✅ Supported   | [Channels](https://www.copilotkit.ai/channels) · [Quickstart](https://docs.copilotkit.ai/slack)         |
+| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [See the Channels roadmap](https://www.copilotkit.ai/channels)                                          |
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework and channel.
 
 ## 💬 Beyond the Browser: Agents in Slack and Microsoft Teams
 
 <img width="1920" height="1080" alt="Write it once, run every channel" src="https://github.com/user-attachments/assets/883e5ede-0387-4ae8-a361-48da3adf8f22" />
-
 
 Your agents can run and generate Generative UI beyond the web app (**[Learn more](https://www.copilotkit.ai/integrations)**).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Generative UI, shared state, and human-in-the-loop workflows for React, Angular,
 
 </div>
 
-[![CopilotKit](https://github.com/user-attachments/assets/aeb56c28-c766-44a5-810c-5d999bb6a32a)](https://go.copilotkit.ai/copilotkit-docs)
+[![Bring Your Own Agent. Any Channel. — CopilotKit and AG-UI connect any agent framework to Slack, Microsoft Teams, Discord, WhatsApp, Telegram, Google Chat, iMessage, and SMS.](assets/bring-your-own-agent-any-channel.png)](https://go.copilotkit.ai/copilotkit-docs)
 
 <div align="center" style="display:flex;justify-content:start;gap:16px;height:20px;margin: 0;">
   <a href="https://www.npmjs.com/package/@copilotkit/react-core" target="_blank">

--- a/README.md
+++ b/README.md
@@ -105,22 +105,29 @@ One agent backend. Every frontend.
 | 💚 Vue                                                          | ✅ Supported   | [Source Code - Quickstart coming soon](https://github.com/CopilotKit/CopilotKit/tree/main/packages/vue) |
 | 📱 React Native                                                 | ✅ Supported   | [Quickstart](https://docs.copilotkit.ai/react-native)                                                   |
 | 💬 Slack / Microsoft Teams                                      | ✅ Supported   | [Channels](https://www.copilotkit.ai/channels) · [Quickstart](https://docs.copilotkit.ai/slack)         |
-| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [See the Channels roadmap](https://www.copilotkit.ai/channels)                                          |
+| 🔜 Discord / WhatsApp / Telegram / Google Chat / iMessage / SMS | 🟡 Coming soon | [Channels SDK](#-channels-one-agent-every-chat-app)                                                     |
 
 Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer for each framework and channel.
 
-## 💬 Beyond the Browser: Agents in Slack and Microsoft Teams
+## 💬 Channels: One Agent, Every Chat App
 
 <img width="1920" height="1080" alt="Write it once, run every channel" src="https://github.com/user-attachments/assets/883e5ede-0387-4ae8-a361-48da3adf8f22" />
 
-Your agents can run and generate Generative UI beyond the web app (**[Learn more](https://www.copilotkit.ai/integrations)**).
-
-CopilotKit now lets you deploy the **same agent** to the places your users already work:
+The **Channels SDK** takes the agent you already built and drops it into the chat apps your users live in — same tools, same shared state, same human-in-the-loop, no rewrite (**[Learn more](https://www.copilotkit.ai/channels)**).
 
 - **Slack** – Agents as first-class Slack apps: threads, tool calls, and human-in-the-loop approvals right in the channel.
 - **Microsoft Teams** – Bring agentic workflows to the enterprise, where your org already lives.
 
-Discord, WhatsApp, Telegram, Google Chat, iMessage, and SMS are on the way.
+| Channel         | Status         |
+| --------------- | -------------- |
+| Slack           | ✅ Supported   |
+| Microsoft Teams | ✅ Supported   |
+| WhatsApp        | 🟡 Coming soon |
+| Discord         | 🟡 Coming soon |
+| Telegram        | 🟡 Coming soon |
+| Google Chat     | 🟡 Coming soon |
+| iMessage        | 🟡 Coming soon |
+| SMS             | 🟡 Coming soon |
 
 👉 **[Explore Channels →](https://www.copilotkit.ai/channels)**
 

--- a/assets/bring-your-own-agent-any-channel.png
+++ b/assets/bring-your-own-agent-any-channel.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:198052201616477e7b46e2c259af49facf870c1cfbc34470132c3b5335f06f1c
+size 856322


### PR DESCRIPTION
Channels is live at [copilotkit.ai/channels](https://www.copilotkit.ai/channels), but the README still gated it behind an early-access form and claimed eight channels were supported when only two of them ship today. This cleans that up and brings the README in line with how we talk about Channels now.

## What changed

**Channels is no longer early access.** The `🔒 Early access — we're onboarding teams now` block and the `Request early access →` form link are gone, replaced with a straight link to the live Channels page.

**"Beyond the Browser" is retired.** That section is now **Channels: One Agent, Every Chat App**, and the copy leads with the Channels SDK — the agent you already built, dropped into the chat apps your users live in, no rewrite.

**Honest status per channel.** The platform table used to claim `✅ Supported` for eight channels in a single row. It now has two: Slack and Microsoft Teams as Supported, with a quickstart you can follow today, and Discord, WhatsApp, Telegram, Google Chat, iMessage, and SMS as Coming soon, pointing at the Channels page.

No per-package or npm links anywhere. Package paths and versions move too fast to keep accurate in a README, and a channel with no shipped quickstart shouldn't send anyone to a 404. When one ships, it moves up to the Supported row with a real link.

**New banner.** The old art above the badges showed only agent-framework logos — half the story. The new one shows both halves: every agent framework *and* every channel. It lives at `assets/bring-your-own-agent-any-channel.png` so it ships with the repo. The link target is unchanged.

**Messaging matches the site.** copilotkit.ai now leads with "Connect any agent to any user," so two lines were updated to match:

- the subtitle now names Slack and Microsoft Teams instead of "beyond the browser"
- "a multi-platform agentic framework" is now "the **horizontal layer between your agents and your users**"

**One restored sentence.** `Your agent logic stays the same — AG-UI handles the wire protocol, CopilotKit handles the UI layer…` was dropped in #6239. It's the only line that explains what the platform table is showing, so it's back.

## How the Supported / Coming soon line was drawn

Checked against the repo, npm, and the docs site rather than going off existing prose. Slack, Teams, and WhatsApp have live docs pages; Discord and Telegram have code but no docs; Google Chat, iMessage, and SMS have neither. Slack and Teams are also the two the site markets today, so those are the Supported rows.

WhatsApp is the debatable one — it has a published package *and* a live docs page, so there's a case for promoting it. Left as Coming soon deliberately; happy to flip it if that's wrong.

Worth a conscious ack: the banner shows all eight channel logos while the table calls six of them Coming soon. That's intentional — it's the launch art already running on the site.

## GTM impact

The `go.copilotkit.ai/beyond-the-web-form` link is removed **from the Channels section only**. It's still live in the Self-Learning section, which is genuinely still early access, so the go-link and its attribution keep working. No campaign loses its destination.

One new outbound destination: `copilotkit.ai/channels`. No tracking, pixels, or analytics touched — this is a README-only change.

## Verification

Everything below was checked against the live rendered branch, not assumed:

- Every link in the diff returns 200 — the Channels page, and the Slack, Teams, and WhatsApp docs pages.
- The new banner renders. `*.png` is LFS-tracked in this repo and no other README image is LFS-backed, so this was worth confirming: `raw.githubusercontent.com` serves the 131-byte LFS pointer, but `github.com/…/raw/…` — the path GitHub's README renderer actually uses — returns the real `image/png`, 856,322 bytes. Confirmed on the rendered branch page.
- No empty or dead links in the README.
- Formatting matches the repo's `oxfmt` config.

## Follow-up

AG-UI's README has the mirror-image problem — it lists Discord, WhatsApp, and Telegram as In Progress and duplicates the 1st-party Slack/Teams row. Handling that separately in ag-ui-protocol/ag-ui#2279.
