### PR TITLE
fix(showcase): serve the CrewAI Flows plain-assistant cells with a Flow, not a crew

### DIFF
--- a/showcase/integrations/crewai-conversational-flows/src/agents/chat_flow.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/chat_flow.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from crewai.flow.flow import Flow, start
 from litellm import acompletion
+from pydantic import Field
 
 from ag_ui_crewai import CopilotKitState, copilotkit_stream
 
@@ -36,7 +37,20 @@ BASE_CHAT_PROMPT = (
 )
 
 
-class PromptedChatFlow(Flow[CopilotKitState]):
+class ChatState(CopilotKitState):
+    """`CopilotKitState` plus the AG-UI request context.
+
+    The bridge puts `RunAgentInput.context` on state under `context`, but
+    `CopilotKitState` does not declare the field, so pydantic drops it during
+    input validation and the model never sees it. Declaring it here is what
+    keeps the readonly-state and agent-config cells honest: those demos exist
+    to prove the agent reads application context.
+    """
+
+    context: list[Any] = Field(default_factory=list)
+
+
+class PromptedChatFlow(Flow[ChatState]):
     """One-turn chat Flow for showcase cells that differ only by prompting."""
 
     system_prompt = BASE_CHAT_PROMPT

--- a/showcase/integrations/crewai-conversational-flows/src/agents/chat_flow.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/chat_flow.py
@@ -1,0 +1,72 @@
+"""Neutral chat Flow for the showcase cells that differ only by prompting.
+
+Chrome, headless, slots, CSS, auth, voice, and agent-config cells need a plain
+assistant: no backend tools, no state mutations, no delegation. They used to
+share the `LatestAiDevelopment` crew through
+`add_crewai_crew_fastapi_endpoint`, which composes its system message with
+CrewAI's `build_system_message`. That boilerplate is unconditional — it tells
+the model to introduce itself and to steer the user back to the crew's purpose,
+using a research-report example — so every one of those cells answered the
+question and then offered to research the latest AI developments.
+
+A regular Flow owns its own prompt, so the assistant behaves like an assistant.
+`crewai-conversational-flows` wraps this same class through its conversational
+registry, which keeps the two columns on one prompt.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from crewai.flow.flow import Flow, start
+from litellm import acompletion
+
+from ag_ui_crewai import CopilotKitState, copilotkit_stream
+
+
+BASE_CHAT_PROMPT = (
+    "You are a concise CopilotKit showcase assistant. CRITICAL: Use any "
+    "frontend tools supplied by the application whenever the user asks for "
+    "their capability. "
+    "Honor application context and configuration included below. After the "
+    "browser returns a tool result, summarize it briefly. Preserve the exact "
+    "spelling of user-chosen proper names across later turns and repeat those "
+    "proper names verbatim when the user asks what was chosen."
+)
+
+
+class PromptedChatFlow(Flow[CopilotKitState]):
+    """One-turn chat Flow for showcase cells that differ only by prompting."""
+
+    system_prompt = BASE_CHAT_PROMPT
+
+    @start()
+    async def chat(self) -> None:
+        state = self.state.model_dump(exclude={"messages", "copilotkit"})
+        state_context = json.dumps(state, default=str, sort_keys=True)
+        actions = self.state.copilotkit.actions or None
+        completion_kwargs: dict[str, Any] = {}
+        if actions:
+            completion_kwargs.update(
+                tools=actions,
+                parallel_tool_calls=False,
+            )
+        response = await copilotkit_stream(
+            await acompletion(
+                model="openai/gpt-5.4",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            f"{self.system_prompt}\n\n"
+                            f"Application context: {state_context}"
+                        ),
+                    },
+                    *self.state.messages,
+                ],
+                stream=True,
+                **completion_kwargs,
+            )
+        )
+        self.state.messages.append(response.choices[0].message)

--- a/showcase/integrations/crewai-conversational-flows/src/agents/conversational_flows.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/conversational_flows.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterator, Mapping
 from typing import Any, TypeVar
 
@@ -10,20 +9,21 @@ from crewai.experimental.conversational import (
     ConversationConfig,
     message_to_llm_dict,
 )
-from crewai.flow.flow import Flow, listen, start
-from litellm import acompletion
+from crewai.flow.flow import listen
 from pydantic import BaseModel, ConfigDict
 
-from ag_ui_crewai import CopilotKitState, copilotkit_stream
+from ag_ui_crewai import CopilotKitState
 
 from agents.a2ui_fixed import A2UIFixedFlow
 from agents.a2ui_recovery_flow import A2UIRecoveryFlow
 from agents.beautiful_chat_flow import BeautifulChatFlow
 from agents.byoc_hashbrown_agent import BYOC_HASHBROWN_SYSTEM_PROMPT
 from agents.byoc_json_render_agent import BYOC_JSON_RENDER_SYSTEM_PROMPT
+from agents.chat_flow import PromptedChatFlow
 from agents.declarative_gen_ui import DeclarativeGenUIFlow
 from agents.frontend_tool_flow import FrontendToolFlow
 from agents.gen_ui_agent import GenUiAgentFlow
+from agents.gen_ui_tool_based import GenUiToolBasedFlow
 from agents.interrupt_flow import InterruptFlow
 from agents.mcp_apps_agent import MCP_APPS_BACKSTORY
 from agents.multimodal_flow import MultimodalFlow
@@ -34,53 +34,6 @@ from agents.shared_state_streaming import SharedStateStreamingFlow
 from agents.subagents import SubagentsFlow
 from agents.tool_rendering import ToolRenderingFlow
 from agents.tool_rendering_reasoning import ToolRenderingReasoningFlow
-
-
-BASE_CHAT_PROMPT = (
-    "You are a concise CopilotKit showcase assistant. CRITICAL: Use any "
-    "frontend tools supplied by the application whenever the user asks for "
-    "their capability. "
-    "Honor application context and configuration included below. After the "
-    "browser returns a tool result, summarize it briefly. Preserve the exact "
-    "spelling of user-chosen proper names across later turns and repeat those "
-    "proper names verbatim when the user asks what was chosen."
-)
-
-
-class PromptedChatFlow(Flow[CopilotKitState]):
-    """One-turn chat Flow for showcase cells that differ only by prompting."""
-
-    system_prompt = BASE_CHAT_PROMPT
-
-    @start()
-    async def chat(self) -> None:
-        state = self.state.model_dump(exclude={"messages", "copilotkit"})
-        state_context = json.dumps(state, default=str, sort_keys=True)
-        actions = self.state.copilotkit.actions or None
-        completion_kwargs: dict[str, Any] = {}
-        if actions:
-            completion_kwargs.update(
-                tools=actions,
-                parallel_tool_calls=False,
-            )
-        response = await copilotkit_stream(
-            await acompletion(
-                model="openai/gpt-5.4",
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            f"{self.system_prompt}\n\n"
-                            f"Application context: {state_context}"
-                        ),
-                    },
-                    *self.state.messages,
-                ],
-                stream=True,
-                **completion_kwargs,
-            )
-        )
-        self.state.messages.append(response.choices[0].message)
 
 
 class ByocHashbrownFlow(PromptedChatFlow):
@@ -179,6 +132,7 @@ CONVERSATIONAL_FLOW_TYPES = {
     "a2ui-recovery": _conversational_type(A2UIRecoveryFlow),
     "subagents": _conversational_type(SubagentsFlow),
     "gen-ui-agent": _conversational_type(GenUiAgentFlow),
+    "gen-ui-tool-based": _conversational_type(GenUiToolBasedFlow),
     "reasoning": _conversational_type(ReasoningFlow),
     "interrupt": _conversational_type(InterruptFlow),
     "tool-rendering": _conversational_type(ToolRenderingFlow),

--- a/showcase/integrations/crewai-conversational-flows/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/gen_ui_agent.py
@@ -3,8 +3,8 @@
 Mirrors `langgraph-python/src/agents/gen_ui_agent.py` and
 `ms-agent-python/src/agents/gen_ui_agent.py`, implemented as a
 `crewai.flow.Flow` so we own the LLM call, tool schema, and state
-mutations directly. The shared `LatestAiDevelopment` crew on "/" cannot
-host this demo: `ChatWithCrewFlow` does not surface per-tool state
+mutations directly. A crew endpoint cannot host this
+demo: `ChatWithCrewFlow` does not surface per-tool state
 mutations to the AG-UI bridge — its only state mutation is appending
 `result.raw` to `state["outputs"]` when the model invokes the special
 `<crew_name>` tool.

--- a/showcase/integrations/crewai-conversational-flows/src/agents/gen_ui_tool_based.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/gen_ui_tool_based.py
@@ -1,0 +1,64 @@
+"""CrewAI Flow backing the Tool-Based Generative UI demo.
+
+Mirrors `langgraph-python/src/agents/gen_ui_tool_based.py`: the frontend
+registers `render_bar_chart` and `render_pie_chart`, the runtime injects them
+as actions, and the model calls one of them so the browser renders the chart.
+
+The cell needs its own backend rather than the neutral chat Flow: it must force
+a chart call on the user's turn and then narrate once the browser returns the
+result, so the run does not bounce between the model and the browser.
+"""
+
+from __future__ import annotations
+
+from crewai.flow.flow import Flow, start
+from litellm import acompletion
+
+from ag_ui_crewai import CopilotKitState, copilotkit_stream
+
+
+SYSTEM_PROMPT = (
+    "You are a data visualization assistant.\n\n"
+    "When the user asks for a chart, call `render_bar_chart` or "
+    "`render_pie_chart` with a concise title, short description, and a `data` "
+    "array of `{label, value}` items. Pick bar for comparisons over a small "
+    "set of categories; pick pie for composition / share-of-whole.\n\n"
+    "If the user names a chart subject but does NOT supply concrete numbers, "
+    "do NOT ask them for data. Invent plausible illustrative sample values "
+    "yourself, call the appropriate `render_*` tool immediately, and briefly "
+    "note in the follow-up that the values are illustrative samples. Always "
+    "render the chart on the first turn -- never reply with a clarifying "
+    "question asking for the data.\n\n"
+    "Keep chat responses brief -- let the chart do the talking."
+)
+
+
+class GenUiToolBasedFlow(Flow[CopilotKitState]):
+    """Stream one model step; the browser owns chart rendering."""
+
+    @start()
+    async def chat(self) -> None:
+        actions = self.state.copilotkit.actions or None
+        on_user_turn = bool(
+            self.state.messages and self.state.messages[-1].get("role") == "user"
+        )
+        response = await copilotkit_stream(
+            await acompletion(
+                model="openai/gpt-5.4",
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    *self.state.messages,
+                ],
+                tools=actions,
+                # Force the chart on the user's turn. Once the browser has
+                # returned the render result the follow-up is plain narration,
+                # so leaving this on "auto" is what ends the run.
+                tool_choice="required" if actions and on_user_turn else "auto",
+                parallel_tool_calls=False,
+                stream=True,
+            )
+        )
+        self.state.messages.append(response.choices[0].message)
+
+
+gen_ui_tool_based_flow = GenUiToolBasedFlow()

--- a/showcase/integrations/crewai-conversational-flows/src/agents/shared_state_read_write.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/shared_state_read_write.py
@@ -2,8 +2,8 @@
 
 Mirrors `langgraph-python/src/agents/shared_state_read_write.py` but
 implemented as a `crewai.flow.Flow` so we own the LLM call, the tool
-schema, and state mutations directly. The shared `LatestAiDevelopment`
-crew on "/" cannot host this demo: `ChatWithCrewFlow` does not surface
+schema, and state mutations directly. A crew endpoint cannot host
+this demo: `ChatWithCrewFlow` does not surface
 per-tool state mutations to the AG-UI bridge — its only state mutation
 is appending `result.raw` to `state["outputs"]` when the model invokes
 the special `<crew_name>` tool.

--- a/showcase/integrations/crewai-conversational-flows/src/agents/tool_rendering.py
+++ b/showcase/integrations/crewai-conversational-flows/src/agents/tool_rendering.py
@@ -1,7 +1,7 @@
 """CrewAI Flow backing the Tool Rendering demo.
 
