### PR TITLE
fix(react-core): key virtualized messages by id for stable measurements

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -595,6 +595,13 @@ export function CopilotChatMessageView({
     // Conservative height estimate. Items are measured by ResizeObserver after
     // first render so the estimate only affects the initial total height.
     estimateSize: () => 100,
+    // Key items by message id instead of index: deduplicatedMessages can
+    // merge/remove entries mid-list (duplicate ids, HITL run syncs), which
+    // shifts every subsequent index. Index-keyed measurement caches then
+    // misattribute heights to the wrong message until re-measured, making the
+    // list jump while scrolling. Stable keys keep the virtualizer's per-item
+    // measurements (and React keys) attached to the right message.
+    getItemKey: (index) => deduplicatedMessages[index]?.id ?? index,
     overscan: 5,
     measureElement: (el: Element) => el?.getBoundingClientRect().height ?? 0,
     // Assume a 600 px viewport before the real element is measured so that


### PR DESCRIPTION
## Fixes #6089 (partially)

When `deduplicatedMessages` merges or drops a message mid-list (duplicate ids from HITL run syncs, double-applied tool-call events), every subsequent message shifts one index. The virtualizer's measurement cache is keyed by index by default, so the cached height of the previous occupant is misattributed to the new item until the ResizeObserver re-fires — the list jumps while scrolling through history.

### Change

Pass `getItemKey` to `useVirtualizer` so the virtualizer keys items (measurement cache, React keys, edge-change detection for auto-scroll anchoring) by the stable `message.id` instead of the positional index:

```ts
getItemKey: (index) => deduplicatedMessages[index]?.id ?? index,
```

This is the documented TanStack recommendation for dynamic-height lists whose indices can shift:

> "If you have a list of items that can change size or be removed, you should provide a `getItemKey` function that returns a stable identifier for each item, so the virtualizer can correctly attribute measurements."

No behavioral change on the happy path (append-only streaming lists keep stable indices).
