### PR TITLE
docs(langgraph): fix 8 verified defects in the LangGraph onboarding docs (refs OSS-857)

### DIFF
--- a/showcase/integrations/langgraph-fastapi/manifest.yaml
+++ b/showcase/integrations/langgraph-fastapi/manifest.yaml
@@ -71,6 +71,7 @@ features:
   - voice
   - agent-config
 a2ui_pattern: schema-loading
+a2ui_agent_form: langgraph-state-graph
 interrupt_pattern: native
 thread_persistence_pattern: langgraph
 agent_config_pattern: shared-state

--- a/showcase/integrations/langgraph-python/.env.example
+++ b/showcase/integrations/langgraph-python/.env.example
@@ -1,7 +1,8 @@
 # API Keys
 OPENAI_API_KEY=replace-with-your-key
 
-# LangGraph server URL (langgraph dev runs on port 8123 by default)
+# LangGraph server URL. Bare `langgraph dev` listens on 2024; this project's
+# dev script pins 8123 with `--port 8123`, so the URL below matches that.
 LANGGRAPH_DEPLOYMENT_URL=http://localhost:8123
 
 # LangSmith (optional, for tracing)

--- a/showcase/integrations/langgraph-python/manifest.yaml
+++ b/showcase/integrations/langgraph-python/manifest.yaml
@@ -76,6 +76,7 @@ features:
   - voice
   - agent-config
 a2ui_pattern: schema-loading
+a2ui_agent_form: langgraph-state-graph
 interrupt_pattern: native
 thread_persistence_pattern: langgraph
 agent_config_pattern: shared-state

--- a/showcase/shared/manifest.schema.json
+++ b/showcase/shared/manifest.schema.json
@@ -197,6 +197,12 @@
       "enum": ["schema-loading", "schema-inline", "llm-driven", null],
       "description": "Implementation pattern used by this integration for `a2ui-fixed-schema`. Set only when the feature is wired. `schema-loading` = backend loads schema JSON at startup; `schema-inline` = schema is declared inline as a typed literal in source; `llm-driven` = backend generates the schema via a secondary LLM call. Consumed by docs `<WhenFrameworkHas>` to gate per-pattern prose."
     },
