### PR TITLE
fix(showcase): restore scripts typecheck

### DIFF
--- a/showcase/scripts/equivalence-gate.ts
+++ b/showcase/scripts/equivalence-gate.ts
@@ -60,8 +60,10 @@ import {
 } from "../shell-dashboard/src/lib/live-status";
 import type { LiveStatusMap } from "../shell-dashboard/src/lib/live-status";
 
-/** A single (integration, feature) cell to compare across envs. */
-export type GateCell = CellModelInput;
+/** A feature-bearing cell to compare across environments. */
+export type GateCell = Omit<CellModelInput, "featureId"> & {
+  featureId: string;
+};
 
 /** Why a cell was excluded from the gate verdict. */
 export type ExclusionReason =

--- a/showcase/scripts/generate-search-index.ts
+++ b/showcase/scripts/generate-search-index.ts
@@ -45,13 +45,13 @@ interface FrontendSearchPage {
   guidanceTitle?: "Docs status";
 }
 
-const FRONTEND_SEARCH_PAGES = [
+const FRONTEND_SEARCH_PAGES: readonly FrontendSearchPage[] = [
   { id: "vue", name: "Vue", guidanceTitle: "Docs status" },
   { id: "react-native", name: "React Native", guidanceTitle: "Docs status" },
   { id: "angular", name: "Angular", guidanceTitle: "Docs status" },
   { id: "slack", name: "Slack" },
   { id: "teams", name: "Microsoft Teams" },
-] as const satisfies readonly FrontendSearchPage[];
+];
 
 const FRONTEND_NAMES = new Map(
   FRONTEND_SEARCH_PAGES.map((frontend) => [frontend.id, frontend.name]),


### PR DESCRIPTION
## Summary

- narrow promotion gate cells to the feature-bearing contract their consumers already require
- widen frontend search page metadata to its declared interface without changing runtime entries
- restore the Showcase scripts TypeScript gate before rebuilding #6493

## Root cause

Two independent type contracts on `main` drifted after their data models changed: promotion `GateCell` inherited a nullable `featureId` even though the closure contains only feature-bearing cells, while the frontend search table retained an overly narrow tuple-derived union after Slack and Teams stopped defining `guidanceTitle`.

## Verification

- reproduced the baseline: 8 TypeScript diagnostics on `origin/main`
- `pnpm exec tsc --noEmit --project showcase/scripts/tsconfig.json`
- focused gate tests: 32/32
- search contract: 7/7
- full uncached Showcase scripts suite: 2511/2511 across 77 files
- generated search indexes unchanged and byte-identical
- scoped formatter and lint clean

Prerequisite for reconciling #6493.