### PR TITLE
fix(showcase): drop inline langgraph-ts heap cap that forced OOM restarts

### DIFF
--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -398,18 +398,8 @@ export LANGGRAPH_DISABLE_FILE_PERSISTENCE=true
 # server it forks (the server is a DESCENDANT, reached only via the tree-kill —
 # see the file header and _kill_agent_tree).  Never `kill $AGENT_PID` directly:
 # that reaps only the wrapper subshell and orphans the real server on :8123.
-# Cap the agent's V8 heap. The @langchain/langgraph-api server is the long-lived
-# process whose old-space drifts unbounded on the many-core Railway host (no
-# cgroup limit → V8 auto-sizes old-space to physical RAM, several GB). Cap it to
-# 1536 MB so steady-state RSS stays bounded. Scoped INLINE to this npm invocation
-# — NOT a global `export` — on purpose: a global NODE_OPTIONS would also cap the
-# `next start` node below, and starving the Next.js frontend (which serves the
-# showcase under D6 probe fan-out) risks its own OOM. Only the agent needs the
-# cap. `${NODE_OPTIONS:+$NODE_OPTIONS }` safe-appends so an explicit Railway
-# NODE_OPTIONS override still applies (and wins on duplicate flags — V8 takes the
-# last --max-old-space-size).
 echo "[entrypoint] Starting LangGraph TS agent on port 8123 (prod mode, no CLI)..."
-cd /app/src/agent && PORT=8123 HOST=0.0.0.0 NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=1536" npm start &> >(awk '{print "[agent] " $0; fflush()}') &
+cd /app/src/agent && PORT=8123 HOST=0.0.0.0 npm start &> >(awk '{print "[agent] " $0; fflush()}') &
 AGENT_PID=$!
 cd /app
 sleep 3


### PR DESCRIPTION
## Problem

PR #6505 added an inline `NODE_OPTIONS="--max-old-space-size=1536"` to the `langgraph-typescript` agent launch in `showcase/integrations/langgraph-typescript/entrypoint.sh`, intending to bound V8 old-space on the many-core Railway host.

In staging this cap is forcing crash-restarts, not delivering savings. Staging `showcase-langgraph-typescript` hit a V8 heap-OOM `exit 134` at `2026-08-18T09:52:31Z` (RSS dropped `2.289 GB -> 0.902 GB` on the crash-reset).

The cap is also structurally un-overridable. It's appended as `${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=1536`, so it is always the *last* `--max-old-space-size` flag on the command line — and V8 takes the last flag when the same one repeats. An operator-supplied `NODE_OPTIONS` override therefore always loses to the inline `1536`, so a Railway env var can't raise the ceiling for this process; only another code change can.

## Change

Removes only the inline `--max-old-space-size=1536` addition (and its now-stale explanatory comment) from `entrypoint.sh`, restoring the exact pre-#6505 launch line:

```
cd /app/src/agent && PORT=8123 HOST=0.0.0.0 npm start &> >(awk '{print "[agent] " $0; fflush()}') &
```

`NODE_OPTIONS` now passes through untouched — an operator override wins again, and with no `NODE_OPTIONS` set V8 falls back to its own default sizing (pre-#6505 behavior).

Untouched, by design:
- Worker-recycle logic in the same entrypoint
- `langgraph-python` / `langgraph-fastapi` entrypoints and their `MALLOC_ARENA_MAX` / `MALLOC_TRIM_THRESHOLD_` allocator tuning (also from #6505)

`git diff --stat` confirms the diff is scoped to exactly one file:
```
showcase/integrations/langgraph-typescript/entrypoint.sh | 12 +-----------
1 file changed, 1 insertion(+), 11 deletions(-)
```

## Local red-green proof

Reconstructed the NODE_OPTIONS composition with plain `node` (v25.8.0 — absolute MiB numbers will vary by machine/Node version, but the *ordering*, which is the defect, will not):

**RED — current (pre-fix) launch, operator override lost:**
```
NODE_OPTIONS="--max-old-space-size=3072 --max-old-space-size=1536" \
  node -e 'console.log(require("v8").getHeapStatistics().heap_size_limit/1048576)'
=> 1728
```
The operator asked for a 3072 MiB ceiling and got capped to 1728 — well below what was requested, and the source of the crash-restart loop.

**GREEN 1/2 — fix applied, operator override now wins:**
```
NODE_OPTIONS="--max-old-space-size=3072" \
  node -e 'console.log(require("v8").getHeapStatistics().heap_size_limit/1048576)'
=> 3264
```

**GREEN 2/2 — fix applied, no NODE_OPTIONS set, V8 default restored (pre-#6505 behavior):**
```
node -e 'console.log(require("v8").getHeapStatistics().heap_size_limit/1048576)'
=> 4288
```

## Post-merge validation gate

This PR does not attempt to prove the fix in production. Before this is considered validated, it needs a **24h+ re-soak on a pinned image digest** of the `showcase-langgraph-typescript` service to confirm the OOM/exit-134 crash-restart loop is gone under real traffic.

Ref: #6505
