### PR TITLE
fix: stale useCoAgent node name, silent content-part drops, and the LangGraph docs gaps

### DIFF
--- a/packages/react-core/src/hooks/__tests__/use-agent-nodename.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/use-agent-nodename.test.tsx
@@ -1,0 +1,149 @@
+import { vi } from "vitest";
+import React from "react";
+import { act, render } from "@testing-library/react";
+import type { AgentSubscriber } from "@ag-ui/client";
+import { useAgentNodeName } from "../use-agent-nodename";
+import { useLangGraphInterrupt } from "../use-langgraph-interrupt";
+
+// The one subscriber the hook under test registers, captured so tests can
+// drive AG-UI events without a live agent.
+let subscriber: AgentSubscriber | null = null;
+const unsubscribe = vi.fn();
+
+const mockAgent = {
+  subscribe: vi.fn((s: AgentSubscriber) => {
+    subscriber = s;
+    return { unsubscribe };
+  }),
+};
+
+// Captured from the `useInterrupt` call `useLangGraphInterrupt` makes.
+let interruptArgs: any = null;
+
+vi.mock("../../v2", () => ({
+  useAgent: vi.fn(() => ({ agent: mockAgent })),
+  useInterrupt: vi.fn((args: any) => {
+    interruptArgs = args;
+  }),
+  useCopilotChatConfiguration: vi.fn(() => ({
+    agentId: "default",
+    threadId: "thread-1",
+  })),
+}));
+
+function emitStepStarted(stepName: string) {
+  subscriber?.onStepStartedEvent?.({ event: { stepName } } as any);
+}
+
+beforeEach(() => {
+  subscriber = null;
+  interruptArgs = null;
+  vi.clearAllMocks();
+});
+
+describe("useAgentNodeName", () => {
+  it("re-renders consumers on every node transition", () => {
+    const renderedNodeNames: string[] = [];
+
+    const Component: React.FC = () => {
+      renderedNodeNames.push(useAgentNodeName("default"));
+      return null;
+    };
+
+    render(<Component />);
+
+    // Nothing else here triggers a render, so every entry after the first
+    // exists only because the node change itself scheduled one.
+    act(() => emitStepStarted("call_model_node"));
+    act(() => emitStepStarted("process_feedback_node"));
+    act(() => {
+      subscriber?.onRunFinishedEvent?.({} as any);
+    });
+
+    expect(renderedNodeNames).toEqual([
+      "start",
+      "call_model_node",
+      "process_feedback_node",
+      "end",
+    ]);
+  });
+
+  it("reports 'end' when a run errors", () => {
+    const renderedNodeNames: string[] = [];
+    const Component: React.FC = () => {
+      renderedNodeNames.push(useAgentNodeName("default"));
+      return null;
+    };
+
+    render(<Component />);
+    act(() => emitStepStarted("call_model_node"));
+    act(() => {
+      subscriber?.onRunErrorEvent?.({} as any);
+    });
+
+    expect(renderedNodeNames.at(-1)).toBe("end");
+  });
+
+  it("resets to 'start' when a new run begins", () => {
+    const renderedNodeNames: string[] = [];
+    const Component: React.FC = () => {
+      renderedNodeNames.push(useAgentNodeName("default"));
+      return null;
+    };
+
+    render(<Component />);
+    act(() => emitStepStarted("call_model_node"));
+    expect(renderedNodeNames.at(-1)).toBe("call_model_node");
+
+    act(() => {
+      subscriber?.onRunStartedEvent?.({} as any);
+    });
+    expect(renderedNodeNames.at(-1)).toBe("start");
+  });
+
+  it("unsubscribes on unmount", () => {
+    const Component: React.FC = () => {
+      useAgentNodeName("default");
+      return null;
+    };
+
+    const { unmount } = render(<Component />);
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useLangGraphInterrupt agentMetadata", () => {
+  // Characterization, not a regression test. `useInterrupt` only evaluates
+  // `enabled` from a `useEffect`/`useMemo` keyed on its `pending` state, so a
+  // render always lands between the interrupt arriving and the predicate
+  // running. This pins that contract down, since nothing covered it before.
+  it("carries the agent, thread, and current node", () => {
+    let captured: any = null;
+
+    const Component: React.FC = () => {
+      useLangGraphInterrupt({
+        enabled: ({ agentMetadata }) => {
+          captured = agentMetadata;
+          return true;
+        },
+        render: () => "interrupt",
+      });
+      return null;
+    };
+
+    render(<Component />);
+
+    act(() => emitStepStarted("process_feedback_node"));
+    act(() => {
+      interruptArgs.enabled({ value: {} });
+    });
+
+    expect(captured).toEqual({
+      agentName: "default",
+      threadId: "thread-1",
+      nodeName: "process_feedback_node",
+    });
+  });
+});

--- a/packages/react-core/src/hooks/use-agent-nodename.ts
+++ b/packages/react-core/src/hooks/use-agent-nodename.ts
@@ -1,25 +1,32 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import type { AgentSubscriber } from "@ag-ui/client";
 import { useAgent } from "../v2";
 
+/**
+ * Tracks the node the agent is currently executing.
+ *
+ * Backed by state rather than a ref: mutating a ref schedules no render, so
+ * consumers such as `useCoAgent().nodeName` kept reporting whichever node was
+ * current at their last render and never updated on their own.
+ */
 export function useAgentNodeName(agentName?: string) {
   const { agent } = useAgent({ agentId: agentName });
-  const nodeNameRef = useRef<string>("start");
+  const [nodeName, setNodeName] = useState<string>("start");
 
   useEffect(() => {
     if (!agent) return;
     const subscriber: AgentSubscriber = {
       onStepStartedEvent: ({ event }) => {
-        nodeNameRef.current = event.stepName;
+        setNodeName(event.stepName);
       },
       onRunStartedEvent: () => {
-        nodeNameRef.current = "start";
+        setNodeName("start");
       },
       onRunFinishedEvent: () => {
-        nodeNameRef.current = "end";
+        setNodeName("end");
       },
       onRunErrorEvent: () => {
-        nodeNameRef.current = "end";
+        setNodeName("end");
       },
     };
 
@@ -29,5 +36,5 @@ export function useAgentNodeName(agentName?: string) {
     };
   }, [agent]);
 
-  return nodeNameRef.current;
+  return nodeName;
 }

--- a/packages/runtime/src/graphql/message-conversion/agui-to-gql.test.ts
+++ b/packages/runtime/src/graphql/message-conversion/agui-to-gql.test.ts
@@ -1382,3 +1382,69 @@ describe("agui-to-gql", () => {
     });
   });
 });
