### PR TITLE
fix(channels-slack): rename decimal_allowed to Slack's is_decimal_allowed (OSS-794)

### DIFF
--- a/packages/channels-slack/src/__tests__/native-field-names.test.ts
+++ b/packages/channels-slack/src/__tests__/native-field-names.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Guards the Slack field names in `native.ts` against Slack's own published
+ * vocabulary in `@slack/types`.
+ *
+ * Why this exists: Slack accepts a message whole or not at all. One key it does
+ * not recognise refuses the entire `chat.postMessage` call with
+ * `invalid_blocks: invalid field at /blocks/N/...`, and the Channels delivery
+ * that carried it ends there. Nothing is thrown at the developer who authored
+ * the payload and nothing arrives in the channel. So a single character wrong
+ * in a prop name is not a typo with a small blast radius — it silently deletes
+ * every message that uses the component.
+ *
+ * That is exactly what `decimal_allowed` did (Slack's name is
+ * `is_decimal_allowed`). It shipped in 0.9.0 and was found by accident. This
+ * test is the thing that would have caught it: every field name the Slack prop
+ * types declare must either appear in Slack's own Block Kit type declarations,
+ * or be listed below with the reason it cannot.
+ *
+ * The comparison reads declarations with the TypeScript parser rather than by
+ * matching text, so it follows the shape of the files instead of their
+ * formatting.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Props that exist for the JSX surface and are never serialised into Slack
+ * JSON. The codec consumes them; Slack never sees them.
+ */
+const SDK_ONLY_PROPS = new Set(["children", "onClick", "onSelect", "onSubmit"]);
+
+/**
+ * The honest limit of this check. `@slack/types` is Slack's own package but it
+ * is not complete, so a name missing from it is not proof the name is wrong —
+ * only that this test cannot judge it. Every entry here is a field this test
+ * therefore does NOT cover, with the reason. Adding a name here is a deliberate
+ * act: it removes that name from the guard.
+ */
+const NOT_COVERED_BY_SLACK_TYPES: ReadonlyMap<string, string> = new Map([
+  [
+    "blocks",
+    "the `container` block's child slot; `@slack/types` declares no container block",
+  ],
+  [
+    "offset",
+    "documented on `rich_text_list` in Slack's Block Kit reference, but absent from `@slack/types`' `RichTextList`",
+  ],
+  [
+    "slack_icon",
+    "accepted on the `card` block; `@slack/types`' `CardBlock` does not declare it",
+  ],
+  [
+    "subtext",
+    "accepted on the `card` block; `@slack/types`' `CardBlock` does not declare it",
+  ],
+  // `data_visualization` has no counterpart in `@slack/types` at all, so its
+  // whole payload vocabulary is outside this comparison.
+  [
+    "chart",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "segments",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "series",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "axis_config",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "categories",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "x_label",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "y_label",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+  [
+    "data",
+    "part of `data_visualization`, a block `@slack/types` does not know",
+  ],
+]);
+
+/**
+ * A comparison against an empty vocabulary passes every name, so the test would
+ * go green precisely when it stopped working. These floors are well under the
+ * present counts and only catch a comparison that has collapsed.
+ */
+const MIN_SLACK_FIELD_NAMES = 100;
+const MIN_FIELDS_COMPARED = 30;
+
+/** Every property name declared by any interface in a `.d.ts` source. */
+function declaredPropertyNames(source: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isPropertySignature(node) || ts.isPropertyDeclaration(node)) &&
+      (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name))
+    ) {
+      names.add(node.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  ts.forEachChild(source, visit);
+  return names;
+}
+
+function parse(path: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+}
+
+/** Slack's Block Kit vocabulary, read from the installed `@slack/types`. */
+function slackBlockKitFieldNames(): Set<string> {
+  const require = createRequire(import.meta.url);
+  const blockKitDir = join(
+    dirname(require.resolve("@slack/types/package.json")),
+    "dist",
+    "block-kit",
+  );
+  const declarations = readdirSync(blockKitDir).filter((file) =>
+    file.endsWith(".d.ts"),
+  );
+
+  const names = new Set<string>();
+  for (const file of declarations) {
+    for (const name of declaredPropertyNames(parse(join(blockKitDir, file)))) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+/** Every field name our Slack prop interfaces declare. */
+function declaredSlackPropNames(): Set<string> {
+  return declaredPropertyNames(parse(join(here, "..", "native.ts")));
+}
+
+describe("Slack native prop names match Slack's own vocabulary", () => {
+  const slackNames = slackBlockKitFieldNames();
+  const ourNames = declaredSlackPropNames();
+
+  it("reads a real vocabulary out of @slack/types", () => {
+    expect(slackNames.size).toBeGreaterThanOrEqual(MIN_SLACK_FIELD_NAMES);
+    // A spot check that the reader found actual Block Kit fields and not, say,
+    // a directory of empty modules.
+    expect(slackNames).toContain("is_decimal_allowed");
+    expect(slackNames).toContain("dispatch_action");
+    expect(slackNames).toContain("accessory");
+  });
+
+  it("reads the prop names out of native.ts", () => {
+    expect(ourNames).toContain("is_decimal_allowed");
+    expect(ourNames).toContain("block_id");
+  });
+
+  it("declares no field name Slack does not know", () => {
+    const unknown = [...ourNames]
+      .filter((name) => !SDK_ONLY_PROPS.has(name))
+      .filter((name) => !slackNames.has(name))
+      .filter((name) => !NOT_COVERED_BY_SLACK_TYPES.has(name))
+      .sort();
+
+    expect(unknown, unknownFieldMessage(unknown)).toEqual([]);
+  });
+
+  it("actually compares a meaningful number of names", () => {
+    const compared = [...ourNames].filter(
+      (name) =>
+        !SDK_ONLY_PROPS.has(name) &&
+        !NOT_COVERED_BY_SLACK_TYPES.has(name) &&
+        slackNames.has(name),
+    );
+
+    expect(compared.length).toBeGreaterThanOrEqual(MIN_FIELDS_COMPARED);
+  });
+
+  it("keeps the uncovered list honest", () => {
+    // A name listed as uncovered that Slack turns out to declare is no longer
+    // an exemption, and leaving it here would hide a future rename of it.
+    const nowKnown = [...NOT_COVERED_BY_SLACK_TYPES.keys()]
+      .filter((name) => slackNames.has(name))
+      .sort();
+
+    expect(
+      nowKnown,
+      `@slack/types now declares ${nowKnown.join(", ")} — remove ${
+        nowKnown.length === 1 ? "it" : "them"
+      } from NOT_COVERED_BY_SLACK_TYPES so the guard covers ${
+        nowKnown.length === 1 ? "it" : "them"
+      }.`,
+    ).toEqual([]);
+
+    // An exemption for a name we no longer declare is dead weight that would
+    // silently pre-approve the name if it ever came back.
+    const unused = [...NOT_COVERED_BY_SLACK_TYPES.keys()]
+      .filter((name) => !ourNames.has(name))
+      .sort();
+
+    expect(
+      unused,
+      `NOT_COVERED_BY_SLACK_TYPES lists ${unused.join(
+        ", ",
+      )}, which native.ts no longer declares — drop the entr${
+        unused.length === 1 ? "y" : "ies"
+      }.`,
+    ).toEqual([]);
+  });
+});
+
+function unknownFieldMessage(unknown: readonly string[]): string {
+  if (unknown.length === 0) return "";
+  return (
+    `native.ts declares ${unknown
+      .map((name) => `\`${name}\``)
+      .join(", ")}, which @slack/types does not. Slack refuses a whole ` +
+    "message for one unrecognised key, so a wrong name here deletes every " +
+    "message using the component. Either correct the name to Slack's, or — " +
+    "if Slack really does accept it and @slack/types is simply behind — add " +
+    "it to NOT_COVERED_BY_SLACK_TYPES with the reason."
+  );
+}

--- a/packages/channels-slack/src/native.ts
+++ b/packages/channels-slack/src/native.ts
@@ -47,7 +47,16 @@ export interface SlackNativeProps<TValue = unknown> {
   max_selected_items?: number;
   min_value?: string;
   max_value?: string;
-  decimal_allowed?: boolean;
+  /**
+   * `number_input`'s decimals switch. Slack's name is `is_decimal_allowed`; the
+   * `is_` prefix is not optional. This shipped as `decimal_allowed` through
+   * 0.9.0, and Slack refused every message that carried it —
+   * `invalid_blocks: invalid field at /blocks/N/element` — because an unknown
+   * key invalidates the whole payload. Verified live against Slack on
+   * 2026-08-17: the same input block delivers under this name and is refused
+   * under the old one.
+   */
+  is_decimal_allowed?: boolean;
   emoji?: boolean;
   verbatim?: boolean;
   indent?: number;


### PR DESCRIPTION
OSS-794.

## The defect

`SlackNativeProps` declared `decimal_allowed`. Slack's `number_input` field is **`is_decimal_allowed`** (confirmed in `@slack/types@2.22.0`, where it is also *required*).

Slack accepts a message whole or not at all. The unrecognised key refused the entire `chat.postMessage` call and ended the Channels delivery that carried it — no exception reached the caller, nothing arrived in the channel.

So the **typed path was the broken one**. Anyone who bypassed our types and hand-wrote `is_decimal_allowed` got it right by accident; anyone using `Slack.Element.NumberInput` silently lost the message. That is the opposite of what an SDK should do.

## Proof, before the change

Verified live against Slack (private `#bot-test`), one delivery per case — a refusal ends the whole turn's delivery, so batching would have made the results meaningless.

| Case | Payload | Outcome |
| --- | --- | --- |
| A | `decimal_allowed: true` (our typed spelling) | **refused** — `invalid_blocks: invalid field at /blocks/0/element` |
| B | no decimals field at all | **refused** — same error |
| C | `is_decimal_allowed: true` (Slack's spelling) | **delivered** |
| E | *both* names present | **refused** — same error |

Case B refuses for its own reason: `@slack/types` marks `is_decimal_allowed` **required**, so omitting it is independently invalid. That makes B a poor control, so case E was added — it satisfies Slack's required field and is otherwise byte-identical to the payload that delivers, leaving the unknown `decimal_allowed` key as the only possible cause. A vs C vs E isolates the name as the whole story.

In the refused threads only the caption arrived; the block itself is simply absent — the silent-loss shape the defect produces in production.

## Is this breaking?

**No, and no alias is kept.** The old name never worked: every payload carrying it was refused by Slack, so no caller can be depending on working behaviour. Keeping `decimal_allowed` as an alias would preserve the trap. Removing it converts a silent message loss into a compile error that names the right field:

```
error TS2561: Object literal may only specify known properties, but 'decimal_allowed'
does not exist in type 'SlackNativeProps<unknown>'. Did you mean to write 'is_decimal_allowed'?
```

## Proof, after the change

Built locally, copied over the installed `@copilotkit/channels-slack` in a real OpenTag runtime, confirmed the process held the new build (`tsc` reads the copied `.d.ts` — it accepts `is_decimal_allowed` with no cast and rejects `decimal_allowed` with the error above), then re-ran case A through the fixed typed surface: **delivered**, block present in the thread.

## Sibling sweep

Every field name `native.ts` declares was compared against Slack's Block Kit vocabulary. **No other mismatch was found.** Names absent from `@slack/types` are absent because `@slack/types` does not model those blocks, not because they are misspelled — they are enumerated in the guard.

Two adjacent observations, not fixed here: `dispatch_action`, `min_length` and `max_length` are Slack fields we do not declare at all (callers reach them via `as never`). Those are gaps rather than mismatches, so they are out of scope for this PR.

## The guard

`src/__tests__/native-field-names.test.ts` compares every field name `native.ts` declares against Slack's own Block Kit declarations in `@slack/types` — already a direct dependency of this package, so no new dependency was added. Declarations are read with the TypeScript parser rather than matched as text.

**It fails when it should.** Temporarily restoring the misspelling turns it red with an actionable message:

> native.ts declares `decimal_allowed`, which @slack/types does not. Slack refuses a whole message for one unrecognised key, so a wrong name here deletes every message using the component. Either correct the name to Slack's, or — if Slack really does accept it and @slack/types is simply behind — add it to NOT_COVERED_BY_SLACK_TYPES with the reason.

**It is honest about coverage.** `@slack/types` is incomplete, so a missing name is not proof a name is wrong. Every uncovered field is listed individually with its reason rather than being waved through:

- `blocks` — `container`'s child slot; `@slack/types` declares no container block
- `offset` — documented on `rich_text_list`, absent from `@slack/types`' `RichTextList`
- `slack_icon`, `subtext` — accepted on `card`, not declared by `CardBlock`
- `chart`, `segments`, `series`, `axis_config`, `categories`, `x_label`, `y_label`, `data` — `data_visualization` has no counterpart in `@slack/types` at all

**It cannot pass trivially.** Floors assert the extracted vocabulary is real (≥100 names, plus spot checks) and that a meaningful number of names were actually compared (≥30), so a collapsed comparison fails instead of looking green. Two further assertions keep the exemption list from rotting: an exemption `@slack/types` has since started declaring, or one for a name we no longer declare, both fail.

## Verification

| Command | Result |
| --- | --- |
| `oxfmt --check packages/channels-slack` | clean, 66 files |
| `oxlint` on both changed files | 0 warnings, 0 errors |
| `nx run @copilotkit/channels-slack:check-types` | pass (+ 8 dependent tasks) |
| `nx run @copilotkit/channels-slack:test` | 31 files, 411 tests passed |
| `nx run @copilotkit/channels-slack:build` | pass |
| lefthook pre-commit (`test-and-check-packages`, all packages) | pass |