### PR TITLE
fix(react-ui): pad the chat header on mobile viewports

### DIFF
--- a/packages/react-ui/src/css/header-padding.test.ts
+++ b/packages/react-ui/src/css/header-padding.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const headerCss = fs.readFileSync(
+  path.join(path.resolve(__dirname), "header.css"),
+  "utf-8",
+);
+
+/**
+ * Returns the declarations of a rule as it applies with no media query in
+ * effect — i.e. the narrow-viewport (mobile) case.
+ */
+function baseDeclarationsFor(css: string, selector: string): string {
+  // Drop every @media block so only unconditional rules remain.
+  const withoutMediaBlocks = css.replace(
+    /@media[^{]*\{(?:[^{}]*\{[^{}]*\}\s*)*\}/g,
+    "",
+  );
+
+  const rule = new RegExp(
+    `(?:^|\\})\\s*${selector.replace(/\./g, "\\.")}\\s*\\{([^}]*)\\}`,
+  ).exec(withoutMediaBlocks);
+
+  expect(rule, `expected an unconditional \`${selector}\` rule`).not.toBeNull();
+  return rule![1];
+}
+
+describe("header horizontal padding (#2493)", () => {
+  it("reserves horizontal padding on mobile, not only at the sm breakpoint", () => {
+    const base = baseDeclarationsFor(headerCss, ".copilotKitHeader");
+
+    // The header lays out `justify-content: space-between`, so the title sits
+    // against the left edge and the close button against the right edge. With
+    // padding declared only inside `@media (min-width: 640px)` both ran flush
+    // to the viewport edge below 640px.
+    expect(base).toMatch(/padding-left:/);
+    expect(base).toMatch(/padding-right:/);
+  });
+});

--- a/packages/react-ui/src/css/header.css
+++ b/packages/react-ui/src/css/header.css
@@ -9,6 +9,7 @@
   border-top-right-radius: 0;
   border-bottom: 1px solid var(--copilot-kit-separator-color);
   padding-left: 1.5rem;
+  padding-right: 1.5rem;
   background-color: var(--copilot-kit-contrast-color);
   justify-content: space-between;
   z-index: 2;
@@ -29,8 +30,6 @@
 
 @media (min-width: 640px) {
   .copilotKitHeader {
-    padding-left: 1.5rem;
-    padding-right: 24px;
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
   }


### PR DESCRIPTION
Fixes #2493.

## Problem

`.copilotKitHeader` declared its horizontal padding like this:

```css
.copilotKitHeader {
  padding-left: 1.5rem;      /* no padding-right */
  justify-content: space-between;
}

@media (min-width: 640px) {
  .copilotKitHeader {
    padding-left: 1.5rem;    /* duplicate of the base rule */
    padding-right: 24px;     /* only above the sm breakpoint */
  }
}
```

`padding-right` existed **only** inside `@media (min-width: 640px)`. The header
lays out `space-between`, so below 640px the title sat against the left edge
(fine — `padding-left` is unconditional) while the controls ran flush to the
right edge with no gutter at all. That is the cramped mobile header in the
report.

Worth noting because it misleads when reading the file: the
`.copilotKitHeader > button { position: absolute; right: 16px }` rule further
down does **not** apply to the close button. `Header.tsx` nests it inside
`.copilotKitHeaderControls`, so the button is a grandchild and the child
combinator never matches. The button is in normal flow, which is why it lands
exactly on the padding edge.

## Fix

Move the horizontal padding onto the unconditional rule and drop the duplicated
declarations from the media query, leaving it responsible only for the border
radii. `24px === 1.5rem` at the default root font size, so layouts at 640px and
above are byte-for-byte unchanged; only the sub-640px case gains the gutter it
was missing.

## Testing

Added `src/css/header-padding.test.ts`, which strips every `@media` block and
asserts the remaining unconditional `.copilotKitHeader` rule declares both
`padding-left` and `padding-right` — i.e. that the padding is not breakpoint-gated
again.

Full `react-ui` suite:

```
 ✓ src/esm-compat.test.ts (1 test) 2ms
 ✓ src/css/sidebar-full-height.test.ts (4 tests) 2ms
 ✓ src/css/header-padding.test.ts (1 test) 1ms
 ✓ src/hooks/__tests__/use-push-to-talk.test.ts (2 tests) 2ms
 ✓ src/components/chat/Markdown.test.ts (29 tests) 5ms
 ✓ src/components/chat/Markdown.xss.test.ts (13 tests) 182ms

 Test Files  10 passed (10)
      Tests  68 passed (68)
```

**Mutation check** — removed `padding-right: 1.5rem` from the base rule and
re-ran, confirming the new test fails rather than passing vacuously:

```
     37|     expect(base).toMatch(/padding-left:/);
     38|     expect(base).toMatch(/padding-right:/);
       |                  ^
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

**Build** — `tsdown` succeeds and the compiled `dist/index.css` carries the
declaration:

```
.copilotKitHeader {
  ...
  padding-left: 1.5rem;
  padding-right: 1.5rem;
  ...
}
```

**Visual** — rendered the real `Header.tsx` markup against the compiled
stylesheet at a 390px viewport, with one copy re-gating `padding-right` behind
the breakpoint to reproduce the previous rule. Before, the close button sits
flush on the right border; after, it clears it by 24px, matching the existing
left gutter. (Screenshot to follow in a comment.)