+
+describe("normalizeMessageContent unsupported content parts", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("warns instead of silently dropping an unrecognized part type", () => {
+    const aguiMessage = {
+      id: "assistant-structured",
+      role: "assistant",
+      content: [
+        { type: "text", text: "Sample png file" },
+        {
+          type: "image",
+          image_data: { data: "aGVsbG8=", format: "image/png" },
+        },
+      ],
+    } as unknown as agui.Message;
+
+    const result = aguiToGQL(aguiMessage);
+
+    // The part is still dropped — carrying it needs a schema change (OSS-767).
+    // What changes here is that the drop is no longer silent.
+    expect((result[0] as gql.TextMessage).content).toBe("Sample png file");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('unsupported type "image"');
+  });
+
+  test("warns once per part type, not once per part", () => {
+    const message = {
+      id: "assistant-repeated",
+      role: "assistant",
+      content: [
+        { type: "video", url: "a" },
+        { type: "video", url: "b" },
+      ],
+    } as unknown as agui.Message;
+
+    aguiToGQL(message);
+    aguiToGQL(message);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not warn for supported part types", () => {
+    const aguiMessage = {
+      id: "assistant-supported",
+      role: "assistant",
+      content: [
+        { type: "text", text: "hello" },
+        { type: "binary", mimeType: "application/pdf", filename: "a.pdf" },
+      ],
+    } as unknown as agui.Message;
+
+    const result = aguiToGQL(aguiMessage);
+
+    expect((result[0] as gql.TextMessage).content).toBe("hello\na.pdf");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/graphql/message-conversion/agui-to-gql.ts
+++ b/packages/runtime/src/graphql/message-conversion/agui-to-gql.ts
@@ -44,6 +44,21 @@ function hasImageProperty(
   return true;
 }
 
+// Content part types we have already warned about. Streaming replays the same
+// unsupported part on every delta, so warn once per type rather than per part.
+const warnedContentPartTypes = new Set<string>();
+
+function warnUnsupportedContentPart(type: unknown): void {
+  const label = typeof type === "string" ? type : String(type);
+  if (warnedContentPartTypes.has(label)) return;
+  warnedContentPartTypes.add(label);
+  console.warn(
+    `[CopilotKit] Dropping message content part of unsupported type "${label}". ` +
+      `Only "text" and "binary" parts are carried through to the client; ` +
+      `see https://github.com/CopilotKit/CopilotKit/issues/1748.`,
+  );
+}
+
 function normalizeMessageContent(content: agui.Message["content"]): string {
   if (typeof content === "string" || typeof content === "undefined") {
     return content || "";
@@ -63,6 +78,7 @@ function normalizeMessageContent(content: agui.Message["content"]): string {
             `[binary:${part.mimeType}]`
           );
         }
+        warnUnsupportedContentPart(part?.type);
         return "";
       })
       .filter(Boolean)

--- a/showcase/shell-docs/src/content/docs/agentic-protocols/mcp.mdx
+++ b/showcase/shell-docs/src/content/docs/agentic-protocols/mcp.mdx
@@ -39,6 +39,57 @@ For further reading, check out the [Model Context Protocol](https://modelcontext
   CopilotKit supports to connect agents to user-facing frontends
 </div>
 
+## When you do (and don't) need an MCP App
+
+"MCP server" covers three quite different things, and only one of them needs an [MCP App](/generative-ui/mcp-apps). Picking the wrong one means either building UI you didn't need or shipping a tool nobody can act on.
+
+Work out which kind of server you have:
+
+| Your server… | What the user should see | What to build |
+| --- | --- | --- |
+| Reads data and returns it | Nothing, or a status line — the answer belongs in the agent's reply | Plain MCP tool. No renderer needed. |
+| Changes something (writes, sends, deletes) | What is about to happen, with a way to stop it | Plain MCP tool + a renderer, plus approval for anything irreversible |
+| Has its own interface (a form, a picker, a chart to interact with) | The interface itself | An MCP App with a UI resource |
+
+### Read-only context servers
+
+The most common case, and the one that needs the least. A docs search, a database query, a "look up this customer" tool — the tool result is *context for the model*, not something the user reads directly. The agent folds it into its answer, and that answer is the UI.
+
+Connect the server and stop there. If you want the call to be visible rather than invisible, a wildcard renderer gives every tool call a status card without writing one renderer per tool:
+
+```tsx
+import { useDefaultRenderTool } from "@copilotkit/react-core/v2";
+
+useDefaultRenderTool({
+  render: ({ name, status, parameters, result }) => (
+    <McpToolCall status={status} name={name} args={parameters} result={result} />
+  ),
+});
+```
+
+Reach for an MCP App here only if the *result* is genuinely interactive — a chart the user filters, not a table they read.
+
+### Action and mutation servers
+
+When a tool sends an email, files a ticket, or deletes a row, the user needs to see it — and usually needs to authorize it. That's still not an MCP App: it's a renderer plus human-in-the-loop.
+
+The renderer shows what happened. The approval step decides whether it happens at all, and belongs on anything the user can't undo. See [Human in the loop](/human-in-the-loop) for the approval flow, and [Tool rendering](/generative-ui/tool-rendering) for renderer options.
+
+A useful test: if you're considering an MCP App purely to render a confirmation button, you want human-in-the-loop instead. Approval is a CopilotKit concern, not a server-supplied UI.
+
+### Interactive MCP Apps
+
+An MCP App is the right answer when the *server* owns the interface — it exposes a tool with an associated UI resource, and CopilotKit fetches and renders that resource in a sandboxed iframe with no frontend code from you.
+
+That's worth it when the interaction is rich enough to need real UI (a seat picker, a configuration form, an embedded editor), and when the server author — not the app author — is the one who should define how it looks. The cost is that the server now ships and versions UI, so a read-only lookup doesn't justify it.
+
+See [MCP Apps](/generative-ui/mcp-apps) for setup.
+
+<Callout type="info">
+  These aren't exclusive. One server can expose plain tools and App-backed tools side by
+  side; CopilotKit renders each call according to whether it carries a UI resource.
+</Callout>
+
 ## Quickstart with CopilotKit
 
 <Steps>

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -450,7 +450,7 @@ Verifying *who* the caller is doesn't yet stop them reaching *someone else's con
 
 | Runtime | Who scopes threads to a user |
 | --- | --- |
-| `CopilotRuntime` with `intelligence` | Mostly the runtime, via [`identifyUser`](#the-intelligence-platform-scopes-most-thread-routes) — with two inspector routes you still have to guard. |
+| `CopilotRuntime` with `intelligence` | Mostly the runtime, via [`identifyUser`](#the-intelligence-platform-scopes-most-thread-routes) — with three routes you still have to guard. |
 | Anything else — SSE runtime, custom store, local in-memory runner | You do. See [Scope threads yourself](#scope-threads-yourself). |
 
 ### The Intelligence Platform scopes most thread routes
@@ -470,7 +470,15 @@ const runtime = new CopilotRuntime({
 });
 ```
 
-Every route resolves the caller this way, so an unauthenticated request is rejected everywhere. What differs is whether the resolved id is then *carried to the platform* as a scope:
+<Callout type="warn" title="`identifyUser` is not an authentication gate">
+  Most routes resolve the caller through `identifyUser`, but **not all of them do** — and the
+  ones that don't never invoke your callback at all. Rejecting unauthenticated requests is
+  `onRequest`'s job: it runs before routing, on every route, without exception. Treat
+  `identifyUser` as the thing that *names* an already-authenticated caller, never as the thing
+  that decides whether a caller gets in.
+</Callout>
+
+Where a route does resolve the caller, what matters next is whether that id is actually *carried to the platform* as a scope:
 
 | Route | Scoped to the resolved user? |
 | --- | --- |
@@ -479,34 +487,53 @@ Every route resolves the caller this way, so an unauthenticated request is rejec
 | `threads/messages` | Yes |
 | `threads/update` (rename via `PATCH`, delete via `DELETE`), `threads/archive` | Yes |
 | Thread subscription token | Yes |
-| `threads/events`, `threads/state` | **No** — see the callout below |
+| `threads/events`, `threads/state` | **No** — resolves the caller, then ignores it |
+| `agent/stop` | **No** — never resolves a caller at all |
 
-<Callout type="warn" title="`threads/events` and `threads/state` are not user-scoped">
-  These two routes back the [inspector](/inspector). Both resolve the caller through
-  `identifyUser` and then discard the result, reading the thread by id alone — the runtime
-  calls the platform's project-authenticated `_inspect` endpoints, which take no user
-  parameter. Any caller `identifyUser` accepts can read the full event log and current agent
-  state of any thread in the project, given its `threadId`.
+<Callout type="warn" title="Three routes are not user-scoped">
+  **`threads/events` and `threads/state`** back the [inspector](/inspector). Both resolve the
+  caller and then discard the result, reading the thread by id alone — the runtime calls the
+  platform's project-authenticated `_inspect` endpoints, which take no user parameter. Any
+  caller can read the full event log and current agent state of any thread in the project,
+  given its `threadId`.
 
-  Guard them yourself until the platform scopes them. The `onBeforeHandler` pattern below
-  applies on the Intelligence path too, narrowed to these two routes:
+  **`agent/stop`** never resolves a caller. It goes straight to `runner.stop({ threadId })`,
+  which aborts whichever run the runtime is tracking under that thread id. Any caller who
+  learns an active `threadId` can kill that run mid-flight.
+
+  Guard all three yourself. The `onBeforeHandler` pattern below applies on the Intelligence
+  path too, narrowed to these routes:
 
   ```ts
-  onBeforeHandler: async ({ route }) => {
-    if (route.method !== "threads/events" && route.method !== "threads/state") return;
+  onBeforeHandler: async ({ request, route }) => {
+    // Switch rather than an array `includes`, so `route` narrows and
+    // `route.threadId` type-checks — all three variants carry one.
+    switch (route.method) {
+      case "threads/events":
+      case "threads/state":
+      case "agent/stop":
+        break;
+      default:
+        return;
+    }
 
-    // Neither route is scoped platform-side. Reject outright unless you keep an
-    // ownership record of your own to check `route.threadId` against.
-    throw new Response("Not found", { status: 404 });
+    // None of these is scoped platform-side; check your own ownership record.
+    const user = await verifyRequest(request);
+    if (!(await userOwnsThread(user.id, route.threadId))) {
+      throw new Response("Not found", { status: 404 });
+    }
   },
   ```
+
+  Without an ownership record of your own, reject these routes outright rather than leaving
+  them open.
 </Callout>
 
 For everything in the Yes rows there is no ownership table to build. What you own is `identifyUser` itself:
 
 - **Derive the id from a server-verified credential.** The callback receives the raw `Request`; whatever it returns is trusted from there on. Reading a user id straight out of a header or request body hands every caller the ability to name themselves.
 - **Return a stable id.** It is the key threads hang off. Change it — swapping an email for a subject claim, say — and that user's existing threads stop resolving.
-- **Send the `401` from `onRequest`.** An `identifyUser` that throws surfaces as a `500`, and returning a malformed id gives a `400` — neither is what an unauthenticated caller should see. Do the authenticate-or-reject step in `onRequest`, which can throw a `Response` directly, and keep the throw inside `identifyUser` as a backstop for the case that slips through.
+- **Send the `401` from `onRequest`.** Beyond the status codes being wrong — an `identifyUser` that throws surfaces as a `500`, a malformed id as a `400` — routes like `agent/stop` never call it, so a check placed only here isn't reached on every request. Authenticate in `onRequest`, which runs on every route and can throw a `Response` directly, and keep the throw inside `identifyUser` as a backstop.
 
 <Callout type="warn">
   A static `identifyUser` value is suitable only for a single-user demo. In a multi-user
@@ -518,7 +545,7 @@ See [Scope Rich Threads to the signed-in user](/threads-lifecycle#scope-rich-thr
 
 ### Scope threads yourself
 
-Without the Intelligence Platform there is no server-side binding between a `threadId` and a user. A `threadId` is just an opaque id travelling in a request: if user A learns user B's, every thread route accepts it. The rest of this section is the pattern for a custom store, a plain SSE runtime, or the local in-memory runner — and it's also what you narrow to `threads/events` and `threads/state` if you *are* on the platform.
+Without the Intelligence Platform there is no server-side binding between a `threadId` and a user. A `threadId` is just an opaque id travelling in a request: if user A learns user B's, every thread route accepts it. The rest of this section is the pattern for a custom store, a plain SSE runtime, or the local in-memory runner — and it's also what you narrow to `threads/events`, `threads/state`, and `agent/stop` if you *are* on the platform.
 
 #### Own the mapping
 
@@ -597,7 +624,8 @@ Filter server-side. Hiding rows in the UI leaves the underlying route open.
 
 - **Always validate** the token on the backend. Never trust the frontend's claim.
 - **Scope every read and write** to the resolved user. Auth context only matters if you actually use it to filter data.
-- **Bind threads to a user.** On the Intelligence Platform that means a correct `identifyUser`, plus your own guard on `threads/events` and `threads/state`; off it, an ownership check on every thread route rather than only at login. See [Thread authorization](#thread-authorization).
+- **Authenticate in `onRequest`.** It is the only hook that runs on every route. `identifyUser` names a caller; it does not gate one, and some routes never invoke it.
+- **Bind threads to a user.** On the Intelligence Platform that means a correct `identifyUser`, plus your own guard on `threads/events`, `threads/state`, and `agent/stop`; off it, an ownership check on every thread route rather than only at login. See [Thread authorization](#thread-authorization).
 - **Don't log raw tokens.** Log the resolved user id (or `anonymous`) instead.
 - **Use HTTPS in production.** The Bearer token is sensitive.
 - **Refresh strategy.** Your frontend is responsible for rotating expired tokens before they reach the agent. CopilotKit doesn't refresh on your behalf.

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -450,12 +450,12 @@ Verifying *who* the caller is doesn't yet stop them reaching *someone else's con
 
 | Runtime | Who scopes threads to a user |
 | --- | --- |
-| `CopilotRuntime` with `intelligence` | The runtime does, via [`identifyUser`](#the-intelligence-platform-scopes-threads-for-you). |
+| `CopilotRuntime` with `intelligence` | Mostly the runtime, via [`identifyUser`](#the-intelligence-platform-scopes-most-thread-routes) — with two inspector routes you still have to guard. |
 | Anything else — SSE runtime, custom store, local in-memory runner | You do. See [Scope threads yourself](#scope-threads-yourself). |
 
-### The Intelligence Platform scopes threads for you
+### The Intelligence Platform scopes most thread routes
 
-The Intelligence runtime requires an `identifyUser` callback — construction throws without one (or without at least one Channel). It runs on the server, once per request, and the id it returns is what the runtime passes to the platform on every thread-bearing route:
+The Intelligence runtime requires an `identifyUser` callback — construction throws without one (or without at least one Channel). It runs on the server, once per request, and the id it returns is the scope the runtime hands to the platform:
 
 ```ts title="app/api/copilotkit/[[...slug]]/route.ts"
 const runtime = new CopilotRuntime({
@@ -470,9 +470,39 @@ const runtime = new CopilotRuntime({
 });
 ```
 
-That resolved id is applied to `agent/run`, `agent/connect`, the thread message, event, and state reads, `threads/update`, `threads/archive`, `threads/delete`, and the token minted for the thread subscription. `threads/list` is scoped by the resolved user *and* filtered by `agentId`, so `useThreads` returns the caller's threads rather than every thread in the project.
+Every route resolves the caller this way, so an unauthenticated request is rejected everywhere. What differs is whether the resolved id is then *carried to the platform* as a scope:
 
-So on this path there is no ownership table to build. What you own is `identifyUser` itself:
+| Route | Scoped to the resolved user? |
+| --- | --- |
+| `agent/run`, `agent/connect` | Yes |
+| `threads/list` | Yes — and filtered by `agentId`, so `useThreads` returns the caller's threads rather than the project's |
+| `threads/messages` | Yes |
+| `threads/update` (rename via `PATCH`, delete via `DELETE`), `threads/archive` | Yes |
+| Thread subscription token | Yes |
+| `threads/events`, `threads/state` | **No** — see the callout below |
+
+<Callout type="warn" title="`threads/events` and `threads/state` are not user-scoped">
+  These two routes back the [inspector](/inspector). Both resolve the caller through
+  `identifyUser` and then discard the result, reading the thread by id alone — the runtime
+  calls the platform's project-authenticated `_inspect` endpoints, which take no user
+  parameter. Any caller `identifyUser` accepts can read the full event log and current agent
+  state of any thread in the project, given its `threadId`.
+
+  Guard them yourself until the platform scopes them. The `onBeforeHandler` pattern below
+  applies on the Intelligence path too, narrowed to these two routes:
+
+  ```ts
+  onBeforeHandler: async ({ route }) => {
+    if (route.method !== "threads/events" && route.method !== "threads/state") return;
+
+    // Neither route is scoped platform-side. Reject outright unless you keep an
+    // ownership record of your own to check `route.threadId` against.
+    throw new Response("Not found", { status: 404 });
+  },
+  ```
+</Callout>
+
+For everything in the Yes rows there is no ownership table to build. What you own is `identifyUser` itself:
 
 - **Derive the id from a server-verified credential.** The callback receives the raw `Request`; whatever it returns is trusted from there on. Reading a user id straight out of a header or request body hands every caller the ability to name themselves.
 - **Return a stable id.** It is the key threads hang off. Change it — swapping an email for a subject claim, say — and that user's existing threads stop resolving.
@@ -488,7 +518,7 @@ See [Scope Rich Threads to the signed-in user](/threads-lifecycle#scope-rich-thr
 
 ### Scope threads yourself
 
-Without the Intelligence Platform there is no server-side binding between a `threadId` and a user. A `threadId` is just an opaque id travelling in a request: if user A learns user B's, every thread route accepts it. The rest of this section is the pattern for a custom store, a plain SSE runtime, or the local in-memory runner.
+Without the Intelligence Platform there is no server-side binding between a `threadId` and a user. A `threadId` is just an opaque id travelling in a request: if user A learns user B's, every thread route accepts it. The rest of this section is the pattern for a custom store, a plain SSE runtime, or the local in-memory runner — and it's also what you narrow to `threads/events` and `threads/state` if you *are* on the platform.
 
 #### Own the mapping
 
@@ -567,7 +597,7 @@ Filter server-side. Hiding rows in the UI leaves the underlying route open.
 
 - **Always validate** the token on the backend. Never trust the frontend's claim.
 - **Scope every read and write** to the resolved user. Auth context only matters if you actually use it to filter data.
-- **Bind threads to a user.** On the Intelligence Platform that means a correct `identifyUser`; off it, an ownership check on every thread route rather than only at login. See [Thread authorization](#thread-authorization).
+- **Bind threads to a user.** On the Intelligence Platform that means a correct `identifyUser`, plus your own guard on `threads/events` and `threads/state`; off it, an ownership check on every thread route rather than only at login. See [Thread authorization](#thread-authorization).
 - **Don't log raw tokens.** Log the resolved user id (or `anonymous`) instead.
 - **Use HTTPS in production.** The Bearer token is sensitive.
 - **Refresh strategy.** Your frontend is responsible for rotating expired tokens before they reach the agent. CopilotKit doesn't refresh on your behalf.

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -446,9 +446,51 @@ This composes with [Human in the loop](/human-in-the-loop): gate on auth first, 
 
 ## Thread authorization
 
-Verifying *who* the caller is doesn't yet stop them reaching *someone else's conversation*. A `threadId` is just an opaque id travelling in a request — nothing in the runtime ties it to a user on its own. If user A learns user B's `threadId`, every thread route accepts it. Scoping threads to their owner is your responsibility, and it belongs in the runtime.
+Verifying *who* the caller is doesn't yet stop them reaching *someone else's conversation*. How much of that you have to build depends on which runtime you're running.
 
-### Own the mapping
+| Runtime | Who scopes threads to a user |
+| --- | --- |
+| `CopilotRuntime` with `intelligence` | The runtime does, via [`identifyUser`](#the-intelligence-platform-scopes-threads-for-you). |
+| Anything else — SSE runtime, custom store, local in-memory runner | You do. See [Scope threads yourself](#scope-threads-yourself). |
+
+### The Intelligence Platform scopes threads for you
+
+The Intelligence runtime requires an `identifyUser` callback — construction throws without one (or without at least one Channel). It runs on the server, once per request, and the id it returns is what the runtime passes to the platform on every thread-bearing route:
+
+```ts title="app/api/copilotkit/[[...slug]]/route.ts"
+const runtime = new CopilotRuntime({
+  agents: { default: agent },
+  intelligence,
+  identifyUser: async (request) => {
+    const session = await verifyAppSession(request); // Your server-side auth.
+    if (!session?.user) throw new Error("Unauthorized"); // Backstop; see below.
+
+    return { id: session.user.id, name: session.user.name };
+  },
+});
+```
+
+That resolved id is applied to `agent/run`, `agent/connect`, the thread message, event, and state reads, `threads/update`, `threads/archive`, `threads/delete`, and the token minted for the thread subscription. `threads/list` is scoped by the resolved user *and* filtered by `agentId`, so `useThreads` returns the caller's threads rather than every thread in the project.
+
+So on this path there is no ownership table to build. What you own is `identifyUser` itself:
+
+- **Derive the id from a server-verified credential.** The callback receives the raw `Request`; whatever it returns is trusted from there on. Reading a user id straight out of a header or request body hands every caller the ability to name themselves.
+- **Return a stable id.** It is the key threads hang off. Change it — swapping an email for a subject claim, say — and that user's existing threads stop resolving.
+- **Send the `401` from `onRequest`.** An `identifyUser` that throws surfaces as a `500`, and returning a malformed id gives a `400` — neither is what an unauthenticated caller should see. Do the authenticate-or-reject step in `onRequest`, which can throw a `Response` directly, and keep the throw inside `identifyUser` as a backstop for the case that slips through.
+
+<Callout type="warn">
+  A static `identifyUser` value is suitable only for a single-user demo. In a multi-user
+  application every request must resolve the authenticated user, or those users share one
+  thread scope.
+</Callout>
+
+See [Scope Rich Threads to the signed-in user](/threads-lifecycle#scope-rich-threads-to-the-signed-in-user) for the full runtime contract.
+
+### Scope threads yourself
+
+Without the Intelligence Platform there is no server-side binding between a `threadId` and a user. A `threadId` is just an opaque id travelling in a request: if user A learns user B's, every thread route accepts it. The rest of this section is the pattern for a custom store, a plain SSE runtime, or the local in-memory runner.
+
+#### Own the mapping
 
 Whatever stores your threads, keep a record of who each one belongs to. The minimum is a table your runtime can query:
 
@@ -462,7 +504,7 @@ create index on thread_owners (user_id);
 
 Write a row when a conversation is first created — see [minting a thread with your own API](/threads-lifecycle#creating-a-thread-with-your-own-api-on-the-first-message) for where that hooks into the chat lifecycle.
 
-### Enforce it in `onBeforeHandler`
+#### Enforce it in `onBeforeHandler`
 
 `onRequest` runs before routing, so it can't see which thread is being addressed. `onBeforeHandler` runs after, and receives a `route` that names the operation and — for thread-scoped routes — the `threadId`:
 
@@ -510,23 +552,22 @@ The routes that carry a `threadId` on `route` are `agent/stop`, `threads/update`
   must own it". Minting UUIDs makes guessing impractical but is not itself a control.
 </Callout>
 
-### Filter the thread list
+#### Filter the thread list
 
-`threads/list` has no `threadId` to check — it returns whatever the configured store holds. On the Enterprise Intelligence Platform, threads are scoped to a project, so every user of one project sees that project's threads. If your product needs per-user thread lists, either give each user their own project scope, or build the list from your own ownership table and drive the chat with the selected id rather than rendering the platform list directly.
+`threads/list` has no `threadId` to check, so `onBeforeHandler` has nothing to authorize against. Off the platform the route returns whatever the configured store holds — the local in-memory runner filters by `agentId` only, and a custom store returns exactly what you wrote. Build the list from your own ownership table instead, and drive the chat with the selected id.
 
-`useThreads` is the platform-backed list. When you filter, filter server-side — hiding rows in the UI leaves the underlying route open.
+Filter server-side. Hiding rows in the UI leaves the underlying route open.
 
 <Callout type="info">
-  Running without the Enterprise Intelligence Platform? Then there is no server-side thread
-  store to authorize in the first place, and the ownership table above *is* your thread list.
-  See [Self-managed thread persistence](/threads-self-managed).
+  With no platform thread store, the ownership table above *is* your thread list. See
+  [Self-managed thread persistence](/threads-self-managed).
 </Callout>
 
 ## Security checklist
 
 - **Always validate** the token on the backend. Never trust the frontend's claim.
 - **Scope every read and write** to the resolved user. Auth context only matters if you actually use it to filter data.
-- **Check thread ownership on every thread route**, not just at login. See [Thread authorization](#thread-authorization).
+- **Bind threads to a user.** On the Intelligence Platform that means a correct `identifyUser`; off it, an ownership check on every thread route rather than only at login. See [Thread authorization](#thread-authorization).
 - **Don't log raw tokens.** Log the resolved user id (or `anonymous`) instead.
 - **Use HTTPS in production.** The Bearer token is sensitive.
 - **Refresh strategy.** Your frontend is responsible for rotating expired tokens before they reach the agent. CopilotKit doesn't refresh on your behalf.

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -444,10 +444,89 @@ def delete_record(record_id: str, *, user: User):
 
 This composes with [Human in the loop](/human-in-the-loop): gate on auth first, surface a confirmation card next, execute last.
 
+## Thread authorization
+
+Verifying *who* the caller is doesn't yet stop them reaching *someone else's conversation*. A `threadId` is just an opaque id travelling in a request — nothing in the runtime ties it to a user on its own. If user A learns user B's `threadId`, every thread route accepts it. Scoping threads to their owner is your responsibility, and it belongs in the runtime.
+
+### Own the mapping
+
+Whatever stores your threads, keep a record of who each one belongs to. The minimum is a table your runtime can query:
+
+```sql
+create table thread_owners (
+  thread_id text primary key,
+  user_id   text not null
+);
+create index on thread_owners (user_id);
+```
+
+Write a row when a conversation is first created — see [minting a thread with your own API](/threads-lifecycle#creating-a-thread-with-your-own-api-on-the-first-message) for where that hooks into the chat lifecycle.
+
+### Enforce it in `onBeforeHandler`
+
+`onRequest` runs before routing, so it can't see which thread is being addressed. `onBeforeHandler` runs after, and receives a `route` that names the operation and — for thread-scoped routes — the `threadId`:
+
+```ts
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  hooks: {
+    onRequest: async ({ request }) => {
+      // Authenticate first: reject anonymous callers outright.
+      const user = await verifyRequest(request);
+      if (!user) throw new Response("Unauthorized", { status: 401 });
+    },
+
+    onBeforeHandler: async ({ request, route }) => {
+      const user = await verifyRequest(request);
+
+      // Routes that name a thread directly.
+      if ("threadId" in route) {
+        if (!(await userOwnsThread(user.id, route.threadId))) {
+          throw new Response("Forbidden", { status: 403 });
+        }
+        return;
+      }
+
+      // agent/run and agent/connect carry the thread in the body instead.
+      if (route.method === "agent/run" || route.method === "agent/connect") {
+        // Clone: the handler still needs to read the original body.
+        const { threadId } = await request.clone().json();
+        if (threadId && !(await userOwnsThread(user.id, threadId))) {
+          throw new Response("Forbidden", { status: 403 });
+        }
+      }
+    },
+  },
+});
+```
+
+The routes that carry a `threadId` on `route` are `agent/stop`, `threads/update`, `threads/archive`, `threads/messages`, `threads/events`, and `threads/state`.
+
+<Callout type="warn" title="A thread id is not a secret">
+  Treat `threadId` as a public identifier, like a database primary key in a URL. It travels
+  through the browser, appears in logs, and is trivially enumerable if you mint sequential
+  ids. Authorization has to be an explicit ownership check — never "they knew the id, so they
+  must own it". Minting UUIDs makes guessing impractical but is not itself a control.
+</Callout>
+
+### Filter the thread list
+
+`threads/list` has no `threadId` to check — it returns whatever the configured store holds. On the Enterprise Intelligence Platform, threads are scoped to a project, so every user of one project sees that project's threads. If your product needs per-user thread lists, either give each user their own project scope, or build the list from your own ownership table and drive the chat with the selected id rather than rendering the platform list directly.
+
+`useThreads` is the platform-backed list. When you filter, filter server-side — hiding rows in the UI leaves the underlying route open.
+
+<Callout type="info">
+  Running without the Enterprise Intelligence Platform? Then there is no server-side thread
+  store to authorize in the first place, and the ownership table above *is* your thread list.
+  See [Self-managed thread persistence](/threads-self-managed).
+</Callout>
+
 ## Security checklist
 
 - **Always validate** the token on the backend. Never trust the frontend's claim.
 - **Scope every read and write** to the resolved user. Auth context only matters if you actually use it to filter data.
+- **Check thread ownership on every thread route**, not just at login. See [Thread authorization](#thread-authorization).
 - **Don't log raw tokens.** Log the resolved user id (or `anonymous`) instead.
 - **Use HTTPS in production.** The Bearer token is sensitive.
 - **Refresh strategy.** Your frontend is responsible for rotating expired tokens before they reach the agent. CopilotKit doesn't refresh on your behalf.

--- a/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
@@ -4,24 +4,25 @@ icon: "lucide/Cloud"
 description: Run the CopilotKit runtime on AWS Lambda, including the response-streaming setup a chat UI requires.
 ---
 
-The CopilotKit runtime is a Fetch handler, so it runs on Lambda without a server. The one thing that needs care is **streaming**: chat responses are served as Server-Sent Events, and most Lambda front doors buffer the whole response before returning it.
+The CopilotKit runtime is a Fetch handler, so it runs on Lambda without a server. The one thing that needs care is **streaming**: chat responses are served as Server-Sent Events, and a front door that buffers turns a live conversation into a long pause followed by the whole reply at once.
 
 ## Start here: pick the right front door
 
-<Callout type="warn" title="API Gateway cannot stream">
-  Neither API Gateway REST APIs nor HTTP APIs support response streaming. They buffer the
-  full response, then return it in one piece (capped at 10 MB). A chat UI put behind API
-  Gateway appears to hang for the length of the agent run, then dumps the entire reply at
-  once. Application Load Balancer buffers the same way.
-</Callout>
-
 | Front door | Streams SSE? | Use it when |
 | --- | --- | --- |
-| **Lambda Function URL** with `RESPONSE_STREAM` | Yes | Anything with a chat UI. This is the path you want. |
-| API Gateway (REST or HTTP) | No | Non-streaming use only, or a runtime you drive entirely through your own non-chat endpoints. |
-| Application Load Balancer | No | Same caveat as API Gateway. |
+| **Lambda Function URL** with `InvokeMode: RESPONSE_STREAM` | Yes | The default. Nothing sits between the browser and the function. |
+| **API Gateway REST API** with `responseTransferMode: STREAM` | Yes | You need REST API features in front of the runtime — WAF, usage plans, a custom authorizer, or an existing REST API to extend. |
+| API Gateway **HTTP** API | No | Response streaming is REST-only. Buffered: 10 MB cap, 29-second timeout. |
+| Application Load Balancer | No | ALB has no streaming path for Lambda targets. |
 
-The rest of this page covers the Function URL path first, then the API Gateway path for the cases that genuinely don't need streaming.
+<Callout type="warn" title="Streaming is opt-in on every path">
+  Both streaming front doors default to buffering — a Function URL to `BUFFERED` invoke mode,
+  an API Gateway integration to `responseTransferMode: BUFFERED`. Deploy either without
+  flipping the switch and chat appears to hang for the length of the agent run, then dumps
+  the entire reply in one piece.
+</Callout>
+
+The handler code below is the same for both streaming paths; only the event shape and the infrastructure config differ.
 
 ## Function URL with response streaming
 
@@ -211,12 +212,141 @@ provideCopilotKit({
 <Callout type="info" title="Verify streaming actually works">
   `curl -N` on the run endpoint should print SSE events progressively. If the whole body
   arrives at once, streaming is not active — check that the Function URL's invoke mode is
-  `RESPONSE_STREAM` and that nothing buffering (API Gateway, an ALB) sits in front of it.
+  `RESPONSE_STREAM`, and that nothing buffering (an HTTP API, an ALB, a CloudFront
+  distribution without streaming configured) sits in front of it.
 </Callout>
 
-## API Gateway (no streaming)
+## API Gateway REST API with response streaming
 
-If you must sit behind API Gateway, `serverless-http` adapts the Express handler to a Lambda event. Chat still functions end to end, but every response arrives in one piece at the end of the run.
+REST APIs gained response streaming in November 2025. It is per-integration and off by default: setting `responseTransferMode` to `STREAM` makes API Gateway invoke the function through [`InvokeWithResponseStream`](https://docs.aws.amazon.com/lambda/latest/api/API_InvokeWithResponseStream.html) and forward bytes as they arrive, which also lifts the 10 MB response cap and the 29-second integration timeout that apply to buffered integrations.
+
+Use this path when you want REST API features in front of the runtime. If you don't, the Function URL above is less to configure.
+
+### 1. Adapt the handler to payload format 1.0
+
+The streaming half of the handler is unchanged — `awslambda.streamifyResponse` and `HttpResponseStream.from` emit exactly the metadata-plus-delimiter format API Gateway expects. What changes is the event: a REST proxy integration delivers payload format 1.0, not the 2.0 shape a Function URL sends.
+
+```ts title="src/handler.ts"
+import type { APIGatewayProxyEvent } from "aws-lambda";
+
+// REST proxy integrations deliver payload format 1.0: `httpMethod` and `path`
+// rather than `requestContext.http.method` and `rawPath`. `path` excludes the
+// stage name, which is what we want — it lines up with the runtime's basePath.
+function toFetchRequest(event: APIGatewayProxyEvent): Request {
+  const method = event.httpMethod;
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(event.headers)) {
+    if (value != null) headers.append(name, value);
+  }
+
+  const query = new URLSearchParams();
+  for (const [name, values] of Object.entries(
+    event.multiValueQueryStringParameters ?? {},
+  )) {
+    for (const value of values ?? []) query.append(name, value);
+  }
+  const search = query.toString();
+
+  const hasBody = method !== "GET" && method !== "HEAD" && event.body != null;
+
+  return new Request(
+    `https://${headers.get("host") ?? "localhost"}${event.path}${search ? `?${search}` : ""}`,
+    {
+      method,
+      headers,
+      body: hasBody
+        ? event.isBase64Encoded
+          ? Buffer.from(event.body!, "base64")
+          : event.body
+        : undefined,
+    },
+  );
+}
+```
+
+The `awslambda.streamifyResponse(...)` block from the Function URL section works as-is on top of this.
+
+### 2. Configure the integration
+
+Three settings matter: a Lambda **proxy** (`AWS_PROXY`) integration, a URI ending in `/response-streaming-invocations`, and `responseTransferMode: STREAM`. Streaming is not supported on non-proxy integration types.
+
+<Tabs groupId="iac" items={["AWS CLI", "AWS CDK", "AWS SAM"]}>
+<Tab value="AWS CLI">
+On an existing integration, patch the URI and the transfer mode together, then redeploy the stage:
+
+```bash
+aws apigateway update-integration \
+  --rest-api-id a1b2c3 \
+  --resource-id aaa111 \
+  --http-method ANY \
+  --patch-operations '[
+    {"op":"replace","path":"/uri","value":"arn:aws:apigateway:us-east-1:lambda:path/2021-11-15/functions/arn:aws:lambda:us-east-1:111122223333:function:copilotkit-runtime/response-streaming-invocations"},
+    {"op":"replace","path":"/responseTransferMode","value":"STREAM"},
+    {"op":"replace","path":"/timeoutInMillis","value":"900000"}
+  ]'
+
+aws apigateway create-deployment --rest-api-id a1b2c3 --stage-name prod
+```
+
+Note the API version in the URI path: `2021-11-15/.../response-streaming-invocations`, not the `2015-03-31/.../invocations` a buffered Lambda proxy integration uses. The permission is unchanged — `InvokeWithResponseStream` authorizes against `lambda:InvokeFunction`, so an existing `add-permission` grant still applies.
+</Tab>
+<Tab value="AWS CDK">
+```ts title="lib/stack.ts"
+import { LambdaIntegration, ResponseTransferMode, RestApi, EndpointType } from "aws-cdk-lib/aws-apigateway";
+import { Duration } from "aws-cdk-lib";
+
+const api = new RestApi(this, "CopilotKitApi", {
+  // Regional gets a 5-minute idle timeout; edge-optimized gets 30 seconds.
+  endpointConfiguration: { types: [EndpointType.REGIONAL] },
+});
+
+api.root.addResource("api").addResource("copilotkit").addResource("{proxy+}").addMethod(
+  "ANY",
+  new LambdaIntegration(fn, {
+    responseTransferMode: ResponseTransferMode.STREAM,
+    timeout: Duration.minutes(15),
+  }),
+);
+```
+
+`responseTransferMode` needs a recent `aws-cdk-lib`; the construct sets the streaming invocation URI for you.
+</Tab>
+<Tab value="AWS SAM">
+```yaml title="template.yaml"
+CopilotKitMethod:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    RestApiId: !Ref CopilotKitApi
+    ResourceId: !Ref CopilotKitProxyResource
+    HttpMethod: ANY
+    AuthorizationType: NONE
+    Integration:
+      Type: AWS_PROXY
+      IntegrationHttpMethod: POST
+      ResponseTransferMode: STREAM
+      TimeoutInMillis: 900000
+      Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2021-11-15/functions/${CopilotKitRuntime.Arn}/response-streaming-invocations
+```
+</Tab>
+</Tabs>
+
+### 3. Plan around the streaming constraints
+
+- **Pick a Regional endpoint.** Streams are subject to an idle timeout: 5 minutes for Regional and private endpoints, but **30 seconds for edge-optimized ones**. An agent that thinks for longer than 30 seconds between SSE events will have its stream cut on an edge-optimized API. Fronting a Regional API with your own CloudFront distribution and raising its response timeout is the way to keep an edge cache.
+- **Raise the integration timeout.** It still defaults to 29 seconds. With `STREAM` you can take it up to 15 minutes on Regional and private APIs — match it to the Lambda timeout.
+- **`STREAM` disables buffered-only features** on that integration: endpoint caching, content encoding, and VTL response transformation. Compress inside the integration if you need it.
+- **Bandwidth.** The first 10 MB of each streamed response is uncapped; beyond that API Gateway throttles to 2 MB/s.
+- **A client timeout doesn't stop the function.** When API Gateway closes the connection, the Lambda keeps running and billing until it finishes or hits its own timeout.
+
+<Callout type="warn" title="The console test tab always buffers">
+  `TestInvokeMethod` and the console's **Test** tab buffer the stream and return it in one
+  piece, so a correctly configured integration still looks buffered there. Verify against a
+  deployed stage with `curl -i --no-buffer` instead.
+</Callout>
+
+## Buffered fallback: HTTP APIs and ALB
+
+Behind an HTTP API or an Application Load Balancer there is no streaming path, so `serverless-http` adapting the Express handler is as good as it gets. Chat still functions end to end, but every response arrives in one piece at the end of the run.
 
 ```
 npm install express serverless-http @copilotkit/runtime
@@ -250,7 +380,7 @@ export const handler = serverlessHttp(app);
 Two constraints to plan around:
 
 - **10 MB response cap.** A long agent run with large tool results can exceed it, and the request fails rather than truncating.
-- **29-second integration timeout** on API Gateway REST and HTTP APIs. Agent runs longer than that return a 504 even though the Lambda keeps executing.
+- **29-second integration timeout.** Agent runs longer than that return a 504 even though the Lambda keeps executing. On an HTTP API this ceiling is fixed; both limits are what `responseTransferMode: STREAM` lifts on a REST API.
 
 Single-route mode pairs well here, since it collapses the runtime to one `POST` and avoids configuring a catch-all proxy resource:
 
@@ -265,7 +395,7 @@ createCopilotExpressHandler({
 
 ## Authentication
 
-Use the runtime's `onRequest` hook to reject unauthenticated calls before any routing happens. It works identically on both paths above.
+Use the runtime's `onRequest` hook to reject unauthenticated calls before any routing happens. It works identically on every front door above.
 
 ```ts
 const copilotHandler = createCopilotRuntimeHandler({
@@ -294,7 +424,7 @@ See [Authentication](/auth) for forwarding user identity through to your agent.
 - **Construct the runtime outside the handler.** Putting `new CopilotRuntime(...)` at module scope means warm invocations reuse it rather than rebuilding it per request.
 - **Set the timeout to cover a full agent run.** Lambda's maximum is 15 minutes; the default of 3 seconds will cut off almost anything.
 - **Cold starts are visible in chat.** Provisioned concurrency is the usual fix if first-token latency matters.
-- **Streaming has its own limits.** Function URL response streaming allows a larger payload than the 6 MB buffered limit, but bandwidth beyond the first 6 MB is billed separately.
+- **Streaming has its own limits.** A streamed response can reach 200 MB against the 6 MB buffered ceiling, but Lambda throttles to 2 MB/s past the first 6 MB (API Gateway, past the first 10 MB). Streaming also incurs cost, and a streamed run is billed for the full function duration even if the client disconnects.
 
 ## Related
 

--- a/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
@@ -1,0 +1,303 @@
+---
+title: AWS Lambda
+icon: "lucide/Cloud"
+description: Run the CopilotKit runtime on AWS Lambda, including the response-streaming setup a chat UI requires.
+---
+
+The CopilotKit runtime is a Fetch handler, so it runs on Lambda without a server. The one thing that needs care is **streaming**: chat responses are served as Server-Sent Events, and most Lambda front doors buffer the whole response before returning it.
+
+## Start here: pick the right front door
+
+<Callout type="warn" title="API Gateway cannot stream">
+  Neither API Gateway REST APIs nor HTTP APIs support response streaming. They buffer the
+  full response, then return it in one piece (capped at 10 MB). A chat UI put behind API
+  Gateway appears to hang for the length of the agent run, then dumps the entire reply at
+  once. Application Load Balancer buffers the same way.
+</Callout>
+
+| Front door | Streams SSE? | Use it when |
+| --- | --- | --- |
+| **Lambda Function URL** with `RESPONSE_STREAM` | Yes | Anything with a chat UI. This is the path you want. |
+| API Gateway (REST or HTTP) | No | Non-streaming use only, or a runtime you drive entirely through your own non-chat endpoints. |
+| Application Load Balancer | No | Same caveat as API Gateway. |
+
+The rest of this page covers the Function URL path first, then the API Gateway path for the cases that genuinely don't need streaming.
+
+## Function URL with response streaming
+
+Response streaming requires three things: a Function URL with its invoke mode set to `RESPONSE_STREAM`, a handler wrapped in `awslambda.streamifyResponse`, and a Node.js managed runtime (Node.js 18 or later).
+
+### 1. The handler
+
+Lambda Function URLs deliver events in payload format 2.0. Convert that into a `Request`, hand it to the CopilotKit handler, then pipe the `Response` body into the Lambda response stream.
+
+```ts title="src/handler.ts"
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { LambdaFunctionURLEvent } from "aws-lambda";
+import {
+  CopilotRuntime,
+  createCopilotRuntimeHandler,
+  BuiltInAgent,
+} from "@copilotkit/runtime/v2";
+
+// Created once per container, reused across warm invocations.
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({ model: "openai/gpt-4o-mini" }),
+  },
+});
+
+const copilotHandler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  cors: true,
+});
+
+function toFetchRequest(event: LambdaFunctionURLEvent): Request {
+  const method = event.requestContext.http.method;
+  const host = event.headers.host ?? "localhost";
+  const query = event.rawQueryString ? `?${event.rawQueryString}` : "";
+
+  const hasBody = method !== "GET" && method !== "HEAD" && event.body != null;
+
+  return new Request(`https://${host}${event.rawPath}${query}`, {
+    method,
+    headers: new Headers(event.headers as Record<string, string>),
+    body: hasBody
+      ? event.isBase64Encoded
+        ? Buffer.from(event.body!, "base64")
+        : event.body
+      : undefined,
+  });
+}
+
+export const handler = awslambda.streamifyResponse(
+  async (event: LambdaFunctionURLEvent, responseStream) => {
+    const response = await copilotHandler(toFetchRequest(event));
+
+    // Status and headers must be attached before the first byte is written.
+    const stream = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode: response.status,
+      headers: Object.fromEntries(response.headers),
+    });
+
+    if (!response.body) {
+      stream.end();
+      return;
+    }
+
+    // Readable.fromWeb bridges the Fetch ReadableStream to a Node stream, so
+    // SSE chunks reach the client as the agent produces them.
+    await pipeline(Readable.fromWeb(response.body as any), stream);
+  },
+);
+```
+
+`awslambda` is a global injected by the managed Node.js runtime, so TypeScript needs to be told it exists:
+
+```ts title="src/awslambda.d.ts"
+import type { Writable } from "node:stream";
+
+declare global {
+  namespace awslambda {
+    function streamifyResponse<TEvent>(
+      handler: (event: TEvent, responseStream: Writable, context: unknown) => Promise<void>,
+    ): (event: TEvent, responseStream: Writable, context: unknown) => Promise<void>;
+
+    namespace HttpResponseStream {
+      function from(
+        stream: Writable,
+        metadata: { statusCode: number; headers?: Record<string, string> },
+      ): Writable;
+    }
+  }
+}
+
+export {};
+```
+
+### 2. Set the invoke mode
+
+Streaming is off by default. The Function URL must be created with `InvokeMode: RESPONSE_STREAM` — flipping it later requires updating the URL config, not the function.
+
+<Tabs groupId="iac" items={["AWS CLI", "AWS CDK", "AWS SAM"]}>
+<Tab value="AWS CLI">
+```bash
+aws lambda create-function-url-config \
+  --function-name copilotkit-runtime \
+  --auth-type NONE \
+  --invoke-mode RESPONSE_STREAM \
+  --cors '{"AllowOrigins":["https://myapp.com"],"AllowHeaders":["content-type","authorization"],"AllowMethods":["GET","POST"]}'
+```
+</Tab>
+<Tab value="AWS CDK">
+```ts title="lib/stack.ts"
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { Runtime, FunctionUrlAuthType, InvokeMode } from "aws-cdk-lib/aws-lambda";
+import { Duration } from "aws-cdk-lib";
+
+const fn = new NodejsFunction(this, "CopilotKitRuntime", {
+  entry: "src/handler.ts",
+  runtime: Runtime.NODEJS_22_X,
+  // Long enough for a full agent run; Lambda's ceiling is 15 minutes.
+  timeout: Duration.minutes(5),
+  memorySize: 1024,
+  environment: {
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
+  },
+});
+
+fn.addFunctionUrl({
+  authType: FunctionUrlAuthType.NONE,
+  invokeMode: InvokeMode.RESPONSE_STREAM,
+  cors: {
+    allowedOrigins: ["https://myapp.com"],
+    allowedHeaders: ["content-type", "authorization"],
+  },
+});
+```
+</Tab>
+<Tab value="AWS SAM">
+```yaml title="template.yaml"
+Resources:
+  CopilotKitRuntime:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: dist/handler.handler
+      Runtime: nodejs22.x
+      Timeout: 300
+      MemorySize: 1024
+      Environment:
+        Variables:
+          OPENAI_API_KEY: !Ref OpenAiApiKey
+      FunctionUrlConfig:
+        AuthType: NONE
+        InvokeMode: RESPONSE_STREAM
+        Cors:
+          AllowOrigins: ["https://myapp.com"]
+          AllowHeaders: ["content-type", "authorization"]
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Target: node22
+        Bundle: true
+        EntryPoints: [src/handler.ts]
+```
+</Tab>
+</Tabs>
+
+### 3. Point the frontend at it
+
+The Function URL is the origin; `basePath` is appended to it.
+
+<FrontendOnly frontend="react">
+```tsx
+<CopilotKit runtimeUrl="https://<url-id>.lambda-url.<region>.on.aws/api/copilotkit">
+  <YourApp />
+</CopilotKit>
+```
+</FrontendOnly>
+
+<FrontendOnly frontend="angular">
+```ts title="src/app/app.config.ts"
+provideCopilotKit({
+  runtimeUrl: "https://<url-id>.lambda-url.<region>.on.aws/api/copilotkit",
+})
+```
+</FrontendOnly>
+
+<Callout type="info" title="Verify streaming actually works">
+  `curl -N` on the run endpoint should print SSE events progressively. If the whole body
+  arrives at once, streaming is not active — check that the Function URL's invoke mode is
+  `RESPONSE_STREAM` and that nothing buffering (API Gateway, an ALB) sits in front of it.
+</Callout>
+
+## API Gateway (no streaming)
+
+If you must sit behind API Gateway, `serverless-http` adapts the Express handler to a Lambda event. Chat still functions end to end, but every response arrives in one piece at the end of the run.
+
+```
+npm install express serverless-http @copilotkit/runtime
+```
+
+```ts title="src/handler.ts"
+import express from "express";
+import serverlessHttp from "serverless-http";
+import { CopilotRuntime, BuiltInAgent } from "@copilotkit/runtime/v2";
+import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: new BuiltInAgent({ model: "openai/gpt-4o-mini" }),
+  },
+});
+
+const app = express();
+
+app.use(
+  createCopilotExpressHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    cors: true,
+  }),
+);
+
+export const handler = serverlessHttp(app);
+```
+
+Two constraints to plan around:
+
+- **10 MB response cap.** A long agent run with large tool results can exceed it, and the request fails rather than truncating.
+- **29-second integration timeout** on API Gateway REST and HTTP APIs. Agent runs longer than that return a 504 even though the Lambda keeps executing.
+
+Single-route mode pairs well here, since it collapses the runtime to one `POST` and avoids configuring a catch-all proxy resource:
+
+```ts
+createCopilotExpressHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  mode: "single-route",
+  cors: true,
+});
+```
+
+## Authentication
+
+Use the runtime's `onRequest` hook to reject unauthenticated calls before any routing happens. It works identically on both paths above.
+
+```ts
+const copilotHandler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  cors: true,
+  hooks: {
+    onRequest: async ({ request }) => {
+      const token = request.headers.get("authorization");
+      if (!token || !(await verifyToken(token))) {
+        // Throwing a Response short-circuits the handler.
+        throw new Response("Unauthorized", { status: 401 });
+      }
+    },
+  },
+});
+```
+
+For AWS-native auth instead, set the Function URL's `AuthType` to `AWS_IAM` and have callers sign requests with SigV4. That moves the check into IAM, but the browser can no longer call the URL directly — you need a signing proxy in between.
+
+See [Authentication](/auth) for forwarding user identity through to your agent.
+
+## Operational notes
+
+- **Bundle your dependencies.** `@copilotkit/runtime` is not in any AWS-managed layer. Use `NodejsFunction` (CDK), `BuildMethod: esbuild` (SAM), or your own bundler.
+- **Construct the runtime outside the handler.** Putting `new CopilotRuntime(...)` at module scope means warm invocations reuse it rather than rebuilding it per request.
+- **Set the timeout to cover a full agent run.** Lambda's maximum is 15 minutes; the default of 3 seconds will cut off almost anything.
+- **Cold starts are visible in chat.** Provisioned concurrency is the usual fix if first-token latency matters.
+- **Streaming has its own limits.** Function URL response streaming allows a larger payload than the 6 MB buffered limit, but bandwidth beyond the first 6 MB is billed separately.
+
+## Related
+
+- [Deploy to any runtime](/runtime-server-adapter) — the adapter reference these examples build on
+- [AWS AgentCore](/deploy/agentcore) — a managed AWS runtime for AG-UI agents, if you'd rather not operate Lambda yourself
+- [Authentication](/auth)

--- a/showcase/shell-docs/src/content/docs/deploy/meta.json
+++ b/showcase/shell-docs/src/content/docs/deploy/meta.json
@@ -5,6 +5,7 @@
   },
   "pages": [
     "agentcore",
+    "aws-lambda",
     "langsmith"
   ]
 }

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/meta.json
@@ -17,7 +17,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/agno/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/meta.json
@@ -17,7 +17,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/agno/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/meta.json
@@ -18,7 +18,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/meta.json
@@ -18,7 +18,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/meta.json
@@ -20,7 +20,8 @@
         "threads",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     }
   ]

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/guardrails.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/guardrails.mdx
@@ -1,0 +1,228 @@
+---
+title: Guardrails & DLP
+description: "Screen agent input and output with LangChain middleware — PII redaction, prompt-injection blocking, and custom policy checks — ordered correctly alongside CopilotKitMiddleware."
+icon: "lucide/ShieldCheck"
+doc_type: how-to
+---
+
+Anything a user types reaches your model, and anything the model produces reaches your user. Screening both is a middleware concern in LangGraph: `AgentMiddleware` gives you hooks around the agent, the model call, and every tool call, and `CopilotKitMiddleware` is itself one of these — so your checks compose with it rather than wrapping around the whole runtime.
+
+This page covers input screening, output and DLP screening, and how to order the two against CopilotKit's own middleware.
+
+## Where the hooks sit
+
+A run passes through these hooks in order:
+
+| Hook | Runs | Use it for |
+| --- | --- | --- |
+| `before_agent` | Once, before the run starts | Rejecting a whole conversation — rate limits, a blocked tenant |
+| `before_model` | Before every model call | Input screening on the latest user message |
+| `wrap_model_call` | Around every model call | Output screening; you see the request going in and the response coming back |
+| `wrap_tool_call` | Around every tool call | Screening tool arguments and tool results |
+| `after_model` | After every model call | Post-hoc inspection that doesn't need to modify the response |
+
+`before_*` hooks return a state-update dict (or `None`). `wrap_*` hooks receive a `handler` they must call to continue the chain — which is what lets them inspect and rewrite the result.
+
+## Start with the built-in PII middleware
+
+Before writing anything custom, check whether `PIIMiddleware` already covers you. It ships with LangChain and handles the common DLP cases in both directions:
+
+```python title="agent.py"
+from langchain.agents import create_agent
+from langchain.agents.middleware import PIIMiddleware
+from copilotkit import CopilotKitMiddleware
+
+agent = create_agent(
+    model="openai:gpt-4o",
+    tools=[...],
+    middleware=[
+        # Redact emails the user sends in.
+        PIIMiddleware("email", strategy="redact"),
+        # Mask card numbers wherever they appear, including in tool results.
+        PIIMiddleware(
+            "credit_card",
+            strategy="mask",
+            apply_to_output=True,
+            apply_to_tool_results=True,
+        ),
+        # Refuse outright if an API key shows up.
+        PIIMiddleware("api_key", detector=r"sk-[a-zA-Z0-9]{32}", strategy="block"),
+        CopilotKitMiddleware(),
+    ],
+)
+```
+
+Built-in types are `email`, `credit_card`, `ip`, `mac_address`, and `url`; any other name becomes a custom type driven by the `detector` you supply (a regex or a callable). Strategies are `block` (raises `PIIDetectionError`), `redact`, `mask`, and `hash`.
+
+<Callout type="info" title="apply_to_output is off by default">
+  `PIIMiddleware` screens **input** unless you say otherwise. Pass `apply_to_output=True` to
+  screen model output and `apply_to_tool_results=True` to screen what tools return — a
+  frequent source of leaked data, since tool results come from your own systems.
+</Callout>
+
+## Input screening
+
+For anything PII detection doesn't express — topic restrictions, prompt-injection heuristics, per-tenant policy — implement `before_model` and end the run when the check fails.
+
+```python title="guardrails.py"
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware, AgentState, hook_config
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.runtime import Runtime
+
+
+class InputFirewall(AgentMiddleware):
+    """Rejects user input that fails policy before it reaches the model."""
+
+    def __init__(self, *, refusal: str = "I can't help with that request."):
+        super().__init__()
+        self.refusal = refusal
+
+    # can_jump_to declares the edge; without it, "jump_to" is ignored.
+    @hook_config(can_jump_to=["end"])
+    def before_model(
+        self, state: AgentState, runtime: Runtime[Any]
+    ) -> dict[str, Any] | None:
+        messages = state.get("messages", [])
+        latest = next(
+            (m for m in reversed(messages) if isinstance(m, HumanMessage)), None
+        )
+        if latest is None:
+            return None
+
+        verdict = screen_input(str(latest.content))  # your classifier or rules
+        if not verdict.allowed:
+            # Ending with an AIMessage means the user sees the refusal in chat
+            # rather than an error toast.
+            return {
+                "jump_to": "end",
+                "messages": [AIMessage(content=self.refusal)],
+            }
+
+        return None
+```
+
+Two things worth knowing:
+
+- **`@hook_config(can_jump_to=["end"])` is required.** It declares the conditional edge at compile time. Returning `{"jump_to": "end"}` without it silently does nothing.
+- **Returning an `AIMessage` is friendlier than raising.** A raised exception surfaces as a run error; an injected message renders as a normal assistant turn, so the user gets an explanation and the conversation stays usable.
+
+## Output and DLP screening
+
+Output screening belongs in `wrap_model_call`, because that's the only hook that can rewrite what the model produced before anything downstream sees it. Call `handler(request)`, inspect the result, and return either the original response or a replacement.
+
+```python title="guardrails.py"
+from dataclasses import replace
+from typing import Awaitable, Callable
+
+from langchain.agents.middleware import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import AIMessage
+
+
+class OutputFirewall(AgentMiddleware):
+    """Scrubs or blocks model output before it leaves the agent."""
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        response = handler(request)
+
+        scrubbed = []
+        for message in response.result:
+            if isinstance(message, AIMessage) and isinstance(message.content, str):
+                clean = redact_sensitive(message.content)  # your DLP pass
+                if clean != message.content:
+                    message = message.model_copy(update={"content": clean})
+            scrubbed.append(message)
+
+        return replace(response, result=scrubbed)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        response = await handler(request)
+        # ...same scrubbing as above
+        return response
+```
+
+<Callout type="warn" title="Streaming bypasses a naive output filter">
+  `wrap_model_call` sees the completed response. When the model streams, tokens have already
+  reached the browser by then — so a scrub applied here fixes the stored message while the
+  user may have briefly seen the original. `PIIMiddleware` handles this by installing a
+  stream transformer alongside its state-level check. If your custom rule must hold during
+  streaming too, either express it as a `PIIMiddleware` custom detector, or don't stream the
+  screened agent.
+</Callout>
+
+Implement the `a`-prefixed variant (`awrap_model_call`, `abefore_model`) for async agents — the sync method is not used on the async path.
+
+## Screening tool calls
+
+Tools are the other boundary worth guarding: arguments carry user-influenced data outward, results carry system data back.
+
+```python
+from langgraph.types import Command
+from langchain_core.messages import ToolMessage
+from langchain.agents.middleware import ToolCallRequest
+
+
+class ToolFirewall(AgentMiddleware):
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        if not tool_call_allowed(request):  # your policy
+            return ToolMessage(
+                content="This action is not permitted.",
+                tool_call_id=request.tool_call["id"],
+            )
+        return handler(request)
+```
+
+Returning a `ToolMessage` without calling `handler` blocks execution while keeping the conversation coherent — the model sees a refusal it can respond to.
+
+## Ordering against `CopilotKitMiddleware`
+
+Middleware compose with **the first entry as the outermost layer**. For `wrap_*` hooks that means the first-listed middleware sees the request earliest and the response latest.
+
+`CopilotKitMiddleware` merges frontend tools into the request and intercepts frontend tool calls on the way back. Put your guardrails **before** it in the list:
+
+```python
+middleware=[
+    InputFirewall(),        # outermost: screens before anything else runs
+    OutputFirewall(),       # sees the final response last
+    CopilotKitMiddleware(), # innermost: frontend tools, state exposure
+]
+```
+
+That ordering matters for a specific reason: `CopilotKitMiddleware` adds the browser's frontend tools to the model request. A guardrail placed *after* it would be inspecting a request that already contains tools your policy layer didn't approve, and — more importantly — an output filter placed after it would run before CopilotKit finished assembling the response the frontend actually receives.
+
+<Callout type="info">
+  The list order is the only ordering control. There is no priority field, and a middleware
+  cannot declare that it must run before another.
+</Callout>
+
+## What this doesn't cover
+
+Middleware guards the agent. It does not guard the runtime around it — authenticating the caller, rate-limiting by user, or rejecting a request outright before an agent run starts belongs at the runtime layer instead:
+
+- [Authentication](/auth) — `onRequest` and `onBeforeHandler` hooks on the runtime handler
+- [Thread authorization](/auth#thread-authorization) — stopping one user reaching another's conversation
+
+And for actions that should require a human rather than a policy check, [Human in the loop](/human-in-the-loop) is the better tool: surface the action for approval instead of silently blocking it.
+
+## Related
+
+- [LangGraph agent configuration](/integrations/langgraph/configurable)
+- [Human in the loop](/human-in-the-loop)
+- [Authentication](/auth)

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/meta.json
@@ -28,6 +28,7 @@
     "configurable",
     "subgraphs",
     "auth",
+    "guardrails",
     "---Deploy---",
     "deploy-agentcore",
     "deploy-langsmith",

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/meta.json
@@ -17,7 +17,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/meta.json
@@ -17,7 +17,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/meta.json
@@ -17,7 +17,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/meta.json
@@ -17,7 +17,8 @@
         "prebuilt-components/copilot-threads-drawer",
         "headless-threads",
         "threads-lifecycle",
-        "threads-import"
+        "threads-import",
+        "threads-self-managed"
       ]
     },
     "custom-look-and-feel",

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -20,6 +20,7 @@
         "headless-threads",
         "threads-lifecycle",
         "threads-import",
+        "threads-self-managed",
         "premium/threads-explained"
       ]
     },

--- a/showcase/shell-docs/src/content/docs/threads-self-managed.mdx
+++ b/showcase/shell-docs/src/content/docs/threads-self-managed.mdx
@@ -1,0 +1,11 @@
+---
+title: Self-Managed Thread Persistence
+nav_title: Self-Managed Persistence
+description: "What conversation persistence looks like without the Enterprise Intelligence Platform: own the threadId, persist at the framework layer, build the thread list yourself."
+icon: "lucide/Database"
+doc_type: explanation
+---
+
+import SelfManagedThreads from "@/snippets/shared/threads/self-managed.mdx";
+
+<SelfManagedThreads components={props.components} />

--- a/showcase/shell-docs/src/content/snippets/shared/threads/self-managed.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/self-managed.mdx
@@ -1,0 +1,108 @@
+A common question: *how do I point CopilotKit's threads at my own database instead of the Enterprise Intelligence Platform?*
+
+The honest answer is that you can't, because there is no such extension point. CopilotKit does not define a "bring your own thread backend" endpoint spec that you can implement against — [Rich Threads](/threads) (`useThreads`, the [Threads Drawer](/prebuilt-components/copilot-threads-drawer), cross-device sync, replayable event history) are a capability of the [Enterprise Intelligence Platform](/premium/overview), not an interface with a swappable implementation.
+
+What you *can* do without the platform is persist conversations yourself. That path is real and it works — it just looks different from Rich Threads, and it's worth being clear about what you get and what you give up before you build it.
+
+## What each path gives you
+
+| | Self-managed | Enterprise Intelligence Platform |
+| --- | --- | --- |
+| Conversation survives a page reload | Yes, if your framework checkpoints it | Yes |
+| Conversation follows the user across devices | Yes, if your store is server-side and user-scoped | Yes |
+| Thread list, rename, archive, delete | You build it | `useThreads`, built in |
+| Full AG-UI event history replayed into the UI | No — you restore framework state, not the event log | Yes |
+| Generative UI and multimodal history restored | No | Yes |
+| Realtime sync across tabs and devices | No | Yes |
+| Resuming a run that's still in flight | No | Yes |
+
+The line that matters most is the fourth row. Framework-native persistence stores your agent's *state*; it does not store the AG-UI event stream that produced the visible conversation. So a restored conversation can continue correctly while still not looking the way it did when the user left it — rendered tool-call components, streamed reasoning, and attachments are re-derived from the event history, which nobody kept.
+
+## The self-managed path
+
+Three pieces, none of them CopilotKit-specific.
+
+### 1. Own the `threadId`
+
+Don't let CopilotKit mint the id. Mint it yourself, store it, and pass it in — that id is the only thing correlating the browser, the runtime, and your agent's store.
+
+```tsx
+<CopilotChat agentId="my-agent" threadId={conversationId} />
+```
+
+An auto-minted id is re-created on remount, which silently starts a new conversation. See [Thread lifecycle](/threads-lifecycle#how-the-threadid-is-created) for the full precedence rules.
+
+### 2. Persist at the framework layer
+
+CopilotKit forwards the `threadId` to your agent as the AG-UI `threadId`. Use it as — or map it to — your framework's own thread identifier, and let the framework's persistence do the storing.
+
+<Tabs items={["LangGraph", "Other frameworks"]}>
+<Tab value="LangGraph">
+A checkpointer persists graph state per thread:
+
+```python title="agent.py"
+from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+
+checkpointer = AsyncPostgresSaver.from_conn_string(DB_URL)
+graph = builder.compile(checkpointer=checkpointer)
+```
+
+The incoming `threadId` becomes the checkpointer's `thread_id`, so the next run against the same id resumes from the stored state. See [LangGraph message persistence](/integrations/langgraph/advanced/persistence/message-persistence).
+
+<Callout type="info">
+  A checkpointer creates LangGraph's own checkpoint tables. It does **not** create a
+  CopilotKit threads table, and configuring one does not make `useThreads` work.
+</Callout>
+</Tab>
+<Tab value="Other frameworks">
+The same shape applies wherever your framework keeps durable state — CrewAI memory, an ADK session service, or your own store keyed by the `threadId` you passed in. What matters is that the id arriving over AG-UI is the key you persist under.
+</Tab>
+</Tabs>
+
+### 3. Build the thread list yourself
+
+`useThreads` is platform-backed and will not return your rows, so the conversation list is application code: a table of `(thread_id, user_id, title, updated_at)` that you query and render, with the selected id handed to `<CopilotChat threadId={...} />`.
+
+Scope every query to the signed-in user, and check ownership on the runtime side too — see [Thread authorization](/auth#thread-authorization).
+
+## Restoring the visible conversation
+
+Framework state alone doesn't repopulate the UI. If you want prior messages on screen at mount, you have to put them there — read them from your store and set them on the agent:
+
+```tsx
+import { useEffect } from "react";
+import { useAgent } from "@copilotkit/react-core/v2";
+
+function RestoreHistory({ threadId }: { threadId: string }) {
+  const { agent } = useAgent({ agentId: "my-agent" });
+
+  useEffect(() => {
+    let cancelled = false;
+    myApi.getMessages(threadId).then((messages) => {
+      if (!cancelled) agent?.setMessages(messages);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, threadId]);
+
+  return null;
+}
+```
+
+This restores text. It does not restore generative UI, tool-call renders, or attachments — those come back only from a replayed AG-UI event history, which is what the platform store provides and a checkpointer does not.
+
+## When to stop building this and use the platform
+
+Self-managed persistence is a reasonable fit when conversations are simple and mostly textual, you already run a database and an auth layer, and you'd rather own the storage than add a dependency.
+
+It stops being the cheaper option once you want a thread list with rename and archive, conversations that look the same on return as when the user left, realtime sync across tabs, or the ability to rejoin a run still in progress. At that point you are re-implementing the platform, and the boundary in [OSS vs Enterprise](/concepts/oss-vs-enterprise) is worth re-reading.
+
+If you have existing conversations in a framework store and want them as Rich Threads, [Importing and synchronizing thread history](/threads-import) covers the migration.
+
+## Related
+
+- [Thread lifecycle](/threads-lifecycle) — how ids are minted, hydrated, and switched
+- [Thread authorization](/auth#thread-authorization) — scoping threads to their owner
+- [OSS vs Enterprise Intelligence Platform](/concepts/oss-vs-enterprise) — where the capability boundary sits
+- [Rich Threads](/threads) — what the platform-backed path looks like

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -514,6 +514,10 @@ describe("framework nav", () => {
       { title: "Thread & History Lifecycle", slug: "threads-lifecycle" },
       { title: "Synchronize Thread History", slug: "threads-import" },
       {
+        title: "Self-Managed Persistence",
+        slug: "threads-self-managed",
+      },
+      {
         title: "Threads & Persistence Architecture",
         slug: "premium/threads-explained",
       },

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -109,6 +109,7 @@ export const ANGULAR_DOC_REDIRECTS: Readonly<Record<string, string>> = {
   "headless-threads": "guides/threads-memory-attachments-headless",
   "threads-lifecycle": "guides/threads-memory-attachments-headless",
   "threads-import": "guides/threads-memory-attachments-headless",
+  "threads-self-managed": "guides/threads-memory-attachments-headless",
   "premium/headless-ui": "guides/threads-memory-attachments-headless",
   "custom-look-and-feel/headless-ui":
     "guides/threads-memory-attachments-headless",


### PR DESCRIPTION
Bundles the CopilotKit-side work from **OSS-769**, **OSS-767** (partial), and the unshipped remainder of **OSS-609**.

## OSS-769 — `useCoAgent().nodeName` never updates

`useAgentNodeName` tracked the current node in a ref and returned `nodeNameRef.current`. Mutating a ref schedules no render, so a component reading `useCoAgent().nodeName` kept showing whichever node was current at its last render and never updated on its own — it only appeared to work when something unrelated happened to re-render it.

Backing the value with state fixes it. Five lines, no API change.

**Credit:** this fix was diagnosed and submitted first by @aartisonigra in #4620 (2026-05-03), and this PR landed the same change without attributing it. The merged commit can't be rewritten to add a `Co-Authored-By` trailer, so the credit is recorded here. The shipped version is @aartisonigra's change with two cosmetic follow-ups I'd asked for (dead ref removed, trailing newline) plus the tests the hook was missing.

## OSS-767 (partial) — silent content-part drops (#1748)

`normalizeMessageContent` handles only `text` and `binary` parts; anything else — the `{"type": "image", ...}` case from the report — maps to `""` and is filtered out with no signal, so an agent emitting structured content sees its output vanish silently.

This makes the drop visible, once per unrecognised part type so streaming doesn't flood the log. Deliberately **not** the schema change: carrying structured assistant content needs an `AssistantMessage` decision upstream in `ag-ui`, which stays open on OSS-767.

## OSS-609 — the five docs gaps that never shipped

Gap #2 shipped in #6403; gaps 1, 3, 4, 5 and 6 did not.

| Gap | Where | Closes |
| --- | --- | --- |
| AWS Lambda self-hosting | `docs/deploy/aws-lambda.mdx` | #1151 |
| Per-user thread authorization | `docs/auth.mdx` (new section) | #2241 |
| Thread persistence without the platform | `docs/threads-self-managed.mdx` | #6090 |
| DIY guardrails / DLP | `docs/integrations/langgraph/guardrails.mdx` | #3414 |
| When you need an MCP App | `docs/agentic-protocols/mcp.mdx` (new section) | #5991 |

The Lambda guide leads with the constraint that actually bites — streaming is opt-in on every front door, so a chat runtime deployed with the defaults appears to hang for the whole run and then dumps the reply at once. It documents the Function URL + `RESPONSE_STREAM` path as the default, and API Gateway REST + `responseTransferMode: STREAM` for anyone who needs a REST API in front.

`threads-self-managed` follows the existing shared-snippet pattern with per-framework wrappers, because two nav contracts require it: every authored framework must publish the page, and every React destination must map to an Angular one (`ANGULAR_DOC_REDIRECTS`). All nine wrappers were confirmed necessary by deleting one and watching the suite fail.

## Review corrections

Two blockers from @MikeRyanDev, both verified against primary sources before changing anything.

**API Gateway REST APIs can stream** ([`91b3e632d5`](https://github.com/CopilotKit/CopilotKit/commit/91b3e632d5)). The guide was built on the pre-November-2025 limitation and claimed no API Gateway type supports response streaming, steering readers to a buffered `serverless-http` setup. REST gained it via `responseTransferMode: STREAM`, which also lifts the 10 MB cap and 29-second timeout. REST and HTTP are now split; REST is documented as a streaming front door (payload-format-1.0 event adapter, `AWS_PROXY` integration on the `2021-11-15/.../response-streaming-invocations` URI, CLI/CDK/SAM config), and the buffered fallback is scoped to HTTP APIs and ALB, which still have no streaming path. Added the constraints that actually matter for chat: the 30-second idle timeout on edge-optimized endpoints (5 min Regional), and the console Test tab always buffering so a working config looks broken.

**`identifyUser` is the platform's thread-scoping binding** ([`91b3e632d5`](https://github.com/CopilotKit/CopilotKit/commit/91b3e632d5)). The section told every reader to build an ownership table and enforce it in `onBeforeHandler`. On the Intelligence path the runtime already resolves `identifyUser(request)` server-side and carries that id to the platform; `listThreads` is scoped by user *and* filtered by `agentId`, so the "every user of one project sees that project's threads" claim was wrong. `identifyUser` is now documented as the binding, and the DIY pattern is scoped to SSE runtimes, custom stores, and the local in-memory runner.

**Follow-up correction — two routes are genuinely unscoped** ([`240672ff56`](https://github.com/CopilotKit/CopilotKit/commit/240672ff56)). My rewrite then over-claimed. `handleGetThreadEvents` and `handleGetThreadState` resolve the caller and discard it, and the platform client takes no `userId` on either method (`client.ts:1113`/`1135`) — unlike `getThreadMessages` at `1063`. Both hit project-authenticated `_inspect` endpoints, so any caller `identifyUser` accepts can read the event log and agent state of **any thread in the project** given its id. The blanket guarantee is replaced by a per-route table marking those two explicitly unscoped, plus an `onBeforeHandler` guard narrowed to them.

That is a live gap in shipped runtime code, not a docs error, and it is tracked as **OSS-851** — a platform-side `_inspect` change plus matching runtime/client work and tests, out of scope for a docs PR. The interim callout in `auth.mdx` comes out when OSS-851 lands.

## Not in this PR

**OSS-772** and **OSS-773** are already merged in `oss-path-to-production` (#237, #238). Both are telemetry-sink changes with no CopilotKit-side component. OSS-773's remaining half — re-keying runtime `distinct_id` from email to the Clerk subject — is recorded on the ticket as an open decision, not a task.

## Testing

**OSS-769.** New `use-agent-nodename.test.tsx`, 5 tests. Against unmodified `origin/main`, **4 of 5 fail**:

```
× re-renders consumers on every node transition
× reports 'end' when a run errors
× resets to 'start' when a new run begins
✓ unsubscribes on unmount
× carries the agent, thread, and current node
  Tests  4 failed | 1 passed (5)
```

With the fix: `Tests 5 passed (5)`. These assert only re-render behaviour under normal `act()` flushing — no manufactured intra-batch window.

**Full react-core suite:** `Tests 7 failed | 1496 passed (1503)`. All 7 failures are **pre-existing** `ResizeObserver is not a constructor` under jsdom, confined to `CopilotChatView.pinToSend` and `use-pin-to-send` — neither of which this PR touches.

**Typecheck:** `packages/react-core` → `tsc --noEmit` exit 0, no output.

**OSS-767:** 3 new tests covering the warn, warn-once-per-type, and no-warn-for-supported-types. `src/graphql/message-conversion/` → `Tests 125 passed (125)`.

**Docs:** `showcase/shell-docs` → `Tests 1 failed | 373 passed (374)`. The single failure (`channels-docs > publishes the Channels overview only through provider navigation`) is **pre-existing**; baselining with all changes stashed reproduces it and nothing else. Re-run unchanged after both review-correction commits.

**Review corrections.** The AWS rewrite was checked against the AWS sources rather than written from memory — the REST streaming announcement, `configuration-response-streaming`, `response-transfer-mode` (endpoint-type idle timeouts, unsupported buffered-only features), `response-streaming-lambda-configure` (CLI/OpenAPI shapes), the CFN `Integration` reference, and the CDK `ResponseTransferMode` enum. Two details corrected in passing: `InvokeWithResponseStream` authorizes against plain `lambda:InvokeFunction` (no new grant, contrary to what the streaming URI suggests), and ALB still has no Lambda streaming path.

The auth corrections were verified by reading the handlers and the platform client, not the tests — `resolve-intelligence-user.ts`, `intelligence/threads.ts` (every `resolveIntelligenceUser` call site), and `intelligence-platform/client.ts`. The existing tests assert the `threadId`-only call shape, so they pass under the defect and could not have surfaced it. Also corrected: there is no `threads/delete` route — delete is `DELETE` on `threads/update` (`fetch-handler.ts:606`).

Both edited pages MDX-compile clean, and all inbound `#thread-authorization` anchors still resolve after the h3→h4 demotions.

Two nav tests broke during this work and are fixed rather than papered over — adding a page to the Rich Threads group violated the cross-framework ordering contract and the React→Angular parity contract:

```
src/lib/__tests__/docs-render.test.ts
src/lib/__tests__/angular-docs-content.test.ts
  Test Files  2 passed (2)
       Tests  33 passed (33)
```

All 15 internal links in the new pages resolve against the content tree.

Closes #1151, #2241, #3414, #5991, #6090
Refs #1748, OSS-851

