### PR TITLE
fix(capture): drain the request journal before moving fixtures / restarting aimock

### DIFF
--- a/showcase/aimock/README.md
+++ b/showcase/aimock/README.md
@@ -71,38 +71,61 @@ The process is manual. There is no CLI for this directory specifically — aimoc
 
 When a package's agent code changes in a way that changes its LLM calls, the person making the change is responsible for updating the corresponding fixture. There is no automation to remind you.
 
-### Proxy-capturing a D4 fixture: drain the journal first
+### Refresh D4: capture the canonical once, then mirror — drain the journal during capture
 
-D4 fixtures are hand-authored, but the shape of a tool-calling flow is often
-easiest to obtain by proxy-capturing it once (boot aimock with `--record`
-against the real provider — as `docker-compose.record.yml` does — drive the D4
-cell, then hand-clean the emitted fixture before committing it under
-`d4/<slug>/`). If you do that, there is a **capture race** you must guard
-against, the same one the D5 recorder hit:
+"Refresh D4" is **not** per-integration recording. Recording each integration's
+own live traffic launders that integration's request-side bugs into a
+forever-green fixture (the matcher keys mainly on `userMessage` + `context`, not
+the system prompt or tool schema), so a buggy prompt or wrong tool name replays
+green. The canonical model — see `showcase/GOTCHAS.md` ("MIRROR the canonical
+(langgraph-python) fixtures — never re-record per-integration") — is:
+
+1. **Capture / verify the canonical live flow ONCE.** `langgraph-python` is the
+   canonical reference. Boot aimock with `--record` against the real provider (as
+   `docker-compose.record.yml` does), drive the D4 cell on langgraph-python, and
+   capture its live tool-calling flow. **This is the only step that proxies
+   upstream, so this is where the journal-drain barrier applies (see below).**
+2. **Normalize the canonical fixture** — hand-clean the captured turns into the
+   canonical `d4/langgraph-python/<cell>.json` shape.
+3. **Mirror across integrations**, copying the canonical fixture to each
+   integration and re-keying `match.context` to the integration slug (never
+   re-recording per integration). This forces every integration onto one shared
+   contract.
+4. **Run fresh replay validation** across the mirrored integrations.
+
+The journal-drain step belongs to **step 1 only**. During the canonical capture
+there is a **capture race**:
 
 > A probe (or your manual click-through) marks the cell satisfied as soon as the
 > tool card meets the assertion, but the **POST-tool-result LLM turn can still be
 > draining** — aimock is still proxying upstream and writing that fixture — after
-> the driving process exits. If you move/commit the captured fixtures or restart
+> the driving process exits. If you move/commit the captured fixture or restart
 > aimock at that instant, the late fixture lands in the wrong place (or is lost),
-> and the D4 cell can go red on replay for a turn that was never captured.
+> and the cell can go red on replay for a turn that was never captured.
 
-So, after driving the D4 cell and **before** moving/committing the captured
-fixtures or restarting aimock, **wait for the request journal to drain**. aimock
-exposes the journal at `GET /__aimock/journal`; a turn is only appended once it
-is fully served (record-mode proxy → `response.source === "proxy"`, or a replay
-→ `response.status === 200 && response.fixture != null` — never
-`source === "fixture"`, which aimock leaves unset on a normal replay).
+So, after driving the canonical cell and **before** normalizing/committing the
+captured fixture or restarting aimock, **wait for the request journal to drain**.
+aimock exposes the journal at `GET /__aimock/journal`. The **only** sound
+"fully-drained" signal is the record path: aimock appends a
+`response.source === "proxy"` entry **after** it has awaited the entire upstream
+stream and written the fixture to disk. A replay entry (`response.status === 200`
+with `response.fixture` set, `response.source` unset) is appended at stream
+**start**, so it means "replay matched," **not** "fully drained" — never treat
+`fixture != null` as a completion signal. Since capture runs aimock in `--record`
+mode, every genuine upstream turn is a `source === "proxy"` entry.
 
 Use the shared barrier rather than re-deriving this rule:
 [`showcase/scripts/lib/journal-drain.mjs`](../scripts/lib/journal-drain.mjs)
-exports `waitForJournalDrain(...)`, which polls the journal until the
-completed-turn count has reached the floor **and** held steady through a
-quiescence window. The D5 recorder
-([`record-d5-fixtures.mjs`](../scripts/record-d5-fixtures.mjs)) calls it
-automatically between the probe and fixture consolidation; a hand-run D4 capture
-must call the same barrier (or poll the same endpoint by hand) at the equivalent
-point.
+exports `waitForJournalDrain({ expectedTurns })`, which polls the journal until
+the drained (`source:"proxy"`) turn count has reached a **required** real
+`expectedTurns` **and** held steady through a quiescence window. `expectedTurns`
+is mandatory — quiescence alone can settle prematurely between turns while a slow
+final turn is still in flight (invisible in the journal until it lands). The D5
+recorder ([`record-d5-fixtures.mjs`](../scripts/record-d5-fixtures.mjs)) calls it
+automatically between the probe and fixture consolidation, aborting the run if
+the journal does not drain; a hand-run canonical capture must call the same
+barrier (or poll the same endpoint by hand, gating on `source === "proxy"`) at
+the equivalent point.
 
 ## Drift risk
 

--- a/showcase/aimock/README.md
+++ b/showcase/aimock/README.md
@@ -71,6 +71,39 @@ The process is manual. There is no CLI for this directory specifically — aimoc
 
 When a package's agent code changes in a way that changes its LLM calls, the person making the change is responsible for updating the corresponding fixture. There is no automation to remind you.
 
+### Proxy-capturing a D4 fixture: drain the journal first
+
+D4 fixtures are hand-authored, but the shape of a tool-calling flow is often
+easiest to obtain by proxy-capturing it once (boot aimock with `--record`
+against the real provider — as `docker-compose.record.yml` does — drive the D4
+cell, then hand-clean the emitted fixture before committing it under
+`d4/<slug>/`). If you do that, there is a **capture race** you must guard
+against, the same one the D5 recorder hit:
+
+> A probe (or your manual click-through) marks the cell satisfied as soon as the
+> tool card meets the assertion, but the **POST-tool-result LLM turn can still be
+> draining** — aimock is still proxying upstream and writing that fixture — after
+> the driving process exits. If you move/commit the captured fixtures or restart
+> aimock at that instant, the late fixture lands in the wrong place (or is lost),
+> and the D4 cell can go red on replay for a turn that was never captured.
+
+So, after driving the D4 cell and **before** moving/committing the captured
+fixtures or restarting aimock, **wait for the request journal to drain**. aimock
+exposes the journal at `GET /__aimock/journal`; a turn is only appended once it
+is fully served (record-mode proxy → `response.source === "proxy"`, or a replay
+→ `response.status === 200 && response.fixture != null` — never
+`source === "fixture"`, which aimock leaves unset on a normal replay).
+
+Use the shared barrier rather than re-deriving this rule:
+[`showcase/scripts/lib/journal-drain.mjs`](../scripts/lib/journal-drain.mjs)
+exports `waitForJournalDrain(...)`, which polls the journal until the
+completed-turn count has reached the floor **and** held steady through a
+quiescence window. The D5 recorder
+([`record-d5-fixtures.mjs`](../scripts/record-d5-fixtures.mjs)) calls it
+automatically between the probe and fixture consolidation; a hand-run D4 capture
+must call the same barrier (or poll the same endpoint by hand) at the equivalent
+point.
+
 ## Drift risk
 
 Drift surfaces as **flaky or silently-wrong E2E tests**, not as a dedicated signal. Symptoms and how to respond:

--- a/showcase/scripts/__tests__/journal-drain-barrier.test.ts
+++ b/showcase/scripts/__tests__/journal-drain-barrier.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
-// The module under test is a .mjs CLI. Its recording orchestration is guarded
-// behind an entry-module check, so importing it here only pulls in the pure,
-// exported barrier helpers — no docker calls fire.
+// The barrier helpers live in a shared .mjs module (imported by BOTH the D5
+// recorder and the hand-run D4 proxy-capture flow). Importing them here pulls
+// in the pure functions only — no docker calls, no recording orchestration.
 import {
   waitForJournalDrain,
   countCompletedTurns,
-  // @ts-expect-error — plain .mjs script, no type declarations
-} from "../record-d5-fixtures.mjs";
+  // @ts-expect-error — plain .mjs module, no type declarations
+} from "../lib/journal-drain.mjs";
 
 /**
  * Build a minimal journal-entries payload with `completed` settled upstream

--- a/showcase/scripts/__tests__/journal-drain-barrier.test.ts
+++ b/showcase/scripts/__tests__/journal-drain-barrier.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 // The barrier helpers live in a shared .mjs module (imported by BOTH the D5
 // recorder and the hand-run D4 proxy-capture flow). Importing them here pulls
 // in the pure functions only — no docker calls, no recording orchestration.
@@ -7,29 +7,33 @@ import {
   countCompletedTurns,
   // @ts-expect-error — plain .mjs module, no type declarations
 } from "../lib/journal-drain.mjs";
+// The abort-before-consolidate ordering seam from the D5 recorder. Imported for
+// the timeout-abort test; importing does NOT run the recorder's main() (it is
+// entry-module guarded), so no docker calls fire.
+import {
+  drainThenConsolidate,
+  // @ts-expect-error — plain .mjs module, no type declarations
+} from "../record-d5-fixtures.mjs";
 
 /**
- * Build a minimal journal-entries payload with `completed` settled upstream
- * turns. Mixes the two completion shapes aimock actually emits:
- *   - RECORD upstream completion  → response.source === "proxy"
- *   - REPLAY completion           → response.status 200 + response.fixture set,
- *                                    response.source UNSET
- * plus one in-flight-ish non-200 entry that must NOT be counted.
+ * Build a minimal journal-entries payload with `drained` fully-drained upstream
+ * turns. A DRAINED turn is ONLY the record path: `response.source === "proxy"`
+ * (aimock appends it after the full upstream drain + fixture write). Replay
+ * entries (`status:200` + `fixture` set, `source` unset) are appended at stream
+ * START, so they are NOT drained and must never count — one is included here to
+ * prove it is ignored, alongside an unsettled non-200.
  */
