### PR TITLE
docs(runtime): map the provider/handler pairs and guard BuiltInAgent (refs OSS-857)

### DIFF
--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -13,6 +13,77 @@ them for you. When you self-host behind a reverse proxy, lock down auth, or debu
 a connection failure with `curl`, use this page to confirm what the runtime
 exposes.
 
+## Provider and handler pairs
+
+The browser provider and the Runtime handler have to agree on the **transport**.
+CopilotKit ships more than one name for each half, and they are not
+interchangeable — they pair up. Docs, starters and older apps each show a
+different pair, so this is the mapping:
+
+<FrontendOnly frontend="react">
+
+| Provider | `useSingleEndpoint` | Transport | Needs handler | Route file |
+| --- | --- | --- | --- | --- |
+| `<CopilotKit>` (v1 wrapper) | omitted → defaults to `true` | `single` | single-route | `route.ts`, `POST` |
+| `<CopilotKit>` (v1 wrapper) | `{false}` | `rest` | multi-route | `[[...slug]]/route.ts`, 4 verbs |
+| `<CopilotKitProvider>` (v2) | omitted | `auto` — detected from `/info` | either | matches the handler |
+| `<CopilotKitProvider>` (v2) | `{true}` | `single` | single-route | `route.ts`, `POST` |
+
+`<CopilotKit>` is a backward-compatible wrapper that renders
+`<CopilotKitProvider>` internally and pins `useSingleEndpoint` to `true` unless
+you pass the prop. That default is the one thing to remember: **the v1 wrapper
+asks for single-route transport even when your Runtime is multi-route.**
+
+Both ship from the same package entry point, so moving between them is an import
+change, not a migration.
+
+</FrontendOnly>
+
+<FrontendOnly frontend="angular">
+
+Angular has no provider pairing to get wrong: `provideCopilotKit` discovers the
+transport from `/info` and exposes no `useSingleEndpoint` option. Only the
+handler half below applies to you.
+
+</FrontendOnly>
+
+### Which handlers serve which mode
+
+| Mode | Handlers |
+| --- | --- |
+| Multi-route (default) | `createCopilotRuntimeHandler`, `createCopilotHonoHandler`, `createCopilotExpressHandler`, `createCopilotNodeHandler`, `createCopilotNodeListener` |
+| Single-route | Any of the above with `mode: "single-route"` |
+| Single-route only, no option | `copilotRuntimeNextJSAppRouterEndpoint`, `copilotRuntimeNextJSPagesRouterEndpoint`, `copilotRuntimeNodeHttpEndpoint`, `copilotRuntimeNodeExpressEndpoint`, `copilotRuntimeNestEndpoint` |
+
+<Callout type="warn" title="The framework wrappers cannot do Rich Threads">
+  Every `copilotRuntime*Endpoint` wrapper builds its handler with
+  `mode: "single-route"` and exposes no option to change it, so a Runtime mounted
+  through one of them only ever honours the single-route envelope — never the
+  REST sub-routes. Setting `useSingleEndpoint={false}` on the provider does not
+  change that; it just points the browser at routes the wrapper will not serve.
+
+  Rich Threads therefore needs one of the handlers above, built on a v2
+  `CopilotRuntime` from `@copilotkit/runtime/v2`. That is a server-side change,
+  not a provider prop. See [Enable Rich Threads routes](#enable-rich-threads-routes).
+</Callout>
+
+You may also meet these deprecated aliases in older code:
+
+| Deprecated | Use instead |
+| --- | --- |
+| `createCopilotEndpoint` | `createCopilotHonoHandler` |
+| `createCopilotEndpointSingleRoute` | `createCopilotHonoHandler` with `mode: "single-route"` |
+| `createCopilotEndpointExpress` | `createCopilotExpressHandler` |
+| `createCopilotEndpointSingleRouteExpress` | `createCopilotExpressHandler` with `mode: "single-route"` |
+
+<Callout type="info" title="Mismatched pair? Read the symptom, not the code">
+  A mismatch fails at discovery, not at your application code. A multi-route
+  provider against a single-route Runtime 404s on `GET {basePath}/info`; a
+  single-route provider against a multi-route Runtime posts an envelope the
+  Runtime does not accept. See
+  [Connect route 404 on a fresh thread](#connect-route-404-on-a-fresh-thread).
+</Callout>
+
 ## Multi-route mode (default)
 
 By default the runtime runs in **multi-route** mode, exposing a separate route per

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -17,8 +17,9 @@ exposes.
 
 The browser provider and the Runtime handler have to agree on the **transport**.
 CopilotKit ships more than one name for each half, and they are not
-interchangeable — they pair up. Docs, starters and older apps each show a
-different pair, so this is the mapping:
+interchangeable: each provider setting requires a matching handler mode.
+Different pages and older apps show different pairs, so this table is the
+mapping:
 
 <FrontendOnly frontend="react">
 
@@ -31,8 +32,8 @@ different pair, so this is the mapping:
 
 `<CopilotKit>` is a backward-compatible wrapper that renders
 `<CopilotKitProvider>` internally and pins `useSingleEndpoint` to `true` unless
-you pass the prop. That default is the one thing to remember: **the v1 wrapper
-asks for single-route transport even when your Runtime is multi-route.**
+you pass the prop. **The v1 wrapper therefore asks for single-route transport
+even when your Runtime is multi-route.**
 
 Both ship from the same package entry point, so moving between them is an import
 change, not a migration.
@@ -41,7 +42,7 @@ change, not a migration.
 
 <FrontendOnly frontend="angular">
 
-Angular has no provider pairing to get wrong: `provideCopilotKit` discovers the
+Angular has no provider pairing to configure: `provideCopilotKit` discovers the
 transport from `/info` and exposes no `useSingleEndpoint` option. Only the
 handler half below applies to you.
 
@@ -58,7 +59,7 @@ handler half below applies to you.
 <Callout type="warn" title="The framework wrappers cannot do Rich Threads">
   Every `copilotRuntime*Endpoint` wrapper builds its handler with
   `mode: "single-route"` and exposes no option to change it, so a Runtime mounted
-  through one of them only ever honours the single-route envelope — never the
+  through one of them only ever serves the single-route envelope — never the
   REST sub-routes. Setting `useSingleEndpoint={false}` on the provider does not
   change that; it just points the browser at routes the wrapper will not serve.
 
@@ -67,7 +68,7 @@ handler half below applies to you.
   not a provider prop. See [Enable Rich Threads routes](#enable-rich-threads-routes).
 </Callout>
 
-You may also meet these deprecated aliases in older code:
+Older code may use these deprecated aliases:
 
 | Deprecated | Use instead |
 | --- | --- |
@@ -76,7 +77,7 @@ You may also meet these deprecated aliases in older code:
 | `createCopilotEndpointExpress` | `createCopilotExpressHandler` |
 | `createCopilotEndpointSingleRouteExpress` | `createCopilotExpressHandler` with `mode: "single-route"` |
 
-<Callout type="info" title="Mismatched pair? Read the symptom, not the code">
+<Callout type="info" title="A mismatched pair fails at discovery">
   A mismatch fails at discovery, not at your application code. A multi-route
   provider against a single-route Runtime 404s on `GET {basePath}/info`; a
   single-route provider against a multi-route Runtime posts an envelope the

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -137,9 +137,9 @@ does the rest:
 
 <Snippet region="backend-render-operations" />
 
-Nothing about A2UI lives in the agent construct — the operations container is
-just the tool's return value, so the tool drops into whatever agent you
-already have.
+Nothing about A2UI depends on how the agent itself is built — the operations
+container is just the tool's return value, so the tool drops into whatever agent
+you already have.
 </Step>
 </WhenFrameworkHas>
 
@@ -149,10 +149,10 @@ already have.
 
 The snippets above stop at the tool. The reference cell builds its agent with
 `langchain.agents.create_agent` plus `CopilotKitMiddleware` — that is what
-those imports are for — but the construction itself is not shown. A developer
-adding A2UI to an agent they already wrote usually has a hand-built
-`StateGraph` instead. The tool is unchanged; put it in a `ToolNode` and leave
-the rest of the graph alone:
+those imports are for — but the construction itself is not shown. If you added
+A2UI to an agent you already wrote, you probably have a hand-built `StateGraph`
+instead. The tool is unchanged; put it in a `ToolNode` and leave the rest of the
+graph alone:
 
 ```python title="agent.py (LangGraph StateGraph form)"
 from langchain_openai import ChatOpenAI
@@ -182,8 +182,8 @@ graph = builder.compile()
 
 Keep whatever system prompt your agent already has. The reference cell's prompt
 tells the model to call `display_flight` exactly once and stop, because the tool
-result *is* the rendered card — without that steer a model tends to call it
-again looking for a status code.
+result *is* the rendered card. Without it, the model tends to call the tool
+again, looking for a status code.
 
 `CopilotKitMiddleware` is a `create_agent` middleware, so it has no
 `StateGraph` equivalent — and the fixed-schema path does not need one: the

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -85,8 +85,8 @@ Before you begin, you'll need the following:
         <Callout type="warn" title="Already have an agent? Do not use BuiltInAgent">
           `BuiltInAgent` is CopilotKit's *own* agent — it calls the model
           directly. Registering it as `default` means chat talks to it, not to
-          any agent you already wrote. It replaces your agent; it does not
-          connect to one.
+          any agent you already wrote. It replaces your agent rather than
+          connecting to it.
 
           If you already have a LangGraph, CrewAI, Mastra, ADK, Pydantic AI or
           other agent, take the frontend steps from this page but get the runtime

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -57,8 +57,12 @@ Before you begin, you'll need the following:
         ### Install CopilotKit packages
 
         ```npm
-        npm install @copilotkit/react-core @copilotkit/react-ui @copilotkit/runtime
+        npm install @copilotkit/react-core @copilotkit/runtime
         ```
+
+        The components used below (`CopilotKit`, `CopilotSidebar`) and the
+        stylesheet all come from `@copilotkit/react-core/v2`, so
+        `@copilotkit/react-ui` is not needed for this setup.
     </Step>
     <Step>
         ### Configure your environment
@@ -77,6 +81,20 @@ Before you begin, you'll need the following:
         ### Setup Copilot Runtime
 
         Create an API route with the `BuiltInAgent` and `CopilotRuntime`:
+
+        <Callout type="warn" title="Already have an agent? Do not use BuiltInAgent">
+          `BuiltInAgent` is CopilotKit's *own* agent — it calls the model
+          directly. Registering it as `default` means chat talks to it, not to
+          any agent you already wrote. It replaces your agent; it does not
+          connect to one.
+
+          If you already have a LangGraph, CrewAI, Mastra, ADK, Pydantic AI or
+          other agent, take the frontend steps from this page but get the runtime
+          wiring from **your framework's** quickstart, which registers *your*
+          agent instead — for example
+          [LangGraph (Python)](/langgraph-python/quickstart). Pick yours from
+          [the docs landing](/).
+        </Callout>
 
         ```ts title="app/api/copilotkit/route.ts"
         import {
@@ -108,6 +126,15 @@ Before you begin, you'll need the following:
         ### Configure CopilotKit Provider
 
         Wrap your application with the CopilotKit provider:
+
+        <Callout type="info" title="Which provider goes with which handler?">
+          `<CopilotKit>` here is the backward-compatible wrapper: it defaults
+          `useSingleEndpoint` to `true`, which is the matching half of the
+          single-route `copilotRuntimeNextJSAppRouterEndpoint` above. `<CopilotKitProvider>`
+          is the v2 provider from the same package and detects the transport from
+          `/info` instead. They are not aliases — see
+          [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+        </Callout>
 
         ```tsx title="app/layout.tsx"
         import { CopilotKit } from "@copilotkit/react-core/v2"; // [!code highlight]

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -428,6 +428,15 @@ Before you begin, you'll need the following:
 
               Wrap your application with the CopilotKit provider:
 
+              <Callout type="info" title="Which provider goes with which handler?">
+                `<CopilotKit>` here is the backward-compatible wrapper: it defaults
+                `useSingleEndpoint` to `true`, which is the matching half of the
+                single-route `copilotRuntimeNextJSAppRouterEndpoint` above. `<CopilotKitProvider>`
+                is the v2 provider from the same package and detects the transport from
+                `/info` instead. They are not aliases — see
+                [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+              </Callout>
+
               ```tsx title="app/layout.tsx"
               // [!code highlight:2]
               import { CopilotKit } from "@copilotkit/react-core/v2";

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -278,7 +278,7 @@ Before you begin, you'll need the following:
 
                   <Callout type="info" title="Why this tab compiles with a checkpointer">
                     Here you run the graph yourself, so nothing supplies
-                    persistence for you. `ag-ui-langgraph` reads thread state via
+                    persistence. `ag-ui-langgraph` reads thread state via
                     `graph.aget_state(...)`, which raises
                     `ValueError: No checkpointer set` on a graph compiled without
                     one — hence `MemorySaver()`. It keeps state in process memory
@@ -286,9 +286,9 @@ Before you begin, you'll need the following:
                     Do **not** copy this into the LangSmith tab's graph.
                   </Callout>
 
-                  `uvicorn` is told to listen on `8123` above, which is the port
-                  the runtime route below expects. Change both together if you
-                  pick a different one.
+                  `main.py` sets uvicorn's port to `8123` above, which is the
+                  port the runtime route below expects. Change both together if
+                  you pick a different one.
                 </Tab>
               </Tabs>
 


### PR DESCRIPTION
Follow-up to #6566. Fixes **defects 5 and 9** of OSS-857, plus the half of **defect 6** that lives on the Built-in Agent quickstart. Defects **1 and 2** are deliberately left — they land with the non-interactive `project list`/`select` work, since the real fix is tooling that provisions and names the key, not prose.

**Do not close OSS-857 on this PR** — 1 and 2 remain.

## The finding that reframes defect 5

The three names are **not interchangeable**. They pair up, and nobody had written the pairing down. Traced through source, not inferred:

| Provider | `useSingleEndpoint` | Transport | Needs handler |
| --- | --- | --- | --- |
| `<CopilotKit>` (v1 wrapper) | omitted → `true` | `single` | single-route |
| `<CopilotKit>` | `{false}` | `rest` | multi-route |
| `<CopilotKitProvider>` (v2) | omitted | `auto`, detected from `/info` | either |
| `<CopilotKitProvider>` | `{true}` | `single` | single-route |

`copilotkit.tsx:108` is the whole story: `useSingleEndpoint={props.useSingleEndpoint ?? true}`. The v1 wrapper renders `<CopilotKitProvider>` internally and **pins single-route transport unless you pass the prop.** So the LangGraph quickstart is internally coherent — v1 provider asks for single, `copilotRuntimeNextJSAppRouterEndpoint` serves single — which is exactly why chat works there and Threads cannot.

### The constraint nobody had documented

I swept every v1-era wrapper:

- `copilotRuntimeNextJSAppRouterEndpoint` → `createCopilotEndpointSingleRoute`
- `copilotRuntimeNodeHttpEndpoint` → `createCopilotEndpointSingleRoute`
- `copilotRuntimeNextJSPagesRouterEndpoint`, `copilotRuntimeNodeExpressEndpoint`, `copilotRuntimeNestEndpoint` → all delegate to `copilotRuntimeNodeHttpEndpoint`

**Every one builds its handler with `mode: "single-route"` and exposes no option to change it.** There is no v1-shaped multi-route handler anywhere in the package.

The consequence is sharper than defect 5 as filed: **Rich Threads and the Inspector are unreachable from the wiring both quickstarts teach, at any provider setting.** Setting `useSingleEndpoint={false}` cannot fix it — it just points the browser at routes the wrapper will not serve. You need a v2 `CopilotRuntime` from `@copilotkit/runtime/v2` plus `createCopilotRuntimeHandler`. That is a server-side change, not a provider prop, and it is the structural reason defect 3's trap exists. Worth its own ticket.

## Why I did not converge the quickstarts on v2

That was the original plan for this PR and I abandoned it after checking the backend half. The split matters:

- **Frontend would have been free.** Both quickstarts already import from `@copilotkit/react-core/v2`, where `CopilotKit` is labelled in source as a *"V1 backward-compat re-export"*. `CopilotKitProvider` ships from that same entry, and `CopilotSidebar` already depends on `useLicenseContext` from it. Swapping is an import change.
- **Backend would not.** The multi-route handler takes a v2 `CopilotRuntimeLike`; the quickstart's v1 `CopilotRuntime` only reaches it via an internal `.instance` getter that lazily news up a `CopilotRuntimeVNext`. Converging means teaching v2 runtime construction and dropping `ExperimentalEmptyAdapter` mid-quickstart — a real v1→v2 migration for every reader of the two highest-traffic pages.

v1 is supported, so the default path stays put. The mapping documents all pairs instead, and the Threads upgrade stays a labelled, complete recipe on the page the quickstarts already link to.

## What changed

**`backend/runtime-endpoints.mdx`** — new "Provider and handler pairs" section: the provider table, the handlers-by-mode table, the deprecated-alias mapping (`createCopilotEndpoint`, `createCopilotEndpointSingleRoute`, and the Express pair), the wrapper constraint above, and a "read the symptom" callout (a mismatch fails at discovery — `GET {basePath}/info` 404s, or the Runtime rejects the envelope — never in your application code).

**Both quickstarts** — a short callout naming the pair the page uses and linking the mapping.

**Defect 9, `integrations/built-in-agent/quickstart.mdx`** — this is what `/quickstart` actually serves (verified: both URLs return the identical 8175-byte body; the root `quickstart.mdx` is a 17-line routing shim that 308-redirects to `/`). `BuiltInAgent` extends `AbstractAgent` and calls the model directly via `streamText`, so registering it as `default` replaces the developer's agent rather than connecting to it. Added a caution: readers with an existing agent take the frontend steps here and the runtime wiring from their framework's quickstart.

**Defect 6, second half** — same page installed `@copilotkit/react-ui` and never used it, importing `CopilotKit`/`CopilotSidebar` from `@copilotkit/react-core/v2`. Dropped, matching #6566.

## Testing

```
$ npx vitest run
Test Files  1 failed | 58 passed (59)
     Tests  1 failed | 417 passed (418)
```

The one failure is `channels-docs.test.ts > publishes the Channels overview only through provider navigation` — pre-existing, and proven so in #6566 by stashing on a clean tree.

**I broke two tests and fixed them, which is worth recording** because it caught a real defect in my first draft. `angular-docs-content.test.ts` flagged:

```
built-in-agent/backend/runtime-endpoints: @copilotkit/react
langgraph-python/backend/runtime-endpoints: @copilotkit/react
... 10 surfaces total
```

`backend/runtime-endpoints.mdx` also serves the **Angular** surface, and my provider prose named React packages there. Correct fix, not a suppression: the provider axis is React-only — Angular's `provideCopilotKit` has no `useSingleEndpoint` — so the provider table is now `<FrontendOnly frontend="react">` with an Angular branch saying only the handler half applies. Both Angular tests pass.

### Render checks

Per surface, `.md` and HTML:

| surface | provider table | Angular note | `@copilotkit/react` | wrapper callout |
|---|---|---|---|---|
| langgraph-python | ✅ | — | 3 | ✅ |
| langgraph-typescript | ✅ | — | 3 | ✅ |
| angular | — | ✅ | **0** | ✅ |

The wrapper-constraint callout correctly stays on all three: it is a server-side fact that applies to Angular too.

Defect 9 / 6b on `/quickstart` and `/built-in-agent/quickstart` — both 8175 bytes, caution present, `react-ui` gone from the install line, pair pointer present.

Every link I added was **body-verified, never by status code** (this site soft-404s with HTTP 200):

```
/langgraph-python/quickstart                 bytes=428497  soft404=0  h1=Quickstart
/                                            bytes=248255  soft404=0  h1=CopilotKit
/backend/runtime-endpoints                   bytes=375782  soft404=0  h1=Runtime HTTP endpoints
/langgraph-python/backend/runtime-endpoints   bytes=395130  soft404=0  h1=Runtime HTTP endpoints
```

New anchors confirmed present (`id="provider-and-handler-pairs"`, `id="which-handlers-serve-which-mode"`), and the pointer rewrites into the reader's namespace correctly — `/langgraph-python/backend/...` from the LangGraph page, `/backend/...` from the root surface.

## Voice pass

A third commit runs a tone/voice check over everything added for OSS-857, measured against the corpus instead of guessed. It also corrects the wording that already landed in #6566, so the whole ticket reads in one voice.

**Second person stays.** It is emphatically the house voice: 22 of 29 top-level and backend pages use `you`/`your`, and the three pages involved used it **17, 23 and 64 times** before any of these edits. Stripping it would make the new prose stand out, not blend in. Mid-sentence `**bold**` also stays — the corpus does that 17 times.

What genuinely drifted, and is now fixed:

| Issue | Was | Now |
|---|---|---|
| British spelling | `honours` | `serves` |
| Third person on a second-person page | `A developer adding A2UI to an agent they already wrote…` | `If you added A2UI to an agent you already wrote…` |
| Essay register | `That default is the one thing to remember:` | plain statement of the fact |
| Meta phrasing | `so this is the mapping` | `so this table is the mapping` |
| Conversational | `no provider pairing to get wrong` | `to configure` |
| Conversational | `` `uvicorn` is told to listen on `8123` `` | `` `main.py` sets uvicorn's port to `8123` `` |
| Literary | `you may also meet these deprecated aliases` | `Older code may use these deprecated aliases` |
| Coinage | `agent construct` | `how the agent itself is built` |
| Coinage | `without that steer` | `Without it, the model tends to…` |
| Aphoristic Callout title | `Mismatched pair? Read the symptom, not the code` | `A mismatched pair fails at discovery` |
| Epigram | `It replaces your agent; it does not connect to one.` | `It replaces your agent rather than connecting to it.` |
| Redundancy | `nothing supplies persistence for you` | `nothing supplies persistence` |

Two of these were objective, not stylistic: the corpus is American English (`behavior` 66:6, `customize` 77:4, `serialize` 18:1, `organize` 15:0) and its only `honour` was mine; and it contains exactly two instances of `a developer`, one of which was mine on a page that addresses the reader directly throughout.

Callout titles were checked against the house set — declarative or plain question (`v1 behaves differently`, `Three routes are not user-scoped`, `Using a custom backend?`) — which is why the aphorism was the one outlier.

Re-verified after the rewording: tests back to the single pre-existing failure, every reworded string renders on the right surface, Angular still shows **zero** React package mentions, and the `StateGraph` step is still gated to langgraph-python + langgraph-fastapi only.

## Coordination

Draft PR #6112 (onsclom) also touches `integrations/built-in-agent/quickstart.mdx`, but only two prose lines — the signup sentence and the "Already have an app?" callout. My hunks are the install line and the runtime step, so they should merge cleanly. Flagging rather than assuming.

## Follow-ups this surfaced

- **Threads needs a v2 server migration** from either quickstart's starting point. No v1-shaped multi-route handler exists. Own ticket.
- **Defects 1 and 2** ride the non-interactive project-selection work.
