### PR TITLE
Railway cost reduction: langgraph memory caps + harness worker recycle

### DIFF
--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -12,6 +12,8 @@ import type {
   ServiceJobResult,
 } from "./contracts.js";
 import type { Logger } from "../types/index.js";
+import { drainFleetWorker, makeRecycleExit } from "../orchestrator.js";
+import { WORKER_RECYCLE_EXIT_CODE } from "./worker/worker-loop.js";
 import { BrowserPool } from "../probes/helpers/browser-pool.js";
 import type {
   LaunchBrowser,
@@ -191,6 +193,122 @@ describe("runWorker default (self-contained) boot", () => {
       note: "no D5 features declared",
     });
   });
+});
+
+describe("runWorker recycle exit — deregister-first before process.exit", () => {
+  it(
+    "forwards the injected recycle exit to the loop so a WORKER_MAX_JOBS recycle runs drainFleetWorker (deregister) BEFORE exiting non-zero",
+    { timeout: 20000 },
+    async () => {
+      // The GAP this guards: a WORKER_MAX_JOBS recycle must deregister the roster
+      // row before the container restarts — otherwise the row strands for ~180s
+      // until fleet-health reclaims it, tripping a transient false-red every
+      // recycle. Pre-fix, fleet `runWorker` did NOT forward the `exit` dep to
+      // `startWorkerLoop`, so the loop fell back to a bare `process.exit` that
+      // skipped deregister. This test wires the PRODUCTION-shaped exit
+      // (`makeRecycleExit` → `gracefulTeardown` → the REAL `drainFleetWorker`),
+      // drives a real recycle, and asserts the deregister ran BEFORE the exit.
+      const order: string[] = [];
+      const registration = {
+        stop: (): void => {
+          order.push("registration.stop");
+        },
+        deregister: async (): Promise<void> => {
+          order.push("deregister");
+        },
+      };
+      const shutdownPool = async (): Promise<void> => {
+        order.push("shutdownPool");
+      };
+      const exitCodes: number[] = [];
+      const processExit = (code: number): void => {
+        order.push("processExit");
+        exitCodes.push(code);
+      };
+
+      // Late-bound worker handle (assigned by runWorker below) — mirrors the
+      // production wiring: the exit only dereferences it at recycle time.
+      let workerHandle: Awaited<ReturnType<typeof runWorker>> | undefined;
+      const gracefulTeardown = (): Promise<void> => {
+        // Runtime guard, NOT an `as NonNullable` cast: a recycle-ordering
+        // regression that fired the teardown before `runWorker` assigned the
+        // handle would otherwise silently pass `undefined` into drainFleetWorker
+        // (the cast hid that case). Fail LOUD so the regression surfaces here.
+        if (workerHandle === undefined) {
+          throw new Error(
+            "gracefulTeardown ran before runWorker assigned the worker handle",
+          );
+        }
+        return drainFleetWorker({
+          worker: workerHandle,
+          registration,
+          shutdownPool,
+        });
+      };
+      const exit = makeRecycleExit({
+        gracefulTeardown,
+        logger: silentLogger,
+        processExit,
+      });
+
+      // Safety net: if a regression drops the forwarding, the loop's DEFAULT exit
+      // is the real `process.exit` — stub it so a broken test can't kill the
+      // vitest worker (and so we can assert the default path was NOT taken).
+      const exitStub = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as never);
+
+      // The loop resolves its recycle threshold from process.env at construction
+      // (resolveNonNegativeIntEnv), NOT the injected `env`. Stub it to recycle
+      // after the FIRST settled job (jitter 0 pins the threshold to 1) using the
+      // suite's vi.stubEnv style so the finally's vi.unstubAllEnvs guarantees
+      // teardown even if runWorker throws.
+      vi.stubEnv("WORKER_MAX_JOBS", "1");
+      vi.stubEnv("WORKER_MAX_JOBS_JITTER", "0");
+
+      const queue = makeQueue([{ claimed: true, lease: makeLease() }]);
+      try {
+        workerHandle = await runWorker(config, {
+          queue,
+          workerId: "worker-recycle-test",
+          logger: silentLogger,
+          env: {},
+          skipHealthServer: true,
+          leaseSeconds: 2000,
+          heartbeatMs: 1_000_000,
+          pollIntervalMs: 1,
+          launchBrowser: makeNoopLauncher(),
+          cgroupPidsReader: headroomPidsReader,
+          exit,
+        });
+        // The threshold was read at construction; unstub NOW so a lazy-threshold-
+        // read regression (reading the knob at recycle time instead) sees the
+        // default, never recycles, and FAILS FAST at the 5s waitFor below — rather
+        // than the stub keeping the recycle alive and masking the regression.
+        vi.unstubAllEnvs();
+
+        // One job settles → recycle fires → the forwarded exit runs to completion.
+        await vi.waitFor(
+          () => expect(exitCodes).toContain(WORKER_RECYCLE_EXIT_CODE),
+          { timeout: 5000 },
+        );
+
+        // Deregister-first: the roster delete ran BEFORE the process exit.
+        const deregisterAt = order.indexOf("deregister");
+        const exitAt = order.indexOf("processExit");
+        expect(deregisterAt).toBeGreaterThanOrEqual(0);
+        expect(exitAt).toBeGreaterThanOrEqual(0);
+        expect(deregisterAt).toBeLessThan(exitAt);
+        // The forwarded exit was used — the loop's default real process.exit was NOT.
+        expect(exitStub).not.toHaveBeenCalled();
+      } finally {
+        exitStub.mockRestore();
+        // Guarantee the recycle-knob stubs are gone even if runWorker threw before
+        // the inline unstub above (idempotent with it).
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 });
 
 /** Bind-then-release an ephemeral port for the worker /health server. */

--- a/showcase/harness/src/fleet/orchestrator.ts
+++ b/showcase/harness/src/fleet/orchestrator.ts
@@ -144,6 +144,16 @@ export interface RunWorkerOptions {
    */
   onCurrentJobChange?: (currentJobId: string | null) => void;
   /**
+   * Injectable process-exit for the loop's WORKER_MAX_JOBS recycle, forwarded
+   * verbatim to `startWorkerLoop`. Production (orchestrator.ts `runWorker`)
+   * injects a RICHER exit that runs the same deregister-first graceful teardown
+   * as SIGTERM (`drainFleetWorker` — roster delete + pool shutdown) BEFORE
+   * exiting non-zero, so a recycled worker never leaves a stale roster row for
+   * fleet-health to reclaim (~180s → transient false-red). When omitted the
+   * loop defaults to a bare `process.exit` (which does NOT deregister).
+   */
+  exit?: (code: number) => void;
+  /**
    * Override the per-service driver (tests inject a fake). Defaults to the real
    * pooled d6 driver wired onto the constructed `BrowserPool`.
    */
@@ -283,6 +293,10 @@ export async function runWorker(
       heartbeatMs: opts.heartbeatMs,
       pollIntervalMs: opts.pollIntervalMs,
       onCurrentJobChange: opts.onCurrentJobChange,
+      // Forward the injectable recycle exit. Production injects a richer exit
+      // that deregisters (drainFleetWorker) before exiting non-zero; when
+      // omitted the loop falls back to a bare process.exit.
+      exit: opts.exit,
     });
   } catch (err) {
     // Loop construction is synchronous and shouldn't throw, but if it does,

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -2974,6 +2974,17 @@ describe("startWorkerLoop PID headroom gate", () => {
       claimNextCalls++;
       return innerClaimNext(...args);
     };
+    // Count poll cycles so we can wait on a CONDITION (the loop has actually
+    // made several gate decisions) rather than a fixed real-timer wall — the
+    // loop sleeps once per poll iteration regardless of whether it claims or
+    // the gate declines, so this is the one signal common to both the claiming
+    // and declining cases below.
+    let sleeps = 0;
+    const sleep = yieldingSleep();
+    const countingSleep = (ms: number, signal?: AbortSignal): Promise<void> => {
+      sleeps++;
+      return sleep(ms, signal);
+    };
     const handle = startWorkerLoop({
       workerId: "worker-test",
       queue,
@@ -2989,13 +3000,15 @@ describe("startWorkerLoop PID headroom gate", () => {
       logger: silentLogger,
       env: {},
       now: () => new Date("2026-06-04T00:04:00.000Z"),
-      sleep: yieldingSleep(),
+      sleep: countingSleep,
       pollIntervalMs: 1,
       leaseSeconds: 2000,
       heartbeatMs: 1_000_000,
     });
-    // Give the loop room to make several claim decisions.
-    await new Promise((r) => setTimeout(r, 40));
+    // Give the loop room to make several claim decisions. A claiming iteration
+    // claims-and-reports BEFORE it sleeps, so once the loop has polled a few
+    // times the claim/report (or the decline) has definitely settled.
+    await vi.waitFor(() => expect(sleeps).toBeGreaterThanOrEqual(3));
     await handle.stop();
     return { claimNextCalls, reports: queue.reports.length };
   }
@@ -3066,5 +3079,183 @@ describe("startWorkerLoop PID headroom gate", () => {
     await new Promise((r) => setTimeout(r, 40));
     await handle.stop();
     expect(claimNextCalls).toBe(0);
+  });
+});
+
+// ── startWorkerLoop: worker recycle (WORKER_MAX_JOBS) ───────────────────────
+//
+// After ~WORKER_MAX_JOBS settled jobs (staggered per-replica by a deterministic
+// jitter) the worker stops claiming, runs the existing graceful drain, and exits
+// NON-ZERO so Railway (restartPolicyType ON_FAILURE) replaces the container —
+// pre-empting slow Chromium/heap growth on long-lived workers. Mirrors Gunicorn
+// --max-requests / Celery max-tasks-per-child.
+
+/** A logger that records every message so drain/recycle lines can be asserted. */
+function recordingLogger(): { logger: Logger; messages: string[] } {
+  const messages: string[] = [];
+  const push =
+    () =>
+    (msg: string): void => {
+      messages.push(msg);
+    };
+  return {
+    messages,
+    logger: {
+      info: push(),
+      warn: push(),
+      error: push(),
+      debug: push(),
+    },
+  };
+}
+
+describe("startWorkerLoop — worker recycle (WORKER_MAX_JOBS)", () => {
+  it("recycles after WORKER_MAX_JOBS settled jobs: drains and exits non-zero", async () => {
+    // Two claimable jobs, threshold 2 (jitter 0 → deterministic). After the 2nd
+    // job SETTLES the worker must stop claiming, fire the drain, and call the
+    // (injected) exit with a NON-ZERO code.
+    const queue = makeQueue([
+      { claimed: true, lease: makeLease({ job: { id: "job-1" } }) },
+      { claimed: true, lease: makeLease({ job: { id: "job-2" } }) },
+    ]);
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const exit = vi.fn<(code: number) => void>();
+    const { logger, messages } = recordingLogger();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      // Recycle after exactly 2 settled jobs (jitter 0 pins the threshold).
+      maxJobs: 2,
+      maxJobsJitter: 0,
+      exit,
+    });
+
+    // The (injected) exit is called with a NON-ZERO code once the 2nd job settles.
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledTimes(1));
+    // The loop stopped on its own (drain → break), so `done` resolves.
+    await handle.done;
+
+    const code = exit.mock.calls[0]![0];
+    expect(code).not.toBe(0);
+    expect(code).toBeGreaterThan(0);
+    // Both jobs ran and were reported before the recycle fired.
+    expect(queue.reports).toHaveLength(2);
+    // The EXISTING drain path was invoked (requestDrain logs drain-requested),
+    // alongside the recycle marker.
+    expect(messages).toContain("fleet.worker.recycle-max-jobs");
+    expect(messages).toContain("fleet.worker.drain-requested");
+
+    await handle.stop();
+  });
+
+  it("does NOT recycle when the feature is disabled (maxJobs=0)", async () => {
+    // With maxJobs 0 the worker must keep claiming past what would otherwise be
+    // the threshold and NEVER exit.
+    const queue = makeQueue([
+      { claimed: true, lease: makeLease({ job: { id: "job-1" } }) },
+      { claimed: true, lease: makeLease({ job: { id: "job-2" } }) },
+      { claimed: true, lease: makeLease({ job: { id: "job-3" } }) },
+    ]);
+    // Count claim ATTEMPTS: a 4th claim only happens if the recycle check after
+    // the 3rd settled job chose NOT to break — a deterministic positive signal
+    // that the recycle window is fully passed, replacing a fixed real-timer wait.
+    let claimAttempts = 0;
+    const origClaimNext = queue.claimNext.bind(queue);
+    queue.claimNext = async (...args: Parameters<typeof origClaimNext>) => {
+      claimAttempts++;
+      return origClaimNext(...args);
+    };
+    const driver = makeDriver({
+      slug: "langgraph-python",
+      cells: [{ featureId: "shared-state", state: "green" }],
+      aggregateState: "green",
+    });
+    const exit = vi.fn<(code: number) => void>();
+    const handle = startWorkerLoop({
+      workerId: "worker-test",
+      queue,
+      pool: budgetWith(5),
+      driver,
+      payloadToInput: passInput,
+      logger: silentLogger,
+      env: {},
+      now: () => new Date("2026-06-04T00:04:00.000Z"),
+      sleep: yieldingSleep(),
+      pollIntervalMs: 1,
+      leaseSeconds: 2000,
+      heartbeatMs: 1_000_000,
+      maxJobs: 0,
+      maxJobsJitter: 0,
+      exit,
+    });
+
+    // Poll for the loop to advance PAST all 3 settled jobs (a 4th claim proves
+    // the post-job-3 recycle check ran and chose to continue). If the disable
+    // were broken the loop would recycle and never make the 4th claim, so this
+    // waitFor would time out (fail loud) instead of the assertion sneaking by.
+    await vi.waitFor(() => expect(claimAttempts).toBeGreaterThanOrEqual(4));
+    expect(exit).not.toHaveBeenCalled();
+    await handle.stop();
+  });
+
+  it("subtracts a stable per-replica jitter from the threshold", async () => {
+    // maxJobs 5, jitter 3 → threshold in [2,5], STABLE within a process. Two
+    // workers with different ids may land on different thresholds; the SAME id
+    // must recycle at the SAME count every run. Assert the recycle count is in
+    // range and deterministic for a fixed workerId.
+    async function recycleAfter(workerId: string): Promise<number> {
+      const claims = Array.from({ length: 10 }, (_v, i) => ({
+        claimed: true as const,
+        lease: makeLease({ job: { id: `job-${i + 1}` } }),
+      }));
+      const queue = makeQueue(claims);
+      const driver = makeDriver({
+        slug: "langgraph-python",
+        cells: [{ featureId: "shared-state", state: "green" }],
+        aggregateState: "green",
+      });
+      const exit = vi.fn<(code: number) => void>();
+      const handle = startWorkerLoop({
+        workerId,
+        queue,
+        pool: budgetWith(5),
+        driver,
+        payloadToInput: passInput,
+        logger: silentLogger,
+        env: {},
+        now: () => new Date("2026-06-04T00:04:00.000Z"),
+        sleep: yieldingSleep(),
+        pollIntervalMs: 1,
+        leaseSeconds: 2000,
+        heartbeatMs: 1_000_000,
+        maxJobs: 5,
+        maxJobsJitter: 3,
+        exit,
+      });
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledTimes(1));
+      await handle.done;
+      await handle.stop();
+      return queue.reports.length;
+    }
+
+    const first = await recycleAfter("worker-alpha");
+    const again = await recycleAfter("worker-alpha");
+    expect(first).toBe(again); // deterministic within a fixed id
+    expect(first).toBeGreaterThanOrEqual(2); // maxJobs - jitter floor
+    expect(first).toBeLessThanOrEqual(5); // maxJobs ceiling
   });
 });

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -209,6 +209,34 @@ export interface WorkerLoopDeps {
    * must never throw into the loop, so the loop swallows its rejection.
    */
   onCurrentJobChange?: (currentJobId: string | null) => void;
+  /**
+   * Max SETTLED jobs this worker processes before it recycles: stops claiming,
+   * runs the existing graceful drain, and exits non-zero so the platform
+   * restarts a fresh container (pre-empting slow Chromium/heap growth on a
+   * long-lived worker — Gunicorn `--max-requests` / Celery
+   * `max-tasks-per-child`). Injectable override; when omitted the loop resolves
+   * `WORKER_MAX_JOBS` (default `DEFAULT_WORKER_MAX_JOBS`). `0` DISABLES the
+   * feature (the worker runs forever, pre-recycle behavior).
+   */
+  maxJobs?: number;
+  /**
+   * Per-replica stagger: a value in `[0, maxJobsJitter]` is derived
+   * DETERMINISTICALLY from `workerId`/HOSTNAME and subtracted from `maxJobs`
+   * ONCE at startup, so replicas recycle at slightly different job counts
+   * instead of all at once (avoiding a fleet-wide simultaneous restart).
+   * Injectable override; when omitted the loop resolves `WORKER_MAX_JOBS_JITTER`
+   * (default `DEFAULT_WORKER_MAX_JOBS_JITTER`).
+   */
+  maxJobsJitter?: number;
+  /**
+   * Injectable process-exit, ABSTRACTED so the recycle path is unit-testable
+   * without killing the test process. Defaults to `process.exit`. The
+   * entrypoint MAY inject a richer exit that runs the full graceful teardown
+   * (`drainFleetWorker` — deregister + pool shutdown) BEFORE exiting non-zero;
+   * the bare default only fires the loop-local `requestDrain()` (which, at the
+   * settle point, has no in-flight run to drain) then exits.
+   */
+  exit?: (code: number) => void;
 }
 
 /** Handle returned by `startWorkerLoop` — `stop()` requests a bounded drain. */
