### PR TITLE
fix(packages): declare the MIT SPDX license on five published packages

### DIFF
--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -2,6 +2,7 @@
   "name": "@copilotkit/agentcore-runner",
   "version": "1.68.1",
   "description": "AWS Bedrock AgentCore-compatible agent runner for CopilotKit2",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/CopilotKit.git"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@copilotkit/core",
   "version": "1.68.1",
   "description": "Core web utilities for CopilotKit2",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/CopilotKit.git"

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -2,6 +2,7 @@
   "name": "@copilotkit/sqlite-runner",
   "version": "1.68.1",
   "description": "SQLite-backed agent runner for CopilotKit2",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/CopilotKit.git"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -2,6 +2,7 @@
   "name": "@copilotkit/voice",
   "version": "1.68.1",
   "description": "Voice services for CopilotKit (transcription, text-to-speech, etc.)",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/CopilotKit.git"

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -2,6 +2,7 @@
   "name": "@copilotkit/web-inspector",
   "version": "1.68.1",
   "description": "Lit-based web component for the CopilotKit web inspector",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/CopilotKit/CopilotKit.git"


### PR DESCRIPTION
Five packages publish to npm with no `license` field, so registry metadata and automated license scanners report them as **Unknown**:

```
@copilotkit/agentcore-runner  published=1.68.1  license=<NONE>
@copilotkit/core              published=1.68.1  license=<NONE>
@copilotkit/sqlite-runner     published=1.68.1  license=<NONE>
@copilotkit/voice             published=1.68.1  license=<NONE>
@copilotkit/web-inspector     published=1.68.1  license=<NONE>
```

The repo is MIT (see `LICENSE`) and every other published `@copilotkit/*` package already declares it — these five were simply missed. This adds `"license": "MIT"` to each, positioned before `"repository"` to match the sibling packages.

## Why

Reported downstream in #2860, where a corporate procurement scan refused packages whose license it could not resolve. That class of scanner reads the `license` field from registry metadata; a `LICENSE` file in the repo is not enough, and these packages ship no `LICENSE` file either.

**Correcting the record on that issue while I am here:** the `@ag-ui/*` packages named in the original report are *not* affected. Every version the reporter’s scanner flagged already carries `"license": "MIT"`:

```
@ag-ui/client@0.0.42     MIT
@ag-ui/core@0.0.37       MIT
@ag-ui/core@0.0.42       MIT
@ag-ui/encoder@0.0.42    MIT
@ag-ui/langgraph@0.0.20  MIT
@ag-ui/proto@0.0.42      MIT
```

`@ag-ui/core` has declared MIT since at least 0.0.35. An earlier triage note on #2860 attributed the failure to a missing SPDX field upstream; that was wrong, and why their scanner reported `Unknown` for `@ag-ui/*` is still unexplained. This PR fixes the part that is genuinely defective on our side.

## Testing

Metadata-only; no source, build, or runtime change.

- Confirmed the five missing fields against the live registry with `npm view <pkg> license` (output above), and confirmed the other published `@copilotkit/*` packages (`runtime`, `react-core`, `react-ui`, `shared`, `sdk-js`, `angular`, `channels`, `channels-core`) already report `MIT`.
- Enumerated every non-private `packages/*/package.json` on `origin/main` to confirm these five are the complete set missing the field.
- Each edited file re-parsed with `json.load` and reports `MIT`.
- The `sync-lockfile` pre-commit hook resolved all 71 workspace projects against the edited manifests without error.

Placement matches `packages/shared/package.json`, where `"license"` immediately precedes `"repository"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)