### PR TITLE
feat(angular): expose agent capabilities

### DIFF
--- a/packages/angular/API.md
+++ b/packages/angular/API.md
@@ -8,9 +8,10 @@ symbol requires the package's normal breaking-change process.
 For task-oriented examples, start with the [package README](./README.md) and the
 [Angular documentation](https://docs.copilotkit.ai/frontends/angular). The high-level
 APIs most applications need are `provideCopilotKit`, `CopilotChat`,
-`CopilotPopup`, `CopilotSidebar`, `injectAgentStore`, the `register*` helpers,
-and the `inject*` controllers. The remaining components and context types are
-supported customization primitives for replacing individual chat slots.
+`CopilotPopup`, `CopilotSidebar`, `injectAgentStore`, `injectCapabilities`, the
+`register*` helpers, and the `inject*` controllers. The remaining components
+and context types are supported customization primitives for replacing
+individual chat slots.
 
 ## Root entry point
 
@@ -222,6 +223,7 @@ Import these symbols from `@copilotkit/angular`.
 - `createSlotRenderer`
 - `getSlotConfig`
 - `injectAgentStore`
+- `injectCapabilities`
 - `injectChatConfiguration`
 - `injectChatLabels`
 - `injectChatState`

--- a/packages/angular/src/lib/capabilities.spec.ts
+++ b/packages/angular/src/lib/capabilities.spec.ts
@@ -1,0 +1,78 @@
+import { signal } from "@angular/core";
+import type { AgentCapabilities } from "@ag-ui/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { injectAgentStore, type AgentStore } from "./agent";
+import { injectCapabilities } from "./capabilities";
+
+const { defaultAgentId } = vi.hoisted(() => ({
+  defaultAgentId: () => "default",
+}));
+
+vi.mock("./agent", () => ({
+  injectAgentStore: vi.fn(),
+}));
+vi.mock("./chat-configuration", () => ({
+  injectChatConfiguration: () => ({ agentId: defaultAgentId }),
+}));
+
+const mockInjectAgentStore = vi.mocked(injectAgentStore);
+
+function mockAgentStore(agent: object | undefined) {
+  const store = signal({ agent } as AgentStore);
+  mockInjectAgentStore.mockReturnValue(store);
+  return store;
+}
+
+describe("injectCapabilities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns capabilities when the agent exposes them", () => {
+    const capabilities: AgentCapabilities = {
+      tools: { supported: true, clientProvided: true },
+    };
+    mockAgentStore({ capabilities });
+
+    const result = injectCapabilities("my-agent");
+
+    expect(result()).toEqual(capabilities);
+    expect(mockInjectAgentStore).toHaveBeenCalledWith("my-agent");
+  });
+
+  it("returns undefined when the agent has no capabilities property", () => {
+    mockAgentStore({ description: "basic agent" });
+
+    const result = injectCapabilities("basic");
+
+    expect(result()).toBeUndefined();
+  });
+
+  it("returns undefined when the agent is undefined", () => {
+    mockAgentStore(undefined);
+
+    const result = injectCapabilities();
+
+    expect(result()).toBeUndefined();
+  });
+
+  it("returns undefined when capabilities are explicitly undefined", () => {
+    mockAgentStore({ capabilities: undefined });
+
+    const result = injectCapabilities();
+
+    expect(result()).toBeUndefined();
+  });
+
+  it("uses the default agent when no agentId is provided", () => {
+    const capabilities: AgentCapabilities = {
+      transport: { streaming: true },
+    };
+    mockAgentStore({ capabilities });
+
+    const result = injectCapabilities();
+
+    expect(result()).toEqual(capabilities);
+    expect(mockInjectAgentStore).toHaveBeenCalledWith(defaultAgentId);
+  });
+});

--- a/packages/angular/src/lib/capabilities.ts
+++ b/packages/angular/src/lib/capabilities.ts
@@ -1,0 +1,25 @@
+import { computed, type Signal } from "@angular/core";
+import type { AgentCapabilities } from "@ag-ui/core";
+import { injectAgentStore } from "./agent";
+import { injectChatConfiguration } from "./chat-configuration";
+
+/**
+ * Returns the capabilities declared by the resolved AG-UI agent.
+ *
+ * @param agentId - Optional agent ID or signal. When omitted, agent resolution
+ * uses the ambient chat configuration and then the default agent.
+ */
+export function injectCapabilities(
+  agentId?: string | Signal<string | undefined>,
+): Signal<AgentCapabilities | undefined> {
+  const resolvedAgentId = agentId ?? injectChatConfiguration().agentId;
+  const agentStore = injectAgentStore(resolvedAgentId);
+
+  return computed(() => {
+    const agent = agentStore().agent;
+    if (agent && "capabilities" in agent) {
+      return (agent as { capabilities?: AgentCapabilities }).capabilities;
+    }
+    return undefined;
+  });
+}

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -5,6 +5,7 @@ export * from "./lib/render-tool-calls";
 export * from "./lib/activity-renderer";
 export * from "./lib/open-generative-ui";
 export * from "./lib/agent";
