### PR TITLE
fix(core): make render/handler consume authoritative TOOL_CALL_ARGS data

### DIFF
--- a/packages/core/src/__tests__/core-tool-args-authoritative.test.ts
+++ b/packages/core/src/__tests__/core-tool-args-authoritative.test.ts
@@ -93,7 +93,11 @@ describe("CopilotKitCore authoritative tool call args (#4935)", () => {
 
   it("re-corrects args regressed by MESSAGES_SNAPSHOT and hands the authoritative args to the handler", async () => {
     const handler = vi.fn(async () => "done");
-    const tool = createTool({ name: "select_address", handler, followUp: false });
+    const tool = createTool({
+      name: "select_address",
+      handler,
+      followUp: false,
+    });
     copilotKitCore.addTool(tool);
 
     const agent = new SequenceAgent({ agentId: "seq-agent", threadId: "t-1" });
@@ -113,9 +117,13 @@ describe("CopilotKitCore authoritative tool call args (#4935)", () => {
     const toolCallMessage = agent.messages.find(
       (m) => m.role === "assistant" && m.toolCalls?.length,
     );
-    expect(
-      toolCallMessage?.toolCalls?.[0].function.arguments,
-    ).toBe(AUTHORITATIVE_ARGS);
+    expect(toolCallMessage?.role).toBe("assistant");
+    if (toolCallMessage?.role !== "assistant") {
+      throw new Error("Expected an assistant message with a tool call");
+    }
+    expect(toolCallMessage.toolCalls?.[0]?.function.arguments).toBe(
+      AUTHORITATIVE_ARGS,
+    );
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(
       JSON.parse(AUTHORITATIVE_ARGS),
@@ -157,7 +165,11 @@ describe("CopilotKitCore authoritative tool call args (#4935)", () => {
 
   it("leaves messages untouched when the snapshot matches the accumulated args", async () => {
     const handler = vi.fn(async () => "done");
-    const tool = createTool({ name: "select_address", handler, followUp: false });
+    const tool = createTool({
+      name: "select_address",
+      handler,
+      followUp: false,
+    });
     copilotKitCore.addTool(tool);
 
     const agent = new SequenceAgent({ agentId: "seq-agent", threadId: "t-1" });
@@ -222,8 +234,12 @@ describe("CopilotKitCore authoritative tool call args (#4935)", () => {
     const toolCallMessage = agent.messages.find(
       (m) => m.role === "assistant" && m.toolCalls?.length,
     );
-    expect(
-      toolCallMessage?.toolCalls?.[0].function.arguments,
-    ).toBe(AUTHORITATIVE_ARGS);
+    expect(toolCallMessage?.role).toBe("assistant");
+    if (toolCallMessage?.role !== "assistant") {
+      throw new Error("Expected an assistant message with a tool call");
+    }
+    expect(toolCallMessage.toolCalls?.[0]?.function.arguments).toBe(
+      AUTHORITATIVE_ARGS,
+    );
   });
 });

--- a/packages/core/src/__tests__/core-tool-args-authoritative.test.ts
+++ b/packages/core/src/__tests__/core-tool-args-authoritative.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { ReplaySubject } from "rxjs";
+import { CopilotKitCore } from "../core";
+import { createTool } from "./test-utils";
+
+// ---------------------------------------------------------------------------
+// Reproduction of #4935: a backend args_streamer enriches tool call arguments
+// via TOOL_CALL_ARGS (authoritative per the AG-UI protocol), but a later
+// MESSAGES_SNAPSHOT — still carrying the LLM's raw, hallucinated values —
+// replaces agent.messages wholesale in @ag-ui/client. Both the render path
+// (toolCall.function.arguments on the message) and the handler path
+// (parseToolArguments in the run handler) must consume the authoritative args.
+// ---------------------------------------------------------------------------
+
+const HALLUCINATED_ARGS = JSON.stringify({
+  postcode: "M1 1AA",
+  addresses: [{ id: "1", line1: "1 Piccadilly Gardens" }],
+});
+const AUTHORITATIVE_ARGS = JSON.stringify({
+  postcode: "M1 1AA",
+  addresses: [
+    { id: "6", line1: "1 Piccadilly" },
+    { id: "7", line1: "15 Portland Street" },
+  ],
+});
+
+class SequenceAgent extends AbstractAgent {
+  public events = new ReplaySubject<BaseEvent>();
+
+  run(_input: RunAgentInput) {
+    return this.events.asObservable();
+  }
+}
+
+function emitIssue4935Sequence(agent: SequenceAgent, toolCallId: string) {
+  agent.events.next({
+    type: EventType.RUN_STARTED,
+    threadId: "t-1",
+    runId: "r-1",
+  });
+  agent.events.next({
+    type: EventType.TOOL_CALL_START,
+    toolCallId,
+    toolCallName: "select_address",
+    parentMessageId: "asst-1",
+  });
+  // The args_streamer's replacement — a complete JSON payload, so the
+  // accumulated buffer at TOOL_CALL_END matches the issue's evidence.
+  agent.events.next({
+    type: EventType.TOOL_CALL_ARGS,
+    toolCallId,
+    delta: AUTHORITATIVE_ARGS,
+  });
+  agent.events.next({ type: EventType.TOOL_CALL_END, toolCallId });
+  // Snapshot built from the LLM's raw output (before enrichment) replaces
+  // the tool-call message by id — the regression under test.
+  agent.events.next({
+    type: EventType.MESSAGES_SNAPSHOT,
+    messages: [
+      {
+        id: "asst-1",
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          {
+            id: toolCallId,
+            type: "function",
+            function: {
+              name: "select_address",
+              arguments: HALLUCINATED_ARGS,
+            },
+          },
+        ],
+      },
+    ],
+  });
+  agent.events.next({
+    type: EventType.RUN_FINISHED,
+    threadId: "t-1",
+    runId: "r-1",
+  });
+  agent.events.complete();
+}
+
+describe("CopilotKitCore authoritative tool call args (#4935)", () => {
+  let copilotKitCore: CopilotKitCore;
+
+  beforeEach(() => {
+    copilotKitCore = new CopilotKitCore({});
+  });
+
+  it("re-corrects args regressed by MESSAGES_SNAPSHOT and hands the authoritative args to the handler", async () => {
+    const handler = vi.fn(async () => "done");
+    const tool = createTool({ name: "select_address", handler, followUp: false });
+    copilotKitCore.addTool(tool);
+
+    const agent = new SequenceAgent({ agentId: "seq-agent", threadId: "t-1" });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "seq-agent",
+      agent: agent as any,
+    });
+    // addAgent__unsafe_dev_only notifies subscribers asynchronously; let the
+    // core-level agent subscriptions (incl. the tool-args manager) settle
+    // before driving the event stream.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const runPromise = copilotKitCore.runAgent({ agent: agent as any });
+    emitIssue4935Sequence(agent, "call-1");
+    await runPromise;
+
+    const toolCallMessage = agent.messages.find(
+      (m) => m.role === "assistant" && m.toolCalls?.length,
+    );
+    expect(
+      toolCallMessage?.toolCalls?.[0].function.arguments,
+    ).toBe(AUTHORITATIVE_ARGS);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      JSON.parse(AUTHORITATIVE_ARGS),
+      expect.objectContaining({
+        toolCall: expect.objectContaining({ id: "call-1" }),
+      }),
+    );
+  });
+
+  it("hands authoritative args to wildcard tools through the same fallback", async () => {
+    const captured: Array<Record<string, unknown>> = [];
+    const wildcard = createTool({
+      name: "*",
+      handler: async (args: any) => {
+        captured.push(args);
+        return "done";
+      },
+      followUp: false,
+    });
+    copilotKitCore.addTool(wildcard);
+
+    const agent = new SequenceAgent({ agentId: "seq-agent", threadId: "t-1" });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "seq-agent",
+      agent: agent as any,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const runPromise = copilotKitCore.runAgent({ agent: agent as any });
+    emitIssue4935Sequence(agent, "call-1");
+    await runPromise;
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual({
+      toolName: "select_address",
+      args: JSON.parse(AUTHORITATIVE_ARGS),
+    });
+  });
+
+  it("leaves messages untouched when the snapshot matches the accumulated args", async () => {
+    const handler = vi.fn(async () => "done");
+    const tool = createTool({ name: "select_address", handler, followUp: false });
+    copilotKitCore.addTool(tool);
+
+    const agent = new SequenceAgent({ agentId: "seq-agent", threadId: "t-1" });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "seq-agent",
+      agent: agent as any,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const runPromise = copilotKitCore.runAgent({ agent: agent as any });
+    // Ordinary flow without an args_streamer: the snapshot carries the same
+    // accumulated args, so no correction should occur.
+    agent.events.next({
+      type: EventType.RUN_STARTED,
+      threadId: "t-1",
+      runId: "r-1",
+    });
+    agent.events.next({
+      type: EventType.TOOL_CALL_START,
+      toolCallId: "call-1",
+      toolCallName: "select_address",
+      parentMessageId: "asst-1",
+    });
+    agent.events.next({
+      type: EventType.TOOL_CALL_ARGS,
+      toolCallId: "call-1",
+      delta: AUTHORITATIVE_ARGS,
+    });
+    agent.events.next({ type: EventType.TOOL_CALL_END, toolCallId: "call-1" });
+    agent.events.next({
+      type: EventType.MESSAGES_SNAPSHOT,
+      messages: [
+        {
+          id: "asst-1",
+          role: "assistant",
+          content: "",
+          toolCalls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: {
+                name: "select_address",
+                arguments: AUTHORITATIVE_ARGS,
+              },
+            },
+          ],
+        },
+      ],
+    });
+    agent.events.next({
+      type: EventType.RUN_FINISHED,
+      threadId: "t-1",
+      runId: "r-1",
+    });
+    agent.events.complete();
+    await runPromise;
+
+    expect(handler).toHaveBeenCalledWith(
+      JSON.parse(AUTHORITATIVE_ARGS),
+      expect.anything(),
+    );
+    const toolCallMessage = agent.messages.find(
+      (m) => m.role === "assistant" && m.toolCalls?.length,
+    );
+    expect(
+      toolCallMessage?.toolCalls?.[0].function.arguments,
+    ).toBe(AUTHORITATIVE_ARGS);
+  });
+});

--- a/packages/core/src/core/__tests__/tool-call-args-registry.test.ts
+++ b/packages/core/src/core/__tests__/tool-call-args-registry.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "@ag-ui/core";
+import {
+  ToolCallArgsRegistry,
+  ToolCallArgsManager,
+  normalizeMessagesWithAuthoritativeArgs,
+} from "../tool-call-args-registry";
+
+function assistantMessageWithToolCall(
+  toolCallId: string,
+  args: string,
+): Message {
+  return {
+    id: `msg-${toolCallId}`,
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      {
+        id: toolCallId,
+        type: "function" as const,
+        function: { name: "select_address", arguments: args },
+      },
+    ],
+  } as Message;
+}
+
+describe("ToolCallArgsRegistry", () => {
+  it("records and returns fully-formed JSON args", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"postcode":"M1 1AA"}');
+
+    expect(registry.get("call-1")).toBe('{"postcode":"M1 1AA"}');
+  });
+
+  it("ignores partial (mid-stream) JSON buffers", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"postcode":"M1 1AA"');
+
+    expect(registry.get("call-1")).toBeUndefined();
+  });
+
+  it("overwrites an earlier recording once the buffer is complete", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"postcode":');
+    registry.record("call-1", '{"postcode":"M1 1AA","addresses":[]}');
+
+    expect(registry.get("call-1")).toBe(
+      '{"postcode":"M1 1AA","addresses":[]}',
+    );
+  });
+
+  it("clear drops all entries", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", "{}");
+    registry.clear();
+
+    expect(registry.get("call-1")).toBeUndefined();
+  });
+});
+
+describe("normalizeMessagesWithAuthoritativeArgs", () => {
+  it("corrects tool call args that regressed from the authoritative value", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record(
+      "call-1",
+      '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
+    );
+    const regressed = [
+      assistantMessageWithToolCall(
+        "call-1",
+        '{"postcode":"M1 1AA","addresses":[{"id":"1"}]}',
+      ),
+    ];
+
+    const corrected = normalizeMessagesWithAuthoritativeArgs(
+      regressed,
+      registry,
+    );
+
+    expect(corrected).not.toBeNull();
+    expect(corrected![0].toolCalls![0].function.arguments).toBe(
+      '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
+    );
+  });
+
+  it("does not mutate the input messages", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"a":2}');
+    const original = [assistantMessageWithToolCall("call-1", '{"a":1}')];
+    const originalArgs =
+      original[0].toolCalls![0].function.arguments;
+
+    normalizeMessagesWithAuthoritativeArgs(original, registry);
+
+    expect(original[0].toolCalls![0].function.arguments).toBe(originalArgs);
+    expect(original[0].toolCalls![0].function.arguments).toBe('{"a":1}');
+  });
+
+  it("returns null when messages already match the registry", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"a":1}');
+
+    expect(
+      normalizeMessagesWithAuthoritativeArgs(
+        [assistantMessageWithToolCall("call-1", '{"a":1}')],
+        registry,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when no tool call is known to the registry", () => {
+    const registry = new ToolCallArgsRegistry();
+
+    expect(
+      normalizeMessagesWithAuthoritativeArgs(
+        [assistantMessageWithToolCall("call-unknown", '{"a":1}')],
+        registry,
+      ),
+    ).toBeNull();
+  });
+
+  it("short-circuits on an empty registry without scanning messages", () => {
+    const registry = new ToolCallArgsRegistry();
+    // Even messages with tool calls are left alone: nothing was ever
+    // observed, so there is no authoritative value to correct towards.
+    expect(
+      normalizeMessagesWithAuthoritativeArgs(
+        [assistantMessageWithToolCall("call-1", "not-even-json")],
+        registry,
+      ),
+    ).toBeNull();
+  });
+
+  it("leaves messages without tool calls untouched", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"a":1}');
+    const messages: Message[] = [
+      { id: "m1", role: "user", content: "hi" },
+      { id: "m2", role: "assistant", content: "hello" },
+    ];
+
+    expect(
+      normalizeMessagesWithAuthoritativeArgs(messages, registry),
+    ).toBeNull();
+  });
+
+  it("corrects multiple regressed tool calls across messages", () => {
+    const registry = new ToolCallArgsRegistry();
+    registry.record("call-1", '{"v":"authoritative-1"}');
+    registry.record("call-2", '{"v":"authoritative-2"}');
+    const messages = [
+      assistantMessageWithToolCall("call-1", '{"v":"stale-1"}'),
+      assistantMessageWithToolCall("call-2", '{"v":"stale-2"}'),
+    ];
+
+    const corrected = normalizeMessagesWithAuthoritativeArgs(
+      messages,
+      registry,
+    );
+
+    expect(corrected!.map((m) => m.toolCalls![0].function.arguments)).toEqual([
+      '{"v":"authoritative-1"}',
+      '{"v":"authoritative-2"}',
+    ]);
+  });
+});
+
+describe("ToolCallArgsManager", () => {
+  function createAgentFixture(agentId = "agent-1") {
+    const subscribers: Array<Record<string, (params: any) => void>> = [];
+    const agent = {
+      agentId,
+      messages: [] as Message[],
+      subscribe(subscriber: Record<string, (params: any) => void>) {
+        subscribers.push(subscriber);
+        return {
+          unsubscribe: () => {
+            const index = subscribers.indexOf(subscriber);
+            if (index !== -1) subscribers.splice(index, 1);
+          },
+        };
+      },
+      setMessages(messages: Message[]) {
+        agent.messages = messages;
+        for (const subscriber of [...subscribers]) {
+          subscriber.onMessagesChanged?.({ messages, agent });
+        }
+      },
+      emitToolCallArgs(toolCallId: string, bufferBeforeDelta: string, delta: string) {
+        for (const subscriber of [...subscribers]) {
+          subscriber.onToolCallArgsEvent?.({
+            event: { toolCallId, delta },
+            toolCallBuffer: bufferBeforeDelta,
+          });
+        }
+      },
+      emitToolCallEnd(toolCallId: string, toolCallArgs: Record<string, unknown>) {
+        for (const subscriber of [...subscribers]) {
+          subscriber.onToolCallEndEvent?.({
+            event: { toolCallId },
+            toolCallArgs,
+          });
+        }
+      },
+    };
+    return agent;
+  }
+
+  it("records args from TOOL_CALL_ARGS events per agent", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+
+    manager.subscribeToAgent(agent as any);
+    agent.emitToolCallArgs("call-1", "", '{"a":1}');
+
+    expect(
+      manager.getAuthoritativeArgs(agent as any, "call-1"),
+    ).toBe('{"a":1}');
+  });
+
+  it("accumulates consecutive deltas as the pipeline does (buffer excludes the current delta)", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+
+    manager.subscribeToAgent(agent as any);
+    agent.emitToolCallArgs("call-1", "", '{"postcode":');
+    agent.emitToolCallArgs("call-1", '{"postcode":', '"M1 1AA"}');
+
+    expect(
+      manager.getAuthoritativeArgs(agent as any, "call-1"),
+    ).toBe('{"postcode":"M1 1AA"}');
+  });
+
+  it("re-records at TOOL_CALL_END with the pipeline's terminal parsed args", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+
+    manager.subscribeToAgent(agent as any);
+    agent.emitToolCallArgs("call-1", "", '{"postcode":"M1 1AA"}');
+    // END carries the pipeline's own parse of the final buffer — the
+    // authoritative completion point, superseding any ARGS-time recording.
+    agent.emitToolCallEnd("call-1", {
+      postcode: "M1 1AA",
+      addresses: [{ id: "6" }],
+    });
+
+    expect(
+      manager.getAuthoritativeArgs(agent as any, "call-1"),
+    ).toBe('{"postcode":"M1 1AA","addresses":[{"id":"6"}]}');
+  });
+
+  it("keeps the mid-stream recording when TOOL_CALL_END parses to an empty object", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+
+    manager.subscribeToAgent(agent as any);
+    agent.emitToolCallArgs("call-1", "", '{"postcode":"M1 1AA"}');
+    // Empty object means upstream's JSON.parse of the final buffer failed —
+    // not a real terminal value; don't clobber the observed complete args.
+    agent.emitToolCallEnd("call-1", {});
+
+    expect(
+      manager.getAuthoritativeArgs(agent as any, "call-1"),
+    ).toBe('{"postcode":"M1 1AA"}');
+  });
+
+  it("re-corrects messages via setMessages when a snapshot regressed args", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+    manager.subscribeToAgent(agent as any);
+
+    agent.emitToolCallArgs(
+      "call-1",
+      "",
+      '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
+    );
+    // Simulate a MESSAGES_SNAPSHOT carrying the hallucinated LLM args.
+    agent.setMessages([
+      assistantMessageWithToolCall(
+        "call-1",
+        '{"postcode":"M1 1AA","addresses":[{"id":"1"}]}',
+      ),
+    ]);
+
+    expect(agent.messages[0].toolCalls![0].function.arguments).toBe(
+      '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
+    );
+  });
+
+  it("does not rewrite messages when args already match", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+    manager.subscribeToAgent(agent as any);
+
+    const message = assistantMessageWithToolCall("call-1", '{"a":1}');
+    let setMessagesCalls = 0;
+    const originalSetMessages = agent.setMessages.bind(agent);
+    agent.setMessages = (messages: Message[]) => {
+      setMessagesCalls++;
+      originalSetMessages(messages);
+    };
+
+    agent.emitToolCallArgs("call-1", "", '{"a":1}');
+    agent.setMessages([message]);
+
+    expect(setMessagesCalls).toBe(1); // only the simulated snapshot, no correction
+  });
+
+  it("skips agents without an agentId", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture("");
+
+    manager.subscribeToAgent(agent as any);
+
+    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBeUndefined();
+  });
+
+  it("drops recorded entries when the same agent is re-subscribed", () => {
+    const manager = new ToolCallArgsManager();
+    const agent = createAgentFixture();
+    manager.subscribeToAgent(agent as any);
+    agent.emitToolCallArgs("call-1", "", '{"a":1}');
+
+    manager.subscribeToAgent(agent as any);
+
+    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBeUndefined();
+  });
+});

