### PR TITLE
fix(showcase): register showcase-crewai-conversational-flows in Railway SSOT

### DIFF
--- a/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/__tests__/emit-railway-envs-json.test.ts
@@ -25,7 +25,7 @@ describe("emit-railway-envs-json", () => {
     expect(json.projectId).toBe("6f8c6bff-a80d-4f8f-b78d-50b32bcf4479");
     expect(json.envIds.staging).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     expect(json.envIds.prod).toBe("b14919f4-6417-429f-848d-c6ae2201e04f");
-    expect(json.services.length).toBe(41);
+    expect(json.services.length).toBe(42);
     const docs = json.services.find((s: { name: string }) => s.name === "docs");
     expect(docs.domains.staging).toBe("docs.staging.copilotkit.ai");
     expect(docs.domains.prod).toBe("docs.copilotkit.ai");

--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -207,6 +207,15 @@
       "repoName": "showcase-claude-sdk-typescript"
     }
   },
+  "showcase-crewai-conversational-flows": {
+    "staging": {
+      "instanceId": "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
+      "domain": "showcase-crewai-conversational-flows-staging.up.railway.app",
+      "probe": true,
+      "driver": "agent",
+      "repoName": "showcase-crewai-conversational-flows"
+    }
+  },
   "showcase-crewai-crews": {
     "prod": {
       "instanceId": "3dab0cc3-cab1-4579-b772-947268088514",

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -260,8 +260,8 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     ["harness", "showcase-harness"],
   ] as const;
 
-  it("has 41 services in the SSOT (29 showcase/infra + 12 starter-*)", () => {
-    expect(Object.keys(SERVICES)).toHaveLength(41);
+  it("has 42 services in the SSOT (30 showcase/infra + 12 starter-*)", () => {
+    expect(Object.keys(SERVICES)).toHaveLength(42);
   });
 
   it("marks every gate-managed service gateValidated (no Phase-2 holdouts)", () => {
@@ -292,20 +292,23 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
     });
   }
 
-  it("findMissingServices treats all 41 gateValidated services as targets (29 showcase/infra + 12 starters)", () => {
+  it("findMissingServices treats every gateValidated service as a target, per the envs it declares", () => {
     // With nothing "present", every gateValidated service should appear in
-    // the missing set. After S2 brought the 12 starter-<slug> services under
-    // the gate (gateValidated:true, dual-env), showcase-strands-typescript
-    // was provisioned in prod (gateValidated:true), and the prod harness-workers
-    // backfill flipped that worker to gateValidated:true (dual-env), that means
-    // all 41 — the 29 showcase/infra gateValidated services plus the 12
-    // starters. (harness-workers is now gateValidated and dual-env, so it IS
-    // required in both envs here.)
+    // the missing set for each env it DECLARES. All dual-env gateValidated
+    // services (the 29 showcase/infra + 12 starters that carry both prod and
+    // staging) are demanded in BOTH envs. The lone single-env gateValidated
+    // service — showcase-crewai-conversational-flows, live in staging only —
+    // is demanded ONLY in staging, so the counts are intentionally asymmetric:
+    //   prod    = 41 (the dual-env services; the staging-only one is skipped)
+    //   staging = 42 (the dual-env services PLUS the staging-only one)
     const missingProd = findMissingServices("prod", new Set<string>());
     const missingStaging = findMissingServices("staging", new Set<string>());
     expect(missingProd).toHaveLength(41);
-    expect(missingStaging).toHaveLength(41);
-    // The 12 starters are now demanded in BOTH envs.
+    expect(missingStaging).toHaveLength(42);
+    // The staging-only service is required in staging but NOT prod.
+    expect(missingStaging).toContain("showcase-crewai-conversational-flows");
+    expect(missingProd).not.toContain("showcase-crewai-conversational-flows");
+    // The 12 starters are still demanded in BOTH envs.
     expect(missingProd).toContain("starter-adk");
     expect(missingStaging).toContain("starter-mastra");
   });

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -435,6 +435,39 @@
       }
     },
     {
+      "name": "showcase-crewai-conversational-flows",
+      "serviceId": "11859593-da4e-486c-a810-6cdffeff9750",
+      "prodInstanceId": "11859593-da4e-486c-a810-6cdffeff9750",
+      "stagingInstanceId": "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
+      "ciBuilt": false,
+      "gateValidated": true,
+      "dispatchName": "crewai-conversational-flows",
+      "domains": {
+        "staging": "showcase-crewai-conversational-flows-staging.up.railway.app",
+        "prod": ""
+      },
+      "probe": {
+        "staging": true,
+        "prod": false,
+        "driver": "agent"
+      },
+      "promoteTier": 2,
+      "runtimeDeps": ["aimock"],
+      "serviceRefs": [
+        {
+          "key": "OPENAI_BASE_URL",
+          "target": "aimock"
+        }
+      ],
+      "healthcheckPath": {
+        "staging": "/api/health"
+      },
+      "autoUpdates": {
+        "staging": "disabled",
+        "prod": "disabled"
+      }
+    },
+    {
       "name": "showcase-crewai-crews",
       "serviceId": "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
       "prodInstanceId": "3dab0cc3-cab1-4579-b772-947268088514",
@@ -1548,6 +1581,11 @@
         "tier": 2
       }
     ],
-    "skipped": []
+    "skipped": [
+      {
+        "name": "showcase-crewai-conversational-flows",
+        "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
+      }
+    ]
   }
 }

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -107,9 +107,9 @@ describe("railway-envs SSOT", () => {
     expect(ENV_IDS.staging).toBe(STAGING_ENV_ID);
   });
 