+    "a2ui_agent_form": {
+      "type": ["string", "null"],
+      "enum": ["langgraph-state-graph", null],
+      "description": "Set only when this integration's docs should also show how to attach the A2UI tool to a hand-built graph instead of the cell's agent factory. `langgraph-state-graph` = the docs render a Python LangGraph `StateGraph` + `ToolNode` form alongside the `create_agent` snippet. Language-specific: do not set it on an integration whose language differs from the rendered snippet. Consumed by docs `<WhenFrameworkHas>`.",
+      "default": null
+    },
     "interrupt_pattern": {
       "type": ["string", "null"],
       "enum": ["native", "promise-based", null],

--- a/showcase/shell-docs/src/components/when-framework-has.tsx
+++ b/showcase/shell-docs/src/components/when-framework-has.tsx
@@ -38,6 +38,7 @@ import { getIntegration } from "@/lib/registry";
  */
 type SupportedFlag =
   | "a2ui_pattern"
+  | "a2ui_agent_form"
   | "interrupt_pattern"
   | "thread_persistence_pattern"
   | "agent_config_pattern"

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -75,6 +75,18 @@ CopilotKit's basic catalog (Card, Column, Row, Text, Button, …) via
 
 <Steps>
 <Step>
+### Install the renderer package
+
+The catalog, definitions and renderers below all import from
+`@copilotkit/a2ui-renderer`. It ships separately from
+`@copilotkit/react-core`, and the definitions use `zod` for prop schemas:
+
+```npm
+npm install @copilotkit/a2ui-renderer zod
+```
+</Step>
+
+<Step>
 ### Declare the component definitions
 
 Each component declares its props as a Zod schema. Props are the
@@ -124,6 +136,55 @@ data fields (`origin`, `destination`, `airline`, `price`); the schema
 does the rest:
 
 <Snippet region="backend-render-operations" />
+
+Nothing about A2UI lives in the agent construct — the operations container is
+just the tool's return value, so the tool drops into whatever agent you
+already have.
+</Step>
+</WhenFrameworkHas>
+
+<WhenFrameworkHas flag="a2ui_agent_form" equals="langgraph-state-graph">
+<Step>
+### Attach the tool to an existing `StateGraph`
+
+The snippet above is the reference cell's `create_agent` form. A developer
+adding A2UI to an agent they already wrote usually has a hand-built
+`StateGraph` instead. The tool is unchanged — put it in a `ToolNode` and
+leave the rest of the graph alone:
+
+```python title="agent.py (LangGraph StateGraph form)"
+from langchain_openai import ChatOpenAI
+from langgraph.graph import START, MessagesState, StateGraph
+from langgraph.prebuilt import ToolNode, tools_condition
+
+# `display_flight` is the tool defined above — unchanged.
+model = ChatOpenAI(model="gpt-4.1-mini").bind_tools([display_flight])
+
+
+def call_model(state: MessagesState):
+    return {"messages": [model.invoke(state["messages"])]}
+
+
+builder = StateGraph(MessagesState)
+builder.add_node("call_model", call_model)
+builder.add_node("tools", ToolNode([display_flight]))
+builder.add_edge(START, "call_model")
+builder.add_conditional_edges("call_model", tools_condition)
+builder.add_edge("tools", "call_model")
+
+# No `checkpointer=` — the LangGraph API server owns persistence and
+# rejects a custom one. See the LangGraph quickstart for the FastAPI case,
+# where you host the graph yourself and do need a checkpointer.
+graph = builder.compile()
+```
+
+`CopilotKitMiddleware` is a `create_agent` middleware, so it has no
+`StateGraph` equivalent — and the fixed-schema path does not need one: the
+A2UI middleware that turns the tool result into a surface runs in the
+TypeScript runtime (see [Registering the runtime](#registering-the-runtime)
+below), not in the graph. Note that dropping it also drops the other things it
+does — frontend-tool injection and exposing agent state to the model — so keep
+`create_agent` if your agent relies on those.
 </Step>
 </WhenFrameworkHas>
 
@@ -237,9 +298,10 @@ When available, a button declares its action like this:
 ```
 
 And the Python tool matches it with a handler keyed by the action
-name (plus a `"*"` catch-all). Until the SDK lands, see the reference
-[fixed-schema guide](/integrations/langgraph/generative-ui/a2ui/fixed-schema)
-for the full pattern.
+name (plus a `"*"` catch-all). Until the SDK lands, handle the click on the
+frontend instead — see
+[Advanced — Action Handlers](./advanced#action-handlers) for the
+`createA2UIMessageRenderer` / `onAction` pattern.
 
 ## When should I use fixed schemas?
 

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -147,10 +147,12 @@ already have.
 <Step>
 ### Attach the tool to an existing `StateGraph`
 
-The snippet above is the reference cell's `create_agent` form. A developer
+The snippets above stop at the tool. The reference cell builds its agent with
+`langchain.agents.create_agent` plus `CopilotKitMiddleware` — that is what
+those imports are for — but the construction itself is not shown. A developer
 adding A2UI to an agent they already wrote usually has a hand-built
-`StateGraph` instead. The tool is unchanged — put it in a `ToolNode` and
-leave the rest of the graph alone:
+`StateGraph` instead. The tool is unchanged; put it in a `ToolNode` and leave
+the rest of the graph alone:
 
 ```python title="agent.py (LangGraph StateGraph form)"
 from langchain_openai import ChatOpenAI
@@ -177,6 +179,11 @@ builder.add_edge("tools", "call_model")
 # where you host the graph yourself and do need a checkpointer.
 graph = builder.compile()
 ```
+
+Keep whatever system prompt your agent already has. The reference cell's prompt
+tells the model to call `display_flight` exactly once and stop, because the tool
+result *is* the rendered card — without that steer a model tends to call it
+again looking for a status code.
 
 `CopilotKitMiddleware` is a `create_agent` middleware, so it has no
 `StateGraph` equivalent — and the fixed-schema path does not need one: the

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -131,9 +131,10 @@ Before you begin, you'll need the following:
               uv add langgraph langchain-openai langchain-core python-dotenv
               ```
 
-              The **FastAPI** tab adds `copilotkit` and `ag-ui-langgraph` in its
-              own step — the LangSmith path never imports either, so this line
-              leaves them out.
+              Both tabs below import all four. The **FastAPI** tab installs what
+              its own code needs on top of these — `ag-ui-langgraph`, `fastapi`,
+              `uvicorn` and `copilotkit` — in its own step; the LangSmith path
+              imports none of them, so they are not in this line.
 
               <Callout type="warn" title="Project with pinned dependencies?">
                 `uv add` resolves and rewrites your lockfile. If your project

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -123,13 +123,23 @@ Before you begin, you'll need the following:
               ```
           </Step>
           <Step>
-              ### Install LangGraph and AG-UI
+              ### Install LangGraph
 
-              Add LangGraph and the required AG-UI packages to your project:
+              Add the packages the agent code below imports:
 
               ```bash
-              uv add langgraph copilotkit langchain-openai langchain-core python-dotenv
+              uv add langgraph langchain-openai langchain-core python-dotenv
               ```
+
+              The **FastAPI** tab adds `copilotkit` and `ag-ui-langgraph` in its
+              own step — the LangSmith path never imports either, so this line
+              leaves them out.
+
+              <Callout type="warn" title="Project with pinned dependencies?">
+                `uv add` resolves and rewrites your lockfile. If your project
+                pins exact versions (`==`), add these to your dependency file by
+                hand instead so the rest of your pins stay put.
+              </Callout>
           </Step>
           <Step>
             ### Expose your agent via AG-UI
@@ -164,6 +174,17 @@ Before you begin, you'll need the following:
                   graph.add_edge("mock_llm", END)
                   graph = graph.compile()
                   ```
+
+                  <Callout type="warn" title="Do not add a checkpointer on this path">
+                    `compile()` is called with no `checkpointer=` on purpose. The
+                    LangGraph API server owns persistence and injects its own
+                    checkpointer at run time. If you compile a custom one in,
+                    `langgraph dev` refuses to load the graph
+                    (`ValueError: ... includes a custom checkpointer ... persistence is
+                    handled automatically by the platform`) and a deployed graph
+                    ignores it. The **FastAPI** tab is the opposite case — see the
+                    note there.
+                  </Callout>
 
                   Then to test and deploy with LangSmith, we'll also need a `langgraph.json`
 
@@ -253,6 +274,20 @@ Before you begin, you'll need the following:
                   if __name__ == "__main__":
                     main()
                   ```
+
+                  <Callout type="info" title="Why this tab compiles with a checkpointer">
+                    Here you run the graph yourself, so nothing supplies
+                    persistence for you. `ag-ui-langgraph` reads thread state via
+                    `graph.aget_state(...)`, which raises
+                    `ValueError: No checkpointer set` on a graph compiled without
+                    one — hence `MemorySaver()`. It keeps state in process memory
+                    only; swap in a durable saver (e.g. Postgres) for production.
+                    Do **not** copy this into the LangSmith tab's graph.
+                  </Callout>
+
+                  `uvicorn` is told to listen on `8123` above, which is the port
+                  the runtime route below expects. Change both together if you
+                  pick a different one.
                 </Tab>
               </Tabs>
 
@@ -287,8 +322,12 @@ Before you begin, you'll need the following:
               ### Install CopilotKit packages
 
               ```npm
-              npm install @copilotkit/react-ui @copilotkit/react-core @copilotkit/runtime
+              npm install @copilotkit/react-core @copilotkit/runtime
               ```
+
+              The components used below (`CopilotKit`, `CopilotSidebar`) and the
+              stylesheet all come from `@copilotkit/react-core/v2`, so
+              `@copilotkit/react-ui` is not needed for this setup.
           </Step>
           <Step>
               ### Setup Copilot Runtime
@@ -298,6 +337,19 @@ Before you begin, you'll need the following:
               ```sh
               mkdir -p app/api/copilotkit && touch app/api/copilotkit/route.ts
               ```
+
+              <Callout type="warn" title="This route is enough for chat, not for Threads or the Inspector">
+                A single `POST /api/copilotkit` is the *minimum* wiring: it runs
+                the runtime in single-route mode, which is all chat needs.
+                Persistent Threads and the Inspector's saved-Threads list need the
+                multi-route handler instead — a catch-all
+                `app/api/copilotkit/[[...slug]]/route.ts` that exports `GET`,
+                `POST`, `PATCH` and `DELETE`, so list, rename, archive and delete
+                requests can reach the runtime. If the Inspector shows **Finish
+                setting up Rich Threads**, this is why. See
+                [Runtime HTTP endpoints](/backend/runtime-endpoints#enable-rich-threads-routes)
+                for the route and the provider setup that goes with it.
+              </Callout>
 
               <Tabs groupId="deployment_method" items={['LangSmith', 'FastAPI']}>
                 <Tab value="LangSmith">
@@ -426,16 +478,31 @@ Before you begin, you'll need the following:
                   cd ..
                   npx @langchain/langgraph-cli dev --port 8123 --no-browser
                   ```
+
+                  <Callout type="warn" title="Port 8123 is not the default">
+                    A bare `langgraph dev` (either the Python `langgraph-cli` or
+                    `@langchain/langgraph-cli`) serves on **2024**. This guide
+                    pins **8123** with `--port 8123` to match the
+                    `http://localhost:8123` fallback in the route above. Keep the
+                    flag, or drop it and change the route's URL to
+                    `http://localhost:2024` — but do not mix the two, or the
+                    runtime will fail to connect with no diagnostic beyond a
+                    connection error.
+                  </Callout>
                 </Tab>
                 <Tab value="FastAPI">
                   ```bash
                   cd ..
                   uv run main.py
                   ```
+
+                  This serves on **8123**, the port set in `main.py`'s
+                  `uvicorn.run(...)` call.
                 </Tab>
               </Tabs>
 
-              Your agent will be available at `http://localhost:8123`.
+              Your agent will be available at `http://localhost:8123` for both
+              tabs above.
           </Step>
           <Step>
               ### Start your UI
@@ -497,6 +564,7 @@ Before you begin, you'll need the following:
                 - Check that your OpenAI API key is correctly set in the `.env` file
                 - If using an existing agent, ensure your LangSmith API key is also configured
                 - Make sure you're in the same folder as your `langgraph.json` file when running the `langgraph dev` command
+                - **Connection refused from the runtime?** Check the port. A bare `langgraph dev` listens on `2024`; this guide's start command pins `8123` with `--port 8123`. The runtime's `LANGGRAPH_DEPLOYMENT_URL` (or its fallback) has to name the port the agent actually bound.
                 - **"graph is nullish" error (JavaScript starters):** This means the LangGraph CLI couldn't load your graph. Ensure the export name in your `langgraph.json` matches your code (e.g., `"starterAgent": "./src/agent.ts:graph"` requires `export const graph = ...` in `agent.ts`). Also verify all dependencies are installed with `npm install` in your agent directory.
                 - Make sure the runtime endpoint path matches the `runtimeUrl` in your CopilotKit provider
             </Accordion>

--- a/showcase/shell-docs/src/lib/__tests__/llm-text.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/llm-text.test.ts
@@ -731,3 +731,40 @@ test("renders executable Deep Agents state streaming in both languages", () => {
   expect(output).not.toContain("copilotkitEmitState");
   expect(output).not.toContain("chatNode");
 });
+
+test("raw Markdown keeps only the active framework's <WhenFrameworkHas> branch", () => {
+  const slug = "generative-ui/a2ui/fixed-schema";
+  const doc = loadDoc(slug);
+  expect(doc).not.toBeNull();
+
+  const page = {
+    url: `langgraph-python/${slug}`,
+    title: doc!.fm.title,
+    description: doc!.fm.description,
+    filePath: doc!.filePath,
+    loadSlug: slug,
+    framework: "langgraph-python",
+  };
+  const langgraph = renderPageToLlmText(page);
+
+  // The gating tags themselves must never reach a Markdown consumer.
+  expect(langgraph).not.toContain("WhenFrameworkHas");
+
+  // langgraph-python is `a2ui_pattern: schema-loading`, so only that branch
+  // survives. Emitting all three used to put the `schema-inline` prose ("the
+  // host language doesn't ship a `load_schema` JSON loader") directly above a
+  // snippet that calls `a2ui.load_schema`, and the `llm-driven` prose above
+  // the very same fixed-schema code.
+  expect(langgraph).toContain("Load the schema JSON at startup");
+  expect(langgraph).not.toContain("Define the schema inline");
+  expect(langgraph).not.toContain("Generate the schema dynamically");
+
+  // A framework on a different pattern gets its own branch, not langgraph's.
+  const mastra = renderPageToLlmText(
+    { ...page, url: `mastra/${slug}`, framework: "mastra" },
+    { framework: "mastra" },
+  );
+  expect(mastra).toContain("Generate the schema dynamically");
+  expect(mastra).not.toContain("Load the schema JSON at startup");
+  expect(mastra).not.toContain("Define the schema inline");
+});

--- a/showcase/shell-docs/src/lib/llm-text.ts
+++ b/showcase/shell-docs/src/lib/llm-text.ts
@@ -63,6 +63,7 @@ import angularSourceContent from "@/data/angular-source-content.json";
 import setupContentData from "@/data/setup-content.json";
 import {
   filterAngularBackendScopedBlocks,
+  filterFrameworkScopedBlocks,
   filterFrontendScopedBlocks,
 } from "./toc";
 import type { FrontendId } from "./frontend-options";
@@ -907,6 +908,25 @@ export function renderPageToLlmText(
   if (frontend === "angular") {
     body = filterAngularBackendScopedBlocks(body, framework);
   }
+
+  // Framework-gated branches (`<WhenFrameworkHas flag=… equals=…>`) have to be
+  // resolved here too, and against the SAME framework the `<Snippet />` tags
+  // below resolve to. The live HTML page drops the non-matching branches (the
+  // component returns null); raw Markdown used to keep every branch verbatim,
+  // so a gated page emitted all of its mutually-exclusive variants at once,
+  // each one carrying the single selected framework's code. On
+  // `generative-ui/a2ui/fixed-schema` that meant three "how the schema is
+  // delivered" sections whose prose contradicted the identical snippet under
+  // each of them — including a branch stating the language ships no
+  // `load_schema` helper directly above a snippet calling `load_schema`.
+  //
+  // `pickFramework` is what `expandSnippets` uses, so routing the gating
+  // decision through it keeps prose and code agreeing even on unscoped
+  // (`/<slug>.md`) requests where no framework was passed in.
+  const gatedFramework = frontmatterCell
+    ? (pickFramework(frontmatterCell, undefined, framework) ?? framework)
+    : framework;
+  body = filterFrameworkScopedBlocks(body, gatedFramework);
 
   // 2) Inline the selected package-owned framework setup. Bare docs URLs use
   // Built-in Agent on the live site, so use that same default for setup

--- a/showcase/shell-docs/src/lib/registry.ts
+++ b/showcase/shell-docs/src/lib/registry.ts
@@ -67,6 +67,17 @@ export interface Integration {
    */
   a2ui_pattern?: "schema-loading" | "schema-inline" | "llm-driven" | null;
   /**
+   * Whether the A2UI docs should additionally show how to attach the
+   * fixed-schema tool to a hand-built graph rather than the cell's agent
+   * factory. Set only where the rendered snippet's language matches the
+   * integration's own — `langgraph-typescript` is deliberately left unset
+   * because the snippet is Python.
+   *
+   * - `langgraph-state-graph`: render the Python `StateGraph` + `ToolNode`
+   *   form next to the `create_agent` snippet.
+   */
+  a2ui_agent_form?: "langgraph-state-graph" | null;
+  /**
    * Implementation pattern for `gen-ui-interrupt` / `interrupt-headless`.
    * Set only when at least one is wired.
    *


### PR DESCRIPTION
Fixes 8 of the 12 defects in OSS-857 (the OSS-856 phase 1 validation run). Defects **1, 2, 5 and 9** are owned by a parallel session working in `backend/runtime-endpoints.mdx`, `integrations/langgraph/inspector.mdx` and the root `quickstart.mdx` — **do not close OSS-857 on this PR.**

Every claim below was re-derived from installed package source or a live run. Nothing here is recalled.

## Scope correction worth flagging first

The task's file table mapped `/langgraph-python/generative-ui/a2ui/fixed-schema` to `integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx`. That is not the file the URL serves. `langgraph-python` is `docs_mode: generated`, so `page.tsx` tries `loadDoc(slugPath)` first and the **root** `generative-ui/a2ui/fixed-schema.mdx` wins. Defects 10, 11 and 12 all live in the root file, which is shared by 21 frameworks — a much larger blast radius than the table implied. Confirmed by rendering, not by reading:

```
$ curl -sL localhost:3013/langgraph-python/generative-ui/a2ui/fixed-schema | grep -c "Load the schema JSON at startup"
2                      # root file's schema-loading branch
$ ... | grep -c "Action handler details"
0                      # the langgraph-scoped file's heading — never served
```

**The langgraph-scoped `integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx` is dead content at every URL.** Same for the sibling `index.mdx` and `dynamic-schema.mdx`. Only `advanced.mdx` and `styling.mdx` survive, because they have no root counterpart — and even those are unreachable from the sidebar. Worth its own ticket; not touched here.

## What changed, defect by defect

### 3 — Route shape (partial, as scoped) ✅

Added a caution at the route step. Deliberately did **not** rewrite the route.

The precise mechanism, which matters for how the caution is worded: `copilotRuntimeNextJSAppRouterEndpoint` calls `createCopilotEndpointSingleRoute` (`packages/runtime/src/lib/integrations/nextjs/app-router.ts:39`). So the quickstart's POST-only route is **single-route mode** and chat genuinely works. It is not a broken route — it is the wrong mode for Threads. The caution says exactly that, names the `[[...slug]]` catch-all with `GET`/`POST`/`PATCH`/`DELETE`, ties it to the Inspector's "Finish setting up Rich Threads" state, and links to `/backend/runtime-endpoints#enable-rich-threads-routes` (anchor verified present).

I did not assert that you can just add verbs to this handler — that would be wrong, and it is entangled with defect 5, which the other session owns.

### 4 — Port mismatch ✅

**Verified the default rather than trusting the ticket.** Both CLIs default to **2024**:

```
$ npx @langchain/langgraph-cli@latest dev --help
  -p, --port <number>   port to run the server on (default: "2024")

$ grep -n -A3 '"--port"' langgraph_cli/cli.py
670:    default=2024,
```

The page was already internally consistent on 8123 — the trap is that nothing said the bare command differs, and 8123 is the convention across every sibling page (`deep-agents.mdx`, `deepagents/quickstart.mdx`, the showcase integration). So I took the second option in the brief: keep `--port 8123` and name the default. Added a callout at the start command, a per-tab note on which port each path serves, and a troubleshooting line.

Also fixed a **factually wrong comment** in `showcase/integrations/langgraph-python/.env.example`, which claimed "langgraph dev runs on port 8123 by default". That is the same mis-belief, committed in the repo. One comment line, no behavior change; called out here because it is outside the two files named in the brief.

### 6 — `@copilotkit/react-ui` installed and never used ✅

Checked the exports; **the install line was wrong**, not the import.

- `CopilotSidebar` is at `packages/react-core/src/v2/components/chat/CopilotSidebar.tsx`, exported via `@copilotkit/react-core/v2`.
- `@copilotkit/react-ui`'s `exports` map has no `./v2` JS entry at all — only `./v2/styles.css`. Its root export does carry a v1 `CopilotSidebar`, which would be the wrong component under a v2 provider.
- `examples/v2/react/demo` does not depend on `@copilotkit/react-ui`.

Dropped it from the install line and said where the components come from. No unused import added.

### 7 — Checkpointer guidance ✅

Added the reason to each tab; kept the code difference, which is correct.

Both directions verified:

**LangSmith tab (bare compile).** `langgraph dev` sets `LANGSMITH_LANGGRAPH_API_VARIANT="local_dev"` (`langgraph_api/cli.py:271`), and under that variant `graph.py:821` raises on a compiled-in checkpointer. Reproduced with a real boot:

```
error  Graph 'sample_agent' failed to load: ValueError: Heads up! Your graph 'graph'
from './main.py' includes a custom checkpointer (type <class
'langgraph.checkpoint.memory.InMemorySaver'>). With LangGraph API, persistence is
handled automatically by the platform, so providing a custom checkpointer ... isn't
necessary and will be ignored when deployed.
```

The server does not start. So a reader who "helpfully" adds `MemorySaver()` here breaks their deployment — exactly the failure the ticket predicted.

**FastAPI tab (`MemorySaver()` required).** `ag_ui_langgraph/agent.py` calls `graph.aget_state(config)` (lines 236, 474), and `Pregel.get_state`/`aget_state` raise `ValueError("No checkpointer set")` when none is configured (`langgraph/pregel/main.py:1402`). The checkpointer is not optional on that path.

### 8 — "Existing agent" install line ✅

Narrowed to `uv add langgraph langchain-openai langchain-core python-dotenv`.

One correction to the ticket's framing: the over-add is **one** package, not two. The line is shared by both tabs, and only `copilotkit` is unused by the LangSmith path — the FastAPI tab already re-adds it in its own step alongside `ag-ui-langgraph`. And `python-dotenv` stays: the code in **both** tabs does `from dotenv import load_dotenv`, so removing it because `langgraph.json` declares `"env"` would break the shown snippet. Removing an import's package is not a docs fix.

Added the pinned-dependency warning.

`doctest.json` **needs no change**: its dep list backs the `doctest="server"` snippet (the FastAPI `main.py`), which still imports all eight. Checked rather than assumed.

### 10 — Three identical conditional branches ✅ (root cause was code, not prose)

The HTML page was already correct — only the `schema-loading` branch renders for langgraph-python. The defect is entirely in the **`.md` view the validation run read**: `renderPageToLlmText` applied `filterFrontendScopedBlocks` and `filterAngularBackendScopedBlocks` but never `filterFrameworkScopedBlocks`, so raw Markdown emitted all three branches *with the literal JSX tags*, and every `<Snippet>` inside them resolved against the one requested framework.

Before:

```
286:<WhenFrameworkHas flag="a2ui_pattern" equals="schema-loading">
402:<WhenFrameworkHas flag="a2ui_pattern" equals="schema-inline">
519:<WhenFrameworkHas flag="a2ui_pattern" equals="llm-driven">
```

…with byte-identical Python under each. That is what put "the host language doesn't ship a `load_schema` JSON loader" directly above a snippet calling `a2ui.load_schema` — the prose was never wrong for its own framework, it was just being shown to the wrong one.

Fixed by gating on the same framework the snippets resolve to (routed through `pickFramework`, so prose and code agree even on unscoped `/<slug>.md`). This also repairs the same class of bug for the other five gated flags across every framework's `.md`. The filter is flat-only by design, so the new block is a sibling, not nested.

Regression test added and **mutation-checked** — disabling the filter fails it:

```
× raw Markdown keeps only the active framework's <WhenFrameworkHas> branch
```

### 11 — `StateGraph` example + missing install ✅

**Install half:** the `definitions-types`, `catalog-creation` and `renderers-tsx` snippets all import `@copilotkit/a2ui-renderer`, and no page installed it. Added a step for it plus `zod` (both are explicit deps of the langgraph-python cell). `@copilotkit/a2ui-renderer` is a real published package at 1.68.1, not private.

**`StateGraph` half:** added, with **verified** code — not a guess.

A re-verification pass sharpened this defect. `create_agent` appears on that page **only as an import** — both snippet regions (`backend-schema-json-load`, `backend-render-operations`) stop inside the tool body, so the agent construction is never shown at all:

```
$ grep -n "create_agent" <rendered .md>
315:from langchain.agents import create_agent      # import only
347:from langchain.agents import create_agent      # import only
```

So the page leaves `create_agent`, `CopilotKitMiddleware` and `ChatOpenAI` as imports the reader cannot act on. My first draft wrongly said "the snippet above is the reference cell's `create_agent` form"; that is corrected in the second commit, and the step now also carries over the cell's system-prompt caveat (the prompt tells the model to call `display_flight` once and stop, because the tool result *is* the card).

Two probes, offline:

1. `ChatOpenAI(model="gpt-4.1-mini").bind_tools([display_flight])` constructs (no network).
2. A `StateGraph` + `ToolNode` + `tools_condition` graph, bare `compile()`, driven by a fake chat model, puts the A2UI container in the `ToolMessage`:

```
operation kinds: ['createSurface', 'updateComponents', 'updateDataModel']
PROBE2 OK (bare compile, ToolNode, tools_condition, bind_tools)
```

Placement needed care, because the root page is shared by 21 frameworks and `WhenFrameworkHas` gates only on manifest flags — `a2ui_pattern: schema-loading` covers 14 non-LangGraph integrations, so putting it there leaked LangGraph code to LlamaIndex/ADK/Pydantic-AI **and Python code to langgraph-typescript**. Confirmed by rendering before gating:

```
llamaindex             stategraph=1     # wrong
langgraph-typescript   stategraph=1     # wrong: Python on a TS framework
```

So I added a narrow docs flag, `a2ui_agent_form: langgraph-state-graph`, via the extension path `when-framework-has.tsx` documents (manifest schema → `Integration` → `SupportedFlag` → manifest). Set on `langgraph-python` and `langgraph-fastapi` only. After gating:

```
langgraph-python       stategraph=1
langgraph-fastapi      stategraph=1
langgraph-typescript   stategraph=0
llamaindex / google-adk / pydantic-ai / mastra / ms-agent-dotnet   stategraph=0
```

**Known gap, stated plainly:** `langgraph-typescript` gets no `StateGraph` form. I did not write one, because I have not verified a TypeScript LangGraph + A2UI form and a plausible-but-unrun TS snippet is worse than the gap. Adding it is a follow-up; the flag is the seam for it.

**One caveat on this snippet:** every other code block on that page is machine-extracted from a running showcase cell. This one is hand-written and probe-verified. Backing it with a real cell (a `StateGraph` A2UI backend + fixture) would be the durable fix and is worth a follow-up.

### 12 — Two unreconciled doc trees ✅

`/integrations/langgraph/generative-ui/a2ui/fixed-schema` was not merely the wrong prefix — it **301s straight back to the page it sits on**:

```
$ curl -o /dev/null -w "%{http_code} %{redirect_url}" .../integrations/langgraph/generative-ui/a2ui/fixed-schema
301 http://localhost:3013/langgraph-python/generative-ui/a2ui/fixed-schema
```

So the sentence promising "the full pattern" linked to itself, and for a langgraph-typescript reader it also silently switched framework. Repointed at the reference it actually promises, relative so it resolves in the reader's own namespace — matching the `./dynamic-schema` convention already on this page.

**Body-verified, not status-verified** (the site soft-404s with HTTP 200):

```
langgraph-python       bytes=353527  id="action-handlers"=1  onAction=9  soft404=0
langgraph-typescript   bytes=354215  id="action-handlers"=1  onAction=9  soft404=0
```

Non-LangGraph frameworks get the graceful "topic specific to other integrations" page listing where it exists — not a dead end.

## Found while double-checking — reported, not changed

Both are on the page I own, both are real, and I left both alone deliberately.

**The LangSmith tab runs a Python agent with the JavaScript CLI.** The start command is `npx @langchain/langgraph-cli dev`, but the agent is `main.py` and `langgraph.json` declares `"python_version": "3.12"`. I expected this to fail. It does not — the JS CLI detects the Python config and delegates, but prints:

```
warn: Launching Python server from @langchain/langgraph-cli is experimental.
      Please use the `langgraph-cli` package from PyPi instead.
info: Downloading uv 0.9.11 for darwin...
Installed 76 packages in 53ms
```

It then boots normally and honours `--port`. So this is not a copy-paste failure — it is an experimental path that LangChain itself advises against, plus a surprise toolchain download. I did **not** change the command: it works, the recommended alternative would change the dependency set (defect 8's territory), and the identical command appears on three other pages (`integrations/langgraph/deep-agents.mdx`, `integrations/deepagents/quickstart.mdx`, `deepagents/index.mdx`), so changing one page in isolation would just create a new inconsistency. Worth its own ticket across all four.

**The quickstart's runtime helper is deprecated.** `copilotRuntimeNextJSAppRouterEndpoint` → `createCopilotEndpointSingleRoute`, which carries `@deprecated Use createCopilotHonoHandler with mode: "single-route" instead` (`packages/runtime/src/v2/runtime/endpoints/hono-single.ts:24`). That is defect 5's territory — the parallel session owns the handler-name mapping — so per the brief I renamed nothing.

The upside of tracing it: it let me word the defect-3 caution precisely. `createCopilotEndpointSingleRoute` calls `createCopilotRuntimeHandler({ mode: "single-route" })`, i.e. literally the same mode the runtime-endpoints page documents, so the caution can say "runs the runtime in single-route mode" as a fact rather than an inference.

## Not resolved / left for others

- **Defects 1, 2, 5, 9** — parallel session's files. Untouched, including cross-references. In particular I renamed **no** providers or handlers.
- **`langgraph-typescript` has no `StateGraph` form** — see defect 11 above.
- **The langgraph-scoped A2UI tree is dead content.** `integrations/langgraph/generative-ui/a2ui/{index,fixed-schema,dynamic-schema}.mdx` are shadowed at every URL; `advanced.mdx` and `styling.mdx` are reachable but absent from the sidebar (`buildFrameworkOverridesNav` surfaces top-level overrides like `subgraphs` and `configurable`, but not these nested ones). Needs its own ticket.
- **The bring-your-own path on the shared quickstart is Python-only** (`uv init`, `uv add`, `main.py`) for all three LangGraph frameworks, including `langgraph-typescript`. Pre-existing; not widened by this PR, but it is a real defect on a shared page.
- **`showcase/integrations/langgraph-fastapi`'s a2ui cell has a source comment** pointing at `docs/integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx` — i.e. the shadowed file. Cosmetic, and inside a cell, so left alone.
- **`generative-ui/a2ui/index.mdx` links `./fixed-schema-streaming`**, which does not exist at root. Noticed while verifying; out of scope.

## Testing

All from `showcase/shell-docs`.

```
$ npx tsc --noEmit
(clean)

$ npm run lint
0 errors  (pre-existing warnings only, none in touched files)

$ npx vitest run
Test Files  1 failed | 58 passed (59)
     Tests  1 failed | 417 passed (418)
```

The single failure is `channels-docs.test.ts > publishes the Channels overview only through provider navigation`, about channels architecture images. **Proven pre-existing** — `git stash -u` on this branch and rerun gives the identical `1 failed | 29 passed`.

Manifest schema change validated:

```
$ cd showcase/scripts && npx vitest run __tests__/generate-registry-pattern.test.ts __tests__/create-integration.test.ts
Test Files  2 passed (2)      Tests  39 passed (39)

$ npm run pretypecheck   # regenerates registry.json from the manifests
langgraph-python  -> langgraph-state-graph
langgraph-fastapi -> langgraph-state-graph
```

Formatted with `oxfmt` (no changes needed). No changeset added.

### Render checks

Dev server on **3013**, not 3003 — 3003 was already held by another worktree's docs server (`CopilotKit-oss844`), and reusing it would have verified the wrong tree.

`quickstart` — identical across all three LangGraph frameworks, `.md` and HTML:

| check | py | ts | fastapi |
|---|---|---|---|
| `npm install @copilotkit/react-core @copilotkit/runtime` | 1 | 1 | 1 |
| `uv add langgraph langchain-openai langchain-core python-dotenv` | 1 | 1 | 1 |
| route caution + `[[...slug]]` | 1 | 1 | 1 |
| "Port 8123 is not the default" / "serves on **2024**" | 1 | 1 | 1 |
| both checkpointer callouts | 1 | 1 | 1 |
| pinned-dependency warning | 1 | 1 | 1 |
| stale "Install LangGraph and AG-UI" heading | 0 | 0 | 0 |

Callouts confirmed rendering as components, not literal text (checked the emitted React payload). Caught and fixed one real rendering bug while doing this: Callout `title` is a plain string, so a backticked title rendered its backticks literally.

Also re-checked the two directional cross-references, since those are easy to get backwards: the "route below" note sits at line 289 and the route step at 334 (below ✓), and the "route above" note at 487 (above ✓).

Cross-page link body-verified for all three LangGraph frameworks — the `.md` view rewrites it into the reader's own namespace (`/langgraph-python/backend/runtime-endpoints#enable-rich-threads-routes`), and the target carries the anchor with no soft-404:

```
langgraph-python       bytes=374111  id="enable-rich-threads-routes"=1  soft404=0
langgraph-typescript   bytes=374871  id="enable-rich-threads-routes"=1  soft404=0
langgraph-fastapi      bytes=374301  id="enable-rich-threads-routes"=1  soft404=0
```

The `#registering-the-runtime` anchor referenced from the new A2UI step was likewise confirmed present on that page.

`generative-ui/a2ui/fixed-schema` — `.md` across eight frameworks:

| framework | install step | StateGraph | old cross-tree link | new link | raw JSX tags |
|---|---|---|---|---|---|
| langgraph-python | 1 | 1 | 0 | 1 | 0 |
| langgraph-fastapi | 1 | 1 | 0 | 1 | 0 |
| langgraph-typescript | 1 | 0 | 0 | 1 | 0 |
| llamaindex | 1 | 0 | 0 | 1 | 0 |
| google-adk | 1 | 0 | 0 | 1 | 0 |
| pydantic-ai | 1 | 0 | 0 | 1 | 0 |
| mastra | 1 | 0 | 0 | 1 | 0 |
| ms-agent-dotnet | 1 | 0 | 0 | 1 | 0 |

Branch selection now matches HTML per framework (`schema-loading` for langgraph, `llm-driven` for mastra, `schema-inline` for ms-agent-dotnet) with zero `WhenFrameworkHas` tags leaking into Markdown.

`doctest.json` was **not** treated as a gate — there is no runner for it in the repo, and its dep set is unchanged anyway.
