### PR TITLE
test(sdk-python): revalidate the poetry lock and cover the partialjson parse path

### DIFF
--- a/sdk-python/poetry.lock
+++ b/sdk-python/poetry.lock
@@ -3115,15 +3115,18 @@ files = [
 
 [[package]]
 name = "partialjson"
-version = "0.0.8"
+version = "1.1.0"
 description = "Parse incomplete or partial json"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "partialjson-0.0.8-py3-none-any.whl", hash = "sha256:22c6c60944137f931a7033fa0eeee2d74b49114f3d45c25a560b07a6ebf22b76"},
-    {file = "partialjson-0.0.8.tar.gz", hash = "sha256:91217e19a15049332df534477f56420065ad1729cedee7d8c7433e1d2acc7dca"},
+    {file = "partialjson-1.1.0-py3-none-any.whl", hash = "sha256:380891bf2f4ae05094839c27dceec9b51db02aabeb46b9a2acef3d63755ddcea"},
+    {file = "partialjson-1.1.0.tar.gz", hash = "sha256:733e540b91e8d9bb6b0d29caf02a4e67e213103d40e25c5f6d16401db3f6ede2"},
 ]
+
+[package.extras]
+json5 = ["json5"]
 
 [[package]]
 name = "pdfminer-six"
@@ -5642,4 +5645,4 @@ crewai = ["crewai"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "5d1af465655fc26c4bfdd9c81edc0760c838e8328ce5ba7c860b18640488d8a4"
+content-hash = "f14f92647724856998f774f4626d99a63de8206a3f56862d8a5d67620f712c62"

--- a/sdk-python/tests/test_predict_state_partial_json.py
+++ b/sdk-python/tests/test_predict_state_partial_json.py
@@ -57,7 +57,10 @@ def _stream(chunk_size: int) -> tuple[list[dict], dict]:
         agent_name="agent",
         run_id="run-1",
         execution=execution,
-        event={"type": RuntimeEventTypes.ACTION_EXECUTION_START, "actionName": TOOL_NAME},
+        event={
+            "type": RuntimeEventTypes.ACTION_EXECUTION_START,
+            "actionName": TOOL_NAME,
+        },
     )
 
     frames = []
@@ -108,7 +111,9 @@ def test_intermediate_predictions_are_prefixes_of_the_final_value():
         assert isinstance(partial, str), f"expected a string, got {partial!r}"
         # Trailing whitespace handling differs across the allowed range, so compare
         # on the stripped prefix rather than the raw frame.
-        assert final.startswith(partial.rstrip()), f"{partial!r} is not a prefix of {final!r}"
+        assert final.startswith(partial.rstrip()), (
+            f"{partial!r} is not a prefix of {final!r}"
+        )
 
 
 def test_unterminated_escape_does_not_escape_predict_state():
@@ -119,7 +124,10 @@ def test_unterminated_escape_does_not_escape_predict_state():
         agent_name="agent",
         run_id="run-1",
         execution=execution,
-        event={"type": RuntimeEventTypes.ACTION_EXECUTION_START, "actionName": TOOL_NAME},
+        event={
+            "type": RuntimeEventTypes.ACTION_EXECUTION_START,
+            "actionName": TOOL_NAME,
+        },
     )
 
     # 0.0.8 raises JSONDecodeError here; 1.x parses it. Either way predict_state()
@@ -129,7 +137,10 @@ def test_unterminated_escape_does_not_escape_predict_state():
         agent_name="agent",
         run_id="run-1",
         execution=execution,
-        event={"type": RuntimeEventTypes.ACTION_EXECUTION_ARGS, "args": '{"task": "line\\'},
+        event={
+            "type": RuntimeEventTypes.ACTION_EXECUTION_ARGS,
+            "args": '{"task": "line\\',
+        },
     )
 
 