-The default ``ChatWithCrewFlow`` (used for the catch-all
-``LatestAiDevelopment`` crew on "/") executes backend tools internally
+``ChatWithCrewFlow``, which backs the crew endpoints, executes
+backend tools internally
 without emitting AG-UI ``TOOL_CALL_START`` / ``TOOL_CALL_END`` events.
 The frontend's ``useRenderTool`` hook never sees the tool call and
 therefore never renders the WeatherCard.

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -6,7 +6,7 @@
 // call so the UI's `useAgent` subscription sees live updates of
 // `state.notes` without waiting for the next turn. See
 // `src/agents/shared_state_read_write.py` for the full rationale on why
-// this demo cannot share the `LatestAiDevelopment` crew on "/".
+// this demo cannot run on a crew endpoint.
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-tool-rendering/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-tool-rendering/route.ts
@@ -4,9 +4,9 @@
 // the FastAPI agent server. The flow uses `copilotkit_stream` to emit
 // AG-UI tool-call events for every tool call, so the frontend's
 // `useRenderTool` hook sees the tool calls and renders custom cards
-// (e.g. WeatherCard). The default `ChatWithCrewFlow` does NOT emit
-// these events for backend-executed tools, which is why the catch-all
-// crew endpoint cannot serve tool-rendering.
+// (e.g. WeatherCard). `ChatWithCrewFlow` does NOT emit these events
+// for backend-executed tools, which is why a crew endpoint cannot serve
+// tool-rendering.
 
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit/route.ts
@@ -119,6 +119,11 @@ agents["interrupt-headless"] = createAgent("/interrupt");
 // `set_steps` tool + per-call STATE_SNAPSHOT emit (see
 // src/agents/gen_ui_agent.py).
 agents["gen-ui-agent"] = createAgent("/gen-ui-agent");
