### PR TITLE
fix(python-sdk): relax partialjson pin to allow 1.x

### DIFF
--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -34,7 +34,7 @@ crewai = { version = ">=0.118.0", optional = true, python = ">=3.10,<3.14" }
 ag-ui-langgraph = { version = ">=0.0.42", extras = ["fastapi"] }
 ag-ui-protocol = ">=0.1.15"
 fastapi = ">=0.115.0,<1.0.0"
-partialjson = "^0.0.8"
+partialjson = ">=0.0.8,<2.0.0"
 toml = "^0.10.2"
 # Pin transitive: cp314 wheels first appear in 2.35.0; older versions
 # would force a Rust source build that fails on PyO3 0.24 (capped at 3.13).


### PR DESCRIPTION
## Summary
- Widen the `partialjson` constraint from `^0.0.8` (which caps at `<0.0.9`) to `>=0.0.8,<2.0.0`
- The SDK only uses `JSONParser.parse()` which remains compatible across 0.0.8 through 1.x per the partialjson changelog

## Motivation
Closes #4131. The current pin blocks downstream projects from accepting Dependabot bumps for `partialjson>=1.0`.

## Verification
- Checked the only usage site: `sdk-python/copilotkit/runloop.py` imports `JSONParser` and calls `.parse()` — both exist unchanged in partialjson 1.x
- partialjson 1.0.0 changelog shows additive changes only

## Test plan
- [ ] CI passes with the widened constraint