### PR TITLE
fix(runtime): only treat a request stream as consumed once it is drained

### DIFF
--- a/packages/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts
+++ b/packages/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts
@@ -1,0 +1,126 @@
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Readable } from "node:stream";
+import { describe, it, expect } from "vitest";
+import { isStreamConsumed } from "../request-handler";
+import type { IncomingWithBody } from "../request-handler";
+
+/**
+ * Tests for OSS-610 (originally diagnosed in #3489 by @AlexNti).
+ *
+ * `isStreamConsumed` decides whether the node-http handler streams the request
+ * body upstream or rebuilds it from `req.body`. When it says "consumed" but no
+ * parsed body exists, the handler forwards an empty payload — which is what
+ * broke Next.js pages-router apps running with `bodyParser: false`.
+ */
+
+function makeStream(): IncomingWithBody {
+  return new Readable({ read() {} }) as unknown as IncomingWithBody;
+}
+
+function drainStream(stream: Readable): Promise<void> {
+  return new Promise((resolve) => {
+    stream.resume();
+    stream.on("end", resolve);
+  });
+}
+
+describe("isStreamConsumed", () => {
+  it("returns false for a fresh, unread stream", () => {
+    expect(isStreamConsumed(makeStream())).toBe(false);
+  });
+
+  it("returns false when the stream has buffered data that has not been read", () => {
+    const stream = makeStream();
+    stream.push('{"foo":"bar"}');
+
+    expect(isStreamConsumed(stream)).toBe(false);
+  });
+
+  it("returns false when EOF was pushed and `complete` is set but nothing was read (async framework)", async () => {
+    const stream = makeStream();
+
+    // What the HTTP parser leaves behind once all network bytes have arrived:
+    // data buffered, EOF queued, `complete` flipped — none of which means the
+    // handler has read anything.
+    stream.push('{"foo":"bar"}');
+    stream.push(null);
+    (stream as any).complete = true;
+
+    // The event-loop tick that Next.js pages-router routing introduces between
+    // the socket read and the route handler.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(isStreamConsumed(stream)).toBe(false);
+  });
+
+  it("returns true once application code has drained the stream to end", async () => {
+    const stream = makeStream();
+    stream.push('{"foo":"bar"}');
+    stream.push(null);
+
+    await drainStream(stream);
+
+    expect(isStreamConsumed(stream)).toBe(true);
+  });
+});
+
+describe("isStreamConsumed over a real http.IncomingMessage", () => {
+  async function withServer(
+    handler: (req: IncomingWithBody) => Promise<unknown>,
+  ): Promise<unknown> {
+    let captured: unknown;
+    const server: Server = createServer((req, res) => {
+      handler(req as IncomingWithBody)
+        .then((value) => {
+          captured = value;
+          res.statusCode = 200;
+          res.end();
+        })
+        .catch(() => {
+          res.statusCode = 500;
+          res.end();
+        });
+    });
+
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      await fetch(`http://127.0.0.1:${port}/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: '{"foo":"bar"}',
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+
+    return captured;
+  }
+
+  it("reports an unread body as not consumed after async routing, and the body is still readable", async () => {
+    const result = (await withServer(async (req) => {
+      // Give the HTTP parser time to receive every byte and set `complete`,
+      // exactly as an async routing layer would before dispatching.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const consumedBefore = isStreamConsumed(req);
+
+      let body = "";
+      for await (const chunk of req) body += chunk;
+
+      return { consumedBefore, body, consumedAfter: isStreamConsumed(req) };
+    })) as { consumedBefore: boolean; body: string; consumedAfter: boolean };
+
+    // Pre-fix this was `true` (via `req.complete` / `_readableState.ended`), so
+    // the handler skipped the streaming path and sent an empty payload.
+    expect(result.consumedBefore).toBe(false);
+    // Proof the body really was still there to stream.
+    expect(result.body).toBe('{"foo":"bar"}');
+    expect(result.consumedAfter).toBe(true);
+  });
+});

--- a/packages/runtime/src/lib/integrations/node-http/request-handler.ts
+++ b/packages/runtime/src/lib/integrations/node-http/request-handler.ts
@@ -84,14 +84,13 @@ export function toHeaders(rawHeaders: IncomingMessage["headers"]): Headers {
 }
 
 export function isStreamConsumed(req: IncomingWithBody): boolean {
-  const readableState = (req as any)._readableState;
-
-  return Boolean(
-    req.readableEnded ||
-    req.complete ||
-    readableState?.ended ||
-    readableState?.endEmitted,
-  );
+  // `readableEnded` is the only signal that means "application code drained this
+  // stream to its end". `req.complete` and the private `_readableState.ended` are
+  // set by the HTTP parser once all network bytes arrive at the socket, which
+  // happens before any handler reads the body. In frameworks that await between
+  // socket read and dispatch (Next.js pages router), checking those flags
+  // reported an unread body as consumed and forwarded an empty payload upstream.
+  return Boolean(req.readableEnded);
 }
 
 export function synthesizeBodyFromParsedBody(


### PR DESCRIPTION
Re-applies a community fix from closed PR #3489 (diagnosed by @AlexNti) on the current tree. That PR patched `packages/v1/runtime/…`, a path retired by the repo restructure, so it could not be merged as-authored — but the bug is real and still live on `main`. Credit for the diagnosis, repro, and original test is theirs.

Linear: OSS-610

## Problem

`isStreamConsumed` in `packages/runtime/src/lib/integrations/node-http/request-handler.ts` over-reported that the request stream had been consumed:

```ts
return Boolean(
  req.readableEnded ||
  req.complete ||
  readableState?.ended ||
  readableState?.endEmitted,
);
```

`req.complete` and the private `_readableState.ended` are set by the Node HTTP parser once all network bytes reach the socket — before the route handler reads anything. Any framework that awaits between socket read and dispatch (notably the **Next.js pages router**) therefore sees them already `true` while the body sits unread in `_readableState.buffer`.

The call site in `node-http/index.ts`:

```ts
const streamConsumed = isStreamConsumed(req) || parsedBody !== undefined;
const canStream = hasBody && !streamConsumed;
```

With `bodyParser: false` there is no `req.body` to rebuild from either, so the handler logged `"Request stream consumed with no available body; sending empty payload."`, forwarded an **empty body** upstream, and the client got `400 Invalid JSON payload` — making agents unreachable on the pages router.

## Fix

Rely only on `req.readableEnded`, which flips true after the `end` event fires from genuinely draining the stream. `readableEnded` is exactly `_readableState.endEmitted`; the two dropped flags conflate *"the message arrived"* with *"the application read it"*.

The body-parser case is unaffected: parsers drain to `end` (so `readableEnded` is true), and the `parsedBody !== undefined` half of the call-site check covers it independently. The `isDisturbedOrLockedError` fallback remains as a backstop.

`copilotRuntimeNodeHttpEndpoint` backs the `nextjs/pages-router`, `node-express`, and `nest` integrations, so all three are covered by this change.

Live-checked the body-parser assumption on express 5.2.1 with `express.json()` + `express.urlencoded()` mounted:

| request | `readableEnded` | `req.body` | path taken |
|---|---|---|---|
| `application/json` | `true` | parsed | synthesis (unchanged) |
| `application/x-www-form-urlencoded` | `true` | parsed | synthesis (unchanged) |
| `text/plain` (parser skips) | `false` | `undefined` | streaming (correct) |
| `multipart/form-data` (parser skips) | `false` | `undefined` | streaming (correct) |


## Testing

New `packages/runtime/src/lib/integrations/node-http/__tests__/request-handler.test.ts` — @AlexNti's four unit cases plus a live `http.IncomingMessage` case that starts a real server, awaits past the parser, and asserts both the verdict and that the body was still readable.

Verified the tests actually pin the bug by running them against the pre-fix implementation:

```
$ git stash -- .../request-handler.ts && vitest run .../request-handler.test.ts
 FAIL  > isStreamConsumed > returns false when EOF was pushed and `complete` is set but nothing was read (async framework)
 AssertionError: expected true to be false
 FAIL  > isStreamConsumed over a real http.IncomingMessage > reports an unread body as not consumed after async routing...
 AssertionError: expected true to be false
 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

With the fix applied:

```
$ vitest run src/lib/integrations/node-http/
 ✓ src/lib/integrations/node-http/__tests__/request-duck-type.test.ts (4 tests)
 ✓ src/lib/integrations/node-http/__tests__/request-handler.test.ts (5 tests)
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

Full `packages/runtime` suite: `133 passed | 6 failed` — the 6 failing files (`google-genai-adapter`, `fetch-handler`, `inspector-metadata-passthrough`, `channel-manager-recovery`, `handle-inspector-metadata`, `intelligence-platform/client`) fail identically on a clean checkout of the same base commit in this worktree (`parseInspectorMetadataV1 is not a function`, a stale cross-package `dist`), so they are unrelated to this change. `oxfmt` + `oxlint` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