--- a/packages/core/src/core/__tests__/tool-call-args-registry.test.ts
+++ b/packages/core/src/core/__tests__/tool-call-args-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Message } from "@ag-ui/core";
+import type { Message } from "@ag-ui/client";
 import {
   ToolCallArgsRegistry,
   ToolCallArgsManager,
@@ -24,6 +24,13 @@ function assistantMessageWithToolCall(
   } as Message;
 }
 
+function firstToolCallArgs(message: Message | undefined): string | undefined {
+  if (message?.role !== "assistant") {
+    return undefined;
+  }
+  return message.toolCalls?.[0]?.function.arguments;
+}
+
 describe("ToolCallArgsRegistry", () => {
   it("records and returns fully-formed JSON args", () => {
     const registry = new ToolCallArgsRegistry();
@@ -44,9 +51,7 @@ describe("ToolCallArgsRegistry", () => {
     registry.record("call-1", '{"postcode":');
     registry.record("call-1", '{"postcode":"M1 1AA","addresses":[]}');
 
-    expect(registry.get("call-1")).toBe(
-      '{"postcode":"M1 1AA","addresses":[]}',
-    );
+    expect(registry.get("call-1")).toBe('{"postcode":"M1 1AA","addresses":[]}');
   });
 
   it("clear drops all entries", () => {
@@ -61,10 +66,7 @@ describe("ToolCallArgsRegistry", () => {
 describe("normalizeMessagesWithAuthoritativeArgs", () => {
   it("corrects tool call args that regressed from the authoritative value", () => {
     const registry = new ToolCallArgsRegistry();
-    registry.record(
-      "call-1",
-      '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
-    );
+    registry.record("call-1", '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}');
     const regressed = [
       assistantMessageWithToolCall(
         "call-1",
@@ -78,7 +80,7 @@ describe("normalizeMessagesWithAuthoritativeArgs", () => {
     );
 
     expect(corrected).not.toBeNull();
-    expect(corrected![0].toolCalls![0].function.arguments).toBe(
+    expect(firstToolCallArgs(corrected?.[0])).toBe(
       '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
     );
   });
@@ -87,13 +89,12 @@ describe("normalizeMessagesWithAuthoritativeArgs", () => {
     const registry = new ToolCallArgsRegistry();
     registry.record("call-1", '{"a":2}');
     const original = [assistantMessageWithToolCall("call-1", '{"a":1}')];
-    const originalArgs =
-      original[0].toolCalls![0].function.arguments;
+    const originalArgs = firstToolCallArgs(original[0]);
 
     normalizeMessagesWithAuthoritativeArgs(original, registry);
 
-    expect(original[0].toolCalls![0].function.arguments).toBe(originalArgs);
-    expect(original[0].toolCalls![0].function.arguments).toBe('{"a":1}');
+    expect(firstToolCallArgs(original[0])).toBe(originalArgs);
+    expect(firstToolCallArgs(original[0])).toBe('{"a":1}');
   });
 
   it("returns null when messages already match the registry", () => {
@@ -158,7 +159,7 @@ describe("normalizeMessagesWithAuthoritativeArgs", () => {
       registry,
     );
 
-    expect(corrected!.map((m) => m.toolCalls![0].function.arguments)).toEqual([
+    expect(corrected!.map((message) => firstToolCallArgs(message))).toEqual([
       '{"v":"authoritative-1"}',
       '{"v":"authoritative-2"}',
     ]);
@@ -186,7 +187,11 @@ describe("ToolCallArgsManager", () => {
           subscriber.onMessagesChanged?.({ messages, agent });
         }
       },
-      emitToolCallArgs(toolCallId: string, bufferBeforeDelta: string, delta: string) {
+      emitToolCallArgs(
+        toolCallId: string,
+        bufferBeforeDelta: string,
+        delta: string,
+      ) {
         for (const subscriber of [...subscribers]) {
           subscriber.onToolCallArgsEvent?.({
             event: { toolCallId, delta },
@@ -194,7 +199,10 @@ describe("ToolCallArgsManager", () => {
           });
         }
       },
-      emitToolCallEnd(toolCallId: string, toolCallArgs: Record<string, unknown>) {
+      emitToolCallEnd(
+        toolCallId: string,
+        toolCallArgs: Record<string, unknown>,
+      ) {
         for (const subscriber of [...subscribers]) {
           subscriber.onToolCallEndEvent?.({
             event: { toolCallId },
@@ -213,9 +221,9 @@ describe("ToolCallArgsManager", () => {
     manager.subscribeToAgent(agent as any);
     agent.emitToolCallArgs("call-1", "", '{"a":1}');
 
-    expect(
-      manager.getAuthoritativeArgs(agent as any, "call-1"),
-    ).toBe('{"a":1}');
+    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBe(
+      '{"a":1}',
+    );
   });
 
   it("accumulates consecutive deltas as the pipeline does (buffer excludes the current delta)", () => {
@@ -226,9 +234,9 @@ describe("ToolCallArgsManager", () => {
     agent.emitToolCallArgs("call-1", "", '{"postcode":');
     agent.emitToolCallArgs("call-1", '{"postcode":', '"M1 1AA"}');
 
-    expect(
-      manager.getAuthoritativeArgs(agent as any, "call-1"),
-    ).toBe('{"postcode":"M1 1AA"}');
+    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBe(
+      '{"postcode":"M1 1AA"}',
+    );
   });
 
   it("re-records at TOOL_CALL_END with the pipeline's terminal parsed args", () => {
@@ -244,9 +252,9 @@ describe("ToolCallArgsManager", () => {
       addresses: [{ id: "6" }],
     });
 
-    expect(
-      manager.getAuthoritativeArgs(agent as any, "call-1"),
-    ).toBe('{"postcode":"M1 1AA","addresses":[{"id":"6"}]}');
+    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBe(
+      '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
+    );
   });
 
   it("keeps the mid-stream recording when TOOL_CALL_END parses to an empty object", () => {
@@ -259,9 +267,9 @@ describe("ToolCallArgsManager", () => {
     // not a real terminal value; don't clobber the observed complete args.
     agent.emitToolCallEnd("call-1", {});
 
-    expect(
-      manager.getAuthoritativeArgs(agent as any, "call-1"),
-    ).toBe('{"postcode":"M1 1AA"}');
+    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBe(
+      '{"postcode":"M1 1AA"}',
+    );
   });
 
   it("re-corrects messages via setMessages when a snapshot regressed args", () => {
@@ -282,7 +290,7 @@ describe("ToolCallArgsManager", () => {
       ),
     ]);
 
-    expect(agent.messages[0].toolCalls![0].function.arguments).toBe(
+    expect(firstToolCallArgs(agent.messages[0])).toBe(
       '{"postcode":"M1 1AA","addresses":[{"id":"6"}]}',
     );
   });
@@ -312,7 +320,9 @@ describe("ToolCallArgsManager", () => {
 
     manager.subscribeToAgent(agent as any);
 
-    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBeUndefined();
+    expect(
+      manager.getAuthoritativeArgs(agent as any, "call-1"),
+    ).toBeUndefined();
   });
 
   it("drops recorded entries when the same agent is re-subscribed", () => {
@@ -323,6 +333,8 @@ describe("ToolCallArgsManager", () => {
 
     manager.subscribeToAgent(agent as any);
 
-    expect(manager.getAuthoritativeArgs(agent as any, "call-1")).toBeUndefined();
+    expect(
+      manager.getAuthoritativeArgs(agent as any, "call-1"),
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -32,6 +32,7 @@ import type {
 import { RunHandler } from "./run-handler";
 import type { DebugConfig } from "@copilotkit/shared";
 import { StateManager } from "./state-manager";
+import { ToolCallArgsManager } from "./tool-call-args-registry";
 import type { CopilotKitCoreContinuationHandoff } from "./state-manager";
 import { ThreadStoreRegistry } from "./thread-store-registry";
 import type { ɵThreadStore } from "../threads";
@@ -378,6 +379,19 @@ export interface CopilotKitCoreFriendsAccess {
       expectedRunId?: string,
     ): CopilotKitCoreContinuationHandoff;
   };
+
+  /**
+   * Authoritative tool call arguments recorded from TOOL_CALL_ARGS events.
+   * The run handler consults it before parsing a tool call's arguments, which
+   * may have been regressed by a MESSAGES_SNAPSHOT carrying the LLM's raw
+   * values (#4935).
+   */
+  readonly toolCallArgsManager: {
+    getAuthoritativeArgs(
+      agent: AbstractAgent,
+      toolCallId: string,
+    ): string | undefined;
+  };
 }
 
 /**
@@ -411,6 +425,7 @@ export class CopilotKitCore {
   private suggestionEngine: SuggestionEngine;
   private runHandler: RunHandler;
   private stateManager: StateManager;
+  private toolCallArgsManager: ToolCallArgsManager;
   private threadStoreRegistry: ThreadStoreRegistry;
   /**
    * The single core-owned memory store, created lazily on first
@@ -450,6 +465,7 @@ export class CopilotKitCore {
     this.suggestionEngine = new SuggestionEngine(this);
     this.runHandler = new RunHandler(this);
     this.stateManager = new StateManager(this);
+    this.toolCallArgsManager = new ToolCallArgsManager();
     this.threadStoreRegistry = new ThreadStoreRegistry(this);
 
     // Initialize each subsystem
@@ -486,6 +502,7 @@ export class CopilotKitCore {
         Object.values(agents).forEach((agent) => {
           if (agent.agentId) {
             this.stateManager.subscribeToAgent(agent);
+            this.toolCallArgsManager.subscribeToAgent(agent);
           }
         });
 

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -783,8 +783,17 @@ export class RunHandler {
     let isArgumentError = false;
 
     let parsedArgs: unknown;
+    // A MESSAGES_SNAPSHOT can regress tool call arguments to the LLM's raw
+    // values after an args_streamer enriched them (#4935). Prefer the
+    // accumulated TOOL_CALL_ARGS data when it was observed for this call.
+    const authoritativeArgs =
+      this._internal.toolCallArgsManager.getAuthoritativeArgs(
+        agent,
+        toolCall.id,
+      );
+    const argsInput = authoritativeArgs ?? handlerArgs;
     try {
-      parsedArgs = parseToolArguments(handlerArgs, toolCall.function.name);
+      parsedArgs = parseToolArguments(argsInput, toolCall.function.name);
     } catch (error) {
       const parseError =
         error instanceof Error ? error : new Error(String(error));
@@ -797,7 +806,7 @@ export class RunHandler {
           agentId,
           toolCallId: toolCall.id,
           toolName: toolCall.function.name,
-          rawArguments: handlerArgs,
+          rawArguments: argsInput,
           toolType,
           ...(messageId ? { messageId } : {}),
         },
@@ -962,9 +971,19 @@ export class RunHandler {
 
     if (wildcardTool?.handler) {
       let parsedArgs: unknown;
+      // Same authoritative-args preference as executeToolHandler (#4935):
+      // wildcard tools parse the same (possibly snapshot-regressed)
+      // message arguments, so they get the same registry fallback.
+      const authoritativeArgs =
+        this._internal.toolCallArgsManager.getAuthoritativeArgs(
+          agent,
+          toolCall.id,
+        );
+      const argsInput =
+        authoritativeArgs ?? toolCall.function.arguments;
       try {
         parsedArgs = parseToolArguments(
-          toolCall.function.arguments,
+          argsInput,
           toolCall.function.name,
         );
       } catch (error) {
@@ -978,7 +997,7 @@ export class RunHandler {
             agentId: agentId,
             toolCallId: toolCall.id,
             toolName: toolCall.function.name,
-            rawArguments: toolCall.function.arguments,
+            rawArguments: argsInput,
             toolType: "wildcard",
             messageId: message.id,
           },

--- a/packages/core/src/core/tool-call-args-registry.ts
+++ b/packages/core/src/core/tool-call-args-registry.ts
@@ -1,5 +1,4 @@
-import type { AbstractAgent } from "@ag-ui/client";
-import type { Message } from "@ag-ui/core";
+import type { AbstractAgent, Message } from "@ag-ui/client";
 
 /**
  * Tracks the authoritative, fully-accumulated arguments for each tool call

--- a/packages/core/src/core/tool-call-args-registry.ts
+++ b/packages/core/src/core/tool-call-args-registry.ts
@@ -1,0 +1,210 @@
+import type { AbstractAgent } from "@ag-ui/client";
+import type { Message } from "@ag-ui/core";
+
+/**
+ * Tracks the authoritative, fully-accumulated arguments for each tool call
+ * observed via AG-UI `TOOL_CALL_ARGS` events.
+ *
+ * Backends with an `args_streamer` re-emit enriched arguments after the LLM's
+ * initial (hallucinated) values. The accumulated event data is authoritative
+ * per the AG-UI protocol, but a later `MESSAGES_SNAPSHOT` — still carrying the
+ * raw LLM values — replaces `agent.messages` wholesale in `@ag-ui/client`,
+ * regressing the arguments that `render` and tool `handler`s consume.
+ * This registry keeps the authoritative values so messages can be re-corrected
+ * after each snapshot (see {@link ToolCallArgsManager}).
+ */
+export class ToolCallArgsRegistry {
+  private entries = new Map<string, string>();
+
+  /**
+   * Record the accumulated arguments observed for a tool call so far.
+   *
+   * Only fully-formed JSON is accepted: mid-stream partial buffers are never
+   * authoritative (a regressing snapshot always follows a complete stream),
+   * and accepting them would let a corrupted buffer (e.g. a backend that
+   * concatenates the LLM's delta with the streamer's replacement) become the
+   * corrected value.
+   */
+  record(toolCallId: string, accumulatedArgs: string): void {
+    if (!this.isCompleteJson(accumulatedArgs)) {
+      return;
+    }
+    this.entries.set(toolCallId, accumulatedArgs);
+  }
+
+  /** The last accumulated arguments for a tool call, if observed. */
+  get(toolCallId: string): string | undefined {
+    return this.entries.get(toolCallId);
+  }
+
+  /** Number of recorded tool calls. Lets consumers skip work when empty. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Drop all recorded entries (used when an agent is unsubscribed). */
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private isCompleteJson(value: string): boolean {
+    try {
+      JSON.parse(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Returns a corrected copy of `messages` where every tool call known to the
+ * registry carries its authoritative arguments, or `null` when no correction
+ * is needed (no known tool calls, or all arguments already match).
+ *
+ * Pure function: never mutates the input array or its messages. The `null`
+ * return (rather than the input) lets callers skip a redundant
+ * `setMessages` round-trip, which is what keeps the correction loop
+ * self-terminating in {@link ToolCallArgsManager}.
+ */
+export function normalizeMessagesWithAuthoritativeArgs(
+  messages: ReadonlyArray<Readonly<Message>>,
+  registry: ToolCallArgsRegistry,
+): Message[] | null {
+  if (registry.size === 0) return null;
+
+  let correctedAny = false;
+  const result = messages.map((message) => {
+    if (!("toolCalls" in message) || !message.toolCalls?.length) {
+      return message;
+    }
+    let correctedToolCall = false;
+    const toolCalls = message.toolCalls.map((toolCall) => {
+      const authoritative = registry.get(toolCall.id);
+      if (
+        authoritative === undefined ||
+        authoritative === toolCall.function.arguments
+      ) {
+        return toolCall;
+      }
+      correctedToolCall = true;
+      correctedAny = true;
+      return {
+        ...toolCall,
+        function: { ...toolCall.function, arguments: authoritative },
+      };
+    });
+    return correctedToolCall ? { ...message, toolCalls } : message;
+  });
+  return correctedAny ? result : null;
+}
+
+/**
+ * Owns per-agent registries and the agent subscriptions that keep
+ * `agent.messages` aligned with authoritative `TOOL_CALL_ARGS` data.
+ *
+ * Subscribes directly via `agent.subscribe()` — the same pattern as
+ * `StateManager.subscribeToAgent` — because AG-UI event callbacks such as
+ * `onToolCallArgsEvent` are intentionally excluded from
+ * `CopilotKitCore.subscribeToAgentWithOptions`.
+ *
+ * Corrections are applied from `onMessagesChanged` (which fires after each
+ * message update, including snapshot replacements) via `agent.setMessages()`,
+ * the public API that assigns a fresh array reference and re-notifies
+ * subscribers so React bindings re-render. Subscriber mutations returned from
+ * `onMessagesSnapshotEvent` cannot be used: `@ag-ui/client` applies them
+ * before merging the snapshot over them.
+ *
+ * Two invariants worth stating explicitly:
+ *
+ * - **Subscription order**: subscribers are notified in registration order,
+ *   and this manager subscribes when the core registers the agent — before
+ *   any framework binding mounts. Framework subscribers later in the list
+ *   therefore read `agent.messages` AFTER the correction has re-assigned it,
+ *   in the very same notification pass. If subscription ordering ever
+ *   changes upstream, UIs would briefly render the regressed args before the
+ *   correction lands (a flash, not a corruption).
+ *
+ * - **Registry lifetime & comparison**: entries accumulate for the agent's
+ *   lifetime (tool call ids are UUIDs, so thread switches cannot collide)
+ *   and are dropped only on re-subscribe; growth is bounded by the session.
+ *   Corrections compare argument strings exactly, so a snapshot carrying
+ *   semantically-equal but differently-formatted args is rewritten once into
+ *   the registry's canonical form and is a no-op from then on (idempotent).
+ */
+export class ToolCallArgsManager {
+  private agentSubscriptions = new Map<string, () => void>();
+  private registries = new Map<string, ToolCallArgsRegistry>();
+
+  /**
+   * Subscribe to an agent to record authoritative tool call arguments and
+   * re-correct `agent.messages` (via `agent.setMessages`) whenever a message
+   * update regresses them, e.g. after a `MESSAGES_SNAPSHOT`.
+   *
+   * Re-subscribing the same agent replaces the previous subscription and
+   * drops its recorded entries.
+   */
+  subscribeToAgent(agent: AbstractAgent): void {
+    if (!agent.agentId) {
+      return;
+    }
+    const agentId = agent.agentId;
+
+    // Replace any existing subscription for this agent only.
+    const existingUnsubscribe = this.agentSubscriptions.get(agentId);
+    if (existingUnsubscribe) {
+      existingUnsubscribe();
+      this.agentSubscriptions.delete(agentId);
+    }
+    this.registries.get(agentId)?.clear();
+    const registry = new ToolCallArgsRegistry();
+    this.registries.set(agentId, registry);
+
+    const correctIfRegressed = () => {
+      const corrected = normalizeMessagesWithAuthoritativeArgs(
+        agent.messages,
+        registry,
+      );
+      // When a correction applies, setMessages re-notifies onMessagesChanged
+      // (asynchronously); by then the messages already match the registry, so
+      // normalize returns null and the loop terminates without a guard flag.
+      if (corrected) {
+        agent.setMessages(corrected);
+      }
+    };
+
+    const { unsubscribe } = agent.subscribe({
+      onToolCallArgsEvent: ({ event, toolCallBuffer }) => {
+        // @ag-ui/client notifies subscribers BEFORE appending the current
+        // delta to the message, so the accumulated value is buffer + delta.
+        registry.record(event.toolCallId, toolCallBuffer + event.delta);
+      },
+      onToolCallEndEvent: ({ event, toolCallArgs }) => {
+        // END is the protocol's completion point: `toolCallArgs` is the
+        // pipeline's own parse of the final buffer. Recording it pins the
+        // registry to upstream's terminal truth, so the ARGS-time
+        // buffer+delta reconstruction above never becomes load-bearing even
+        // if the notification ordering upstream ever changes. An empty
+        // object here means the parse failed upstream — keep whatever
+        // complete value was observed mid-stream instead of recording "{}".
+        if (toolCallArgs && Object.keys(toolCallArgs).length > 0) {
+          registry.record(event.toolCallId, JSON.stringify(toolCallArgs));
+        }
+      },
+      onMessagesChanged: correctIfRegressed,
+    });
+    this.agentSubscriptions.set(agentId, unsubscribe);
+  }
+
+  /**
+   * The authoritative accumulated arguments for a tool call on an agent, if
+   * observed. Consumed by the run handler as a fallback before parsing the
+   * (possibly regressed) arguments on the message.
+   */
+  getAuthoritativeArgs(
+    agent: AbstractAgent,
+    toolCallId: string,
+  ): string | undefined {
+    return this.registries.get(agent.agentId ?? "")?.get(toolCallId);
+  }
+}

--- a/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool.e2e.test.tsx
@@ -2145,4 +2145,118 @@ describe("useFrontendTool E2E - Dynamic Registration", () => {
       agent.complete();
     });
   });
+
+  describe("Authoritative args after MESSAGES_SNAPSHOT regression (#4935)", () => {
+    it("render receives the accumulated TOOL_CALL_ARGS data, not the snapshot's raw LLM args", async () => {
+      const agent = new MockStepwiseAgent({ agentId: "default" });
+
+      let renderedArgs: { addresses?: Array<{ id: string }> } | null = null;
+
+      const AuthoritativeArgsTool: React.FC = () => {
+        const tool: ReactFrontendTool<{ postcode: string; addresses: Array<{ id: string; line1: string }> }> = {
+          name: "selectAddress",
+          render: ({ args }) => {
+            renderedArgs = args;
+            return (
+              <div data-testid="authoritative-tool">
+                {args.addresses?.map((address) => (
+                  <span key={address.id} data-testid={`address-${address.id}`}>
+                    {address.line1}
+                  </span>
+                ))}
+              </div>
+            );
+          },
+        };
+        useFrontendTool(tool);
+        return null;
+      };
+
+      renderWithCopilotKit({
+        agent,
+        children: (
+          <>
+            <AuthoritativeArgsTool />
+            <div style={{ height: 400 }}>
+              <CopilotChat welcomeScreen={false} />
+            </div>
+          </>
+        ),
+      });
+
+      const input = await screen.findByRole("textbox");
+      fireEvent.change(input, { target: { value: "Look up addresses" } });
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+      await waitFor(() => {
+        expect(screen.getByText("Look up addresses")).toBeDefined();
+      });
+
+      const messageId = testId("msg");
+      const toolCallId = testId("tc");
+      const authoritativeArgs = JSON.stringify({
+        postcode: "M1 1AA",
+        addresses: [
+          { id: "6", line1: "1 Piccadilly" },
+          { id: "7", line1: "15 Portland Street" },
+        ],
+      });
+      const hallucinatedArgs = JSON.stringify({
+        postcode: "M1 1AA",
+        addresses: [{ id: "1", line1: "1 Piccadilly Gardens" }],
+      });
+
+      // args_streamer flow: START, one ARGS delta carrying the full enriched
+      // payload, END — the accumulated buffer matches the enriched args.
+      agent.emit({ type: EventType.RUN_STARTED } as BaseEvent);
+      agent.emit({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: "selectAddress",
+        parentMessageId: messageId,
+      } as BaseEvent);
+      agent.emit({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: authoritativeArgs,
+      } as BaseEvent);
+      agent.emit({ type: EventType.TOOL_CALL_END, toolCallId } as BaseEvent);
+
+      // The streamed args render first.
+      await waitFor(() => {
+        expect(screen.getByTestId("address-6")).toBeDefined();
+      });
+
+      // A later MESSAGES_SNAPSHOT still carries the LLM's raw args and
+      // replaces the message — the render must keep the authoritative args.
+      agent.emit({
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [
+          {
+            id: messageId,
+            role: "assistant",
+            content: "",
+            toolCalls: [
+              {
+                id: toolCallId,
+                type: "function",
+                function: { name: "selectAddress", arguments: hallucinatedArgs },
+              },
+            ],
+          },
+        ],
+      } as unknown as BaseEvent);
+
+      // Give the snapshot regression + core-side correction a tick.
+      await waitFor(() => {
+        expect(renderedArgs?.addresses?.map((a) => a.id)).toEqual(["6", "7"]);
+      });
+
+      expect(screen.queryByTestId("address-1")).toBeNull();
+      expect(screen.getByTestId("address-7")).toBeDefined();
+
+      agent.emit({ type: EventType.RUN_FINISHED } as BaseEvent);
+      agent.complete();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

When a backend uses an `args_streamer` to enrich frontend-tool arguments (e.g. server-side address lookups), the AG-UI `TOOL_CALL_ARGS` events carry the enriched values and `TOOL_CALL_END`'s `toolCallArgs` confirms them — but a later `MESSAGES_SNAPSHOT`, still carrying the LLM's raw hallucinated values, replaces `agent.messages` wholesale in `@ag-ui/client`. Both consumers then read the wrong data: the `render` function (via `toolCall.function.arguments` on the message) and the tool `handler` (via `parseToolArguments`). See #4935 for the full event-stream evidence.

## Solution

Keep the authoritative values at the message level, so every consumer is covered in one place:

- A per-agent `ToolCallArgsManager` in core subscribes via `agent.subscribe()` and records the accumulated args per `toolCallId` (ARGS deltas, re-anchored at `TOOL_CALL_END` with the pipeline's own terminal parse).
- Whenever a message update regresses recorded args (e.g. after a snapshot), the manager re-applies the authoritative values via `agent.setMessages()` — idempotent, self-terminating (the correction pass finds nothing to fix).
- Both tool execution gates (specific and wildcard) additionally fall back to the registry before parsing, so the handler path is protected even if a correction hasn't landed yet.

This deliberately does not touch `@ag-ui/client` semantics: the snapshot merge stays authoritative upstream; CopilotKit re-corrects after each message update. The ARGS-time reconstruction (`toolCallBuffer + delta`, since subscribers are notified before the delta is appended) is never load-bearing because the END recording pins the registry to the pipeline's terminal truth.

## Changes

- `packages/core/src/core/tool-call-args-registry.ts` (new) — `ToolCallArgsRegistry` (complete-JSON-only recording), `normalizeMessagesWithAuthoritativeArgs` (pure), `ToolCallArgsManager` (subscription + correction + lookup).
- `packages/core/src/core/core.ts` — instantiate the manager; subscribe per agent alongside `StateManager`; expose a narrow lookup through the friends interface.
- `packages/core/src/core/run-handler.ts` — registry fallback before parsing in `executeToolHandler` and `executeWildcardTool`; error context reports the actual parse input.
- `packages/core/src/core/__tests__/tool-call-args-registry.test.ts` (new) and `packages/core/src/__tests__/core-tool-args-authoritative.test.ts` (new).
- `packages/react-core/src/v2/hooks/__tests__/use-frontend-tool.e2e.test.tsx` — render-path e2e.

## Testing

- Reproduction test on a real `AbstractAgent` pipeline with the issue's exact event sequence (`TOOL_CALL_START → ARGS(enriched) → END → MESSAGES_SNAPSHOT(hallucinated) → RUN_FINISHED`): fails on main (handler and messages see the hallucinated args), passes with this change.
- Unit tests: registry lifecycle, partial-JSON rejection, END re-anchoring (and empty-parse no-op), pure-function immutability, idempotent correction, empty-registry short-circuit.
- Integration: specific-tool and wildcard handler paths both receive authoritative args; no correction when the snapshot matches.
- E2E via CopilotChat: the render keeps the enriched addresses after the regressing snapshot.
- `nx run @copilotkit/core:test --skipNxCache`: 63 test files, 701 tests passed.
- `nx run @copilotkit/core:check-types --skipNxCache`: passed.
- `nx run @copilotkit/react-core:check-types --skipNxCache`: passed with all 33 dependency tasks.
- The React Core authoritative-args render regression passes. One unrelated `A2UIMessageRenderer` test hit its 5s timeout on a cold full-suite run; the targeted file passed 8/8 on rerun (the same test completed in 4.23s).

## Notes for Reviewer

- The fix is intentionally at the message level rather than in the render layer: Vue/Angular renders and the `runTool` path benefit without per-framework changes.
- Two invariants are documented on the manager: subscription ordering (core subscribes before framework bindings, so UIs read the corrected array in the same notification pass — if that ever changes, the worst case is a one-frame flash, not corruption) and registry lifetime (entries bounded by the session, UUID tool-call ids can't collide across threads).
- Longer term, "a snapshot must not regress completed tool-call args" is arguably an upstream `@ag-ui/client` behavior question — happy to file that separately; the core-side tolerance here is valuable either way.

Fixes #4935