### PR TITLE
fix(react, vue): popup wrapper background masks rounded corners

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -209,7 +209,7 @@ function CopilotPopupViewInternal({
     <div
       data-copilotkit
       className={cn(
-        "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch",
+        "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent",
         "cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4",
       )}
     >

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotPopupView.wrapperBackground.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotPopupView.wrapperBackground.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Regression test: the popup positioning wrapper must not paint a background.
+ *
+ * The outer `[data-copilotkit]` wrapper inherits `background-color` from the
+ * default theme, but has no border-radius. The inner dialog uses `rounded-2xl`
+ * on desktop viewports. An opaque wrapper background bleeds through the inner
+ * dialog's rounded corners, making the popup appear rectangular on non-white
+ * host pages.
+ *
+ * Fix: the wrapper carries `cpk:bg-transparent` so only the inner dialog
+ * paints a background.
+ *
+ * This test renders a popup and asserts the outer wrapper includes the
+ * transparent background class while the inner dialog retains its own
+ * background.
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { AbstractAgent } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { Subject } from "rxjs";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotPopup } from "../CopilotPopup";
+
+class MockAgent extends AbstractAgent {
+  private subject = new Subject<BaseEvent>();
+  clone(): MockAgent {
+    const cloned = new MockAgent();
+    cloned.agentId = this.agentId;
+    (cloned as unknown as { subject: Subject<BaseEvent> }).subject =
+      this.subject;
+    return cloned;
+  }
+  async detachActiveRun(): Promise<void> {}
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return this.subject.asObservable();
+  }
+}
+
+describe("CopilotPopupView wrapper background", () => {
+  it("outer wrapper has transparent background, inner dialog has opaque background", () => {
+    const agent = new MockAgent();
+    const { container } = render(
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotPopup defaultOpen />
+      </CopilotKitProvider>,
+    );
+
+    const wrapper = container.querySelector("[data-copilotkit]");
+    expect(wrapper).toBeTruthy();
+    expect(wrapper!.className).toContain("cpk:bg-transparent");
+
+    const dialog = container.querySelector("[data-copilot-popup]");
+    expect(dialog).toBeTruthy();
+    expect(dialog!.className).toContain("cpk:bg-background");
+  });
+});

--- a/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
+++ b/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
@@ -366,7 +366,7 @@ onBeforeUnmount(() => {
   <div
     v-if="isRendered"
     data-copilotkit
-    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
+    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
   >
     <div
       ref="containerRef"


### PR DESCRIPTION
## Problem

The CopilotKit v2 popup renders inside a fixed outer wrapper carrying `data-copilotkit`. The default theme applies `background-color: var(--background)` to every `[data-copilotkit]` element.

The inner dialog has a 16px radius (`rounded-2xl`) on desktop viewports, but the outer wrapper has no radius. Because both elements share the same dimensions, the wrapper's opaque background bleeds through the inner dialog's rounded corners — making the popup appear as a sharp rectangle on any non-white host page.

## Root cause

The `[data-copilotkit]` selector in the default theme sets `background-color: var(--background)` on **all** scoped elements, including the positioning wrapper that should be purely structural. The wrapper has no `border-radius`, so its painted background is visible outside the inner dialog's rounded corners.

## Fix

Add `cpk:bg-transparent` to the outer positioning wrapper in both:
- **React**: `packages/react-core/src/v2/components/chat/CopilotPopupView.tsx`
- **Vue**: `packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue`

Angular is unaffected — its popup host already uses `display: contents`, which does not paint a background.

## Regression test

Added `CopilotPopupView.wrapperBackground.test.tsx` that renders a popup and asserts:
- The outer `[data-copilotkit]` wrapper includes `cpk:bg-transparent`
- The inner `[data-copilot-popup]` dialog retains `cpk:bg-background`

This prevents future theme changes from re-introducing the bleed-through.

## Test plan

- [ ] Render `CopilotPopupView` on a page with a dark/colored background
- [ ] Verify rounded corners are visible on desktop (>=768px) viewports
- [ ] Verify mobile (full-screen) layout is unaffected — wrapper is full-bleed, so transparency is a no-op
- [ ] Confirm Vue `CopilotPopupViewInternal` behaves identically
- [ ] Regression test passes: `vitest run CopilotPopupView.wrapperBackground`

Fixes #6472