### PR TITLE
ci: stop Playwright browser installs shelling out to apt

### DIFF
--- a/.github/workflows/showcase_capture-previews.yml
+++ b/.github/workflows/showcase_capture-previews.yml
@@ -91,8 +91,13 @@ jobs:
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
+      # No --with-deps: it shells out to apt, which on the runners cannot always
+      # reach azure.archive.ubuntu.com and retries for many minutes — long enough to
+      # burn this job's whole timeout before a test runs. Chromium's system libraries
+      # are already present on the Ubuntu runner image, so downloading the browser is
+      # all this step needs.
       - name: Install Playwright
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       - name: Install script dependencies
         working-directory: showcase/scripts

--- a/.github/workflows/showcase_eval.yml
+++ b/.github/workflows/showcase_eval.yml
@@ -321,8 +321,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 
+      # No --with-deps: it shells out to apt, which on the runners cannot always
+      # reach azure.archive.ubuntu.com and retries for many minutes — long enough to
+      # burn this job's whole timeout before a test runs. Chromium's system libraries
+      # are already present on the Ubuntu runner image, so downloading the browser is
+      # all this step needs.
       - name: Install Playwright chromium
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       # docker-compose.local.yml declares `env_file: .env` on every service, so
       # `docker compose` hard-fails if showcase/.env is missing — and .env is

--- a/.github/workflows/test_e2e-legacy-v1.yml
+++ b/.github/workflows/test_e2e-legacy-v1.yml
@@ -113,9 +113,14 @@ jobs:
         working-directory: examples/e2e
         run: pnpm install --frozen-lockfile
 
+      # No --with-deps: it shells out to apt, which on the runners cannot always
+      # reach azure.archive.ubuntu.com and retries for many minutes — long enough to
+      # burn this job's whole timeout before a test runs. Chromium's system libraries
+      # are already present on the Ubuntu runner image, so downloading the browser is
+      # all this step needs.
       - name: Install Playwright browsers
         working-directory: examples/e2e
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
       - name: Run e2e tests
         working-directory: examples/e2e

--- a/.github/workflows/test_e2e-showcase-on-demand.yml
+++ b/.github/workflows/test_e2e-showcase-on-demand.yml
@@ -467,10 +467,15 @@ jobs:
           done
           curl -sf --max-time 2 --connect-timeout 1 http://localhost:3000 || { echo "Dev server failed to start"; exit 1; }
 
+      # No --with-deps: it shells out to apt, which on the runners cannot always
+      # reach azure.archive.ubuntu.com and retries for many minutes — long enough to
+      # burn this job's whole timeout before a test runs. Chromium's system libraries
+      # are already present on the Ubuntu runner image, so downloading the browser is
+      # all this step needs.
       - name: Install Playwright
         run: |
           cd "showcase/integrations/${{ steps.slug.outputs.slug }}"
-          npx playwright install chromium --with-deps
+          npx playwright install chromium
 
       - name: Re-probe aimock liveness
         # aimock was readiness-checked once right after startup, but several

--- a/.github/workflows/test_showcase-frontend-matrix.yml
+++ b/.github/workflows/test_showcase-frontend-matrix.yml
@@ -104,8 +104,13 @@ jobs:
             --max-shards 1 \
             --output "$RUNNER_TEMP/frontend-matrix-plan.json"
 
+      # No --with-deps: it shells out to apt, which on the runners cannot always
+      # reach azure.archive.ubuntu.com and retries for many minutes — long enough to
+      # burn this job's whole timeout before a test runs. Chromium's system libraries
+      # are already present on the Ubuntu runner image, so downloading the browser is
+      # all this step needs.
       - name: Install Chromium
-        run: pnpm --dir pr/showcase/harness exec playwright install --with-deps chromium
+        run: pnpm --dir pr/showcase/harness exec playwright install chromium
 
       - name: Stage frozen shared sources
         run: |

--- a/.github/workflows/test_unit.yml
+++ b/.github/workflows/test_unit.yml
@@ -244,9 +244,14 @@ jobs:
         if: matrix.node-version == '20.x'
         run: pnpm run verify:channels-umbrella
 
+      # No --with-deps: it shells out to apt, which on the runners cannot always
+      # reach azure.archive.ubuntu.com and retries for many minutes — long enough to
+      # burn this job's whole timeout before a test runs. Chromium's system libraries
+      # are already present on the Ubuntu runner image, so downloading the browser is
+      # all this step needs.
       - name: Install Chromium for packed Angular browser smoke
         if: matrix.node-version == '22.x'
-        run: pnpm --dir showcase/scripts exec playwright install --with-deps chromium
+        run: pnpm --dir showcase/scripts exec playwright install chromium
 
       - name: Verify packed Angular consumer matrix
         if: matrix.node-version == '22.x'