--- a/sdk-python/tests/test_predict_state_partial_json.py
+++ b/sdk-python/tests/test_predict_state_partial_json.py
@@ -1,0 +1,148 @@
+"""Tripwire coverage for the partialjson dependency behind predict_state().
+
+`pyproject.toml` allows any partialjson in `>=0.0.8,<2.0.0` (#6123, issue #4131).
+The only consumer is `predict_state()` in copilotkit/runloop.py, which parses the
+still-incomplete tool-call argument buffer via `JSONParser().parse(...)` inside a
+bare `except`. That makes a regression silent: every partialjson failure mode
+degrades to "no predicted state was emitted", and nothing else in the suite looks
+at this path — disabling `JSONParser.parse` outright left all other tests passing.
+
+These assertions are deliberately version-agnostic. Intermediate frames legitimately
+differ across the allowed range (1.1.0 keeps trailing whitespace inside a partially
+streamed string where 0.0.8 dropped it), so we pin only the guarantees the range must
+keep: a completed payload parses exactly, and a prefix yields a prefix.
+"""
+
+import json
+
+from partialjson.json_parser import JSONParser
+
+from copilotkit.protocol import RuntimeEventTypes
+from copilotkit.runloop import predict_state
+
+TOOL_NAME = "set_plan"
+ARGUMENTS = {
+    "task": "Write a haiku about the sea",
+    "steps": ["draft", "revise"],
+    "done": False,
+}
+PAYLOAD = json.dumps(ARGUMENTS)
+
+
+def _execution() -> dict:
+    """A CopilotKitRunExecution primed to predict `task` and the whole argument dict."""
+    return {
+        "thread_id": "t-1",
+        "agent_name": "agent",
+        "run_id": "run-1",
+        "should_exit": False,
+        "node_name": "node",
+        "is_finished": False,
+        "predict_state_configuration": {
+            "plan": {"tool_name": TOOL_NAME, "tool_argument": "task"},
+            "whole": {"tool_name": TOOL_NAME},
+        },
+        "predicted_state": {},
+        "argument_buffer": "",
+        "current_tool_call": None,
+        "state": {},
+    }
+
+
+def _stream(chunk_size: int) -> tuple[list[dict], dict]:
+    """Stream PAYLOAD through predict_state() and collect each predicted state."""
+    execution = _execution()
+    predict_state(
+        thread_id="t-1",
+        agent_name="agent",
+        run_id="run-1",
+        execution=execution,
+        event={"type": RuntimeEventTypes.ACTION_EXECUTION_START, "actionName": TOOL_NAME},
+    )
+
+    frames = []
+    for start in range(0, len(PAYLOAD), chunk_size):
+        message = predict_state(
+            thread_id="t-1",
+            agent_name="agent",
+            run_id="run-1",
+            execution=execution,
+            event={
+                "type": RuntimeEventTypes.ACTION_EXECUTION_ARGS,
+                "args": PAYLOAD[start : start + chunk_size],
+            },
+        )
+        if message is not None:
+            frames.append(dict(execution["predicted_state"]))
+    return frames, execution["predicted_state"]
+
+
+def test_streaming_arguments_emit_predicted_state():
+    """A streamed tool call must produce predicted-state updates, not silence."""
+    frames, _ = _stream(chunk_size=1)
+
+    assert frames, (
+        "no predicted state was emitted while arguments streamed — partialjson "
+        "parsed nothing usable from any prefix of the buffer"
+    )
+    assert len(frames) > 10, f"expected many incremental frames, got {len(frames)}"
+
+
+def test_completed_arguments_parse_exactly():
+    """Once the buffer is complete the prediction must equal the real arguments."""
+    for chunk_size in (1, 3, 7, 20):
+        _, predicted = _stream(chunk_size)
+        assert predicted["whole"] == ARGUMENTS, f"chunk_size={chunk_size}"
+        assert predicted["plan"] == ARGUMENTS["task"], f"chunk_size={chunk_size}"
+
+
+def test_intermediate_predictions_are_prefixes_of_the_final_value():
+    """Every partial value must be a prefix of the finished string, never garbage."""
+    frames, predicted = _stream(chunk_size=1)
+    final = predicted["plan"]
+
+    for frame in frames:
+        partial = frame.get("plan")
+        if partial is None:
+            continue
+        assert isinstance(partial, str), f"expected a string, got {partial!r}"
+        # Trailing whitespace handling differs across the allowed range, so compare
+        # on the stripped prefix rather than the raw frame.
+        assert final.startswith(partial.rstrip()), f"{partial!r} is not a prefix of {final!r}"
+
+
+def test_unterminated_escape_does_not_escape_predict_state():
+    """Prefixes that older partialjson rejects must stay contained by the bare except."""
+    execution = _execution()
+    predict_state(
+        thread_id="t-1",
+        agent_name="agent",
+        run_id="run-1",
+        execution=execution,
+        event={"type": RuntimeEventTypes.ACTION_EXECUTION_START, "actionName": TOOL_NAME},
+    )
+
+    # 0.0.8 raises JSONDecodeError here; 1.x parses it. Either way predict_state()
+    # must not propagate the failure to the run loop.
+    predict_state(
+        thread_id="t-1",
+        agent_name="agent",
+        run_id="run-1",
+        execution=execution,
+        event={"type": RuntimeEventTypes.ACTION_EXECUTION_ARGS, "args": '{"task": "line\\'},
+    )
+
+
+def test_partialjson_api_contract():
+    """The API predict_state() depends on, asserted directly against the dependency.
+
+    This is the tripwire for a future release inside `>=0.0.8,<2.0.0`: the range
+    admits versions that do not exist yet, and this is what notices if one of them
+    changes the constructor, the method, or the parse of a truncated object.
+    """
+    parser = JSONParser()
+
+    assert parser.parse(PAYLOAD) == ARGUMENTS
+    assert parser.parse('{"task": "wri') == {"task": "wri"}
+    assert parser.parse('{"steps": ["draft"') == {"steps": ["draft"]}
+    assert parser.parse("") == {}


