### PR TITLE
fix(channels-slack): deliver a message click's state.values to the handler

### DIFF
--- a/packages/channels-slack/src/__tests__/views.test.ts
+++ b/packages/channels-slack/src/__tests__/views.test.ts
@@ -100,20 +100,72 @@ describe("decodeViewSubmission", () => {
     });
   });
 
-  it("reports a select with nothing chosen as undefined, not a crash", () => {
-    // Slack sends `selected_option: null` for an untouched select.
+  // A field that reports nothing is OMITTED, never present-and-undefined. The
+  // managed path carries `values` as JSON, which cannot express `undefined`, so
+  // a key kept here would promise a field the managed runtime never delivers —
+  // `Object.keys`, `in` and `Object.entries` have to agree on both.
+  // `toStrictEqual` is load-bearing: `toEqual` ignores undefined-valued keys and
+  // would pass whether the key exists or not.
+  it.each([
+    ["an untouched select", { type: "static_select", selected_option: null }],
+    ["an untouched datepicker", { type: "datepicker", selected_date: null }],
+    ["an untouched user picker", { type: "users_select", selected_user: null }],
+    ["an element reporting nothing", { type: "plain_text_input" }],
+  ])("omits the key for %s", (_label, element) => {
+    const evt = decodeViewSubmission(
+      { callback_id: "triage", state: { values: { prio: { prio: element } } } },
+      { id: "U1", kind: "human" },
+    );
+    expect(evt.values).toStrictEqual({});
+    expect(evt.values).not.toHaveProperty("prio");
+    expect(Object.keys(evt.values)).toEqual([]);
+  });
+
+  // `decodeViewSubmission` has shipped for several releases handing free text
+  // back verbatim; sharing the value ladder with the message-click path must not
+  // retype it. A handler doing `values.orderId.trim()` would throw.
+  it("hands free text back verbatim, never JSON-parsed", () => {
     const evt = decodeViewSubmission(
       {
-        callback_id: "triage",
+        callback_id: "order",
         state: {
           values: {
-            prio: { prio: { type: "static_select", selected_option: null } },
+            order_id: { order_id: { type: "plain_text_input", value: "1234" } },
+            note: { note: { type: "plain_text_input", value: "true" } },
+            qty: { qty: { type: "number_input", value: "7" } },
+            blank: { blank: { type: "plain_text_input", value: "null" } },
           },
         },
       },
       { id: "U1", kind: "human" },
     );
-    expect(evt.values).toEqual({ prio: undefined });
+    expect(evt.values).toStrictEqual({
+      order_id: "1234",
+      note: "true",
+      qty: "7",
+      blank: "null",
+    });
+  });
+
+  // The author encoded these, so they still round-trip through JSON.
+  it("still JSON-parses an author-encoded option value", () => {
+    const evt = decodeViewSubmission(
+      {
+        callback_id: "order",
+        state: {
+          values: {
+            plan: {
+              plan: {
+                type: "static_select",
+                selected_option: { value: '{"id":7}' },
+              },
+            },
+          },
+        },
+      },
+      { id: "U1", kind: "human" },
+    );
+    expect(evt.values).toStrictEqual({ plan: { id: 7 } });
   });
 
   it("decodes a __cpk envelope into conversationKey + replyTarget and restores pm", () => {

--- a/packages/channels-slack/src/__tests__/views.test.ts
+++ b/packages/channels-slack/src/__tests__/views.test.ts
@@ -38,6 +38,84 @@ describe("decodeViewSubmission", () => {
     });
   });
 
+  // OSS-846: the message-click path now shares this flattening. The helper it
+  // shares used to read `value ?? selected_option.value` only, so every element
+  // family that reports under a different key came back `undefined` — silently,
+  // in modal submissions too.
+  it("parses element families the old value ?? selected_option reader lost", () => {
+    const evt = decodeViewSubmission(
+      {
+        callback_id: "triage",
+        state: {
+          values: {
+            services: {
+              services: {
+                type: "multi_static_select",
+                selected_options: [{ value: "payments" }, { value: "search" }],
+              },
+            },
+            responders: {
+              responders: {
+                type: "multi_users_select",
+                selected_users: ["U1", "U2"],
+              },
+            },
+            owner: { owner: { type: "users_select", selected_user: "U9" } },
+            escalate_in: {
+              escalate_in: { type: "channels_select", selected_channel: "C7" },
+            },
+            notify: {
+              notify: {
+                type: "multi_conversations_select",
+                selected_conversations: ["C1"],
+              },
+            },
+            target_date: {
+              target_date: { type: "datepicker", selected_date: "2026-08-20" },
+            },
+            cutover_at: {
+              cutover_at: { type: "timepicker", selected_time: "14:32" },
+            },
+            deadline: {
+              deadline: {
+                type: "datetimepicker",
+                selected_date_time: 1786451118,
+              },
+            },
+          },
+        },
+      },
+      { id: "U1", kind: "human" },
+    );
+
+    expect(evt.values).toEqual({
+      services: ["payments", "search"],
+      responders: ["U1", "U2"],
+      owner: "U9",
+      escalate_in: "C7",
+      notify: ["C1"],
+      target_date: "2026-08-20",
+      cutover_at: "14:32",
+      deadline: 1786451118,
+    });
+  });
+
+  it("reports a select with nothing chosen as undefined, not a crash", () => {
+    // Slack sends `selected_option: null` for an untouched select.
+    const evt = decodeViewSubmission(
+      {
+        callback_id: "triage",
+        state: {
+          values: {
+            prio: { prio: { type: "static_select", selected_option: null } },
+          },
+        },
+      },
+      { id: "U1", kind: "human" },
+    );
+    expect(evt.values).toEqual({ prio: undefined });
+  });
+
   it("decodes a __cpk envelope into conversationKey + replyTarget and restores pm", () => {
     const evt = decodeViewSubmission(
       {

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -145,6 +145,119 @@ describe("decodeInteraction", () => {
     expect(evt!.value).toBeUndefined();
   });
 
+  // OSS-846: Slack sends `state.values` — the current value of every input block
+  // on the clicked message — alongside a block_actions click. The decoder built
+  // its event from `actions[0]` alone and never read it, so a "fill the fields,
+  // then press the button" message reached the handler with `ctx.values` empty.
+  describe("state.values on a message click (OSS-846)", () => {
+    /** A button click on a message hosting five named input blocks. */
+    const clickWithForm = () =>
+      decodeInteraction({
+        type: "block_actions",
+        user: { id: "U1", name: "Ana" },
+        channel: { id: "C1" },
+        message: { ts: "111.1", thread_ts: "100.0" },
+        actions: [{ action_id: "ck:submit", value: "report" }],
+        state: {
+          values: {
+            root_cause: {
+              "ck:a": { type: "plain_text_input", value: "pool exhausted" },
+            },
+            severity: {
+              "ck:b": {
+                type: "radio_buttons",
+                selected_option: { value: "high" },
+              },
+            },
+            services: {
+              "ck:c": {
+                type: "checkboxes",
+                selected_options: [{ value: "payments" }, { value: "search" }],
+              },
+            },
+            target_date: {
+              "ck:d": { type: "datepicker", selected_date: "2026-08-20" },
+            },
+            owner: { "ck:e": { type: "users_select", selected_user: "U9" } },
+          },
+        },
+      });
+
+    it("delivers every input block's value, keyed by block id", () => {
+      expect(clickWithForm()!.values).toEqual({
+        root_cause: "pool exhausted",
+        severity: "high",
+        services: ["payments", "search"],
+        target_date: "2026-08-20",
+        owner: "U9",
+      });
+    });
+
+    it("keeps the clicked button's own value separate from the form state", () => {
+      const evt = clickWithForm();
+      expect(evt!.value).toBe("report");
+      expect(evt!.values).not.toHaveProperty("ck:submit");
+    });
+
+    it("omits values entirely when the message hosts no input blocks", () => {
+      // Byte-identical to what a plain button produced before `values` existed,
+      // so filling this in cannot perturb an existing single-button message.
+      const evt = decodeInteraction({
+        type: "block_actions",
+        channel: { id: "C1" },
+        message: { ts: "1.0" },
+        actions: [{ action_id: "ck:x", value: "yes" }],
+        state: { values: {} },
+      });
+      expect(evt!.values).toBeUndefined();
+    });
+
+    it("omits values when the payload carries no state at all", () => {
+      const evt = decodeInteraction({
+        type: "block_actions",
+        channel: { id: "C1" },
+        message: { ts: "1.0" },
+        actions: [{ action_id: "ck:x", value: "yes" }],
+      });
+      expect(evt!.values).toBeUndefined();
+    });
+
+    it("JSON-parses a form field's value the same way an action value is parsed", () => {
+      const evt = decodeInteraction({
+        type: "block_actions",
+        channel: { id: "C1" },
+        message: { ts: "1.0" },
+        actions: [{ action_id: "ck:x", value: "go" }],
+        state: {
+          values: {
+            payload: {
+              "ck:p": {
+                type: "static_select",
+                selected_option: { value: '{"id":7}' },
+              },
+            },
+          },
+        },
+      });
+      expect(evt!.values).toEqual({ payload: { id: 7 } });
+    });
+
+    it("reports an empty multi-select as [] rather than dropping the field", () => {
+      const evt = decodeInteraction({
+        type: "block_actions",
+        channel: { id: "C1" },
+        message: { ts: "1.0" },
+        actions: [{ action_id: "ck:x", value: "go" }],
+        state: {
+          values: {
+            services: { "ck:s": { type: "checkboxes", selected_options: [] } },
+          },
+        },
+      });
+      expect(evt!.values).toEqual({ services: [] });
+    });
+  });
+
   it("carries trigger_id from a block_actions payload", () => {
     const evt = decodeInteraction({
       type: "block_actions",

--- a/packages/channels-slack/src/interaction.test.ts
+++ b/packages/channels-slack/src/interaction.test.ts
@@ -256,6 +256,138 @@ describe("decodeInteraction", () => {
       });
       expect(evt!.values).toEqual({ services: [] });
     });
+
+    /** A click carrying the given `state.values` and nothing else. */
+    const clickWith = (values: Record<string, unknown>) =>
+      decodeInteraction({
+        type: "block_actions",
+        channel: { id: "C1" },
+        message: { ts: "1.0" },
+        actions: [{ action_id: "ck:x", value: "go" }],
+        state: { values },
+      });
+
+    // The managed normalizer omits a field that reports no value, and carries
+    // `values` over the wire as JSON — which cannot express `undefined`. Keeping
+    // the key here would make `Object.keys`/`in`/`Object.entries` disagree
+    // between self-hosted and managed: the exact divergence this field exists to
+    // prevent. `toStrictEqual` is load-bearing — `toEqual` ignores keys whose
+    // value is `undefined` and would pass either way.
+    describe("a field that reports no value is omitted, not undefined", () => {
+      it.each([
+        // Slack sends an explicit `null` for an untouched picker, and
+        // `null !== undefined` — so an undefined-only guard leaks it, and unlike
+        // `undefined` a `null` survives JSON all the way to the handler.
+        ["datepicker", { type: "datepicker", selected_date: null }],
+        ["timepicker", { type: "timepicker", selected_time: null }],
+        ["users_select", { type: "users_select", selected_user: null }],
+        [
+          "conversations_select",
+          { type: "conversations_select", selected_conversation: null },
+        ],
+        [
+          "channels_select",
+          { type: "channels_select", selected_channel: null },
+        ],
+        [
+          "datetimepicker",
+          { type: "datetimepicker", selected_date_time: null },
+        ],
+        ["static_select", { type: "static_select", selected_option: null }],
+        ["an empty text input", { type: "plain_text_input" }],
+      ])(
+        "omits an untouched %s, and with it the whole values key",
+        (_label, element) => {
+          const evt = clickWith({ prio: { "ck:p": element } });
+          expect(evt!.values).toBeUndefined();
+        },
+      );
+
+      it("keeps the fields that DO report, and only those", () => {
+        const evt = clickWith({
+          root_cause: {
+            "ck:a": { type: "plain_text_input", value: "pool exhausted" },
+          },
+          target_date: { "ck:b": { type: "datepicker", selected_date: null } },
+        });
+        expect(evt!.values).toStrictEqual({ root_cause: "pool exhausted" });
+        expect(evt!.values).not.toHaveProperty("target_date");
+        expect(Object.keys(evt!.values!)).toEqual(["root_cause"]);
+      });
+    });
+
+    // The value ladder is shared with the modal path, which has shipped for
+    // several releases handing free text back verbatim. Discriminate on the
+    // element type: JSON-parse what the AUTHOR encoded, never what the user
+    // typed.
+    describe("JSON parsing reaches author-encoded values only", () => {
+      it.each([
+        ["plain_text_input", "1234"],
+        ["plain_text_input", "true"],
+        ["plain_text_input", "null"],
+        ["email_text_input", "7"],
+        ["url_text_input", "12.50"],
+        ["number_input", "42"],
+      ])("hands %s content back as the verbatim string", (type, typed) => {
+        const evt = clickWith({ f: { "ck:f": { type, value: typed } } });
+        expect(evt!.values).toStrictEqual({ f: typed });
+        expect(typeof (evt!.values as Record<string, unknown>).f).toBe(
+          "string",
+        );
+      });
+
+      it("still parses an author-encoded button value", () => {
+        const evt = clickWith({
+          f: { "ck:f": { type: "button", value: '{"id":7}' } },
+        });
+        expect(evt!.values).toStrictEqual({ f: { id: 7 } });
+      });
+    });
+
+    // `render/block-kit.ts` packs up to SLACK_LIMITS.actionsElements elements
+    // into ONE `actions` block, and a hand-authored native block may do the
+    // same. Taking `Object.values(inner)[0]` silently dropped every element but
+    // the first. Slack's own reference describes `state` as carrying "all
+    // stateful elements, not just input blocks", so this shape does reach us.
+    describe("a block holding several stateful elements", () => {
+      it("delivers every element, keyed by action id, dropping none", () => {
+        const evt = clickWith({
+          // One auto-generated actions-block id holding two selects.
+          block1: {
+            "ck:region": {
+              type: "static_select",
+              selected_option: { value: "emea" },
+            },
+            "ck:tier": {
+              type: "static_select",
+              selected_option: { value: "gold" },
+            },
+          },
+        });
+        expect(evt!.values).toStrictEqual({
+          "ck:region": "emea",
+          "ck:tier": "gold",
+        });
+      });
+
+      it("still keys the element the block id names by the BLOCK id", () => {
+        // The modal vocabulary (block id == action id) and every single-element
+        // block must decode exactly as before.
+        const evt = clickWith({
+          severity: {
+            severity: {
+              type: "static_select",
+              selected_option: { value: "high" },
+            },
+            "ck:extra": { type: "datepicker", selected_date: "2026-08-20" },
+          },
+        });
+        expect(evt!.values).toStrictEqual({
+          severity: "high",
+          "ck:extra": "2026-08-20",
+        });
+      });
+    });
   });
 
   it("carries trigger_id from a block_actions payload", () => {

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -137,15 +137,63 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   };
 }
 
-/** JSON-parse a control value so non-string option values round-trip; else keep the raw string. */
-function parseValue(raw: string | undefined): unknown {
-  if (typeof raw !== "string") return raw;
+/**
+ * JSON-parse an AUTHOR-ENCODED control value so a non-string option value
+ * round-trips; keep the raw string when it is not JSON.
+ *
+ * Only ever applied to values the author put on the element (a button's
+ * `value`, an option's `value`) — never to text the user typed. See
+ * `FREE_TEXT_ELEMENT_TYPES`.
+ */
+function parseValue(raw: string): unknown {
   try {
     return JSON.parse(raw);
   } catch {
     return raw;
   }
 }
+
+/**
+ * Element families whose `value` is text the USER typed, not a token the author
+ * encoded. Their content is handed back as the verbatim string.
+ *
+ * `decodeViewSubmission` has shipped for several releases returning raw strings
+ * here, so JSON-parsing them would silently retype existing modal handlers'
+ * fields: an order number typed as `1234` would arrive as the number `1234` and
+ * `values.orderId.trim()` would throw. `number_input` is in the set for the same
+ * reason — Slack reports it as a string and that is what handlers already read.
+ */
+const FREE_TEXT_ELEMENT_TYPES = new Set([
+  "plain_text_input",
+  "rich_text_input",
+  "email_text_input",
+  "url_text_input",
+  "number_input",
+]);
+
+/**
+ * Keys under which Slack reports a multi-select as an array of bare ids (unlike
+ * `selected_options`, which carries option objects).
+ */
+const SELECTED_ID_LIST_KEYS = [
+  "selected_users",
+  "selected_conversations",
+  "selected_channels",
+] as const satisfies readonly (keyof SlackElementState)[];
+
+/**
+ * Keys under which Slack reports a single picker's choice as one scalar. Dates
+ * and times arrive as strings; `selected_date_time` arrives as unix seconds, so
+ * numbers have to survive too.
+ */
+const SELECTED_SCALAR_KEYS = [
+  "selected_user",
+  "selected_conversation",
+  "selected_channel",
+  "selected_date",
+  "selected_time",
+  "selected_date_time",
+] as const satisfies readonly (keyof SlackElementState)[];
 
 /**
  * Every shape a Slack interactive element reports its current value in — the
@@ -155,17 +203,19 @@ function parseValue(raw: string | undefined): unknown {
 interface SlackElementState {
   type?: string;
   value?: string;
+  /** Slack sends an explicit `null` for an untouched select. */
   selected_option?: { value?: string } | null;
-  selected_options?: Array<{ value?: string }>;
-  selected_user?: string;
-  selected_users?: string[];
-  selected_conversation?: string;
-  selected_conversations?: string[];
-  selected_channel?: string;
-  selected_channels?: string[];
-  selected_date?: string;
-  selected_time?: string;
-  selected_date_time?: number;
+  selected_options?: Array<{ value?: string }> | null;
+  /** Every picker below reports an explicit `null` while untouched. */
+  selected_user?: string | null;
+  selected_users?: string[] | null;
+  selected_conversation?: string | null;
+  selected_conversations?: string[] | null;
+  selected_channel?: string | null;
+  selected_channels?: string[] | null;
+  selected_date?: string | null;
+  selected_time?: string | null;
+  selected_date_time?: number | null;
   /** `rich_text_input` reports a rich-text document, not a string. */
   rich_text_value?: unknown;
 }
@@ -181,37 +231,80 @@ interface SlackBlockState {
  * Slack reports a value under a different key per element family, and reading
  * only `value ?? selected_option.value` silently yields `undefined` for every
  * multi-select, picker, date/time control and rich-text field. Each family
- * therefore gets an explicit arm. The plural arms come first because a
- * multi-select reports ONLY the plural key, and an empty multi-select reports it
- * as `[]` — which must stay an empty array rather than falling through to the
- * text-input arm and becoming `undefined`.
+ * therefore gets an explicit arm.
+ *
+ * Every guard is on the value's TYPE, not on `!== undefined`: Slack sends an
+ * explicit `null` for an untouched picker (`selected_date: null`,
+ * `selected_user: null`), and `null !== undefined`, so an `undefined` check
+ * would hand a literal `null` to the handler. A `null` falls through here and
+ * the field is then omitted by `flattenStateValues`, which is what the managed
+ * normalizer does — the two must agree key-for-key.
+ *
+ * Returns `undefined` when the element genuinely carries no value.
+ *
+ * Order mirrors the managed normalizer arm-for-arm so the two produce the same
+ * map for the same payload; the families are disjoint in practice.
  */
 function elementStateValue(el: SlackElementState): unknown {
-  if (el.selected_users) return el.selected_users;
-  if (el.selected_conversations) return el.selected_conversations;
-  if (el.selected_channels) return el.selected_channels;
-  if (el.selected_user !== undefined) return el.selected_user;
-  if (el.selected_conversation !== undefined) return el.selected_conversation;
-  if (el.selected_channel !== undefined) return el.selected_channel;
-  if (el.selected_date !== undefined) return el.selected_date;
-  if (el.selected_time !== undefined) return el.selected_time;
-  if (el.selected_date_time !== undefined) return el.selected_date_time;
-  if (el.selected_options) {
-    return el.selected_options.map((o) => parseValue(o.value));
+  if (Array.isArray(el.selected_options)) {
+    // An empty multi-select reports `[]`, which must stay an empty array rather
+    // than falling through to the text arm and becoming `undefined`.
+    return el.selected_options
+      .map((o) => o?.value)
+      .filter((v): v is string => typeof v === "string")
+      .map(parseValue);
   }
+  if (el.selected_option) {
+    const raw = el.selected_option.value;
+    return typeof raw === "string" ? parseValue(raw) : undefined;
+  }
+  for (const key of SELECTED_ID_LIST_KEYS) {
+    const selected = el[key];
+    if (Array.isArray(selected)) {
+      return selected.filter((id): id is string => typeof id === "string");
+    }
+  }
+  for (const key of SELECTED_SCALAR_KEYS) {
+    const selected = el[key];
+    if (typeof selected === "string" || typeof selected === "number") {
+      return selected;
+    }
+  }
+  // A `rich_text_input` reports a rich-text document rather than a string.
   if (el.rich_text_value !== undefined) return el.rich_text_value;
-  return parseValue(el.value ?? el.selected_option?.value ?? undefined);
+  if (typeof el.value !== "string") return undefined;
+  // Free text is the user's, verbatim; anything else is an author-encoded token.
+  return FREE_TEXT_ELEMENT_TYPES.has(el.type ?? "")
+    ? el.value
+    : parseValue(el.value);
 }
 
 /**
  * Flatten a Slack surface's `state.values` to a flat `fieldId → value` map.
  *
- * Slack nests the state as `blockId → actionId → element`. The modal vocabulary
- * names every block id == action id (see `render/modal.ts`), so `inner[blockId]`
- * hits directly there; on a message the two differ, and the first (in practice
- * only) element of the block is taken. The key is always the BLOCK id, because
- * that is the half an author can name — Slack generates a random one per render
- * when they do not.
+ * Slack nests the state as `blockId → actionId → element`. The key is the BLOCK
+ * id wherever a block id can name the element, because that is the half an
+ * author can name (`render/block-kit.ts` derives it from `props.name`, matching
+ * Teams; `render/modal.ts` names block id == action id).
+ *
+ * A block can hold MORE than one stateful element, though: an `<Actions>` packs
+ * up to `SLACK_LIMITS.actionsElements` elements into one block, and a
+ * hand-authored native block may do the same. One block id cannot name several
+ * elements, so the rule is:
+ *
+ * - the element whose action id equals the block id, or the sole element of the
+ *   block, is keyed by the BLOCK id — every shape the renderers emit today, and
+ *   every modal submission, therefore decodes exactly as before;
+ * - any further element in the same block is keyed by its own ACTION id, which
+ *   is the only identifier left that distinguishes it.
+ *
+ * Nothing is dropped silently, and an existing key is never clobbered.
+ *
+ * A field whose element reports no value is left out rather than set to
+ * `undefined`: the managed path carries `values` over the wire as JSON, which
+ * cannot express `undefined`, so keeping the key would promise the self-hosted
+ * handler a field the managed one never sees. `Object.keys`, `in` and
+ * `Object.entries` must agree on both deployments.
  */
 function flattenStateValues(
   state: SlackBlockState | undefined,
@@ -221,9 +314,18 @@ function flattenStateValues(
   for (const blockId of Object.keys(values)) {
     const inner = values[blockId];
     if (!inner) continue;
-    const el = inner[blockId] ?? Object.values(inner)[0];
-    if (!el) continue;
-    out[blockId] = elementStateValue(el);
+    const entries = Object.entries(inner).filter(
+      (entry): entry is [string, SlackElementState] =>
+        typeof entry[1] === "object" && entry[1] !== null,
+    );
+    for (const [actionId, el] of entries) {
+      const key =
+        actionId === blockId || entries.length === 1 ? blockId : actionId;
+      const value = elementStateValue(el);
+      if (value === undefined) continue;
+      if (Object.prototype.hasOwnProperty.call(out, key)) continue;
+      out[key] = value;
+    }
   }
   return out;
 }

--- a/packages/channels-slack/src/interaction.ts
+++ b/packages/channels-slack/src/interaction.ts
@@ -19,10 +19,16 @@ export function conversationKeyOf(key: ConversationKey): string {
 /**
  * Decode a Slack `block_actions` payload into a bot `InteractionEvent`.
  *
- * Carries ONLY the opaque minted action id (`ck:...`) plus the tiny, non-sensitive
- * button/option value — there is NO resume-data smuggling through the payload.
- * Durability rides on the ActionStore keyed by that opaque id, not on what Slack
- * round-trips back to us.
+ * Carries the opaque minted action id (`ck:...`), the clicked element's own
+ * value, and — in `values` — the current state of every input block on the
+ * message, which is what Slack sends alongside the click in `state.values`.
+ * There is still NO resume-data smuggling: durability rides on the ActionStore
+ * keyed by the opaque id, not on what Slack round-trips back to us.
+ *
+ * Note that `values` is user-entered form content, not a tiny opaque token: a
+ * click on a message hosting a text input carries whatever the user typed. It is
+ * surfaced because a "fill the fields, then press the button" message is
+ * otherwise unreadable (OSS-846) — but callers should treat it as user input.
  */
 export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
   const body = raw as {
@@ -38,22 +44,11 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
       message_ts?: string;
       channel_id?: string;
     };
-    actions?: Array<{
-      action_id?: string;
-      value?: string;
-      selected_option?: { value?: string };
-      selected_options?: Array<{ value?: string }>;
-      selected_user?: string;
-      selected_users?: string[];
-      selected_conversation?: string;
-      selected_conversations?: string[];
-      selected_channel?: string;
-      selected_channels?: string[];
-      selected_date?: string;
-      selected_time?: string;
-      selected_date_time?: number;
-      action_ts?: string;
-    }>;
+    /** Current value of every input block on the clicked message. */
+    state?: SlackBlockState;
+    actions?: Array<
+      SlackElementState & { action_id?: string; action_ts?: string }
+    >;
   };
   if (body.type !== "block_actions") return undefined;
   const action = body.actions?.[0];
@@ -85,33 +80,10 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
     threadTs: isDm && !explicitThreadTs ? undefined : threadTs,
   };
 
-  // Tiny, non-sensitive value: the clicked button's value (or selected option
-  // value), JSON-parsed if it round-trips, otherwise the raw string. A
-  // multi_static_select reports `selected_options` (an array) → a `string[]`.
-  let value: unknown;
-  if (action.selected_users) {
-    value = action.selected_users;
-  } else if (action.selected_conversations) {
-    value = action.selected_conversations;
-  } else if (action.selected_channels) {
-    value = action.selected_channels;
-  } else if (action.selected_user !== undefined) {
-    value = action.selected_user;
-  } else if (action.selected_conversation !== undefined) {
-    value = action.selected_conversation;
-  } else if (action.selected_channel !== undefined) {
-    value = action.selected_channel;
-  } else if (action.selected_date !== undefined) {
-    value = action.selected_date;
-  } else if (action.selected_time !== undefined) {
-    value = action.selected_time;
-  } else if (action.selected_date_time !== undefined) {
-    value = action.selected_date_time;
-  } else if (action.selected_options) {
-    value = action.selected_options.map((o) => parseValue(o.value));
-  } else {
-    value = parseValue(action.value ?? action.selected_option?.value);
-  }
+  // The clicked element's own value, read through the same vocabulary as the
+  // message's input state below so a control reports identically whichever of
+  // the two it arrives in.
+  const value = elementStateValue(action);
 
   const actor = body.user?.id
     ? {
@@ -138,11 +110,18 @@ export function decodeInteraction(raw: unknown): InteractionEvent | undefined {
       ? `${channelId}:${messageTs}:${action.action_ts}`
       : body.trigger_id;
 
+  // Slack sends the current state of every input block on the message alongside
+  // the click. Omitted rather than sent as `{}` when the message hosts no inputs
+  // (the Teams decoder's convention), so a plain button is byte-identical to
+  // what it produced before this field existed.
+  const values = flattenStateValues(body.state);
+
   return {
     id: action.action_id,
     conversationKey,
     replyTarget,
     value,
+    ...(Object.keys(values).length > 0 ? { values } : {}),
     actor,
     messageRef,
     triggerId: body.trigger_id,
@@ -166,6 +145,87 @@ function parseValue(raw: string | undefined): unknown {
   } catch {
     return raw;
   }
+}
+
+/**
+ * Every shape a Slack interactive element reports its current value in — the
+ * same set whether it arrives as the clicked `actions[0]` or as an entry in a
+ * surface's `state.values`.
+ */
+interface SlackElementState {
+  type?: string;
+  value?: string;
+  selected_option?: { value?: string } | null;
+  selected_options?: Array<{ value?: string }>;
+  selected_user?: string;
+  selected_users?: string[];
+  selected_conversation?: string;
+  selected_conversations?: string[];
+  selected_channel?: string;
+  selected_channels?: string[];
+  selected_date?: string;
+  selected_time?: string;
+  selected_date_time?: number;
+  /** `rich_text_input` reports a rich-text document, not a string. */
+  rich_text_value?: unknown;
+}
+
+/** A Slack surface's input state: `blockId → actionId → element state`. */
+interface SlackBlockState {
+  values?: Record<string, Record<string, SlackElementState | undefined>>;
+}
+
+/**
+ * Read one element's current value.
+ *
+ * Slack reports a value under a different key per element family, and reading
+ * only `value ?? selected_option.value` silently yields `undefined` for every
+ * multi-select, picker, date/time control and rich-text field. Each family
+ * therefore gets an explicit arm. The plural arms come first because a
+ * multi-select reports ONLY the plural key, and an empty multi-select reports it
+ * as `[]` — which must stay an empty array rather than falling through to the
+ * text-input arm and becoming `undefined`.
+ */
+function elementStateValue(el: SlackElementState): unknown {
+  if (el.selected_users) return el.selected_users;
+  if (el.selected_conversations) return el.selected_conversations;
+  if (el.selected_channels) return el.selected_channels;
+  if (el.selected_user !== undefined) return el.selected_user;
+  if (el.selected_conversation !== undefined) return el.selected_conversation;
+  if (el.selected_channel !== undefined) return el.selected_channel;
+  if (el.selected_date !== undefined) return el.selected_date;
+  if (el.selected_time !== undefined) return el.selected_time;
+  if (el.selected_date_time !== undefined) return el.selected_date_time;
+  if (el.selected_options) {
+    return el.selected_options.map((o) => parseValue(o.value));
+  }
+  if (el.rich_text_value !== undefined) return el.rich_text_value;
+  return parseValue(el.value ?? el.selected_option?.value ?? undefined);
+}
+
+/**
+ * Flatten a Slack surface's `state.values` to a flat `fieldId → value` map.
+ *
+ * Slack nests the state as `blockId → actionId → element`. The modal vocabulary
+ * names every block id == action id (see `render/modal.ts`), so `inner[blockId]`
+ * hits directly there; on a message the two differ, and the first (in practice
+ * only) element of the block is taken. The key is always the BLOCK id, because
+ * that is the half an author can name — Slack generates a random one per render
+ * when they do not.
+ */
+function flattenStateValues(
+  state: SlackBlockState | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const values = state?.values ?? {};
+  for (const blockId of Object.keys(values)) {
+    const inner = values[blockId];
+    if (!inner) continue;
+    const el = inner[blockId] ?? Object.values(inner)[0];
+    if (!el) continue;
+    out[blockId] = elementStateValue(el);
+  }
+  return out;
 }
 
 interface SlackReactionEvent {
@@ -230,38 +290,7 @@ export function decodeReaction(
 interface SlackViewState {
   callback_id?: string;
   private_metadata?: string;
-  state?: {
-    values?: Record<
-      string,
-      Record<
-        string,
-        {
-          type?: string;
-          value?: string;
-          selected_option?: { value?: string };
-        }
-      >
-    >;
-  };
-}
-
-/**
- * Flatten a Slack view's `state.values` to a flat `fieldId → value` map. The
- * modal vocabulary names every block id == action id (the field id), so for
- * each block we take the inner element keyed by that same block id, falling
- * back to the first element. Text inputs expose `value`; selects/radios expose
- * `selected_option.value`.
- */
-function flattenViewValues(view: SlackViewState): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const values = view.state?.values ?? {};
-  for (const blockId of Object.keys(values)) {
-    const inner = values[blockId]!;
-    const el = inner[blockId] ?? Object.values(inner)[0];
-    if (!el) continue;
-    out[blockId] = el.value ?? el.selected_option?.value;
-  }
-  return out;
+  state?: SlackBlockState;
 }
 
 /**
@@ -330,7 +359,7 @@ export function decodeViewSubmission(
   const ctx = decodeModalContext(v.private_metadata);
   return {
     callbackId: v.callback_id ?? "",
-    values: flattenViewValues(v),
+    values: flattenStateValues(v.state),
     actor: actor ?? { id: "unknown", kind: "unknown" },
     identityContext: {
       tenant: { id: "unknown" },

--- a/packages/channels-slack/src/render/block-kit.test.ts
+++ b/packages/channels-slack/src/render/block-kit.test.ts
@@ -1,6 +1,15 @@
-import { Header, Message, Section, renderToIR } from "@copilotkit/channels-ui";
+import {
+  Actions,
+  Header,
+  Input,
+  Message,
+  Section,
+  Select,
+  renderToIR,
+} from "@copilotkit/channels-ui";
 import type { ChannelNode } from "@copilotkit/channels-ui";
 import { describe, expect, it } from "vitest";
+import { decodeInteraction } from "../interaction.js";
 import { renderBlockKit, renderSlackMessage } from "./block-kit.js";
 
 const ISSUE_URL = "https://linear.app/copilotkit/issue/CPK-1234";
@@ -111,6 +120,8 @@ describe("renderBlockKit", () => {
     ).toEqual([
       {
         type: "input",
+        // No `name` given, so the block id falls back to the minted handler id.
+        block_id: "ck:in1",
         dispatch_action: true,
         element: {
           type: "plain_text_input",
@@ -435,5 +446,142 @@ describe("renderSlackMessage", () => {
       blocks: [{ type: "section", text: { type: "mrkdwn", text: "hi" } }],
       accent: undefined,
     });
+  });
+});
+
+/**
+ * OSS-848: the `ctx.values` key a handler reads is the rendered BLOCK id, so it
+ * has to come from the author's `name` — Teams already keys its fields that way
+ * (`channels-teams/src/render/adaptive-card.ts`), and without it Slack hands the
+ * handler a fresh random key per render.
+ *
+ * These go through the renderer on purpose. Tests that hand-write a payload
+ * cannot catch this: they invent block ids that are already meaningful names,
+ * which is a shape only a hand-authored native block produces.
+ */
+/**
+ * Rebuild the `state.values` Slack would send for these blocks: `blockId →
+ * actionId → element`. A block the renderer left unnamed gets the random id
+ * Slack would mint, which is exactly the failure mode under test.
+ */
+const stateValuesFor = (
+  blocks: unknown[],
+  report: Record<string, unknown>,
+): Record<string, Record<string, unknown>> => {
+  const out: Record<string, Record<string, unknown>> = {};
+  let random = 0;
+  for (const raw of blocks) {
+    const block = raw as {
+      type: string;
+      block_id?: string;
+      element?: { action_id?: string; type?: string };
+      elements?: { action_id?: string; type?: string }[];
+    };
+    const elements =
+      block.type === "input" && block.element
+        ? [block.element]
+        : block.type === "actions"
+          ? (block.elements ?? [])
+          : [];
+    const stateful = elements.filter((el) => el.type !== "button");
+    if (stateful.length === 0) continue;
+    const blockId = block.block_id ?? `slack-random-${++random}`;
+    out[blockId] = {};
+    for (const el of stateful) {
+      out[blockId]![el.action_id ?? "?"] = { type: el.type, ...report };
+    }
+  }
+  return out;
+};
+
+describe("author-named fields survive into the rendered block (OSS-848)", () => {
+  /** The blocks' `block_id`s, in render order. */
+  const blockIds = (ir: ChannelNode[]): (string | undefined)[] =>
+    renderBlockKit(ir).map((b) => (b as { block_id?: string }).block_id);
+
+  it("keys an <Input name> block by the author's name", () => {
+    expect(
+      blockIds(renderToIR(Input({ name: "root_cause", placeholder: "Why?" }))),
+    ).toEqual(["root_cause"]);
+  });
+
+  it("keys a <Select multi name> block by the author's name", () => {
+    expect(
+      blockIds(
+        renderToIR(
+          Actions({
+            children: Select({
+              name: "services",
+              multi: true,
+              options: [{ label: "Payments", value: "pay" }],
+            }),
+          }),
+        ),
+      ),
+    ).toEqual(["services"]);
+  });
+
+  it("gives a named <Select> in <Actions> a block of its own so its name is representable", () => {
+    // A block carries ONE block_id, so a named select cannot share one.
+    const ir = renderToIR(
+      Actions({
+        children: [
+          Select({
+            name: "severity",
+            options: [{ label: "High", value: "h" }],
+          }),
+          Select({ options: [{ label: "A", value: "a" }] }),
+        ],
+      }),
+    );
+    expect(blockIds(ir)).toEqual(["severity", undefined]);
+  });
+
+  it("falls back to the minted handler id, then to a positional id", () => {
+    // `onSubmit` is pre-bound by the action registry to a `{ id }` stamp.
+    const ir: ChannelNode[] = [
+      { type: "input", props: { onSubmit: { id: "ck:h1" } } },
+      { type: "input", props: { placeholder: "unnamed" } },
+    ];
+    expect(blockIds(ir)).toEqual(["ck:h1", "input_2"]);
+  });
+
+  it("de-duplicates a repeated name, because Slack rejects a duplicate block_id", () => {
+    const ir = renderToIR(
+      Message({
+        children: [Input({ name: "note" }), Input({ name: "note" })],
+      }),
+    );
+    expect(blockIds(ir)).toEqual(["note", "note_1"]);
+  });
+
+  it("round-trips <Input name> through render → Slack state.values → ctx.values", () => {
+    const blocks = renderBlockKit(
+      renderToIR(
+        Message({
+          children: [
+            Input({ name: "root_cause", placeholder: "Why?" }),
+            Actions({
+              children: Select({
+                name: "severity",
+                options: [{ label: "High", value: "high" }],
+              }),
+            }),
+          ],
+        }),
+      ),
+    );
+    const evt = decodeInteraction({
+      type: "block_actions",
+      channel: { id: "C1" },
+      message: { ts: "1.0" },
+      actions: [{ action_id: "ck:submit", value: "go" }],
+      state: { values: stateValuesFor(blocks, { value: "pool exhausted" }) },
+    });
+    // The author's own names, not Slack's random ids.
+    expect(Object.keys(evt!.values!).sort()).toEqual([
+      "root_cause",
+      "severity",
+    ]);
   });
 });

--- a/packages/channels-slack/src/render/block-kit.ts
+++ b/packages/channels-slack/src/render/block-kit.ts
@@ -74,8 +74,9 @@ export function buildFeedbackBlocks(opts?: {
 export function renderBlockKit(ir: ChannelNode[]): KnownBlock[] {
   const blocks: KnownBlock[] = [];
   const native = containsNativeNode(ir);
+  const fields = newFieldIdContext();
   for (const node of ir) {
-    renderNode(node, blocks);
+    renderNode(node, blocks, fields);
   }
 
   const dataVisualizations = blocks.filter(
@@ -152,8 +153,72 @@ function overflowSignal(count: number): KnownBlock {
   } as KnownBlock;
 }
 
+/**
+ * Per-message allocator for the `block_id`s that become a handler's
+ * `ctx.values` keys (OSS-848).
+ *
+ * Slack only reports a field under its BLOCK id, so a block rendered without
+ * one gets a fresh random id on every render and the value it carries is
+ * unreadable by name. Teams already keys a field by `props.name`
+ * (`channels-teams/src/render/adaptive-card.ts`), so a cross-platform
+ * `<Input name="root_cause">` has to arrive as `ctx.values.root_cause` here
+ * too. This mirrors that allocator arm-for-arm — same precedence, same
+ * reserved names, same `_1` de-duplication — so the two platforms mint the
+ * SAME key for the same tree.
+ */
+interface FieldIdContext {
+  nextFieldIndex: number;
+  used: Set<string>;
+}
+
+function newFieldIdContext(): FieldIdContext {
+  // Reserved on the Teams side; excluded here purely to keep the two in step.
+  return { nextFieldIndex: 0, used: new Set(["ckActionId", "value"]) };
+}
+
+/** The author's explicit `name`, if usable as a field key. */
+function explicitFieldName(props: Record<string, unknown>): string | undefined {
+  const raw = typeof props.name === "string" ? props.name.trim() : "";
+  if (!raw || raw === "ckActionId" || raw === "value") return undefined;
+  return raw;
+}
+
+/**
+ * Allocate the `block_id` for one stateful field: the author's `name`, else the
+ * registry-minted handler id (unique per render, and what a handler already
+ * addresses), else a positional `input_1` / `select_1`. Collisions get a `_N`
+ * suffix so a message can never carry two identical block ids, which Slack
+ * rejects outright.
+ */
+function fieldBlockId(
+  node: ChannelNode,
+  handlerProp: "onSelect" | "onSubmit",
+  fallback: "select" | "input",
+  ctx: FieldIdContext,
+): string {
+  const props = node.props ?? {};
+  const index = ++ctx.nextFieldIndex;
+  const base = truncateText(
+    explicitFieldName(props) ??
+      idFromHandler(props[handlerProp]) ??
+      `${fallback}_${index}`,
+    SLACK_LIMITS.blockId,
+  );
+  let candidate = base;
+  let suffix = 1;
+  while (ctx.used.has(candidate)) {
+    candidate = `${base}_${suffix++}`;
+  }
+  ctx.used.add(candidate);
+  return candidate;
+}
+
 /** Render a single IR node, pushing zero or more blocks onto `out`. */
-function renderNode(node: ChannelNode, out: KnownBlock[]): void {
+function renderNode(
+  node: ChannelNode,
+  out: KnownBlock[],
+  fields: FieldIdContext,
+): void {
   if (isNativeNode(node)) {
     if (node.props.nativeKind !== "block" && node.props.nativeKind !== "raw") {
       throw new Error(
@@ -168,7 +233,7 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
   switch (node.type) {
     case "message": {
       // The message container is not a block; flatten its children.
-      for (const child of childNodes(node)) renderNode(child, out);
+      for (const child of childNodes(node)) renderNode(child, out, fields);
       return;
     }
     case "header": {
@@ -257,7 +322,35 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
       for (const child of items) {
         if (child.type === "select" && child.props.multi) {
           flush();
-          out.push(multiSelectInput(child));
+          out.push(
+            multiSelectInput(
+              child,
+              fieldBlockId(child, "onSelect", "select", fields),
+            ),
+          );
+          continue;
+        }
+        if (child.type === "select") {
+          // Allocate unconditionally so the field index advances in step with
+          // the Teams renderer, whether or not the id is used as a block id.
+          const blockId = fieldBlockId(child, "onSelect", "select", fields);
+          const el = renderActionElement(child);
+          if (el === null) continue;
+          // A named select gets an `actions` block to itself, because a block
+          // carries ONE block_id and that is the only half Slack reports a
+          // field under. Grouping it with siblings would make the author's name
+          // unrepresentable; unnamed selects stay grouped as before and are
+          // delivered by action id (see `flattenStateValues`).
+          if (explicitFieldName(child.props ?? {})) {
+            flush();
+            out.push({
+              type: "actions",
+              block_id: blockId,
+              elements: [el],
+            } as KnownBlock);
+            continue;
+          }
+          elements.push(el);
           continue;
         }
         const el = renderActionElement(child);
@@ -282,6 +375,10 @@ function renderNode(node: ChannelNode, out: KnownBlock[]): void {
     case "input": {
       out.push({
         type: "input",
+        // Slack reports this field's value under the BLOCK id, so without one
+        // the handler's `ctx.values` key is a fresh random string per render
+        // (OSS-848). Derived from `props.name` to match Teams.
+        block_id: fieldBlockId(node, "onSubmit", "input", fields),
         dispatch_action: true,
         element: {
           type: "plain_text_input",
@@ -427,8 +524,9 @@ function renderActionElement(node: ChannelNode): object | null {
  * Render a `<Select multi>` as a dispatching input block holding a
  * `multi_static_select` (which Slack forbids inside an `actions` block). The
  * block_actions payload carries `selected_options`, decoded to a `string[]`.
+ * `blockId` is the author-facing `ctx.values` key (OSS-848).
  */
-function multiSelectInput(node: ChannelNode): KnownBlock {
+function multiSelectInput(node: ChannelNode, blockId: string): KnownBlock {
   const props = node.props ?? {};
   const action_id = truncateText(
     idFromHandler(props.onSelect) ?? "select",
@@ -439,6 +537,7 @@ function multiSelectInput(node: ChannelNode): KnownBlock {
   const { items } = clampArray(options, SLACK_LIMITS.selectOptions);
   return {
     type: "input",
+    block_id: blockId,
     dispatch_action: true,
     element: {
       type: "multi_static_select",

--- a/packages/channels-slack/src/render/budget.ts
+++ b/packages/channels-slack/src/render/budget.ts
@@ -8,6 +8,7 @@ export const SLACK_LIMITS = {
   contextElements: 10,
   buttonText: 75,
   actionId: 255,
+  blockId: 255,
   buttonValue: 2000,
   selectOptions: 100,
   tableColumns: 20,


### PR DESCRIPTION
## OSS-846 + OSS-848

When a user clicks a button in a Slack message, Slack's `block_actions` payload includes `state.values` — the current value of every stateful element on that message. It never reached the developer's handler: `ctx.values` was always `{}` for a message click.

This PR delivers it, **and** makes the delivered keys author-nameable (OSS-848), which is what makes the field usable at all. Its managed-path twin is Intelligence#866; the two only make sense as a pair, and this side owns the shape both must agree on.

## Where the data actually stopped

1. **`channels-slack` `decodeInteraction`** (`packages/channels-slack/src/interaction.ts`) — **the defect.** It built its event from `actions[0]` alone and never read `body.state`. `values` was populated only by `decodeViewSubmission` for a modal `view_submission`.
2. **`channels-core`** (`create-channel.ts:1038`, `values: evt.values ?? {}`) — **not a bug.** A faithful passthrough; `InteractionEvent.values` and `InteractionContext.values` already existed, the latter documented as "Submitted input id → value". The contract was designed for this and only the Slack decoder never filled it.
3. **Slack renderer** (`render/block-kit.ts`) — **now fixed here** (OSS-848). Previously `<Input>` / `<Select multi>` emitted no `block_id`, so Slack minted a random one per render. See "Author-named keys" below.
4. **Managed path (Intelligence)** — out of this repo. The SDK already whitelists and forwards `values`; Intelligence#866 populates it. On a managed deployment this fix is inert until #866 ships.

## The change

### Shape — aligned with the managed normalizer

`state.values` flattens to the same flat `fieldId → value` map modal submissions already produce, keyed by block id. Two rules now match Intelligence#866 exactly, so `Object.keys`, `in` and `Object.entries` agree on managed and self-hosted:

- **A field whose element reports no value is omitted**, not assigned `undefined`. The managed path carries `values` over the wire as JSON, which cannot express `undefined`, so keeping the key would promise a field the managed runtime never delivers.
- **Every guard in the value ladder is on the value's type**, not `!== undefined`. Slack sends an explicit `null` for an untouched picker (`selected_date: null`, `selected_user: null`), and `null !== undefined` — so the previous guards returned a literal `null`, which *does* survive JSON all the way to the handler.

`values` is omitted entirely when that leaves the map empty (the Teams decoder's convention).

### Free text is no longer JSON-parsed — a modal-path behaviour change, called out

Sharing the value ladder with `flattenViewValues` made it JSON-parse text the user typed. `decodeViewSubmission` has shipped for several releases, so this would have **retyped fields for existing modal handlers**: an order id typed as `1234` arriving as the number `1234`, and `values.orderId.trim()` throwing.

The ladder now discriminates on the element type. Author-encoded values (a button's `value`, an option's `selected_option(s).value`) are still JSON-parsed; `plain_text_input`, `rich_text_input`, `email_text_input`, `url_text_input` and `number_input` content is handed back as the verbatim string it always was.

**Net effect on the shipped modal path:** free text is unchanged; the eight element families the old `value ?? selected_option.value` reader silently dropped (multi-selects, user/channel/conversation pickers, date, time, datetime, rich text) now arrive populated instead of `undefined`; and an untouched field is now omitted rather than present-and-`undefined`.

### Author-named keys (OSS-848), folded in

The key this PR delivers is the **block id**, and the renderer did not emit one on a message — so Slack minted a random id per render. Teams honours `props.name`, so `<Input name="root_cause">` yielded `ctx.values.root_cause` on Teams and `ctx.values["<random>"]` on Slack. That made the field unusable for the cross-platform vocabulary, which is most of its point, so the renderer change lands here rather than as a follow-up.

`block_id` now comes from `props.name`, mirroring the Teams allocator arm-for-arm — same precedence (`name` → minted handler id → positional `input_1`), same reserved names, same `_1` de-duplication — so both platforms mint the **same key for the same tree**. `<Select multi>` (already routed through an `input` block) is covered. A **named** `<Select>` inside `<Actions>` gets an `actions` block of its own, because a block carries one `block_id` and grouping would make the name unrepresentable; unnamed selects stay grouped exactly as before.

### Multiple stateful elements per block

Both flatteners took `inner[blockId] ?? Object.values(inner)[0]`, documented as "the block's first (in practice only) element". That does not hold: `<Actions>` packs up to `SLACK_LIMITS.actionsElements` elements into one block, so a second `<Select>` was dropped silently.

Every element is now delivered. The element the block id names (and any sole element) is keyed by **block id** — so modals, and every shape today's renderer emits, decode exactly as before — and any further element in the same block is keyed by its own **action id**, the only identifier left that distinguishes it. An existing key is never clobbered.

## What is settled and what is not

**Documented:** Slack's `block_actions` reference describes `state` as "A property including all stateful elements, not just input blocks", so elements in `actions` / `section` blocks are expected to appear in `state.values`.

**Unconfirmed:** that has not been observed against a real payload. Slack live testing was not available for this work — the only live deployment is managed, and dev does not carry the Intelligence fix, so no `state.values` reaches anything. **No claim here rests on a live measurement; the tests are unit tests.**

The code is written to be correct either way: if Slack does report them, multi-element blocks are delivered in full instead of silently truncated to one; if it does not, the multi-element branch is simply never taken and nothing else changes. A real click on a message with two selects in one `<Actions>` would settle it.

## Compatibility

Additive, but the earlier framing was too broad. **"Decodes byte-identically" holds only for a message carrying no stateful element at all.** If Slack does report elements outside `input` blocks, any existing message rendering a `<Select>`, a picker or an `<Input>` alongside a button now newly carries a `values` object on a button click where the field was previously absent. Still additive — nothing that existed changes value — but it is not "no change" for those messages.

Otherwise: no production code in the repo reads `ctx.values`; no consumer-side emptiness check, exhaustive-key assumption or spread-merge exists; `values` is not consulted by the HITL `awaitChoice` waiter, which reads only `evt.value`.

The renderer change is additive too — no `block_id` was emitted on these blocks before — but it does change render output, and a message that previously relied on a random block id now gets a stable one.

## Tests

Every new rule is pinned by a test **verified to fail when the rule is removed** (mutation applied, suite run, rule restored):

| Rule removed | Tests that go red |
| --- | --- |
| omit a field that reports no value | 13 |
| type-guard the scalar arms (so `null` leaks) | 9 |
| free text exempt from JSON parsing | 7 |
| deliver every element in a block | 2 |
| emit `block_id` from `props.name` | 6 |
| give a named `<Select>` its own block | 2 |

The earlier omission tests were **vacuous** and are fixed: `expect(evt.values).toEqual({ prio: undefined })` passes whether or not the key exists, because vitest's `toEqual` ignores undefined-valued keys. Those assertions now use `toStrictEqual` / `not.toHaveProperty` / `Object.keys`.

The OSS-848 coverage deliberately goes **through the renderer** (`render → Slack state.values → decodeInteraction → ctx.values`). Hand-written payloads cannot catch that class of bug: they invent block ids that are already meaningful names, a shape only a hand-authored native block produces.

## Verification

`oxfmt --check`, `oxlint` (0 errors), `check-types`, `test` and `build` all pass for `@copilotkit/channels-slack` and its dependents (`channels-core`, `channels-ui`, `channels-teams`, `channels-intelligence`, `channels`). 443 tests pass in `channels-slack`.

## Note for Intelligence#866

`readInteractionValue` there inherits the same free-text coercion (finding 2) and needs the matching type discrimination, or a `plain_text_input` will decode differently on the two halves. The omission and `null` rules already match #866 — this PR moved to them.
