### PR TITLE
docs(contributing): fix documentation typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,6 @@ Our Code of Conduct means that you are responsible for treating everyone on the 
 ## Need Help?
 
 - **Questions**: Use our [Discord support channel](https://discord.com/invite/6dffbvGU3D) for any questions you have.
-- **Resources**: Visit [CopilotKit documentation](https://docs.copilotkit.ai/) for more helpful documentatation info.
+- **Resources**: Visit [CopilotKit documentation](https://docs.copilotkit.ai/) for more helpful documentation info.
 
 ⭐ Happy coding, and we look forward to your contributions!


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the contributor resources section: `documentatation` is corrected to `documentation`.

This is a documentation-only change and does not affect runtime behavior.

## Related PRs and Issues

- No related issue; checked the open pull requests for the same typo and found no duplicate.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (not applicable; no functionality changes)
- [x] "Allow edits by maintainers" is checked