### PR DESCRIPTION
## What does this PR do?

Follow-up to #6123, which relaxed `partialjson` to `>=0.0.8,<2.0.0` (issue #4131). Two loose ends from reviewing that change:

1. **`sdk-python/poetry.lock` was left invalid.** Any edit to the dependency table invalidates the lock's content-hash, so on current `main` a bare `poetry install` in `sdk-python` fails with `pyproject.toml changed significantly since poetry.lock was last generated`. Refreshed here.
2. **The parse path had zero test coverage.** `partialjson` has exactly one consumer — `JSONParser().parse(...)` at `copilotkit/runloop.py:306` — sitting inside a bare `except` that returns `None`. Every failure mode therefore degrades to "no predicted state was emitted", which nothing asserted. A widened range with no tripwire under it means a future release inside `<2.0.0` could regress streaming predicted state silently.

## Choices worth flagging

- **Refreshed the lock with Poetry 2.1.3**, the generator the lock itself names. Poetry 2.4.x rewrites the header and adds unrelated entries (~120 lines of churn); 2.1.3 keeps the diff to the hash.
- **Moved `partialjson` to 1.1.0 in the lock** (`poetry update partialjson`, 7 insertions) so CI exercises the version a fresh install now resolves, rather than the floor of the range.
- **Left `ag-ui-langgraph` at 0.0.42 on purpose.** A from-scratch resolve (deleting the lock rather than refreshing it) pulls 0.0.43, which fails four `test_intercepted_tool_call_events` tests on `AttributeError: 'LangGraphAGUIAgent' object has no attribute 'emit_raw_events'`. That latent break is worth its own issue; it is not addressed here.
- **Tests are version-agnostic about intermediate frames.** Values mid-stream legitimately differ across the allowed range — 1.1.0 preserves trailing whitespace inside a partially streamed string where 0.0.8 dropped it — so the assertions pin what the range must keep: a completed payload parses exactly, and a prefix yields a prefix.
- Not touched here: `examples/integrations/langgraph-{fastapi,python}/Dockerfile:50` still hardcode `"partialjson>=0.0.8,<0.0.9"`, a hand-copy of the old pin that keeps those two images on 0.0.8.

## Testing

**Lock validity — the actual bug, before and after**

Pristine `main` before #6123 was consistent; #6123's one-line edit is what broke it. Verified in a clean worktree:

```
# main + only the constraint edit
$ poetry check --lock
Error: pyproject.toml changed significantly since poetry.lock was last generated.
$ poetry install --with dev
Installing dependencies from lock file
pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock` to fix the lock file.

# with this PR's lock
$ poetry check --lock
(no error)
```

**CI simulated exactly** (`poetry lock && poetry install --with dev`, as in `test_unit-python-sdk.yml:54`):

```
resolved partialjson in venv: 1.1.0
locked ag-ui-langgraph: version = "0.0.42"
230 passed, 11 skipped, 18 warnings in 0.75s
```

225 were passing before; the 5 new tests are the difference.

**New tests pass on every version the range admits**

```
partialjson 0.0.8 -> 5 passed
partialjson 0.0.9 -> 5 passed
partialjson 0.1.0 -> 5 passed
partialjson 1.0.0 -> 5 passed
partialjson 1.1.0 -> 5 passed
```

**Mutation-checked, three ways** — the tests were confirmed to fail when the mechanism is broken, not merely to pass:

| Mutation to `JSONParser.parse` | Result |
| --- | --- |
| baseline (unmodified) | 5 passed |
| `raise RuntimeError` | 4 failed, 1 passed |
| return values with strings reversed | 3 failed, 2 passed |
| always return `{}` (the realistic silent regression) | 3 failed, 2 passed |

For contrast, the same "disable `parse` entirely" mutation against the pre-existing suite left **all 225 tests passing** — which is what motivated this file.

The one test that survives every mutation is `test_unterminated_escape_does_not_escape_predict_state`, by design: it asserts that a prefix older versions reject stays contained by the bare `except`, so a raising parser is the case it exists to tolerate.

**Behavioural evidence that 1.1.0 is safe in the lock** (from reviewing #6123): a differential fuzz over every prefix of 9 realistic streamed tool-call payloads, 1232 cases per version across 0.0.8 / 0.0.9 / 0.1.0 / 1.0.0 / 1.1.0 — zero parse-to-raise regressions on any version, 75 cases improve from raise to parse, all 9 complete payloads parse identically. Driving the real `predict_state()` at chunk sizes 1/3/7/20 gives a byte-identical final `predicted_state` on all five versions.