### PR DESCRIPTION
Ports [CopilotKit/website#529](https://github.com/CopilotKit/website/pull/529) to this repo. CI workflow config only — six files under `.github/workflows/`, no package or source code touched.

## The problem

Every Playwright browser install in this repo passes `--with-deps`, which runs `apt-get update` before downloading the browser. apt on the runners cannot always reach `azure.archive.ubuntu.com`; when it can't, it retries for many minutes before falling back to `archive.ubuntu.com`. In the website repo that burned ~14 of a job's 15 minute `timeout-minutes` budget and the job was killed before it ran a single test — and GitHub renders a `timeout-minutes` kill as "The operation was canceled", so it shows up in the checks list looking like a test failure rather than an infrastructure hang.

One thing is worse here than in website. Website only took the apt branch on PRs that touched `pnpm-lock.yaml` (a cache-key interaction). **This repo has no Playwright browser cache at all** — `grep -rn ms-playwright .github/` returns nothing — so all six of these jobs shell out to apt unconditionally, on every run.

## The change

```diff
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
```

Chromium's system libraries are already present on the Ubuntu runner images, and **every one of these six steps installs chromium only**, so the browser download is all any of them needs. A comment records the reasoning in-file at each site so the next person doesn't helpfully restore `--with-deps`.

| Workflow | Step | Job timeout |
|---|---|---|
| `test_unit.yml` | Install Chromium for packed Angular browser smoke | 25m |
| `test_e2e-legacy-v1.yml` | Install Playwright browsers | 20m |
| `test_e2e-showcase-on-demand.yml` | Install Playwright | 15m |
| `test_showcase-frontend-matrix.yml` | Install Chromium | 45m / 15m |
| `showcase_eval.yml` | Install Playwright chromium | 45m |
| `showcase_capture-previews.yml` | Install Playwright | 30m |

## Verification

The substantive claim — "Chromium launches without `install-deps` on the runner images" — is about the runner image and cannot be checked locally. **This PR's own CI run is the verification, and it holds:** 23 checks pass, 2 skipped, 0 failures.

Two jobs here actually launch a browser:

- **`test / e2e / legacy-v1`** — success. All five example legs (`chat-with-your-data`, `form-filling`, `research-canvas`, `state-machine`, `travel`) ran their Playwright suites to completion on `depot-ubuntu-24.04-4`.
- **`test / unit`** — success. The packed Angular browser smoke launched Chromium on both Node 22.x legs.

Confirmed independently in ag-ui-protocol/ag-ui#2468, where all 24 `dojo / *` legs ran their Playwright suites green on `depot-ubuntu-24.04` after the same change. Between the two PRs that is 31 browser-launching jobs on Depot images with no `install-deps` anywhere.

### Measured effect

Same step, same workflow, `main` vs this branch:

| | `Install Chromium for packed Angular browser smoke` |
|---|---|
| `main` — run [32271967199](https://github.com/CopilotKit/CopilotKit/actions/runs/32271967199) | **86s**, **104s** |
| this PR — run [32281720527](https://github.com/CopilotKit/CopilotKit/actions/runs/32281720527) | **7s**, **8s** |

apt was ~92% of that step even on a run where it *wasn't* hanging. The failure mode this PR removes is the tail, not the mean.

Static checks:

```
$ python3 -c "yaml.safe_load each touched workflow"
ok .github/workflows/test_unit.yml
ok .github/workflows/showcase_capture-previews.yml
ok .github/workflows/showcase_eval.yml
ok .github/workflows/test_e2e-showcase-on-demand.yml
ok .github/workflows/test_e2e-legacy-v1.yml
ok .github/workflows/test_showcase-frontend-matrix.yml
```

`actionlint` on the six touched files, `origin/main` vs this branch (line:col stripped so comment insertions don't shift the comparison):

```
$ diff before.txt after.txt
before=27 after=27
IDENTICAL — no new actionlint findings
```

The 27 findings are pre-existing on `main` — `depot-ubuntu-*` runner labels actionlint doesn't know, and shellcheck `SC2086`/`SC2129` info in unrelated steps.

Current timings, for what the change is worth: on run [32271967199](https://github.com/CopilotKit/CopilotKit/actions/runs/32271967199) the `Install Chromium` step took **86s and 104s** across the two Node 22.x matrix legs. So apt is reachable from our runners *today* — this is preventive, plus ~1–1.5 min per job, not a fix for something currently red.

## Risk

~~Guido proved the no-`install-deps` claim on GitHub's `ubuntu-latest`. Three of these jobs run on `depot-ubuntu-24.04-*`, and Depot mirroring GitHub's image is the one thing this PR's CI needs to confirm.~~ **Resolved** — see Verification above; Chromium launches on the Depot images.

The residual risk is coverage, not the claim. Four of the six workflows are `workflow_dispatch`/`issue_comment`-gated and so do not run on this PR: `test_e2e-showcase-on-demand`, `test_showcase-frontend-matrix`, `showcase_eval`, `showcase_capture-previews`. Their edit is textually identical to the two that *were* exercised and all six installed chromium only, so this is one shared claim rather than four independent ones — but say the word and I'll dispatch any of them against the branch before merge.

If a library does turn out to be missing, the fallback is `timeout 300 pnpm exec playwright install-deps chromium` — bounding the hang instead of removing it — rather than restoring the unbounded `--with-deps`.

## Notes for review

- **A companion change is needed in ag-ui.** `apps/dojo/e2e/package.json` there has `"postinstall": "playwright install --with-deps"`, and our `test_e2e-dojo.yml` installs that package with `pnpm install` (scripts enabled), so our dojo job has been pulling all three browser engines through apt while `playwright.config.ts` declares a chromium project only. ag-ui's own workflow dodges it with `--ignore-scripts`. Fixed in [ag-ui-protocol/ag-ui#2468](https://github.com/ag-ui-protocol/ag-ui/pull/2468); since e2e-dojo pulls ag-ui at floating `main`, it reaches this repo's CI as soon as that lands.
- `showcase_capture-previews.yml` still does `sudo apt-get update && apt-get install -y ffmpeg` one step earlier, so that job keeps an apt call with the same hang exposure. Left alone — separate concern, happy to bound it in a follow-up.
- Dockerfiles under `showcase/` keep `--with-deps` deliberately: those build on Debian/Alpine images that genuinely lack the libraries. Local-dev docs (`examples/e2e/AGENTS.md`) are unchanged for the same reason.
- No changeset: CI config only, nothing published.
