### PR TITLE
fix(runtime): run render_a2ui locally so BuiltInAgent A2UI can paint

### DIFF
--- a/packages/runtime/src/agent/__tests__/a2ui-builtin-agent.test.ts
+++ b/packages/runtime/src/agent/__tests__/a2ui-builtin-agent.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { EventType } from "@ag-ui/client";
+import { A2UIMiddleware } from "@ag-ui/a2ui-middleware";
+import type { BaseEvent } from "@ag-ui/client";
+import {
+  createClassicAgentWithTools,
+  createDefaultInput,
+  collectEvents,
+  toolCall,
+  finish,
+  eventField,
+} from "./agent-test-helpers";
+import {
+  A2UI_OPERATIONS_KEY,
+  buildA2uiOperationsFromRenderArgs,
+} from "../a2ui-render-tool";
+
+const RENDER_A2UI_TOOL = {
+  name: "render_a2ui",
+  description: "Render a dynamic A2UI v0.9 surface",
+  parameters: {
+    type: "object" as const,
+    properties: {
+      surfaceId: { type: "string" },
+      components: { type: "array", items: { type: "object" } },
+      data: { type: "object" },
+    },
+    required: ["surfaceId", "components"],
+  },
+};
+
+const RENDER_ARGS = {
+  surfaceId: "filings",
+  components: [
+    { id: "root", component: "Column", children: ["title"] },
+    { id: "title", component: "Text", text: "Pending FDA filings" },
+  ],
+};
+
+const SCHEMA_CONTEXT = {
+  description:
+    "A2UI Component Schema — available components for generating UI surfaces",
+  value: JSON.stringify({
+    catalogId: "filing-tracker-catalog",
+    components: {},
+  }),
+};
+
+describe("BuiltInAgent A2UI render_a2ui (#6526)", () => {
+  it("emits TOOL_CALL_RESULT with a2ui_operations when the model calls render_a2ui", async () => {
+    const agent = createClassicAgentWithTools(
+      [toolCall("tc-1", "render_a2ui", RENDER_ARGS), finish()],
+      [],
+    );
+
+    const events = await collectEvents(
+      agent.run(
+        createDefaultInput({
+          messages: [
+            { id: "u1", role: "user", content: "show pending filings" },
+          ] as never,
+          tools: [RENDER_A2UI_TOOL],
+          context: [SCHEMA_CONTEXT],
+        }),
+      ),
+    );
+
+    const result = events.find((e) => e.type === EventType.TOOL_CALL_RESULT);
+    expect(result).toBeDefined();
+    const content = JSON.parse(eventField<string>(result!, "content"));
+    expect(content[A2UI_OPERATIONS_KEY]).toEqual(
+      buildA2uiOperationsFromRenderArgs(RENDER_ARGS, "filing-tracker-catalog")[
+        A2UI_OPERATIONS_KEY
+      ],
+    );
+  });
+
+  it("emits ACTIVITY_SNAPSHOT when A2UIMiddleware wraps BuiltInAgent", async () => {
+    const agent = createClassicAgentWithTools(
+      [toolCall("tc-1", "render_a2ui", RENDER_ARGS), finish()],
+      [],
+    );
+    agent.use(new A2UIMiddleware({ injectA2UITool: true }));
+
+    const events: BaseEvent[] = [];
+    await agent.runAgent(
+      createDefaultInput({
+        messages: [
+          { id: "u1", role: "user", content: "show pending filings" },
+        ] as never,
+        context: [SCHEMA_CONTEXT],
+      }),
+      {
+        onEvent: ({ event }) => {
+          events.push(event);
+        },
+      },
+    );
+
+    const snapshots = events.filter(
+      (e) => e.type === EventType.ACTIVITY_SNAPSHOT,
+    );
+    expect(snapshots.length).toBeGreaterThan(0);
+    expect(
+      snapshots.some((e) => eventField(e, "activityType") === "a2ui-surface"),
+    ).toBe(true);
+    expect(
+      snapshots.some((e) => {
+        const content = eventField<Record<string, unknown>>(e, "content");
+        return Array.isArray(content?.[A2UI_OPERATIONS_KEY]);
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/runtime/src/agent/__tests__/a2ui-render-tool.test.ts
+++ b/packages/runtime/src/agent/__tests__/a2ui-render-tool.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import type { RunAgentInput } from "@ag-ui/client";
+import type { ToolSet } from "ai";
+import {
+  A2UI_OPERATIONS_KEY,
+  a2uiRenderToolNames,
+  buildA2uiOperationsFromRenderArgs,
+  catalogIdFromA2UIContext,
+  withA2UIRenderToolExecutors,
+} from "../a2ui-render-tool";
+
+function input(overrides?: Partial<RunAgentInput>): RunAgentInput {
+  return {
+    threadId: "t",
+    runId: "r",
+    messages: [],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+describe("buildA2uiOperationsFromRenderArgs", () => {
+  it("emits createSurface + updateComponents using the host catalog id", () => {
+    const result = buildA2uiOperationsFromRenderArgs(
+      {
+        surfaceId: "filings",
+        components: [{ id: "root", component: "Column", children: ["title"] }],
+      },
+      "filing-tracker-catalog",
+    );
+
+    expect(result[A2UI_OPERATIONS_KEY]).toEqual([
+      {
+        version: "v0.9",
+        createSurface: {
+          surfaceId: "filings",
+          catalogId: "filing-tracker-catalog",
+        },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "filings",
+          components: [
+            { id: "root", component: "Column", children: ["title"] },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("includes updateDataModel only when data is a non-empty object", () => {
+    const withData = buildA2uiOperationsFromRenderArgs(
+      { surfaceId: "s", components: [], data: { status: "pending" } },
+      "cat",
+    );
+    expect(withData[A2UI_OPERATIONS_KEY]).toHaveLength(3);
+    expect(withData[A2UI_OPERATIONS_KEY][2]).toEqual({
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId: "s",
+        path: "/",
+        value: { status: "pending" },
+      },
+    });
+
+    expect(
+      buildA2uiOperationsFromRenderArgs(
+        { surfaceId: "s", components: [], data: {} },
+        "cat",
+      )[A2UI_OPERATIONS_KEY],
+    ).toHaveLength(2);
+  });
+});
+
+describe("catalogIdFromA2UIContext", () => {
+  it("reads catalogId from the frontend schema context entry", () => {
+    expect(
+      catalogIdFromA2UIContext(
+        input({
+          context: [
+            {
+              description: "A2UI Component Schema — available components",
+              value: JSON.stringify({
+                catalogId: "filing-tracker-catalog",
+                components: {},
+              }),
+            },
+          ],
+        }),
+      ),
+    ).toBe("filing-tracker-catalog");
+  });
+
+  it("falls back to the v0.9 basic catalog when no schema is forwarded", () => {
+    expect(catalogIdFromA2UIContext(input())).toBe(
+      "https://a2ui.org/specification/v0_9/basic_catalog.json",
+    );
+  });
+});
+
+async function hostProvidedExecute() {
+  return { custom: true };
+}
+
+describe("withA2UIRenderToolExecutors", () => {
+  it("attaches execute to render_a2ui and leaves other tools as client tools", async () => {
+    const tools = {
+      render_a2ui: { description: "render" },
+      other_tool: { description: "frontend" },
+    } as unknown as ToolSet;
+
+    const next = withA2UIRenderToolExecutors(tools, input());
+
+    expect(typeof next.render_a2ui.execute).toBe("function");
+    expect(next.other_tool.execute).toBeUndefined();
+
+    const envelope = await next.render_a2ui.execute!(
+      {
+        surfaceId: "s1",
+        components: [{ id: "root", component: "Text", text: "hi" }],
+      },
+      { toolCallId: "tc-1", messages: [] },
+    );
+    expect(envelope).toEqual(
+      buildA2uiOperationsFromRenderArgs(
+        {
+          surfaceId: "s1",
+          components: [{ id: "root", component: "Text", text: "hi" }],
+        },
+        catalogIdFromA2UIContext(input()),
+      ),
+    );
+  });
+
+  it("does not overwrite a host-provided execute", () => {
+    const tools = {
+      render_a2ui: { description: "render", execute: hostProvidedExecute },
+    } as unknown as ToolSet;
+
+    const next = withA2UIRenderToolExecutors(tools, input());
+    expect(next.render_a2ui.execute).toBe(hostProvidedExecute);
+  });
+
+  it("attaches execute under a custom injectA2UITool name", () => {
+    const tools = {
+      draw_ui: { description: "render" },
+    } as unknown as ToolSet;
+
+    const next = withA2UIRenderToolExecutors(
+      tools,
+      input({ forwardedProps: { injectA2UITool: "draw_ui" } }),
+    );
+    expect(typeof next.draw_ui.execute).toBe("function");
+  });
+});
+
+describe("a2uiRenderToolNames", () => {
+  it("always includes the default render_a2ui name", () => {
+    expect([...a2uiRenderToolNames(input())]).toContain("render_a2ui");
+  });
+});

--- a/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { convertInputToTanStackAI } from "../converters/tanstack";
 import { createDefaultInput } from "./agent-test-helpers";
+import { buildA2uiOperationsFromRenderArgs } from "../a2ui-render-tool";
 
 describe("convertInputToTanStackAI", () => {
   // -------------------------------------------------------------------------
@@ -168,6 +169,59 @@ describe("convertInputToTanStackAI", () => {
     it("returns an empty tools array when input has no tools", () => {
       const { tools } = convertInputToTanStackAI(createDefaultInput());
       expect(tools).toEqual([]);
+    });
+
+    it("converts render_a2ui into a server tool that returns a2ui_operations", async () => {
+      const input = createDefaultInput({
+        tools: [
+          {
+            name: "render_a2ui",
+            description: "Render a dynamic A2UI surface",
+            parameters: {
+              type: "object" as const,
+              properties: {
+                surfaceId: { type: "string" },
+                components: { type: "array", items: { type: "object" } },
+              },
+              required: ["surfaceId", "components"],
+            },
+          },
+        ],
+        context: [
+          {
+            description: "A2UI Component Schema — available components",
+            value: JSON.stringify({
+              catalogId: "filing-tracker-catalog",
+              components: {},
+            }),
+          },
+        ],
+      });
+
+      const { tools } = convertInputToTanStackAI(input);
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toMatchObject({
+        name: "render_a2ui",
+        description: "Render a dynamic A2UI surface",
+      });
+      expect(tools[0]).not.toHaveProperty("__toolSide");
+      expect("execute" in tools[0]).toBe(true);
+
+      const envelope = await (
+        tools[0] as { execute: (args: Record<string, unknown>) => unknown }
+      ).execute({
+        surfaceId: "filings",
+        components: [{ id: "root", component: "Text", text: "hi" }],
+      });
+      expect(envelope).toEqual(
+        buildA2uiOperationsFromRenderArgs(
+          {
+            surfaceId: "filings",
+            components: [{ id: "root", component: "Text", text: "hi" }],
+          },
+          "filing-tracker-catalog",
+        ),
+      );
     });
 
     it("closes open objects (additionalProperties → false) for OpenAI compatibility", () => {

--- a/packages/runtime/src/agent/a2ui-render-tool.ts
+++ b/packages/runtime/src/agent/a2ui-render-tool.ts
@@ -1,0 +1,137 @@
+import type { RunAgentInput } from "@ag-ui/client";
+import type { ToolSet } from "ai";
+import { z } from "zod";
+
+/** Container key the A2UI middleware looks for in tool results. */
+export const A2UI_OPERATIONS_KEY = "a2ui_operations";
+
+/** Default name A2UIMiddleware injects when `injectA2UITool` is true. */
+export const DEFAULT_A2UI_RENDER_TOOL_NAME = "render_a2ui";
+
+const BASIC_A2UI_CATALOG_ID =
+  "https://a2ui.org/specification/v0_9/basic_catalog.json";
+
+/**
+ * Permissive input schema for the injected render tool. The middleware's JSON
+ * Schema uses `components.items: { type: "object" }` with no properties, which
+ * `convertJsonSchemaToZodSchema` turns into `z.object({})` and strips every
+ * component field. A2UI components are open objects by design.
+ */
+export const A2UI_RENDER_TOOL_INPUT_SCHEMA = z.object({
+  surfaceId: z.string().optional(),
+  components: z.array(z.record(z.string(), z.any())).optional(),
+  data: z.any().optional(),
+});
+
+const A2UI_SCHEMA_CONTEXT_MARKERS = ["A2UI Component Schema", "A2UI catalog"];
+
+/**
+ * Names of A2UI *render* tools on this run. The middleware injects
+ * `render_a2ui` by default, or a custom name when `injectA2UITool` is a string.
+ */
+export function a2uiRenderToolNames(input: RunAgentInput): Set<string> {
+  const names = new Set<string>([DEFAULT_A2UI_RENDER_TOOL_NAME]);
+  const injected = (
+    input.forwardedProps as { injectA2UITool?: unknown } | undefined
+  )?.injectA2UITool;
+  if (typeof injected === "string" && injected.length > 0) {
+    names.add(injected);
+  }
+  return names;
+}
+
+/**
+ * Catalog id the frontend registered, read from the A2UI schema context entry
+ * the renderer ships on every run. Falls back to the v0.9 basic catalog.
+ */
+export function catalogIdFromA2UIContext(input: RunAgentInput): string {
+  for (const entry of input.context ?? []) {
+    const description = entry.description ?? "";
+    const matchesSchemaContext = A2UI_SCHEMA_CONTEXT_MARKERS.some((marker) =>
+      description.includes(marker),
+    );
+    if (!matchesSchemaContext) continue;
+    if (typeof entry.value !== "string") continue;
+    try {
+      const parsed = JSON.parse(entry.value) as { catalogId?: unknown };
+      const catalogId = parsed?.catalogId;
+      if (typeof catalogId === "string" && catalogId.length > 0) {
+        return catalogId;
+      }
+    } catch {
+      // Unparseable schema context — use the basic catalog.
+    }
+  }
+  return BASIC_A2UI_CATALOG_ID;
+}
+
+/**
+ * Turn a `render_a2ui` argument payload into the `a2ui_operations` envelope
+ * the A2UI middleware paints from `TOOL_CALL_RESULT`.
+ */
+export function buildA2uiOperationsFromRenderArgs(
+  args: Record<string, unknown>,
+  catalogId: string,
+): { [A2UI_OPERATIONS_KEY]: Array<Record<string, unknown>> } {
+  const surfaceId =
+    typeof args.surfaceId === "string" && args.surfaceId.length > 0
+      ? args.surfaceId
+      : "dynamic-surface";
+  const components = Array.isArray(args.components) ? args.components : [];
+  const ops: Array<Record<string, unknown>> = [
+    { version: "v0.9", createSurface: { surfaceId, catalogId } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
+  ];
+  const data = args.data;
+  if (
+    data != null &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    Object.keys(data as object).length > 0
+  ) {
+    ops.push({
+      version: "v0.9",
+      updateDataModel: { surfaceId, path: "/", value: data },
+    });
+  }
+  return { [A2UI_OPERATIONS_KEY]: ops };
+}
+
+/**
+ * `render_a2ui` is injected by A2UIMiddleware with no `execute`. BuiltInAgent
+ * otherwise advertises it as a client tool, so the run ends with raw
+ * TOOL_CALL_* events and no `a2ui_operations` result — the chat skeleton
+ * never resolves. Attach a local executor that returns the envelope the
+ * middleware already knows how to paint.
+ *
+ * An existing `execute` (a host-owned generate/render tool) is left alone.
+ */
+export function withA2UIRenderToolExecutors(
+  tools: ToolSet,
+  input: RunAgentInput,
+): ToolSet {
+  const names = a2uiRenderToolNames(input);
+  const catalogId = catalogIdFromA2UIContext(input);
+  const next: ToolSet = { ...tools };
+  let changed = false;
+
+  for (const name of names) {
+    const tool = next[name];
+    if (
+      !tool ||
+      typeof tool !== "object" ||
+      typeof tool.execute === "function"
+    ) {
+      continue;
+    }
+    next[name] = {
+      ...(tool as object),
+      inputSchema: A2UI_RENDER_TOOL_INPUT_SCHEMA,
+      execute: async (args: Record<string, unknown>) =>
+        buildA2uiOperationsFromRenderArgs(args ?? {}, catalogId),
+    } as (typeof next)[string];
+    changed = true;
+  }
+
+  return changed ? next : tools;
+}

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -20,6 +20,7 @@ import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
 import { createStateEventNormalizer } from "../state-delta";
 import {
+<<<<<<< HEAD
   aggregateRunUsage,
   collectStandardRunFinishedDetails,
   getNonEmptyString,
@@ -27,6 +28,12 @@ import {
   isRecord,
 } from "./usage";
 import type { AgentRunFinishedDetails } from "./usage";
+=======
+  a2uiRenderToolNames,
+  buildA2uiOperationsFromRenderArgs,
+  catalogIdFromA2UIContext,
+} from "../a2ui-render-tool";
+>>>>>>> 926b34c4f (fix(runtime): run render_a2ui locally so BuiltInAgent A2UI can paint)
 
 type ContentPartSource =
   | { type: "data"; value: string; mimeType: string }
@@ -82,6 +89,21 @@ export interface TanStackClientTool {
 }
 
 /**
+ * A TanStack server tool. A2UI's injected `render_a2ui` is converted this way
+ * so the run emits `a2ui_operations` in TOOL_CALL_RESULT instead of pausing
+ * as a client tool (which leaves the "Building interface" skeleton hung).
+ */
+export interface TanStackServerTool {
+  name: string;
+  description: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  inputSchema: any;
+  execute: (args: Record<string, unknown>) => unknown | Promise<unknown>;
+}
+
+export type TanStackTool = TanStackClientTool | TanStackServerTool;
+
+/**
  * Result of converting RunAgentInput to TanStack AI format.
  */
 export interface TanStackInputResult {
@@ -90,13 +112,12 @@ export interface TanStackInputResult {
   /** System prompts extracted from system/developer messages, context, and state */
   systemPrompts: string[];
   /**
-   * Client-side tools derived from `input.tools` (the frontend-provided tools
-   * the CopilotKit client forwards on every run). Pass these into `chat()`
-   * alongside any server/provider tools so the model can call the frontend's
-   * generative-UI and human-in-the-loop tools; TanStack pauses the run on a
-   * client-tool call and the client executes it.
+   * Tools derived from `input.tools`. Frontend tools stay client-side (TanStack
+   * pauses for the CopilotKit client to execute them). A2UI's injected
+   * `render_a2ui` is a server tool so the A2UI middleware receives
+   * `a2ui_operations` in TOOL_CALL_RESULT and can paint the surface.
    */
-  tools: TanStackClientTool[];
+  tools: TanStackTool[];
 }
 
 /**
@@ -316,12 +337,28 @@ export function convertInputToTanStackAI(
   // Frontend-provided tools become client-side TanStack tools (no executor):
   // the model can call them, TanStack pauses the run, and the AG-UI client
   // executes them and resumes — the CopilotKit client-tool round-trip.
-  const tools: TanStackClientTool[] = (input.tools ?? []).map((t) => ({
-    __toolSide: "client",
-    name: t.name,
-    description: t.description,
-    inputSchema: sanitizeClientToolSchema(t.parameters),
-  }));
+  // A2UI render tools are the exception: they must run on the server so the
+  // middleware sees `a2ui_operations` in TOOL_CALL_RESULT (#6526).
+  const a2uiRenderNames = a2uiRenderToolNames(input);
+  const a2uiCatalogId = catalogIdFromA2UIContext(input);
+  const tools: TanStackTool[] = (input.tools ?? []).map((t) => {
+    const inputSchema = sanitizeClientToolSchema(t.parameters);
+    if (a2uiRenderNames.has(t.name)) {
+      return {
+        name: t.name,
+        description: t.description,
+        inputSchema,
+        execute: (args: Record<string, unknown>) =>
+          buildA2uiOperationsFromRenderArgs(args ?? {}, a2uiCatalogId),
+      };
+    }
+    return {
+      __toolSide: "client" as const,
+      name: t.name,
+      description: t.description,
+      inputSchema,
+    };
+  });
 
   return { messages, systemPrompts, tools };
 }

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -20,7 +20,11 @@ import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
 import { createStateEventNormalizer } from "../state-delta";
 import {
-<<<<<<< HEAD
+  a2uiRenderToolNames,
+  buildA2uiOperationsFromRenderArgs,
+  catalogIdFromA2UIContext,
+} from "../a2ui-render-tool";
+import {
   aggregateRunUsage,
   collectStandardRunFinishedDetails,
   getNonEmptyString,
@@ -28,12 +32,6 @@ import {
   isRecord,
 } from "./usage";
 import type { AgentRunFinishedDetails } from "./usage";
-=======
-  a2uiRenderToolNames,
-  buildA2uiOperationsFromRenderArgs,
-  catalogIdFromA2UIContext,
-} from "../a2ui-render-tool";
->>>>>>> 926b34c4f (fix(runtime): run render_a2ui locally so BuiltInAgent A2UI can paint)
 
 type ContentPartSource =
   | { type: "data"; value: string; mimeType: string }

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -61,6 +61,7 @@ import {
 } from "./converters/usage";
 import type { AgentRunFinishedDetails } from "./converters/usage";
 import { createStateEventNormalizer } from "./state-delta";
+import { withA2UIRenderToolExecutors } from "./a2ui-render-tool";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { randomUUID } from "@copilotkit/shared";
@@ -1146,6 +1147,9 @@ export class BuiltInAgent extends AbstractAgent {
         const configTools = convertToolDefinitionsToVercelAITools(config.tools);
         allTools = { ...allTools, ...configTools };
       }
+      // A2UIMiddleware injects `render_a2ui` without execute. Run it locally
+      // so TOOL_CALL_RESULT carries `a2ui_operations` and the surface paints.
+      allTools = withA2UIRenderToolExecutors(allTools, input);
 
       const streamTextParams: Parameters<typeof streamText>[0] = {
         model,


### PR DESCRIPTION
## What does this PR do?

Fixes BuiltInAgent + `a2ui: { injectA2UITool: true }` hanging on a "Building interface" skeleton that never resolves.

`A2UIMiddleware` injects `render_a2ui` with no `execute`. BuiltInAgent then advertised it as a client tool, so the run ended with `TOOL_CALL_*` / `RUN_FINISHED` and never emitted `ACTIVITY_SNAPSHOT` / `STATE_SNAPSHOT`. Working LangGraph / Feature Viewer demos get those snapshots because their generate/render tools actually return `a2ui_operations`.

This PR:

- Attaches a local `execute` on `render_a2ui` (and a custom `injectA2UITool` name) that returns `{ a2ui_operations: [createSurface, updateComponents, optional updateDataModel] }` so the existing middleware can paint the surface
- Uses a permissive Zod input schema so `convertJsonSchemaToZodSchema` does not strip A2UI component fields (`components.items: { type: "object" }` was becoming `z.object({})`)
- Leaves a host-provided `execute` alone
- Converts `render_a2ui` as a TanStack server tool for the same reason

## Related PRs and Issues

- https://github.com/CopilotKit/CopilotKit/issues/6526

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rendering A2UI surfaces through the built-in agent.
  - A2UI render tool results now provide surface operations for creating surfaces, updating components, and optionally updating data.
  - Added catalog context handling with a fallback catalog for rendering.
  - Render tools are processed server-side while preserving existing custom executors.

- **Tests**
  - Added coverage for A2UI rendering, middleware integration, catalog handling, tool conversion, and emitted activity events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->