### PR TITLE
fix(a2ui-renderer): convert Zod v4 catalog schemas instead of silently emptying them

### DIFF
--- a/packages/a2ui-renderer/package.json
+++ b/packages/a2ui-renderer/package.json
@@ -77,6 +77,7 @@
   },
   "dependencies": {
     "@a2ui/web_core": "0.10.4",
+    "@copilotkit/shared": "workspace:*",
     "clsx": "^2.1.1",
     "lit": "^3.3.2",
     "zod": "^3.25.75",

--- a/packages/a2ui-renderer/src/__tests__/catalog-schema.test.ts
+++ b/packages/a2ui-renderer/src/__tests__/catalog-schema.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { z as z3 } from "zod";
+import { catalogSchemaToJsonSchema } from "../catalog-schema";
+import { extractCatalogComponentSchemas as extractReactCatalogSchemas } from "../react-renderer/catalog-utils";
+
+/**
+ * A schema shaped like Zod v4, without adding a second copy of Zod to the
+ * workspace — an aliased `zod@4` devDependency re-resolves the `zod` peer of
+ * unrelated packages (openai, the @ag-ui/* family) across the whole monorepo.
+ *
+ * Faithful in the two respects this conversion depends on: v4 renamed
+ * `_def.typeName` to `_def.type`, which is the lookup `zodToJsonSchema` uses to
+ * recognise a schema, and v4 implements Standard JSON Schema V1. Passing this to
+ * `zodToJsonSchema` returns a bare `{ $schema }` — no `properties`, no
+ * `required`, and no error — exactly as a real v4 schema does.
+ */
+function zodV4Like() {
+  return {
+    _def: { type: "object" },
+    "~standard": {
+      version: 1,
+      vendor: "zod",
+      validate: (value: unknown) => ({ value }),
+      jsonSchema: {
+        input: () => ({
+          type: "object",
+          properties: {
+            filingId: { type: "string" },
+            status: { type: "string" },
+            risk: { type: "string" },
+          },
+          required: ["filingId", "status", "risk"],
+        }),
+      },
+    },
+  };
+}
+
+/**
+ * `@copilotkit/react-core` accepts `zod >= 3.0.0` as a peer dependency, so an
+ * application may legitimately build its A2UI catalog with Zod v4 while this
+ * package pins Zod v3 for its own catalog. `zodToJsonSchema` understands v3
+ * internals only and returns a bare `{ $schema }` for a v4 schema — no
+ * `properties`, no `required`, and no error — which silently strips every prop
+ * from the catalog the model is shown and leaves the surface unpaintable.
+ */
+describe("catalogSchemaToJsonSchema", () => {
+  const shape = {
+    filingId: "string",
+    status: "string",
+    risk: "string",
+  } as const;
+
+  it("converts a Zod v3 schema", () => {
+    const converted = catalogSchemaToJsonSchema(
+      z3.object({
+        filingId: z3.string(),
+        status: z3.string(),
+        risk: z3.string(),
+      }),
+      { target: "jsonSchema2019-09" },
+    ) as { properties?: Record<string, unknown>; required?: string[] };
+
+    expect(Object.keys(converted.properties ?? {})).toEqual(Object.keys(shape));
+    expect(converted.required).toEqual(Object.keys(shape));
+  });
+
+  it("converts a Zod v4 schema instead of silently dropping its props", () => {
+    const converted = catalogSchemaToJsonSchema(zodV4Like(), {
+      target: "jsonSchema2019-09",
+    }) as { properties?: Record<string, unknown>; required?: string[] };
+
+    expect(Object.keys(converted.properties ?? {})).toEqual(Object.keys(shape));
+    expect(converted.required).toEqual(Object.keys(shape));
+  });
+
+  it("converts any Standard JSON Schema V1 implementation", () => {
+    const jsonSchema = {
+      type: "object",
+      properties: { filingId: { type: "string" } },
+      required: ["filingId"],
+    };
+    const standardSchema = {
+      "~standard": {
+        version: 1,
+        vendor: "not-zod",
+        validate: (value: unknown) => ({ value }),
+        jsonSchema: { input: () => jsonSchema },
+      },
+    };
+
+    expect(catalogSchemaToJsonSchema(standardSchema)).toEqual(jsonSchema);
+  });
+
+  it("throws rather than returning an empty schema for an unconvertible schema", () => {
+    const opaque = {
+      "~standard": {
+        version: 1,
+        vendor: "mystery-lib",
+        validate: (value: unknown) => ({ value }),
+      },
+    };
+
+    expect(() => catalogSchemaToJsonSchema(opaque)).toThrow(/mystery-lib/);
+  });
+});
+
+const makeCatalog = (schema: unknown) =>
+  ({
+    id: "filing-tracker-catalog",
+    components: new Map([["FilingCard", { schema, render: () => null }]]),
+  }) as never;
+
+describe("extractCatalogComponentSchemas", () => {
+  it("keeps a Zod v4 component's props in the emitted catalog schema", () => {
+    const { catalogId, components } = extractReactCatalogSchemas(
+      makeCatalog(zodV4Like()),
+    );
+
+    expect(catalogId).toBe("filing-tracker-catalog");
+    const entry = components.FilingCard as {
+      allOf: Array<{
+        properties?: Record<string, unknown>;
+        required?: string[];
+      }>;
+    };
+    const [, shapeEntry] = entry.allOf;
+
+    // Without the conversion fix this is `["component"]` alone — the model is
+    // told the component exists but takes no props at all.
+    expect(Object.keys(shapeEntry.properties ?? {})).toEqual([
+      "component",
+      "filingId",
+      "status",
+      "risk",
+    ]);
+    expect(shapeEntry.required).toEqual([
+      "component",
+      "filingId",
+      "status",
+      "risk",
+    ]);
+  });
+});

--- a/packages/a2ui-renderer/src/catalog-schema.ts
+++ b/packages/a2ui-renderer/src/catalog-schema.ts
@@ -1,0 +1,61 @@
+import { schemaToJsonSchema } from "@copilotkit/shared";
+import type { StandardSchemaV1 } from "@copilotkit/shared";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+// `zodToJsonSchema` also accepts a bare name string; the catalog only ever passes
+// the options object, and narrowing to it keeps the merge below well-typed.
+type ZodToJsonSchemaOptions = Extract<
+  Parameters<typeof zodToJsonSchema>[1],
+  Record<string, unknown>
+>;
+
+function isStandardSchema(schema: unknown): schema is StandardSchemaV1 {
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "~standard" in schema &&
+    typeof (schema as { "~standard": unknown })["~standard"] === "object"
+  );
+}
+
+/**
+ * Convert a catalog component's props schema to JSON Schema.
+ *
+ * Catalogs are built from schemas the *application* supplies, so the schema
+ * library version is outside this package's control: `@copilotkit/react-core`
+ * accepts `zod >= 3.0.0` as a peer, while this package pins `zod ^3` for its own
+ * built-in catalog. `zodToJsonSchema` only understands Zod v3 internals and
+ * returns a bare `{ $schema }` — no `properties`, no `required`, and no error —
+ * for a Zod v4 schema. That silently strips every prop from the catalog the
+ * model is shown, so it emits components the renderer can never paint.
+ *
+ * Dispatch through `schemaToJsonSchema`, which prefers Standard JSON Schema V1
+ * (Zod v4, Valibot, ArkType), then a native `toJSONSchema()`, and only then the
+ * injected Zod v3 converter — and throws rather than returning something empty
+ * when it recognises nothing.
+ */
+export function catalogSchemaToJsonSchema(
+  schema: unknown,
+  options?: ZodToJsonSchemaOptions,
+): Record<string, unknown> {
+  // Zod v3 releases before 3.24 predate Standard Schema and carry no
+  // `~standard` marker, so `schemaToJsonSchema` cannot dispatch on them at all.
+  // Convert those directly to keep older-but-supported setups working.
+  if (!isStandardSchema(schema)) {
+    return zodToJsonSchema(
+      schema as Parameters<typeof zodToJsonSchema>[0],
+      options,
+    ) as Record<string, unknown>;
+  }
+
+  return schemaToJsonSchema(schema, {
+    // `schemaToJsonSchema` supplies `$refStrategy: "none"` so the model sees an
+    // inlined schema rather than dangling `$ref`s; the caller's `target` still
+    // wins, keeping the emitted dialect identical to the previous behaviour.
+    zodToJsonSchema: (zodSchema, injectedOptions) =>
+      zodToJsonSchema(zodSchema as Parameters<typeof zodToJsonSchema>[0], {
+        ...(injectedOptions as ZodToJsonSchemaOptions),
+        ...options,
+      }) as Record<string, unknown>,
+  });
+}