@@ -420,6 +448,78 @@ export function safeLog(
     // Swallow: the logger is the failing component; nothing load-bearing may
     // sit behind a forensic log line.
   }
+}
+
+/**
+ * Default recycle threshold: after this many SETTLED jobs a worker drains and
+ * exits non-zero for a fresh restart. 100 mirrors a conservative Gunicorn
+ * `--max-requests`; the exact value trades restart churn against how much
+ * Chromium/heap growth accumulates on a long-lived worker. Env-overridable via
+ * `WORKER_MAX_JOBS`; `0` disables the feature.
+ */
+export const DEFAULT_WORKER_MAX_JOBS = 100;
+/**
+ * Default per-replica recycle stagger. A deterministic value in `[0, this]`
+ * (derived from the worker id) is subtracted from `WORKER_MAX_JOBS` once at
+ * startup so a fleet of identically-configured replicas does not all recycle on
+ * the same job count (Gunicorn `--max-requests-jitter`). Env-overridable via
+ * `WORKER_MAX_JOBS_JITTER`.
+ */
+export const DEFAULT_WORKER_MAX_JOBS_JITTER = 15;
+/**
+ * Exit code the worker uses when RECYCLING (max-jobs reached). NON-ZERO is
+ * REQUIRED: Railway's `restartPolicyType: ON_FAILURE` only replaces the
+ * container on a non-zero exit — a zero exit reads as an intentional stop and
+ * may NOT restart, which would silently drain the fleet. 42 is an arbitrary
+ * distinctive non-zero sentinel (distinct from the boot-failure `1`) so a
+ * recycle is greppable in platform logs.
+ */
+export const WORKER_RECYCLE_EXIT_CODE = 42;
+
+/**
+ * Resolve a NON-NEGATIVE integer env knob (the recycle max-jobs / jitter share
+ * this shape: `0` is a MEANINGFUL value — disabled / no-stagger — so unlike the
+ * strictly-positive `resolveDrainGraceMs` this accepts `>= 0`). Unset/empty
+ * falls back to `fallback`; a present-but-garbage or negative override warns and
+ * falls back (fail-loud-ish, matching the drain-grace resolver) rather than
+ * silently mis-tuning. Construction-time; the warn is the same deliberately
+ * unguarded fail-loud misconfig surface as the other knob resolvers.
+ */
+function resolveNonNegativeIntEnv(
+  envName: string,
+  fallback: number,
+  logger: Logger,
+): number {
+  const raw = process.env[envName];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+  logger.warn("fleet.worker.recycle-knob-invalid", {
+    envName,
+    raw,
+    fallback,
+  });
+  return fallback;
+}
+
+/**
+ * Deterministic per-process jitter in `[0, jitter]` derived from a stable seed
+ * (the worker id / HOSTNAME). Uses a 32-bit FNV-1a hash so the value is STABLE
+ * within a process (computed once at startup) yet DIFFERS across replicas with
+ * distinct ids — never `Math.random`, which would pick a fresh value per call
+ * and could not stagger a fixed replica reproducibly. Returns 0 when `jitter`
+ * is 0 (no stagger).
+ */
+export function deterministicJitter(seed: string, jitter: number): number {
+  if (jitter <= 0) return 0;
+  let h = 0x811c9dc5; // FNV-1a offset basis
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193); // FNV prime
+  }
+  // `h` is a signed 32-bit int; `>>> 0` makes it unsigned before the modulus so
+  // the result is always in `[0, jitter]`.
+  return (h >>> 0) % (jitter + 1);
 }
 
 function resolveDrainGraceMs(logger: Logger): number {
@@ -1155,6 +1255,59 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
     deps.pidClaimGateRatio ?? resolvePidClaimGateRatio(logger);
   let pidGateLatched = false;
 
+  // RECYCLE knobs (resolved ONCE at construction, like the gate ratio above).
+  // `maxJobs` 0 disables the feature; otherwise the effective per-process
+  // threshold is `maxJobs` minus a deterministic per-replica jitter, so a fleet
+  // of identical replicas does not all recycle on the same job count. Floored at
+  // 1 so a jitter >= maxJobs can never yield a 0/negative threshold (which would
+  // recycle on the very first job or never). Computed here, BEFORE the claim
+  // loop, so the stagger is fixed for the process lifetime.
+  const maxJobs =
+    deps.maxJobs ??
+    resolveNonNegativeIntEnv(
+      "WORKER_MAX_JOBS",
+      DEFAULT_WORKER_MAX_JOBS,
+      logger,
+    );
+  const maxJobsJitter =
+    deps.maxJobsJitter ??
+    resolveNonNegativeIntEnv(
+      "WORKER_MAX_JOBS_JITTER",
+      DEFAULT_WORKER_MAX_JOBS_JITTER,
+      logger,
+    );
+  const recycleEnabled = maxJobs > 0;
+  const recycleThreshold = recycleEnabled
+    ? Math.max(
+        1,
+        maxJobs -
+          deterministicJitter(
+            `${workerId}:${process.env.HOSTNAME ?? ""}`,
+            maxJobsJitter,
+          ),
+      )
+    : 0;
+  const exit =
+    deps.exit ??
+    ((code: number): void => {
+      process.exit(code);
+    });
+  // Count of SETTLED jobs (claimed → ran → reported). Never incremented on
+  // empty poll cycles or abandoned (grace-expiry) runs. Closure-scoped so each
+  // loop instance counts independently (one worker per process in production;
+  // isolation keeps the unit tests free of cross-test counter bleed a
+  // module-scoped counter would introduce).
+  let completedJobs = 0;
+  let recycleTriggered = false;
+  if (recycleEnabled) {
+    safeLog(logger, "info", "fleet.worker.recycle-armed", {
+      workerId,
+      maxJobs,
+      maxJobsJitter,
+      recycleThreshold,
+    });
+  }
+
   // Fail-loud at construction: the heartbeat must fire (and renew) BEFORE the
   // lease expires, or the sweeper reclaims a live worker's job and synthesizes a
   // false `worker-crashed-mid-job` (REQ-B). `heartbeatMs` and `leaseSeconds` are
@@ -1525,8 +1678,40 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
         // again on the next registration heartbeat.
         notifyCurrentJob(null);
       }
