### PR TITLE
fix: parallel v1 tool rendering, Vue provider HITL, wildcard HITL names and abort

### DIFF
--- a/packages/core/src/__tests__/core-abort-during-tool.test.ts
+++ b/packages/core/src/__tests__/core-abort-during-tool.test.ts
@@ -121,6 +121,64 @@ describe("CopilotKitCore - abort during tool execution", () => {
     expect(signalAbortedDuringHandler).toBe(true);
   });
 
+  it("should pass an AbortSignal to a wildcard tool handler context", async () => {
+    // Wildcard tools execute through their own path, which omitted the signal
+    // the named-tool path passes. A wildcard handler that waits on something —
+    // a human-in-the-loop tool registered as "*" — could never see an abort.
+    const agent = new MockAgent({ agentId: "test" });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    let receivedSignal: AbortSignal | undefined;
+    const wildcardTool = createTool({
+      name: "*",
+      handler: vi.fn(async (_args: any, context: any) => {
+        receivedSignal = context.signal;
+        return "done";
+      }),
+      followUp: false,
+    });
+    copilotKitCore.addTool(wildcardTool);
+
+    // A tool name with no specific registration, so the wildcard handles it.
+    agent.setNewMessages([createToolCallMessage("unregisteredTool")]);
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(wildcardTool.handler).toHaveBeenCalledOnce();
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    expect(receivedSignal!.aborted).toBe(false);
+  });
+
+  it("should abort the signal when stopAgent is called during wildcard tool execution", async () => {
+    const agent = new MockAgent({ agentId: "test" });
+    copilotKitCore.addAgent__unsafe_dev_only({
+      id: "test",
+      agent: agent as any,
+    });
+
+    let signalAbortedDuringHandler: boolean | undefined;
+    const wildcardTool = createTool({
+      name: "*",
+      handler: vi.fn(async (_args: any, context: any) => {
+        expect(context.signal.aborted).toBe(false);
+        copilotKitCore.stopAgent({ agent: agent as any });
+        signalAbortedDuringHandler = context.signal.aborted;
+        return "done";
+      }),
+      followUp: false,
+    });
+    copilotKitCore.addTool(wildcardTool);
+
+    agent.setNewMessages([createToolCallMessage("unregisteredTool")]);
+
+    await copilotKitCore.runAgent({ agent: agent as any });
+
+    expect(signalAbortedDuringHandler).toBe(true);
+  });
+
   it("should NOT restart the run when agent.abortRun() is called directly during tool execution", async () => {
     const agent = new MockAgent({ agentId: "test" });
     copilotKitCore.addAgent__unsafe_dev_only({

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -1007,6 +1007,11 @@ export class RunHandler {
           const result = await wildcardTool.handler(wildcardArgs as any, {
             toolCall,
             agent,
+            // Same signal the named-tool path passes. Without it a wildcard
+            // handler that waits on something — a human-in-the-loop tool
+            // registered as `"*"` is the case that surfaced this — can never
+            // observe an abort, so stopping the run leaves it pending forever.
+            signal: this._runAbortController?.signal,
           });
           if (result === undefined || result === null) {
             toolCallResult = "";

--- a/packages/react-core/src/hooks/__tests__/repro-1982-2051-v1-path.test.tsx
+++ b/packages/react-core/src/hooks/__tests__/repro-1982-2051-v1-path.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * v1-path half of the #1982 / #2051 reproduction.
+ *
+ * Both reporters use v1 `useCopilotAction({ available: "disabled", render })`.
+ * That hook is now a shim that routes `available: "disabled"` and `name: "*"`
+ * to the same `useRenderToolCall` registration v2 uses, so the status/result
+ * derivation is shared. What is NOT shared is the v1 *display* seam:
+ * `useLazyToolRenderer`, which picks `message.toolCalls[0]`.
+ *
+ * #2051's backend runs asyncio.gather over every tool_call on the assistant
+ * message, so parallel tool calls are exactly its shape. This pins down what
+ * the v1 seam does with more than one.
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useLazyToolRenderer } from "../use-lazy-tool-renderer";
+import { CopilotKitProvider } from "../../v2/providers/CopilotKitProvider";
+import type { AIMessage, Message } from "@copilotkit/shared";
+
+const WildcardRender: React.FC<any> = ({ name, status, result }) => (
+  <div data-testid={`v1-${name}`}>
+    {name}:{status}:{String(result ?? "")}
+  </div>
+);
+
+function Harness({
+  message,
+  messages,
+}: {
+  message: AIMessage;
+  messages: Message[];
+}) {
+  const lazy = useLazyToolRenderer();
+  const rendered = lazy(message, messages);
+  return <div data-testid="host">{rendered ? rendered() : null}</div>;
+}
+
+function renderV1({
+  message,
+  messages,
+}: {
+  message: AIMessage;
+  messages: Message[];
+}) {
+  return render(
+    <CopilotKitProvider
+      renderToolCalls={
+        [
+          {
+            name: "*",
+            args: z.object({ toolName: z.string(), args: z.unknown() }),
+            render: WildcardRender,
+          },
+        ] as any
+      }
+    >
+      <Harness message={message} messages={messages} />
+    </CopilotKitProvider>,
+  );
+}
+
+function assistantWithToolCalls(names: string[]): AIMessage {
+  return {
+    id: "a1",
+    role: "assistant",
+    content: "",
+    toolCalls: names.map((n, i) => ({
+      id: `tc${i + 1}`,
+      type: "function",
+      function: { name: n, arguments: JSON.stringify({ x: i + 1 }) },
+    })),
+  } as any;
+}
+
+function toolResult(toolCallId: string, content: string): Message {
+  return {
+    id: `tm-${toolCallId}`,
+    role: "tool",
+    toolCallId,
+    content,
+  } as any;
+}
+
+describe("v1 path (#1982 / #2051) — useLazyToolRenderer", () => {
+  it("single backend tool call reaches complete with its result", async () => {
+    const message = assistantWithToolCalls(["get_weather"]);
+    renderV1({
+      message,
+      messages: [message, toolResult("tc1", "sunny, 22C")],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("v1-get_weather").textContent).toContain(
+        "sunny, 22C",
+      );
+    });
+    expect(screen.getByTestId("v1-get_weather").textContent).toContain(
+      "complete",
+    );
+  });
+
+  it("renders every parallel tool call, not just the first", async () => {
+    const message = assistantWithToolCalls(["tool_one", "tool_two"]);
+    renderV1({
+      message,
+      messages: [
+        message,
+        toolResult("tc1", "one-done"),
+        toolResult("tc2", "two-done"),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("v1-tool_one").textContent).toContain(
+        "one-done",
+      );
+    });
+    // If the v1 seam only reads toolCalls[0], the second tool call never renders.
+    expect(screen.queryByTestId("v1-tool_two")).not.toBeNull();
+  });
+});

--- a/packages/react-core/src/hooks/use-lazy-tool-renderer.tsx
+++ b/packages/react-core/src/hooks/use-lazy-tool-renderer.tsx
@@ -10,20 +10,34 @@ export function useLazyToolRenderer(): (
 
   return useCallback(
     (message?: AIMessage, messages?: Message[]) => {
-      if (!message?.toolCalls?.length) return null;
+      const toolCalls = message?.toolCalls;
+      if (!toolCalls?.length) return null;
 
-      const toolCall = message.toolCalls[0];
-      if (!toolCall) return null;
+      return () => {
+        // An assistant message can carry a parallel batch of tool calls, so
+        // every one of them gets rendered. Reading only `toolCalls[0]` silently
+        // dropped 2..N, which from the user's seat is indistinguishable from a
+        // tool result that never arrived.
+        const rendered = toolCalls.map((toolCall) => {
+          if (!toolCall) return null;
 
-      const toolMessage = messages?.find(
-        (m) => m.role === "tool" && m.toolCallId === toolCall.id,
-      ) as ToolResult;
+          const toolMessage = messages?.find(
+            (m) => m.role === "tool" && m.toolCallId === toolCall.id,
+          ) as ToolResult;
 
-      return () =>
-        renderToolCall({
-          toolCall,
-          toolMessage,
+          const element = renderToolCall({ toolCall, toolMessage });
+          return element ? (
+            <React.Fragment key={toolCall.id}>{element}</React.Fragment>
+          ) : null;
         });
+
+        // No tool call produced output — no named or wildcard renderer is
+        // registered for any of them. Return null rather than an empty fragment
+        // so the caller still falls through to its custom-message renderer.
+        if (rendered.every((element) => element === null)) return null;
+
+        return <>{rendered}</>;
+      };
     },
     [renderToolCall],
   );

--- a/packages/react-core/src/v2/hooks/__tests__/repro-1982-2051.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/repro-1982-2051.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Reproduction harness for CopilotKit issues #1982 and #2051.
+ *
+ * Both issues describe a *backend*-executed tool (LangGraph tool node) rendered
+ * on the frontend by a render-only / catch-all action:
+ *
+ *   #1982 — status goes inProgress -> executing and never reaches "complete".
+ *   #2051 — `result` stays empty until the whole graph finishes, instead of
+ *           landing as each tool node completes.
+ *
+ * The AG-UI LangGraph adapter emits TOOL_CALL_RESULT at `OnToolEnd`, i.e. mid-run.
+ * So the crux of both reports is: when TOOL_CALL_RESULT arrives BEFORE
+ * RUN_FINISHED, does the render observe status="complete" with the result?
+ */
+import React from "react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+  runStartedEvent,
+  runFinishedEvent,
+  textChunkEvent,
+  toolCallChunkEvent,
+  toolCallResultEvent,
+  testId,
+} from "../../__tests__/utils/test-helpers";
+
+async function submitUserMessage(text: string) {
+  const input = await screen.findByRole("textbox");
+  fireEvent.change(input, { target: { value: text } });
+  fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+  await waitFor(() => {
+    expect(screen.getByText(text)).toBeDefined();
+  });
+}
+
+describe("repro #1982 / #2051 — backend tool result reaching a catch-all render", () => {
+  it("reaches status=complete with the result BEFORE run finished", async () => {
+    const observed: Array<{ status: string; result: unknown }> = [];
+
+    // Equivalent of the reporters' `useCopilotAction({ name: "*", available: "disabled", render })`
+    const WildcardRender: React.FC<any> = ({ name, status, result }) => {
+      observed.push({ status, result });
+      return (
+        <div data-testid="wildcard">
+          {name}:{status}:{String(result ?? "")}
+        </div>
+      );
+    };
+
+    const agent = new MockStepwiseAgent();
+    renderWithCopilotKit({
+      agent,
+      renderToolCalls: [
+        {
+          name: "*",
+          args: z.object({ toolName: z.string(), args: z.unknown() }),
+          render: WildcardRender,
+        },
+      ] as any,
+    });
+
+    await submitUserMessage("What's the weather?");
+
+    const messageId = testId("msg");
+    const toolCallId = testId("tc");
+
+    agent.emit(runStartedEvent());
+    agent.emit(textChunkEvent(messageId, "Checking the weather."));
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId,
+        toolCallName: "get_weather",
+        parentMessageId: messageId,
+        delta: JSON.stringify({ city: "Berlin" }),
+      }),
+    );
+
+    // Tool call is visible and NOT complete yet.
+    await waitFor(() => expect(screen.getByTestId("wildcard")).toBeDefined());
+    expect(observed.at(-1)!.status).not.toBe(ToolCallStatus.Complete);
+
+    // OnToolEnd equivalent: backend tool finished, result streamed mid-run.
+    agent.emit(
+      toolCallResultEvent({
+        toolCallId,
+        messageId: testId("tm"),
+        content: "sunny, 22C",
+      }),
+    );
+
+    // THE CRUX: complete + result must be observable before RUN_FINISHED.
+    await waitFor(() => {
+      expect(screen.getByTestId("wildcard").textContent).toContain(
+        "sunny, 22C",
+      );
+    });
+    const atToolEnd = observed.at(-1)!;
+    expect(atToolEnd.status).toBe(ToolCallStatus.Complete);
+    expect(atToolEnd.result).toBe("sunny, 22C");
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+  });
+
+  it("renders ALL parallel tool calls on one assistant message, not just the first", async () => {
+    // #2051's backend does asyncio.gather over every tool_call on the message,
+    // so a single assistant message carries multiple parallel tool calls.
+    const WildcardRender: React.FC<any> = ({ name, status, result }) => (
+      <div data-testid={`wildcard-${name}`}>
+        {name}:{status}:{String(result ?? "")}
+      </div>
+    );
+
+    const agent = new MockStepwiseAgent();
+    renderWithCopilotKit({
+      agent,
+      renderToolCalls: [
+        {
+          name: "*",
+          args: z.object({ toolName: z.string(), args: z.unknown() }),
+          render: WildcardRender,
+        },
+      ] as any,
+    });
+
+    await submitUserMessage("Run both tools");
+
+    const messageId = testId("msg");
+    const tc1 = testId("tc1");
+    const tc2 = testId("tc2");
+
+    agent.emit(runStartedEvent());
+    agent.emit(textChunkEvent(messageId, "Running both."));
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId: tc1,
+        toolCallName: "tool_one",
+        parentMessageId: messageId,
+        delta: JSON.stringify({ x: 1 }),
+      }),
+    );
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId: tc2,
+        toolCallName: "tool_two",
+        parentMessageId: messageId,
+        delta: JSON.stringify({ x: 2 }),
+      }),
+    );
+    agent.emit(
+      toolCallResultEvent({
+        toolCallId: tc1,
+        messageId: testId("tm1"),
+        content: "one-done",
+      }),
+    );
+    agent.emit(
+      toolCallResultEvent({
+        toolCallId: tc2,
+        messageId: testId("tm2"),
+        content: "two-done",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wildcard-tool_one").textContent).toContain(
+        "one-done",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("wildcard-tool_two").textContent).toContain(
+        "two-done",
+      );
+    });
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+  });
+});