+export * from "./lib/capabilities";
 export * from "./lib/interrupt";
 export * from "./lib/threads";
 export * from "./lib/chat-config";

--- a/showcase/shell-docs/src/content/reference/angular/functions/injectCapabilities.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/injectCapabilities.mdx
@@ -1,0 +1,89 @@
+---
+title: "injectCapabilities"
+description: "Angular function for reading an agent's declared capabilities as a readonly signal."
+---
+
+## Overview
+
+`injectCapabilities` returns the [AG-UI `AgentCapabilities`](https://docs.ag-ui.com/concepts/capabilities) declared by the resolved agent as an Angular signal.
+
+Capabilities are populated from the runtime `/info` response. This function is a convenience selector over `injectAgentStore`; it does not keep separate capability state or make its own request. The signal is `undefined` until runtime discovery completes or when the agent does not declare capabilities.
+
+## Signature
+
+```ts
+import { injectCapabilities } from "@copilotkit/angular";
+import type { Signal } from "@angular/core";
+import type { AgentCapabilities } from "@ag-ui/core";
+
+function injectCapabilities(
+  agentId?: string | Signal<string | undefined>,
+): Signal<AgentCapabilities | undefined>;
+```
+
+## Parameters
+
+<PropertyReference
+  name="agentId"
+  type="string | Signal<string | undefined>"
+  required={false}
+>
+  ID of the agent whose capabilities to read. A provided id takes precedence.
+  When omitted or `undefined`, the function uses the surrounding
+  `CopilotChatConfiguration` agent and then falls back to the default agent.
+  Pass a signal to switch agents reactively.
+</PropertyReference>
+
+## Return Value
+
+<PropertyReference
+  name="capabilities"
+  type="Signal<AgentCapabilities | undefined>"
+>
+  A readonly signal containing the resolved agent's capability declaration.
+  `undefined` means runtime discovery is still pending or the agent did not
+  declare capabilities; it does not confirm that a capability is unsupported.
+</PropertyReference>
+
+## Usage
+
+```ts title="src/app/tool-panel.component.ts"
+import { Component } from "@angular/core";
+import { injectCapabilities } from "@copilotkit/angular";
+
+@Component({
+  selector: "app-tool-panel",
+  standalone: true,
+  template: `
+    @if (capabilities()?.tools?.supported === true) {
+      <p>This agent supports tools.</p>
+    }
+  `,
+})
+export class ToolPanelComponent {
+  readonly capabilities = injectCapabilities();
+}
+```
+
+To read another agent or switch reactively, pass its id or an id signal from a component class:
+
+```ts
+import { signal } from "@angular/core";
+import { injectCapabilities } from "@copilotkit/angular";
+
+export class AgentCapabilitiesComponent {
+  readonly agentId = signal<string | undefined>("support");
+  readonly capabilities = injectCapabilities(this.agentId);
+}
+```
+
+## Related
+
+<Cards>
+  <Card
+    title="injectAgentStore"
+    description="Access the resolved agent and its reactive messages, state, and run status."
+    href="/reference/angular/functions/injectAgentStore"
+    icon={<LinkIcon />}
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/public-api.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/public-api.mdx
@@ -18,9 +18,10 @@ requires every export to appear exactly once in that inventory.
 - **Composable chat UI:** `CopilotChatView`, message, input, textarea,
   suggestion, toolbar, button, attachment, audio, scroll, cursor, disclaimer,
   feather, tools-menu, and renderer components plus their slot/context types.
-- **Agents and application state:** `injectAgentStore`, `AgentStore`,
-  `connectAgentContext`, `CopilotKitAgentContext`, `injectChatState`,
-  `injectThreads`, `injectMemories`, and their stores, controllers, and types.
+- **Agents and application state:** `injectAgentStore`, `injectCapabilities`,
+  `AgentStore`, `connectAgentContext`, `CopilotKitAgentContext`,
+  `injectChatState`, `injectThreads`, `injectMemories`, and their stores,
+  controllers, and types.
 - **Tools and activities:** `registerFrontendTool`, `registerRenderToolCall`,
   `registerHumanInTheLoop`, `registerRenderActivityMessage`, `RenderToolCalls`,
   `CopilotDefaultToolRenderer`, schemas, configurations, renderer interfaces,


### PR DESCRIPTION
## Summary

Closes another React–Angular parity gap by adding the Angular equivalent of React’s `useCapabilities`.

- Add `injectCapabilities` as a readonly signal
- Support the configured or explicitly selected agent
- Add React-parity tests
- Document the new Angular API

## Testing

- Angular tests, typecheck, build, publint, and API checks pass
- Angular docs tests pass
- Full workspace tests executed; unrelated Vue and React Native failures remain