+// gen-ui-tool-based has its own Flow (src/agents/gen_ui_tool_based.py) for
+// the same reason langgraph-python gives it a dedicated graph: it must force
+// a `render_*` chart call on the user turn, which the neutral chat Flow does
+// not do.
+agents["gen-ui-tool-based"] = createAgent("/gen-ui-tool-based");
 // tool-rendering-custom-catchall routes to a dedicated CrewAI Flow
 // backend (`/tool-rendering`, src/agents/tool_rendering.py) that emits
 // AG-UI TOOL_CALL_* events for `get_weather` / `get_stock_price` so the

--- a/showcase/integrations/crewai-conversational-flows/tests/python/test_chat_flow.py
+++ b/showcase/integrations/crewai-conversational-flows/tests/python/test_chat_flow.py
@@ -76,3 +76,59 @@ async def test_prompted_chat_forwards_frontend_actions_as_tools(monkeypatch):
 
     assert captured["tools"] == [action]
     assert captured["parallel_tool_calls"] is False
+
+
+@pytest.mark.asyncio
+async def test_flow_state_keeps_the_agui_request_context():
+    """`CopilotKitState` drops undeclared inputs, so `context` must be declared.
+
+    Without the field the readonly-state and agent-config cells send their
+    application context and the model never sees it.
+    """
+    flow = chat_flow.PromptedChatFlow()
+    assert "context" in type(flow.state).model_fields
+
+
+def test_endpoint_puts_the_request_context_in_the_model_system_message(monkeypatch):
+    """End-to-end through the real endpoint, not a hand-built state.
+
+    Instantiating the Flow directly cannot catch the loss: the drop happens when
+    the endpoint validates `RunAgentInput` into the Flow's state model.
+    """
+    from fastapi.testclient import TestClient
+
+    captured: dict = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_stream(_response):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
+        )
+
+    monkeypatch.setattr(chat_flow, "acompletion", fake_completion)
+    monkeypatch.setattr(chat_flow, "copilotkit_stream", fake_stream)
+
+    from agent_server import app
+
+    body = {
+        "threadId": "t-context",
+        "runId": "r-context",
+        "state": {},
+        "messages": [{"id": "m1", "role": "user", "content": "what tone am I set to?"}],
+        "tools": [],
+        "context": [
+            {"description": "tone", "value": "casual"},
+            {"description": "expertise", "value": "beginner"},
+        ],
+        "forwardedProps": {},
+    }
+    with TestClient(app) as client:
+        response = client.post("/conversational_flows/chat", json=body)
+
+    assert response.status_code == 200
+    system_message = captured["messages"][0]["content"]
+    assert "casual" in system_message
+    assert "beginner" in system_message

