### PR TITLE
fix(showcase): canonicalize multimodal fixtures

### DIFF
--- a/showcase/aimock/d4/ag2/chat.json
+++ b/showcase/aimock/d4/ag2/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "ag2"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "ag2"
       },
       "response": {

--- a/showcase/aimock/d4/ag2/chat.json
+++ b/showcase/aimock/d4/ag2/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "ag2"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "ag2"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "ag2"
       },

--- a/showcase/aimock/d4/agno/chat.json
+++ b/showcase/aimock/d4/agno/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "agno"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "agno"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "agno"
       },

--- a/showcase/aimock/d4/agno/chat.json
+++ b/showcase/aimock/d4/agno/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "agno"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "agno"
       },
       "response": {

--- a/showcase/aimock/d4/built-in-agent/chat.json
+++ b/showcase/aimock/d4/built-in-agent/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "built-in-agent"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "built-in-agent"
       },
       "response": {

--- a/showcase/aimock/d4/built-in-agent/chat.json
+++ b/showcase/aimock/d4/built-in-agent/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "built-in-agent"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "built-in-agent"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "built-in-agent"
       },

--- a/showcase/aimock/d4/claude-sdk-python/chat.json
+++ b/showcase/aimock/d4/claude-sdk-python/chat.json
@@ -569,7 +569,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "claude-sdk-python"
       },
       "response": {
@@ -578,7 +578,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "claude-sdk-python"
       },
       "response": {

--- a/showcase/aimock/d4/claude-sdk-python/chat.json
+++ b/showcase/aimock/d4/claude-sdk-python/chat.json
@@ -569,24 +569,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "claude-sdk-python"
       },

--- a/showcase/aimock/d4/claude-sdk-typescript/chat.json
+++ b/showcase/aimock/d4/claude-sdk-typescript/chat.json
@@ -562,7 +562,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "claude-sdk-typescript"
       },
       "response": {
@@ -571,7 +571,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "claude-sdk-typescript"
       },
       "response": {

--- a/showcase/aimock/d4/claude-sdk-typescript/chat.json
+++ b/showcase/aimock/d4/claude-sdk-typescript/chat.json
@@ -562,24 +562,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "claude-sdk-typescript"
       },

--- a/showcase/aimock/d4/crewai-conversational-flows/chat.json
+++ b/showcase/aimock/d4/crewai-conversational-flows/chat.json
@@ -569,24 +569,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "crewai-conversational-flows"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "crewai-conversational-flows"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "crewai-conversational-flows"
       },

--- a/showcase/aimock/d4/crewai-crews/chat.json
+++ b/showcase/aimock/d4/crewai-crews/chat.json
@@ -569,24 +569,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "crewai-crews"
       },

--- a/showcase/aimock/d4/google-adk/chat.json
+++ b/showcase/aimock/d4/google-adk/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "google-adk"
       },

--- a/showcase/aimock/d4/google-adk/chat.json
+++ b/showcase/aimock/d4/google-adk/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "google-adk"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "google-adk"
       },
       "response": {

--- a/showcase/aimock/d4/langgraph-fastapi/chat.json
+++ b/showcase/aimock/d4/langgraph-fastapi/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "langgraph-fastapi"
       },

--- a/showcase/aimock/d4/langgraph-fastapi/chat.json
+++ b/showcase/aimock/d4/langgraph-fastapi/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "langgraph-fastapi"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "langgraph-fastapi"
       },
       "response": {

--- a/showcase/aimock/d4/langgraph-python/chat.json
+++ b/showcase/aimock/d4/langgraph-python/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "langgraph-python"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "langgraph-python"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "langgraph-python"
       },

--- a/showcase/aimock/d4/langgraph-python/chat.json
+++ b/showcase/aimock/d4/langgraph-python/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "langgraph-python"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "langgraph-python"
       },
       "response": {

--- a/showcase/aimock/d4/langgraph-typescript/chat.json
+++ b/showcase/aimock/d4/langgraph-typescript/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "langgraph-typescript"
       },

--- a/showcase/aimock/d4/langgraph-typescript/chat.json
+++ b/showcase/aimock/d4/langgraph-typescript/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "langgraph-typescript"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "langgraph-typescript"
       },
       "response": {

--- a/showcase/aimock/d4/langroid/chat.json
+++ b/showcase/aimock/d4/langroid/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "langroid"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "langroid"
       },
       "response": {

--- a/showcase/aimock/d4/langroid/chat.json
+++ b/showcase/aimock/d4/langroid/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "langroid"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "langroid"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "langroid"
       },

--- a/showcase/aimock/d4/llamaindex/chat.json
+++ b/showcase/aimock/d4/llamaindex/chat.json
@@ -569,7 +569,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "llamaindex"
       },
       "response": {
@@ -578,7 +578,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "llamaindex"
       },
       "response": {

--- a/showcase/aimock/d4/llamaindex/chat.json
+++ b/showcase/aimock/d4/llamaindex/chat.json
@@ -569,24 +569,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "llamaindex"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "llamaindex"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "llamaindex"
       },

--- a/showcase/aimock/d4/mastra/chat.json
+++ b/showcase/aimock/d4/mastra/chat.json
@@ -568,7 +568,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "mastra"
       },
       "response": {
@@ -577,7 +577,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "mastra"
       },
       "response": {

--- a/showcase/aimock/d4/mastra/chat.json
+++ b/showcase/aimock/d4/mastra/chat.json
@@ -568,24 +568,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "mastra"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "mastra"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo \u2014 a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "mastra"
       },

--- a/showcase/aimock/d4/ms-agent-dotnet/chat.json
+++ b/showcase/aimock/d4/ms-agent-dotnet/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "ms-agent-dotnet"
       },
       "response": {

--- a/showcase/aimock/d4/ms-agent-dotnet/chat.json
+++ b/showcase/aimock/d4/ms-agent-dotnet/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "ms-agent-dotnet"
       },

--- a/showcase/aimock/d4/ms-agent-harness-dotnet/chat.json
+++ b/showcase/aimock/d4/ms-agent-harness-dotnet/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "ms-agent-harness-dotnet"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "ms-agent-harness-dotnet"
       },
       "response": {

--- a/showcase/aimock/d4/ms-agent-harness-dotnet/chat.json
+++ b/showcase/aimock/d4/ms-agent-harness-dotnet/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "ms-agent-harness-dotnet"
       },

