### PR TITLE
fix(react-core): repoint v1 getContextString onto the v2 context store

### DIFF
--- a/packages/react-core/src/components/copilot-provider/__tests__/v1-readable-context-bridge.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/v1-readable-context-bridge.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CopilotKit } from "../copilotkit";
+import { useCopilotContext } from "../../../context/copilot-context";
+import { useCopilotReadable } from "../../../hooks/use-copilot-readable";
+
+/**
+ * Writer: registers context through useCopilotReadable, which writes into the
+ * v2 context store (via the v2 provider the v1 <CopilotKit> wraps internally).
+ */
+function ReadableWriter() {
+  useCopilotReadable({
+    description: "The user's name",
+    value: "Ada Lovelace",
+  });
+  return null;
+}
+
+/**
+ * Reader: reads through the v1 context surface on demand — exactly what
+ * CopilotTask, the dev-console and CopilotTextarea autosuggestions do.
+ */
+function ContextReader() {
+  const { getContextString } = useCopilotContext();
+  const [result, setResult] = React.useState("");
+  return (
+    <>
+      <button data-testid="read" onClick={() => setResult(getContextString([], []))}>
+        read
+      </button>
+      <div data-testid="contextString">{result}</div>
+    </>
+  );
+}
+
+/**
+ * Regression coverage for #6408: useCopilotReadable was repointed onto the
+ * v2 context store, but the v1 <CopilotKit> bridge's getContextString kept
+ * reading the v1 context tree — which has no writers anymore — so CopilotTask
+ * and CopilotTextarea autosuggestions shipped an empty ("\n\n") context.
+ */
+describe("v1 <CopilotKit> bridge → readable context", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("exposes useCopilotReadable entries through getContextString", () => {
+    render(
+      <CopilotKit publicApiKey="test-key">
+        <ReadableWriter />
+        <ContextReader />
+      </CopilotKit>,
+    );
+
+    act(() => {
+      screen.getByTestId("read").click();
+    });
+
+    const contextString = screen.getByTestId("contextString").textContent;
+    expect(contextString).toContain("The user's name:");
+    expect(contextString).toContain('"Ada Lovelace"');
+  });
+
+  it("clears the context string after the readable unmounts", () => {
+    function Toggle() {
+      const [mounted, setMounted] = React.useState(true);
+      return (
+        <>
+          <button data-testid="toggle" onClick={() => setMounted(!mounted)}>
+            toggle
+          </button>
+          {mounted ? <ReadableWriter /> : null}
+          <ContextReader />
+        </>
+      );
+    }
+
+    render(
+      <CopilotKit publicApiKey="test-key">
+        <Toggle />
+      </CopilotKit>,
+    );
+
+    act(() => {
+      screen.getByTestId("read").click();
+    });
+    expect(screen.getByTestId("contextString").textContent).toContain(
+      "The user's name:",
+    );
+
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+    act(() => {
+      screen.getByTestId("read").click();
+    });
+
+    expect(screen.getByTestId("contextString").textContent).toBe("\n\n");
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -207,7 +207,9 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
     coAgentStateRenders: {},
   });
 
-  const { addElement, removeElement, printTree, getAllElements } = useTree();
+  const { copilotkit } = useCopilotKit();
+
+  const { addElement, removeElement, getAllElements } = useTree();
   const [isLoading, setIsLoading] = useState(false);
   const [chatInstructions, setChatInstructions] = useState("");
   const [authStates, setAuthStates] = useState<Record<string, AuthState>>({});
@@ -241,18 +243,20 @@ export function CopilotKitInternal(cpkProps: CopilotKitProps) {
   }, []);
 
   const getContextString = useCallback(
-    (documents: DocumentPointer[], categories: string[]) => {
+    (documents: DocumentPointer[], _categories: string[]) => {
       const documentsString = documents
         .map((document) => {
           return `${document.name} (${document.sourceApplication}):\n${document.getContents()}`;
         })
         .join("\n\n");
 
-      const nonDocumentStrings = printTree(categories);
+      const contextString = Object.values(copilotkit.context)
+        .map((entry) => `${entry.description}:\n${entry.value}`)
+        .join("\n\n");
 
-      return `${documentsString}\n\n${nonDocumentStrings}`;
+      return `${documentsString}\n\n${contextString}`;
     },
-    [printTree],
+    [copilotkit],
   );
 
   const addContext = useCallback(


### PR DESCRIPTION
## What

Fixes #6408 (readable context missing from v1 context readers).

`useCopilotReadable` was repointed onto the v2 context store (via `copilotkit.addContext`), but the v1 `<CopilotKit>` bridge's `getContextString` kept reading the v1 context tree — which has no writers anymore. Every v1 reader that calls `getContextString` therefore received an empty context string (`"\n\n"`):

- `CopilotTask` (task context shipped to the agent)
- dev-console "Readable context" log
- `CopilotTextarea` autosuggestions / insertion prompt (`useMakeAutosuggestionsFunction`, `useMakeStandardInsertionFunction`)

This PR repoints `getContextString` at the live v2 context store entries (`{ description, value }`), restoring readable context to all of those surfaces.

## Changes

- `packages/react-core/src/components/copilot-provider/copilotkit.tsx`
  - `CopilotKitInternal` now reads the v2 core via `useCopilotKit()` (the v1 component already wraps the v2 provider internally)
  - `getContextString` serializes `copilotkit.context` entries (`description:\nvalue`, joined by blank lines) instead of the dead v1 tree; the `documents` argument keeps its existing formatting
- `packages/react-core/src/components/copilot-provider/__tests__/v1-readable-context-bridge.test.tsx` (new)
  - writer (`useCopilotReadable`) + on-demand reader (`getContextString`) through the v1 bridge — asserts the readable's description/value show up, and that the string clears after the readable unmounts

## Verification

- New tests exercise the exact writer/reader split used in production (context written in an effect, read on demand like `CopilotTask.run()`)