### PR TITLE
fix(showcase): clear probe thread state after runs

### DIFF
--- a/showcase/harness/src/probes/drivers/d3-readiness.test.ts
+++ b/showcase/harness/src/probes/drivers/d3-readiness.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -25,6 +25,16 @@ import type {
   ProbeResult,
   ProbeResultWriter,
 } from "../../types/index.js";
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(null, { status: 204 }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // In-memory logger spy used by the registry-error and writer-missing
 // dedupe tests. Captures level + msg + meta so assertions can pin the
@@ -183,6 +193,63 @@ describe("e2e-demos driver", () => {
 
   it("exposes kind === 'e2e_demos'", () => {
     expect(e2eReadinessDriver.kind).toBe("e2e_demos");
+  });
+
+  it("clears backend thread state once without changing a green result when cleanup times out", async () => {
+    const { browser, state } = makeBrowser([{}]);
+    const driver = createE2eDemosDriver({
+      launcher: async () => browser,
+      demosResolver: async () => [],
+    });
+    const { writer } = mkWriter();
+    const { logger: spyLogger, entries } = mkSpyLogger();
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    fetchSpy.mockImplementationOnce(async () => {
+      expect(state.closed).toBe(true);
+      throw new DOMException("thread clear timed out", "TimeoutError");
+    });
+
+    const result = await driver.run(mkCtxWithLogger(writer, {}, spyLogger), {
+      key: "e2e-demos:langgraph-python",
+      backendUrl: "https://backend.example.com",
+      publicUrl: "https://public.example.com",
+      demos: ["agentic-chat"],
+      shape: "package",
+    });
+
+    expect(result).toEqual({
+      key: "e2e-demos:langgraph-python",
+      state: "green",
+      signal: {
+        shape: "package",
+        slug: "langgraph-python",
+        backendUrl: "https://backend.example.com",
+        total: 1,
+        passed: 1,
+        failed: [],
+      },
+      observedAt: "2026-04-23T00:00:00.000Z",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://backend.example.com/api/copilotkit-voice/threads/clear",
+      {
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: "warn",
+          msg: "probe.e2e.threads-clear-failed",
+          meta: expect.objectContaining({
+            slug: "langgraph-python",
+            err: "thread clear timed out",
+          }),
+        }),
+      ]),
+    );
   });
 
   it("emits one e2e:<slug>/<feature> row per declared demo", async () => {

--- a/showcase/harness/src/probes/drivers/d3-readiness.ts
+++ b/showcase/harness/src/probes/drivers/d3-readiness.ts
@@ -5,6 +5,7 @@ import { showcaseShapeSchema } from "../discovery/railway-services.js";
 import type { ProbeDriver } from "../types.js";
 import type { Logger, ProbeContext, ProbeResult } from "../../types/index.js";
 import type { BrowserPool } from "../helpers/browser-pool.js";
+import { clearRemoteThreads } from "../helpers/clear-remote-threads.js";
 
 /**
  * Phase 4B.1 — e2e-demos driver.
@@ -865,6 +866,10 @@ export function createE2eDemosDriver(
             });
           }
         }
+        // Fresh probe UUIDs otherwise accumulate forever in the default
+        // runner's process-wide store. The voice catch-all is intentional:
+        // it is the ungated route that accepts the service-wide clear path.
+        await clearRemoteThreads(backendUrl, slug, ctx.logger);
       }
     },
   };

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   e2eChatToolsDriver,
   createE2eSmokeDriver,
@@ -24,6 +24,16 @@ import type { BrowserPool } from "../helpers/browser-pool.js";
 import type { Browser } from "playwright";
 import { logger } from "../../logger.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(null, { status: 204 }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // Driver-level tests for the Playwright-in-process e2e-smoke driver. The
 // real chromium launch path is never exercised here — tests inject a
@@ -203,6 +213,51 @@ describe("e2eChatToolsDriver L3 (chat)", () => {
     expect(chat?.state).toBe("green");
     // Browser must always be torn down.
     expect(state.closed).toBe(true);
+  });
+
+  it("clears backend thread state once without changing a green result when cleanup rejects", async () => {
+    const { browser, state } = makeBrowser([{ assistantText: "Hi there!" }]);
+    const driver = createE2eSmokeDriver({ launcher: async () => browser });
+    const writer = new CapturingWriter();
+    const fetchSpy = vi.mocked(globalThis.fetch);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    fetchSpy.mockImplementationOnce(async () => {
+      expect(state.closed).toBe(true);
+      throw new Error("thread clear rejected");
+    });
+
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://backend.example.com",
+      publicUrl: "https://public.example.com",
+      demos: [],
+    });
+
+    expect(result).toEqual({
+      key: "e2e-smoke:foo",
+      state: "green",
+      signal: {
+        shape: "package",
+        slug: "foo",
+        backendUrl: "https://backend.example.com",
+        l3: "green",
+        l4: "skipped",
+        failureSummary: "",
+      },
+      observedAt: "2026-04-21T00:00:00.000Z",
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://backend.example.com/api/copilotkit-voice/threads/clear",
+      {
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      },
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "probe.e2e.threads-clear-failed",
+      expect.objectContaining({ slug: "foo", err: "thread clear rejected" }),
+    );
   });
 
   it("red when chat yields an empty assistant response", async () => {

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -7,6 +7,7 @@ import {
   showcaseShapeSchema,
 } from "../discovery/railway-services.js";
 import type { BrowserPool } from "../helpers/browser-pool.js";
+import { clearRemoteThreads } from "../helpers/clear-remote-threads.js";
 import type { ProbeDriver } from "../types.js";
 import type { ProbeContext, ProbeResult } from "../../types/index.js";
 import { mintRunId } from "../helpers/cv-diag.js";
@@ -1579,6 +1580,10 @@ export function createE2eSmokeDriver(
           });
         }
         await tearDown();
+        // Fresh probe UUIDs otherwise accumulate forever in the default
+        // runner's process-wide store. The voice catch-all is intentional:
+        // it is the ungated route that accepts the service-wide clear path.
+        await clearRemoteThreads(backendUrl, slug, ctx.logger);
       }
     },
   };

--- a/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   BrowserDisconnectedError,
   createE2eFullDriver,
@@ -33,6 +33,16 @@ import type {
   ProbeResult,
   ProbeResultWriter,
 } from "../../types/index.js";
+
+beforeEach(() => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(null, { status: 204 }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // Driver tests for the e2e-full (D6) ProbeDriver.
 //
@@ -307,6 +317,61 @@ describe("e2e-full driver", () => {
   });
 
   describe("happy path", () => {
+    it("clears backend thread state once without changing a green result when cleanup rejects", async () => {
+      registerD5Script(makeScript(["agentic-chat"]));
+
+      const browser = makeBrowser();
+      let browserClosed = false;
+      browser.close = async () => {
+        browserClosed = true;
+      };
+      const driver = createE2eFullDriver({
+        launcher: async () => browser,
+        scriptLoader: noopScriptLoader(),
+      });
+      const fetchSpy = vi.mocked(globalThis.fetch);
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      fetchSpy.mockImplementationOnce(async () => {
+        expect(browserClosed).toBe(true);
+        throw new Error("thread clear rejected");
+      });
+
+      const result = await driver.run(makeCtx(), {
+        key: "e2e_d6:showcase-test-slug",
+        backendUrl: "https://backend.example.com",
+        publicUrl: "https://public.example.com",
+        features: ["agentic-chat"],
+      });
+
+      expect(result).toMatchObject({
+        key: "e2e_d6:showcase-test-slug",
+        state: "green",
+        signal: {
+          shape: "package",
+          slug: "test-slug",
+          backendUrl: "https://backend.example.com",
+          total: 1,
+          passed: 1,
+          failed: [],
+        },
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://backend.example.com/api/copilotkit-voice/threads/clear",
+        {
+          method: "POST",
+          signal: expect.any(AbortSignal),
+        },
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        "probe.e2e.threads-clear-failed",
+        expect.objectContaining({
+          slug: "test-slug",
+          err: "thread clear rejected",
+        }),
+      );
+    });
+
     it("runs registered features and emits aggregate green", async () => {
       registerD5Script(makeScript(["agentic-chat"]));
 

--- a/showcase/harness/src/probes/drivers/d6-all-pills.ts
+++ b/showcase/harness/src/probes/drivers/d6-all-pills.ts
@@ -48,6 +48,7 @@ import type { CvdiagPbWriter } from "../../cvdiag/pb-writer.js";
 import type { ProbeDriver } from "../types.js";
 import type { Logger, ProbeContext, ProbeResult } from "../../types/index.js";
 import type { BrowserPool } from "../helpers/browser-pool.js";
+import { clearRemoteThreads } from "../helpers/clear-remote-threads.js";
 import type playwright from "playwright";
 
 /**
@@ -1632,6 +1633,10 @@ export function createE2eFullDriver(
             });
           }
         }
+        // Fresh probe UUIDs otherwise accumulate forever in the default
+        // runner's process-wide store. The voice catch-all is intentional:
+        // it is the ungated route that accepts the service-wide clear path.
+        await clearRemoteThreads(backendUrl, slug, ctx.logger);
       }
     },
   };

--- a/showcase/harness/src/probes/helpers/clear-remote-threads.ts
+++ b/showcase/harness/src/probes/helpers/clear-remote-threads.ts
@@ -1,0 +1,54 @@
+import type { Logger } from "../../types/index.js";
+
+const THREADS_CLEAR_PATH = "/api/copilotkit-voice/threads/clear";
+const THREADS_CLEAR_TIMEOUT_MS = 5_000;
+const THREADS_CLEAR_WARN_KEY = "probe.e2e.threads-clear-failed";
+
+function warnClearFailure(logger: Logger, meta: Record<string, unknown>): void {
+  try {
+    logger.warn(THREADS_CLEAR_WARN_KEY, meta);
+  } catch {
+    // Thread cleanup is strictly best-effort; even a broken logging sink must
+    // not change the probe result returned by the driver.
+  }
+}
+
+/**
+ * Clear a showcase service's process-wide InMemoryAgentRunner thread store.
+ * Probes mint a fresh thread id on every run, while the default runner keeps
+ * every thread indefinitely, so omitting this cleanup leaks heap over time.
+ *
+ * The copilotkit-voice catch-all is intentional: it is the ungated route that
+ * accepts `/threads/clear`. Other copilotkit routes match only their exact
+ * path, and the auth catch-all requires credentials. Because the store is
+ * module-scoped, this one request clears threads created through every route
+ * on the service.
+ *
+ * Cleanup is never load-bearing. Network, timeout, HTTP, and logging failures
+ * are swallowed so they cannot turn a green probe red or alter its result.
+ */
+export async function clearRemoteThreads(
+  backendUrl: string,
+  slug: string,
+  logger: Logger,
+): Promise<void> {
+  try {
+    const response = await fetch(`${backendUrl}${THREADS_CLEAR_PATH}`, {
+      method: "POST",
+      signal: AbortSignal.timeout(THREADS_CLEAR_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      warnClearFailure(logger, {
+        slug,
+        status: response.status,
+        err: `http ${response.status}`,
+      });
+    }
+  } catch (err) {
+    warnClearFailure(logger, {
+      slug,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- add best-effort remote thread cleanup for showcase probe runs
- clear the process-wide in-memory runner store through the ungated `copilotkit-voice` catch-all after D3, D4, and D6 browser teardown
- keep cleanup failures non-fatal while warning with the probe slug
- cover per-invocation cleanup, rejected/timed-out requests, unchanged probe results, and backend URL selection

## Verification

- Nx format check for the seven changed files
- Nx showcase harness typecheck
- D3, D4, and D6 sibling test suites (175 tests)
- Nx showcase harness build