--- a/showcase/aimock/d4/ms-agent-python/chat.json
+++ b/showcase/aimock/d4/ms-agent-python/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "ms-agent-python"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "ms-agent-python"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "ms-agent-python"
       },

--- a/showcase/aimock/d4/ms-agent-python/chat.json
+++ b/showcase/aimock/d4/ms-agent-python/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "ms-agent-python"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "ms-agent-python"
       },
       "response": {

--- a/showcase/aimock/d4/pydantic-ai/chat.json
+++ b/showcase/aimock/d4/pydantic-ai/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "pydantic-ai"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "pydantic-ai"
       },
       "response": {

--- a/showcase/aimock/d4/pydantic-ai/chat.json
+++ b/showcase/aimock/d4/pydantic-ai/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "pydantic-ai"
       },

--- a/showcase/aimock/d4/spring-ai/chat.json
+++ b/showcase/aimock/d4/spring-ai/chat.json
@@ -570,7 +570,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "spring-ai"
       },
       "response": {
@@ -579,7 +579,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "spring-ai"
       },
       "response": {

--- a/showcase/aimock/d4/spring-ai/chat.json
+++ b/showcase/aimock/d4/spring-ai/chat.json
@@ -570,24 +570,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "spring-ai"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "spring-ai"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "spring-ai"
       },

--- a/showcase/aimock/d4/strands-typescript/chat.json
+++ b/showcase/aimock/d4/strands-typescript/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "strands-typescript"
       },

