### PR TITLE
fix(core): hydrate self-hosted threads whose /connect replay contains an errored run

### DIFF
--- a/packages/core/src/__tests__/proxied-connect-replay-multi-run.test.ts
+++ b/packages/core/src/__tests__/proxied-connect-replay-multi-run.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+
+/**
+ * Issue #4943 (part 2): hydrating an existing thread through `/connect` on a
+ * self-hosted runtime.
+ *
+ * A `/connect` response replays the thread's history, so it can legitimately
+ * carry events from several past runs — including a run that ended in
+ * RUN_ERROR followed by a later RUN_STARTED. AbstractAgent's connect pipeline
+ * runs the stream through `verifyEvents`, which enforces single-run lifecycle
+ * rules and rejects a RUN_STARTED after a RUN_ERROR:
+ *
+ *   Cannot send event type 'RUN_STARTED': The run has already errored with
+ *   'RUN_ERROR'. No further events can be sent.
+ *
+ * IntelligenceAgent already omits `verifyEvents` from its connect pipeline for
+ * exactly this reason (see intelligence-agent.ts). Self-hosted runtimes
+ * (RUNTIME_MODE_SSE) still inherit the base pipeline, so replay of a thread
+ * whose history contains an errored run fails to hydrate.
+ */
+
+const encoder = new TextEncoder();
+
+function createConnectReplayResponse(): Response {
+  const stream = new ReadableStream({
+    start(controller) {
+      const events = [
+        // ---- first past run: ended in RUN_ERROR ----
+        { type: "RUN_STARTED", threadId: "existing-thread", runId: "run-1" },
+        {
+          type: "TEXT_MESSAGE_START",
+          messageId: "msg-1",
+          role: "assistant",
+        },
+        {
+          type: "TEXT_MESSAGE_CONTENT",
+          messageId: "msg-1",
+          delta: "first run answer",
+        },
+        { type: "TEXT_MESSAGE_END", messageId: "msg-1" },
+        {
+          type: "RUN_ERROR",
+          threadId: "existing-thread",
+          runId: "run-1",
+          message: "upstream model error",
+        },
+        // ---- second past run: replayed in the same /connect stream ----
+        { type: "RUN_STARTED", threadId: "existing-thread", runId: "run-2" },
+        {
+          type: "TEXT_MESSAGE_START",
+          messageId: "msg-2",
+          role: "assistant",
+        },
+        {
+          type: "TEXT_MESSAGE_CONTENT",
+          messageId: "msg-2",
+          delta: "second run answer",
+        },
+        { type: "TEXT_MESSAGE_END", messageId: "msg-2" },
+        {
+          type: "RUN_FINISHED",
+          threadId: "existing-thread",
+          runId: "run-2",
+          result: { newMessages: [] },
+        },
+      ];
+      controller.enqueue(
+        encoder.encode(
+          events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""),
+        ),
+      );
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("self-hosted /connect replay across multiple past runs (#4943)", () => {
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve(createConnectReplayResponse()));
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("hydrates a thread whose replayed history contains an errored run", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example/hono",
+      agentId: "hydrating-agent",
+      transport: "rest",
+    });
+    agent.threadId = "existing-thread";
+
+    await expect(agent.connectAgent()).resolves.toBeDefined();
+
+    expect(agent.messages.map((m) => m.id)).toEqual(["msg-1", "msg-2"]);
+  });
+});

