### PR TITLE
Warn readers on deprecated V1 reference pages

### DIFF
--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
 import { ReferenceVersionSelector } from "@/components/reference-version-selector";
+import { V1ReferenceDeprecationNotice } from "@/components/v1-reference-deprecation-notice";
 import {
   REFERENCE_VERSIONS,
   buildReferencePageTree,
@@ -215,6 +216,8 @@ export default async function ReferenceSlugPage({
               );
             })}
           </nav>
+
+          <V1ReferenceDeprecationNotice version={version} />
 
           <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
             {title}

--- a/showcase/shell-docs/src/components/__tests__/v1-reference-deprecation-notice.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/v1-reference-deprecation-notice.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { V1ReferenceDeprecationNotice } from "../v1-reference-deprecation-notice";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+afterEach(cleanup);
+
+describe("V1ReferenceDeprecationNotice", () => {
+  it("warns V1 readers and links to the V2 reference", () => {
+    render(<V1ReferenceDeprecationNotice version="v1" />);
+
+    expect(
+      screen.getByRole("complementary", {
+        name: "CopilotKit V1 is deprecated",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This page documents a legacy API and is no longer maintained. Use the V2 reference for current APIs, examples, and guidance.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Go to V2 reference" })
+        .getAttribute("href"),
+    ).toBe("/reference/v2");
+  });
+
+  it("does not render on current reference pages", () => {
+    render(<V1ReferenceDeprecationNotice version="v2" />);
+
+    expect(screen.queryByText("CopilotKit V1 is deprecated")).toBeNull();
+  });
+});

--- a/showcase/shell-docs/src/components/v1-reference-deprecation-notice.tsx
+++ b/showcase/shell-docs/src/components/v1-reference-deprecation-notice.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { ArrowRight, TriangleAlert } from "lucide-react";
+
+export function V1ReferenceDeprecationNotice({ version }: { version: string }) {
+  if (version !== "v1") {
+    return null;
+  }
+
+  return (
+    <aside
+      aria-labelledby="v1-reference-deprecation-title"
+      className="shell-docs-radius-surface my-5 border border-[var(--warning-border)] bg-[var(--warning-dim)] p-5 shadow-[var(--shadow-control)] md:p-6"
+    >
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 gap-4">
+          <div className="shell-docs-radius-icon flex size-10 shrink-0 items-center justify-center border border-[var(--warning-border)] bg-[var(--bg-surface)] text-[var(--warning-text)] shadow-[var(--shadow-control)]">
+            <TriangleAlert className="size-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <p className="mb-1 text-xs font-semibold tracking-[0.12em] text-[var(--warning-text)] uppercase">
+              Legacy documentation
+            </p>
+            <h2
+              id="v1-reference-deprecation-title"
+              className="text-xl font-semibold tracking-[-0.02em] text-[var(--text)]"
+            >
+              CopilotKit V1 is deprecated
+            </h2>
+            <p className="mt-2 max-w-[65ch] text-sm leading-6 text-[var(--text-secondary)]">
+              This page documents a legacy API and is no longer maintained. Use
+              the V2 reference for current APIs, examples, and guidance.
+            </p>
+          </div>
+        </div>
+
+        <Link
+          href="/reference/v2"
+          className="shell-docs-radius-control inline-flex min-h-10 shrink-0 items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none sm:mt-6"
+        >
+          Go to V2 reference
+          <ArrowRight className="size-4" aria-hidden="true" />
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/showcase/shell-docs/src/content/docs/channels/index.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/index.mdx
@@ -27,7 +27,7 @@ between those systems and the path each message takes.
   className="block dark:hidden my-8 w-full rounded-xl"
 />
 <Image
-  src="/images/channels/channels-architecture-light.png"
+  src="/images/channels/channels-architecture-dark.png"
   alt="Channels architecture showing agent frameworks connected through AG-UI and the CopilotKit Runtime to the Channels SDK, with the channel runner — Enterprise Intelligence's managed runner or your own — connecting to Slack, Microsoft Teams, WhatsApp, Discord, and more."
   width={4000}
   height={2608}

--- a/showcase/shell-docs/src/content/reference/v1/index.mdx
+++ b/showcase/shell-docs/src/content/reference/v1/index.mdx
@@ -5,10 +5,6 @@ description: "API Reference for CopilotKit's components, classes and hooks."
 
 import { LinkIcon } from "lucide-react";
 
-<Callout type="warning">
-  The v1 APIs will continue to work, but we strongly recommend using or migrating to the [v2 APIs](/reference/v2).
-</Callout>
-
 <Cards>
   <Card
     title="UI Components"


### PR DESCRIPTION
## Before and after

Before is the current production V1 Groq reference page. After is this PR branch.

### Desktop

| Before | After |
|---|---|
| ![Desktop before](https://github.com/CopilotKit/CopilotKit/releases/download/pr-6517-visuals/before-desktop.png) | ![Desktop after](https://github.com/CopilotKit/CopilotKit/releases/download/pr-6517-visuals/after-desktop.png) |

### Mobile

| Before | After |
|---|---|
| ![Mobile before](https://github.com/CopilotKit/CopilotKit/releases/download/pr-6517-visuals/before-mobile.png) | ![Mobile after](https://github.com/CopilotKit/CopilotKit/releases/download/pr-6517-visuals/after-mobile.png) |

## Summary

- show a prominent, theme-aware deprecation notice on every V1 reference page
- link readers directly to the current V2 reference
- remove the older one-off V1 index callout so the warning is consistent and not duplicated
- cover V1-only rendering and the V2 destination with a component test
- restore the existing dark-mode Channels architecture asset so the touched package suite remains green

## Why

CPK-7914 includes two blog links that correctly need the legacy Groq and Google Generative AI adapter references. Keeping those valid V1 destinations requires an unmistakable migration path to the maintained V2 docs.

## Validation

- `npm run lint` (passes; existing unrelated warnings remain)
- `npm run typecheck`
- `npm run build`
- focused component test: 2/2 pass
- browser verified Groq and Google adapter routes at 1440×900 and 390×844 in light and dark themes
- browser verified the CTA navigates to `/reference/v2` and the notice is absent on V2
- `npm test` (full shell-docs suite)