### PR TITLE
Fix CopilotTask readable context inclusion

### DIFF
--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -199,6 +199,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
   });
 
   const { addElement, removeElement, printTree, getAllElements } = useTree();
+  const { copilotkit } = useCopilotKit();
   const [isLoading, setIsLoading] = useState(false);
   const [chatInstructions, setChatInstructions] = useState("");
   const [authStates, setAuthStates] = useState<Record<string, AuthState>>({});
@@ -245,6 +246,14 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     },
     [printTree],
   );
+
+  const getCopilotReadableContextString = useCallback(() => {
+    if (!copilotkit) return "";
+
+    return Object.values(copilotkit.context)
+      .map(({ description, value }) => `${description}:\n${value}`)
+      .join("\n\n");
+  }, [copilotkit]);
 
   const addContext = useCallback(
     (
@@ -665,6 +674,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       setRegisteredActions: handleSetRegisteredActions,
       removeRegisteredAction: handleRemoveRegisteredAction,
       getContextString,
+      getCopilotReadableContextString,
       addContext,
       removeContext,
       getAllContext,
@@ -723,6 +733,7 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
       handleSetRegisteredActions,
       handleRemoveRegisteredAction,
       getContextString,
+      getCopilotReadableContextString,
       addContext,
       removeContext,
       getAllContext,

--- a/packages/react-core/src/context/copilot-context.tsx
+++ b/packages/react-core/src/context/copilot-context.tsx
@@ -151,6 +151,7 @@ export interface CopilotContextParams {
     documents: DocumentPointer[],
     categories: string[],
   ) => string;
+  getCopilotReadableContextString?: () => string;
 
   // document context
   addDocumentContext: (

--- a/packages/react-core/src/lib/__tests__/copilot-task.test.ts
+++ b/packages/react-core/src/lib/__tests__/copilot-task.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestCopilotContext } from "../../test-helpers/copilot-context";
+import { CopilotTask } from "../copilot-task";
+
+const { generateCopilotResponse, functionCallHandler } = vi.hoisted(() => ({
+  generateCopilotResponse: vi.fn(),
+  functionCallHandler: vi.fn(),
+}));
+
+vi.mock("@copilotkit/runtime-client-gql", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@copilotkit/runtime-client-gql")>();
+
+  return {
+    ...actual,
+    CopilotRuntimeClient: vi.fn(() => ({
+      generateCopilotResponse,
+    })),
+  };
+});
+
+function createContext(overrides = {}) {
+  return createTestCopilotContext({
+    getFunctionCallHandler: () => functionCallHandler,
+    ...overrides,
+  });
+}
+
+function systemPromptFromLastRequest() {
+  return generateCopilotResponse.mock.calls.at(-1)?.[0].data.messages[0]
+    .textMessage.content;
+}
+
+describe("CopilotTask", () => {
+  beforeEach(() => {
+    generateCopilotResponse.mockClear();
+    generateCopilotResponse.mockReturnValue({
+      toPromise: () =>
+        Promise.resolve({
+          data: { generateCopilotResponse: { messages: [] } },
+        }),
+    });
+    functionCallHandler.mockReset();
+    vi.stubGlobal("window", { location: { href: "http://localhost" } });
+  });
+
+  it("includes active v2 readable context by default", async () => {
+    const task = new CopilotTask({ instructions: "Do the task" });
+
+    await task.run(
+      createContext({
+        getCopilotReadableContextString: () =>
+          "User profile:\n{\"name\":\"Ada\"}",
+      }),
+    );
+
+    expect(systemPromptFromLastRequest()).toContain(
+      "User profile:\n{\"name\":\"Ada\"}",
+    );
+  });
+
+  it("does not include readable context when includeCopilotReadable is false", async () => {
+    const task = new CopilotTask({
+      instructions: "Do the task",
+      includeCopilotReadable: false,
+    });
+
+    await task.run(
+      createContext({
+        getCopilotReadableContextString: () => "Hidden readable context",
+      }),
+    );
+
+    expect(systemPromptFromLastRequest()).not.toContain(
+      "Hidden readable context",
+    );
+  });
+
+  it("preserves explicit data with readable context", async () => {
+    const task = new CopilotTask<{ selectedId: number }>({
+      instructions: "Do the task",
+    });
+
+    await task.run(
+      createContext({
+        getCopilotReadableContextString: () => "Readable context",
+      }),
+      { selectedId: 42 },
+    );
+
+    const systemPrompt = systemPromptFromLastRequest();
+    expect(systemPrompt).toContain('{"selectedId":42}');
+    expect(systemPrompt).toContain("Readable context");
+    expect(systemPrompt.indexOf('{"selectedId":42}')).toBeLessThan(
+      systemPrompt.indexOf("Readable context"),
+    );
+  });
+});

--- a/packages/react-core/src/lib/__tests__/copilot-task.test.ts
+++ b/packages/react-core/src/lib/__tests__/copilot-task.test.ts
@@ -8,7 +8,8 @@ const { generateCopilotResponse, functionCallHandler } = vi.hoisted(() => ({
 }));
 
 vi.mock("@copilotkit/runtime-client-gql", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@copilotkit/runtime-client-gql")>();
+  const actual =
+    await importOriginal<typeof import("@copilotkit/runtime-client-gql")>();
 
   return {
     ...actual,
@@ -48,13 +49,12 @@ describe("CopilotTask", () => {
 
     await task.run(
       createContext({
-        getCopilotReadableContextString: () =>
-          "User profile:\n{\"name\":\"Ada\"}",
+        getCopilotReadableContextString: () => 'User profile:\n{"name":"Ada"}',
       }),
     );
 
     expect(systemPromptFromLastRequest()).toContain(
-      "User profile:\n{\"name\":\"Ada\"}",
+      'User profile:\n{"name":"Ada"}',
     );
   });
 

--- a/packages/react-core/src/lib/copilot-task.ts
+++ b/packages/react-core/src/lib/copilot-task.ts
@@ -63,7 +63,6 @@ import {
   processActionsForRuntimeRequest,
 } from "../types/frontend-action";
 import { CopilotContextParams } from "../context";
-import { defaultCopilotContextCategories } from "../components";
 
 export interface CopilotTaskConfig {
   /**
@@ -127,10 +126,7 @@ export class CopilotTask<T = any> {
     }
 
     if (this.includeCopilotReadable) {
-      contextString += context.getContextString(
-        [],
-        defaultCopilotContextCategories,
-      );
+      contextString += context.getCopilotReadableContextString?.() ?? "";
     }
 
     const systemMessage = new TextMessage({


### PR DESCRIPTION
## Summary
- Wire `CopilotTask` readable-context inclusion to the active v2 flat context store exposed through the React provider.
- Preserve explicit `data` prepending and the `includeCopilotReadable: false` gate.
- Add focused regression coverage for default include, false gate, and explicit data preservation.

## Verification
- Attempted: `pnpm --dir "/tmp/CopilotKit" exec vitest run packages/react-core/src/lib/__tests__/copilot-task.test.ts`
- Blocked by sandbox dependency/environment issue: `spawn vitest EACCES` (same class of unusable dependency install / executable permission failure reported in the previous attempt). No test assertion failure was observed.