+
+      // RECYCLE CHECK — settle point. Count this SETTLED job (claimed → ran →
+      // reported) EXACTLY ONCE; empty poll cycles and abandoned (grace-expiry)
+      // runs never reach here. Once the per-process threshold is crossed, stop
+      // claiming (the EXISTING loop-local drain, `requestDrain()` — no in-flight
+      // run remains at the settle point, so nothing to wait on), break the loop,
+      // and exit NON-ZERO below so the platform restart policy replaces the
+      // container — pre-empting slow Chromium/heap growth on a long-lived worker
+      // (Gunicorn `--max-requests` / Celery `max-tasks-per-child`).
+      completedJobs++;
+      if (recycleEnabled && completedJobs >= recycleThreshold) {
+        safeLog(logger, "info", "fleet.worker.recycle-max-jobs", {
+          workerId,
+          completedJobs,
+          recycleThreshold,
+          maxJobs,
+          maxJobsJitter,
+          exitCode: WORKER_RECYCLE_EXIT_CODE,
+        });
+        recycleTriggered = true;
+        requestDrain();
+        break;
+      }
     }
     safeLog(logger, "info", "fleet.worker.loop-stopped", { workerId });
+    if (recycleTriggered) {
+      // Exit NON-ZERO so the platform (Railway `restartPolicyType: ON_FAILURE`)
+      // replaces this container with a fresh one. A zero exit would read as an
+      // intentional stop and might NOT restart — silently shrinking the fleet.
+      // `exit` is injectable (default `process.exit`) so the recycle path is
+      // testable without killing the test process; a richer injected exit MAY
+      // run the full graceful teardown (deregister + pool shutdown) first.
+      exit(WORKER_RECYCLE_EXIT_CODE);
+    }
   })();
 
   return {

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -30,6 +30,8 @@ import {
   hydrateProbeLastRuns,
   verifyWorkerRegistered,
   drainFleetWorker,
+  makeRecycleExit,
+  latchOnce,
   DRAIN_DEREGISTER_TIMEOUT_MS,
 } from "./orchestrator.js";
 import { runWorker as runFleetWorker } from "./fleet/orchestrator.js";
@@ -60,7 +62,7 @@ import {
   E2E_SMOKE_DRIVER_KIND,
 } from "./fleet/worker/payload-mapper.js";
 import type { WorkerRegistryReadPb } from "./orchestrator.js";
-import type { State, ProbeResult } from "./types/index.js";
+import type { State, ProbeResult, Logger } from "./types/index.js";
 import type {
   StatusWriter,
   OverlayWriteOutcome,
@@ -3599,6 +3601,163 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
       workerId: "worker-drain-idle",
       abandoningJobId: null,
     });
