### PR TITLE
fix(ci): stop enabling LangSmith tracing in the dojo e2e run

### DIFF
--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -292,24 +292,29 @@ jobs:
         run: |
           pnpm install
 
+      # Deliberately no LANGSMITH_API_KEY: langgraph-api turns tracing on
+      # whenever it sees one (config/__init__.py: LANGSMITH_CONTROL_PLANE_API_KEY
+      # defaults to LANGSMITH_API_KEY, which force-sets LANGSMITH_TRACING).
+      # With tracing on, the LangSmith client merges every LANGSMITH_*/LANGCHAIN_*
+      # env var into each run's metadata dict — and langchain_core hands the
+      # tracer the *same* dict the run config streams out, so `langgraph dev`'s
+      # LANGSMITH_LANGGRAPH_API_VARIANT=local_dev leaks into STATE_SNAPSHOT and
+      # breaks the dojo's golden event traces. Upstream ag-ui runs these suites
+      # keyless against LLMock; keep parity.
       - name: write langgraph env files
         working-directory: ag-ui/integrations/langgraph
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
         if: steps.should-run.outputs.skip != 'true' && (contains(join(matrix.services, ','), 'langgraph-fastapi') || contains(join(matrix.services, ','), 'langgraph-platform-python') || contains(join(matrix.services, ','), 'langgraph-platform-typescript'))
         run: |
           echo "OPENAI_API_KEY=${OPENAI_API_KEY}" > python/examples/.env
-          echo "LANGSMITH_API_KEY=${LANGSMITH_API_KEY}" >> python/examples/.env
           echo "OPENAI_API_KEY=${OPENAI_API_KEY}" > typescript/examples/.env
-          echo "LANGSMITH_API_KEY=${LANGSMITH_API_KEY}" >> typescript/examples/.env
 
       - name: Run dojo+agents
         uses: JarvusInnovations/background-action@1f5e5fa2462e48a95f97b54b4842d076d1008e3b # v2
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_GEMINI_API_KEY }}
         if: steps.should-run.outputs.skip != 'true' && join(matrix.services, ',') != '' && contains(join(matrix.services, ','), 'dojo')
         with:

--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -316,6 +316,11 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=8192
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_GEMINI_API_KEY }}
+          # Backend tool-rendering demos call the live open-meteo API, which
+          # rate-limits CI's shared egress IPs and hangs the e2e tests. Return
+          # canned weather data instead so these suites are deterministic.
+          # Mirrors ag-ui's own dojo-e2e workflow.
+          AG_UI_MOCK_WEATHER: "1"
         if: steps.should-run.outputs.skip != 'true' && join(matrix.services, ',') != '' && contains(join(matrix.services, ','), 'dojo')
         with:
           run: |


### PR DESCRIPTION
## Problem

Every same-repo PR has been failing `e2e / dojo / langgraph-python` since **18:11:58 UTC today** — #6527, #6530, #6531, #6533 and counting:

```
EventTraceAssertionError: Event trace mismatch: agenticChatPage.event-trace.ts#sendsAndReceivesMessage
  events: expected=33, actual=33
  event type counts: identical across 9 types
  event 2: expected STATE_SNAPSHOT, actual STATE_SNAPSHOT
  first difference: events[2].rawEvent.data.metadata.LANGSMITH_LANGGRAPH_API_VARIANT
    expected: <missing>
    actual: "local_dev"
```

That timestamp is when ag-ui merged its golden event-trace assertions ([ag-ui#2392](https://github.com/ag-ui-protocol/ag-ui/pull/2392)). We check ag-ui out at floating `main`, so it landed in our CI with no commit of ours. Nothing in any of those PRs is at fault — main's last e2e run passed at 18:06, six minutes before the merge.

## Root cause

Our workflow injects a real `LANGSMITH_API_KEY` into the dojo. That is enough to turn LangSmith tracing on, and tracing pollutes the streamed metadata the golden traces assert on:

1. `langgraph dev` always exports `LANGSMITH_LANGGRAPH_API_VARIANT=local_dev` (`langgraph_api/cli.py:271`) — unconditionally, in every environment.
2. `langgraph_api/config/__init__.py:518-546`: `LANGSMITH_CONTROL_PLANE_API_KEY` defaults to `LANGSMITH_API_KEY`; if it is set and no explicit tracing flag exists, langgraph-api force-sets `LANGSMITH_TRACING=true`. The comment above it says so outright: *"if langsmith api key is set, enable tracing unless explicitly disabled"*.
3. With tracing on, `langsmith/client.py:2482` (`_insert_runtime_env`) merges **every** `LANGSMITH_*`/`LANGCHAIN_*` env var into each run's `extra["metadata"]`.
4. `langchain_core/tracers/core.py:197-203` builds the run with `extra=kwargs` where `kwargs["metadata"]` is the **same dict object** as the run config's metadata — the one langgraph streams out. So step 3's mutation leaks into `STATE_SNAPSHOT`.

Upstream ag-ui is green on the exact same commit because its `dojo-e2e.yml` runs these suites **keyless** — it `touch`es empty `.env` files and passes no API keys at all, since everything routes to LLMock. Our copy of the workflow drifted and kept injecting real secrets.

Note the latent trap this also removes: because fork PRs get no secrets, fork PRs would have *passed* while same-repo PRs failed.

## Change

- Drop `LANGSMITH_API_KEY` from the langgraph `.env` write step and from the dojo run step. The dojo never needed it — `OPENAI_BASE_URL` already points at LLMock, so no traffic reaches a real provider. Restores parity with upstream.
- Add `AG_UI_MOCK_WEATHER: "1"`, which upstream sets because the backend tool-rendering demos call the live open-meteo API, which rate-limits CI's shared egress IPs and hangs the suites. Another drift item, and a trace-divergence source now that traces are asserted.

`OPENAI_API_KEY` and `GOOGLE_API_KEY` are left in place: they are inert behind the LLMock base URLs, so removing them is unrelated churn.

## Testing

- **YAML parses, jobs intact** — `python3 -c "import yaml; ..."` → `OK jobs: ['detect-changes', 'dojo']`
- **No `LANGSMITH_API_KEY` reference remains** — `grep -n LANGSMITH .github/workflows/test_e2e-dojo.yml` returns only the explanatory comment.
- **Mechanism verified in the dependency source, not inferred** — every link in the chain above was read out of the installed `langgraph-api` 0.12.4, `langsmith` 0.11.0 and `langchain-core` 1.5.5 wheels; file/line references are cited inline.
- **This PR's own e2e-dojo run is the live proof.** It touches `.github/workflows/test_e2e-dojo.yml`, which is in the workflow's `paths` filter, so the full dojo matrix runs here with the key removed. `langgraph-python` going green with ag-ui `main` unchanged is the confirmation. Results pasted below once it finishes.

## Follow-up

Upstream companion hardening so this cannot bite any other ag-ui consumer (or anyone with a LangSmith key in their local shell): teach the trace normalizer to drop `LANGSMITH_*`/`LANGCHAIN_*` env metadata, which is the same class of environment noise it already tokenizes for `langgraph_api_url`/`langgraph_version`. Linked once opened.