### PR TITLE
docs(built-in-agent): mention Novita in OpenAI-compatible providers list

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -129,6 +129,12 @@ a self-hosted gateway, an internal LLM proxy, [Ollama](https://ollama.com), [Tog
 `createOpenAI({ baseURL })` pattern shown in [Custom Models](#custom-models-ai-sdk)
 above. Point `baseURL` at the provider's OpenAI-compatible route and pass your key:
 
+<Callout type="warn" title="Novita: use provider.chat(model)">
+  Novita only implements the Chat Completions endpoint, not Responses. Call it as
+  `provider.chat("model")` (not `provider("model")`) — the bare call form used in
+  the example below routes through Responses and returns an error on Novita.
+</Callout>
+
 ```typescript
 import { BuiltInAgent } from "@copilotkit/runtime/v2";
 import { createOpenAI } from "@ai-sdk/openai"; // [!code highlight]

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -125,7 +125,7 @@ const agent = new BuiltInAgent({
 
 Anything that exposes an **OpenAI-compatible** API, including [OpenRouter](https://openrouter.ai),
 a self-hosted gateway, an internal LLM proxy, [Ollama](https://ollama.com), [Together](https://together.ai),
-[Groq](https://groq.com), or your own fine-tuned endpoint, works through the same
+[Groq](https://groq.com), [Novita](https://novita.ai), or your own fine-tuned endpoint, works through the same
 `createOpenAI({ baseURL })` pattern shown in [Custom Models](#custom-models-ai-sdk)
 above. Point `baseURL` at the provider's OpenAI-compatible route and pass your key:
 


### PR DESCRIPTION

## What does this PR do?

Adds Novita to the list of OpenAI-compatible providers documented for the built-in agent's model selection, alongside OpenRouter, Ollama, Together, and Groq. Novita exposes an OpenAI-compatible `/openai/v1` endpoint, so it works through the existing `createOpenAI({ baseURL })` pattern already documented for those providers.

A follow-up commit adds a callout clarifying that Novita only implements the Chat Completions endpoint, not Responses — so readers should call `provider.chat(model)` rather than the bare `provider(model)` form shown in the adjacent OpenRouter example, which routes through Responses and would error on Novita's endpoint.

## Related PRs and Issues

- None

## Verification

- `npm run typecheck` — pass
- `npm run test` — 55/55 files, 374/374 tests pass
- `npm run build` — Next.js production build succeeded, 222/222 static pages generated
- Live verification: called Novita's OpenAI-compatible endpoint via `createOpenAI({ baseURL }).chat(model)` with model `deepseek/deepseek-v4-pro-0813` — HTTP 200, finish reason `stop`, usage populated

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [ ] "Allow edits by maintainers" is checked