-  it("contains exactly 41 services (29 showcase/infra + 12 starter-*)", () => {
+  it("contains exactly 42 services (30 showcase/infra + 12 starter-*)", () => {
     const names = listServiceNames();
-    expect(names.length).toBe(41);
+    expect(names.length).toBe(42);
   });
 
   it("contains the expected canonical services", () => {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -1049,6 +1049,38 @@ export const SERVICES: Record<
       },
     },
   },
+  "showcase-crewai-conversational-flows": {
+    serviceId: "11859593-da4e-486c-a810-6cdffeff9750",
+    autoUpdates: { staging: "disabled", prod: "disabled" },
+    // NOT built+pushed by showcase_build.yml's ALL_SERVICES matrix — this
+    // integration is only wired into the PR-check build (showcase_build_check.
+    // yml). So it is deliberately NOT in CI_BUILT_SERVICES (whose members must
+    // each carry a matching dispatch_name in showcase_build.yml), exactly like
+    // `webhooks`. ciBuilt:false keeps that invariant intact.
+    ciBuilt: false,
+    gateValidated: true,
+    dispatchName: "crewai-conversational-flows",
+    probeDriver: "agent",
+    // Tier-2 leaf (default). Runtime dep: the agent routes its LLM traffic at
+    // the env-local aimock, so a cluster promote pulls aimock (tier-0) into the
+    // closure — same wiring as its `showcase-crewai-crews` sibling.
+    runtimeDeps: ["aimock"],
+    serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
+    // STAGING-ONLY: the live Railway service currently has a serviceInstance in
+    // staging only (no prod instance is provisioned). The env-map schema models
+    // a single-env service by declaring only the env that exists — the image-ref
+    // gate then requires it in staging (findMissingServices) and never demands a
+    // (non-existent) prod instance. All values below are read verbatim from the
+    // live Railway service, not derived.
+    environments: {
+      staging: {
+        instanceId: "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
+        healthcheckPath: "/api/health",
+        domain: "showcase-crewai-conversational-flows-staging.up.railway.app",
+        probe: true,
+      },
+    },
+  },
   "showcase-crewai-crews": {
     serviceId: "0e9c284d-8d87-4fcf-9f82-6b704d7e4bd4",
     autoUpdates: { staging: "disabled", prod: "disabled" },


### PR DESCRIPTION
## Problem

The `verify-image-refs` job in the "Showcase: Build & Push" workflow was failing. Its gate script `showcase/scripts/verify-railway-image-refs.ts` compares live Railway services against the SSOT `SERVICES` map in `showcase/scripts/railway-envs.ts`, and the live Railway service `showcase-crewai-conversational-flows` had no SSOT entry — tripping the Railway→SSOT drift check.

## Fix

Register `showcase-crewai-conversational-flows` in the `SERVICES` map. It is added as a **staging-only** entry because the live Railway service currently has a serviceInstance in **staging only** (no prod instance is provisioned). The env-map schema explicitly supports single-env services, and the gate's `findMissingServices` only demands a service in the envs it declares — so declaring only `staging` is correct and does not create a false "missing prod instance" failure in the other drift direction.

All values were read verbatim from the **live Railway GraphQL API**, not guessed:

- `serviceId`: `11859593-da4e-486c-a810-6cdffeff9750`
- staging `instanceId`: `3d44daba-b417-4c6c-a366-d1b94e5fe8fa`
- staging `domain`: `showcase-crewai-conversational-flows-staging.up.railway.app`
- staging `healthcheckPath`: `/api/health` (staging `/api/health` returns HTTP 200 live)
- staging image on Railway: `ghcr.io/copilotkit/showcase-crewai-conversational-flows:latest` (matches the canonical staging `:latest` shape)

`ciBuilt: false` because this integration is wired only into the PR-check build (`showcase_build_check.yml`), **not** `showcase_build.yml`'s `ALL_SERVICES` build matrix — so it stays out of `CI_BUILT_SERVICES` (whose members must each have a matching `dispatch_name` in `showcase_build.yml`), exactly like `webhooks`. `runtimeDeps: ["aimock"]` + the `OPENAI_BASE_URL` serviceRef mirror its `showcase-crewai-crews` sibling (every `agent`-driver service must declare an aimock runtime dep).

### SERVICES entry added

```ts
"showcase-crewai-conversational-flows": {
  serviceId: "11859593-da4e-486c-a810-6cdffeff9750",
  autoUpdates: { staging: "disabled", prod: "disabled" },
  ciBuilt: false,
  gateValidated: true,
  dispatchName: "crewai-conversational-flows",
  probeDriver: "agent",
  runtimeDeps: ["aimock"],
  serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
  environments: {
    staging: {
      instanceId: "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
      healthcheckPath: "/api/health",
      domain: "showcase-crewai-conversational-flows-staging.up.railway.app",
      probe: true,
    },
  },
},
```

Also regenerated `railway-envs.generated.json` (the Ruby-consumed artifact) and updated the count/coverage assertions in the affected tests. The SSOT now has 42 services; `findMissingServices` is intentionally **asymmetric** for the staging-only entry (41 prod, 42 staging).

## Red / Green proof (real gate: `showcase/scripts/verify-railway-image-refs.ts`)

The proof exercises the exact script CI runs, against the live Railway API (not a unit fake).

### RED — before the change (exit 1)

```
✗ Railway image-ref drift detected (0 violations across 82 env-scoped instances; 0 missing services; 1 untracked Railway services; 0 skipped)

  ✗ [railway] showcase-crewai-conversational-flows
    current:  <present on Railway, absent from SSOT>
    reason:   Railway service "showcase-crewai-conversational-flows" is not in the SSOT. Either add it to SERVICES in showcase/scripts/railway-envs.ts (preferred), or mark an existing entry with gateIgnore: true if it is deliberately unmanaged by WS4.

Fix via Railway dashboard, `bin/railway pin`, `bin/railway promote`, or `showcase/scripts/redeploy-env.ts`.
```
(process exit code: 1)

### GREEN — after the change (exit 0)

```
✓ 83 env-scoped instances verified (0 skipped)
```
(process exit code: 0 — 0 untracked, the previously-untracked service is now the 83rd verified instance)

## Other checks

- `showcase/scripts` vitest (4 affected suites): **175 passed**.
- Full `showcase/scripts` vitest suite: no new failures vs. pristine `main` (the same pre-existing env-only failures appear with and without this change).
- `oxfmt --check`: clean on all changed TS. `oxlint`: 0 errors.
- `tsc --noEmit`: no type errors in `railway-envs.ts` or the changed tests.

## CI expectation

The `verify-image-refs` job is expected to pass: the previously-untracked service is now registered, and the staging image matches the canonical `:latest` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnxXBdQ2gBmvBBNKAr8Zsb