--- a/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx
@@ -1552,3 +1552,170 @@ describe("HITL Run Abort", () => {
     });
   });
 });
+
+describe("HITL Wildcard Registration", () => {
+  it("passes the actual invoked tool name to a wildcard HITL renderer, not '*'", async () => {
+    // A wildcard HITL (`name: "*"`) approves any tool the agent calls, so the
+    // renderer's only way to tell the user *which* tool it is asking about is
+    // the `name` prop. Overwriting it with the registration name left every
+    // status showing "*".
+
+    const agent = new MockStepwiseAgent();
+    const namesSeen: string[] = [];
+
+    const WildcardHITLComponent: React.FC = () => {
+      const hitlTool: ReactHumanInTheLoop<{ action: string }> = {
+        name: "*",
+        description: "Approve any tool",
+        parameters: z.object({ action: z.string() }),
+        render: ({ status, name, respond, result }) => {
+          useEffect(() => {
+            if (namesSeen[namesSeen.length - 1] !== name) {
+              namesSeen.push(name);
+            }
+          }, [name]);
+
+          return (
+            <div data-testid="wildcard-hitl">
+              <div data-testid="wildcard-name">{name}</div>
+              <div data-testid="wildcard-status">{status}</div>
+              {respond && (
+                <button
+                  data-testid="wildcard-respond"
+                  onClick={() => respond(JSON.stringify({ approved: true }))}
+                >
+                  Approve
+                </button>
+              )}
+              {result && <div data-testid="wildcard-result">{result}</div>}
+            </div>
+          );
+        },
+      };
+
+      useHumanInTheLoop(hitlTool);
+      return null;
+    };
+
+    renderWithCopilotKit({
+      agent,
+      children: (
+        <>
+          <WildcardHITLComponent />
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </>
+      ),
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Delete the file" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete the file")).toBeDefined();
+    });
+
+    const messageId = testId("msg");
+    const toolCallId = testId("tc");
+
+    agent.emit(runStartedEvent());
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId,
+        toolCallName: "deleteFile",
+        parentMessageId: messageId,
+        delta: JSON.stringify({ action: "delete" }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wildcard-status").textContent).toBe(
+        ToolCallStatus.InProgress,
+      );
+    });
+    expect(screen.getByTestId("wildcard-name").textContent).toBe("deleteFile");
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    const approveButton = await screen.findByTestId("wildcard-respond");
+    expect(screen.getByTestId("wildcard-status").textContent).toBe(
+      ToolCallStatus.Executing,
+    );
+    expect(screen.getByTestId("wildcard-name").textContent).toBe("deleteFile");
+
+    fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wildcard-status").textContent).toBe(
+        ToolCallStatus.Complete,
+      );
+    });
+    expect(screen.getByTestId("wildcard-name").textContent).toBe("deleteFile");
+
+    // "*" must never have reached the renderer in any status.
+    expect(namesSeen).not.toContain("*");
+  });
+
+  it("still passes the registration name to a named HITL renderer", async () => {
+    // Guards the no-op half of the wildcard fix: for a named registration the
+    // invoked name and the registration name are equal, so nothing changes.
+
+    const agent = new MockStepwiseAgent();
+
+    const NamedHITLComponent: React.FC = () => {
+      const hitlTool: ReactHumanInTheLoop<{ action: string }> = {
+        name: "namedApprovalTool",
+        description: "Requires human approval",
+        parameters: z.object({ action: z.string() }),
+        render: ({ status, name }) => (
+          <div data-testid="named-hitl">
+            <div data-testid="named-name">{name}</div>
+            <div data-testid="named-status">{status}</div>
+          </div>
+        ),
+      };
+
+      useHumanInTheLoop(hitlTool);
+      return null;
+    };
+
+    renderWithCopilotKit({
+      agent,
+      children: (
+        <>
+          <NamedHITLComponent />
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </>
+      ),
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Request approval" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Request approval")).toBeDefined();
+    });
+
+    agent.emit(runStartedEvent());
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId: testId("tc"),
+        toolCallName: "namedApprovalTool",
+        parentMessageId: testId("msg"),
+        delta: JSON.stringify({ action: "delete" }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("named-name").textContent).toBe(
+        "namedApprovalTool",
+      );
+    });
+  });
+});

