### PR TITLE
fix(release): keep generated artifacts current in release PRs

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -97,6 +97,10 @@ jobs:
             pnpm tsx scripts/release/prepare-release.ts --bump ${{ inputs.bump }} --scope ${{ inputs.scope }}
           fi
 
+      - name: Generate public API manifest
+        if: inputs.dry_run != true
+        run: pnpm generate:public-api-manifest
+
       - name: Sync plugin skills
         if: inputs.dry_run != true
         run: pnpm sync:plugin-skills

--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -119,6 +119,55 @@ describe("syncPluginSkills", () => {
     expect(result.message).toContain("skills/runtime/SKILL.md");
   });
 
+  it("write mode syncs package skill versions before mirroring", async () => {
+    await makeRepo(repo);
+    await writeFile(
+      join(repo, "packages/runtime/package.json"),
+      JSON.stringify({ name: "@copilotkit/runtime", version: "1.68.0" }),
+    );
+    await writeFile(
+      join(repo, "packages/runtime/skills/runtime/SKILL.md"),
+      '---\nname: runtime\nlibrary_version: "1.67.1"\n---\n# Runtime\n',
+    );
+
+    const result = await syncPluginSkills({ cwd: repo, mode: "write" });
+
+    expect(result.exitCode).toBe(0);
+    expect(
+      await readFile(
+        join(repo, "packages/runtime/skills/runtime/SKILL.md"),
+        "utf8",
+      ),
+    ).toContain('library_version: "1.68.0"');
+    expect(
+      await readFile(join(repo, "skills/runtime/SKILL.md"), "utf8"),
+    ).toContain('library_version: "1.68.0"');
+  });
+
+  it("check mode detects stale package skill versions", async () => {
+    await makeRepo(repo);
+    await writeFile(
+      join(repo, "packages/runtime/package.json"),
+      JSON.stringify({ name: "@copilotkit/runtime", version: "1.68.0" }),
+    );
+    await writeFile(
+      join(repo, "packages/runtime/skills/runtime/SKILL.md"),
+      '---\nname: runtime\nlibrary_version: "1.67.1"\n---\n# Runtime\n',
+    );
+    await mkdir(join(repo, "skills/runtime"), { recursive: true });
+    await writeFile(
+      join(repo, "skills/runtime/SKILL.md"),
+      '---\nname: runtime\nlibrary_version: "1.67.1"\n---\n# Runtime\n',
+    );
+
+    const result = await syncPluginSkills({ cwd: repo, mode: "check" });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain(
+      "packages/runtime/skills/runtime/SKILL.md",
+    );
+  });
+
   it("check mode flags orphan files in the mirror (e.g., skill deleted from source)", async () => {
     await makeRepo(repo);
     await syncPluginSkills({ cwd: repo, mode: "write" });

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -44,6 +44,7 @@ export interface SyncResult {
 
 interface PackageSkill {
   slug: string; // e.g. "runtime"
+  packageDir: string; // absolute path to packages/<pkg>
   sourceDir: string; // absolute path of packages/<pkg>/skills/<slug>
   mirrorDir: string; // absolute path of skills/<slug>
 }
@@ -66,6 +67,7 @@ async function findPackageSkills(cwd: string): Promise<PackageSkill[]> {
       if (!existsSync(join(sourceDir, "SKILL.md"))) continue;
       out.push({
         slug: slug.name,
+        packageDir: join(packagesDir, pkg.name),
         sourceDir,
         mirrorDir: join(cwd, "skills", slug.name),
       });
@@ -106,6 +108,7 @@ export async function syncPluginSkills(opts: SyncOptions): Promise<SyncResult> {
   const orphans: string[] = [];
 
   for (const s of skills) {
+    await syncPackageSkillVersion(opts, s, changed);
     const files = await listFilesRec(s.sourceDir);
     for (const relPath of files) {
       const srcPath = join(s.sourceDir, relPath);
@@ -198,6 +201,32 @@ export async function syncPluginSkills(opts: SyncOptions): Promise<SyncResult> {
 }
 
 // ─── Version sync helper ─────────────────────────────────────────────────────
+
+async function syncPackageSkillVersion(
+  opts: SyncOptions,
+  skill: PackageSkill,
+  changed: string[],
+): Promise<void> {
+  const packageJsonPath = join(skill.packageDir, "package.json");
+  const skillPath = join(skill.sourceDir, "SKILL.md");
+  if (!existsSync(packageJsonPath) || !existsSync(skillPath)) return;
+
+  const packageVersion: string = JSON.parse(
+    await readFile(packageJsonPath, "utf8"),
+  ).version;
+  const source = await readFile(skillPath, "utf8");
+  const expected = source.replace(
+    /^library_version:\s*["']?[^"'\n]+["']?$/m,
+    `library_version: "${packageVersion}"`,
+  );
+  if (source === expected) return;
+
+  if (opts.mode === "check") {
+    changed.push(toPosix(relative(opts.cwd, skillPath)));
+  } else {
+    await writeFile(skillPath, expected);
+  }
+}
 
 // Returns a drift description string (for check mode), or empty string if in sync.
 // In write mode, mutates the files and always returns empty string.


### PR DESCRIPTION
## What changed

- Regenerate the public API manifest after stable release version bumps.
- Update package skill `library_version` metadata from each package before mirroring.
- Detect stale package skill versions in check mode.
- Cover write-mode synchronization and check-mode drift detection.

## Why

The v1.68.0 release PR bumped package versions without refreshing generated release artifacts. That made the public API manifest test fail, and refreshing the manifest then exposed stale package-skill versions.

This keeps both derived artifacts synchronized as part of the existing stable-release workflow.

## Validation

- `pnpm exec vitest run scripts/__tests__/sync-plugin-skills.test.ts scripts/__tests__/public-skill-drift.test.ts` — 19 passed
- `pnpm check:plugin-skills`
- `pnpm check:public-api-manifest`
- Targeted `oxfmt` check
- Pre-commit and commitlint hooks