### PR TITLE
feat(angular): support fetch credentials

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -107,6 +107,7 @@ The `agent` is an AG-UI `AbstractAgent`. Refer to your AG-UI agent implementatio
 export interface CopilotKitConfig {
   runtimeUrl?: string;
   headers?: Record<string, string>;
+  credentials?: RequestCredentials;
   licenseKey?: string;
   properties?: Record<string, unknown>;
   agents?: Record<string, AbstractAgent>;
@@ -125,6 +126,8 @@ export interface CopilotKitConfig {
 
 - `runtimeUrl`: URL to your CopilotKit runtime.
 - `headers`: Default headers sent to the runtime.
+- `credentials`: Fetch credentials mode. Use `"include"` for cross-origin
+  HTTP-only cookies.
 - `properties`: Arbitrary props forwarded to agent runs.
 - `agents`: Local, in-browser agents keyed by `agentId`.
 - `selfManagedAgents`: AG-UI agents managed directly by the application.
@@ -153,6 +156,7 @@ export interface CopilotKitConfig {
 - `runtimeUrl`: `Signal<string | undefined>`
 - `runtimeTransport`: `Signal<CopilotRuntimeTransport>` (`"rest" | "single"`)
 - `headers`: `Signal<Record<string, string>>`
+- `credentials`: `Signal<RequestCredentials | undefined>`
 - `toolCallRenderConfigs`: `Signal<RenderToolCallConfig[]>`
 - `clientToolCallRenderConfigs`: `Signal<FrontendToolConfig[]>`
 - `humanInTheLoopToolRenderConfigs`: `Signal<HumanInTheLoopConfig[]>`
@@ -164,7 +168,7 @@ export interface CopilotKitConfig {
 - `addRenderToolCall(config: RenderToolCallConfig): void`
 - `addHumanInTheLoop(config: HumanInTheLoopConfig): void`
 - `removeTool(toolName: string, agentId?: string): void`
-- `updateRuntime(options: { runtimeUrl?: string; runtimeTransport?: CopilotRuntimeTransport; headers?: Record<string,string>; properties?: Record<string, unknown>; agents?: Record<string, AbstractAgent>; }): void`
+- `updateRuntime(options: { runtimeUrl?: string; runtimeTransport?: CopilotRuntimeTransport; headers?: Record<string,string>; credentials?: RequestCredentials; properties?: Record<string, unknown>; agents?: Record<string, AbstractAgent>; selfManagedAgents?: Record<string, AbstractAgent>; }): void`
 
 ### Advanced
 
@@ -395,6 +399,8 @@ Tool arguments are parsed with `partialJSONParse`, so incomplete JSON during str
 - Set `runtimeUrl` to your CopilotKit runtime endpoint.
 - If you need to change runtime settings at runtime, call `CopilotKit.updateRuntime(...)`.
 - `runtimeTransport` supports `"rest"` or `"single"` (SSE single-stream transport).
+- For cross-origin cookie authentication, set `credentials: "include"` and
+  enable credentialed CORS for the Angular app's exact origin.
 
 ## Activity renderers and generative UI
 

--- a/packages/angular/src/lib/agent.spec.ts
+++ b/packages/angular/src/lib/agent.spec.ts
@@ -151,12 +151,14 @@ class CopilotKitStub {
   readonly #runtimeUrl = signal<string | undefined>(undefined);
   readonly #runtimeTransport = signal<"rest" | "single" | "auto">("auto");
   readonly #headers = signal<Record<string, string>>({});
+  readonly #credentials = signal<RequestCredentials | undefined>(undefined);
   getAgent = vi.fn((id: string) => this.#agents()[id]);
   agents = this.#agents.asReadonly();
   runtimeConnectionStatus = this.#runtimeConnectionStatus.asReadonly();
   runtimeUrl = this.#runtimeUrl.asReadonly();
   runtimeTransport = this.#runtimeTransport.asReadonly();
   headers = this.#headers.asReadonly();
+  credentials = this.#credentials.asReadonly();
   #coreInstance = new CopilotKitCore({});
   core: StubCore = {
     runtimeUrl: undefined,
@@ -185,6 +187,10 @@ class CopilotKitStub {
   setHeaders(value: Record<string, string>) {
     this.#headers.set(value);
     this.core = { ...this.core, headers: value };
+  }
+
+  setCredentials(value: RequestCredentials | undefined) {
+    this.#credentials.set(value);
   }
 
   setRuntimeTransport(value: "rest" | "single" | "auto") {
@@ -325,6 +331,36 @@ describe("injectAgentStore", () => {
     const proxiedAgent = proxied as ProxiedCopilotRuntimeAgent;
     expect(proxiedAgent.agentId).toBe("missing");
     expect(proxiedAgent.headers).toEqual({ "x-test": "1" });
+  });
+
+  it("keeps credentials current on the cached provisional agent", () => {
+    copilotKitStub.setAgents({});
+    copilotKitStub.setRuntimeUrl("https://runtime.local");
+    copilotKitStub.setCredentials("include");
+    copilotKitStub.setRuntimeConnectionStatus(
+      CopilotKitCoreRuntimeConnectionStatus.Connecting,
+    );
+
+    @Component({
+      standalone: true,
+      template: "",
+    })
+    class MissingAgentHost {
+      store = injectAgentStore("missing");
+    }
+
+    const fixture = TestBed.createComponent(MissingAgentHost);
+    const initialAgent = fixture.componentInstance.store()
+      .agent as ProxiedCopilotRuntimeAgent;
+    expect(initialAgent).toBeInstanceOf(ProxiedCopilotRuntimeAgent);
+    expect(initialAgent.credentials).toBe("include");
+
+    copilotKitStub.setCredentials("omit");
+
+    const updatedAgent = fixture.componentInstance.store()
+      .agent as ProxiedCopilotRuntimeAgent;
+    expect(updatedAgent).toBe(initialAgent);
+    expect(updatedAgent.credentials).toBe("omit");
   });
 
   it("shares a provisional runtime agent across same-id consumers", () => {

--- a/packages/angular/src/lib/agent.ts
+++ b/packages/angular/src/lib/agent.ts
@@ -22,9 +22,18 @@ import {
  *  by the factory so that AgentStore stays decoupled from the concrete class. */
 type SubscribeToAgentFn = CopilotKitCore["subscribeToAgentWithOptions"];
 type AgentWithHeaders = AbstractAgent & { headers?: Record<string, string> };
+type AgentWithCredentials = AbstractAgent & {
+  credentials?: RequestCredentials;
+};
 
 function hasAgentHeaders(agent: AbstractAgent): agent is AgentWithHeaders {
   return "headers" in agent;
+}
+
+function hasAgentCredentials(
+  agent: AbstractAgent,
+): agent is AgentWithCredentials {
+  return "credentials" in agent;
 }
 
 export class AgentStore {
@@ -144,10 +153,14 @@ export class CopilotkitAgentFactory {
             CopilotKitCoreRuntimeConnectionStatus.Error)
       ) {
         const headers = this.#copilotkit.headers();
+        const credentials = this.#copilotkit.credentials();
         const cached = this.#provisionalCache.get(resolvedAgentId);
         if (cached) {
           if (hasAgentHeaders(cached.provisional)) {
             cached.provisional.headers = { ...headers };
+          }
+          if (hasAgentCredentials(cached.provisional)) {
+            cached.provisional.credentials = credentials;
           }
           return cached.provisional;
         }
@@ -156,6 +169,7 @@ export class CopilotkitAgentFactory {
           runtimeUrl,
           agentId: resolvedAgentId,
           transport: this.#copilotkit.runtimeTransport(),
+          credentials,
         });
         if (hasAgentHeaders(provisional)) {
           provisional.headers = { ...headers };
@@ -184,6 +198,7 @@ export class CopilotkitAgentFactory {
       this.#copilotkit.runtimeUrl();
       this.#copilotkit.runtimeTransport();
       this.#copilotkit.headers();
+      this.#copilotkit.credentials();
 
       const agent = resolveAgent();
 

--- a/packages/angular/src/lib/config.ts
+++ b/packages/angular/src/lib/config.ts
@@ -37,6 +37,8 @@ export interface A2UIRecoveryOptions {
 export interface CopilotKitConfig {
   runtimeUrl?: string;
   headers?: Record<string, string>;
+  /** Fetch credentials mode used for CopilotKit runtime requests. */
+  credentials?: RequestCredentials;
   licenseKey?: string;
   properties?: Record<string, unknown>;
   agents?: Record<string, AbstractAgent>;

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -103,6 +103,8 @@ export class CopilotKit {
   readonly runtimeTransport = this.#runtimeTransport.asReadonly();
   readonly #headers = signal<Record<string, string>>({});
   readonly headers = this.#headers.asReadonly();
+  readonly #credentials = signal<RequestCredentials | undefined>(undefined);
+  readonly credentials = this.#credentials.asReadonly();
   readonly #threadEndpoints = signal<ThreadEndpointRuntimeInfo | undefined>(
     undefined,
   );
@@ -140,6 +142,7 @@ export class CopilotKit {
   readonly core = new CopilotKitCore({
     runtimeUrl: this.#config.runtimeUrl,
     headers: this.#config.headers,
+    credentials: this.#config.credentials,
     agents__unsafe_dev_only: {
       ...this.#config.agents,
       ...this.#config.selfManagedAgents,
@@ -204,6 +207,7 @@ export class CopilotKit {
     this.#runtimeUrl.set(this.core.runtimeUrl);
     this.#runtimeTransport.set(this.core.runtimeTransport);
     this.#headers.set(this.core.headers);
+    this.#credentials.set(this.core.credentials);
     this.#threadEndpoints.set(this.core.threadEndpoints);
     this.#intelligence.set(this.core.intelligence);
     this.#licenseStatus.set(this.core.licenseStatus);
@@ -598,6 +602,7 @@ export class CopilotKit {
     runtimeUrl?: string;
     runtimeTransport?: CopilotRuntimeTransport;
     headers?: Record<string, string>;
+    credentials?: RequestCredentials;
     properties?: Record<string, unknown>;
     agents?: Record<string, AbstractAgent>;
     selfManagedAgents?: Record<string, AbstractAgent>;
@@ -613,6 +618,10 @@ export class CopilotKit {
     if (options.headers !== undefined) {
       this.core.setHeaders(options.headers);
       this.#headers.set(options.headers);
+    }
+    if ("credentials" in options) {
+      this.core.setCredentials(options.credentials);
+      this.#credentials.set(options.credentials);
     }
     if (options.properties !== undefined) {
       this.core.setProperties(

--- a/showcase/shell-docs/src/content/docs/frontends/angular/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/auth.mdx
@@ -57,6 +57,28 @@ The runnable Angular Showcase uses the same header shape:
 
 <AngularSnippet region="runtime-auth-headers" />
 
+## Send cookies to a cross-origin runtime
+
+To enable HTTP-only cookie authentication, set `credentials: "include"` and
+configure CORS on your runtime endpoint:
+
+```ts title="src/app/app.config.ts"
+import { ApplicationConfig } from "@angular/core";
+import { provideCopilotKit } from "@copilotkit/angular";
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideCopilotKit({
+      runtimeUrl: "https://runtime.example.com/api/copilotkit",
+      credentials: "include",
+    }),
+  ],
+};
+```
+
+Configure the runtime with `credentials: true` and the Angular app's exact
+origin. Credentialed CORS requests cannot use `*` as the allowed origin.
+
 ## Validate every runtime request
 
 Use the runtime adapter's request hook to reject missing, expired, or

--- a/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/provideCopilotKit.mdx
@@ -37,6 +37,12 @@ function provideCopilotKit(config: CopilotKitConfig): Provider;
     already set one here.
   </PropertyReference>
 
+  <PropertyReference name="credentials" type="RequestCredentials">
+    Credentials mode for runtime fetch requests. Use `"include"` for HTTP-only
+    cookies in cross-origin requests. When omitted, the browser Fetch default
+    applies.
+  </PropertyReference>
+
   <PropertyReference name="licenseKey" type="string">
     Your CopilotCloud public key. A value matching `ck_pub_` followed by 32
     hexadecimal characters is sent as the

--- a/showcase/shell-docs/src/content/reference/angular/services/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/services/CopilotKit.mdx
@@ -54,6 +54,10 @@ All reactive state is exposed as read-only Angular signals. Read a signal by cal
   The HTTP headers currently sent with runtime requests.
 </PropertyReference>
 
+<PropertyReference name="credentials" type="Signal<RequestCredentials | undefined>">
+  The current Fetch credentials mode, or `undefined` when none is configured.
+</PropertyReference>
+
 <PropertyReference name="threadEndpoints" type="Signal<ThreadEndpointRuntimeInfo | undefined>">
   Thread endpoint support advertised by the connected runtime's `/info`
   response. It is `undefined` until the runtime reports the capability.
@@ -169,9 +173,10 @@ All reactive state is exposed as read-only Angular signals. Read a signal by cal
 
 <PropertyReference name="updateRuntime" type="(options) => void">
   Update the runtime connection at runtime. `options` may include `runtimeUrl`,
-  `runtimeTransport`, `headers`, `properties`, `agents`, and
+  `runtimeTransport`, `headers`, `credentials`, `properties`, `agents`, and
   `selfManagedAgents`. Only the fields you pass are applied; `runtimeUrl`,
-  `runtimeTransport`, and `headers` also update the corresponding signals.
+  `runtimeTransport`, `headers`, and `credentials` also update the corresponding
+  signals.
 </PropertyReference>
 
 ## Usage


### PR DESCRIPTION
## Summary

This closes an Angular parity gap with React by adding Fetch `credentials` support.

- Forwards credentials through the runtime and provisional agents.
- Keeps cached provisional agents synchronized with credential changes.
- Documents cross-origin cookie authentication and CORS requirements.

## Testing

- Angular tests, typecheck, and build passed.
- Full workspace suite executed; unrelated React Native configuration failures remain.