+  });
+});
+
+/**
+ * `makeRecycleExit` — the WORKER_MAX_JOBS recycle `exit` dep injected into the
+ * worker loop. It must run the deregister-first graceful teardown
+ * (`gracefulTeardown` → `drainFleetWorker`) BEFORE exiting, and it must ALWAYS
+ * exit (with the non-zero recycle code) even if the teardown rejects — otherwise
+ * a failed drain would strand a recycled worker that never surrenders to the
+ * platform restart policy.
+ */
+describe("makeRecycleExit — deregister BEFORE process.exit", () => {
+  const silentLogger: Logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+
+  it("runs gracefulTeardown (deregister) BEFORE process-exit and forwards the recycle code", async () => {
+    const order: string[] = [];
+    const gracefulTeardown = vi.fn(async (): Promise<void> => {
+      order.push("teardown");
+    });
+    const processExit = vi.fn((code: number): void => {
+      order.push(`exit:${code}`);
+    });
+    const exit = makeRecycleExit({
+      gracefulTeardown,
+      logger: silentLogger,
+      processExit,
+    });
+
+    exit(42);
+
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(42));
+    // Teardown ran FIRST, then the exit — the ordering the roster-row fix needs.
+    expect(order).toEqual(["teardown", "exit:42"]);
+    expect(gracefulTeardown).toHaveBeenCalledTimes(1);
+  });
+
+  it("STILL exits with the non-zero code even if gracefulTeardown REJECTS (finally-guaranteed restart)", async () => {
+    const processExit = vi.fn<(code: number) => void>();
+    const gracefulTeardown = vi.fn(async (): Promise<void> => {
+      throw new Error("deregister blew up");
+    });
+    const exit = makeRecycleExit({
+      gracefulTeardown,
+      logger: silentLogger,
+      processExit,
+    });
+
+    exit(42);
+
+    // The rejected teardown does not swallow the exit — Railway still restarts.
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(42));
+  });
+});
+
+/**
+ * TEARDOWN ONCE-LATCH (`latchOnce`) — `gracefulTeardown` in `runWorker` is
+ * reachable from BOTH the WORKER_MAX_JOBS recycle exit (`makeRecycleExit`) AND
+ * the SIGTERM/SIGINT handler (bootFleet's `drainAndExit` → the handle's
+ * `stop()`). The signal handler's own `draining` guard protects only its own
+ * re-entry, NOT a recycle firing concurrently with a SIGTERM — so without a
+ * latch the shared deregister + pool.shutdown sequence would run TWICE. These
+ * tests compose the REAL `makeRecycleExit` + `latchOnce` + `drainFleetWorker`
+ * exactly as `runWorker` wires them and pin the once-only invariant.
+ */
+describe("teardown once-latch (recycle + SIGTERM do not double-teardown)", () => {
+  const silentLogger: Logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+
+  function makeTeardownSpies() {
+    const registration = {
+      stop: vi.fn(),
+      deregister: vi.fn(async () => {}),
+    };
+    const shutdownPool = vi.fn(async () => {});
+    const worker = { drain: vi.fn(), stop: vi.fn(async () => {}) };
+    return { registration, shutdownPool, worker };
+  }
+
+  it("runs drainFleetWorker's deregister + pool shutdown EXACTLY ONCE when the recycle exit and the SIGTERM stop() both fire", async () => {
+    const { registration, shutdownPool, worker } = makeTeardownSpies();
+    // EXACT runWorker wiring: one shared latched teardown behind both callers.
+    const gracefulTeardown = latchOnce(() =>
+      drainFleetWorker({ worker, registration, shutdownPool }),
+    );
+    const processExit = vi.fn<(code: number) => void>();
+    const exit = makeRecycleExit({
+      gracefulTeardown,
+      logger: silentLogger,
+      processExit,
+    });
+
+    // Fire the recycle exit (path 1) and the handle's stop() (path 2 — SIGTERM)
+    // concurrently, then await both settling.
+    exit(0); // makeRecycleExit calls gracefulTeardown() then processExit
+    await gracefulTeardown(); // the handle's stop() awaits the same teardown
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledTimes(1));
+
+    // The shared teardown ran once: deregister (roster delete) and pool shutdown
+    // each fired exactly once despite two callers. Pre-latch this was 2 each.
+    expect(registration.deregister).toHaveBeenCalledTimes(1);
+    expect(shutdownPool).toHaveBeenCalledTimes(1);
+    expect(worker.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("MUTATION GUARD: without the latch (raw thunk) the same two callers double-teardown", async () => {
+    // This is the RED the latch fixes: wiring the two callers to the RAW,
+    // un-latched teardown thunk makes drainFleetWorker run twice — proving the
+    // test above is non-vacuous (it fails if `latchOnce` is removed).
+    const { registration, shutdownPool, worker } = makeTeardownSpies();
+    const rawTeardown = () =>
+      drainFleetWorker({ worker, registration, shutdownPool });
+    const processExit = vi.fn<(code: number) => void>();
+    const exit = makeRecycleExit({
+      gracefulTeardown: rawTeardown,
+      logger: silentLogger,
+      processExit,
+    });
+
+    exit(0);
+    await rawTeardown();
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledTimes(1));
+
+    expect(registration.deregister).toHaveBeenCalledTimes(2);
+    expect(shutdownPool).toHaveBeenCalledTimes(2);
+  });
+
+  it("memoizes a REJECTING teardown so a second caller observes the same failure without re-running it", async () => {
+    // A teardown that rejects (e.g. worker.stop() threw) is memoized too: the
+    // second caller awaits the SAME rejected promise rather than re-running a
+    // partial teardown. drainFleetWorker still ran its deregister + pool
+    // shutdown exactly once.
+    const { registration, shutdownPool } = makeTeardownSpies();
+    const worker = {
+      drain: vi.fn(),
+      stop: vi.fn(async () => {
+        throw new Error("teardown exploded");
+      }),
+    };
+    const gracefulTeardown = latchOnce(() =>
+      drainFleetWorker({ worker, registration, shutdownPool }),
+    );
+
+    await expect(gracefulTeardown()).rejects.toThrow("teardown exploded");
+    await expect(gracefulTeardown()).rejects.toThrow("teardown exploded");
+
+    expect(registration.deregister).toHaveBeenCalledTimes(1);
+    expect(shutdownPool).toHaveBeenCalledTimes(1);
+    expect(worker.stop).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -3995,6 +3995,67 @@ export async function drainFleetWorker(args: {
 }
 
 /**
+ * Memoize a zero-arg async thunk so it runs AT MOST ONCE, no matter how many
+ * callers (concurrent or sequential) invoke the returned function.
+ *
+ * This is the once-latch for `gracefulTeardown` below. That teardown is
+ * reachable from BOTH the WORKER_MAX_JOBS recycle exit (`makeRecycleExit`) AND
+ * the SIGTERM/SIGINT signal handler (`bootFleet`'s `drainAndExit` → the handle's
+ * `stop()`). The signal handler has its OWN `draining` boolean guard, but that
+ * guard protects only its own re-entry — it does NOT stop a recycle firing
+ * concurrently with (or moments before) a SIGTERM from running the whole
+ * deregister + `pool.shutdown()` sequence a SECOND time. The downstream is
+ * already idempotent / `.catch`-wrapped so a double-teardown does not crash, but
+ * the once-only invariant must be EXPLICIT: latching here makes every caller
+ * share the first invocation's promise, so `drainFleetWorker` (roster delete +
+ * pool shutdown) runs exactly once and concurrent callers all await the same
+ * outcome. A rejection is memoized too — a later caller observes (and logs) the
+ * same teardown failure rather than re-running a partial teardown.
+ */
+export function latchOnce<T>(fn: () => Promise<T>): () => Promise<T> {
+  let inflight: Promise<T> | undefined;
+  return (): Promise<T> => {
+    if (inflight === undefined) inflight = fn();
+    return inflight;
+  };
+}
+
+/**
+ * Build the injectable `exit` dep for the worker loop's WORKER_MAX_JOBS recycle.
+ *
+ * The recycle must NOT bare-`process.exit`: that skips the roster deregister and
+ * leaves a stale `workers` row for ~180s until fleet-health reclaims it, tripping
+ * a transient false-red on the dashboard every recycle. Instead run the SAME
+ * deregister-first graceful teardown as SIGTERM (`gracefulTeardown`, which wraps
+ * `drainFleetWorker` — roster delete + pool shutdown) BEFORE exiting.
+ *
+ * The `finally` GUARANTEES the (non-zero) exit even if the teardown rejects, so a
+ * failed drain still surrenders the container to Railway's restart policy — the
+ * recycle's whole purpose. Teardown is best-effort; the exit is load-bearing.
+ * `processExit` is injectable so the recycle path is unit-testable without
+ * killing the test process (defaults to `process.exit`).
+ */
+export function makeRecycleExit(deps: {
+  gracefulTeardown: () => Promise<void>;
+  logger: Logger;
+  processExit?: (code: number) => void;
+}): (code: number) => void {
+  const doExit = deps.processExit ?? ((code: number) => process.exit(code));
+  return (code: number): void => {
+    void deps
+      .gracefulTeardown()
+      .catch((err) =>
+        logErrorWithStack(
+          deps.logger,
+          "showcase-harness.fleet.worker.recycle-drain-failed",
+          err,
+        ),
+      )
+      .finally(() => doExit(code));
+  };
+}
+
+/**
  * Worker role entrypoint: runs the BrowserPool and pulls per-service jobs from
  * the control-plane queue.
  *
@@ -4227,6 +4288,51 @@ export async function runWorker(
   });
 
   let worker: Awaited<ReturnType<typeof runFleetWorker>>;
+
+  // SINGLE SOURCE OF TRUTH for this worker's deregister-first graceful teardown:
+  // drain (stop claiming) → registration.stop() → deregister (roster delete) →
+  // fleet worker.stop() → pool shutdown (WE own the pool since we injected
+  // budgetSource, so drainFleetWorker's shutdownPool is the one that runs it).
+  // Used by BOTH the handle's stop() (the SIGTERM path in bootFleet) AND the
+  // recycle `exit` dep injected below, so a WORKER_MAX_JOBS recycle tears down
+  // IDENTICALLY to SIGTERM — deregistering cleanly instead of stranding a stale
+  // roster row for fleet-health to reclaim at its 180s stale window (a transient
+  // false-red on every recycle). `worker` is captured by reference (assigned by
+  // the runFleetWorker call below); this closure only dereferences it at
+  // teardown time, long after boot.
+  //
+  // ONCE-LATCH (latchOnce): BOTH the recycle exit (makeRecycleExit below) and
+  // the SIGTERM/SIGINT handler (bootFleet's drainAndExit → this handle's stop())
+  // reference this SAME closure. The signal handler's `draining` boolean only
+  // guards its own re-entry — it cannot stop a recycle firing concurrently with
+  // a SIGTERM from running the whole deregister + pool.shutdown sequence twice.
+  // Latching makes the shared teardown run at most once; concurrent callers all
+  // await the first invocation's promise.
+  const gracefulTeardown = latchOnce(
+    (): Promise<void> =>
+      drainFleetWorker({
+        worker,
+        registration,
+        shutdownPool: () =>
+          pool.shutdown().catch((err) => {
+            logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
+              workerId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+            // CVDIAG: the worker's pool shutdown threw — chromium processes may
+            // be stranded. Surface the swallowed error with the worker_id.
+            console.log(
+              formatCvdiag({
+                component: "harness-orchestrator:worker-pool-shutdown-failed",
+                boundary: "als-snapshot",
+                status: "error",
+                error: `workerId=${workerId} ${err instanceof Error ? err.message : String(err)}`,
+              }),
+            );
+          }),
+      }),
+  );
+
   try {
     worker = await runFleetWorker(config, {
       queue,
@@ -4234,6 +4340,13 @@ export async function runWorker(
       port,
       logger,
       env,
+      // WORKER_MAX_JOBS recycle exit: run the SAME deregister-first graceful
+      // teardown as SIGTERM (deregister roster row + pool shutdown) BEFORE
+      // exiting non-zero so Railway restarts a fresh container. Without this the
+      // recycle used a bare process.exit that skipped deregister, leaving a
+      // stale roster row for ~180s that could trip a transient false-red on the
+      // fleet dashboard on every recycle.
+      exit: makeRecycleExit({ gracefulTeardown, logger }),
       // Inject the pool we own as the budget gate and the driver REGISTRY
       // (driverKind → { driver, payloadToInput }) we built above — fleet
       // runWorker skips constructing its own pool when both are supplied.
@@ -4309,28 +4422,10 @@ export async function runWorker(
       // job-settle heartbeat — which now fires AFTER the delete — is latched
       // into a logged no-op.
       // We injected BOTH budgetSource and drivers, so fleet runWorker did NOT
-      // construct its own pool — WE own it and shut it down here (last).
-      await drainFleetWorker({
-        worker,
-        registration,
-        shutdownPool: () =>
-          pool.shutdown().catch((err) => {
-            logger.error("showcase-harness.fleet.worker.pool-shutdown-failed", {
-              workerId,
-              err: err instanceof Error ? err.message : String(err),
-            });
-            // CVDIAG: the worker's pool shutdown threw — chromium processes may
-            // be stranded. Surface the swallowed error with the worker_id.
-            console.log(
-              formatCvdiag({
-                component: "harness-orchestrator:worker-pool-shutdown-failed",
-                boundary: "als-snapshot",
-                status: "error",
-                error: `workerId=${workerId} ${err instanceof Error ? err.message : String(err)}`,
-              }),
-            );
-          }),
-      });
+      // construct its own pool — WE own it and shut it down here (last). Shared
+      // with the recycle `exit` dep via `gracefulTeardown` (single source of
+      // truth) so SIGTERM and WORKER_MAX_JOBS recycle tear down identically.
+      await gracefulTeardown();
     },
   };
 }

--- a/showcase/integrations/langgraph-fastapi/entrypoint.sh
+++ b/showcase/integrations/langgraph-fastapi/entrypoint.sh
@@ -11,6 +11,15 @@ trap cleanup EXIT
 # sitting in Python's userspace buffer until the process exits.
 export PYTHONUNBUFFERED=1
 
+# Cap glibc malloc arena fragmentation. `langgraph dev` runs as a long-lived
+# in-memory dev server; on the many-core Railway host glibc otherwise spawns a
+# per-CPU malloc-arena pool (up to 8*ncpu arenas) and never trims freed pages
+# back to the OS, so steady-state RSS balloons far above live heap. Cap arenas
+# to 2 and lower the trim threshold so freed chunks are released back promptly.
+# `${VAR:-default}` so an explicit Railway override still wins.
+export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-2}"
+export MALLOC_TRIM_THRESHOLD_="${MALLOC_TRIM_THRESHOLD_:-131072}"
+
 echo "========================================="
 echo "[entrypoint] Starting showcase package: langgraph-fastapi"
 echo "[entrypoint] Time: $(date -u)"

--- a/showcase/integrations/langgraph-python/entrypoint.sh
+++ b/showcase/integrations/langgraph-python/entrypoint.sh
@@ -12,6 +12,15 @@ trap cleanup EXIT
 # `python -u` on the langgraph_cli invocation below.
 export PYTHONUNBUFFERED=1
 
+# Cap glibc malloc arena fragmentation. `langgraph dev` runs as a long-lived
+# in-memory dev server; on the many-core Railway host glibc otherwise spawns a
+# per-CPU malloc-arena pool (up to 8*ncpu arenas) and never trims freed pages
+# back to the OS, so steady-state RSS balloons far above live heap. Cap arenas
+# to 2 and lower the trim threshold so freed chunks are released back promptly.
+# `${VAR:-default}` so an explicit Railway override still wins.
+export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-2}"
+export MALLOC_TRIM_THRESHOLD_="${MALLOC_TRIM_THRESHOLD_:-131072}"
+
 echo "========================================="
 echo "[entrypoint] Starting showcase: langgraph-python"
 echo "[entrypoint] Time: $(date -u)"

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -398,8 +398,18 @@ export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true
 # server it forks (the server is a DESCENDANT, reached only via the tree-kill —
 # see the file header and _kill_agent_tree).  Never `kill $AGENT_PID` directly:
 # that reaps only the wrapper subshell and orphans the real server on :8123.
+# Cap the agent's V8 heap. The @langchain/langgraph-api server is the long-lived
+# process whose old-space drifts unbounded on the many-core Railway host (no
+# cgroup limit → V8 auto-sizes old-space to physical RAM, several GB). Cap it to
+# 1536 MB so steady-state RSS stays bounded. Scoped INLINE to this npm invocation
+# — NOT a global `export` — on purpose: a global NODE_OPTIONS would also cap the
+# `next start` node below, and starving the Next.js frontend (which serves the
+# showcase under D6 probe fan-out) risks its own OOM. Only the agent needs the
+# cap. `${NODE_OPTIONS:+$NODE_OPTIONS }` safe-appends so an explicit Railway
+# NODE_OPTIONS override still applies (and wins on duplicate flags — V8 takes the
+# last --max-old-space-size).
 echo "[entrypoint] Starting LangGraph TS agent on port 8123 (prod mode, no CLI)..."
-cd /app/src/agent && PORT=8123 HOST=0.0.0.0 npm start &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app/src/agent && PORT=8123 HOST=0.0.0.0 NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=1536" npm start &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 cd /app
 sleep 3


### PR DESCRIPTION
## What & why

Railway **memory** is the showcase project's largest cost line (~$1.2k/mo; egress was already fixed by the July internal-URL flip). This PR attacks it two ways:

1. **Cap langgraph integration backend memory.** The three `langgraph-*` showcase backends run the in-memory `langgraph dev` server and were drifting to 6–13 GB RSS each. Set `MALLOC_ARENA_MAX=2` + `MALLOC_TRIM_THRESHOLD_` on the python/fastapi entrypoints (glibc arena fragmentation on the many-core Railway host) and `NODE_OPTIONS=--max-old-space-size=1536` scoped to the langgraph-typescript **agent** process (not the sibling Next.js server) to cap the V8 heap. All values use `${VAR:-default}` so explicit Railway overrides win.

2. **Recycle harness workers** after `WORKER_MAX_JOBS` settled jobs (default 100, per-replica jitter via `WORKER_MAX_JOBS_JITTER`) to pre-empt slow Chromium/heap growth — the Gunicorn `--max-requests` / Celery `max-tasks-per-child` pattern. The recycle exits non-zero (`WORKER_RECYCLE_EXIT_CODE=42`) so Railway's `ON_FAILURE` policy restarts a fresh container, and routes teardown through the **same deregister-first `gracefulTeardown` → `drainFleetWorker`** SIGTERM uses (made idempotent via a once-latch) so a recycling worker deletes its roster row instead of stranding it ~180s (a transient dashboard false-red).

## Commits (by area of concern)

- `perf(showcase): cap langgraph integration backend memory`
- `feat(showcase/harness): recycle workers after WORKER_MAX_JOBS to pre-empt leaks`
- `feat(showcase/harness): deregister workers cleanly on recycle exit`

## Validation

- **207/207** harness tests pass (recycle counter/threshold/jitter, disabled-when-0, deterministic jitter, idempotent teardown, recycle-exit deregister — all red-green + mutation-checked).
- oxfmt clean, oxlint 0 errors, typecheck clean (the only `tsc` errors are 4 pre-existing `frontend-matrix.test.ts` errors from a missing generated catalog, unrelated to this diff).
- Reviewed via a 4-round code-review loop (converged: 0 mandatory findings; Procedure-3 promotion audit `PROMOTE_TO_A: 0`).

## ⚠️ Deploy / rollout notes

- **`WORKER_MAX_JOBS` defaults to 100 (recycle ON).** Set `WORKER_MAX_JOBS=0` to disable if you want a staged rollout. Recommend enabling on **staging first**.
- **The langgraph memory savings are not yet empirically measured.** `MALLOC_ARENA_MAX` reclaims glibc fragmentation on the many-core host but the GB delta must be confirmed by a **staging A/B** (deploy, compare RSS with/without) before quoting a dollar figure. The change itself is safe/standard; only the magnitude is unverified.
- Precondition confirmed: harness-workers restart policy is `ON_FAILURE` (in-repo docs) — the non-zero recycle exit will restart. Recommend pinning `restartPolicyType: ON_FAILURE` explicitly in IaC as defense-in-depth (follow-up).

## Follow-up (out of scope — pre-existing, surfaced by review)

The review surfaced a large pre-existing debt backlog in touched files, none load-bearing on this PR's subject (all deferred). Notable candidates for a separate PR:
- **Recycle-teardown hardening:** bound `pool.shutdown` in the recycle path with a timeout so a hard-wedged Chromium can't delay the voluntary exit (currently backstopped by the `/health` 503 healthcheck); make the recycle-vs-SIGTERM exit-code deterministic; `latchOnce` sync-throw guard.
- **Monitor write-only-red:** `onPidSaturation` writes RED with no clear path (permanent false-red once tripped).
- **Entrypoint robustness:** `wait -n` under `set -e` making the exit-code/diagnostic block dead code; `kill` of wrapper PIDs orphaning node children; TS watchdog probing the `:8124` sidecar not `:8123`.
- **Control-plane parity:** `runControlPlane` missing the S3 backup cron / `hydrateProbeLastRuns` / `probe_runs` metric wiring that `boot()` has.
- Assorted test-hygiene (afterEach `doUnmock` leaks, a few vacuous assertions, fixed-timer flakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
