### PR TITLE
fix(runtime): do not treat an unread stream as a pre-parsed body in the express bridge

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/express-fetch-bridge.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/express-fetch-bridge.test.ts
@@ -140,6 +140,73 @@ describe("express-fetch-bridge — pre-parsed body", () => {
 });
 
 /* ------------------------------------------------------------------------------------------------
+ * `req.body` set without the stream being consumed
+ * --------------------------------------------------------------------------------------------- */
+
+/**
+ * body-parser 1.x (Express 4) assigns `req.body = req.body || {}` *before* it
+ * checks whether it should parse at all, so a request it declines — multipart,
+ * text/plain — arrives with `req.body === {}` and the stream still full. This
+ * middleware reproduces that state; the awaiting middleware after it lets the
+ * HTTP parser finish, which is what sets `req.complete` on an unread stream.
+ */
+function legacyParserThatDeclinesToParse(): express.RequestHandler {
+  return (req, _res, next) => {
+    req.body = req.body || {};
+    next();
+  };
+}
+
+const echoBody: CopilotRuntimeFetchHandler = async (req) => {
+  const text = await req.text();
+  return new Response(
+    JSON.stringify({ text, contentType: req.headers.get("content-type") }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+};
+
+describe("express-fetch-bridge — req.body set but stream not consumed", () => {
+  function createLegacyApp(fetchHandler: CopilotRuntimeFetchHandler) {
+    const app = express();
+    const nodeHandler = createExpressNodeHandler(fetchHandler);
+
+    app.use(legacyParserThatDeclinesToParse());
+    app.use(async (_req, _res, next) => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      next();
+    });
+    app.all(/.*/, (req, res) => nodeHandler(req, res));
+    return app;
+  }
+
+  it("streams a text/plain body instead of rebuilding it from an empty req.body", async () => {
+    const res = await request(createLegacyApp(echoBody))
+      .post("/test")
+      .set("Content-Type", "text/plain")
+      .send("hello");
+
+    expect(res.status).toBe(200);
+    // Previously the bridge saw `req.body === {}` plus `req.complete` and
+    // rebuilt the request as `"{}"`, silently discarding the real payload.
+    expect(res.body.text).toBe("hello");
+  });
+
+  it("streams a multipart body instead of rebuilding it from an empty req.body", async () => {
+    const payload =
+      '--xyz\r\nContent-Disposition: form-data; name="file"\r\n\r\nAUDIOBYTES\r\n--xyz--';
+
+    const res = await request(createLegacyApp(echoBody))
+      .post("/test")
+      .set("Content-Type", "multipart/form-data; boundary=xyz")
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.text).toContain("AUDIOBYTES");
+    expect(res.body.contentType).toContain("multipart/form-data");
+  });
+});
+
+/* ------------------------------------------------------------------------------------------------
  * URL reconstruction
  * --------------------------------------------------------------------------------------------- */
 