--- a/showcase/integrations/crewai-conversational-flows/tests/python/test_chat_flow.py
+++ b/showcase/integrations/crewai-conversational-flows/tests/python/test_chat_flow.py
@@ -1,0 +1,78 @@
+"""Contracts for the neutral chat Flow shared by the plain-assistant cells."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import agents.chat_flow as chat_flow
+
+
+def test_base_chat_prompt_preserves_exact_user_chosen_names_across_turns():
+    assert "exact spelling" in chat_flow.BASE_CHAT_PROMPT
+    assert "proper names" in chat_flow.BASE_CHAT_PROMPT
+
+
+def test_base_chat_prompt_carries_no_crew_chat_boilerplate():
+    """A crew endpoint would append CrewAI's purpose-reminder instructions.
+
+    `build_system_message` tells the model to introduce itself and to steer
+    every answer back to the crew's purpose. The plain-assistant cells are
+    served by this Flow precisely so none of that reaches the model.
+    """
+    prompt = chat_flow.BASE_CHAT_PROMPT.lower()
+    assert "crew" not in prompt
+    assert "introduce yourself" not in prompt
+    assert "research report" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_prompted_chat_omits_tool_options_when_no_actions(monkeypatch):
+    captured = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_stream(_response):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
+        )
+
+    monkeypatch.setattr(chat_flow, "acompletion", fake_completion)
+    monkeypatch.setattr(chat_flow, "copilotkit_stream", fake_stream)
+
+    flow = chat_flow.PromptedChatFlow()
+    flow.state.messages = [{"role": "user", "content": "hello"}]
+    await flow.chat()
+
+    assert "tools" not in captured
+    assert "parallel_tool_calls" not in captured
+
+
+@pytest.mark.asyncio
+async def test_prompted_chat_forwards_frontend_actions_as_tools(monkeypatch):
+    captured = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_stream(_response):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
+        )
+
+    monkeypatch.setattr(chat_flow, "acompletion", fake_completion)
+    monkeypatch.setattr(chat_flow, "copilotkit_stream", fake_stream)
+
+    action = {
+        "type": "function",
+        "function": {"name": "generate_haiku", "parameters": {"type": "object"}},
+    }
+    flow = chat_flow.PromptedChatFlow()
+    flow.state.messages = [{"role": "user", "content": "Write me a haiku"}]
+    flow.state.copilotkit.actions = [action]
+    await flow.chat()
+
+    assert captured["tools"] == [action]
+    assert captured["parallel_tool_calls"] is False

--- a/showcase/integrations/crewai-conversational-flows/tests/python/test_conversational_flows.py
+++ b/showcase/integrations/crewai-conversational-flows/tests/python/test_conversational_flows.py
@@ -1,8 +1,3 @@
-from types import SimpleNamespace
-
-import pytest
-
-import agents.conversational_flows as conversational_flows
 from agents.conversational_flows import CONVERSATIONAL_FLOW_TYPES
 
 
@@ -22,6 +17,7 @@ EXPECTED_FEATURES = {
     "a2ui-recovery",
     "subagents",
     "gen-ui-agent",
+    "gen-ui-tool-based",
     "reasoning",
     "interrupt",
     "tool-rendering",
@@ -47,11 +43,6 @@ def test_conversational_flows_complete_each_public_turn_without_terminating_sess
         assert flow.finish_ag_ui_turn() is None
 
 
-def test_base_chat_prompt_preserves_exact_user_chosen_names_across_turns():
-    assert "exact spelling" in conversational_flows.BASE_CHAT_PROMPT
-    assert "proper names" in conversational_flows.BASE_CHAT_PROMPT
-
-
 def test_server_registers_one_public_conversational_endpoint_per_backend():
     from agent_server import app
 
@@ -64,27 +55,3 @@ def test_server_registers_one_public_conversational_endpoint_per_backend():
     assert paths == {
         f"/conversational_flows/{feature}" for feature in EXPECTED_FEATURES
     }
-
-
-@pytest.mark.asyncio
-async def test_prompted_chat_omits_tool_options_when_no_actions(monkeypatch):
-    captured = {}
-
-    async def fake_completion(**kwargs):
-        captured.update(kwargs)
-        return object()
-
-    async def fake_stream(_response):
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
-        )
-
-    monkeypatch.setattr(conversational_flows, "acompletion", fake_completion)
-    monkeypatch.setattr(conversational_flows, "copilotkit_stream", fake_stream)
-
-    flow = conversational_flows.PromptedChatFlow()
-    flow.state.messages = [{"role": "user", "content": "hello"}]
-    await flow.chat()
-
-    assert "tools" not in captured
-    assert "parallel_tool_calls" not in captured

--- a/showcase/integrations/crewai-crews/PARITY_NOTES.md
+++ b/showcase/integrations/crewai-crews/PARITY_NOTES.md
@@ -8,6 +8,13 @@ slug for existing links and deployment wiring.
 
 - Feature-specific routes run through regular CrewAI Flow `kickoff` or
   `astream` execution.
+- Cells with no feature-specific backend (chrome, headless, slots, CSS, auth,
+  voice, agent-config) share the neutral chat Flow on `/chat`. Every demo route
+  is served by `add_crewai_flow_fastapi_endpoint`, so no cell inherits CrewAI's
+  crew-chat system prompt. The remaining crew endpoints (`/mcp-apps`,
+  `/byoc-hashbrown`, `/byoc-json-render`) each override that prompt explicitly.
+- There is no root catch-all endpoint: a demo whose agent name is not routed
+  fails loudly instead of silently landing on someone else's backend.
 - The integration is pinned to the official `ag-ui-crewai==0.3.0` release,
   `ag-ui-protocol==0.1.19`, and `crewai==1.15.11`.
 - All model-backed showcase paths use `gpt-5.4`.

--- a/showcase/integrations/crewai-crews/docs/setup/channels-agent-setup.mdx
+++ b/showcase/integrations/crewai-crews/docs/setup/channels-agent-setup.mdx
@@ -1,4 +1,4 @@
-Expose your CrewAI Crew through an AG-UI server. The
+Expose your CrewAI Flow through an AG-UI server. The
 [CopilotKit CrewAI Crews showcase](https://github.com/CopilotKit/CopilotKit/tree/main/showcase/integrations/crewai-crews)
 includes a reference server; from that integration directory, run:
 
@@ -6,10 +6,10 @@ includes a reference server; from that integration directory, run:
 PYTHONPATH=src python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 --reload
 ```
 
-The shared crew is mounted at the server root:
+The shared chat Flow is mounted at `/chat`:
 
 ```dotenv title=".env"
-AGENT_URL=http://localhost:8000/
+AGENT_URL=http://localhost:8000/chat
 ```
 
 Install the HTTP adapter in the Channels process:

--- a/showcase/integrations/crewai-crews/src/agent_server.py
+++ b/showcase/integrations/crewai-crews/src/agent_server.py
@@ -35,10 +35,11 @@ from agents.a2ui_recovery_flow import a2ui_recovery_flow  # noqa: E402
 from agents.beautiful_chat_flow import beautiful_chat_flow  # noqa: E402
 from agents.byoc_hashbrown_agent import ByocHashbrown  # noqa: E402
 from agents.byoc_json_render_agent import ByocJsonRender  # noqa: E402
-from agents.crew import LatestAiDevelopment  # noqa: E402
+from agents.chat_flow import PromptedChatFlow  # noqa: E402
 from agents.declarative_gen_ui import declarative_gen_ui_flow  # noqa: E402
 from agents.frontend_tool_flow import frontend_tool_flow  # noqa: E402
 from agents.gen_ui_agent import gen_ui_agent_flow  # noqa: E402
+from agents.gen_ui_tool_based import gen_ui_tool_based_flow  # noqa: E402
 from agents.interrupt_flow import interrupt_flow  # noqa: E402
 from agents.mcp_apps_agent import MCPApps  # noqa: E402
 from agents.multimodal_flow import multimodal_flow  # noqa: E402
@@ -63,7 +64,7 @@ app = FastAPI(title="CrewAI (Crews) Agent Server")
 
 
 class HealthMiddleware(BaseHTTPMiddleware):
-    """Keep health reachable despite the shared root catch-all endpoint."""
+    """Keep the backend health contract independent of agent endpoints."""
 
     async def dispatch(self, request, call_next):
         if request.url.path == "/health" and request.method == "GET":
@@ -81,7 +82,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Dedicated endpoints must be registered before the shared root catch-all.
+# Cells that only need a plain assistant share the neutral chat Flow. A Flow
+# owns its own prompt, so they get no CrewAI crew-chat boilerplate.
+add_crewai_flow_fastapi_endpoint(app, PromptedChatFlow(), "/chat")
+
 add_crewai_flow_fastapi_endpoint(app, declarative_gen_ui_flow, "/declarative-gen-ui")
 add_crewai_flow_fastapi_endpoint(app, a2ui_fixed_flow, "/a2ui-fixed-schema")
 add_crewai_crew_fastapi_endpoint(app, ByocHashbrown(), "/byoc-hashbrown")
@@ -101,6 +105,7 @@ add_crewai_flow_fastapi_endpoint(app, frontend_tool_flow, "/frontend-tools")
 add_crewai_flow_fastapi_endpoint(app, a2ui_recovery_flow, "/a2ui-recovery")
 add_crewai_flow_fastapi_endpoint(app, subagents_flow, "/subagents")
 add_crewai_flow_fastapi_endpoint(app, gen_ui_agent_flow, "/gen-ui-agent")
+add_crewai_flow_fastapi_endpoint(app, gen_ui_tool_based_flow, "/gen-ui-tool-based")
 add_crewai_flow_fastapi_endpoint(app, reasoning_flow, "/reasoning")
 add_crewai_flow_fastapi_endpoint(
     app,
@@ -114,5 +119,3 @@ if tool_rendering_flow is not None:
 add_crewai_flow_fastapi_endpoint(
     app, tool_rendering_reasoning_flow, "/tool-rendering-reasoning"
 )
-
-add_crewai_crew_fastapi_endpoint(app, LatestAiDevelopment(), "/")

--- a/showcase/integrations/crewai-crews/src/agents/chat_flow.py
+++ b/showcase/integrations/crewai-crews/src/agents/chat_flow.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from crewai.flow.flow import Flow, start
 from litellm import acompletion
+from pydantic import Field
 
 from ag_ui_crewai import CopilotKitState, copilotkit_stream
 
@@ -36,7 +37,20 @@ BASE_CHAT_PROMPT = (
 )
 
 
-class PromptedChatFlow(Flow[CopilotKitState]):
+class ChatState(CopilotKitState):
+    """`CopilotKitState` plus the AG-UI request context.
+
+    The bridge puts `RunAgentInput.context` on state under `context`, but
+    `CopilotKitState` does not declare the field, so pydantic drops it during
+    input validation and the model never sees it. Declaring it here is what
+    keeps the readonly-state and agent-config cells honest: those demos exist
+    to prove the agent reads application context.
+    """
+
+    context: list[Any] = Field(default_factory=list)
+
+
+class PromptedChatFlow(Flow[ChatState]):
     """One-turn chat Flow for showcase cells that differ only by prompting."""
 
     system_prompt = BASE_CHAT_PROMPT

--- a/showcase/integrations/crewai-crews/src/agents/chat_flow.py
+++ b/showcase/integrations/crewai-crews/src/agents/chat_flow.py
@@ -1,0 +1,72 @@
+"""Neutral chat Flow for the showcase cells that differ only by prompting.
+
+Chrome, headless, slots, CSS, auth, voice, and agent-config cells need a plain
+assistant: no backend tools, no state mutations, no delegation. They used to
+share the `LatestAiDevelopment` crew through
+`add_crewai_crew_fastapi_endpoint`, which composes its system message with
+CrewAI's `build_system_message`. That boilerplate is unconditional — it tells
+the model to introduce itself and to steer the user back to the crew's purpose,
+using a research-report example — so every one of those cells answered the
+question and then offered to research the latest AI developments.
+
+A regular Flow owns its own prompt, so the assistant behaves like an assistant.
+`crewai-conversational-flows` wraps this same class through its conversational
+registry, which keeps the two columns on one prompt.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from crewai.flow.flow import Flow, start
+from litellm import acompletion
+
+from ag_ui_crewai import CopilotKitState, copilotkit_stream
+
+
+BASE_CHAT_PROMPT = (
+    "You are a concise CopilotKit showcase assistant. CRITICAL: Use any "
+    "frontend tools supplied by the application whenever the user asks for "
+    "their capability. "
+    "Honor application context and configuration included below. After the "
+    "browser returns a tool result, summarize it briefly. Preserve the exact "
+    "spelling of user-chosen proper names across later turns and repeat those "
+    "proper names verbatim when the user asks what was chosen."
+)
+
+
+class PromptedChatFlow(Flow[CopilotKitState]):
+    """One-turn chat Flow for showcase cells that differ only by prompting."""
+
+    system_prompt = BASE_CHAT_PROMPT
+
+    @start()
+    async def chat(self) -> None:
+        state = self.state.model_dump(exclude={"messages", "copilotkit"})
+        state_context = json.dumps(state, default=str, sort_keys=True)
+        actions = self.state.copilotkit.actions or None
+        completion_kwargs: dict[str, Any] = {}
+        if actions:
+            completion_kwargs.update(
+                tools=actions,
+                parallel_tool_calls=False,
+            )
+        response = await copilotkit_stream(
+            await acompletion(
+                model="openai/gpt-5.4",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            f"{self.system_prompt}\n\n"
+                            f"Application context: {state_context}"
+                        ),
+                    },
+                    *self.state.messages,
+                ],
+                stream=True,
+                **completion_kwargs,
+            )
+        )
+        self.state.messages.append(response.choices[0].message)