--- a/showcase/aimock/d4/strands-typescript/chat.json
+++ b/showcase/aimock/d4/strands-typescript/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "strands-typescript"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "strands-typescript"
       },
       "response": {

--- a/showcase/aimock/d4/strands/chat.json
+++ b/showcase/aimock/d4/strands/chat.json
@@ -567,7 +567,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
+        "userMessage": "_d4_unused_multimodal_pdf",
         "context": "strands"
       },
       "response": {
@@ -576,7 +576,7 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
+        "userMessage": "_d4_unused_multimodal_image",
         "context": "strands"
       },
       "response": {

--- a/showcase/aimock/d4/strands/chat.json
+++ b/showcase/aimock/d4/strands/chat.json
@@ -567,24 +567,6 @@
     },
     {
       "match": {
-        "userMessage": "_d4_unused_multimodal_pdf",
-        "context": "strands"
-      },
-      "response": {
-        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through three steps: install `@copilotkit/react-core` and `@copilotkit/react-ui`, wrap your app in a `<CopilotKit runtimeUrl=\"/api/copilotkit\">` provider, and drop a `<CopilotChat />` wherever you want the assistant to appear."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "_d4_unused_multimodal_image",
-        "context": "strands"
-      },
-      "response": {
-        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
-      }
-    },
-    {
-      "match": {
         "userMessage": "Plan a 3-day Tokyo trip for a solo traveler interested in food, art, and architecture. Keep it concise.",
         "context": "strands"
       },

--- a/showcase/aimock/d6/ag2/multimodal.json
+++ b/showcase/aimock/d6/ag2/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal — sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage matches the autoPrompt in sample-attachment-buttons.tsx.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "ag2"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal — sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "ag2"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/ag2/multimodal.json
+++ b/showcase/aimock/d6/ag2/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal — sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage matches the autoPrompt in sample-attachment-buttons.tsx.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "ag2"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal — sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "ag2"
       },
       "response": {

--- a/showcase/aimock/d6/agno/agentic-chat.json
+++ b/showcase/aimock/d6/agno/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "agno"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "agno"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "agno"

--- a/showcase/aimock/d6/agno/multimodal.json
+++ b/showcase/aimock/d6/agno/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "Multimodal image turn \u2014 the D5 script clicks the 'Try with sample image' button which auto-sends a message. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage match uses the describe prompt keyed in agentic-chat.json.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "agno"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "Multimodal PDF turn \u2014 the D5 script clicks the 'Try with sample PDF' button which auto-sends a message. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "agno"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/built-in-agent/agentic-chat.json
+++ b/showcase/aimock/d6/built-in-agent/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "built-in-agent"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "built-in-agent"

--- a/showcase/aimock/d6/built-in-agent/multimodal.json
+++ b/showcase/aimock/d6/built-in-agent/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 the D5 script clicks the sample-image button which auto-sends a message. The assertion checks for 'image' keyword in the assistant transcript. The input text is 'image-sample-button (auto-sent)' but skipSend=true, so the actual userMessage comes from the sample button's inject. We match on 'can you tell me what is in this demo image I just attached' which is what the sample button sends.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "built-in-agent"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal pdf turn \u2014 the D5 script clicks the sample-pdf button which auto-sends. The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "built-in-agent"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/claude-sdk-python/agentic-chat.json
+++ b/showcase/aimock/d6/claude-sdk-python/agentic-chat.json
@@ -61,26 +61,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "claude-sdk-python"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "claude-sdk-python"

--- a/showcase/aimock/d6/claude-sdk-python/multimodal.json
+++ b/showcase/aimock/d6/claude-sdk-python/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal image turn \u2014 preFill clicks the sample-image button which auto-sends. The D5 script asserts the assistant transcript contains 'image'. The input text is descriptive only (skipSend=true in the script).",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "claude-sdk-python"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal PDF turn \u2014 preFill clicks the sample-pdf button which auto-sends. The D5 script asserts the assistant transcript contains 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "claude-sdk-python"
       },
       "response": {

--- a/showcase/aimock/d6/claude-sdk-python/multimodal.json
+++ b/showcase/aimock/d6/claude-sdk-python/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 preFill clicks the sample-image button which auto-sends. The D5 script asserts the assistant transcript contains 'image'. The input text is descriptive only (skipSend=true in the script).",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal PDF turn \u2014 preFill clicks the sample-pdf button which auto-sends. The D5 script asserts the assistant transcript contains 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "claude-sdk-python"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/claude-sdk-typescript/agentic-chat.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/agentic-chat.json
@@ -61,26 +61,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "claude-sdk-typescript"

--- a/showcase/aimock/d6/claude-sdk-typescript/multimodal.json
+++ b/showcase/aimock/d6/claude-sdk-typescript/multimodal.json
@@ -6,42 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 the D5 script clicks the sample-image button which auto-sends. The user message comes from the sample button's injected text. Response must contain 'image' keyword for the assertion.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal PDF turn \u2014 the D5 script clicks the sample-pdf button which auto-sends. Response must contain 'document' keyword for the assertion.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "claude-sdk-typescript"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "_comment": "multimodal fallback \u2014 matches common auto-sent messages from the sample attachment buttons that may vary across integrations.",
-      "match": {
-        "userMessage": "Describe this image",
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "The image shows a small test pattern \u2014 a colorful abstract composition used to validate the multimodal image upload pipeline."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "Summarize this document",
-        "context": "claude-sdk-typescript"
-      },
-      "response": {
-        "content": "The document is a single-page test PDF used by the multimodal demo to validate the document upload and text extraction pipeline."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/crewai-conversational-flows/agentic-chat.json
+++ b/showcase/aimock/d6/crewai-conversational-flows/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "crewai-conversational-flows"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "crewai-conversational-flows"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "crewai-conversational-flows"

--- a/showcase/aimock/d6/crewai-conversational-flows/multimodal.json
+++ b/showcase/aimock/d6/crewai-conversational-flows/multimodal.json
@@ -7,23 +7,23 @@
   },
   "fixtures": [
     {
-      "_comment": "Image attachment turn \u2014 probe clicks sample-image-button, attaches sample.png, sends 'can you tell me what is in this demo image I just attached'.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "crewai-conversational-flows"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "PDF attachment turn \u2014 probe clicks sample-pdf-button, attaches sample.pdf, sends 'can you tell me what is in this demo pdf I just attached'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "crewai-conversational-flows"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/crewai-crews/agentic-chat.json
+++ b/showcase/aimock/d6/crewai-crews/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "crewai-crews"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "crewai-crews"

--- a/showcase/aimock/d6/crewai-crews/multimodal.json
+++ b/showcase/aimock/d6/crewai-crews/multimodal.json
@@ -7,23 +7,23 @@
   },
   "fixtures": [
     {
-      "_comment": "Image attachment turn \u2014 probe clicks sample-image-button, attaches sample.png, sends 'can you tell me what is in this demo image I just attached'.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "crewai-crews"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "PDF attachment turn \u2014 probe clicks sample-pdf-button, attaches sample.pdf, sends 'can you tell me what is in this demo pdf I just attached'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "crewai-crews"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/google-adk/agentic-chat.json
+++ b/showcase/aimock/d6/google-adk/agentic-chat.json
@@ -63,26 +63,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "google-adk"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "google-adk"

--- a/showcase/aimock/d6/google-adk/multimodal.json
+++ b/showcase/aimock/d6/google-adk/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "google-adk"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "google-adk"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/google-adk/multimodal.json
+++ b/showcase/aimock/d6/google-adk/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "google-adk"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "google-adk"
       },
       "response": {

--- a/showcase/aimock/d6/langgraph-fastapi/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-fastapi/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "langgraph-fastapi"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "langgraph-fastapi"

--- a/showcase/aimock/d6/langgraph-fastapi/multimodal.json
+++ b/showcase/aimock/d6/langgraph-fastapi/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 image attachment pill. The script clicks the sample-image button, attaches sample.png, then sends this query.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal \u2014 PDF attachment pill. The script attaches the sample PDF, then sends this query.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langgraph-fastapi"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/langgraph-python/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-python/agentic-chat.json
@@ -63,26 +63,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "langgraph-python"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "langgraph-python"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "langgraph-python"

--- a/showcase/aimock/d6/langgraph-python/multimodal.json
+++ b/showcase/aimock/d6/langgraph-python/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langgraph-python"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langgraph-python"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/langgraph-python/multimodal.json
+++ b/showcase/aimock/d6/langgraph-python/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "langgraph-python"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "langgraph-python"
       },
       "response": {

--- a/showcase/aimock/d6/langgraph-typescript/agentic-chat.json
+++ b/showcase/aimock/d6/langgraph-typescript/agentic-chat.json
@@ -63,26 +63,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "langgraph-typescript"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "langgraph-typescript"

--- a/showcase/aimock/d6/langgraph-typescript/multimodal.json
+++ b/showcase/aimock/d6/langgraph-typescript/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal — sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal — sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langgraph-typescript"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ],

--- a/showcase/aimock/d6/langgraph-typescript/multimodal.json
+++ b/showcase/aimock/d6/langgraph-typescript/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal — sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "langgraph-typescript"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal — sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "langgraph-typescript"
       },
       "response": {

--- a/showcase/aimock/d6/langroid/agentic-chat.json
+++ b/showcase/aimock/d6/langroid/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "langroid"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "langroid"

--- a/showcase/aimock/d6/langroid/multimodal.json
+++ b/showcase/aimock/d6/langroid/multimodal.json
@@ -6,43 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "Image sample turn \u2014 the D5 script clicks the sample-image button (which auto-sends). The assertion checks for 'image' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "langroid"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "PDF sample turn \u2014 the D5 script clicks the sample-pdf button (which auto-sends). The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "langroid"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "_comment": "Fallback for auto-sent image prompt \u2014 the sample button sends a canned user message that may differ from 'can you tell me what is in this demo image I just attached'. Match on 'image' substring to catch it.",
-      "match": {
-        "userMessage": "sample image",
-        "context": "langroid"
-      },
-      "response": {
-        "content": "The image shows a small test pattern \u2014 confirming the image upload pipeline round-tripped through the runtime successfully."
-      }
-    },
-    {
-      "_comment": "Fallback for auto-sent PDF prompt \u2014 match on 'sample' + 'pdf' or 'document' substring.",
-      "match": {
-        "userMessage": "sample pdf",
-        "context": "langroid"
-      },
-      "response": {
-        "content": "The document is a single-page PDF test fixture. The text was extracted and forwarded as content to the model, confirming the document upload path works end to end."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/llamaindex/agentic-chat.json
+++ b/showcase/aimock/d6/llamaindex/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "llamaindex"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "llamaindex"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "llamaindex"

--- a/showcase/aimock/d6/llamaindex/multimodal.json
+++ b/showcase/aimock/d6/llamaindex/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 the sample image button auto-sends 'can you tell me what is in this demo image I just attached'. The D5 assertion checks assistant transcript contains 'image'. Already present in agentic-chat.json but duplicated here for the dedicated multimodal fixture file match.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "llamaindex"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal PDF turn \u2014 the sample PDF button auto-sends 'can you tell me what is in this demo pdf I just attached'. The D5 assertion checks assistant transcript contains 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "llamaindex"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/llamaindex/multimodal.json
+++ b/showcase/aimock/d6/llamaindex/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal image turn \u2014 the sample image button auto-sends 'can you tell me what is in this demo image I just attached'. The D5 assertion checks assistant transcript contains 'image'. Already present in agentic-chat.json but duplicated here for the dedicated multimodal fixture file match.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "llamaindex"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal PDF turn \u2014 the sample PDF button auto-sends 'can you tell me what is in this demo pdf I just attached'. The D5 assertion checks assistant transcript contains 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "llamaindex"
       },
       "response": {

--- a/showcase/aimock/d6/mastra/agentic-chat.json
+++ b/showcase/aimock/d6/mastra/agentic-chat.json
@@ -65,26 +65,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "mastra"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "mastra"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "mastra"

--- a/showcase/aimock/d6/mastra/multimodal.json
+++ b/showcase/aimock/d6/mastra/multimodal.json
@@ -7,23 +7,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "mastra"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "mastra"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/mastra/multimodal.json
+++ b/showcase/aimock/d6/mastra/multimodal.json
@@ -10,7 +10,6 @@
       "_comment": "multimodal \u2014 sample image turn. The probe clicks 'Try with sample image' which auto-sends via agent.addMessage. The assertion checks the assistant transcript contains the keyword 'image'. The userMessage here matches the agentic-chat fixture for 'can you tell me what is in this demo image I just attached' which is the message the sample-attachment-buttons component dispatches.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "mastra"
       },
       "response": {
@@ -21,7 +20,6 @@
       "_comment": "multimodal \u2014 sample PDF turn. The probe clicks 'Try with sample PDF' which auto-sends. The assertion checks the assistant transcript contains the keyword 'document'.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "mastra"
       },
       "response": {

--- a/showcase/aimock/d6/ms-agent-dotnet/agentic-chat.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/agentic-chat.json
@@ -63,26 +63,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "ms-agent-dotnet"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "ms-agent-dotnet"

--- a/showcase/aimock/d6/ms-agent-dotnet/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal PDF turn \u2014 the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "ms-agent-dotnet"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/ms-agent-dotnet/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-dotnet/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal image turn \u2014 the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal PDF turn \u2014 the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "ms-agent-dotnet"
       },
       "response": {

--- a/showcase/aimock/d6/ms-agent-harness-dotnet/agentic-chat.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/agentic-chat.json
@@ -63,26 +63,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "ms-agent-harness-dotnet"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"

--- a/showcase/aimock/d6/ms-agent-harness-dotnet/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/multimodal.json
@@ -9,7 +9,6 @@
       "_comment": "multimodal image turn \u2014 the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"
       },
       "response": {
@@ -20,7 +19,6 @@
       "_comment": "multimodal PDF turn \u2014 the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
         "context": "ms-agent-harness-dotnet"
       },
       "response": {

--- a/showcase/aimock/d6/ms-agent-harness-dotnet/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-harness-dotnet/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 the D5 script clicks 'Try with sample image' which auto-sends a message with the image attachment. The assertion checks for 'image' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "ms-agent-harness-dotnet"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal PDF turn \u2014 the D5 script clicks 'Try with sample PDF' which auto-sends a message with the PDF attachment. The assertion checks for 'document' keyword in the assistant transcript.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "ms-agent-harness-dotnet"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/ms-agent-python/agentic-chat.json
+++ b/showcase/aimock/d6/ms-agent-python/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "ms-agent-python"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "ms-agent-python"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "ms-agent-python"

--- a/showcase/aimock/d6/ms-agent-python/multimodal.json
+++ b/showcase/aimock/d6/ms-agent-python/multimodal.json
@@ -11,7 +11,7 @@
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
@@ -20,7 +20,7 @@
         "context": "ms-agent-python"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/pydantic-ai/agentic-chat.json
+++ b/showcase/aimock/d6/pydantic-ai/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "pydantic-ai"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "pydantic-ai"

--- a/showcase/aimock/d6/pydantic-ai/multimodal.json
+++ b/showcase/aimock/d6/pydantic-ai/multimodal.json
@@ -11,7 +11,7 @@
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
@@ -20,7 +20,7 @@
         "context": "pydantic-ai"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/spring-ai/agentic-chat.json
+++ b/showcase/aimock/d6/spring-ai/agentic-chat.json
@@ -64,26 +64,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "spring-ai"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "spring-ai"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "spring-ai"

--- a/showcase/aimock/d6/spring-ai/multimodal.json
+++ b/showcase/aimock/d6/spring-ai/multimodal.json
@@ -6,23 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal image turn \u2014 the probe clicks 'Try with sample image' which auto-sends. Response must contain 'image' keyword for the assertion.",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "spring-ai"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal PDF turn \u2014 the probe clicks 'Try with sample PDF' which auto-sends. Response must contain 'document' keyword for the assertion.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "spring-ai"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/strands-typescript/agentic-chat.json
+++ b/showcase/aimock/d6/strands-typescript/agentic-chat.json
@@ -61,26 +61,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "strands-typescript"

--- a/showcase/aimock/d6/strands-typescript/multimodal.json
+++ b/showcase/aimock/d6/strands-typescript/multimodal.json
@@ -29,7 +29,6 @@
       "_comment": "multimodal \u2014 fallback for image analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "image",
-        "turnIndex": 0,
         "context": "strands-typescript"
       },
       "response": {
@@ -40,7 +39,6 @@
       "_comment": "multimodal \u2014 fallback for document analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "document",
-        "turnIndex": 0,
         "context": "strands-typescript"
       },
       "response": {

--- a/showcase/aimock/d6/strands-typescript/multimodal.json
+++ b/showcase/aimock/d6/strands-typescript/multimodal.json
@@ -6,43 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 image upload turn. The D5 script clicks the 'Try with sample image' button (auto-sends), then asserts the assistant transcript contains 'image'. The input text is a label only (skipSend:true in the script).",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "strands-typescript"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. The colors form a gradient grid that confirms the binary payload round-tripped through the runtime without corruption."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal \u2014 PDF upload turn. The D5 script clicks the 'Try with sample PDF' button (auto-sends), then asserts the assistant transcript contains 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "strands-typescript"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was extracted and forwarded as content to the model. Receiving this response confirms the document upload path works end-to-end."
-      }
-    },
-    {
-      "_comment": "multimodal \u2014 fallback for image analysis when the auto-send injects a different message shape.",
-      "match": {
-        "userMessage": "image",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "I can see the image you uploaded. It appears to be a test pattern used to validate the image processing pipeline in the multimodal demo."
-      }
-    },
-    {
-      "_comment": "multimodal \u2014 fallback for document analysis when the auto-send injects a different message shape.",
-      "match": {
-        "userMessage": "document",
-        "context": "strands-typescript"
-      },
-      "response": {
-        "content": "I've reviewed the document you uploaded. It contains test content used to validate the PDF processing pipeline in the multimodal demo."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/aimock/d6/strands/agentic-chat.json
+++ b/showcase/aimock/d6/strands/agentic-chat.json
@@ -61,26 +61,6 @@
     },
     {
       "match": {
-        "userMessage": "can you tell me what is in this demo image I just attached",
-        "turnIndex": 0,
-        "context": "strands"
-      },
-      "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
-      }
-    },
-    {
-      "match": {
-        "userMessage": "can you tell me what is in this demo pdf I just attached",
-        "turnIndex": 0,
-        "context": "strands"
-      },
-      "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
-      }
-    },
-    {
-      "match": {
         "userMessage": "hi from the popup test",
         "turnIndex": 0,
         "context": "strands"

--- a/showcase/aimock/d6/strands/multimodal.json
+++ b/showcase/aimock/d6/strands/multimodal.json
@@ -29,7 +29,6 @@
       "_comment": "multimodal \u2014 fallback for image analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "image",
-        "turnIndex": 0,
         "context": "strands"
       },
       "response": {
@@ -40,7 +39,6 @@
       "_comment": "multimodal \u2014 fallback for document analysis when the auto-send injects a different message shape.",
       "match": {
         "userMessage": "document",
-        "turnIndex": 0,
         "context": "strands"
       },
       "response": {

--- a/showcase/aimock/d6/strands/multimodal.json
+++ b/showcase/aimock/d6/strands/multimodal.json
@@ -6,43 +6,23 @@
   },
   "fixtures": [
     {
-      "_comment": "multimodal \u2014 image upload turn. The D5 script clicks the 'Try with sample image' button (auto-sends), then asserts the assistant transcript contains 'image'. The input text is a label only (skipSend:true in the script).",
+      "_comment": "Canonical multimodal image turn — the sample button sends sample.png with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached",
         "context": "strands"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. The colors form a gradient grid that confirms the binary payload round-tripped through the runtime without corruption."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
-      "_comment": "multimodal \u2014 PDF upload turn. The D5 script clicks the 'Try with sample PDF' button (auto-sends), then asserts the assistant transcript contains 'document'.",
+      "_comment": "Canonical multimodal PDF turn — the sample button sends sample.pdf with this exact prompt. The response describes the checked-in asset; prompt-based fixture selection alone does not prove attachment transport.",
       "match": {
         "userMessage": "can you tell me what is in this demo pdf I just attached",
         "context": "strands"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was extracted and forwarded as content to the model. Receiving this response confirms the document upload path works end-to-end."
-      }
-    },
-    {
-      "_comment": "multimodal \u2014 fallback for image analysis when the auto-send injects a different message shape.",
-      "match": {
-        "userMessage": "image",
-        "context": "strands"
-      },
-      "response": {
-        "content": "I can see the image you uploaded. It appears to be a test pattern used to validate the image processing pipeline in the multimodal demo."
-      }
-    },
-    {
-      "_comment": "multimodal \u2014 fallback for document analysis when the auto-send injects a different message shape.",
-      "match": {
-        "userMessage": "document",
-        "context": "strands"
-      },
-      "response": {
-        "content": "I've reviewed the document you uploaded. It contains test content used to validate the PDF processing pipeline in the multimodal demo."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/harness/fixtures/d5/multimodal.json
+++ b/showcase/harness/fixtures/d5/multimodal.json
@@ -1,12 +1,12 @@
 {
-  "_comment": "D5 fixture for /demos/multimodal. The script clicks [data-testid=\"multimodal-sample-image-button\"] to attach the bundled sample.png and auto-sends via agent.addMessage; second turn does the same with the PDF sample. The aimock response references \"image\" / \"document\" so the assertion can verify a non-trivial substring lands in the assistant transcript. Substrings are unique autoPrompt phrases.",
+  "_comment": "Canonical D5 fixture for /demos/multimodal. The sample buttons attach the bundled sample.png and sample.pdf and auto-send the exact prompts below. Responses describe the checked-in assets; prompt-based fixture selection alone does not prove attachment transport.",
   "fixtures": [
     {
       "match": {
         "userMessage": "can you tell me what is in this demo image I just attached"
       },
       "response": {
-        "content": "The image attachment shows a small abstract test pattern used by the multimodal demo to validate the image-upload pipeline. Successful render of this response confirms the binary attachment round-tripped through the runtime."
+        "content": "The attached image is the CopilotKit logo — a clean, geometric mark used across CopilotKit branding."
       }
     },
     {
@@ -14,7 +14,7 @@
         "userMessage": "can you tell me what is in this demo pdf I just attached"
       },
       "response": {
-        "content": "The PDF document contains a single test page used by the multimodal demo. Its text was flattened by pypdf on the Python side and forwarded as text content to the model. Receiving this response confirms the document upload path works."
+        "content": "The attached PDF document is the CopilotKit Quickstart guide. It walks through installing the React packages, configuring the CopilotKit provider, and adding a CopilotKit chat component to an application."
       }
     }
   ]

--- a/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
@@ -126,7 +126,7 @@ describe("d5-multimodal script", () => {
     );
   });
 
-  it("turn-1 assertion succeeds for the D6 abstract-test-pattern response", async () => {
+  it("turn-1 assertion succeeds for the actual CopilotKit logo response", async () => {
     const ctx: D5BuildContext = {
       integrationSlug: "x",
       featureType: "multimodal",
@@ -135,13 +135,13 @@ describe("d5-multimodal script", () => {
     const turns = buildTurns(ctx);
     await expect(
       turns[0]!.assertions!(
-        makePage("the image attachment shows a small abstract test pattern"),
+        makePage("the attached image is the copilotkit logo."),
         { bubbleIndex: 0, text: "" },
       ),
     ).resolves.toBeUndefined();
   });
 
-  it("turn-1 assertion rejects the legacy generic image response", async () => {
+  it("turn-1 assertion rejects the fabricated abstract-pattern response", async () => {
     const ctx: D5BuildContext = {
       integrationSlug: "x",
       featureType: "multimodal",
@@ -151,14 +151,14 @@ describe("d5-multimodal script", () => {
     await expect(
       turns[0]!.assertions!(
         makePage(
-          "The attached image is the CopilotKit logo — a clean geometric mark.",
+          "The image attachment shows a small abstract test pattern used by the demo.",
         ),
         { bubbleIndex: 0, text: "" },
       ),
     ).rejects.toThrow(/missing expected phrase/);
   }, 8_000);
 
-  it("turn-2 assertion requires the D6 single-test-page response", async () => {
+  it("turn-2 assertion requires the actual CopilotKit Quickstart response", async () => {
     const ctx: D5BuildContext = {
       integrationSlug: "x",
       featureType: "multimodal",
@@ -167,7 +167,7 @@ describe("d5-multimodal script", () => {
     const turns = buildTurns(ctx);
     await expect(
       turns[1]!.assertions!(
-        makePage("The PDF document contains a single test page."),
+        makePage("the attached pdf is the copilotkit quickstart guide."),
         { bubbleIndex: 1, text: "" },
       ),
     ).resolves.toBeUndefined();
@@ -188,6 +188,6 @@ describe("d5-multimodal script", () => {
         bubbleIndex: 0,
         text: "",
       }),
-    ).rejects.toThrow(/missing expected phrase "small abstract test pattern"/);
+    ).rejects.toThrow(/missing expected phrase "copilotkit logo"/);
   }, 8_000);
 });

--- a/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-multimodal.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getD5Script } from "../helpers/d5-registry.js";
 import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { Page } from "../helpers/conversation-runner.js";
@@ -7,6 +10,27 @@ import {
   SAMPLE_IMAGE_BUTTON_SELECTOR,
   SAMPLE_PDF_BUTTON_SELECTOR,
 } from "./d5-multimodal.js";
+
+interface MultimodalFixtureFile {
+  fixtures: Array<{
+    match: { userMessage?: string };
+    response: { content: string };
+  }>;
+}
+
+function loadCanonicalFixture(): MultimodalFixtureFile {
+  const here = fileURLToPath(import.meta.url);
+  const fixturePath = path.resolve(
+    path.dirname(here),
+    "..",
+    "..",
+    "..",
+    "fixtures",
+    "d5",
+    "multimodal.json",
+  );
+  return JSON.parse(readFileSync(fixturePath, "utf8")) as MultimodalFixtureFile;
+}
 
 function makePage(transcript: string): Page {
   return {
@@ -61,6 +85,30 @@ describe("d5-multimodal script", () => {
     expect(script).toBeDefined();
     expect(script?.featureTypes).toEqual(["multimodal"]);
     expect(script?.fixtureFile).toBe("multimodal.json");
+  });
+
+  it("keeps the canonical D5 fixture aligned with the actual sample assets", () => {
+    const fixture = loadCanonicalFixture();
+    expect(fixture.fixtures).toHaveLength(2);
+
+    expect(fixture.fixtures[0]!.match.userMessage).toBe(
+      "can you tell me what is in this demo image I just attached",
+    );
+    expect(fixture.fixtures[0]!.response.content.toLowerCase()).toContain(
+      "copilotkit logo",
+    );
+
+    expect(fixture.fixtures[1]!.match.userMessage).toBe(
+      "can you tell me what is in this demo pdf I just attached",
+    );
+    expect(fixture.fixtures[1]!.response.content.toLowerCase()).toContain(
+      "copilotkit quickstart",
+    );
+
+    const serialized = JSON.stringify(fixture).toLowerCase();
+    expect(serialized).not.toContain("small abstract test pattern");
+    expect(serialized).not.toContain("single test page");
+    expect(serialized).not.toContain("confirms the binary attachment");
   });
 
   it("buildTurns produces two turns covering image + PDF", () => {

--- a/showcase/harness/src/probes/scripts/d5-multimodal.ts
+++ b/showcase/harness/src/probes/scripts/d5-multimodal.ts
@@ -11,9 +11,11 @@
  * the attachment, then the regular fill+press flow sends both message +
  * attachment together.
  *
- * Aimock returns canned responses keyed off unique substrings. Assertions
- * require phrases unique to the D6 fixture so broad legacy fixture replies
- * cannot make the probe pass.
+ * AIMock returns canned responses keyed off the two exact sample prompts.
+ * Assertions require descriptions of the actual checked-in assets so a broad
+ * fallback or a fabricated fixture response cannot make the probe pass. This
+ * verifies deterministic fixture routing and the UI round trip; attachment
+ * bytes at the model boundary require the separate attachment-aware matcher.
  */
 
 import { registerD5Script } from "../helpers/d5-registry.js";
@@ -27,8 +29,8 @@ export const SAMPLE_PDF_BUTTON_SELECTOR =
 
 const SAMPLE_BUTTON_TIMEOUT_MS = 5_000;
 const ASSISTANT_TRANSCRIPT_TIMEOUT_MS = 5_000;
-const IMAGE_EXPECTED_PHRASE = "small abstract test pattern";
-const PDF_EXPECTED_PHRASE = "single test page";
+const IMAGE_EXPECTED_PHRASE = "copilotkit logo";
+const PDF_EXPECTED_PHRASE = "copilotkit quickstart";
 
 /** Read concatenated assistant transcript text (lowercased). */
 async function readAssistantTranscript(page: Page): Promise<string> {

--- a/showcase/scripts/__tests__/aimock-fixtures.test.ts
+++ b/showcase/scripts/__tests__/aimock-fixtures.test.ts
@@ -99,10 +99,14 @@ function scopeOf(entry: RawFixtureEntry): string {
 }
 
 // ---------------------------------------------------------------------------
-// Deployment scopes — d4 and d6 fixtures never coexist at runtime, so
-// collision detection must check within each deployment's load set:
-//   d4 runtime loads: shared/ + d4/
-//   d6 runtime loads: shared/ + d6/
+// Logical deployment scopes used by the broad collision ratchets below:
+//   d4 validation scope: shared/ + d4/
+//   d6 validation scope: shared/ + d6/
+//
+// Some deployed AIMock bundles load the fixture root recursively, so targeted
+// cross-depth invariants must also account for D4 and D6 coexisting. Keep those
+// checks narrow: combining every fixture here would mix intentional aliases
+// that are selected by the active feature route.
 // ---------------------------------------------------------------------------
 const sharedFiles = globSync("showcase/aimock/shared/*.json", {
   cwd: REPO_ROOT,
@@ -194,10 +198,80 @@ describe("aimock fixtures across repo", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cross-depth multimodal routing
+//
+// The deployed fixture root is loaded recursively in lexical order, so a D4
+// chat fixture with the same context and prompt wins before the D6 multimodal
+// fixture. Multimodal probes also reuse a conversation across both attachment
+// turns, which makes a turnIndex gate inappropriate for these fixtures.
+// ---------------------------------------------------------------------------
+describe("multimodal fixture routing", () => {
+  const prompts = [
+    "can you tell me what is in this demo image I just attached",
+    "can you tell me what is in this demo pdf I just attached",
+  ];
+
+  it("keeps D6 multimodal fixtures reachable in recursively loaded bundles", () => {
+    const violations: string[] = [];
+    const multimodalFiles = d6Files.filter(
+      (file) => path.basename(file) === "multimodal.json",
+    );
+
+    for (const file of multimodalFiles) {
+      const relative = path.relative(REPO_ROOT, file);
+      const fixtures = loadRawFixtures(file);
+
+      fixtures.forEach((fixture, index) => {
+        if (fixture.match.turnIndex != null) {
+          violations.push(
+            `${relative}[${index}]: fixture is gated by turnIndex=${fixture.match.turnIndex}`,
+          );
+        }
+      });
+
+      for (const prompt of prompts) {
+        const promptFixtures = fixtures.filter(
+          (entry) => entry.match.userMessage === prompt,
+        );
+
+        if (promptFixtures.length === 0) {
+          violations.push(`${relative}: missing prompt "${prompt}"`);
+          continue;
+        }
+
+        for (const fixture of promptFixtures) {
+          const context = fixture.match.context;
+          if (!context) {
+            violations.push(`${relative}: prompt "${prompt}" has no context`);
+            continue;
+          }
+
+          for (const shadow of d4Tagged) {
+            if (
+              scopeOf(shadow.entry) === context &&
+              shadow.entry.match.userMessage === prompt
+            ) {
+              violations.push(
+                `${relative}: prompt "${prompt}" is shadowed by ${shadow.file}[${shadow.index}]`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    expect(
+      violations,
+      `D6 multimodal fixtures must remain reachable when D4 and D6 are loaded together:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Fixture collision detection
 //
-// Each test iterates over deployment scopes (d4, d6) independently because
-// d4 and d6 fixtures never coexist at runtime.
+// Each broad ratchet iterates over the logical D4 and D6 scopes independently.
+// Targeted cross-depth hazards are checked above.
 // ---------------------------------------------------------------------------
 describe("fixture collision detection", () => {
   it("no exact duplicate match keys within the same context scope", () => {

--- a/showcase/scripts/__tests__/aimock-fixtures.test.ts
+++ b/showcase/scripts/__tests__/aimock-fixtures.test.ts
@@ -52,6 +52,18 @@ interface RawFixtureEntry {
   [key: string]: unknown;
 }
 
+function responseText(entry: RawFixtureEntry): string {
+  if (
+    typeof entry.response === "object" &&
+    entry.response !== null &&
+    "content" in entry.response &&
+    typeof entry.response.content === "string"
+  ) {
+    return entry.response.content;
+  }
+  return "";
+}
+
 /**
  * Build a deterministic match key from the match object. The key encodes
  * every field that aimock uses for disambiguation so two fixtures with
@@ -198,20 +210,32 @@ describe("aimock fixtures across repo", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Cross-depth multimodal routing
+// Multimodal fixture ownership and semantics
 //
-// The deployed fixture root is loaded recursively in lexical order, so a D4
-// chat fixture with the same context and prompt wins before the D6 multimodal
-// fixture. Multimodal probes also reuse a conversation across both attachment
-// turns, which makes a turnIndex gate inappropriate for these fixtures.
+// AIMock recursively loads every JSON file under each configured directory in
+// lexical order. Each multimodal prompt therefore needs exactly one owner per
+// context across the entire D6 tree, not merely one owner inside
+// multimodal.json. D4 does not exercise attachments, so it must not retain
+// active aliases or fake `_d4_unused_*` tombstones for these turns.
 // ---------------------------------------------------------------------------
 describe("multimodal fixture routing", () => {
-  const prompts = [
-    "can you tell me what is in this demo image I just attached",
-    "can you tell me what is in this demo pdf I just attached",
+  const IMAGE_PROMPT =
+    "can you tell me what is in this demo image I just attached";
+  const PDF_PROMPT = "can you tell me what is in this demo pdf I just attached";
+  const D4_TOMBSTONES = new Set([
+    "_d4_unused_multimodal_image",
+    "_d4_unused_multimodal_pdf",
+  ]);
+  const EXPECTED_PHRASE = new Map([
+    [IMAGE_PROMPT, "copilotkit logo"],
+    [PDF_PROMPT, "copilotkit quickstart"],
+  ]);
+  const FABRICATED_PHRASES = [
+    "small abstract test pattern",
+    "single test page",
   ];
 
-  it("keeps D6 multimodal fixtures reachable in recursively loaded bundles", () => {
+  it("keeps one factual D6 owner per prompt and no D4 aliases", () => {
     const violations: string[] = [];
     const multimodalFiles = d6Files.filter(
       (file) => path.basename(file) === "multimodal.json",
@@ -219,7 +243,14 @@ describe("multimodal fixture routing", () => {
 
     for (const file of multimodalFiles) {
       const relative = path.relative(REPO_ROOT, file);
+      const context = path.basename(path.dirname(file));
       const fixtures = loadRawFixtures(file);
+
+      if (fixtures.length !== 2) {
+        violations.push(
+          `${relative}: expected exactly 2 canonical fixtures, found ${fixtures.length}`,
+        );
+      }
 
       fixtures.forEach((fixture, index) => {
         if (fixture.match.turnIndex != null) {
@@ -227,42 +258,71 @@ describe("multimodal fixture routing", () => {
             `${relative}[${index}]: fixture is gated by turnIndex=${fixture.match.turnIndex}`,
           );
         }
+        if (scopeOf(fixture) !== context) {
+          violations.push(
+            `${relative}[${index}]: context "${scopeOf(fixture)}" does not match directory "${context}"`,
+          );
+        }
       });
 
-      for (const prompt of prompts) {
+      for (const [prompt, expectedPhrase] of EXPECTED_PHRASE) {
         const promptFixtures = fixtures.filter(
           (entry) => entry.match.userMessage === prompt,
         );
 
-        if (promptFixtures.length === 0) {
-          violations.push(`${relative}: missing prompt "${prompt}"`);
+        if (promptFixtures.length !== 1) {
+          violations.push(
+            `${relative}: expected one canonical fixture for "${prompt}", found ${promptFixtures.length}`,
+          );
           continue;
         }
 
-        for (const fixture of promptFixtures) {
-          const context = fixture.match.context;
-          if (!context) {
-            violations.push(`${relative}: prompt "${prompt}" has no context`);
-            continue;
-          }
-
-          for (const shadow of d4Tagged) {
-            if (
-              scopeOf(shadow.entry) === context &&
-              shadow.entry.match.userMessage === prompt
-            ) {
-              violations.push(
-                `${relative}: prompt "${prompt}" is shadowed by ${shadow.file}[${shadow.index}]`,
-              );
-            }
+        const fixture = promptFixtures[0]!;
+        const content = responseText(fixture).toLowerCase();
+        if (!content.includes(expectedPhrase)) {
+          violations.push(
+            `${relative}: response for "${prompt}" must contain factual phrase "${expectedPhrase}"`,
+          );
+        }
+        for (const fabricated of FABRICATED_PHRASES) {
+          if (content.includes(fabricated)) {
+            violations.push(
+              `${relative}: response for "${prompt}" retains fabricated phrase "${fabricated}"`,
+            );
           }
         }
+
+        const owners = d6Tagged.filter(
+          (candidate) =>
+            scopeOf(candidate.entry) === context &&
+            candidate.entry.match.userMessage === prompt,
+        );
+        if (owners.length !== 1 || owners[0]?.file !== relative) {
+          violations.push(
+            `${relative}: prompt "${prompt}" must be owned only by this file; found ${owners
+              .map((owner) => `${owner.file}[${owner.index}]`)
+              .join(", ")}`,
+          );
+        }
+      }
+    }
+
+    for (const fixture of d4Tagged) {
+      const userMessage = fixture.entry.match.userMessage;
+      if (
+        userMessage === IMAGE_PROMPT ||
+        userMessage === PDF_PROMPT ||
+        (userMessage !== undefined && D4_TOMBSTONES.has(userMessage))
+      ) {
+        violations.push(
+          `${fixture.file}[${fixture.index}]: obsolete D4 multimodal fixture "${userMessage}" must be deleted`,
+        );
       }
     }
 
     expect(
       violations,
-      `D6 multimodal fixtures must remain reachable when D4 and D6 are loaded together:\n${violations.join("\n")}`,
+      `Multimodal prompts need one factual D6 owner and no D4 aliases:\n${violations.join("\n")}`,
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- delete obsolete D4 multimodal fixtures instead of disguising them with the unrecognized `_d4_unused_multimodal_image` field
- make each D6 `multimodal.json` the sole owner of the exact image and PDF prompts by removing duplicate `agentic-chat.json` entries and broad fallback aliases
- align the canonical D5 fixture, all D6 canned responses, and probe assertions with the real CopilotKit logo and CopilotKit Quickstart assets, with ownership/semantics ratchets

## Root cause

`_d4_unused_multimodal_image` was introduced as a fixture tombstone, but AIMock does not interpret that field. D4 does not run a multimodal turn, so retaining those fixtures did not preserve D4 coverage.

The D6 fixture tree also had the same multimodal prompts in both `agentic-chat.json` and `multimodal.json`. Because fixtures are loaded recursively and matching is first-match-wins, the file named `multimodal.json` was not reliably the fixture that answered the probe. Four integrations additionally had broad aliases such as `image` and `document`.

Both the D6 responses and the canonical harness D5 fixture described assets that do not exist and claimed the canned response proved upload transport. The actual checked-in assets are the CopilotKit logo and CopilotKit Quickstart PDF, and prompt matching cannot prove that their bytes reached the model boundary.

This revision removes those ambiguities rather than renaming them: one exact owner per prompt and integration, no D4 tombstones, and factual expected content.

## Verification

- regression coverage was run red against the prior layout, then green after canonicalizing ownership and semantics, including the canonical harness D5 fixture
- `nx format:check --uncommitted`
- changed TypeScript files: oxlint found 0 warnings and 0 errors
- `@copilotkit/showcase-scripts:test`: 2,512 passed
- `@copilotkit/showcase-harness:test`: 3,712 passed, 18 skipped
- `@copilotkit/showcase-harness:typecheck`: passed
- `@copilotkit/showcase-harness:build`: passed
- fresh isolated D6 cells:
  - `google-adk:multimodal` — green
  - `langgraph-python:multimodal` — green
  - `crewai-crews:multimodal` — green

## Scope boundary

The current fixture schema still matches these cases by prompt. This PR proves deterministic fixture ownership and truthful assertions; it does not prove that attachment bytes reached the model boundary. [OSS-845](https://linear.app/copilotkit/issue/OSS-845) tracks attachment-aware normalization, matching, journal evidence, and prompt-without-attachment negative tests.