--- a/packages/core/src/__tests__/proxied-connect-replay-multi-run.test.ts
+++ b/packages/core/src/__tests__/proxied-connect-replay-multi-run.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { AGUIConnectNotImplementedError } from "@ag-ui/client";
 import { ProxiedCopilotRuntimeAgent } from "../agent";
 
 /**
@@ -105,5 +106,41 @@ describe("self-hosted /connect replay across multiple past runs (#4943)", () => 
     await expect(agent.connectAgent()).resolves.toBeDefined();
 
     expect(agent.messages.map((m) => m.id)).toEqual(["msg-1", "msg-2"]);
+  });
+
+  /**
+   * The verifyEvents-free pipeline must keep the base implementation's special
+   * case for agents that don't implement `connect()`: swallow the error rather
+   * than route it through `onError`.
+   *
+   * `CopilotKitCore` awaits `detachActiveRun()` before every run and only
+   * resolves because this path reaches the pipeline's finalize block (see the
+   * historical deadlock note in run-handler.ts). Surfacing it through onError
+   * would also fire run-failure callbacks on every subscriber for a benign
+   * condition.
+   */
+  it("swallows AGUIConnectNotImplementedError instead of failing the run", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example/hono",
+      agentId: "no-connect-agent",
+      transport: "rest",
+    });
+
+    // Stand in for an agent whose transport has no /connect implementation.
+    (agent as unknown as { connect: () => never }).connect = () => {
+      throw new AGUIConnectNotImplementedError();
+    };
+
+    const onRunFailed = vi.fn();
+    const onRunErrorEvent = vi.fn();
+    agent.subscribe({ onRunFailed, onRunErrorEvent });
+
+    await expect(agent.connectAgent()).resolves.toBeDefined();
+
+    expect(onRunFailed).not.toHaveBeenCalled();
+    expect(onRunErrorEvent).not.toHaveBeenCalled();
+    // The finalize block must still have run, or detachActiveRun() would hang.
+    expect(agent.isRunning).toBe(false);
+    await expect(agent.detachActiveRun()).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -29,6 +29,7 @@ import type {
 import { IntelligenceAgent } from "./intelligence-agent";
 import type { CopilotRuntimeTransport } from "./types";
 import { runtimeInfoError } from "./utils/runtime-info-error";
+import { ɵconnectWithoutEventVerification } from "./utils/connect-replay";
 
 type ResolvedRuntimeMode = RuntimeMode | "pending";
 
@@ -269,7 +270,12 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     subscriber?: AgentSubscriber,
   ): Promise<RunAgentResult> {
     if (this.runtimeMode !== RUNTIME_MODE_INTELLIGENCE) {
-      return super.connectAgent(parameters, subscriber);
+      // A self-hosted `/connect` response replays the thread's history, so it
+      // can carry several past runs — including one that ended in RUN_ERROR
+      // followed by a later RUN_STARTED. The base pipeline's `verifyEvents`
+      // step enforces single-run lifecycle rules and rejects that stream
+      // outright, so an existing thread never hydrates (#4943).
+      return ɵconnectWithoutEventVerification(this, parameters, subscriber);
     }
 
     // If the delegate already has an active run (e.g. from a previous

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -5,22 +5,14 @@ import type {
   AgentSubscriber,
   BaseEvent,
 } from "@ag-ui/client";
-import {
-  AbstractAgent,
-  EventType,
-  randomUUID,
-  transformChunks,
-  structuredClone_,
-} from "@ag-ui/client";
+import { AbstractAgent, EventType } from "@ag-ui/client";
 
 import {
   EMPTY,
-  Subject,
   Notification,
   combineLatest,
   defer,
   dematerialize,
-  lastValueFrom,
   merge,
   switchMap,
   throwError,
@@ -42,6 +34,7 @@ import {
   tap,
 } from "rxjs/operators";
 import { phoenixExponentialBackoff } from "@copilotkit/shared";
+import { ɵconnectWithoutEventVerification } from "./utils/connect-replay";
 import {
   ɵphoenixChannel$,
   ɵphoenixSocket$,
@@ -216,106 +209,35 @@ export class IntelligenceAgent extends AbstractAgent {
   /**
    * Override of AbstractAgent.connectAgent that removes the `verifyEvents` step.
    *
-   * Background: AbstractAgent's connectAgent pipeline runs events through
-   * `verifyEvents`, which validates that the stream follows the AG-UI protocol
-   * lifecycle — specifically, it expects a RUN_STARTED event before any content
-   * events and a RUN_FINISHED/RUN_ERROR event to complete the stream.
-   *
    * IntelligenceAgent uses long-lived WebSocket connections rather than
    * request-scoped SSE streams. When connecting to replay historical messages
    * for an existing thread, the connection semantics don't map to a single
-   * agent run start/stop cycle. The replayed events may not include
-   * RUN_STARTED/RUN_FINISHED bookends (or may contain events from multiple
-   * past runs), which causes verifyEvents to either never complete or to
-   * error out.
+   * agent run start/stop cycle: the replayed events may omit the
+   * RUN_STARTED/RUN_FINISHED bookends, or carry events from several past runs,
+   * either of which makes `verifyEvents` stall or error out.
    *
-   * This override replicates the base connectAgent implementation exactly,
-   * substituting only `transformChunks` (which is still needed for message
-   * reassembly) and omitting `verifyEvents`.
-   *
-   * TODO: Remove this override once AG-UI's AbstractAgent supports opting out
-   * of verifyEvents for transports with different connection life-cycles.
+   * See {@link ɵconnectWithoutEventVerification} for the pipeline itself, which
+   * the self-hosted `/connect` path shares for the same reason.
    */
   override async connectAgent(
     parameters?: RunAgentParameters,
     subscriber?: AgentSubscriber,
   ): Promise<RunAgentResult> {
-    // Access private fields through a type escape hatch — these are set/read
-    // by the base class and must be managed identically to the original.
-    // Using `any` because these fields are private in AbstractAgent, and
-    // intersecting private+public members of the same name produces `never`.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const self = this as any;
+    // A run already in flight owns the canonical run id; reuse it so the
+    // replay is attributed to that run rather than minting a new one.
+    const effectiveParameters =
+      parameters?.runId || !this.canonicalRunId
+        ? parameters
+        : {
+            ...parameters,
+            runId: this.canonicalRunId,
+          };
 
-    try {
-      this.isRunning = true;
-      this.agentId = this.agentId ?? randomUUID();
-
-      const effectiveParameters =
-        parameters?.runId || !this.canonicalRunId
-          ? parameters
-          : {
-              ...parameters,
-              runId: this.canonicalRunId,
-            };
-      const input = this.prepareRunAgentInput(effectiveParameters);
-      let result: RunAgentResult["result"];
-      const previousMessageIds = new Set(this.messages.map((m) => m.id));
-      const subscribers: AgentSubscriber[] = [
-        {
-          onRunFinishedEvent: (event) => {
-            if (event.outcome === "success") {
-              result = event.result;
-            }
-          },
-        },
-        ...this.subscribers,
-        subscriber ?? {},
-      ];
-
-      await this.onInitialize(input, subscribers);
-
-      self.activeRunDetach$ = new Subject<void>();
-      let resolveCompletion: (() => void) | undefined;
-      self.activeRunCompletionPromise = new Promise<void>((resolve) => {
-        resolveCompletion = resolve;
-      });
-
-      const source$ = defer(() => this.connect(input)).pipe(
-        // transformChunks reassembles partial/streamed messages — still needed.
-        transformChunks(this.debugLogger),
-        // NOTE: verifyEvents is intentionally omitted here. See JSDoc above.
-        takeUntil(self.activeRunDetach$),
-      );
-
-      const applied$ = this.apply(input, source$, subscribers);
-      const processed$ = this.processApplyEvents(input, applied$, subscribers);
-
-      await lastValueFrom(
-        processed$.pipe(
-          catchError((error) => {
-            this.isRunning = false;
-            return this.onError(input, error, subscribers);
-          }),
-          finalize(() => {
-            this.isRunning = false;
-            this.onFinalize(input, subscribers);
-            resolveCompletion?.();
-            resolveCompletion = undefined;
-            self.activeRunCompletionPromise = undefined;
-            self.activeRunDetach$ = undefined;
-          }),
-        ),
-        { defaultValue: undefined },
-      );
-
-      const newMessages = structuredClone_(this.messages).filter(
-        (m) => !previousMessageIds.has(m.id),
-      );
-      return { result, newMessages };
-    } finally {
-      this.isRunning = false;
-    }
+    return ɵconnectWithoutEventVerification(
+      this,
+      effectiveParameters,
+      subscriber,
+    );
   }
 
   abortRun(): void {

--- a/packages/core/src/utils/connect-replay.ts
+++ b/packages/core/src/utils/connect-replay.ts
@@ -1,0 +1,120 @@
+import type {
+  AbstractAgent,
+  AgentSubscriber,
+  BaseEvent,
+  RunAgentParameters,
+  RunAgentResult,
+} from "@ag-ui/client";
+import { randomUUID, structuredClone_, transformChunks } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { Subject, defer, lastValueFrom } from "rxjs";
+import { catchError, finalize, takeUntil } from "rxjs/operators";
+
+/**
+ * Runs an agent's `connect()` stream through the AbstractAgent apply pipeline
+ * with the `verifyEvents` step omitted.
+ *
+ * `verifyEvents` enforces AG-UI's *single run* lifecycle rules: exactly one
+ * RUN_STARTED opening the stream, no events after a terminal RUN_FINISHED /
+ * RUN_ERROR. Those rules are correct for `/run`, but a `/connect` response is a
+ * replay of a thread's history and can legitimately carry several past runs
+ * back to back — including a run that ended in RUN_ERROR followed by a later
+ * RUN_STARTED. Verifying a replay against single-run rules makes hydration of
+ * an existing thread fail outright:
+ *
+ *   Cannot send event type 'RUN_STARTED': The run has already errored with
+ *   'RUN_ERROR'. No further events can be sent.
+ *
+ * `transformChunks` is still applied — message reassembly is needed either way.
+ *
+ * This mirrors the base `AbstractAgent.connectAgent` implementation exactly
+ * apart from that omission, so callers keep the same subscriber notifications,
+ * detach semantics, and `{ result, newMessages }` return shape.
+ *
+ * TODO: Remove this in favour of the base implementation once AG-UI's
+ * AbstractAgent supports opting out of `verifyEvents` for transports whose
+ * connection life-cycle isn't a single run. As of `@ag-ui/client@0.0.57`
+ * `connectAgent(parameters?, subscriber?)` takes no such option.
+ *
+ * @param agent - The agent whose `connect()` stream should be consumed.
+ * @param parameters - Run parameters, forwarded to `prepareRunAgentInput`.
+ * @param subscriber - Optional one-shot subscriber for this connect call.
+ */
+export async function ɵconnectWithoutEventVerification(
+  agent: AbstractAgent,
+  parameters?: RunAgentParameters,
+  subscriber?: AgentSubscriber,
+): Promise<RunAgentResult> {
+  // Access protected/private members through a type escape hatch — they are
+  // set and read by the base class and must be managed identically to the
+  // original implementation. `any` is required because these fields are
+  // private in AbstractAgent, and intersecting private+public members of the
+  // same name produces `never`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const self = agent as any;
+
+  try {
+    agent.isRunning = true;
+    agent.agentId = agent.agentId ?? randomUUID();
+
+    const input = self.prepareRunAgentInput(parameters);
+    let result: RunAgentResult["result"];
+    const previousMessageIds = new Set(agent.messages.map((m) => m.id));
+    const subscribers: AgentSubscriber[] = [
+      {
+        onRunFinishedEvent: (event) => {
+          if (event.outcome === "success") {
+            result = event.result;
+          }
+        },
+      },
+      ...agent.subscribers,
+      subscriber ?? {},
+    ];
+
+    await self.onInitialize(input, subscribers);
+
+    self.activeRunDetach$ = new Subject<void>();
+    let resolveCompletion: (() => void) | undefined;
+    self.activeRunCompletionPromise = new Promise<void>((resolve) => {
+      resolveCompletion = resolve;
+    });
+
+    const source$ = defer(
+      () => self.connect(input) as Observable<BaseEvent>,
+    ).pipe(
+      // transformChunks reassembles partial/streamed messages — still needed.
+      transformChunks(self.debugLogger),
+      // NOTE: verifyEvents is intentionally omitted here. See JSDoc above.
+      takeUntil(self.activeRunDetach$),
+    );
+
+    const applied$ = self.apply(input, source$, subscribers);
+    const processed$ = self.processApplyEvents(input, applied$, subscribers);
+
+    await lastValueFrom(
+      processed$.pipe(
+        catchError((error: unknown) => {
+          agent.isRunning = false;
+          return self.onError(input, error, subscribers);
+        }),
+        finalize(() => {
+          agent.isRunning = false;
+          self.onFinalize(input, subscribers);
+          resolveCompletion?.();
+          resolveCompletion = undefined;
+          self.activeRunCompletionPromise = undefined;
+          self.activeRunDetach$ = undefined;
+        }),
+      ),
+      { defaultValue: undefined },
+    );
+
+    const newMessages = structuredClone_(agent.messages).filter(
+      (m) => !previousMessageIds.has(m.id),
+    );
+    return { result, newMessages };
+  } finally {
+    agent.isRunning = false;
+  }
+}

--- a/packages/core/src/utils/connect-replay.ts
+++ b/packages/core/src/utils/connect-replay.ts
@@ -5,9 +5,14 @@ import type {
   RunAgentParameters,
   RunAgentResult,
 } from "@ag-ui/client";
-import { randomUUID, structuredClone_, transformChunks } from "@ag-ui/client";
+import {
+  AGUIConnectNotImplementedError,
+  randomUUID,
+  structuredClone_,
+  transformChunks,
+} from "@ag-ui/client";
 import type { Observable } from "rxjs";
-import { Subject, defer, lastValueFrom } from "rxjs";
+import { EMPTY, Subject, defer, lastValueFrom } from "rxjs";
 import { catchError, finalize, takeUntil } from "rxjs/operators";
 
 /**
@@ -96,11 +101,21 @@ export async function ɵconnectWithoutEventVerification(
       processed$.pipe(
         catchError((error: unknown) => {
           agent.isRunning = false;
+          // An agent that doesn't implement connect() is not an error worth
+          // surfacing: the base pipeline swallows it, and callers rely on that.
+          // `CopilotKitCore` awaits `detachActiveRun()` before every run, which
+          // only resolves because this path still reaches the finalize block
+          // below (see the historical note in run-handler.ts). Routing it
+          // through onError would also fire run-failure callbacks on every
+          // subscriber for a benign condition.
+          if (error instanceof AGUIConnectNotImplementedError) {
+            return EMPTY;
+          }
           return self.onError(input, error, subscribers);
         }),
         finalize(() => {
           agent.isRunning = false;
-          self.onFinalize(input, subscribers);
+          void self.onFinalize(input, subscribers);
           resolveCompletion?.();
           resolveCompletion = undefined;
           self.activeRunCompletionPromise = undefined;

--- a/packages/react-core/src/v1-deprecated/hooks/__tests__/legacy-chat-explicit-threadid.test.tsx
+++ b/packages/react-core/src/v1-deprecated/hooks/__tests__/legacy-chat-explicit-threadid.test.tsx
@@ -4,7 +4,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { CopilotKit } from "../../components/copilot-provider/copilotkit";
 import type { CopilotKitProps } from "../../components/copilot-provider/copilotkit-props";
 import { useCopilotChatInternal } from "../use-copilot-chat_internal";
-import { useAgent } from "../../../v2";
 
 /**
  * Issue #4943: the legacy CopilotPopup / useCopilotChatInternal path must reuse
@@ -15,6 +14,12 @@ import { useAgent } from "../../../v2";
  * These tests exercise the REAL v2 useAgent through the legacy hook — the
  * pre-existing use-copilot-chat-internal-connect suite mocks useAgent wholesale
  * and therefore cannot observe threadId propagation at all.
+ *
+ * The assertion reads `useCopilotChatInternal().agent`, i.e. the very instance
+ * the hook itself resolved. Calling `useAgent` in the probe instead would make
+ * the test self-fulfilling: the probe's own call would perform the threadId
+ * assignment being asserted, and the test would pass even with the legacy hook
+ * removed entirely.
  */
 
 // `agents__unsafe_dev_only` isn't declared on v1 CopilotKitProps but is
@@ -35,12 +40,11 @@ describe("legacy useCopilotChatInternal → agent.threadId (#4943)", () => {
 
   /**
    * Drives the legacy chat hook (the surface CopilotPopup renders through) and
-   * reports the agent instance that hook is operating on.
+   * reports the threadId of the agent that hook is operating on.
    */
   function LegacyChatProbe() {
-    useCopilotChatInternal();
-    const { agent } = useAgent({ agentId: "default" });
-    return <div data-testid="threadId">{agent.threadId ?? ""}</div>;
+    const { agent } = useCopilotChatInternal();
+    return <div data-testid="threadId">{agent?.threadId ?? ""}</div>;
   }
 
   it("adopts an explicit threadId supplied to <CopilotKit>", () => {

--- a/packages/react-core/src/v1-deprecated/hooks/__tests__/legacy-chat-explicit-threadid.test.tsx
+++ b/packages/react-core/src/v1-deprecated/hooks/__tests__/legacy-chat-explicit-threadid.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CopilotKit } from "../../components/copilot-provider/copilotkit";
+import type { CopilotKitProps } from "../../components/copilot-provider/copilotkit-props";
+import { useCopilotChatInternal } from "../use-copilot-chat_internal";
+import { useAgent } from "../../../v2";
+
+/**
+ * Issue #4943: the legacy CopilotPopup / useCopilotChatInternal path must reuse
+ * an app-supplied threadId for connect, run, and reload. If the resolved
+ * threadId never lands on the agent, ProxiedCopilotRuntimeAgent ships its own
+ * auto-minted UUID to /agent/connect and the existing thread never hydrates.
+ *
+ * These tests exercise the REAL v2 useAgent through the legacy hook — the
+ * pre-existing use-copilot-chat-internal-connect suite mocks useAgent wholesale
+ * and therefore cannot observe threadId propagation at all.
+ */
+
+// `agents__unsafe_dev_only` isn't declared on v1 CopilotKitProps but is
+// forwarded via spread to the v2 provider underneath.
+type V1Props = CopilotKitProps & {
+  agents__unsafe_dev_only?: Record<string, unknown>;
+};
+const CopilotKitAny = CopilotKit as unknown as React.FC<V1Props>;
+
+describe("legacy useCopilotChatInternal → agent.threadId (#4943)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  /**
+   * Drives the legacy chat hook (the surface CopilotPopup renders through) and
+   * reports the agent instance that hook is operating on.
+   */
+  function LegacyChatProbe() {
+    useCopilotChatInternal();
+    const { agent } = useAgent({ agentId: "default" });
+    return <div data-testid="threadId">{agent.threadId ?? ""}</div>;
+  }
+
+  it("adopts an explicit threadId supplied to <CopilotKit>", () => {
+    render(
+      <CopilotKitAny publicApiKey="test-key" threadId="cookie-backed-thread">
+        <LegacyChatProbe />
+      </CopilotKitAny>,
+    );
+
+    expect(screen.getByTestId("threadId").textContent).toBe(
+      "cookie-backed-thread",
+    );
+  });
+
+  it("keeps the agent's own threadId when the app supplies none", () => {
+    // No explicit threadId: the ThreadsProvider mints a non-explicit
+    // placeholder. Adopting it would make /connect ask the backend for a
+    // thread it never created.
+    render(
+      <CopilotKitAny publicApiKey="test-key">
+        <LegacyChatProbe />
+      </CopilotKitAny>,
+    );
+
+    const threadId = screen.getByTestId("threadId").textContent;
+    expect(threadId).toBeTruthy();
+    expect(threadId).not.toBe("mock-thread-id");
+  });
+});


### PR DESCRIPTION
Hydrating an existing thread through `/connect` fails on a **self-hosted** runtime whenever that thread's history contains a run that ended in `RUN_ERROR`.

## The defect

A `/connect` response is a *replay* of a thread's history, so it can legitimately carry several past runs back to back — including an errored run followed by a later `RUN_STARTED`. The base `AbstractAgent` connect pipeline pushes that stream through `verifyEvents`, which enforces AG-UI's **single run** lifecycle rules and rejects the sequence outright:

```
Cannot send event type 'RUN_STARTED': The run has already errored with 'RUN_ERROR'. No further events can be sent.
```

The user-visible effect is the one reported in #4943: `agent_connect_failed` on reload, and the existing thread never hydrates its prior messages.

`IntelligenceAgent` already omitted `verifyEvents` from its connect pipeline for exactly this reason (its JSDoc spells it out). But `ProxiedCopilotRuntimeAgent.connectAgent` only takes that path in `RUNTIME_MODE_INTELLIGENCE` — self-hosted (`RUNTIME_MODE_SSE`) fell through to `super.connectAgent()` and inherited the single-run verification. So the managed product was fine and self-hosting was not.

## The fix

`ɵconnectWithoutEventVerification` (`packages/core/src/utils/connect-replay.ts`) holds the verifyEvents-free pipeline, and **both** paths now use it. `transformChunks` is still applied — message reassembly is needed either way.

This is a de-duplication rather than a third copy: `IntelligenceAgent.connectAgent` drops ~100 lines of hand-replicated base pipeline (including its private-field `any` escape hatch) and keeps only its canonical-run-id handling before delegating. Net `intelligence-agent.ts` change is −101 lines.

### Fidelity to the base implementation

The helper was diffed statement-by-statement against the **real** `AbstractAgent.connectAgent` in `@ag-ui/client@0.0.57` (recovered from the shipped source map), not just against `IntelligenceAgent`'s replica. `verifyEvents` is the only intended difference.

That diff caught a defect in the first push: the base special-cases `AGUIConnectNotImplementedError` (swallow → `EMPTY`) and the replica did not. `IntelligenceAgent` never needed it — it always implements `connect()` — so the gap was invisible there, but on the SSE path it is load-bearing: `run-handler.ts:447-450` documents that `await agent.detachActiveRun()` only stopped deadlocking because that error path still reaches the pipeline's finalize block. Routing it through `onError` would also fire run-failure callbacks on every subscriber for a benign condition. Restored, with a regression test.

Also confirmed that dropping `verifyEvents` cannot alter a well-formed replay: it is a pure gate — 18 `return of(event)` pass-throughs, 42 error paths, and zero `endWith` / `startWith` / `tap` side effects. It only removes the single-run rejection.

The existing upstream TODO still stands and is carried over: `@ag-ui/client@0.0.57`'s `connectAgent(parameters?, subscriber?)` takes no option to skip verification, so this override is still the only way to express "this stream is a replay, not a run."

## On the second half of #4943

The issue also reports that the legacy chat path doesn't copy the resolved `threadId` onto the agent before connect/run. **That half is already fixed on `main`** — the #5041/#4739 fix put `agent.threadId = resolvedThreadId` in v2 `useAgent`, and `useCopilotChatInternal` delegates to that same hook. Nothing more was needed.

It was untested, though, and untestable from the suite that looked like it covered it: `use-copilot-chat-internal-connect.test.tsx` mocks `useAgent` wholesale, so it cannot observe threadId propagation at all. This PR adds `legacy-chat-explicit-threadid.test.tsx`, which drives the legacy hook through the **real** `useAgent` under a real `<CopilotKit>`, covering both the explicit-threadId case and the "don't adopt a non-explicit placeholder UUID" case.

It reads the agent off `useCopilotChatInternal()`'s own return value rather than calling `useAgent` in the probe. That distinction matters: the first version of this test did call `useAgent`, so the probe itself performed the assignment under test and the test passed **even with `useCopilotChatInternal()` removed entirely**. The current version is mutation-checked — disabling the assignment in v2 `useAgent` fails it (`expected 'dc051f13-…' to be 'cookie-backed-thread'`).

Contributor PR #4969 proposed a manual assignment for this half; it is now redundant.

## Testing

Worktree caveat, stated up front: this worktree symlinks the primary checkout's `node_modules`, so `@copilotkit/shared` and `@copilotkit/core` resolve to that checkout's **stale `dist`**. That produces failures unrelated to this change; each is baselined against clean `main` in the same environment below. CI installs fresh and is the authoritative gate.

**1. Reproduces the reported failure before the fix.** The new core test, run on unmodified `origin/main`, fails with the exact error from the issue:

```
FAIL  src/__tests__/proxied-connect-replay-multi-run.test.ts > hydrates a thread whose replayed history contains an errored run
AssertionError: promise rejected "Error: Cannot send event type 'RUN_STARTE…" instead of resolving
Caused by: Error: Cannot send event type 'RUN_STARTED': The run has already errored with 'RUN_ERROR'. No further events can be sent.
```

**2. Passes after the fix**, hydrating both runs' messages (`["msg-1", "msg-2"]`):

```
✓ src/__tests__/proxied-connect-replay-multi-run.test.ts (1 test) 11ms
Test Files  1 passed (1)
```

**3. Connect-not-implemented guard, fail-first.** With the guard removed, the new second test fails exactly as the base contract predicts:

```
× swallows AGUIConnectNotImplementedError instead of failing the run
AssertionError: promise rejected "Error: Connect not implemented. This meth…" instead of resolving
```

**4. Full `@copilotkit/core` suite** — this is the evidence the `IntelligenceAgent` extraction is behavior-identical, since `intelligence-agent.test.ts` exercises that path heavily:

```
Test Files  59 passed (59)
      Tests  635 passed (635)
```

(excludes `core-inspector-metadata.test.ts`; its 20 failures are the stale-`shared`-dist artifact — verified identical on clean `main`: `20 failed | 2 passed`, missing export `InspectorMetadataV1`)

**5. `@copilotkit/react-core` — new + adjacent existing suites:**

```
✓ src/hooks/__tests__/use-copilot-chat-internal-connect.test.tsx (7 tests)
✓ src/hooks/__tests__/legacy-chat-explicit-threadid.test.tsx (2 tests)
✓ src/components/copilot-provider/__tests__/v1-explicit-threadid-bridge.test.tsx (5 tests)
Test Files  3 passed (3)
      Tests  14 passed (14)
```

Full react-core suite: `8 failed | 1492 passed (1500)`. All 8 are in `use-interrupt` / `use-pin-to-send` / `CopilotChatView.pinToSend` — none touch connect replay or threadId, and clean `main` in this worktree fails the identical 8 (`8 failed | 37 passed (45)` for those three files alone).

**6. `@copilotkit/vue`** (affected via core): `100 passed (100)` files, `1072 passed (1072)` tests.

**7. Types, lint, format:**

```
tsc -p packages/core/tsconfig.json --noEmit   → no errors in any changed file
oxlint  <5 changed files>                     → Found 0 warnings and 0 errors
oxfmt --check <5 changed files>               → All matched files use the correct format
```

The only remaining `tsc` errors are 4 pre-existing stale-dist ones in `agent-registry.ts` / `types.ts` (`InspectorMetadataV1`), untouched by this PR.

Fixes #4943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread hydration when reconnecting to histories containing multiple runs, including runs that previously ended in error.
  * Prevented unsupported connection errors from being reported as run failures.
  * Ensured connection state is properly finalized after replaying a thread.
  * Legacy chat components now correctly reuse an explicitly provided thread ID while preserving generated IDs when none is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->