### PR TITLE
fix(release): collect commit bodies so breaking-change footers reach release notes

### DIFF
--- a/scripts/release/generate-ai-release-notes.ts
+++ b/scripts/release/generate-ai-release-notes.ts
@@ -25,7 +25,7 @@ import { createReleaseDraft } from "./lib/notion.js";
 function getRecentCommits(count = 50): string {
   const result = spawnSync(
     "git",
-    ["log", "--oneline", `-${count}`, "--no-merges"],
+    ["log", `-${count}`, "--no-merges", "--format=%h%x09%s%x09%b"],
     { cwd: ROOT, encoding: "utf8" },
   );
   return result.stdout.trim();
@@ -101,7 +101,7 @@ Here is the raw changelog extracted from git history:
 
 ${rawChangelog}
 
-Here are the recent git commits for additional context:
+Here are the recent git commits (hash, subject, body) for additional context:
 
 ${recentCommits}
 

--- a/scripts/release/lib/changes.test.ts
+++ b/scripts/release/lib/changes.test.ts
@@ -16,7 +16,10 @@ function mockGitHistory(): void {
     }
 
     if (args[0] === "log") {
-      return { stdout: "abc1234 feat(channels): shared release\n" };
+      return {
+        stdout:
+          "abc1234\tfeat(channels): shared release\tSome detail about the release\n",
+      };
     }
 
     throw new Error(`unexpected git arguments: ${args.join(" ")}`);
@@ -49,7 +52,7 @@ describe("Channels release history", () => {
         "channels/v0.1.1..HEAD",
         "--oneline",
         "--no-merges",
-        "--format=%H %s",
+        "--format=%H%x09%s%x09%b",
       ],
       expect.any(Object),
     );

--- a/scripts/release/lib/changes.ts
+++ b/scripts/release/lib/changes.ts
@@ -33,6 +33,7 @@ export function getLastReleaseTag(scope: ReleaseScope): string | null {
 export interface Commit {
   hash: string;
   subject: string;
+  body: string;
 }
 
 function getCommitsSince(lastTag: string | null): Commit[] {
@@ -40,7 +41,7 @@ function getCommitsSince(lastTag: string | null): Commit[] {
 
   const result = spawnSync(
     "git",
-    ["log", range, "--oneline", "--no-merges", "--format=%H %s"],
+    ["log", range, "--oneline", "--no-merges", "--format=%H%x09%s%x09%b"],
     { cwd: ROOT, encoding: "utf8" },
   );
 
@@ -49,10 +50,20 @@ function getCommitsSince(lastTag: string | null): Commit[] {
     .split("\n")
     .filter(Boolean)
     .map((line) => {
-      const spaceIdx = line.indexOf(" ");
+      const firstTab = line.indexOf("\t");
+      const secondTab = line.indexOf("\t", firstTab + 1);
+      const hash = line.slice(0, firstTab);
+      if (secondTab === -1) {
+        return {
+          hash,
+          subject: line.slice(firstTab + 1),
+          body: "",
+        };
+      }
       return {
-        hash: line.slice(0, spaceIdx),
-        subject: line.slice(spaceIdx + 1),
+        hash,
+        subject: line.slice(firstTab + 1, secondTab),
+        body: line.slice(secondTab + 1),
       };
     });
 }

--- a/scripts/release/lib/release-notes.test.ts
+++ b/scripts/release/lib/release-notes.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractBreakingChangeNotes,
+  generateRawReleaseNotes,
+} from "./release-notes.js";
+import type { ChangesSummary } from "./changes.js";
+
+const summary = (commits: ChangesSummary["commits"]): ChangesSummary => ({
+  lastTag: "v1.0.0",
+  commitCount: commits.length,
+  commits,
+  oneline: commits.map((c) => `- ${c.subject}`).join("\n"),
+});
+
+describe("extractBreakingChangeNotes", () => {
+  it("extracts the BREAKING CHANGE footer paragraph", () => {
+    const notes = extractBreakingChangeNotes({
+      hash: "abc1234",
+      subject: "refactor(react-native)!: RenderToolProps args type",
+      body: "Migration guidance.\n\nBREAKING CHANGE: RenderToolProps `args` becomes `Partial<T>` on the in-progress arm, so a renderer reading `args.foo` without narrowing on `status` now fails `check-types` with TS18048.\n\nCo-authored-by: someone <s@example.com>\nRefs: #6438",
+    });
+
+    expect(notes).toEqual([
+      "RenderToolProps `args` becomes `Partial<T>` on the in-progress arm, so a renderer reading `args.foo` without narrowing on `status` now fails `check-types` with TS18048.",
+    ]);
+  });
+
+  it("supports the BREAKING-CHANGE variant and continuation lines", () => {
+    expect(
+      extractBreakingChangeNotes({
+        hash: "x",
+        subject: "s",
+        body: "BREAKING-CHANGE: same semantics\nsecond line of the note",
+      }),
+    ).toEqual(["same semantics\nsecond line of the note"]);
+  });
+
+  it("returns nothing when there is no footer", () => {
+    expect(
+      extractBreakingChangeNotes({
+        hash: "x",
+        subject: "fix(channels): typo",
+        body: "just a fix",
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores the marker when it is not at the start of a line", () => {
+    expect(
+      extractBreakingChangeNotes({
+        hash: "x",
+        subject: "s",
+        body: "note: BREAKING CHANGE: not a footer",
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("generateRawReleaseNotes", () => {
+  it("renders a Breaking Changes section from commit bodies", () => {
+    const notes = generateRawReleaseNotes(
+      "1.1.0",
+      "monorepo",
+      summary([
+        {
+          hash: "abc1234",
+          subject: "refactor(react-native)!: RenderToolProps args type",
+          body: "BREAKING CHANGE: RenderToolProps `args` becomes `Partial<T>` on the in-progress arm.",
+        },
+        {
+          hash: "def5678",
+          subject: "feat(channels): shared release",
+          body: "Some detail",
+        },
+      ]),
+    );
+
+    expect(notes).toContain("### Features");
+    expect(notes).toContain("- feat(channels): shared release (def5678)");
+    expect(notes).toContain("### Breaking Changes");
+    expect(notes).toContain(
+      "- RenderToolProps `args` becomes `Partial<T>` on the in-progress arm.",
+    );
+  });
+
+  it("keeps prior behavior when no commit has a breaking footer", () => {
+    const notes = generateRawReleaseNotes(
+      "1.1.0",
+      "monorepo",
+      summary([
+        {
+          hash: "abc1234",
+          subject: "fix(channels): typo",
+          body: "",
+        },
+      ]),
+    );
+
+    expect(notes).toContain("### Fixes");
+    expect(notes).not.toContain("### Breaking Changes");
+  });
+});

--- a/scripts/release/lib/release-notes.ts
+++ b/scripts/release/lib/release-notes.ts
@@ -1,0 +1,79 @@
+import type { ChangesSummary, Commit } from "./changes.js";
+import type { ReleaseScope } from "./config.js";
+
+const BREAKING_CHANGE_MARKER = /^BREAKING[ -]CHANGE:\s*/m;
+
+export function extractBreakingChangeNotes(commit: Commit): string[] {
+  const match = BREAKING_CHANGE_MARKER.exec(commit.body);
+  if (!match) return [];
+
+  const lines = commit.body.slice(match.index).split(/\r?\n/);
+  const paragraph: string[] = [lines[0].replace(BREAKING_CHANGE_MARKER, "")];
+  for (const line of lines.slice(1)) {
+    // Stop at the next footer/trailer (e.g. Co-authored-by, Refs).
+    if (/^[A-Za-z][A-Za-z-]*:/.test(line)) break;
+    paragraph.push(line.trimEnd());
+  }
+
+  const note = paragraph.join("\n").trim();
+  return note.length > 0 ? [note] : [];
+}
+
+export function generateRawReleaseNotes(
+  version: string,
+  scope: ReleaseScope,
+  summary: ChangesSummary,
+): string {
+  const lines: string[] = [];
+  const label = scope === "monorepo" ? "" : ` (${scope})`;
+  lines.push(`## v${version}${label}`, "");
+
+  if (summary.commits.length === 0) {
+    lines.push("No changes since last release.");
+    return lines.join("\n");
+  }
+
+  const features: Commit[] = [];
+  const fixes: Commit[] = [];
+  const other: Commit[] = [];
+
+  for (const c of summary.commits) {
+    if (/^feat[:(]/.test(c.subject)) features.push(c);
+    else if (/^fix[:(]/.test(c.subject)) fixes.push(c);
+    else other.push(c);
+  }
+
+  if (features.length > 0) {
+    lines.push("### Features", "");
+    for (const c of features)
+      lines.push(`- ${c.subject} (${c.hash.slice(0, 7)})`);
+    lines.push("");
+  }
+
+  if (fixes.length > 0) {
+    lines.push("### Fixes", "");
+    for (const c of fixes) lines.push(`- ${c.subject} (${c.hash.slice(0, 7)})`);
+    lines.push("");
+  }
+
+  if (other.length > 0) {
+    lines.push("### Other Changes", "");
+    for (const c of other) lines.push(`- ${c.subject} (${c.hash.slice(0, 7)})`);
+    lines.push("");
+  }
+
+  const breakingChanges = summary.commits.flatMap(extractBreakingChangeNotes);
+  if (breakingChanges.length > 0) {
+    lines.push("### Breaking Changes", "");
+    for (const note of breakingChanges) {
+      const noteLines = note.split(/\r?\n/);
+      lines.push(`- ${noteLines[0]}`);
+      for (const continuation of noteLines.slice(1)) {
+        lines.push(`  ${continuation}`);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/scripts/release/prepare-release.ts
+++ b/scripts/release/prepare-release.ts
@@ -15,55 +15,9 @@ import {
 } from "./lib/versions.js";
 import type { BumpLevel } from "./lib/versions.js";
 import { getChangesSummary } from "./lib/changes.js";
-import type { ChangesSummary, Commit } from "./lib/changes.js";
+import { generateRawReleaseNotes } from "./lib/release-notes.js";
 import { ROOT, loadConfig } from "./lib/config.js";
 import type { ReleaseScope } from "./lib/config.js";
-
-function generateRawReleaseNotes(
-  version: string,
-  scope: ReleaseScope,
-  summary: ChangesSummary,
-): string {
-  const lines: string[] = [];
-  const label = scope === "monorepo" ? "" : ` (${scope})`;
-  lines.push(`## v${version}${label}`, "");
-
-  if (summary.commits.length === 0) {
-    lines.push("No changes since last release.");
-    return lines.join("\n");
-  }
-
-  const features: Commit[] = [];
-  const fixes: Commit[] = [];
-  const other: Commit[] = [];
-
-  for (const c of summary.commits) {
-    if (/^feat[:(]/.test(c.subject)) features.push(c);
-    else if (/^fix[:(]/.test(c.subject)) fixes.push(c);
-    else other.push(c);
-  }
-
-  if (features.length > 0) {
-    lines.push("### Features", "");
-    for (const c of features)
-      lines.push(`- ${c.subject} (${c.hash.slice(0, 7)})`);
-    lines.push("");
-  }
-
-  if (fixes.length > 0) {
-    lines.push("### Fixes", "");
-    for (const c of fixes) lines.push(`- ${c.subject} (${c.hash.slice(0, 7)})`);
-    lines.push("");
-  }
-
-  if (other.length > 0) {
-    lines.push("### Other Changes", "");
-    for (const c of other) lines.push(`- ${c.subject} (${c.hash.slice(0, 7)})`);
-    lines.push("");
-  }
-
-  return lines.join("\n");
-}
 
 // Valid scopes come from release.config.json — the single source of truth.
 const VALID_SCOPES = Object.keys(loadConfig().scopes);


### PR DESCRIPTION
## What

`BREAKING CHANGE:` footers never reach release notes. The commit collector reads subjects only, so migration guidance and breaking-change details written in commit footers are silently discarded before the release-notes step sees them.

## Why

This repo migrated off Changesets to conventional-commit-driven releases, and changeset files were the artifact that carried migration prose. With footers unread, the repo currently has no channel from commit to release notes except the 72-character subject line.

## How

- `scripts/release/lib/changes.ts`: widened the collector format from `--format=%H %s` to `--format=%H%x09%s%x09%b` so commit bodies (and `BREAKING CHANGE:`/`BREAKING-CHANGE:` footers) are captured. `Commit` gains a `body` field; parsing handles commits without a body.
- `scripts/release/lib/release-notes.ts` (new): `generateRawReleaseNotes` moved here from `prepare-release.ts` and now renders a `### Breaking Changes` section from extracted footer paragraphs (stops at the next footer/trailer such as `Co-authored-by:`).
- `scripts/release/generate-ai-release-notes.ts`: recent commits fed to the release-notes generator now include bodies (`%h%x09%s%x09%b`), so the model sees migration details.
- Tests: `scripts/release/lib/release-notes.test.ts` (new) + updated `changes.test.ts` for the new format string.

Fixes #6479