### PR TITLE
docs(channels): document the shipped Teams setup flow

### DIFF
--- a/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/files-and-multimodality.mdx
@@ -118,13 +118,17 @@ For Graph-backed team-channel messages:
   grants it during installation; it does not need tenant-admin Graph consent.
   Microsoft documents it as a
   [resource-specific consent permission](https://learn.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent).
-- Add the broad `Files.ReadWrite.All` **application** permission to the Entra
-  app for SharePoint-reference file ingest and managed outbound file support.
-  It requires tenant-admin consent. Teams setup probes this permission and does
-  not report the connection ready when the required Graph access is missing.
+- `Files.Read.All` is an **application** permission and covers only one case:
+  a file uploaded to a Team channel, which arrives as a SharePoint reference
+  rather than as content. It requires tenant-admin consent, so Teams setup
+  offers it and defaults to skipping it. A tenant that already consented to the
+  broader `Files.ReadWrite.All` satisfies this without a second grant.
 
-Without the required consent, the text turn still runs but affected files are
-omitted or represented by a retrieval-failure note. Test personal chat,
+This permission is optional and its absence does not hold the connection back
+from reporting ready. Without it the text turn still runs and the message is
+still delivered; only the referenced file is omitted or represented by a
+retrieval-failure note. Files shared in a 1:1 chat and images pasted into a
+channel do not go through SharePoint and are unaffected. Test personal chat,
 standard/private team channels, inline media, pasted images, and
 SharePoint-reference uploads separately.
 

--- a/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
@@ -157,35 +157,59 @@ for both Slack and Microsoft Teams.
   <Step>
     ### Connect Microsoft Teams
 
-    Intelligence creates the Channel draft before Microsoft setup. Keep the
-    default app name, descriptions, and CopilotKit kite icons, or expand the
-    branding control to customize them. Custom icons and the generated ZIP stay
-    in browser memory and operating-system temporary files; Intelligence never
-    stores them.
+    Intelligence creates the Channel draft, then shows you a command to run:
 
-    Follow the guided setup one current action at a time in Teams Developer
-    Portal and Microsoft Entra. Enter the write-only client ID, tenant ID, and
-    secret, then download the finished upload-ready package. Do not edit
-    `manifest.json`. Azure Bot is not part of the normal path.
+    ```bash title="Terminal"
+    npx copilotkit@latest channels add \
+      --project-id <project-id> --channel-id <channel-id> \
+      --adapter teams --provision
+    ```
 
-    The generated app configures personal and Team scopes,
-    `ChannelMessage.Read.Group`, and the required `Files.ReadWrite.All`
-    application permission. The latter lets the app read, create, update, and
-    delete files across SharePoint and OneDrive site collections and requires
-    administrator consent.
+    Use the wizard's copy button rather than retyping it. The wizard fills in
+    the project and channel ids that bind the Microsoft app it creates to this
+    exact Channel; retyping them is the most common way this goes wrong.
 
-    Finish by selecting **Add to a team**. A personal-only installation does
-    not complete setup. Intelligence reports **Created and installed** only
-    after it records a Team installation, required file access, and Team message
-    access. This result does not claim that your runtime is online or that a
-    real message was delivered.
+    The command signs you in to Microsoft, creates a Teams bot in your own
+    tenant, points it at the Intelligence messaging endpoint, builds the app
+    package, and installs it to a Team you choose. You are not asked for a
+    client ID, tenant ID, or secret: the command reads them from the bot it
+    just created and stores them write-only in Intelligence. There is no
+    package to download and no `manifest.json` to edit.
 
-    If a custom-package attempt is interrupted, reopen the Channel and select
-    the icons again (or explicitly choose the default kite) before downloading
-    a fresh package. Package and icon bytes are never restored from the server.
+    You need a Microsoft account that is allowed to upload a custom app to the
+    Team you pick. The bot is registered in Teams Developer Portal; no Azure
+    subscription and no Azure Bot resource are involved.
 
-    Do not replace the generated messaging endpoint with your Channels runner
-    URL. Intelligence owns the public Teams edge.
+    #### The two permissions
+
+    Reading messages in a Team channel uses `ChannelMessage.Read.Group`, granted
+    by a Team owner as the app is added. This one is required — without it the
+    app is installed but deaf in channels.
+
+    Reading a file someone uploads to a Team channel additionally needs the
+    `Files.Read.All` application permission, which a Microsoft administrator
+    must consent to. The command asks and defaults to skipping it. It is
+    genuinely optional: skip it and everything works except attachments
+    uploaded to a Team channel — files shared in a 1:1 chat and images pasted
+    into a channel are unaffected, and the message still arrives, just without
+    that attachment. It reads only; the app never creates, updates, or deletes.
+    You can grant it later.
+
+    Teams settles app permissions only while the app is being added, so
+    changing your mind later means removing the app from the Team and adding it
+    again.
+
+    #### What finishing does and does not prove
+
+    Finish by adding the app to a team. A personal-only installation does not
+    complete setup. Intelligence then reports **Created and installed**, which
+    means the bot exists, the credentials were accepted, and a Team
+    installation was recorded. It does not claim your runtime is online or that
+    a real message was ever delivered — that is the next guide.
+
+    Do not replace the messaging endpoint with your Channels runner URL.
+    Intelligence owns the public Teams edge, and the runner takes no inbound
+    provider traffic at all.
 
   </Step>
 

--- a/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/intelligence.mdx
@@ -170,15 +170,34 @@ for both Slack and Microsoft Teams.
     exact Channel; retyping them is the most common way this goes wrong.
 
     The command signs you in to Microsoft, creates a Teams bot in your own
-    tenant, points it at the Intelligence messaging endpoint, builds the app
-    package, and installs it to a Team you choose. You are not asked for a
-    client ID, tenant ID, or secret: the command reads them from the bot it
-    just created and stores them write-only in Intelligence. There is no
-    package to download and no `manifest.json` to edit.
+    tenant, and points it at the Intelligence messaging endpoint. You are not
+    asked for a client ID, tenant ID, or secret: the command reads them from
+    the bot it just created and stores them write-only in Intelligence. You
+    never edit `manifest.json`.
+
+    It then writes `<channel-name>-teams-app.zip` next to where you ran it and
+    stops to hand that file to you. Microsoft exposes no install API, so
+    producing the package is as far as any tool can take you — the upload is
+    yours. Upload it from the **target team → … → Manage team → Apps**, not
+    from your personal Apps section: a personal-scope upload gives you a
+    working DM, no Team installation, and no way to promote it afterwards. The
+    command prints these steps with your package path filled in, then waits for
+    you to press Enter, and verifies the installation before it finishes.
+
+    If Teams offers no upload option, the tenant disallows custom apps and an
+    administrator has to add the package for you. Stop with Ctrl-C and run the
+    same command again once it is installed — it resumes rather than creating a
+    second app.
 
     You need a Microsoft account that is allowed to upload a custom app to the
-    Team you pick. The bot is registered in Teams Developer Portal; no Azure
-    subscription and no Azure Bot resource are involved.
+    Team you pick. The bot is registered in Teams Developer Portal.
+
+    If you customized the app name or icons, the wizard builds that branding in
+    your browser and its command carries an extra `--teams-package "./<file>"`.
+    Run it from the folder holding that download. The CLI validates the file,
+    builds the app from it, and deletes the local copy; an invalid or
+    mistargeted path is rejected before anything is removed. This does not
+    replace the Team upload above — it only decides how the app looks.
 
     #### The two permissions
 

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -20,6 +20,30 @@ how the SDK, Runtime, Intelligence, and provider connection fit together.
 Before you continue, [configure the Channel in Intelligence](/channels/intelligence).
 You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
 
+## What kind of bot this is
+
+Microsoft supports more than one kind of bot identity. Setup creates a
+**Teams-managed** bot: Teams Developer Portal owns the registration, and its app
+ID and client secrets live there under **Tools → Bot management**, in your
+directory, rotatable by your own admins. It is registered single-tenant, so it is
+scoped to your organization. Nothing is created in your Azure account and nothing
+is billable. If you stop using CopilotKit the registration stays in your
+Developer Portal; removing it is yours to do.
+
+The alternative Microsoft offers is an **Azure Bot** — a billable Azure Bot
+Service resource in your own subscription, needing a subscription, resource
+group, and region. Microsoft's Teams CLI recognizes only these two kinds; a
+self-managed Microsoft Entra app registration that you create and manage yourself
+is not something it can produce or consume.
+
+Treat the choice as permanent. Microsoft provides a one-way `teams app bot
+migrate` to Azure that replaces the existing registration, with nothing to
+migrate back. CopilotKit itself is indifferent to which kind you point a Channel
+at — Intelligence performs an ordinary client-credentials grant with the app ID,
+tenant ID, and secret — but the app ID is embedded in the app package as the bot
+ID, so changing identity means generating a fresh package, uploading it, and
+re-installing.
+
 ## Before you start
 
 - Node.js 22 or later; the managed launcher requires the global `WebSocket`

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -5,10 +5,14 @@ icon: "lucide/MessagesSquare"
 doc_type: tutorial
 ---
 
-In this guide, you will connect an AG-UI agent to a managed Azure Bot,
-start a long-running Channels SDK listener, and verify a real Microsoft Teams
-message. CopilotKit Intelligence owns the public messaging endpoint and Teams
-credentials; your process owns the agent and application logic.
+In this guide, you will connect an AG-UI agent to a managed Microsoft Teams
+bot, start a long-running Channels SDK listener, and verify a real Microsoft
+Teams message. CopilotKit Intelligence owns the public messaging endpoint and
+Teams credentials; your process owns the agent and application logic.
+
+The bot is created in your own Microsoft tenant and belongs to you. Setup
+registers it in Teams Developer Portal — no Azure subscription and no Azure Bot
+resource are involved.
 
 New to the product? Start with the [Channels overview](/channels) to understand
 how the SDK, Runtime, Intelligence, and provider connection fit together.
@@ -169,8 +173,9 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
     Channel online. Skip `ready()` and activation failures land in your logs
     instead.
 
-    The runner does not expose a Teams webhook. The public messaging endpoint
-    remains the Intelligence endpoint you copied into Azure Bot.
+    The runner does not expose a Teams webhook. Teams delivers to the
+    Intelligence messaging endpoint, which setup registered on the bot for
+    you.
 
   </Step>
 
@@ -231,8 +236,11 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
     Summarize the decisions in this conversation.
     ```
 
-    In a team channel, mention the bot if the Teams surface requires it. A real
-    response validates the Azure Bot registration, Intelligence messaging
+    In a team channel, mention the bot. A message that does not mention it is
+    ambient, and an ambient message only reaches your agent once a thread has
+    been subscribed to.
+
+    A real response validates the bot registration, Intelligence messaging
     endpoint, managed credentials, gateway listener, agent, and Adaptive Card
     reply path.
 
@@ -248,13 +256,21 @@ You should have `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`.
     attached in Intelligence, not from a `createChannel` option.
   </Accordion>
   <Accordion title="Teams cannot reach the bot">
-    In Azure Bot Configuration, use the exact read-only Messaging endpoint from
-    Intelligence and confirm the Microsoft Teams channel is enabled. Do not use
-    your runner's `PORT`.
+    In Teams Developer Portal, open **Tools → Bot management**, select the bot,
+    and compare its endpoint address with the messaging endpoint shown in
+    Intelligence. They must match exactly, including no leading or trailing
+    space — Developer Portal rejects a padded value and reports it as a save
+    failure, which reads like a portal fault rather than a bad value. A bot with
+    the wrong endpoint completes setup and then never receives anything.
+
+    This is not your runner's `PORT`. The runner takes no inbound provider
+    traffic at all.
   </Accordion>
-  <Accordion title="The custom app package is rejected">
-    Download a fresh package after entering the Azure Bot App ID. Upload the
-    complete zip; do not unzip and upload only `manifest.json`.
+  <Accordion title="The app package is rejected">
+    Upload the complete zip that setup produced; do not unzip it and upload only
+    `manifest.json`. If the app is already in the team and you are re-adding it
+    to change permissions, remove it first — Teams settles app permissions only
+    while the app is being added.
   </Accordion>
   <Accordion title="Startup settles but does not become Online">
     Inspect `channels.status()` after the guard in the runner. Finish any

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -518,14 +518,24 @@ describe("Channels documentation journey", () => {
     expect(slack).not.toContain("Directory (tenant) ID");
 
     expect(teams).toContain("### Connect Microsoft Teams");
-    expect(teams).toContain("Microsoft Entra");
-    expect(teams).toContain("Azure Bot");
-    expect(teams).toMatch(/Follow the guided setup/);
-    expect(teams).toMatch(/Teams\s+Developer\s+Portal/);
-    expect(teams).toMatch(/never\s+stores them/);
-    expect(teams).toContain("Add to a team");
     expect(teams).toContain("Microsoft Teams");
-    expect(teams).toContain("fresh package");
+    expect(teams).toMatch(/Teams\s+Developer\s+Portal/);
+    // Setup is one CLI command, not a form the reader fills in. Pinning the
+    // flags keeps the doc from drifting back to hand-entered credentials.
+    expect(teams).toContain("--adapter teams --provision");
+    expect(teams).toMatch(/copy\s+button/);
+    // Both permissions, and which one is optional. Naming only the required
+    // one is how the file-access permission got documented as mandatory.
+    expect(teams).toContain("ChannelMessage.Read.Group");
+    expect(teams).toContain("Files.Read.All");
+    expect(teams).toMatch(/genuinely\s+optional/);
+    expect(teams).toContain("Created and installed");
+    expect(teams).toMatch(/adding\s+the\s+app\s+to\s+a\s+team/);
+    // Azure Bot and Entra app registration are not the shipped path. They may
+    // only appear to say so.
+    expect(teams).toMatch(/no\s+Azure\s+subscription/);
+    expect(teams).not.toContain("Microsoft Entra");
+    expect(teams).not.toContain("Files.ReadWrite.All");
     expect(teams).not.toContain("### Connect Slack");
     expect(teams).not.toContain("connections:write");
     expect(teams).not.toContain("`xapp-…`");

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -531,9 +531,14 @@ describe("Channels documentation journey", () => {
     expect(teams).toMatch(/genuinely\s+optional/);
     expect(teams).toContain("Created and installed");
     expect(teams).toMatch(/adding\s+the\s+app\s+to\s+a\s+team/);
-    // Azure Bot and Entra app registration are not the shipped path. They may
-    // only appear to say so.
-    expect(teams).toMatch(/no\s+Azure\s+subscription/);
+    // Microsoft exposes no install API, so the command produces a package and
+    // the reader uploads it. Saying the command "installs the app" is the drift
+    // this guards, and the upload has to name the Team's own Apps tab: the
+    // personal Apps section installs to personal scope, which cannot be
+    // promoted to a Team afterwards.
+    expect(teams).toContain("teams-app.zip");
+    expect(teams).toMatch(/Manage\s+team/);
+    expect(teams).toMatch(/no\s+install\s+API/);
     expect(teams).not.toContain("Microsoft Entra");
     expect(teams).not.toContain("Files.ReadWrite.All");
     expect(teams).not.toContain("### Connect Slack");

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -364,6 +364,29 @@ describe("Channels documentation journey", () => {
     expect(intelligence).toMatch(/browser wizard[\s\S]*released setup path/i);
   });
 
+  it("names which kind of Microsoft bot identity Teams setup creates", () => {
+    const teams = bodyFor("frontends/teams");
+
+    // A tenant administrator's first question. Saying only what we do NOT
+    // create (the previous "Azure Bot is not part of the normal path") does not
+    // answer it, so the kind we DO create has to be named, along with where its
+    // credentials live and who can rotate them.
+    expect(teams).toContain("Teams-managed");
+    expect(teams).toMatch(/Tools\s+→\s+Bot\s+management/);
+    expect(teams).toMatch(/single-tenant/);
+    expect(teams).toMatch(/nothing\s+is\s+billable/);
+    // Azure Bot and a self-managed Entra app are the alternatives, and both may
+    // only appear as alternatives. What separates them from what we create is
+    // the cost and where the resource lives, so pin that rather than the prose.
+    expect(teams).toContain("Azure Bot");
+    expect(teams).toContain("Microsoft Entra");
+    expect(teams).toMatch(/billable\s+Azure\s+Bot/);
+    expect(teams).toMatch(/your\s+own\s+subscription/);
+    // Switching kinds is not a toggle: the app ID is the manifest's bot ID.
+    expect(teams).toMatch(/teams\s+app\s+bot\s+migrate/);
+    expect(teams).toMatch(/fresh\s+package/);
+  });
+
   it("documents provider-scoped identity and per-run Memory", () => {
     const source = bodyFor("channels/identity-and-memory");
     const slackQuickstart = bodyFor("frontends/slack");


### PR DESCRIPTION
The Teams docs described a setup flow that no longer exists: register an app by
hand in Microsoft Entra, point an Azure Bot at the Intelligence messaging
endpoint, paste a client ID, tenant ID, and secret into the wizard, then
download a package to upload. Setup is now a single CLI command that creates a
Teams-managed bot in the reader's own tenant, registers the endpoint, and
produces the app package the reader uploads.

This rewrites the three pages a reader hits while connecting Teams, repoints the
doc test that pinned the old prose, and rolls in OSS-833 (refs OSS-833) — naming
which kind of Microsoft bot identity setup creates.

All three pages were reviewed rendered, not just as a diff.

## What changed

**`channels/intelligence.mdx`** — the Connect Microsoft Teams step is now the
command the wizard shows you (`channels add --adapter teams --provision`), with
a note to use the copy button because the project and channel ids bind the
Microsoft app to that exact Channel. Documents the package hand-off: the command
writes `<channel-name>-teams-app.zip`, prints the upload steps, and blocks until
you confirm, because Microsoft exposes no install API. The upload must come from
the team's own Apps tab — the personal Apps section installs to personal scope,
which cannot be promoted to a Team afterwards. Adds a section on the two
permissions and one on what **Created and installed** does and does not prove.
Drops the Entra walkthrough and the credential entry.

**`frontends/teams.mdx`** — "managed Azure Bot" → "managed Microsoft Teams bot",
and states up front that the bot lives in the reader's own tenant with no Azure
subscription involved. This is the one place that sentence survives; the
Intelligence step no longer repeats it. The "Teams cannot reach the bot" accordion now points at
Teams Developer Portal → Bot management, and calls out that Developer Portal
reports a padded endpoint value as a save failure, which reads like a portal
fault rather than a bad value. Also: in a team channel you must mention the bot
— an unmentioned message is ambient and only reaches the agent on a subscribed
thread.

**`frontends/teams.mdx`, `## What kind of bot this is`** — rolls in **OSS-833**,
minimally. The docs said only what setup does *not* create, which does not
answer the tenant administrator who has to account for a new identity in their
own directory; the only way to learn the answer was to read the CLI source and
notice `--teams-managed`. One section now names the Teams-managed bot we create
(credentials in Developer Portal → Tools → Bot management, rotatable by their
admins, single-tenant, nothing billable, and it stays theirs if they stop using
CopilotKit), contrasts it with an Azure Bot and a self-managed Entra app
registration, and says the choice is effectively permanent because the app ID is
the manifest's bot ID. Left as a section on the page that already carried the
bot-ownership sentence rather than a new page, placed after the orientation links
so it reads as its own section rather than swallowing them.

**`channels/files-and-multimodality.mdx`** — corrects the file permission. The
manifest requests the read-only `Files.Read.All`, not the broad
`Files.ReadWrite.All`, and it is optional rather than a gate on the connection
reporting ready. Skipping it costs only files uploaded to a Team channel, which
arrive as SharePoint references; 1:1 chat files and pasted images are unaffected.

## Testing

Every factual claim was checked against the shipped implementation in the
Intelligence repo, not against the previous docs:

| Claim | Verified at |
| --- | --- |
| `channels add --adapter teams --provision` is the command | `apps/cli/src/commands/channels.ts:925` quotes it verbatim in its own error message |
| `--project-id` / `--channel-id` are only valid on that path | `apps/cli/src/commands/channels.ts:1044` |
| `Files.Read.All` is prompted and defaults to skipping | `apps/cli/src/commands/channels.ts:381` — prompt is `[y/N]`, "It can be granted later." |
| `Files.ReadWrite.All` satisfies it without a second grant | `apps/app-api/src/channels/teams-graph-access.ts:81`; `apps/cli/src/services/microsoft-teams-graph.ts:107` leaves such an app untouched |
| Absence omits only the attachment; 1:1 and pasted images unaffected | `apps/app-api/src/channels/teams-graph-files.ts:460` — the doc prose matches the shipped warning |
| Team-channel uploads arrive as SharePoint references | `apps/app-api/src/channels/teams-graph-files.ts:252` |
| `ChannelMessage.Read.Group` is per-Team RSC and required | `teams-graph-access.ts:88`; `apps/app-api/src/channels/teams-ingress.ts:1480` |
| The command writes a zip and waits rather than installing | `apps/cli/src/services/teams-provision.ts:766-803` — "Microsoft's tooling has no install command", then blocks on `waitForAction('installation')` |
| Upload from the team's Apps tab, not personal Apps | `apps/cli/src/commands/channels.ts:407-419` — the printed steps, and why personal scope is a dead end |
| No upload option ⇒ Ctrl-C, admin installs, re-run resumes | `apps/cli/src/commands/channels.ts:419` |
| `--teams-package` is browser-built branding, validated then deleted | `apps/cli/src/index.ts:279`; `channels.ts:533-552` validates before authorizing removal, `channels.ts:631-633` deletes |
| The wizard really does render a copy button for the command | `Intelligence:apps/app-frontend/react-shell/src/channels/teams-guided-adapter-setup.tsx:652-674` |
| We create a Teams-managed bot, registered single-tenant | `apps/cli/src/services/microsoft-teams-cli.ts:411` passes `--teams-managed` and `--sign-in-audience myOrg`; `:127` pins `botLocation: z.literal('teams-managed')` |
| Microsoft's CLI knows only two kinds, so no self-managed Entra app | `@microsoft/teams.cli@3.0.3` `dist/apps/bot-location.d.ts` — `BotLocation = 'tm' \| 'azure'` |
| Migration to Azure is one-way and replaces the registration | `dist/commands/app/bot/migrate.js:15,58,68`; the `bot` command group contains only `get` and `migrate` |
| The app ID is the manifest's bot ID, so identity changes need a new package | `Intelligence:libs/channels-setup/src/teams-package.ts:51-53` (`botId: id`), built by `createTeamsAppPackage(label, clientId)` |

The second commit exists because the first got two of these wrong — it said the
command "installs it to a Team you choose" and that "there is no package to
download", which also contradicted the Teams tutorial's own "upload the complete
zip that setup produced". Both are corrected, and the doc test now pins the
package hand-off in place of the struck Azure sentence.

Doc test, rebased onto `main` (`4526bb00d2`):

```
$ npx vitest run src/lib/__tests__/channels-docs.test.ts   # showcase/shell-docs
 Test Files  1 failed (1)
      Tests  1 failed | 29 passed (30)

 ❯ src/lib/__tests__/channels-docs.test.ts:97:30
```

The 30th test is new: it pins the bot-identity section, since "name the kind we
create" is exactly the claim that erodes back into "Azure Bot is not part of the
normal path".

The one remaining failure is **pre-existing on `main`** and unrelated to this
PR. It asserts the Channels overview embeds
`channels-architecture-dark.png`; `channels/index.mdx` references
`channels-architecture-light.png` twice and no dark variant, as of
`47a4a84896 docs(channels): re-export architecture diagram at 4000px` — a commit
on `main` that this branch does not touch. Proof it is not mine: running main's
version of the test file against this branch's docs gives **2** failures — line
97 plus line 521, main's now-stale `expect(teams).toContain("Microsoft Entra")`
— and this PR's updated test file removes only the second.

That pre-existing break is left alone here rather than folded in, since fixing
it means deciding whether the overview wants a dark diagram or the assertion is
obsolete.