--- a/showcase/integrations/crewai-crews/src/agents/gen_ui_agent.py
+++ b/showcase/integrations/crewai-crews/src/agents/gen_ui_agent.py
@@ -3,8 +3,8 @@
 Mirrors `langgraph-python/src/agents/gen_ui_agent.py` and
 `ms-agent-python/src/agents/gen_ui_agent.py`, implemented as a
 `crewai.flow.Flow` so we own the LLM call, tool schema, and state
-mutations directly. The shared `LatestAiDevelopment` crew on "/" cannot
-host this demo: `ChatWithCrewFlow` does not surface per-tool state
+mutations directly. A crew endpoint cannot host this
+demo: `ChatWithCrewFlow` does not surface per-tool state
 mutations to the AG-UI bridge — its only state mutation is appending
 `result.raw` to `state["outputs"]` when the model invokes the special
 `<crew_name>` tool.

--- a/showcase/integrations/crewai-crews/src/agents/gen_ui_tool_based.py
+++ b/showcase/integrations/crewai-crews/src/agents/gen_ui_tool_based.py
@@ -1,0 +1,64 @@
+"""CrewAI Flow backing the Tool-Based Generative UI demo.
+
+Mirrors `langgraph-python/src/agents/gen_ui_tool_based.py`: the frontend
+registers `render_bar_chart` and `render_pie_chart`, the runtime injects them
+as actions, and the model calls one of them so the browser renders the chart.
+
+The cell needs its own backend rather than the neutral chat Flow: it must force
+a chart call on the user's turn and then narrate once the browser returns the
+result, so the run does not bounce between the model and the browser.
+"""
+
+from __future__ import annotations
+
+from crewai.flow.flow import Flow, start
+from litellm import acompletion
+
+from ag_ui_crewai import CopilotKitState, copilotkit_stream
+
+
+SYSTEM_PROMPT = (
+    "You are a data visualization assistant.\n\n"
+    "When the user asks for a chart, call `render_bar_chart` or "
+    "`render_pie_chart` with a concise title, short description, and a `data` "
+    "array of `{label, value}` items. Pick bar for comparisons over a small "
+    "set of categories; pick pie for composition / share-of-whole.\n\n"
+    "If the user names a chart subject but does NOT supply concrete numbers, "
+    "do NOT ask them for data. Invent plausible illustrative sample values "
+    "yourself, call the appropriate `render_*` tool immediately, and briefly "
+    "note in the follow-up that the values are illustrative samples. Always "
+    "render the chart on the first turn -- never reply with a clarifying "
+    "question asking for the data.\n\n"
+    "Keep chat responses brief -- let the chart do the talking."
+)
+
+
+class GenUiToolBasedFlow(Flow[CopilotKitState]):
+    """Stream one model step; the browser owns chart rendering."""
+
+    @start()
+    async def chat(self) -> None:
+        actions = self.state.copilotkit.actions or None
+        on_user_turn = bool(
+            self.state.messages and self.state.messages[-1].get("role") == "user"
+        )
+        response = await copilotkit_stream(
+            await acompletion(
+                model="openai/gpt-5.4",
+                messages=[
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    *self.state.messages,
+                ],
+                tools=actions,
+                # Force the chart on the user's turn. Once the browser has
+                # returned the render result the follow-up is plain narration,
+                # so leaving this on "auto" is what ends the run.
+                tool_choice="required" if actions and on_user_turn else "auto",
+                parallel_tool_calls=False,
+                stream=True,
+            )
+        )
+        self.state.messages.append(response.choices[0].message)
+
+
+gen_ui_tool_based_flow = GenUiToolBasedFlow()