--- a/packages/a2ui-renderer/src/react-renderer/catalog-utils.ts
+++ b/packages/a2ui-renderer/src/react-renderer/catalog-utils.ts
@@ -1,6 +1,6 @@
 import { basicCatalog } from "./a2ui-react";
 import type { ComponentApi, Catalog } from "@a2ui/web_core/v0_9";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import { catalogSchemaToJsonSchema } from "../catalog-schema";
 
 const BASIC_CATALOG_ID =
   "https://a2ui.org/specification/v0_9/basic_catalog.json";
@@ -74,7 +74,7 @@ export function buildCatalogContextValue(
   for (const name of customNames) {
     const comp = resolved.components.get(name);
     if (!comp) continue;
-    const jsonSchema = zodToJsonSchema(comp.schema);
+    const jsonSchema = catalogSchemaToJsonSchema(comp.schema);
     lines.push(`  - ${name}:`);
     lines.push(
       `    ${JSON.stringify(jsonSchema, null, 2).split("\n").join("\n    ")}`,
@@ -116,7 +116,7 @@ export function extractCatalogComponentSchemas(
   const components: Record<string, Record<string, unknown>> = {};
 
   for (const [name, comp] of resolved.components) {
-    const zodSchema = zodToJsonSchema(comp.schema, {
+    const zodSchema = catalogSchemaToJsonSchema(comp.schema, {
       target: "jsonSchema2019-09",
     }) as { properties?: Record<string, unknown>; required?: string[] };
 

--- a/packages/a2ui-renderer/src/web-components/create-catalog.ts
+++ b/packages/a2ui-renderer/src/web-components/create-catalog.ts
@@ -1,8 +1,8 @@
 import type { z } from "zod";
-import type { ZodObject, ZodRawShape, ZodTypeAny } from "zod";
+import type { ZodObject, ZodRawShape } from "zod";
 import { Catalog } from "@a2ui/web_core/v0_9";
 import type { ComponentApi } from "@a2ui/web_core/v0_9";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import { catalogSchemaToJsonSchema } from "../catalog-schema";
 import { basicCatalog } from "./catalog/basic";
 import { createLitComponent } from "./adapter";
 import type {
@@ -173,9 +173,9 @@ function resolveCatalog(catalog?: unknown): CatalogContextValue {
 
 function toJsonSchema(
   schema: unknown,
-  options?: Parameters<typeof zodToJsonSchema>[1],
-): ReturnType<typeof zodToJsonSchema> {
-  return zodToJsonSchema(schema as ZodTypeAny, options);
+  options?: Parameters<typeof catalogSchemaToJsonSchema>[1],
+): Record<string, unknown> {
+  return catalogSchemaToJsonSchema(schema, options);
 }
 
 function extendsBasicCatalog(catalog: CatalogContextValue): boolean {

--- a/packages/vue/src/v2/components/a2ui/A2UICatalogContext.ts
+++ b/packages/vue/src/v2/components/a2ui/A2UICatalogContext.ts
@@ -5,9 +5,55 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import {
   A2UI_DEFAULT_GENERATION_GUIDELINES,
   A2UI_DEFAULT_DESIGN_GUIDELINES,
+  schemaToJsonSchema,
 } from "@copilotkit/shared";
+import type { StandardSchemaV1 } from "@copilotkit/shared";
 import type { CopilotKitCoreVue } from "../../lib/vue-core";
 import { vueBasicCatalog } from "./catalog";
+
+/**
+ * Convert a catalog component's props schema to JSON Schema.
+ *
+ * Mirrors `catalogSchemaToJsonSchema` in @copilotkit/a2ui-renderer, duplicated
+ * here rather than imported for the same reason as the schema-context constant
+ * below: importing it would pull React into the Vue package.
+ * `zodToJsonSchema` understands Zod v3 internals only and returns a bare
+ * `{ $schema }` — no `properties`, no error — for the Zod v4 schemas an
+ * application may legitimately build its catalog from, which silently strips
+ * every prop from the catalog the model is shown.
+ */
+type ZodToJsonSchemaOptions = Extract<
+  Parameters<typeof zodToJsonSchema>[1],
+  Record<string, unknown>
+>;
+
+function toCatalogJsonSchema(
+  schema: unknown,
+  options?: ZodToJsonSchemaOptions,
+): Record<string, unknown> {
+  const isStandardSchema =
+    typeof schema === "object" &&
+    schema !== null &&
+    "~standard" in schema &&
+    typeof (schema as { "~standard": unknown })["~standard"] === "object";
+
+  // Zod v3 releases before 3.24 predate Standard Schema, so there is nothing
+  // for `schemaToJsonSchema` to dispatch on — convert those directly.
+  if (!isStandardSchema) {
+    return zodToJsonSchema(
+      schema as Parameters<typeof zodToJsonSchema>[0],
+      options,
+    ) as Record<string, unknown>;
+  }
+
+  return schemaToJsonSchema(schema as StandardSchemaV1, {
+    zodToJsonSchema: (zodSchema, injectedOptions) =>
+      zodToJsonSchema(zodSchema as Parameters<typeof zodToJsonSchema>[0], {
+        ...(injectedOptions as ZodToJsonSchemaOptions),
+        ...options,
+      }) as Record<string, unknown>,
+  });
+}
 
 /**
  * Context description used to identify the A2UI component schema in
@@ -68,7 +114,7 @@ function buildCatalogContextValue(catalog?: Catalog<ComponentApi>): string {
   for (const name of customNames) {
     const comp = resolved.components.get(name);
     if (!comp) continue;
-    const jsonSchema = zodToJsonSchema(comp.schema);
+    const jsonSchema = toCatalogJsonSchema(comp.schema);
     lines.push(`  - ${name}:`);
     lines.push(
       `    ${JSON.stringify(jsonSchema, null, 2).split("\n").join("\n    ")}`,
@@ -90,7 +136,7 @@ function extractCatalogComponentSchemas(catalog?: Catalog<ComponentApi>): {
   const components: Record<string, Record<string, unknown>> = {};
 
   for (const [name, comp] of resolved.components) {
-    const zodSchema = zodToJsonSchema(comp.schema, {
+    const zodSchema = toCatalogJsonSchema(comp.schema, {
       target: "jsonSchema2019-09",
     }) as { properties?: Record<string, unknown>; required?: string[] };
 

--- a/packages/vue/src/v2/components/a2ui/__tests__/A2UICatalogContext.test.ts
+++ b/packages/vue/src/v2/components/a2ui/__tests__/A2UICatalogContext.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { shallowRef } from "vue";
+import { z as z3 } from "zod";
+import { registerA2UICatalogContext } from "../A2UICatalogContext";
+import type { CopilotKitCoreVue } from "../../../lib/vue-core";
+
+/**
+ * A schema shaped like Zod v4, without adding a second copy of Zod to the
+ * workspace — an aliased `zod@4` devDependency re-resolves the `zod` peer of
+ * unrelated packages across the whole monorepo.
+ *
+ * Faithful in the two respects this conversion depends on: v4 renamed
+ * `_def.typeName` to `_def.type`, which is the lookup `zodToJsonSchema` uses to
+ * recognise a schema, and v4 implements Standard JSON Schema V1. Passing this to
+ * `zodToJsonSchema` returns a bare `{ $schema }` — no `properties`, no
+ * `required`, and no error — exactly as a real v4 schema does.
+ */
+function zodV4Like() {
+  return {
+    _def: { type: "object" },
+    "~standard": {
+      version: 1,
+      vendor: "zod",
+      validate: (value: unknown) => ({ value }),
+      jsonSchema: {
+        input: () => ({
+          type: "object",
+          properties: {
+            filingId: { type: "string" },
+            status: { type: "string" },
+            risk: { type: "string" },
+          },
+          required: ["filingId", "status", "risk"],
+        }),
+      },
+    },
+  };
+}
+
+/**
+ * An application may build its A2UI catalog with Zod v4 while this package pins
+ * Zod v3. `zodToJsonSchema` understands v3 internals only and returns a bare
+ * `{ $schema }` for a v4 schema — no `properties`, no error — which silently
+ * strips every prop from the catalog schema the model is shown.
+ */
+interface RegisteredContext {
+  description: string;
+  value: string;
+}
+
+function collectRegisteredContext(catalog: unknown): RegisteredContext[] {
+  const registered: RegisteredContext[] = [];
+  const core = {
+    a2uiAgents: undefined,
+    addContext: (entry: RegisteredContext) => {
+      registered.push(entry);
+      return `ctx-${registered.length}`;
+    },
+    removeContext: () => {},
+  };
+
+  registerA2UICatalogContext(
+    shallowRef(core) as unknown as ReturnType<
+      typeof shallowRef<CopilotKitCoreVue>
+    >,
+    {
+      enabled: () => true,
+      catalog: () => catalog as never,
+      includeSchema: () => true,
+    },
+  );
+
+  return registered;
+}
+
+function filingCardSchemaFor(catalog: unknown) {
+  const schemaEntry = collectRegisteredContext(catalog).find((entry) =>
+    entry.description.startsWith("A2UI Component Schema"),
+  );
+  expect(schemaEntry, "schema context was never registered").toBeDefined();
+
+  const parsed = JSON.parse(schemaEntry!.value) as {
+    components: Record<
+      string,
+      {
+        allOf: Array<{
+          properties?: Record<string, unknown>;
+          required?: string[];
+        }>;
+      }
+    >;
+  };
+  return parsed.components.FilingCard.allOf[1];
+}
+
+const makeCatalog = (schema: unknown) => ({
+  id: "filing-tracker-catalog",
+  components: new Map([["FilingCard", { schema, render: () => null }]]),
+});
+
+describe("registerA2UICatalogContext", () => {
+  const expectedProps = ["component", "filingId", "status", "risk"];
+
+  it("keeps a Zod v3 component's props in the emitted catalog schema", () => {
+    const shape = filingCardSchemaFor(
+      makeCatalog(
+        z3.object({
+          filingId: z3.string(),
+          status: z3.string(),
+          risk: z3.string(),
+        }),
+      ),
+    );
+
+    expect(Object.keys(shape.properties ?? {})).toEqual(expectedProps);
+    expect(shape.required).toEqual(expectedProps);
+  });
+
+  it("keeps a Zod v4 component's props in the emitted catalog schema", () => {
+    const shape = filingCardSchemaFor(makeCatalog(zodV4Like()));
+
+    // Without the conversion fix this is `["component"]` alone — the model is
+    // told the component exists but takes no props at all.
+    expect(Object.keys(shape.properties ?? {})).toEqual(expectedProps);
+    expect(shape.required).toEqual(expectedProps);
+  });
+});


### PR DESCRIPTION
Fixes #6526.

## The problem

A2UI catalogs are built from schemas the *application* supplies, so the schema library version is outside these packages' control: `@copilotkit/react-core` accepts `zod >= 3.0.0` as a peer, while `a2ui-renderer` pins `zod ^3` for its own built-in catalog. The catalog code converted those schemas with `zodToJsonSchema`, which reads `_def.typeName` to recognise a schema. Zod v4 renamed that to `_def.type`, so a v4 schema converts to a bare `{ $schema }` — no `properties`, no `required`, and **no error**:

| | `properties` sent to the model | `required` |
|---|---|---|
| Zod v3 | `component`, `filingId`, `status`, `risk` | all four |
| **Zod v4** | **`component` only** | **`["component"]`** |

So the model is told the component exists and takes no props at all. It cannot emit a component the renderer can paint, the surface never resolves past its "Building interface" skeleton, and the run completes clean with nothing to point at. The reporter is on `zod@4.4.3`.

Five call sites were affected: two in `web-components/create-catalog.ts` (via its `toJsonSchema` wrapper), two in `react-renderer/catalog-utils.ts`, and two in the Vue package, which carries its own copy of the catalog-context logic to avoid pulling React in.

## The fix

Route conversion through `schemaToJsonSchema` from `@copilotkit/shared` — the dispatcher that already backs `BuiltInAgent`'s tool conversion. It prefers Standard JSON Schema V1 (Zod v4, Valibot, ArkType), then a native `toJSONSchema()`, then the injected Zod v3 converter, and **throws** rather than returning something empty when it recognises nothing.

Two deliberate details:

- Zod v3 releases before 3.24 predate Standard Schema and carry no `~standard` marker for the dispatcher to read, so those keep converting directly.
- On the v3 path the caller's `target` is merged over the `$refStrategy: "none"` that `shared` injects, so the emitted dialect is unchanged from today rather than shifting what the model sees.

Vue gets a small local mirror rather than a dependency on `a2ui-renderer`, for the same reason the schema-context constant is already duplicated there — importing it would pull React into the Vue package. Happy to restructure if you'd rather share it another way.

## Tests

Both packages get a regression test. Reverting just the source and re-running fails exactly one case in each, with the reported symptom:

```
× keeps a Zod v4 component's props in the emitted catalog schema
  → expected [ 'component' ] to deeply equal [ 'component', 'filingId', …(2) ]
```

The tests use a schema *shaped* like Zod v4 rather than a second copy of Zod. I first tried an aliased `zod@4` devDependency and backed it out: it re-resolved the `zod` peer of unrelated packages (openai, the `@ag-ui/*` family) from 3.25.76 to 4.4.3 across 51 lockfile entries. The fixture is faithful in the two respects the conversion depends on — `_def.type` instead of `_def.typeName`, and Standard JSON Schema V1 — and reproduces the identical silent `{ $schema }` result. This PR touches no lockfile.

## Verification

- `a2ui-renderer`: 27/27 tests, `tsc --noEmit` clean, `tsdown` build succeeds with the new workspace dependency.
- `vue`: 1074/1074 tests. `tsc` reports 29 errors both with and without this change — pre-existing, unrelated.
- `oxlint` clean on all changed files (one warning in `catalog-utils.ts` is pre-existing on `main`); `oxfmt --check` clean.
- No `.changeset/` file, per CONTRIBUTING.

## One thing I could not explain

The reporter says requesting generic `Card` / `Row` / `Text` also failed. Those come from the built-in catalog, built with this package's own Zod 3, so they convert correctly either way — this fix does not account for that leg, and I'd rather flag it than overclaim. It may be that the agent `instructions` kept steering the model to `FilingCard`, or that one invalid component fails the whole surface paint, but I haven't verified either.

Related: I could not reproduce the end-to-end flow (it needs a live model), so the chain from "empty prop schema" to "skeleton never paints" is read from the code rather than observed. The schema corruption itself is directly demonstrated by the tests.

Worth noting for triage: the `BuiltInAgent`-specific theory in the issue thread looks like a dead end. `AbstractAgent` provides `use()`, the in-memory runner goes through `agent.runAgent()` where the middleware chain is folded in, and `BuiltInAgent.run()` reads both `input.tools` and `input.context` — so the A2UI middleware does attach and the injected `render_a2ui` tool does reach the model. Also, since the "Building interface" skeleton is only rendered from an `a2ui-surface` activity, at least one `ACTIVITY_SNAPSHOT` must have arrived, contrary to the report.