--- a/packages/runtime/src/v2/runtime/endpoints/express-fetch-bridge.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/express-fetch-bridge.ts
@@ -113,11 +113,17 @@ function buildPreParsedRequest(
 function hasPreParsedBody(req: IncomingMessage & { body?: unknown }): boolean {
   if (req.body === undefined || req.body === null) return false;
 
-  // Check if the stream has already been consumed.
-  const state = (req as any)._readableState;
-  return Boolean(
-    req.readableEnded || req.complete || state?.ended || state?.endEmitted,
-  );
+  // Only `readableEnded` means "a parser drained this stream to its end".
+  // `req.complete` and the private `_readableState.ended` are set by the HTTP
+  // parser once the socket has all the bytes, whether or not anything read them.
+  //
+  // That distinction matters because `req.body` being set does not prove a parser
+  // ran: body-parser 1.x (Express 4) assigns `req.body = req.body || {}` before
+  // its own content-type checks, so a request it declines to parse — multipart
+  // upload, text/plain — reaches us with `req.body === {}` and a full, unread
+  // stream. Treating that as pre-parsed rebuilt the request from `{}` and
+  // dropped the real payload.
+  return Boolean(req.readableEnded);
 }
 
 function synthesizeBody(body: unknown): {


### PR DESCRIPTION
Follow-up to #6489. Same root cause — flags that report "the socket has the bytes" being read as "the application consumed the stream" — in a second, independent code path found while auditing for other copies of the check. Different trigger and different file, so it ships separately. **#6489 has since merged**, so this is the remaining half.

## Problem

`hasPreParsedBody` in `packages/runtime/src/v2/runtime/endpoints/express-fetch-bridge.ts` decides whether to rebuild the Fetch `Request` from `req.body` instead of streaming the Node request:

```ts
if (req.body === undefined || req.body === null) return false;
const state = (req as any)._readableState;
return Boolean(
  req.readableEnded || req.complete || state?.ended || state?.endEmitted,
);
```

`req.complete` and the private `_readableState` flags are set by the HTTP parser once the socket holds every byte, whether or not anything read them — so they do not establish that a parser ran.

And `req.body` being set does not establish it either. **body-parser 1.x (Express 4)** assigns `req.body = req.body || {}` at [`lib/types/json.js:108`](https://github.com/expressjs/body-parser/blob/1.20.3/lib/types/json.js#L108) — *before* its `hasBody` (111) and `shouldParse` (120) checks. So a request it declines to parse arrives at the bridge with `req.body === {}` and a full, unread stream. `req.complete` satisfied the check, the bridge rebuilt the request as `JSON.stringify({})`, and the real payload was silently dropped.

The reachable cases are any non-JSON POST behind a global `express.json()` — multipart uploads (audio transcription), `text/plain`, custom content types.

On Express 5 / body-parser 2.x the declined path sets `req.body = undefined`, so the function's first guard already returns false. This is an Express 4 exposure specifically.

## Fix

Gate on `req.readableEnded` alone — the one flag that only becomes true after a parser drains the stream to its end. When a parser genuinely ran, it is true and the rebuild path is taken exactly as before; when `req.body` is a placeholder over an unread stream, the request now falls through to the generic streaming handler, which reads the real body.

## Testing

Reproduced on **express 4.22.2 / body-parser 1.20.6** (installed outside the repo, since the workspace pins express 5), with a global `express.json()` and an awaiting middleware standing in for a real app's auth/routing layer. `current` is the predicate on `main`, `fixed` is this change:

| request | `req.body` | `readableEnded` | `complete` | `current` | `fixed` | what reaches the runtime today |
|---|---|---|---|---|---|---|
| `application/json` | `{"a":1}` | `true` | `true` | `true` | `true` | `{"a":1}` — correct |
| `multipart/form-data` | `{}` | `false` | `true` | `true` | `false` | **`{}` — payload dropped** |
| `text/plain` | `{}` | `false` | `true` | `true` | `false` | **`{}` — payload dropped** |

Two regression tests added to `express-fetch-bridge.test.ts`. They reproduce that state without adding an Express 4 dependency: a middleware that assigns `req.body = req.body || {}` without reading the stream, then an awaiting middleware so the parser sets `complete`.

Against the predicate on `main`, both fail with exactly the reported symptom:

```
 × streams a text/plain body instead of rebuilding it from an empty req.body
 × streams a multipart body instead of rebuilding it from an empty req.body
 AssertionError: expected '{}' to be 'hello'
```

With the fix, the whole bridge suite passes — including the 14 pre-existing tests, of which `receives JSON body when express.json() runs first` is the guard on the genuinely-pre-parsed path:

```
$ vitest run src/v2/runtime/__tests__/express-fetch-bridge.test.ts
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Full `packages/runtime` suite: `132 passed | 6 failed` — the 6 failing files are the same ones that fail on a clean checkout of the base commit in this worktree (`parseInspectorMetadataV1 is not a function`, a stale cross-package `dist`), unrelated to this change. `oxfmt` clean; `oxlint` adds no new warnings (16 before and after, all pre-existing in this file).

*(Those counts are the original pre-rebase run, against the old base. The rebased numbers are below and differ only because the base moved 1304 commits.)*

### Re-verified after rebase

The branch was 1304 commits behind main, so I rebased it onto `origin/main` (`0f6c616` → `1a93586`) and re-ran everything. Neither changed file was touched on main since the old merge-base, and the rebase took no conflicts.

A passing test does not prove the mechanism is live, so I mutation-checked both halves: with the old predicate restored, exactly the new tests fail and every pre-existing test still passes.

| | tests | mutation check (old predicate restored) |
|---|---|---|
| this PR — `express-fetch-bridge.test.ts` | 16/16 pass | 2 fail: `expected '{}' to be 'hello'`, `expected '{}' to contain 'AUDIOBYTES'` |
| #6489 on main — `request-handler.test.ts` | 5/5 pass | 2 fail: `consumedBefore` flips `false` → `true` |

#6489's fix survived the v1 → `v1-deprecated/` tree move and is still live at `packages/runtime/src/v1-deprecated/lib/integrations/node-http/request-handler.ts:93`.

**No regression from the rebase.** The full `packages/runtime` suite and `tsc --noEmit` give identical results on this branch and on a clean `origin/main` worktree:

| | full suite | `tsc --noEmit` |
|---|---|---|
| `origin/main` | 72 failed files, 380 failed, 1472 passed | 65 errors |
| this branch | 72 failed files, 380 failed, **1474** passed | 65 errors, byte-identical set |

The +2 are the new tests. The shared failures are the stale cross-package `@copilotkit/shared` dist in the worktree (`parseInspectorMetadataV1`, `computeSamplingMeta`), not this change — none of the 65 type errors is in either changed file, and CI builds `shared` fresh and reports `check-types` green. `oxfmt` clean; `oxlint` 16 warnings and 0 errors, the same count before and after.

I also re-ran the structural search for other copies of the predicate across the 1304 new commits. `_readableState` and `endEmitted` now appear only inside the explanatory comments at the two fixed sites, so there is no third copy.

## Note on the duplication

#6489 and this PR now hold the same one-line predicate in two files. I did not extract a shared helper: the other copy lives in the v1 tree, now at `packages/runtime/src/v1-deprecated/lib/integrations/`, and importing it into `v2/runtime` would couple v2 to code that is on its way out. Each site carries a comment explaining the flag semantics instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Express request handling so text and multipart request bodies are preserved when legacy body-parsing middleware assigns an empty body without consuming the request stream.
  - Prevented valid request payloads from being replaced with empty data when the original request stream remains available.
- **Tests**
  - Added coverage for legacy Express body-parser scenarios involving text and multipart requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
