### PR TITLE
feat(react-ui): report feedback state to onThumbsUp/onThumbsDown

### DIFF
--- a/packages/react-ui/src/components/chat/Chat.tsx
+++ b/packages/react-ui/src/components/chat/Chat.tsx
@@ -102,6 +102,8 @@ import type {
   UserMessageProps,
 } from "./props";
 
+import type { FeedbackKind } from "./feedback";
+import { applyFeedbackClick } from "./feedback";
 import { AttachmentQueue } from "./AttachmentQueue";
 import type { Attachment, AttachmentsConfig } from "./props";
 import {
@@ -185,14 +187,20 @@ export interface CopilotChatProps {
   onCopy?: (message: string) => void;
 
   /**
-   * A callback function for thumbs up feedback
+   * A callback function for thumbs up feedback.
+   *
+   * `isActive` reports the feedback state the click is transitioning to:
+   * `true` when thumbs up is being applied, `false` when it is being
+   * retracted. It is optional so existing one-argument handlers keep working.
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
-   * A callback function for thumbs down feedback
+   * A callback function for thumbs down feedback.
+   *
+   * See `onThumbsUp` for the meaning of `isActive`.
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * A list of markdown components to render in assistant message.
@@ -894,34 +902,36 @@ export function CopilotChat({
     }
   };
 
-  const handleThumbsUp = (message: Message) => {
-    if (onThumbsUp) {
-      onThumbsUp(message);
+  // `isActive` is the state the click transitions to. The built-in
+  // AssistantMessage derives it from the message's current feedback so a second
+  // click on an active button retracts it; a custom AssistantMessage may pass
+  // its own value. When omitted, treat the click as applying feedback.
+  const recordFeedback = (
+    message: Message,
+    kind: FeedbackKind,
+    isActive?: boolean,
+  ) => {
+    const nextActive = isActive ?? true;
+
+    setMessageFeedback((prev) =>
+      applyFeedbackClick(prev, message.id, kind, nextActive),
+    );
+
+    // `onFeedbackGiven` has no way to express a retraction, so only report the
+    // click that applies feedback.
+    if (nextActive) {
+      triggerObservabilityHook("onFeedbackGiven", message.id, kind);
     }
-
-    // Update feedback state
-    setMessageFeedback((prev) => ({
-      ...prev,
-      [message.id]: "thumbsUp",
-    }));
-
-    // Trigger feedback given event
-    triggerObservabilityHook("onFeedbackGiven", message.id, "thumbsUp");
   };
 
-  const handleThumbsDown = (message: Message) => {
-    if (onThumbsDown) {
-      onThumbsDown(message);
-    }
+  const handleThumbsUp = (message: Message, isActive?: boolean) => {
+    onThumbsUp?.(message, isActive ?? true);
+    recordFeedback(message, "thumbsUp", isActive);
+  };
 
-    // Update feedback state
-    setMessageFeedback((prev) => ({
-      ...prev,
-      [message.id]: "thumbsDown",
-    }));
-
-    // Trigger feedback given event
-    triggerObservabilityHook("onFeedbackGiven", message.id, "thumbsDown");
+  const handleThumbsDown = (message: Message, isActive?: boolean) => {
+    onThumbsDown?.(message, isActive ?? true);
+    recordFeedback(message, "thumbsDown", isActive);
   };
 
   return (

--- a/packages/react-ui/src/components/chat/feedback.test.ts
+++ b/packages/react-ui/src/components/chat/feedback.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyFeedbackClick,
+  isActivatingClick,
+  type MessageFeedbackMap,
+} from "./feedback";
+
+describe("isActivatingClick (#2615)", () => {
+  it("activates when no feedback has been given", () => {
+    expect(isActivatingClick(null, "thumbsUp")).toBe(true);
+    expect(isActivatingClick(undefined, "thumbsDown")).toBe(true);
+  });
+
+  it("deactivates when clicking the already-active button", () => {
+    expect(isActivatingClick("thumbsUp", "thumbsUp")).toBe(false);
+    expect(isActivatingClick("thumbsDown", "thumbsDown")).toBe(false);
+  });
+
+  it("activates when switching to the opposite button", () => {
+    expect(isActivatingClick("thumbsDown", "thumbsUp")).toBe(true);
+    expect(isActivatingClick("thumbsUp", "thumbsDown")).toBe(true);
+  });
+});
+
+describe("applyFeedbackClick (#2615)", () => {
+  it("records feedback for a message that had none", () => {
+    expect(applyFeedbackClick({}, "m1", "thumbsUp", true)).toEqual({
+      m1: "thumbsUp",
+    });
+  });
+
+  it("replaces the opposite feedback rather than keeping both", () => {
+    const previous: MessageFeedbackMap = { m1: "thumbsDown" };
+    expect(applyFeedbackClick(previous, "m1", "thumbsUp", true)).toEqual({
+      m1: "thumbsUp",
+    });
+  });
+
+  it("removes the entry when the click retracts feedback", () => {
+    const previous: MessageFeedbackMap = { m1: "thumbsUp", m2: "thumbsDown" };
+    const next = applyFeedbackClick(previous, "m1", "thumbsUp", false);
+
+    expect(next).toEqual({ m2: "thumbsDown" });
+    expect("m1" in next).toBe(false);
+  });
+
+  it("leaves other messages untouched", () => {
+    const previous: MessageFeedbackMap = { m1: "thumbsUp" };
+    expect(applyFeedbackClick(previous, "m2", "thumbsDown", true)).toEqual({
+      m1: "thumbsUp",
+      m2: "thumbsDown",
+    });
+  });
+
+  it("does not mutate the map it is given", () => {
+    const previous: MessageFeedbackMap = { m1: "thumbsUp" };
+    applyFeedbackClick(previous, "m1", "thumbsUp", false);
+    expect(previous).toEqual({ m1: "thumbsUp" });
+  });
+
+  it("returns the same reference when nothing changes", () => {
+    const previous: MessageFeedbackMap = { m1: "thumbsUp" };
+    expect(applyFeedbackClick(previous, "m1", "thumbsUp", true)).toBe(previous);
+    expect(applyFeedbackClick(previous, "m2", "thumbsUp", false)).toBe(
+      previous,
+    );
+  });
+
+  it("round-trips a toggle back to the starting state", () => {
+    const applied = applyFeedbackClick({}, "m1", "thumbsUp", true);
+    const retracted = applyFeedbackClick(applied, "m1", "thumbsUp", false);
+    expect(retracted).toEqual({});
+  });
+});

--- a/packages/react-ui/src/components/chat/feedback.ts
+++ b/packages/react-ui/src/components/chat/feedback.ts
@@ -1,0 +1,38 @@
+export type FeedbackKind = "thumbsUp" | "thumbsDown";
+
+export type MessageFeedbackMap = Record<string, FeedbackKind>;
+
+/**
+ * The feedback state a click on `kind` transitions to.
+ *
+ * Clicking the button that is already active retracts the feedback, so the
+ * click deactivates it; every other click applies feedback.
+ */
+export function isActivatingClick(
+  current: FeedbackKind | null | undefined,
+  kind: FeedbackKind,
+): boolean {
+  return current !== kind;
+}
+
+/**
+ * Applies a feedback click to the message-id keyed map.
+ *
+ * A deactivating click removes the entry entirely rather than storing a falsy
+ * value, so `messageFeedback[id]` stays absent for "no feedback given".
+ */
+export function applyFeedbackClick(
+  previous: MessageFeedbackMap,
+  messageId: string,
+  kind: FeedbackKind,
+  isActive: boolean,
+): MessageFeedbackMap {
+  if (!isActive) {
+    if (!(messageId in previous)) return previous;
+    const { [messageId]: _retracted, ...rest } = previous;
+    return rest;
+  }
+
+  if (previous[messageId] === kind) return previous;
+  return { ...previous, [messageId]: kind };
+}

--- a/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
+++ b/packages/react-ui/src/components/chat/messages/AssistantMessage.tsx
@@ -4,6 +4,7 @@ import { Markdown } from "../Markdown";
 import { useState } from "react";
 import React from "react";
 import { copyToClipboard } from "@copilotkit/shared";
+import { isActivatingClick } from "../feedback";
 
 export const AssistantMessage = (props: AssistantMessageProps) => {
   const { icons, labels } = useChatContext();
@@ -36,15 +37,17 @@ export const AssistantMessage = (props: AssistantMessageProps) => {
     if (onRegenerate) onRegenerate();
   };
 
+  // Clicking the already-active button retracts the feedback, so report the
+  // state the click transitions to rather than an unconditional `true`.
   const handleThumbsUp = () => {
     if (onThumbsUp && message) {
-      onThumbsUp(message);
+      onThumbsUp(message, isActivatingClick(feedback, "thumbsUp"));
     }
   };
 
   const handleThumbsDown = () => {
     if (onThumbsDown && message) {
-      onThumbsDown(message);
+      onThumbsDown(message, isActivatingClick(feedback, "thumbsDown"));
     }
   };
 

--- a/packages/react-ui/src/components/chat/props.ts
+++ b/packages/react-ui/src/components/chat/props.ts
@@ -118,14 +118,20 @@ export interface MessagesProps {
   onCopy?: (message: string) => void;
 
   /**
-   * Callback function for thumbs up feedback
+   * Callback function for thumbs up feedback.
+   *
+   * `isActive` reports the feedback state the click is transitioning to:
+   * `true` when thumbs up is being applied, `false` when it is being
+   * retracted. It is optional so existing one-argument handlers keep working.
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
-   * Callback function for thumbs down feedback
+   * Callback function for thumbs down feedback.
+   *
+   * See `onThumbsUp` for the meaning of `isActive`.
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Map of message IDs to their feedback state
@@ -214,14 +220,20 @@ export interface AssistantMessageProps {
   onCopy?: (message: string) => void;
 
   /**
-   * Callback function for thumbs up feedback
+   * Callback function for thumbs up feedback.
+   *
+   * `isActive` reports the feedback state the click is transitioning to:
+   * `true` when thumbs up is being applied, `false` when it is being
+   * retracted. It is optional so existing one-argument handlers keep working.
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
-   * Callback function for thumbs down feedback
+   * Callback function for thumbs down feedback.
+   *
+   * See `onThumbsUp` for the meaning of `isActive`.
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * The feedback state for this message ("thumbsUp" or "thumbsDown")
@@ -310,14 +322,20 @@ export interface RenderMessageProps {
   onCopy?: (message: string) => void;
 
   /**
-   * Callback function for thumbs up feedback
+   * Callback function for thumbs up feedback.
+   *
+   * `isActive` reports the feedback state the click is transitioning to:
+   * `true` when thumbs up is being applied, `false` when it is being
+   * retracted. It is optional so existing one-argument handlers keep working.
    */
-  onThumbsUp?: (message: Message) => void;
+  onThumbsUp?: (message: Message, isActive?: boolean) => void;
 
   /**
-   * Callback function for thumbs down feedback
+   * Callback function for thumbs down feedback.
+   *
+   * See `onThumbsUp` for the meaning of `isActive`.
    */
-  onThumbsDown?: (message: Message) => void;
+  onThumbsDown?: (message: Message, isActive?: boolean) => void;
 
   /**
    * Map of message IDs to their feedback state


### PR DESCRIPTION
Closes #2615.

## Problem

The v1 thumbs callbacks were typed `(message: Message) => void`, so a consumer
received the message but not *what the click did*. A custom `AssistantMessage`
that keeps its own toggle state — the case in the issue — had nowhere to put
that value:

```tsx
onClick={() => {
  setReactionValue((v) => (v === "like" ? null : "like"));
  onThumbsUp?.(message); // 👈 no way to say whether this applied or retracted
}}
```

The only workaround was counting clicks per message.

The built-in path had the matching gap. `Chat.tsx` already tracked
`messageFeedback`, but `handleThumbsUp` unconditionally wrote `"thumbsUp"`, so
the state was write-only: clicking an active button re-applied the same value
and there was no way to un-vote.

These callbacks are live API — `RenderMessage` forwards `onThumbsUp`,
`onThumbsDown` and `feedback` to whatever component is passed as the
`AssistantMessage` prop, which is exactly the customisation the issue describes.

## Fix

Add an optional second argument reporting the state the click transitions to:

```ts
onThumbsUp?: (message: Message, isActive?: boolean) => void;
```

- The built-in `AssistantMessage` derives it from the message's current
  `feedback`, so a second click on an active button now reports `false` and
  **retracts** the feedback rather than re-applying it.
- A custom `AssistantMessage` can pass its own value straight through.
- The parameter is optional and appended, so existing one-argument handlers
  keep type-checking and keep working unchanged.

`onFeedbackGiven` fires only on the applying click — its signature is
`(messageId, "thumbsUp" | "thumbsDown")` and has no way to express a
retraction, so reporting one would be a lie.

Note this is a small behavioural change to the built-in buttons: previously a
repeat click was a no-op, now it clears the vote. That is what makes the
reported state meaningful, and it matches the toggle UX in the issue.

The toggle logic lives in a new `./feedback` module. This package's vitest
project runs `environment: "node"` and only collects `*.test.ts`, so there is no
component-rendering harness here — extracting the pure functions is what makes
the behaviour testable at all.

## Testing

`packages/react-ui` — full suite, including the 10 new cases:

```
 ✓ src/components/chat/feedback.test.ts (10 tests) 3ms
 ✓ src/components/chat/Markdown.test.ts (29 tests) 5ms
 ✓ src/components/chat/Markdown.xss.test.ts (13 tests) 182ms
 ✓ src/css/sidebar-full-height.test.ts (4 tests) 2ms

 Test Files  10 passed (10)
      Tests  68 passed (68)
```

Coverage: activation from no feedback, deactivation on the already-active
button, switching to the opposite button, retraction removing the map entry
rather than storing a falsy value, other messages left untouched, no mutation of
the previous map, referential stability when nothing changes, and a toggle
round-trip.

**Mutation checks** — broke each mechanism and confirmed the tests fail, so they
are not self-fulfilling:

| Mutation | Result |
| --- | --- |
| `isActivatingClick` → `return true` | `Tests 1 failed \| 9 passed` |
| `applyFeedbackClick` retraction branch → `if (false)` | `Tests 3 failed \| 7 passed` |

Both were reverted and the suite returned to 68 passing.

**Types/build** — `tsc --noEmit` clean, `tsdown` clean, and the widened
signature reaches the published types:

```
$ grep -n "onThumbsUp" dist/index.d.mts
102:  onThumbsUp?: (message: Message, isActive?: boolean) => void;
185:  onThumbsUp?: (message: Message, isActive?: boolean) => void;
272:  onThumbsUp?: (message: Message, isActive?: boolean) => void;
```
