### PR TITLE
docs(backend): construct the Intelligence client and name its key (refs OSS-857)

### DIFF
--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -163,6 +163,43 @@ discovers the multi-route transport from `/info`; it has no
 </Step>
 
 <Step>
+### Construct the Intelligence client
+
+`intelligence` is a `CopilotKitIntelligence` instance, not a plain object. Build
+it from your project's Intelligence API key:
+
+```ts
+import { CopilotKitIntelligence } from "@copilotkit/runtime/v2";
+
+const intelligence = new CopilotKitIntelligence({
+  apiKey: process.env.INTELLIGENCE_API_KEY!,
+});
+```
+
+`apiKey` is the only required option. `copilotkit project select` writes this
+key into your project's `.env` as `INTELLIGENCE_API_KEY`, and this is what
+consumes it.
+
+Keep the key server-side. It is a project API key, so it is a different
+credential from the browser-visible `NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY` used by
+the [Inspector](/inspector) — do not substitute one for the other.
+
+`apiUrl` and `wsUrl` default to CopilotKit's managed platform. The API and
+realtime planes are deployed to **different hosts**, so one cannot be derived
+from the other by swapping the scheme. Override them only for a self-hosted or
+non-production deployment, and override **both together** — setting one alone
+points the two planes at different deployments, which logs a warning:
+
+```ts
+const intelligence = new CopilotKitIntelligence({
+  apiKey: process.env.INTELLIGENCE_API_KEY!,
+  apiUrl: process.env.INTELLIGENCE_API_URL,
+  wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL,
+});
+```
+</Step>
+
+<Step>
 ### Identify the signed-in application user
 
 An Intelligence-backed web Runtime exposes Threads only when it can scope them

--- a/showcase/shell-docs/src/content/snippets/shared/premium/inspector.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/premium/inspector.mdx
@@ -104,3 +104,10 @@ By default, the Inspector appears only on `localhost`, `127.0.0.1`, and
 
 Set `enableInspector` to `true` to show it on another host, including in a
 production build. CopilotKit always uses an explicit `true` or `false` value.
+
+`NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY` is a browser-visible publishable key and is
+a **different credential** from the server-side `INTELLIGENCE_API_KEY` that
+`copilotkit project select` writes into your `.env`. The server-side key is
+consumed by the `CopilotKitIntelligence` client described in
+[Runtime endpoints](/backend/runtime-endpoints). Do not substitute one for the
+other, and never expose the server-side key to the browser.


### PR DESCRIPTION
Fixes OSS-857 defects 1 and 2, which turn out to be one root cause.

## The problem

`backend/runtime-endpoints.mdx` shows this:

```ts
const runtime = new CopilotRuntime({
  agents,
  intelligence,
  identifyUser: async (request) => { /* ... */ },
});
```

`intelligence` is a bare identifier. No import, no shape, no env source, and no
page on the web path constructs it — so the example is not copyable.

That is also why `INTELLIGENCE_API_KEY` appeared to have no consumer, which the
ticket called its "defect that matters most". `copilotkit project select` writes
that key into `.env`, and `apiKey` on the Intelligence client is what reads it.
Because no web page ever built the client, the variable looked orphaned.

## The fix

The construction was already documented correctly — but only on the Channels
pages (`frontends/slack.mdx:120`, `frontends/teams.mdx`). This adds a step to
the web path using that same pattern rather than inventing a second vocabulary
for it:

```ts
import { CopilotKitIntelligence } from "@copilotkit/runtime/v2";

const intelligence = new CopilotKitIntelligence({
  apiKey: process.env.INTELLIGENCE_API_KEY!,
});
```

It also documents the paired-override rule for `apiUrl` / `wsUrl`, because the
API and realtime planes are separate hosts and setting one alone logs a warning.

## The Inspector page was not wrong

`NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY` is the correct variable for the Inspector.
The defect is that a reader whose `.env` holds `INTELLIGENCE_API_KEY` cannot tell
whether the two are the same credential. So `snippets/shared/premium/inspector.mdx`
now disambiguates them — publishable browser key versus server-side project key,
with a pointer to what consumes the latter — rather than substituting one for the
other.

## Verified against source, not inferred

- `CopilotKitIntelligence` is publicly exported from `@copilotkit/runtime/v2`
  (`intelligence-platform` → `v2/runtime/index.ts` → `v2/index.ts`)
- `apiKey` is the only required field of `CopilotKitIntelligenceConfig`
- `apiUrl` and `wsUrl` default to the managed platform, and
  `warnOnPartialHostOverride` logs a warning when one is set without the other

## What I could not verify

The site build and its vitest suite did not run: this was authored in a fresh
worktree with no installed toolchain, and `oxlint` covers JS/TS rather than MDX,
so it would not have exercised these edits anyway. CI is the first real gate.

Checked instead:

- `<Step>`, `<FrontendOnly>` and code-fence balance in both files
- both new links against existing usage in the content tree — `](/inspector)`
  appears 7 times and `](/backend/runtime-endpoints)` 10 times. The site
  soft-404s on unknown paths, so a link cannot be verified by status code.

## Scope

Defects 3, 4, 6, 7, 8, 10, 11 and 12 landed in #6566. Defects 5 and 9 are being
handled separately and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