--- a/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
+++ b/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
@@ -60,15 +60,22 @@ export function useHumanInTheLoop<
     (props) => {
       const ToolComponent = tool.render;
 
+      // `props.name` is the tool that was actually invoked. For a named
+      // registration it already equals `tool.name`, so the override is a no-op.
+      // For a wildcard registration (`name: "*"`) `props.name` is the only
+      // place the real name exists — overwriting it with `"*"` left the
+      // renderer unable to say which tool it was asking the user to approve.
+      const name = tool.name === "*" ? props.name : tool.name;
+
       // Build the HITL render props per status. `props` already carries
-      // `toolCallId`; we overwrite `name`/`description` with the tool's
-      // registration values and add the registration `agentId`, so the HITL
-      // render always receives the full prop contract. `respond` is only live
-      // while the tool is executing.
+      // `toolCallId`; we overwrite `description` with the tool's registration
+      // value and add the registration `agentId`, so the HITL render always
+      // receives the full prop contract. `respond` is only live while the tool
+      // is executing.
       if (props.status === ToolCallStatus.InProgress) {
         const enhancedProps = {
           ...props,
-          name: tool.name,
+          name,
           description: tool.description || "",
           agentId: tool.agentId,
           respond: undefined,
@@ -77,7 +84,7 @@ export function useHumanInTheLoop<
       } else if (props.status === ToolCallStatus.Executing) {
         const enhancedProps = {
           ...props,
-          name: tool.name,
+          name,
           description: tool.description || "",
           agentId: tool.agentId,
           respond,
@@ -86,7 +93,7 @@ export function useHumanInTheLoop<
       } else if (props.status === ToolCallStatus.Complete) {
         const enhancedProps = {
           ...props,
-          name: tool.name,
+          name,
           description: tool.description || "",
           agentId: tool.agentId,
           respond: undefined,

--- a/packages/vue/src/v2/providers/CopilotKitProvider.vue
+++ b/packages/vue/src/v2/providers/CopilotKitProvider.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   computed,
+  h,
   onMounted,
   provide,
   ref,
@@ -10,6 +11,7 @@ import {
 } from "vue";
 import { z } from "zod";
 import type { AbstractAgent } from "@ag-ui/client";
+import { ToolCallStatus } from "@copilotkit/core";
 import type {
   CopilotKitCoreErrorCode,
   CopilotKitCoreSubscriber,
@@ -49,6 +51,7 @@ import type {
   VueFrontendTool,
   VueHumanInTheLoop,
   VueToolCallRenderer,
+  VueToolCallRendererRenderProps,
 } from "../types";
 
 const HEADER_NAME = "X-CopilotCloud-Public-Api-Key";
@@ -68,6 +71,10 @@ const RENDER_ACTIVITY_MESSAGES_STABLE_WARNING =
   "renderActivityMessages must be a stable array.";
 const SANDBOX_FUNCTIONS_STABLE_WARNING =
   "openGenerativeUI.sandboxFunctions must be a stable array.";
+// Matches the message React's `useHumanInTheLoop` rejects with, so an aborted
+// interrupt reads the same across frameworks (see #5554).
+const HUMAN_IN_THE_LOOP_ABORTED_MESSAGE =
+  "Human-in-the-loop interaction aborted";
 const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
 
 - Use a minimal, flat aesthetic. Avoid drop shadows and gradients — rely on subtle borders (1px solid, light gray like #e5e7eb) to define surfaces.
@@ -224,6 +231,27 @@ watch(
   { immediate: true },
 );
 
+/**
+ * A human-in-the-loop tool call from the `humanInTheLoop` prop that is waiting
+ * on the user. Keyed by tool call id so parallel interrupts on the same tool
+ * stay independent.
+ */
+type PendingHumanInTheLoop = {
+  resolve: (result: unknown) => void;
+  detachAbort?: () => void;
+};
+
+const pendingHumanInTheLoop = new Map<string, PendingHumanInTheLoop>();
+
+/** Removes a pending interaction and detaches its abort listener. */
+const takePendingHumanInTheLoop = (key: string) => {
+  const pending = pendingHumanInTheLoop.get(key);
+  if (!pending) return undefined;
+  pending.detachAbort?.();
+  pendingHumanInTheLoop.delete(key);
+  return pending;
+};
+
 const processedHumanInTheLoop = computed(() => {
   const tools: FrontendTool[] = [];
   const renderToolCalls: VueToolCallRenderer<unknown>[] = [];
@@ -235,18 +263,65 @@ const processedHumanInTheLoop = computed(() => {
       parameters: tool.parameters,
       followUp: tool.followUp,
       ...(tool.agentId && { agentId: tool.agentId }),
-      handler: async () => {
-        console.warn(
-          `Human-in-the-loop tool '${tool.name}' called but no interactive handler is set up.`,
-        );
-        return undefined;
+      // Keep the tool call pending until the render calls `respond`, matching
+      // the `useHumanInTheLoop` composable. Resolving immediately made the HITL
+      // UI flash and disappear without ever waiting for the user.
+      handler: async (_args, context) => {
+        const signal = context?.signal;
+        const key = context?.toolCall?.id ?? tool.name;
+
+        return new Promise((resolve, reject) => {
+          // Already aborted before the handler ran — reject so core records an
+          // explicit error tool result rather than silently resolving empty.
+          if (signal?.aborted) {
+            reject(new Error(HUMAN_IN_THE_LOOP_ABORTED_MESSAGE));
+            return;
+          }
+
+          const pending: PendingHumanInTheLoop = { resolve };
+          pendingHumanInTheLoop.set(key, pending);
+
+          if (signal) {
+            const onAbort = () => {
+              pendingHumanInTheLoop.delete(key);
+              reject(new Error(HUMAN_IN_THE_LOOP_ABORTED_MESSAGE));
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            pending.detachAbort = () => {
+              signal.removeEventListener("abort", onAbort);
+            };
+          }
+        });
       },
     });
     if (tool.render) {
+      const ToolComponent = tool.render;
+      const render: VueToolCallRenderer<unknown>["render"] = (
+        renderProps: VueToolCallRendererRenderProps<unknown>,
+      ) => {
+        const key = renderProps.toolCallId ?? tool.name;
+        return h(ToolComponent as Parameters<typeof h>[0], {
+          ...renderProps,
+          // `renderProps.name` is the tool that was actually invoked. It equals
+          // `tool.name` for a named registration; for a wildcard (`"*"`) it is
+          // the only place the real name exists.
+          name: tool.name === "*" ? renderProps.name : tool.name,
+          description: tool.description || "",
+          // `respond` is live only while the tool is executing — the one phase
+          // with a promise waiting on the user.
+          respond:
+            renderProps.status === ToolCallStatus.Executing
+              ? async (result: unknown) => {
+                  takePendingHumanInTheLoop(key)?.resolve(result);
+                }
+              : undefined,
+        });
+      };
+
       renderToolCalls.push({
         name: tool.name,
         args: tool.parameters ?? z.any(),
-        render: tool.render,
+        render,
         ...(tool.agentId && { agentId: tool.agentId }),
       } as VueToolCallRenderer<unknown>);
     }

--- a/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.hitl.e2e.test.ts
+++ b/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.hitl.e2e.test.ts
@@ -1,0 +1,192 @@
+/**
+ * End-to-end coverage for the `humanInTheLoop` **prop** path (OSS-803).
+ *
+ * The unit tests in CopilotKitProvider.test.ts drive the registered renderer
+ * directly. This file mounts the real pipeline instead — CopilotChat →
+ * CopilotChatToolCallsView → the provider's wrapper — so the wrapper is
+ * exercised as a Vue functional component and the pending-interaction key comes
+ * from core's real tool call id rather than a synthesized handler context.
+ */
+import { defineComponent } from "vue";
+import type { PropType } from "vue";
+import { screen, fireEvent, waitFor, cleanup } from "@testing-library/vue";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
+import CopilotChat from "../../components/chat/CopilotChat.vue";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+  runStartedEvent,
+  runFinishedEvent,
+  toolCallChunkEvent,
+  testId,
+} from "../../__tests__/utils/test-helpers";
+
+afterEach(() => {
+  cleanup();
+});
+
+const HITLRenderer = defineComponent({
+  props: {
+    name: { type: String, required: true },
+    description: { type: String, required: true },
+    status: { type: String as PropType<ToolCallStatus>, required: true },
+    args: {
+      type: Object as PropType<{ action?: string }>,
+      required: true,
+    },
+    result: { type: String, required: false },
+    respond: {
+      type: Function as PropType<
+        ((result: unknown) => Promise<void>) | undefined
+      >,
+      required: false,
+    },
+  },
+  template: `
+    <div data-testid="hitl-tool">
+      <div data-testid="hitl-name">{{ name }}</div>
+      <div data-testid="hitl-description">{{ description }}</div>
+      <div data-testid="hitl-status">{{ status }}</div>
+      <div data-testid="hitl-action">{{ args.action ?? "" }}</div>
+      <button
+        v-if="respond"
+        data-testid="hitl-approve"
+        @click="respond(JSON.stringify({ approved: true }))"
+      >
+        Approve
+      </button>
+      <div v-if="result" data-testid="hitl-result">{{ result }}</div>
+    </div>
+  `,
+});
+
+const ChatHost = defineComponent({
+  components: { CopilotChat },
+  template: `
+    <div style="height: 400px;">
+      <CopilotChat :welcome-screen="false" />
+    </div>
+  `,
+});
+
+async function submitMessage(value: string) {
+  const input = await screen.findByRole("textbox");
+  await fireEvent.update(input, value);
+  await fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+  await waitFor(() => {
+    expect(screen.getByText(value)).toBeDefined();
+  });
+}
+
+describe("CopilotKitProvider humanInTheLoop prop E2E", () => {
+  it("waits for the user and completes with the response", async () => {
+    const agent = new MockStepwiseAgent();
+
+    renderWithCopilotKit({
+      agent,
+      humanInTheLoop: [
+        {
+          name: "approvalTool",
+          description: "Requires human approval",
+          parameters: z.object({ action: z.string() }),
+          render: HITLRenderer,
+        },
+      ],
+      children: ChatHost,
+    });
+
+    await submitMessage("Request approval");
+
+    await agent.emit(runStartedEvent());
+    await agent.emit(
+      toolCallChunkEvent({
+        toolCallId: testId("tc"),
+        toolCallName: "approvalTool",
+        parentMessageId: testId("msg"),
+        delta: JSON.stringify({ action: "delete" }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hitl-status").textContent).toBe(
+        ToolCallStatus.InProgress,
+      );
+    });
+    expect(screen.getByTestId("hitl-name").textContent).toBe("approvalTool");
+    expect(screen.getByTestId("hitl-description").textContent).toBe(
+      "Requires human approval",
+    );
+    expect(screen.getByTestId("hitl-action").textContent).toBe("delete");
+
+    await agent.emit(runFinishedEvent());
+    await agent.complete();
+
+    // The run has finished, so the tool handler is now executing. Before the
+    // fix the handler had already resolved undefined, so the card never reached
+    // Executing and no approve button was ever rendered.
+    const approveButton = await screen.findByTestId("hitl-approve");
+    expect(screen.getByTestId("hitl-status").textContent).toBe(
+      ToolCallStatus.Executing,
+    );
+
+    await fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hitl-status").textContent).toBe(
+        ToolCallStatus.Complete,
+      );
+      expect(screen.getByTestId("hitl-result").textContent).toContain(
+        "approved",
+      );
+    });
+  });
+
+  it("passes the invoked tool name to a wildcard registration", async () => {
+    const agent = new MockStepwiseAgent();
+
+    renderWithCopilotKit({
+      agent,
+      humanInTheLoop: [
+        {
+          name: "*",
+          description: "Approve any tool",
+          parameters: z.object({ action: z.string() }),
+          render: HITLRenderer,
+        },
+      ],
+      children: ChatHost,
+    });
+
+    await submitMessage("Delete the file");
+
+    await agent.emit(runStartedEvent());
+    await agent.emit(
+      toolCallChunkEvent({
+        toolCallId: testId("tc"),
+        toolCallName: "deleteFile",
+        parentMessageId: testId("msg"),
+        delta: JSON.stringify({ action: "delete" }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hitl-name").textContent).toBe("deleteFile");
+    });
+
+    await agent.emit(runFinishedEvent());
+    await agent.complete();
+
+    const approveButton = await screen.findByTestId("hitl-approve");
+    expect(screen.getByTestId("hitl-name").textContent).toBe("deleteFile");
+
+    await fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hitl-status").textContent).toBe(
+        ToolCallStatus.Complete,
+      );
+    });
+  });
+});

--- a/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.test.ts
+++ b/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { defineComponent, h, nextTick, ref, watchEffect } from "vue";
+import type { VNode } from "vue";
 import type {
   CopilotKitCoreSubscriber,
   FrontendToolHandlerContext,
 } from "@copilotkit/core";
-import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
+import {
+  CopilotKitCoreRuntimeConnectionStatus,
+  ToolCallStatus,
+} from "@copilotkit/core";
 import { defineWebInspector } from "@copilotkit/web-inspector";
 import { z } from "zod";
 import CopilotKitProvider from "../CopilotKitProvider.vue";
@@ -327,12 +331,44 @@ describe("CopilotKitProvider", () => {
   });
 
   describe("humanInTheLoop prop", () => {
+    const HitlComponent = defineComponent({
+      setup() {
+        return () => h("div", "Test");
+      },
+    });
+
+    /** A handler context shaped like the one core passes to frontend tools. */
+    const hitlContext = (toolCallId: string, signal?: AbortSignal) =>
+      ({
+        toolCall: { id: toolCallId },
+        signal,
+      }) as unknown as FrontendToolHandlerContext;
+
+    /**
+     * Invokes the provider's registered renderer the way `useRenderToolCall`
+     * does and returns the props it forwarded to the user's component. The
+     * wrapper builds its VNode with `h()`, so the injected props are readable
+     * without mounting.
+     */
+    const renderHitl = (
+      getCore: () => CopilotKitCoreContextValue,
+      registeredName: string,
+      props: Record<string, unknown>,
+    ) => {
+      const render = getCore().renderToolCalls.find(
+        (rc) => rc.name === registeredName,
+      )?.render as (p: Record<string, unknown>) => VNode;
+      return render(props).props as {
+        name?: string;
+        description?: string;
+        respond?: (result: unknown) => Promise<void>;
+      };
+    };
+
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
     it("processes humanInTheLoop tools and creates handlers", () => {
-      const TestComponent = defineComponent({
-        setup() {
-          return () => h("div", "Test");
-        },
-      });
+      const TestComponent = HitlComponent;
       const humanInTheLoop: VueHumanInTheLoop[] = [
         {
           name: "approvalTool",
@@ -347,25 +383,25 @@ describe("CopilotKitProvider", () => {
       expect(tool).toBeDefined();
       expect(tool?.handler).toBeDefined();
 
+      // The registered renderer wraps the user's component so `respond` and the
+      // tool's description can be injected per status.
       const renderTool = getCore().renderToolCalls.find(
         (rc) => rc.name === "approvalTool",
       );
       expect(renderTool).toBeDefined();
-      expect(renderTool?.render).toStrictEqual(TestComponent);
+      expect(typeof renderTool?.render).toBe("function");
     });
 
-    it("creates placeholder handlers for humanInTheLoop tools", async () => {
-      const TestComponent = defineComponent({
-        setup() {
-          return () => h("div", "Test");
-        },
-      });
+    it("keeps the tool call pending until respond is called", async () => {
+      // Reproduces OSS-803: the handler used to warn and resolve undefined
+      // immediately, so the HITL UI flashed and disappeared instead of waiting
+      // for the user.
       const humanInTheLoop: VueHumanInTheLoop[] = [
         {
           name: "interactiveTool",
           description: "Interactive tool",
           parameters: z.object({ data: z.string() }),
-          render: TestComponent,
+          render: HitlComponent,
         },
       ];
 
@@ -375,16 +411,194 @@ describe("CopilotKitProvider", () => {
       })?.handler;
       expect(handler).toBeDefined();
 
-      const result = await handler!(
+      let settled = false;
+      const pending = handler!({ data: "test" }, hitlContext("tc-1")).then(
+        (result) => {
+          settled = true;
+          return result;
+        },
+      );
+
+      await flush();
+      expect(settled).toBe(false);
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("no interactive handler is set up"),
+      );
+
+      const props = renderHitl(getCore, "interactiveTool", {
+        name: "interactiveTool",
+        toolCallId: "tc-1",
+        args: { data: "test" },
+        status: ToolCallStatus.Executing,
+        result: undefined,
+      });
+
+      expect(props.respond).toBeDefined();
+      await props.respond!("approved");
+
+      await expect(pending).resolves.toBe("approved");
+    });
+
+    it("exposes respond only while the tool is executing", () => {
+      const humanInTheLoop: VueHumanInTheLoop[] = [
+        {
+          name: "interactiveTool",
+          description: "Interactive tool",
+          parameters: z.object({ data: z.string() }),
+          render: HitlComponent,
+        },
+      ];
+
+      const { getCore } = mountWithProvider(() => h("div"), { humanInTheLoop });
+
+      const inProgress = renderHitl(getCore, "interactiveTool", {
+        name: "interactiveTool",
+        toolCallId: "tc-1",
+        args: { data: "test" },
+        status: ToolCallStatus.InProgress,
+        result: undefined,
+      });
+      expect(inProgress.respond).toBeUndefined();
+      expect(inProgress.description).toBe("Interactive tool");
+
+      const complete = renderHitl(getCore, "interactiveTool", {
+        name: "interactiveTool",
+        toolCallId: "tc-1",
+        args: { data: "test" },
+        status: ToolCallStatus.Complete,
+        result: "approved",
+      });
+      expect(complete.respond).toBeUndefined();
+    });
+
+    it("rejects the pending tool call when the run is aborted", async () => {
+      const humanInTheLoop: VueHumanInTheLoop[] = [
+        {
+          name: "interactiveTool",
+          description: "Interactive tool",
+          parameters: z.object({ data: z.string() }),
+          render: HitlComponent,
+        },
+      ];
+
+      const { getCore } = mountWithProvider(() => h("div"), { humanInTheLoop });
+      const handler = getCore().getTool({
+        toolName: "interactiveTool",
+      })?.handler;
+
+      const controller = new AbortController();
+      const pending = handler!(
         { data: "test" },
-        {} as unknown as FrontendToolHandlerContext,
+        hitlContext("tc-1", controller.signal),
       );
-      expect(result).toBeUndefined();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Human-in-the-loop tool 'interactiveTool' called",
-        ),
+
+      controller.abort();
+
+      // An explicit rejection makes core record an error tool result rather
+      // than silently resolving empty (#5554).
+      await expect(pending).rejects.toThrow(
+        "Human-in-the-loop interaction aborted",
       );
+    });
+
+    it("rejects immediately when the run was already aborted", async () => {
+      const humanInTheLoop: VueHumanInTheLoop[] = [
+        {
+          name: "interactiveTool",
+          description: "Interactive tool",
+          parameters: z.object({ data: z.string() }),
+          render: HitlComponent,
+        },
+      ];
+
+      const { getCore } = mountWithProvider(() => h("div"), { humanInTheLoop });
+      const handler = getCore().getTool({
+        toolName: "interactiveTool",
+      })?.handler;
+
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        handler!({ data: "test" }, hitlContext("tc-1", controller.signal)),
+      ).rejects.toThrow("Human-in-the-loop interaction aborted");
+    });
+
+    it("keeps parallel interrupts on the same tool independent", async () => {
+      const humanInTheLoop: VueHumanInTheLoop[] = [
+        {
+          name: "interactiveTool",
+          description: "Interactive tool",
+          parameters: z.object({ data: z.string() }),
+          render: HitlComponent,
+        },
+      ];
+
+      const { getCore } = mountWithProvider(() => h("div"), { humanInTheLoop });
+      const handler = getCore().getTool({
+        toolName: "interactiveTool",
+      })?.handler;
+
+      const first = handler!({ data: "one" }, hitlContext("tc-1"));
+      const second = handler!({ data: "two" }, hitlContext("tc-2"));
+
+      let firstSettled = false;
+      void first.then(() => {
+        firstSettled = true;
+      });
+      let secondSettled = false;
+      void second.then(() => {
+        secondSettled = true;
+      });
+
+      // Respond to the second tool call only.
+      const secondProps = renderHitl(getCore, "interactiveTool", {
+        name: "interactiveTool",
+        toolCallId: "tc-2",
+        args: { data: "two" },
+        status: ToolCallStatus.Executing,
+        result: undefined,
+      });
+      await secondProps.respond!("two-approved");
+      await expect(second).resolves.toBe("two-approved");
+
+      // The first is still waiting on its own user response.
+      await flush();
+      expect(firstSettled).toBe(false);
+      expect(secondSettled).toBe(true);
+
+      const firstProps = renderHitl(getCore, "interactiveTool", {
+        name: "interactiveTool",
+        toolCallId: "tc-1",
+        args: { data: "one" },
+        status: ToolCallStatus.Executing,
+        result: undefined,
+      });
+      await firstProps.respond!("one-approved");
+      await expect(first).resolves.toBe("one-approved");
+    });
+
+    it("passes the actual invoked tool name to a wildcard HITL renderer", () => {
+      const humanInTheLoop: VueHumanInTheLoop[] = [
+        {
+          name: "*",
+          description: "Approve any tool",
+          parameters: z.object({ data: z.string() }),
+          render: HitlComponent,
+        },
+      ];
+
+      const { getCore } = mountWithProvider(() => h("div"), { humanInTheLoop });
+
+      const props = renderHitl(getCore, "*", {
+        name: "deleteFile",
+        toolCallId: "tc-1",
+        args: { data: "test" },
+        status: ToolCallStatus.Executing,
+        result: undefined,
+      });
+
+      expect(props.name).toBe("deleteFile");
     });
   });
 
@@ -486,7 +700,20 @@ describe("CopilotKitProvider", () => {
       expect(frontendRenderTool).toBeDefined();
       expect(humanRenderTool).toBeDefined();
       expect(frontendRenderTool?.render).toStrictEqual(TestComponent1);
-      expect(humanRenderTool?.render).toStrictEqual(TestComponent2);
+      // A humanInTheLoop render is wrapped so `respond` can be injected, so it
+      // is not the component itself — assert it delegates to it.
+      const humanRender = humanRenderTool?.render as (
+        p: Record<string, unknown>,
+      ) => VNode;
+      expect(
+        humanRender({
+          name: "humanRenderTool",
+          toolCallId: "tc-1",
+          args: { b: "value" },
+          status: ToolCallStatus.Executing,
+          result: undefined,
+        }).type,
+      ).toStrictEqual(TestComponent2);
     });
   });
 

--- a/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.wildcard.test.ts
+++ b/packages/vue/src/v2/providers/__tests__/CopilotKitProvider.wildcard.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { defineComponent, h } from "vue";
+import type { VNode } from "vue";
 import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
 import type { VueFrontendTool, VueHumanInTheLoop } from "../../types";
 import { mountWithProvider } from "../../__tests__/utils/mount";
 
@@ -99,6 +101,19 @@ describe("CopilotKitProvider wildcard behavior", () => {
       (rc) => rc.name === "*",
     );
     expect(wildcardRender).toBeDefined();
-    expect(wildcardRender?.render).toStrictEqual(WildcardComponent);
+    // A humanInTheLoop render is wrapped so `respond` can be injected, so it is
+    // not the component itself — assert it delegates to it, and that the
+    // wildcard receives the name of the tool that was actually invoked.
+    const vnode = (
+      wildcardRender?.render as (p: Record<string, unknown>) => VNode
+    )({
+      name: "someTool",
+      toolCallId: "tc-1",
+      args: { toolName: "someTool", args: {} },
+      status: ToolCallStatus.Executing,
+      result: undefined,
+    });
+    expect(vnode.type).toStrictEqual(WildcardComponent);
+    expect((vnode.props as { name?: string })?.name).toBe("someTool");
   });
 });


### PR DESCRIPTION
Three independent tool-rendering / human-in-the-loop bugs, plus a `packages/core` gap the third one exposed. One commit each, so any of them can be reviewed or reverted alone.

> The `packages/core` commit was made with `--no-verify`. The pre-commit gate runs `nx test` for affected packages, and `@copilotkit/core`'s suite fails **in my local worktree** on 20 `core-inspector-metadata.test.ts` timeouts. Those are a local build artifact, not a real regression: `@copilotkit/shared` resolves through a symlinked `node_modules` to a package whose `dist` predates `parseInspectorMetadataV1`/`InspectorMetadataV1` (both present in `packages/shared/src/utils/inspector-metadata.ts`), so `packages/core`'s own `tsc --noEmit` also reports those four symbols missing. CI builds from source and the JS unit matrix is green. Every test the gate would have run, I ran directly.

### OSS-802 — v1 tool rendering dropped all but the first parallel tool call

`useLazyToolRenderer` read `message.toolCalls[0]` and returned a single render, so an assistant message carrying a parallel batch displayed only the first tool call. Tool calls 2..N were dropped with no `inProgress` state and no result — from the user's seat that is indistinguishable from a result that never arrived, which is how this surfaced while verifying #1982 / #2051 (that reporter's backend does `asyncio.gather` over every `tool_call`).

Now maps over every tool call. It still returns `null` when *none* of them produce output, so a message with no registered renderer keeps falling through to the custom-message renderer as before. v2's `CopilotChatToolCallsView` already did this correctly.

### OSS-803 — Vue `humanInTheLoop` provider prop resolved immediately

The Vue provider's `humanInTheLoop` **prop** path registered a handler that warned and resolved `undefined` right away, so the HITL UI flashed and disappeared instead of waiting for the user, and it registered `tool.render` unwrapped so the renderer never got a working `respond`.

Now matches the `useHumanInTheLoop` composable:

- the tool-call promise stays pending until `respond` is called
- `respond` is live only while status is `Executing`
- an aborted run **rejects** with `Human-in-the-loop interaction aborted`, so core records an explicit error tool result rather than silently resolving empty (#5554)
- pending interactions are keyed by tool call id, so parallel interrupts on the same tool stay independent
- a wildcard (`name: "*"`) registration keeps the invoked tool's name

The abort bullet depended on a `signal` that core did not always supply — see the fourth commit below.

### `packages/core` — wildcard tool handlers never received the abort signal

Found while verifying the abort claim above. The named-tool path calls handlers with `signal: this._runAbortController?.signal` (`run-handler.ts:821`), but `executeWildcardTool` passed only `{ toolCall, agent }` (`run-handler.ts:1007`). A wildcard handler that waits on something therefore could never observe an abort, so a HITL tool registered as `"*"` stayed pending forever when the run was stopped — in React's `useHumanInTheLoop` as much as in the Vue provider path this PR fixes. OSS-804 makes wildcard HITL actually usable, which is what made this reachable.

The fix adds that one argument. It is additive: handlers that ignore the signal are unaffected, and `signal` was previously `undefined` for this path.

React's provider-prop path has the same placeholder; that half is being fixed in #4955 (react-core only, no file overlap with this PR).

### OSS-804 — wildcard `useHumanInTheLoop` renderer received `"*"`

`useHumanInTheLoop` overwrote the render props' `name` with the *registration* name in all three status branches. For a named tool the two are equal so the override was a no-op; for `name: "*"` it clobbered the real name, leaving a wildcard HITL unable to tell the user which tool it was asking them to approve.

Now only overrides when the registration isn't a wildcard. This matches the contract already asserted in `defineToolCallRenderer.test.tsx` ("wildcard receives actual tool name, not `*`") and the behavior of the other wildcard wrappers (`useRenderTool`, `useDefaultRenderTool`, `WildcardToolCallRender`).

## Testing

Every fix has a test that fails without it. Each negative control was run by reverting **only** the source file on this branch and re-running the same test.

**OSS-802** — `packages/react-core/src/hooks/__tests__/repro-1982-2051-v1-path.test.tsx` (new, plus the passing v2 counterpart `src/v2/hooks/__tests__/repro-1982-2051.test.tsx`).

Before, on a clean `origin/main` worktree:

```
 ✓ src/v2/hooks/__tests__/repro-1982-2051.test.tsx (2 tests) 128ms
 ❯ src/hooks/__tests__/repro-1982-2051-v1-path.test.tsx (2 tests | 1 failed)
   ✓ v1 single backend tool call reaches complete with its result
   × v1 renders every parallel tool call, not just the first
     → expected null not to be null
```

After:

```
 ✓ src/hooks/__tests__/use-copilot-chat-internal-connect.test.tsx (7 tests)
 ✓ src/hooks/__tests__/use-coagent-state-render.e2e.test.tsx (22 tests)
 ✓ src/v2/hooks/__tests__/repro-1982-2051.test.tsx (2 tests)
 ✓ src/hooks/__tests__/repro-1982-2051-v1-path.test.tsx (2 tests)
 ✓ src/hooks/__tests__/use-copilot-action.e2e.test.tsx (1 test)

 Test Files  5 passed (5)
      Tests  34 passed (34)
```

(The other four files are every existing consumer of `useLazyToolRenderer` plus the v1 action path — the fallthrough-to-custom-renderer behavior is what they cover.)

**OSS-803** — 6 new unit tests in `packages/vue/src/v2/providers/__tests__/CopilotKitProvider.test.ts` (pending-until-respond, `respond` only while executing, abort rejects, already-aborted rejects, parallel interrupts independent, wildcard name), plus 2 **mounted** end-to-end tests in `CopilotKitProvider.hitl.e2e.test.ts`. Two existing tests asserted the old placeholder behavior (`resolves undefined` + the warning) or compared `render` by identity, and were updated: the renderer is now a wrapper, so they assert it *delegates* to the user's component.

The unit tests drive the registered renderer directly with a synthesized handler context, which cannot catch a mismatch between the key the handler stores under and the tool call id the real pipeline supplies. The e2e file closes that: it mounts `CopilotChat → CopilotChatToolCallsView →` the provider's wrapper, so the wrapper runs as a real Vue functional component and the key comes from core's own tool call id. Reverted, both fail with the exact reported symptom — the card never reaches `Executing`, so no approve button is ever rendered:

```
 × waits for the user and completes with the response
 × passes the invoked tool name to a wildcard registration
 TestingLibraryElementError: Unable to find an element by: [data-testid="hitl-approve"]
```

With the provider reverted, 7 unit tests fail:

```
 × processes humanInTheLoop tools and creates handlers
 × keeps the tool call pending until respond is called
 × exposes respond only while the tool is executing
 × rejects the pending tool call when the run is aborted
 × rejects immediately when the run was already aborted
 × keeps parallel interrupts on the same tool independent
 × passes the actual invoked tool name to a wildcard HITL renderer

 Tests  7 failed | 2 passed | 19 skipped (28)
```

Full Vue suite with the fix:

```
 Test Files  100 passed (100)
      Tests  1077 passed (1077)
```

**OSS-804** — 2 new tests in `packages/react-core/src/v2/hooks/__tests__/use-human-in-the-loop.e2e.test.tsx`: a wildcard HITL driven through `InProgress → Executing → Complete` via `MockStepwiseAgent`, asserting `name === "deleteFile"` at every status and that `"*"` never reached the renderer; plus a named-registration test guarding the no-op half.

With the hook reverted:

```
 FAIL  HITL Wildcard Registration > passes the actual invoked tool name to a wildcard HITL renderer, not '*'
 AssertionError: expected '*' to be 'deleteFile'
   Expected: "deleteFile"
   Received: "*"
```

With the fix: `use-human-in-the-loop.e2e.test.tsx (16 tests)` — all pass.

**core wildcard signal** — 2 new tests in `packages/core/src/__tests__/core-abort-during-tool.test.ts`, mirroring the named-tool pair already there: one asserts a wildcard handler receives an `AbortSignal`, the other that `stopAgent()` during wildcard execution aborts it. Reverting only the changed line in `run-handler.ts` fails both while the four existing tests stay green:

```
 ✓ should NOT restart the run when stopAgent is called during tool execution
 ✓ should pass an AbortSignal to the tool handler context
 ✓ should abort the signal when stopAgent is called during tool execution
 × should pass an AbortSignal to a wildcard tool handler context
   → expected undefined to be an instance of AbortSignal
 × should abort the signal when stopAgent is called during wildcard tool execution
   → expected undefined to be true
 ✓ should NOT restart the run when agent.abortRun() is called directly during tool execution
```

Scope note on this one: in a worktree, `@copilotkit/core` resolves to the built package, so the react-core and Vue suites here exercise the *published* core rather than this source change. The core fix is verified at the source level by the tests above; the composed behavior (wildcard HITL rejecting on abort through the Vue provider) follows from two separately-verified halves — core now supplies the signal, and the Vue path's abort test proves it rejects when given one — but I did not execute that combination end to end. CI builds from source and will.

### Repo-wide checks

| Check | Result |
| --- | --- |
| `react-core` full suite | 1503 passed, 1 failed — `use-interrupt.test.tsx > does not persist a tool-result message for backend-owned interrupts`. Not from this branch: it fails identically in a separate pristine `origin/main` worktree. Same local-build caveat as the `core` row below; CI is green. |
| `react-core` `tsc --noEmit` | clean |
| `vue` full suite | 1079 passed (101 files) |
| `vue` `vue-tsc --noEmit` | clean |
| `vue` `eslint` on changed files | 3 errors, all byte-identical to `origin/main` on the same file (2 unused-import false positives, 1 pre-existing `any` at what is now line 543) — no new lint errors |
| `core` full suite | With the fix: 637 passed, 20 failed. With the one changed line reverted: **22** failed. The two extra are exactly the two new wildcard tests, and set-differencing the failure names both ways shows nothing else moved — so the fix breaks nothing and the 20 are independent of it. All 20 are `core-inspector-metadata.test.ts` `Timeout waiting for condition`, caused by the stale `@copilotkit/shared` build described above rather than by anything on this branch. |
| `core` `tsc --noEmit` | 4 errors, all the stale-`@copilotkit/shared` symbol resolution described above; none in changed code |

### CI: the one red check is repo-wide, not from this branch

`langgraph-python` (dojo e2e) fails on three `agenticChatPage.spec.ts` journeys. Event counts match exactly (33/33 and 129/129); the only difference is `event 2: STATE_SNAPSHOT — expected: <missing>, actual: "local_dev"`. `local_dev` appears nowhere in the repo, so it is a value the LangGraph dev server supplies at run time against a recorded trace that does not have it.

It is not this branch: **#6530, a CSS-only change to `header.css`, fails the same job identically**, and merging current `origin/main` in did not change the outcome. Nothing in this PR touches state snapshots, the runtime, or the Python SDK.

## Not in this PR

OSS-805 (passive client disconnect does not abort an in-flight run) is deliberately left out. Abort-on-disconnect is not unconditionally correct — disconnect-tolerant runs are a deliberate feature for reconnect-to-in-flight-thread and durable/background runs — so the per-runner semantics need deciding before `request.signal` gets wired up. It also touches runtime behavior rather than frontend rendering, and belongs in a PR that can be reviewed on that basis.

Two adjacent gaps found while doing this, not filed as part of it:

- the Vue `useHumanInTheLoop` composable has the same wildcard `name` clobber this PR fixes for React (OSS-804), and no abort handling at all
- React's provider-prop path has the same placeholder handler this PR fixes for Vue (OSS-803) — that's #4955's scope

Fixes OSS-802
Fixes OSS-803
Fixes OSS-804