--- a/showcase/integrations/crewai-crews/src/agents/shared_state_read_write.py
+++ b/showcase/integrations/crewai-crews/src/agents/shared_state_read_write.py
@@ -2,8 +2,8 @@
 
 Mirrors `langgraph-python/src/agents/shared_state_read_write.py` but
 implemented as a `crewai.flow.Flow` so we own the LLM call, the tool
-schema, and state mutations directly. The shared `LatestAiDevelopment`
-crew on "/" cannot host this demo: `ChatWithCrewFlow` does not surface
+schema, and state mutations directly. A crew endpoint cannot host
+this demo: `ChatWithCrewFlow` does not surface
 per-tool state mutations to the AG-UI bridge — its only state mutation
 is appending `result.raw` to `state["outputs"]` when the model invokes
 the special `<crew_name>` tool.

--- a/showcase/integrations/crewai-crews/src/agents/tool_rendering.py
+++ b/showcase/integrations/crewai-crews/src/agents/tool_rendering.py
@@ -1,7 +1,7 @@
 """CrewAI Flow backing the Tool Rendering demo.
 
-The default ``ChatWithCrewFlow`` (used for the catch-all
-``LatestAiDevelopment`` crew on "/") executes backend tools internally
+``ChatWithCrewFlow``, which backs the crew endpoints, executes
+backend tools internally
 without emitting AG-UI ``TOOL_CALL_START`` / ``TOOL_CALL_END`` events.
 The frontend's ``useRenderTool`` hook never sees the tool call and
 therefore never renders the WeatherCard.

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-agent-config/route.ts
@@ -14,7 +14,7 @@ import { AbstractAgent, HttpAgent } from "@ag-ui/client";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 function createAgent() {
-  return new HttpAgent({ url: `${AGENT_URL}/` });
+  return new HttpAgent({ url: `${AGENT_URL}/chat` });
 }
 
 const agents: Record<string, AbstractAgent> = {

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-auth/[[...slug]]/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-auth/[[...slug]]/route.ts
@@ -32,7 +32,7 @@ import { DEMO_AUTH_HEADER } from "@/app/demos/auth/demo-token";
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
 function createAgent() {
-  return new HttpAgent({ url: `${AGENT_URL}/` });
+  return new HttpAgent({ url: `${AGENT_URL}/chat` });
 }
 
 const runtime = new CopilotRuntime({

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -6,7 +6,7 @@
 // call so the UI's `useAgent` subscription sees live updates of
 // `state.notes` without waiting for the next turn. See
 // `src/agents/shared_state_read_write.py` for the full rationale on why
-// this demo cannot share the `LatestAiDevelopment` crew on "/".
+// this demo cannot run on a crew endpoint.
 
 import { NextRequest, NextResponse } from "next/server";
 import {

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-tool-rendering/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-tool-rendering/route.ts
@@ -4,9 +4,9 @@
 // the FastAPI agent server. The flow uses `copilotkit_stream` to emit
 // AG-UI tool-call events for every tool call, so the frontend's
 // `useRenderTool` hook sees the tool calls and renders custom cards
-// (e.g. WeatherCard). The default `ChatWithCrewFlow` does NOT emit
-// these events for backend-executed tools, which is why the catch-all
-// crew endpoint cannot serve tool-rendering.
+// (e.g. WeatherCard). `ChatWithCrewFlow` does NOT emit these events
+// for backend-executed tools, which is why a crew endpoint cannot serve
+// tool-rendering.
 
 import { NextRequest, NextResponse } from "next/server";
 import {

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-voice/[[...slug]]/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-voice/[[...slug]]/route.ts
@@ -27,7 +27,7 @@ import OpenAI from "openai";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
-const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/` });
+const voiceDemoAgent = new HttpAgent({ url: `${AGENT_URL}/chat` });
 
 class GuardedOpenAITranscriptionService extends TranscriptionService {
   private delegate: TranscriptionServiceOpenAI | null;

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
@@ -23,15 +23,20 @@ const ROUTE_DEBUG =
   process.env.SHOWCASE_ROUTE_DEBUG === "1" ||
   process.env.SHOWCASE_ROUTE_DEBUG === "true";
 
-function createAgent(path = "/") {
+function createAgent(path = "/chat") {
   return new HttpAgent({ url: `${AGENT_URL}${path}` });
 }
 
-// CrewAI hosts a single shared `LatestAiDevelopment` crew. We register
-// many agent names here so individual demo pages can scope their
-// per-cell frontend tool / component registrations independently; all
-// names resolve to the same HttpAgent bridge. See
-// ../../../../PARITY_NOTES.md (integration root).
+// Cells that only need a plain assistant share the neutral chat Flow on
+// `/chat` (src/agents/chat_flow.py). We register many agent names here so
+// individual demo pages can scope their per-cell frontend tool / component
+// registrations independently; the names below with no explicit override all
+// resolve to that Flow. See ../../../../PARITY_NOTES.md (integration root).
+//
+// The default deliberately is NOT a CrewAI crew endpoint. A crew endpoint
+// composes its system message with CrewAI's `build_system_message`, whose
+// unconditional boilerplate makes the assistant introduce itself and steer
+// every answer back to the crew's purpose.
 const agentNames = [
   // Existing base demos
   "agentic_chat",
@@ -83,7 +88,7 @@ for (const name of agentNames) {
 
 // CrewAI Flows own the state, tool-result, and delegation lifecycles for
 // these cells. Keep every alias explicit: silently falling back to the root
-// Crew endpoint makes the UI appear connected while dropping the specialized
+// chat endpoint makes the UI appear connected while dropping the specialized
 // AG-UI events that each demo exists to prove.
 agents["shared-state-read"] = createAgent("/shared-state-read");
 agents["shared-state-write"] = createAgent("/shared-state-read-write");
@@ -107,25 +112,30 @@ agents["open-gen-ui-advanced"] = createAgent("/frontend-tools");
 for (const name of reasoningAgentNames) {
   agents[name] = createAgent("/reasoning");
 }
-// Interrupt-adapted demos route to the dedicated scheduling crew backend.
-// Both gen-ui-interrupt and interrupt-headless share the same crew; only the
+// Interrupt-adapted demos route to the dedicated scheduling Flow backend.
+// Both gen-ui-interrupt and interrupt-headless share the same Flow; only the
 // frontend UX differs (inline in chat vs. external popup).
 agents["gen-ui-interrupt"] = createAgent("/interrupt");
 agents["interrupt-headless"] = createAgent("/interrupt");
 // gen-ui-agent routes to a dedicated CrewAI Flow backend that owns the
 // `set_steps` tool + per-call STATE_SNAPSHOT emit (see
-// src/agents/gen_ui_agent.py). The shared LatestAiDevelopment crew on "/"
-// cannot host this demo because ChatWithCrewFlow does not surface
-// per-tool state mutations to the AG-UI bridge — same architectural
-// reason as shared-state-read-write and subagents.
+// src/agents/gen_ui_agent.py). A crew endpoint cannot host this demo
+// because ChatWithCrewFlow does not surface per-tool state mutations to
+// the AG-UI bridge — same architectural reason as
+// shared-state-read-write and subagents.
 agents["gen-ui-agent"] = createAgent("/gen-ui-agent");
+// gen-ui-tool-based has its own Flow (src/agents/gen_ui_tool_based.py) for
+// the same reason langgraph-python gives it a dedicated graph: it must force
+// a `render_*` chart call on the user turn, which the neutral chat Flow does
+// not do.
+agents["gen-ui-tool-based"] = createAgent("/gen-ui-tool-based");
 // tool-rendering-custom-catchall routes to a dedicated CrewAI Flow
 // backend (`/tool-rendering`, src/agents/tool_rendering.py) that emits
-// AG-UI TOOL_CALL_* events for `get_weather` / `get_stock_price`. The
-// shared `LatestAiDevelopment` ChatWithCrewFlow on "/" runs backend
-// tools internally without emitting tool-call events, so the frontend's
-// custom wildcard renderer (`useDefaultRenderTool`) would never paint
-// the `[data-testid="custom-wildcard-card"]` shell that the
+// AG-UI TOOL_CALL_* events for `get_weather` / `get_stock_price`.
+// `ChatWithCrewFlow` runs backend tools internally without emitting
+// tool-call events, so the frontend's custom wildcard renderer
+// (`useDefaultRenderTool`) would never paint the
+// `[data-testid="custom-wildcard-card"]` shell that the
 // `d5-tool-rendering-custom-catchall` probe asserts on.
 agents["default"] = createAgent();
 

--- a/showcase/integrations/crewai-crews/tests/python/test_chat_flow.py
+++ b/showcase/integrations/crewai-crews/tests/python/test_chat_flow.py
@@ -76,3 +76,59 @@ async def test_prompted_chat_forwards_frontend_actions_as_tools(monkeypatch):
 
     assert captured["tools"] == [action]
     assert captured["parallel_tool_calls"] is False
+
+
+@pytest.mark.asyncio
+async def test_flow_state_keeps_the_agui_request_context():
+    """`CopilotKitState` drops undeclared inputs, so `context` must be declared.
+
+    Without the field the readonly-state and agent-config cells send their
+    application context and the model never sees it.
+    """
+    flow = chat_flow.PromptedChatFlow()
+    assert "context" in type(flow.state).model_fields
+
+
+def test_endpoint_puts_the_request_context_in_the_model_system_message(monkeypatch):
+    """End-to-end through the real endpoint, not a hand-built state.
+
+    Instantiating the Flow directly cannot catch the loss: the drop happens when
+    the endpoint validates `RunAgentInput` into the Flow's state model.
+    """
+    from fastapi.testclient import TestClient
+
+    captured: dict = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_stream(_response):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
+        )
+
+    monkeypatch.setattr(chat_flow, "acompletion", fake_completion)
+    monkeypatch.setattr(chat_flow, "copilotkit_stream", fake_stream)
+
+    from agent_server import app
+
+    body = {
+        "threadId": "t-context",
+        "runId": "r-context",
+        "state": {},
+        "messages": [{"id": "m1", "role": "user", "content": "what tone am I set to?"}],
+        "tools": [],
+        "context": [
+            {"description": "tone", "value": "casual"},
+            {"description": "expertise", "value": "beginner"},
+        ],
+        "forwardedProps": {},
+    }
+    with TestClient(app) as client:
+        response = client.post("/chat", json=body)
+
+    assert response.status_code == 200
+    system_message = captured["messages"][0]["content"]
+    assert "casual" in system_message
+    assert "beginner" in system_message

--- a/showcase/integrations/crewai-crews/tests/python/test_chat_flow.py
+++ b/showcase/integrations/crewai-crews/tests/python/test_chat_flow.py
@@ -1,0 +1,78 @@
+"""Contracts for the neutral chat Flow shared by the plain-assistant cells."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import agents.chat_flow as chat_flow
+
+
+def test_base_chat_prompt_preserves_exact_user_chosen_names_across_turns():
+    assert "exact spelling" in chat_flow.BASE_CHAT_PROMPT
+    assert "proper names" in chat_flow.BASE_CHAT_PROMPT
+
+
+def test_base_chat_prompt_carries_no_crew_chat_boilerplate():
+    """A crew endpoint would append CrewAI's purpose-reminder instructions.
+
+    `build_system_message` tells the model to introduce itself and to steer
+    every answer back to the crew's purpose. The plain-assistant cells are
+    served by this Flow precisely so none of that reaches the model.
+    """
+    prompt = chat_flow.BASE_CHAT_PROMPT.lower()
+    assert "crew" not in prompt
+    assert "introduce yourself" not in prompt
+    assert "research report" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_prompted_chat_omits_tool_options_when_no_actions(monkeypatch):
+    captured = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_stream(_response):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
+        )
+
+    monkeypatch.setattr(chat_flow, "acompletion", fake_completion)
+    monkeypatch.setattr(chat_flow, "copilotkit_stream", fake_stream)
+
+    flow = chat_flow.PromptedChatFlow()
+    flow.state.messages = [{"role": "user", "content": "hello"}]
+    await flow.chat()
+
+    assert "tools" not in captured
+    assert "parallel_tool_calls" not in captured
+
+
+@pytest.mark.asyncio
+async def test_prompted_chat_forwards_frontend_actions_as_tools(monkeypatch):
+    captured = {}
+
+    async def fake_completion(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_stream(_response):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message={"role": "assistant", "content": "ok"})]
+        )
+
+    monkeypatch.setattr(chat_flow, "acompletion", fake_completion)
+    monkeypatch.setattr(chat_flow, "copilotkit_stream", fake_stream)
+
+    action = {
+        "type": "function",
+        "function": {"name": "generate_haiku", "parameters": {"type": "object"}},
+    }
+    flow = chat_flow.PromptedChatFlow()
+    flow.state.messages = [{"role": "user", "content": "Write me a haiku"}]
+    flow.state.copilotkit.actions = [action]
+    await flow.chat()
+
+    assert captured["tools"] == [action]
+    assert captured["parallel_tool_calls"] is False