-function journal(completed: number): unknown[] {
+function journal(drained: number): unknown[] {
   const entries: unknown[] = [];
-  for (let i = 0; i < completed; i++) {
-    if (i % 2 === 0) {
-      entries.push({
-        response: { status: 200, source: "proxy", fixture: null },
-      });
-    } else {
-      // Replay-shaped: fixture populated, source deliberately unset.
-      entries.push({
-        response: { status: 200, fixture: { match: {}, response: {} } },
-      });
-    }
+  for (let i = 0; i < drained; i++) {
+    entries.push({
+      response: { status: 200, source: "proxy", fixture: null },
+    });
   }
+  // Replay-shaped (fixture set, source unset) — replay started, NOT drained.
+  entries.push({
+    response: { status: 200, fixture: { match: {}, response: {} } },
+  });
   // A not-yet-settled entry (no fixture, not proxied) — never counts.
   entries.push({ response: { status: 503, fixture: null } });
   return entries;
@@ -54,18 +58,20 @@ function fakeJournalFetch(states: unknown[][]): {
 }
 
 describe("countCompletedTurns", () => {
-  it("counts proxy (record) AND fixture-replay 200s, ignores non-200 / unsettled", () => {
+  it("counts ONLY proxy (record) 200s; ignores replay, non-200, unsettled", () => {
     expect(countCompletedTurns(journal(3))).toBe(3);
     expect(countCompletedTurns(journal(0))).toBe(0);
   });
 
-  it("does NOT count a replay entry via source (source is unset on replay)", () => {
-    // A replay 200 with a fixture but no source must still count. This guards
-    // against the Mark-observed trap of gating on source === "fixture".
+  it("does NOT count a replay entry as drained (fixture set, source unset)", () => {
+    // A replay 200 with a fixture but no source means "replay started / matched,"
+    // NOT "fully drained" — aimock journals it BEFORE it finishes streaming. It
+    // must NOT count toward the drain floor. Guards against the Mark-observed trap
+    // of treating `fixture != null` as a completion signal.
     const replayOnly = [
       { response: { status: 200, fixture: { match: {}, response: {} } } },
     ];
-    expect(countCompletedTurns(replayOnly)).toBe(1);
+    expect(countCompletedTurns(replayOnly)).toBe(0);
   });
 
   it("tolerates malformed input", () => {
@@ -75,6 +81,20 @@ describe("countCompletedTurns", () => {
 });
 
 describe("waitForJournalDrain", () => {
+  it("requires expectedTurns — throws when it is omitted (no quiescence-only default)", async () => {
+    // The unsound quiescence-only path (old `expectedTurns` defaulting to 0) is
+    // gone: omitting expectedTurns must throw, not silently drain on quiescence.
+    await expect(
+      waitForJournalDrain({
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          json: async () => [],
+        }),
+      }),
+    ).rejects.toThrow(/expectedTurns is required/);
+  });
+
   it("proceeds immediately when the journal is already drained", async () => {
     const f = fakeJournalFetch([journal(3)]);
     const result = await waitForJournalDrain({
@@ -88,10 +108,16 @@ describe("waitForJournalDrain", () => {
     expect(f.calls()).toBe(1);
   });
 
-  it("WAITS for a still-draining post-tool-result turn, then proceeds (the race)", async () => {
-    // Probe exited with only 2 of 3 turns settled; the post-tool-result turn
-    // lands on the 3rd poll. The barrier must NOT return until it sees 3.
+  it("WAITS through a QUIESCENT stretch at N-1 for a slow final turn, then proceeds", async () => {
+    // The race Mark flagged: the journal sits QUIESCENT at 2 drained turns for
+    // several polls (the 3rd, post-tool-result turn is still in flight — INVISIBLE
+    // in the journal until it lands), then the 3rd turn drains. With a real
+    // expectedTurns=3 the barrier must NOT settle during the quiescent 2/3 stretch
+    // (the old `expectedTurns: 0` behavior WOULD have settled at 2, moving fixtures
+    // out from under the in-flight final turn). It must hold out for 3.
     const f = fakeJournalFetch([
+      journal(2),
+      journal(2),
       journal(2),
       journal(2),
       journal(3),
@@ -104,14 +130,14 @@ describe("waitForJournalDrain", () => {
       quiesceMs: 0,
     });
     expect(result.completed).toBe(3);
-    // Proves it polled past the premature 2/3 state before proceeding.
-    expect(f.calls()).toBeGreaterThanOrEqual(3);
+    // Proves it polled through the premature 2/3 quiescent window before proceeding.
+    expect(f.calls()).toBeGreaterThanOrEqual(5);
   });
 
   it("waits for QUIESCENCE even after the floor is met (no in-flight)", async () => {
-    // Floor (expectedTurns=0) is met on poll 1, but the count keeps growing —
-    // a late turn is still in flight. The barrier must not settle until the
-    // count holds steady for the quiescence window.
+    // Floor (expectedTurns=1) is met on poll 1, but the drained count keeps
+    // growing — later turns are still landing. The barrier must not settle until
+    // the count holds steady for the quiescence window.
     const f = fakeJournalFetch([
       journal(1),
       journal(2),
@@ -120,7 +146,7 @@ describe("waitForJournalDrain", () => {
       journal(3),
     ]);
     const result = await waitForJournalDrain({
-      expectedTurns: 0,
+      expectedTurns: 1,
       fetchImpl: f.fetchImpl,
       pollIntervalMs: 1,
       quiesceMs: 15,
@@ -172,5 +198,47 @@ describe("waitForJournalDrain", () => {
         }),
       }),
     ).rejects.toThrow(/non-negative integer/);
+  });
+});
+
+describe("drainThenConsolidate (timeout is FATAL — fixtures NOT moved)", () => {
+  it("aborts BEFORE consolidation when the drain barrier times out", async () => {
+    // The whole point of the barrier: if the journal never drains, we must NOT
+    // move / consolidate fixtures (they'd land in the next demo's directory or be
+    // lost). A drain rejection must propagate and consolidation must never run.
+    const consolidate = vi.fn(async () => ({ count: 0 }));
+    const waitForDrain = vi.fn(async () => {
+      throw new Error(
+        "waitForJournalDrain: journal did not drain within 120000ms — expected >= 3",
+      );
+    });
+
+    await expect(
+      drainThenConsolidate({
+        feature: "gen-ui-tool-based",
+        waitForDrain,
+        consolidate,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/did not drain/);
+
+    // The critical assertion: consolidation (which moves fixtures) never ran.
+    expect(consolidate).not.toHaveBeenCalled();
+  });
+
+  it("consolidates only after a successful drain", async () => {
+    const consolidate = vi.fn(async () => ({ count: 7 }));
+    const waitForDrain = vi.fn(async () => ({ completed: 3 }));
+
+    const result = await drainThenConsolidate({
+      feature: "tool-rendering-default-catchall",
+      waitForDrain,
+      consolidate,
+      log: () => {},
+    });
+
+    expect(waitForDrain).toHaveBeenCalledTimes(1);
+    expect(consolidate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ count: 7 });
   });
 });

--- a/showcase/scripts/__tests__/journal-drain-barrier.test.ts
+++ b/showcase/scripts/__tests__/journal-drain-barrier.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+// The module under test is a .mjs CLI. Its recording orchestration is guarded
+// behind an entry-module check, so importing it here only pulls in the pure,
+// exported barrier helpers — no docker calls fire.
+import {
+  waitForJournalDrain,
+  countCompletedTurns,
+  // @ts-expect-error — plain .mjs script, no type declarations
+} from "../record-d5-fixtures.mjs";
+
+/**
+ * Build a minimal journal-entries payload with `completed` settled upstream
+ * turns. Mixes the two completion shapes aimock actually emits:
+ *   - RECORD upstream completion  → response.source === "proxy"
+ *   - REPLAY completion           → response.status 200 + response.fixture set,
+ *                                    response.source UNSET
+ * plus one in-flight-ish non-200 entry that must NOT be counted.
+ */
+function journal(completed: number): unknown[] {
+  const entries: unknown[] = [];
+  for (let i = 0; i < completed; i++) {
+    if (i % 2 === 0) {
+      entries.push({
+        response: { status: 200, source: "proxy", fixture: null },
+      });
+    } else {
+      // Replay-shaped: fixture populated, source deliberately unset.
+      entries.push({
+        response: { status: 200, fixture: { match: {}, response: {} } },
+      });
+    }
+  }
+  // A not-yet-settled entry (no fixture, not proxied) — never counts.
+  entries.push({ response: { status: 503, fixture: null } });
+  return entries;
+}
+
+/** Fake fetch returning a scripted sequence of journal states as JSON. */
+function fakeJournalFetch(states: unknown[][]): {
+  fetchImpl: (
+    url: string,
+  ) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+  calls: () => number;
+} {
+  let i = 0;
+  return {
+    calls: () => i,
+    fetchImpl: async () => {
+      const entries = states[Math.min(i, states.length - 1)];
+      i += 1;
+      return { ok: true, status: 200, json: async () => entries };
+    },
+  };
+}
+
+describe("countCompletedTurns", () => {
+  it("counts proxy (record) AND fixture-replay 200s, ignores non-200 / unsettled", () => {
+    expect(countCompletedTurns(journal(3))).toBe(3);
+    expect(countCompletedTurns(journal(0))).toBe(0);
+  });
+
+  it("does NOT count a replay entry via source (source is unset on replay)", () => {
+    // A replay 200 with a fixture but no source must still count. This guards
+    // against the Mark-observed trap of gating on source === "fixture".
+    const replayOnly = [
+      { response: { status: 200, fixture: { match: {}, response: {} } } },
+    ];
+    expect(countCompletedTurns(replayOnly)).toBe(1);
+  });
+
+  it("tolerates malformed input", () => {
+    expect(countCompletedTurns(null as unknown as unknown[])).toBe(0);
+    expect(countCompletedTurns([{}, { response: null }])).toBe(0);
+  });
+});
+
+describe("waitForJournalDrain", () => {
+  it("proceeds immediately when the journal is already drained", async () => {
+    const f = fakeJournalFetch([journal(3)]);
+    const result = await waitForJournalDrain({
+      expectedTurns: 3,
+      fetchImpl: f.fetchImpl,
+      pollIntervalMs: 1,
+      quiesceMs: 0,
+    });
+    expect(result.completed).toBe(3);
+    // One poll is enough when quiesceMs is 0 and the count already satisfies.
+    expect(f.calls()).toBe(1);
+  });
+
+  it("WAITS for a still-draining post-tool-result turn, then proceeds (the race)", async () => {
+    // Probe exited with only 2 of 3 turns settled; the post-tool-result turn
+    // lands on the 3rd poll. The barrier must NOT return until it sees 3.
+    const f = fakeJournalFetch([
+      journal(2),
+      journal(2),
+      journal(3),
+      journal(3),
+    ]);
+    const result = await waitForJournalDrain({
+      expectedTurns: 3,
+      fetchImpl: f.fetchImpl,
+      pollIntervalMs: 1,
+      quiesceMs: 0,
+    });
+    expect(result.completed).toBe(3);
+    // Proves it polled past the premature 2/3 state before proceeding.
+    expect(f.calls()).toBeGreaterThanOrEqual(3);
+  });
+
+  it("waits for QUIESCENCE even after the floor is met (no in-flight)", async () => {
+    // Floor (expectedTurns=0) is met on poll 1, but the count keeps growing —
+    // a late turn is still in flight. The barrier must not settle until the
+    // count holds steady for the quiescence window.
+    const f = fakeJournalFetch([
+      journal(1),
+      journal(2),
+      journal(3),
+      journal(3),
+      journal(3),
+    ]);
+    const result = await waitForJournalDrain({
+      expectedTurns: 0,
+      fetchImpl: f.fetchImpl,
+      pollIntervalMs: 1,
+      quiesceMs: 15,
+    });
+    expect(result.completed).toBe(3);
+    expect(f.calls()).toBeGreaterThanOrEqual(4);
+  });
+
+  it("times out with a clear error when the journal never drains", async () => {
+    // Stuck at 2/3 forever — the post-tool-result turn never lands.
+    const f = fakeJournalFetch([journal(2)]);
+    await expect(
+      waitForJournalDrain({
+        expectedTurns: 3,
+        fetchImpl: f.fetchImpl,
+        pollIntervalMs: 2,
+        quiesceMs: 0,
+        timeoutMs: 40,
+      }),
+    ).rejects.toThrow(/did not drain within 40ms.*observed 2/s);
+  });
+
+  it("keeps polling through transient journal read failures", async () => {
+    let i = 0;
+    const fetchImpl = async () => {
+      i += 1;
+      if (i < 3) throw new Error("ECONNREFUSED (aimock mid-restart)");
+      return { ok: true, status: 200, json: async () => journal(3) };
+    };
+    const result = await waitForJournalDrain({
+      expectedTurns: 3,
+      fetchImpl,
+      pollIntervalMs: 1,
+      quiesceMs: 0,
+      timeoutMs: 2000,
+    });
+    expect(result.completed).toBe(3);
+    expect(i).toBeGreaterThanOrEqual(3);
+  });
+
+  it("rejects an invalid expectedTurns", async () => {
+    await expect(
+      waitForJournalDrain({
+        expectedTurns: -1,
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          json: async () => [],
+        }),
+      }),
+    ).rejects.toThrow(/non-negative integer/);
+  });
+});

--- a/showcase/scripts/lib/journal-drain.mjs
+++ b/showcase/scripts/lib/journal-drain.mjs
@@ -1,0 +1,153 @@
+// Journal-drain barrier for aimock fixture capture.
+//
+// A probe marks a cell satisfied as soon as the tool card meets the assertion,
+// but the POST-tool-result LLM turn can still be draining (aimock still
+// proxying upstream + writing the fixture) after the probe process exits. If a
+// capture flow moves fixtures / restarts aimock at that instant, the late
+// fixture lands in the NEXT run's directory. This module lets any capture flow
+// (D5's `record-d5-fixtures.mjs`, or a hand-run D4 proxy-capture — see
+// `showcase/aimock/README.md`) block until the run has fully drained first.
+//
+// Kept as plain `.mjs` (no TS) so it is importable both from the plain-`node`
+// recorder CLI and from vitest without a transpile step.
+
+// Host-side URL of the aimock request journal. docker-compose.local.yml maps
+// the aimock container's port 4010 to localhost:4010, so a recorder driving a
+// capture reaches the journal here. Overridable for tests / non-default
+// topologies via AIMOCK_URL.
+const AIMOCK_BASE_URL = process.env.AIMOCK_URL ?? "http://localhost:4010";
+export const JOURNAL_URL = `${AIMOCK_BASE_URL.replace(/\/+$/, "")}/__aimock/journal`;
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * True when a journal entry represents a COMPLETED upstream turn — i.e. aimock
+ * has fully served the request and appended the entry (so any fixture it
+ * produced is already written to disk).
+ *
+ * Two completion shapes exist, both observed live on this aimock build:
+ *   - RECORD mode: no fixture matched, aimock proxied to the real provider and
+ *     wrote a fixture. The entry carries `response.source === "proxy"`.
+ *   - REPLAY: a fixture served the request. `response.fixture` is populated but
+ *     `response.source` is UNSET (aimock does not stamp source:"fixture" on a
+ *     normal replay), so we MUST gate on `status === 200 && fixture != null`
+ *     and never on `source === "fixture"`.
+ *
+ * Both are 200s; anything else (in-flight has no entry yet, errors, chaos
+ * fallbacks) is not a settled upstream turn.
+ */
+export function isCompletedTurn(entry) {
+  const r = entry?.response;
+  if (!r || r.status !== 200) return false;
+  return r.source === "proxy" || r.fixture != null;
+}
+
+/**
+ * Count the completed upstream turns in a journal entries array. Tolerant of
+ * non-array / malformed input (returns 0) so a transient bad journal read
+ * cannot throw out of the drain loop.
+ */
+export function countCompletedTurns(entries) {
+  if (!Array.isArray(entries)) return 0;
+  return entries.filter(isCompletedTurn).length;
+}
+
+/**
+ * Journal-drain barrier. Poll aimock's request journal until the run has fully
+ * drained before the caller moves fixtures or restarts aimock.
+ *
+ * Why this exists: a probe marks a cell satisfied as soon as the tool card
+ * meets the assertion, but the POST-tool-result LLM turn can still be draining
+ * (aimock still proxying upstream + writing the fixture) after the probe
+ * process exits. If we move fixtures / restart aimock at that instant, the late
+ * fixture lands in the NEXT run's directory — observed as a run-3 follow-up
+ * landing under run 4, and a run-4 EMPTY initial-weather fixture landing under
+ * run 5 (weather then went red on replay).
+ *
+ * "Drained" here = the completed-turn count has reached `expectedTurns` AND has
+ * stopped growing for `quiesceMs` (nothing else is in flight). Because the
+ * journal only appends an entry once a turn is fully served, a turn still
+ * draining is simply absent from the count; requiring the count to hold steady
+ * for a quiescence window is how we know no further turn is about to land.
+ *
+ * `expectedTurns` is a floor (e.g. the built-in-agent D4 weather flow expects 3:
+ * greeting, tool-call turn, post-tool-result turn); pass 0 to wait purely for
+ * quiescence when the exact turn count for a demo is not known ahead of time.
+ *
+ * Rejects with a clear error if the journal never drains within `timeoutMs`.
+ *
+ * The injectable `fetchImpl` is deliberately typed to the MINIMAL journal-fetch
+ * seam this barrier actually uses — a `(url) => Promise<{ ok, status, json() }>`
+ * — NOT the full DOM `fetch` signature. Tests inject a tiny fake shaped exactly
+ * to this seam; typing it here (rather than to `fetch`) keeps them from having
+ * to satisfy `RequestInfo | URL` / `Response`.
+ *
+ * @typedef {{ ok?: boolean, status: number, json: () => Promise<unknown> }} JournalResponse
+ * @param {object} [opts]
+ * @param {number} [opts.expectedTurns]
+ * @param {string} [opts.journalUrl]
+ * @param {(url: string) => Promise<JournalResponse>} [opts.fetchImpl]
+ * @param {number} [opts.timeoutMs]
+ * @param {number} [opts.pollIntervalMs]
+ * @param {number} [opts.quiesceMs]
+ * @returns {Promise<{ completed: number }>}
+ */
+export async function waitForJournalDrain({
+  expectedTurns = 0,
+  journalUrl = JOURNAL_URL,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 120000,
+  pollIntervalMs = 500,
+  quiesceMs = 2000,
+} = {}) {
+  if (!Number.isInteger(expectedTurns) || expectedTurns < 0) {
+    throw new Error(
+      `waitForJournalDrain: expectedTurns must be a non-negative integer, got ${expectedTurns}`,
+    );
+  }
+  const deadline = Date.now() + timeoutMs;
+  let lastCount = -1;
+  let lastChangeAt = Date.now();
+  let observed = 0;
+  for (;;) {
+    let entries = [];
+    try {
+      const res = await fetchImpl(journalUrl);
+      if (!res.ok)
+        throw new Error(`journal endpoint returned HTTP ${res.status}`);
+      const body = await res.json();
+      // aimock may return the entries array directly or wrapped in { entries }.
+      entries = Array.isArray(body)
+        ? body
+        : Array.isArray(body?.entries)
+          ? body.entries
+          : [];
+    } catch {
+      // Transient read failure (e.g. aimock mid-restart) — treat as not-yet-
+      // drained and keep polling until the timeout.
+      entries = [];
+    }
+    observed = countCompletedTurns(entries);
+    const now = Date.now();
+    if (observed !== lastCount) {
+      lastCount = observed;
+      lastChangeAt = now;
+    }
+    const quiesced = now - lastChangeAt >= quiesceMs;
+    if (observed >= expectedTurns && quiesced) {
+      return { completed: observed };
+    }
+    if (now >= deadline) {
+      throw new Error(
+        `waitForJournalDrain: journal did not drain within ${timeoutMs}ms — ` +
+          `expected >= ${expectedTurns} completed upstream turns (quiescent for ` +
+          `${quiesceMs}ms) but observed ${observed}. A late post-tool-result turn ` +
+          `may still be in flight; moving fixtures now risks landing it in the ` +
+          `next run's directory.`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+}

--- a/showcase/scripts/lib/journal-drain.mjs
+++ b/showcase/scripts/lib/journal-drain.mjs
@@ -23,25 +23,38 @@ function sleep(ms) {
 }
 
 /**
- * True when a journal entry represents a COMPLETED upstream turn — i.e. aimock
- * has fully served the request and appended the entry (so any fixture it
- * produced is already written to disk).
+ * True when a journal entry represents a fully-DRAINED upstream turn — aimock
+ * has finished serving the request AND written any fixture it produced to disk.
  *
- * Two completion shapes exist, both observed live on this aimock build:
- *   - RECORD mode: no fixture matched, aimock proxied to the real provider and
- *     wrote a fixture. The entry carries `response.source === "proxy"`.
- *   - REPLAY: a fixture served the request. `response.fixture` is populated but
- *     `response.source` is UNSET (aimock does not stamp source:"fixture" on a
- *     normal replay), so we MUST gate on `status === 200 && fixture != null`
- *     and never on `source === "fixture"`.
+ * The ONLY sound journal signal for that is the RECORD (proxy) path:
+ *   - RECORD mode: no fixture matched, aimock proxied to the real provider,
+ *     awaited the ENTIRE upstream stream, wrote the fixture to disk, and only
+ *     THEN appended the journal entry with `response.source === "proxy"`
+ *     (verified in aimock `server.ts`: the `source:"proxy"` `journal.add` runs
+ *     AFTER `await proxyAndRecord(...)`, which awaits the full upstream body).
+ *     So a `source:"proxy"` entry proves the turn drained and its fixture is on
+ *     disk — exactly the guarantee this barrier needs.
  *
- * Both are 200s; anything else (in-flight has no entry yet, errors, chaos
- * fallbacks) is not a settled upstream turn.
+ * A REPLAY entry is deliberately NOT counted as drained. On a fixture hit aimock
+ * appends the journal entry (`status:200`, `fixture` set, `source` UNSET) BEFORE
+ * it streams the response — verified in aimock `server.ts`, where the replay
+ * `journal.add(... response:{status:200, fixture})` runs BEFORE
+ * `await writeSSEStream(...)`; the entry is only mutated afterward if the stream
+ * is interrupted. So `fixture != null` means "replay started / matched," NOT
+ * "fully drained," and gating on it would let the barrier settle while a slow
+ * replay is still streaming. Replay therefore has NO sound journal-based
+ * completion signal; this barrier's "drained" definition is scoped to the
+ * record path on purpose. The D5/D4 proxy-capture flows that use this barrier
+ * run aimock in `--record` mode, where every genuine upstream turn is a
+ * `source:"proxy"` entry, so this scoping is exactly right for them.
+ *
+ * Anything else (in-flight has no entry yet, errors, chaos fallbacks, or a
+ * bare replay hit) is not a settled upstream-record turn.
  */
 export function isCompletedTurn(entry) {
   const r = entry?.response;
   if (!r || r.status !== 200) return false;
-  return r.source === "proxy" || r.fixture != null;
+  return r.source === "proxy";
 }
 
 /**
@@ -66,15 +79,27 @@ export function countCompletedTurns(entries) {
  * landing under run 4, and a run-4 EMPTY initial-weather fixture landing under
  * run 5 (weather then went red on replay).
  *
- * "Drained" here = the completed-turn count has reached `expectedTurns` AND has
- * stopped growing for `quiesceMs` (nothing else is in flight). Because the
- * journal only appends an entry once a turn is fully served, a turn still
- * draining is simply absent from the count; requiring the count to hold steady
- * for a quiescence window is how we know no further turn is about to land.
+ * "Drained" here = the drained-turn count (record-path `source:"proxy"`
+ * entries — see `isCompletedTurn`) has reached `expectedTurns` AND has stopped
+ * growing for `quiesceMs`. Both conditions are REQUIRED and neither is
+ * sufficient alone:
  *
- * `expectedTurns` is a floor (e.g. the built-in-agent D4 weather flow expects 3:
- * greeting, tool-call turn, post-tool-result turn); pass 0 to wait purely for
- * quiescence when the exact turn count for a demo is not known ahead of time.
+ *   - The count floor alone is not enough: a run can momentarily sit at the
+ *     floor between turns.
+ *   - Quiescence alone is NOT sound, which is why `expectedTurns` is REQUIRED
+ *     and must be the REAL number of upstream turns. An in-flight upstream
+ *     request is INVISIBLE in the journal until it completes (aimock appends the
+ *     `source:"proxy"` entry only AFTER the full upstream drain). So during the
+ *     gap between the (N-1)th turn finishing and the Nth turn landing, the count
+ *     is quiescent at N-1 while the slow final turn is still in flight. Waiting
+ *     "purely for quiescence" (the old `expectedTurns: 0` behavior) would settle
+ *     prematurely at N-1 and move fixtures out from under the Nth turn. Requiring
+ *     the count to reach a real `expectedTurns` closes that hole.
+ *
+ * `expectedTurns` is REQUIRED — there is no default. It must be the true number
+ * of upstream turns the captured flow drives (e.g. the built-in-agent D4 weather
+ * flow expects 3: greeting, tool-call turn, post-tool-result turn). Omitting it
+ * throws, rather than silently degrading to unsound quiescence-only draining.
  *
  * Rejects with a clear error if the journal never drains within `timeoutMs`.
  *
@@ -85,8 +110,8 @@ export function countCompletedTurns(entries) {
  * to satisfy `RequestInfo | URL` / `Response`.
  *
  * @typedef {{ ok?: boolean, status: number, json: () => Promise<unknown> }} JournalResponse
- * @param {object} [opts]
- * @param {number} [opts.expectedTurns]
+ * @param {object} opts
+ * @param {number} opts.expectedTurns REQUIRED — the true number of upstream turns.
  * @param {string} [opts.journalUrl]
  * @param {(url: string) => Promise<JournalResponse>} [opts.fetchImpl]
  * @param {number} [opts.timeoutMs]
@@ -95,13 +120,24 @@ export function countCompletedTurns(entries) {
  * @returns {Promise<{ completed: number }>}
  */
 export async function waitForJournalDrain({
-  expectedTurns = 0,
+  expectedTurns,
   journalUrl = JOURNAL_URL,
   fetchImpl = globalThis.fetch,
   timeoutMs = 120000,
   pollIntervalMs = 500,
   quiesceMs = 2000,
 } = {}) {
+  // expectedTurns is REQUIRED and must be a real turn count. Defaulting it to 0
+  // (the old behavior) degrades the barrier to unsound quiescence-only draining
+  // that settles prematurely while a slow final upstream turn is still in flight
+  // (invisible in the journal until it completes). Fail loudly instead.
+  if (expectedTurns === undefined) {
+    throw new Error(
+      "waitForJournalDrain: expectedTurns is required — pass the real number of " +
+        "upstream turns the captured flow drives. Quiescence alone is not a sound " +
+        "drain signal (an in-flight turn is invisible in the journal until it lands).",
+    );
+  }
   if (!Number.isInteger(expectedTurns) || expectedTurns < 0) {
     throw new Error(
       `waitForJournalDrain: expectedTurns must be a non-negative integer, got ${expectedTurns}`,

--- a/showcase/scripts/record-d5-fixtures.mjs
+++ b/showcase/scripts/record-d5-fixtures.mjs
@@ -51,7 +51,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../..");
@@ -61,6 +61,13 @@ const RECORDED_DIR = path.join(
 );
 const OUTPUT_DIR = path.join(REPO_ROOT, "showcase/aimock/d5-recorded");
 const HARNESS_DIR = path.join(REPO_ROOT, "showcase/harness");
+
+// Host-side URL of the aimock request journal. docker-compose.local.yml maps
+// the aimock container's port 4010 to localhost:4010, so the recorder driving
+// this script reaches the journal here. Overridable for tests / non-default
+// topologies via AIMOCK_URL.
+const AIMOCK_BASE_URL = process.env.AIMOCK_URL ?? "http://localhost:4010";
+const JOURNAL_URL = `${AIMOCK_BASE_URL.replace(/\/+$/, "")}/__aimock/journal`;
 
 // Catalog feature IDs as listed in `showcase/integrations/langgraph-python/manifest.yaml`'s
 // top-level `features` array. The harness target shape is `<slug>:<feature>`,
@@ -141,6 +148,124 @@ async function probeRecorderPatch() {
   }
 }
 
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * True when a journal entry represents a COMPLETED upstream turn — i.e. aimock
+ * has fully served the request and appended the entry (so any fixture it
+ * produced is already written to disk).
+ *
+ * Two completion shapes exist, both observed live on this aimock build:
+ *   - RECORD mode: no fixture matched, aimock proxied to the real provider and
+ *     wrote a fixture. The entry carries `response.source === "proxy"`.
+ *   - REPLAY: a fixture served the request. `response.fixture` is populated but
+ *     `response.source` is UNSET (aimock does not stamp source:"fixture" on a
+ *     normal replay), so we MUST gate on `status === 200 && fixture != null`
+ *     and never on `source === "fixture"`.
+ *
+ * Both are 200s; anything else (in-flight has no entry yet, errors, chaos
+ * fallbacks) is not a settled upstream turn.
+ */
+function isCompletedTurn(entry) {
+  const r = entry?.response;
+  if (!r || r.status !== 200) return false;
+  return r.source === "proxy" || r.fixture != null;
+}
+
+/**
+ * Count the completed upstream turns in a journal entries array. Tolerant of
+ * non-array / malformed input (returns 0) so a transient bad journal read
+ * cannot throw out of the drain loop.
+ */
+export function countCompletedTurns(entries) {
+  if (!Array.isArray(entries)) return 0;
+  return entries.filter(isCompletedTurn).length;
+}
+
+/**
+ * Journal-drain barrier. Poll aimock's request journal until the run has fully
+ * drained before the caller moves fixtures or restarts aimock.
+ *
+ * Why this exists: a probe marks a cell satisfied as soon as the tool card
+ * meets the assertion, but the POST-tool-result LLM turn can still be draining
+ * (aimock still proxying upstream + writing the fixture) after the probe
+ * process exits. If we move fixtures / restart aimock at that instant, the late
+ * fixture lands in the NEXT run's directory — observed as a run-3 follow-up
+ * landing under run 4, and a run-4 EMPTY initial-weather fixture landing under
+ * run 5 (weather then went red on replay).
+ *
+ * "Drained" here = the completed-turn count has reached `expectedTurns` AND has
+ * stopped growing for `quiesceMs` (nothing else is in flight). Because the
+ * journal only appends an entry once a turn is fully served, a turn still
+ * draining is simply absent from the count; requiring the count to hold steady
+ * for a quiescence window is how we know no further turn is about to land.
+ *
+ * `expectedTurns` is a floor (e.g. the built-in-agent D4 weather flow expects 3:
+ * greeting, tool-call turn, post-tool-result turn); pass 0 to wait purely for
+ * quiescence when the exact turn count for a demo is not known ahead of time.
+ *
+ * Rejects with a clear error if the journal never drains within `timeoutMs`.
+ */
+export async function waitForJournalDrain({
+  expectedTurns = 0,
+  journalUrl = JOURNAL_URL,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = 120000,
+  pollIntervalMs = 500,
+  quiesceMs = 2000,
+} = {}) {
+  if (!Number.isInteger(expectedTurns) || expectedTurns < 0) {
+    throw new Error(
+      `waitForJournalDrain: expectedTurns must be a non-negative integer, got ${expectedTurns}`,
+    );
+  }
+  const deadline = Date.now() + timeoutMs;
+  let lastCount = -1;
+  let lastChangeAt = Date.now();
+  let observed = 0;
+  for (;;) {
+    let entries = [];
+    try {
+      const res = await fetchImpl(journalUrl);
+      if (!res.ok)
+        throw new Error(`journal endpoint returned HTTP ${res.status}`);
+      const body = await res.json();
+      // aimock may return the entries array directly or wrapped in { entries }.
+      entries = Array.isArray(body)
+        ? body
+        : Array.isArray(body?.entries)
+          ? body.entries
+          : [];
+    } catch {
+      // Transient read failure (e.g. aimock mid-restart) — treat as not-yet-
+      // drained and keep polling until the timeout.
+      entries = [];
+    }
+    observed = countCompletedTurns(entries);
+    const now = Date.now();
+    if (observed !== lastCount) {
+      lastCount = observed;
+      lastChangeAt = now;
+    }
+    const quiesced = now - lastChangeAt >= quiesceMs;
+    if (observed >= expectedTurns && quiesced) {
+      return { completed: observed };
+    }
+    if (now >= deadline) {
+      throw new Error(
+        `waitForJournalDrain: journal did not drain within ${timeoutMs}ms — ` +
+          `expected >= ${expectedTurns} completed upstream turns (quiescent for ` +
+          `${quiesceMs}ms) but observed ${observed}. A late post-tool-result turn ` +
+          `may still be in flight; moving fixtures now risks landing it in the ` +
+          `next run's directory.`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
 async function restartAimock() {
   // Forces aimock to drop in-memory fixtures from previous recordings and
   // reload from disk. Without this, prompts already recorded in the current
@@ -212,7 +337,7 @@ async function consolidateNewFiles(demo, beforeSet) {
   return { count: fixtures.length };
 }
 
-(async () => {
+async function main() {
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
   await fs.mkdir(RECORDED_DIR, { recursive: true });
   await probeRecorderPatch();
@@ -232,6 +357,19 @@ async function consolidateNewFiles(demo, beforeSet) {
 
     const before = await listRecordedFiles();
     const code = await runProbe(demo);
+    // The probe process can exit while aimock is still draining the final
+    // post-tool-result turn. Block on the journal-drain barrier BEFORE moving
+    // fixtures so a late fixture cannot land in the next demo's directory.
+    try {
+      const drain = await waitForJournalDrain({ expectedTurns: 0 });
+      console.log(
+        `[record] ${demo}: journal drained (${drain.completed} turns)`,
+      );
+    } catch (err) {
+      console.warn(
+        `[record] ${demo}: journal-drain barrier did not settle — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     const result = await consolidateNewFiles(demo, before);
     summary.push({ demo, probeExit: code, fixtureCount: result.count });
   }
@@ -241,7 +379,16 @@ async function consolidateNewFiles(demo, beforeSet) {
       `  ${row.demo.padEnd(40)} probe=${row.probeExit === 0 ? "pass" : "fail"} fixtures=${row.fixtureCount}`,
     );
   }
-})().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+}
+
+// Only run the recording orchestration when invoked directly as a CLI. Guarding
+// on the entry module keeps the exported helpers (waitForJournalDrain,
+// countCompletedTurns) importable from tests without triggering docker calls.
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/showcase/scripts/record-d5-fixtures.mjs
+++ b/showcase/scripts/record-d5-fixtures.mjs
@@ -52,6 +52,10 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+// The journal-drain barrier lives in a shared module so the D4 proxy-capture
+// flow (hand-run — see showcase/aimock/README.md) and this D5 recorder both
+// gate on the exact same drain semantics.
+import { waitForJournalDrain } from "./lib/journal-drain.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../..");
@@ -61,13 +65,6 @@ const RECORDED_DIR = path.join(
 );
 const OUTPUT_DIR = path.join(REPO_ROOT, "showcase/aimock/d5-recorded");
 const HARNESS_DIR = path.join(REPO_ROOT, "showcase/harness");
-
-// Host-side URL of the aimock request journal. docker-compose.local.yml maps
-// the aimock container's port 4010 to localhost:4010, so the recorder driving
-// this script reaches the journal here. Overridable for tests / non-default
-// topologies via AIMOCK_URL.
-const AIMOCK_BASE_URL = process.env.AIMOCK_URL ?? "http://localhost:4010";
-const JOURNAL_URL = `${AIMOCK_BASE_URL.replace(/\/+$/, "")}/__aimock/journal`;
 
 // Catalog feature IDs as listed in `showcase/integrations/langgraph-python/manifest.yaml`'s
 // top-level `features` array. The harness target shape is `<slug>:<feature>`,
@@ -145,124 +142,6 @@ async function probeRecorderPatch() {
         "  @copilotkit/aimock to ship.",
       ].join("\n"),
     );
-  }
-}
-
-function sleep(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-/**
- * True when a journal entry represents a COMPLETED upstream turn — i.e. aimock
- * has fully served the request and appended the entry (so any fixture it
- * produced is already written to disk).
- *
- * Two completion shapes exist, both observed live on this aimock build:
- *   - RECORD mode: no fixture matched, aimock proxied to the real provider and
- *     wrote a fixture. The entry carries `response.source === "proxy"`.
- *   - REPLAY: a fixture served the request. `response.fixture` is populated but
- *     `response.source` is UNSET (aimock does not stamp source:"fixture" on a
- *     normal replay), so we MUST gate on `status === 200 && fixture != null`
- *     and never on `source === "fixture"`.
- *
- * Both are 200s; anything else (in-flight has no entry yet, errors, chaos
- * fallbacks) is not a settled upstream turn.
- */
-function isCompletedTurn(entry) {
-  const r = entry?.response;
-  if (!r || r.status !== 200) return false;
-  return r.source === "proxy" || r.fixture != null;
-}
-
-/**
- * Count the completed upstream turns in a journal entries array. Tolerant of
- * non-array / malformed input (returns 0) so a transient bad journal read
- * cannot throw out of the drain loop.
- */
-export function countCompletedTurns(entries) {
-  if (!Array.isArray(entries)) return 0;
-  return entries.filter(isCompletedTurn).length;
-}
-
-/**
- * Journal-drain barrier. Poll aimock's request journal until the run has fully
- * drained before the caller moves fixtures or restarts aimock.
- *
- * Why this exists: a probe marks a cell satisfied as soon as the tool card
- * meets the assertion, but the POST-tool-result LLM turn can still be draining
- * (aimock still proxying upstream + writing the fixture) after the probe
- * process exits. If we move fixtures / restart aimock at that instant, the late
- * fixture lands in the NEXT run's directory — observed as a run-3 follow-up
- * landing under run 4, and a run-4 EMPTY initial-weather fixture landing under
- * run 5 (weather then went red on replay).
- *
- * "Drained" here = the completed-turn count has reached `expectedTurns` AND has
- * stopped growing for `quiesceMs` (nothing else is in flight). Because the
- * journal only appends an entry once a turn is fully served, a turn still
- * draining is simply absent from the count; requiring the count to hold steady
- * for a quiescence window is how we know no further turn is about to land.
- *
- * `expectedTurns` is a floor (e.g. the built-in-agent D4 weather flow expects 3:
- * greeting, tool-call turn, post-tool-result turn); pass 0 to wait purely for
- * quiescence when the exact turn count for a demo is not known ahead of time.
- *
- * Rejects with a clear error if the journal never drains within `timeoutMs`.
- */
-export async function waitForJournalDrain({
-  expectedTurns = 0,
-  journalUrl = JOURNAL_URL,
-  fetchImpl = globalThis.fetch,
-  timeoutMs = 120000,
-  pollIntervalMs = 500,
-  quiesceMs = 2000,
-} = {}) {
-  if (!Number.isInteger(expectedTurns) || expectedTurns < 0) {
-    throw new Error(
-      `waitForJournalDrain: expectedTurns must be a non-negative integer, got ${expectedTurns}`,
-    );
-  }
-  const deadline = Date.now() + timeoutMs;
-  let lastCount = -1;
-  let lastChangeAt = Date.now();
-  let observed = 0;
-  for (;;) {
-    let entries = [];
-    try {
-      const res = await fetchImpl(journalUrl);
-      if (!res.ok)
-        throw new Error(`journal endpoint returned HTTP ${res.status}`);
-      const body = await res.json();
-      // aimock may return the entries array directly or wrapped in { entries }.
-      entries = Array.isArray(body)
-        ? body
-        : Array.isArray(body?.entries)
-          ? body.entries
-          : [];
-    } catch {
-      // Transient read failure (e.g. aimock mid-restart) — treat as not-yet-
-      // drained and keep polling until the timeout.
-      entries = [];
-    }
-    observed = countCompletedTurns(entries);
-    const now = Date.now();
-    if (observed !== lastCount) {
-      lastCount = observed;
-      lastChangeAt = now;
-    }
-    const quiesced = now - lastChangeAt >= quiesceMs;
-    if (observed >= expectedTurns && quiesced) {
-      return { completed: observed };
-    }
-    if (now >= deadline) {
-      throw new Error(
-        `waitForJournalDrain: journal did not drain within ${timeoutMs}ms — ` +
-          `expected >= ${expectedTurns} completed upstream turns (quiescent for ` +
-          `${quiesceMs}ms) but observed ${observed}. A late post-tool-result turn ` +
-          `may still be in flight; moving fixtures now risks landing it in the ` +
-          `next run's directory.`,
-      );
-    }
-    await sleep(pollIntervalMs);
   }
 }
 
@@ -382,8 +261,9 @@ async function main() {
 }
 
 // Only run the recording orchestration when invoked directly as a CLI. Guarding
-// on the entry module keeps the exported helpers (waitForJournalDrain,
-// countCompletedTurns) importable from tests without triggering docker calls.
+// on the entry module keeps this file importable without triggering docker
+// calls; the barrier helpers it uses live in ./lib/journal-drain.mjs and are
+// unit-tested there.
 const invokedDirectly =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (invokedDirectly) {

--- a/showcase/scripts/record-d5-fixtures.mjs
+++ b/showcase/scripts/record-d5-fixtures.mjs
@@ -68,17 +68,49 @@ const HARNESS_DIR = path.join(REPO_ROOT, "showcase/harness");
 
 // Catalog feature IDs as listed in `showcase/integrations/langgraph-python/manifest.yaml`'s
 // top-level `features` array. The harness target shape is `<slug>:<feature>`,
-// so these MUST be the manifest feature IDs (not d5 script featureTypes nor
+// so `feature` MUST be the manifest feature ID (not d5 script featureTypes nor
 // per-pill sub-keys). Beautiful chat exercises five sub-pills under one
 // feature, so a single `beautiful-chat` run records all five.
+//
+// `expectedTurns` is the number of upstream (record-mode `source:"proxy"`) LLM
+// turns a single full-feature run drives. It is REQUIRED by the journal-drain
+// barrier (`waitForJournalDrain` throws without it) and is what makes the
+// barrier sound: quiescence alone can settle prematurely between turns while a
+// slow final turn is still in flight (invisible in the journal until it lands),
+// so the barrier must wait for a REAL turn count, not just for the journal to
+// go quiet. See `lib/journal-drain.mjs`.
+//
+// The counts below are seeded from each feature's committed canonical fixture
+// file (`aimock/d6/langgraph-python/<feature>.json`), which is the normalized
+// consolidation of a prior real full-feature capture — the best static estimate
+// available (`d5-recorded/` output is gitignored). They are a per-run turn count,
+// NOT gospel: if a feature's flow changes, update the count. A count set too HIGH
+// fails LOUD — the barrier never reaches it and times out, aborting the run
+// (see the FATAL drain handling in `main`) rather than silently corrupting
+// fixtures; a count set too LOW is the only unsafe direction, so err high and
+// confirm against the live capture. `reasoning-custom` has no 1:1 canonical file
+// (its d5 script also serves `reasoning-default`); its count is seeded from
+// `reasoning.json`.
 const DEMOS = [
-  "tool-rendering-default-catchall",
-  "beautiful-chat",
-  "headless-complete",
-  "gen-ui-interrupt",
-  "gen-ui-tool-based",
-  "reasoning-custom",
+  { feature: "tool-rendering-default-catchall", expectedTurns: 3 },
+  { feature: "beautiful-chat", expectedTurns: 10 },
+  { feature: "headless-complete", expectedTurns: 10 },
+  { feature: "gen-ui-interrupt", expectedTurns: 4 },
+  { feature: "gen-ui-tool-based", expectedTurns: 18 },
+  { feature: "reasoning-custom", expectedTurns: 2 },
 ];
+
+// Guard: every demo MUST declare a positive expectedTurns. A missing/zero count
+// would reintroduce the unsound quiescence-only drain the barrier exists to
+// prevent, so fail loudly at module load rather than silently.
+for (const d of DEMOS) {
+  if (!Number.isInteger(d.expectedTurns) || d.expectedTurns < 1) {
+    throw new Error(
+      `record-d5-fixtures: DEMOS entry "${d.feature}" must declare a positive integer ` +
+        `expectedTurns (the real upstream turn count for its full-feature run), got ${d.expectedTurns}`,
+    );
+  }
+}
 
 async function listRecordedFiles() {
   try {
@@ -216,17 +248,50 @@ async function consolidateNewFiles(demo, beforeSet) {
   return { count: fixtures.length };
 }
 
+/**
+ * Ordering-critical seam: block on the journal-drain barrier, then (ONLY if it
+ * drained) consolidate the captured fixtures.
+ *
+ * A drain TIMEOUT is FATAL. `waitForDrain` throws on timeout and we deliberately
+ * do NOT catch it — the rejection propagates so the whole run aborts (main's
+ * `.catch` exits non-zero) BEFORE any fixture consolidation or aimock restart.
+ * The previous code caught this and logged a warning, then consolidated anyway;
+ * that let a still-in-flight post-tool-result fixture land in the NEXT demo's
+ * directory (or be lost) — a silent-failure hole. Never move fixtures on an
+ * un-drained journal.
+ *
+ * Extracted (and exported) so this abort-before-consolidate ordering is unit
+ * testable without spawning docker / a probe.
+ *
+ * @param {object} args
+ * @param {string} args.feature
+ * @param {() => Promise<{ completed: number }>} args.waitForDrain
+ * @param {() => Promise<{ count: number }>} args.consolidate
+ * @param {(msg: string) => void} [args.log]
+ * @returns {Promise<{ count: number }>}
+ */
+export async function drainThenConsolidate({
+  feature,
+  waitForDrain,
+  consolidate,
+  log = console.log,
+}) {
+  const drain = await waitForDrain();
+  log(`[record] ${feature}: journal drained (${drain.completed} turns)`);
+  return consolidate();
+}
+
 async function main() {
   await fs.mkdir(OUTPUT_DIR, { recursive: true });
   await fs.mkdir(RECORDED_DIR, { recursive: true });
   await probeRecorderPatch();
   const summary = [];
-  for (const demo of DEMOS) {
-    console.log(`\n===== Recording ${demo} =====`);
+  for (const { feature, expectedTurns } of DEMOS) {
+    console.log(`\n===== Recording ${feature} =====`);
     // Drop the demo's prior consolidated file (if any) so we don't double-
     // append on re-runs, then restart aimock so its in-memory fixture cache
     // doesn't carry that demo's prompts forward from a previous session.
-    const outPath = path.join(OUTPUT_DIR, `${demo}.json`);
+    const outPath = path.join(OUTPUT_DIR, `${feature}.json`);
     try {
       await fs.unlink(outPath);
     } catch (err) {
@@ -235,22 +300,23 @@ async function main() {
     await restartAimock();
 
     const before = await listRecordedFiles();
-    const code = await runProbe(demo);
+    const code = await runProbe(feature);
     // The probe process can exit while aimock is still draining the final
     // post-tool-result turn. Block on the journal-drain barrier BEFORE moving
-    // fixtures so a late fixture cannot land in the next demo's directory.
-    try {
-      const drain = await waitForJournalDrain({ expectedTurns: 0 });
-      console.log(
-        `[record] ${demo}: journal drained (${drain.completed} turns)`,
-      );
-    } catch (err) {
-      console.warn(
-        `[record] ${demo}: journal-drain barrier did not settle — ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-    const result = await consolidateNewFiles(demo, before);
-    summary.push({ demo, probeExit: code, fixtureCount: result.count });
+    // fixtures so a late fixture cannot land in the next demo's directory. A
+    // timeout here is FATAL (drainThenConsolidate does NOT catch it): the run
+    // aborts before consolidation rather than moving fixtures off an un-drained
+    // journal.
+    const result = await drainThenConsolidate({
+      feature,
+      waitForDrain: () => waitForJournalDrain({ expectedTurns }),
+      consolidate: () => consolidateNewFiles(feature, before),
+    });
+    summary.push({
+      demo: feature,
+      probeExit: code,
+      fixtureCount: result.count,
+    });
   }
   console.log("\n===== Summary =====");
   for (const row of summary) {


### PR DESCRIPTION
## The race

The d5 fixture-capture workflow (`showcase/scripts/record-d5-fixtures.mjs`) had a capture race. A probe marks a cell satisfied as soon as the tool card meets its assertion, but the **post-tool-result LLM turn can still be draining** — aimock is still proxying upstream and writing the fixture file — after the probe process exits.

The script then immediately consolidated/moved the newly-recorded fixtures and restarted aimock for the next demo. When a late turn was still in flight, its fixture landed in the **next run's** directory. Observed live by Mark:

- a run-3 follow-up fixture landed under run 4, and
- a run-4 **empty** initial-weather fixture landed under run 5 → weather went **red** on replay.

## The fix

Add a **journal-drain barrier** that polls aimock's `GET /__aimock/journal` until the run has fully drained, called **before** any fixture move / aimock restart (between `runProbe` and `consolidateNewFiles`).

A journal entry counts as a completed upstream turn when it is a `200` that is **either**:

- a record-mode proxy completion — `response.source === "proxy"`, **or**
- a replay completion — `response.status === 200 && response.fixture != null`.

Critically it does **not** gate on `response.source === "fixture"`: on a normal replay aimock populates `response.fixture` but leaves `response.source` **unset** (verified against `showcase/scripts` `@copilotkit/aimock` 1.37.4 `JournalEntry` typedoc and Mark's live validation).

"Drained" = the completed-turn count reached the floor (`expectedTurns`, e.g. 3 for the built-in-agent weather flow: greeting + tool-call turn + post-tool-result turn) **and** held steady for a quiescence window — since the journal only appends an entry once a turn is fully served, a still-draining turn is simply absent from the count, so requiring the count to hold steady is how we know nothing else is about to land. Bounded by a timeout that throws a clear error naming observed vs expected.

The recorder's trailing IIFE is wrapped in a guarded `main()` (entry-module check) so the pure helpers (`waitForJournalDrain`, `countCompletedTurns`) are importable/testable without firing docker calls.

## Local RED → GREEN proof

Offline unit test (`__tests__/journal-drain-barrier.test.ts`) with a mocked journal fetch. **RED** was captured against a pre-fix variant of the module (barrier absent, import-guard only); **GREEN** against the fixed module — identical test body, identical harness, only the module under test differs.

**RED — barrier absent (workflow would move fixtures with no wait):**

```
 FAIL  journal-drain-barrier.test.ts > waitForJournalDrain > times out ...
TypeError: waitForJournalDrain is not a function
 FAIL  journal-drain-barrier.test.ts > waitForJournalDrain > WAITS for a still-draining post-tool-result turn ...
TypeError: waitForJournalDrain is not a function
 ... (countCompletedTurns is not a function on the count tests) ...

 Test Files  1 failed (1)
      Tests  9 failed (9)
```

**GREEN — barrier present:**

```
 RUN  v4.1.5 .../showcase/scripts

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The suite covers: counting proxy + replay-fixture 200s (and the `source`-unset replay trap); proceeding immediately when already drained; **waiting past a premature 2/3 state until the 3rd turn lands** (the race); waiting for quiescence when a late turn is still in flight; timing out with a clear error when the journal never drains; polling through transient journal read failures; and rejecting an invalid `expectedTurns`.

## Package suite / lint / format

- **Full `showcase/scripts` vitest suite:** `75 test files passed, Tests 2450 passed`. The one failing file (`generate-registry-pattern.test.ts`, 13 tests) fails **identically without this change** — a pre-existing environmental `Cannot find package 'js-yaml'` inside a spawned `tsx` subprocess under Node 25.8.0, unrelated to these files.
- **New test in-place (relative import):** `9 passed (9)`.
- **oxfmt** (`--check`, repo `.oxfmtrc.json`, printWidth 80): both files clean; diff touches only the added lines (no pre-existing reformatting churn).
- **oxlint:** `0 warnings and 0 errors` on both files.
- No build step for the `showcase/scripts` package (tsx-run, `type: module`).

## Context

This is the **capture-race follow-up** to the recorder collapser PR (`CopilotKit/aimock#380`): the collapser fixed multi-turn recording on the aimock recorder side; this fixes the orchestration-side race in the showcase capture script. **D4 re-recording stays paused until this lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5dSyNeU6xH9ofPf9ZLaNQ


---

## Update: shared-module extraction + D4 coverage

**Shared module.** The barrier (`waitForJournalDrain` + `countCompletedTurns` + `isCompletedTurn`) is extracted out of `record-d5-fixtures.mjs` into a shared, importable module: **`showcase/scripts/lib/journal-drain.mjs`** (plain `.mjs`, so it is importable both from the plain-`node` recorder CLI and from vitest without a transpile step). The D5 recorder now imports the barrier instead of defining it inline — its behavior is unchanged. The barrier unit tests are repointed at the shared module.

The injectable `fetchImpl` seam is JSDoc-typed to the **minimal journal-fetch interface** the barrier actually uses (`(url) => Promise<{ ok?, status, json() }>`) rather than the full DOM `fetch` signature, so tests inject a tiny fake without having to satisfy `RequestInfo | URL` / `Response`.

**D4 coverage is documentation, not a script wire-in.** The same capture race lives in the D4 proxy-capture flow, but D4 fixtures are **hand-authored / mirrored** — there is no committable D4 capture entry point to wire the barrier into. Confirmed in-repo: `showcase/aimock/README.md` ("The process is manual. There is no CLI for this directory specifically … the showcase repo does not wire [`--record`] up and does not commit recorded fixtures.") and `showcase/GOTCHAS.md` (mirror the canonical fixtures, do **not** re-record per integration). The only `--record` compose (`docker-compose.record.yml`) is the generic D5 record path.

So the D4 deliverable is: **(a)** the shared, importable helper (above), and **(b)** documenting the required drain step for the hand-run D4 proxy-capture path. `showcase/aimock/README.md` now has a **"Proxy-capturing a D4 fixture: drain the journal first"** subsection describing the race and instructing that, after driving the D4 cell and **before** moving/committing fixtures or restarting aimock, the operator must wait for the journal to drain — via the shared `waitForJournalDrain(...)` (or by polling `GET /__aimock/journal` by hand), with the same completed-turn rule (proxy `source:"proxy"` OR replay `status:200 && fixture!=null`, never `source:"fixture"`).

### RED → GREEN (extraction)

Same 9-test barrier suite, now importing from the shared module. RED with the shared module removed, GREEN with it restored — identical test body and harness, only the module's presence differs.

**RED — shared module absent:**

```
 FAIL  __tests__/journal-drain-barrier.test.ts [ __tests__/journal-drain-barrier.test.ts ]
Error: Cannot find module '../lib/journal-drain.mjs' imported from .../__tests__/journal-drain-barrier.test.ts
 Test Files  1 failed (1)
      Tests  no tests
```

**GREEN — shared module present:**

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

### Checks (this change)

- **Barrier suite:** `9 passed (9)` against the shared module.
- **`showcase/scripts` full vitest suite:** run in an isolated worktree without root workspace deps, so a handful of env-dependent registry/railway-envs tests fail purely because the root `oxfmt` binary and workspace deps (`js-yaml`, spawned `tsx`) are absent. Proven inert: the **identical 8 failures occur at baseline with this change reverted**, and none of the failing files import the changed modules. This change introduces **zero** new failures.
- **`check-types`:** the changed `.ts` test is under `showcase/scripts/__tests__/`, which the scripts `tsconfig.json` **excludes**, and the two `.mjs` files are outside the `*.ts` include — so nothing new enters the typecheck surface. Direct `tsc --strict` over the changed test = **0 errors**; the shared `.mjs` and recorder `.mjs` are not typechecked (and `check-types` already passed on the identical mocks at the prior head).
- **oxfmt** (`--check`, repo `.oxfmtrc.json`): all 3 changed JS files clean.
- **oxlint:** `0 warnings and 0 errors` on all 3 changed JS files.


---

## Code-review corrections (post-review, commit `e0dc20dc69`)

Four blocking corrections from review. All claims were re-verified against the aimock source (checkout of `@copilotkit/aimock`) before implementing.

### 1. Timeout is now FATAL (was warn-and-continue)
The recorder previously caught the barrier's timeout, logged a warning, and consolidated/restarted anyway — a silent-failure hole. The drain→consolidate sequence is extracted into an exported `drainThenConsolidate`; the barrier's rejection now **propagates**, aborting the run (non-zero exit) **before** any fixture consolidation or aimock restart. New test proves timeout → abort with consolidation never called.

### 2. `expectedTurns: 0` was unsound → now a REQUIRED real count
Quiescence alone is not a sound drain signal: an in-flight upstream turn is **invisible** in the journal until it lands (aimock appends the entry only after the full upstream drain — verified in `server.ts`: the `source:"proxy"` `journal.add` runs *after* `await proxyAndRecord(...)`). A journal quiescent at N-1 can therefore settle prematurely while the slow final turn is still streaming.

- **aimock exposes no in-flight/pending/active signal** — the `Journal` class (`src/journal.ts`) only appends entries via `add()`; there is no active-request count or per-entry "streaming complete" flag to gate on. So the barrier must rely on a real expected turn count.
- `waitForJournalDrain` now **throws if `expectedTurns` is omitted** (no `0` default). The recorder supplies a per-demo count (`DEMOS[].expectedTurns`), seeded from each feature's committed canonical fixture count (`aimock/d6/langgraph-python/<feature>.json`) — the best static estimate available (`d5-recorded/` output is gitignored). A count set too high fails **loud** (timeout → abort) rather than corrupting; a too-low count is the only unsafe direction, so err high and confirm on the live capture. New test: journal quiescent at N-1 for several polls, then Nth lands — barrier waits for N.

### 3. Replay-semantic error corrected
Verified in aimock `server.ts`: on a replay hit `journal.add({status:200, fixture})` runs **before** `await writeSSEStream(...)`; the entry is only mutated afterward on interruption. So `status:200 && fixture != null` means "replay started/matched," **not** "fully drained." `isCompletedTurn` now counts **only the record path** (`response.source === "proxy"`), which aimock writes after the full upstream drain + fixture write — the sound completion signal. Since capture runs aimock in `--record` mode, every genuine upstream turn is a `source:"proxy"` entry. Replay has no sound journal-based completion signal; the "drained" definition is scoped to the record path and documented as such. (This supersedes the earlier "either proxy or replay-fixture" description above.)

### 4. D4 README rewritten to the canonical model
The "Refresh D4" section previously implied per-integration recording. Rewritten per `GOTCHAS.md`: (1) capture/verify the canonical **langgraph-python** live flow **once**, (2) normalize the canonical fixture, (3) mirror across integrations re-keying `match.context`, (4) fresh replay validation. The journal-drain step applies during the canonical capture (step 1) only.

### RED → GREEN (new/changed tests, `__tests__/journal-drain-barrier.test.ts`)
Same test body run against pre-fix source (via `git stash` of the two source files) vs. post-fix:

```
RED (old source):   Tests  10 failed | 2 passed (12)
  - countCompletedTurns counted replay entries (journal(3) → 4)
  - waitForJournalDrain did not throw on omitted expectedTurns
  - slow-final-turn: settled at N-1 (f.calls() < 5)
  - drainThenConsolidate is not a function

GREEN (new source): Tests  12 passed (12)
```

### Suite / lint / format
- `showcase/scripts` vitest: my file 12/12 green. The 4 failing files (`emit-railway-envs-json`, `generate-catalog`, `generate-registry`, `integration-smoke-registry`) fail **identically on clean HEAD** — pre-existing environmental `tsx`/`oxfmt` spawn + `js-yaml` failures, unrelated to this change (baseline-diffed).
- **oxfmt** `--check`: all four files clean. **oxlint:** clean (the one `no-underscore-dangle` warning on `__dirname` is pre-existing and unchanged). **tsc:** no errors in the changed files.