--- a/showcase/integrations/crewai-crews/tests/python/test_specialized_flows.py
+++ b/showcase/integrations/crewai-crews/tests/python/test_specialized_flows.py
@@ -1343,6 +1343,36 @@ def test_server_and_runtime_register_dedicated_flow_routes():
     assert "`${AGENT_URL}/frontend-tools`" in open_gen_ui_route
 
 
+def test_plain_assistant_cells_never_reach_a_crew_endpoint():
+    """Cells with no dedicated backend must land on the neutral chat Flow.
+
+    A crew endpoint composes its system message with CrewAI's
+    `build_system_message`, whose unconditional boilerplate makes the
+    assistant introduce itself and steer every answer back to the crew's
+    purpose. The chat Flow owns its own prompt, so the fall-through path is
+    a Flow and the server registers no root catch-all to fall back to.
+    """
+    server = AGENT_SERVER.read_text()
+    route = MAIN_RUNTIME_ROUTE.read_text()
+
+    assert (
+        'add_crewai_flow_fastapi_endpoint(app, PromptedChatFlow(), "/chat")' in server
+    )
+    assert not re.search(r'add_crewai_crew_fastapi_endpoint\([^)]*"/"\s*\)', server)
+    assert 'function createAgent(path = "/chat")' in route
+
+    for dedicated in (
+        "copilotkit-agent-config",
+        "copilotkit-auth/[[...slug]]",
+        "copilotkit-voice/[[...slug]]",
+    ):
+        source = (
+            INTEGRATION_ROOT / "src" / "app" / "api" / dedicated / "route.ts"
+        ).read_text()
+        assert "${AGENT_URL}/chat`" in source
+        assert "${AGENT_URL}/`" not in source
+
+
 def test_byoc_hashbrown_legacy_route_is_operational():
     page = INTEGRATION_ROOT / "src" / "app" / "demos" / "byoc-hashbrown" / "page.tsx"
     declarative_page = (


### PR DESCRIPTION
## What

Eleven demos in the `crewai-crews` showcase column (labelled **CrewAI Flows** in the UI) were served by `add_crewai_crew_fastapi_endpoint` through a root catch-all, not by the Flow helper. This moves them onto a real CrewAI Flow and removes the catch-all.

Affected demos: agentic-chat, gen-ui-tool-based, prebuilt-sidebar, prebuilt-popup, chat-slots, chat-customization-css, headless-simple, readonly-state-agent-context, agent-config, auth, voice.

## Why

`add_crewai_crew_fastapi_endpoint` wraps the crew in `ChatWithCrewFlow`, which composes its system message with CrewAI's `build_system_message`. That boilerplate is unconditional: it instructs the model to introduce itself and to steer every answer back to the crew's purpose, using a research-report example. Because the catch-all served the scaffold research crew, those demos answered the user's question and then offered to research the latest AI developments.

Measured against real OpenAI on `main`, first turn:

> Hey! I'm here to help you with researching cutting-edge developments and producing detailed, actionable reports.
> The capital of France is **Paris**. If you'd like, I can also help by generating a **current research report** on a topic of your choice.

Second turn, arithmetic question:

> 12 × 12 = 144.
> I'm here to help with researching the latest AI developments and producing actionable reports.

Pre-seeding a hand-written `crew_description` (the existing `_chat_flow_helpers.preseed_system_prompt`) only retargets that tail, it does not remove it — verified on `/mcp-apps`, which is pre-seeded and still introduces itself and offers a diagram.

## How

- New `src/agents/chat_flow.py` holds `PromptedChatFlow`, a one-turn Flow that owns its own prompt and forwards frontend tools. `crewai-conversational-flows` already had this class inline; it now imports the same file, so both columns share one prompt.
- `agent_server.py` registers it at `/chat` via `add_crewai_flow_fastapi_endpoint`, and the root catch-all registration is gone. An unrouted agent name now fails loudly instead of landing on someone else's backend.
- The runtime route's default target becomes `/chat`; the `agent-config`, `auth`, and `voice` routes point there too.
- The remaining crew endpoints (`/mcp-apps`, `/byoc-hashbrown`, `/byoc-json-render`) are untouched — each already overrides the composed system message explicitly.
- Comments that described the removed catch-all were corrected in both CrewAI columns.

## Verification

Against real OpenAI on the patched backend:

- `/chat` answers `Paris.` and `12 × 12 = 144.` with no purpose-reminder tail.
- A frontend tool still round-trips: `generate_haiku` emits `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END`.
- `POST /` returns 404.

Python suites: 162 passed (`crewai-crews`), 164 passed (`crewai-conversational-flows`). New coverage in `test_chat_flow.py` (prompt contract, no crew-chat boilerplate, tool forwarding) plus a routing contract test asserting no cell can reach a crew endpoint by fall-through.

D6 replay: see the checklist below.

### D6 replay (local, `--d6 --direct`, warm stack)

All fourteen green: the eleven affected cells (agentic-chat, gen-ui-tool-based, prebuilt-sidebar, prebuilt-popup, chat-slots, chat-customization-css, headless-simple, readonly-state-agent-context, agent-config, auth, voice) plus tool-rendering, hitl-in-chat and shared-state-read-write as untouched controls.

gen-ui-tool-based needed the second commit: the shared probe had both CrewAI columns off its chart-integration list, so it sent the haiku prompt and waited for a haiku card the page cannot draw. The probe's own unit tests still pass (11).

The conversational column's D6 was not run — it is not deployed, and its image was not built in this session. Its Python suite passes and its wiring mirrors the crews column line for line.
