### PR TITLE
docs(inspector): document mounting the Inspector in Angular (refs OSS-857)

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/troubleshooting.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/troubleshooting.mdx
@@ -131,6 +131,13 @@ starts. Do not cache it outside the injector that created it.
 The complete contract is in
 [Angular production and lifecycle](/reference/angular/production-lifecycle).
 
+## Watch the live event stream
+
+The [Inspector](/inspector) overlays the running application and reports the
+AG-UI event stream, the advertised agents, agent state, your registered tools,
+and the context you sent. It is a web component that an Angular application
+mounts itself; that page has the mount component and the production guard.
+
 ## Continue through the shared stack
 
 - [Common Copilot issues](/troubleshooting/common-issues)

--- a/showcase/shell-docs/src/content/docs/frontends/angular/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/inspector.mdx
@@ -1,0 +1,161 @@
+---
+title: Inspector
+description: Mount the CopilotKit Inspector in an Angular application and keep it out of production builds.
+icon: "lucide/SearchCheck"
+doc_type: how-to
+---
+
+The Inspector is a debugging overlay for the live connection between your Angular
+application and your agents. It opens from a floating launcher and reports what
+the application and the runtime exchange as a run happens.
+
+Its navigation has three groups — **Threads**, **Agents**, and **Learning** — and
+opens on Threads, whose contents depend on the runtime's license state. The
+agent-debugging views sit under Agents:
+
+| View                 | What it shows                                                        |
+| -------------------- | -------------------------------------------------------------------- |
+| **AG-UI Events**     | The raw event stream between your application and the agent.          |
+| **Available Agents** | The agents the runtime advertises to your application.                |
+| **Agent State**      | The selected agent's state as it updates.                             |
+| **Frontend Tools**   | The tools you registered, with their parameter schemas.               |
+| **Context**          | The context you sent to the agent, including readables and documents. |
+
+## Mount the element
+
+The Inspector is `cpk-web-inspector`, a framework-agnostic web component in
+`@copilotkit/web-inspector`. `@copilotkit/angular` does not depend on that
+package and does not mount the element, so an Angular application creates it and
+supplies the core itself.
+
+Install the package as a dev dependency to keep it out of your production
+dependency graph:
+
+```bash
+npm install --save-dev @copilotkit/web-inspector
+```
+
+Add a component that owns the element's lifecycle. It reuses an existing element
+or creates one after the first browser render, supplies the core, appends the
+element to `document.body`, and removes it when the component is destroyed:
+
+```ts title="src/app/web-inspector.ts"
+import { afterNextRender, Component, DestroyRef, inject } from "@angular/core";
+import { CopilotKit } from "@copilotkit/angular";
+import { WEB_INSPECTOR_TAG } from "@copilotkit/web-inspector";
+import type { WebInspectorElement } from "@copilotkit/web-inspector";
+
+@Component({
+  selector: "app-web-inspector",
+  template: "",
+})
+export class WebInspector {
+  readonly #copilotKit = inject(CopilotKit);
+  readonly #destroyRef = inject(DestroyRef);
+
+  constructor() {
+    afterNextRender(() => {
+      const existing =
+        document.querySelector<WebInspectorElement>(WEB_INSPECTOR_TAG);
+      const inspector =
+        existing ??
+        (document.createElement(WEB_INSPECTOR_TAG) as WebInspectorElement);
+
+      // Supply the application's core instead of letting the element find one.
+      inspector.core = this.#copilotKit.core;
+      inspector.setAttribute("auto-attach-core", "false");
+
+      if (!existing) {
+        document.body.appendChild(inspector);
+      }
+
+      this.#destroyRef.onDestroy(() => {
+        if (inspector.isConnected) {
+          inspector.remove();
+        }
+      });
+    });
+  }
+}
+```
+
+Render the component once, from the root component, behind a development-only
+`@defer`:
+
+```ts title="src/app/app.ts"
+import { Component, isDevMode } from "@angular/core";
+import { WebInspector } from "./web-inspector";
+
+@Component({
+  selector: "app-root",
+  imports: [WebInspector],
+  template: `
+    <!-- your application -->
+
+    @defer (when isDev) {
+      <app-web-inspector />
+    }
+  `,
+})
+export class App {
+  protected readonly isDev = isDevMode();
+}
+```
+
+## Supply the application's core
+
+`inspector.core = copilotKit.core` is what makes the Inspector report your
+application rather than show an empty panel. Without an assigned core, the
+element searches development globals such as `window.__COPILOTKIT_CORE__` for
+one. Setting `auto-attach-core="false"` disables that search, so the element
+observes the core you assigned and nothing else.
+
+Assign `core` directly. It is a property, not an attribute, and
+`auto-attach-core` is the only attribute the element observes.
+
+## Position the launcher
+
+The launcher defaults to the top-right corner, and the element positions itself
+with an inline transform. Override both from your global stylesheet. A
+bottom-left corner keeps the launcher clear of the close button on a chat panel
+or sidebar:
+
+```css title="src/styles.css"
+cpk-web-inspector {
+  /* The panel is draggable and sets an inline transform. Neutralize it before
+     choosing a corner. */
+  transform: none !important;
+  top: auto !important;
+  bottom: 1rem !important;
+  left: 1rem !important;
+  right: auto !important;
+}
+```
+
+## Keep it out of production builds
+
+The element has no production guard of its own, so exclude it in the same place
+you mount it. `@defer (when isDev)` compiles the component and its
+`@copilotkit/web-inspector` import into a lazy chunk, and `isDevMode()` returns
+`false` in a production build, so that chunk is never requested. Removing the
+component and its `<app-web-inspector />` usage removes the Inspector entirely.
+
+## Server rendering
+
+`afterNextRender` runs only in the browser, so the element is never created
+during a server render. The deferred import also keeps the package out of the
+server bundle. Both matter: the web component registers itself against
+`customElements`, which does not exist on the server.
+
+## Clean up on destroy
+
+The element lives in `document.body`, outside the component's own view, so
+Angular does not remove it. `DestroyRef.onDestroy` removes it explicitly.
+Without that cleanup, a route change that destroys the component leaves an
+orphaned panel bound to a core the application no longer uses.
+
+## Next steps
+
+- [Troubleshooting Angular apps](/angular/guides/troubleshooting)
+- [AG-UI Event Inspector](/troubleshooting/event-inspector)
+- [Angular API: CopilotKit](/reference/angular/services/CopilotKit)

--- a/showcase/shell-docs/src/content/docs/troubleshooting/event-inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/troubleshooting/event-inspector.mdx
@@ -27,13 +27,30 @@ Use it when:
   The `/cpk-debug-events` endpoint is disabled when `NODE_ENV=production`. This is intentional — it streams internal event data that should not be exposed in production environments.
 </Callout>
 
+<Callout type="warning">
+  This stream carries the AG-UI events a **self-hosted** runtime sends over SSE.
+  A runtime configured with `intelligence` does not send them: it answers runs
+  over the Intelligence platform's realtime connection instead. On that runtime
+  `/cpk-debug-events` still connects and reports `: connected`, then stays
+  empty. To trace an Intelligence-backed run, use the in-app
+  [Inspector](/inspector), which reads the events on the client.
+</Callout>
+
 ## Connect and inspect
 
 <Steps>
 <Step>
 ### Ensure your runtime is running in development mode
 
-The debug event endpoint is available at `GET /cpk-debug-events` on your CopilotKit runtime. It activates automatically when `NODE_ENV !== 'production'` — no extra configuration needed. If you're using the default dev setup, you're already good to go.
+The debug event endpoint is available at `GET {runtimeUrl}/cpk-debug-events`. It activates automatically when `NODE_ENV !== 'production'` — no extra configuration needed. If you're using the default dev setup, you're already good to go.
+
+The path is relative to the `basePath` the runtime is mounted at, not to the server's origin. A runtime mounted at `/api/copilotkit` on port 8200 serves the stream at `http://localhost:8200/api/copilotkit/cpk-debug-events`; requesting `http://localhost:8200/cpk-debug-events` returns `404 {"error":"Not found"}`. Confirm the URL before you connect:
+
+```bash
+curl -N http://localhost:8200/api/copilotkit/cpk-debug-events
+```
+
+A working endpoint responds immediately with `: connected` and then holds the connection open.
 </Step>
 
 <Step>
@@ -51,7 +68,7 @@ This opens a dedicated webview panel.
 <Step>
 ### Enter your runtime URL and connect
 
-Type your runtime URL in the input field at the top of the panel (default: `http://localhost:4000`) and click **Connect**. The panel status indicator turns green when the SSE connection is established.
+Type your runtime URL in the input field at the top of the panel (default: `http://localhost:4000`) and click **Connect**. Use the full mounted runtime URL — the same value your frontend passes as `runtimeUrl`, including its base path — not just the origin. The panel status indicator turns green when the SSE connection is established.
 </Step>
 
 <Step>

--- a/showcase/shell-docs/src/content/docs/vs-code-extension.mdx
+++ b/showcase/shell-docs/src/content/docs/vs-code-extension.mdx
@@ -143,7 +143,7 @@ Each top-level key is a named fixture. Switch between them from the fixture drop
 
 ## AG-UI Inspector
 
-You're running a CopilotKit runtime and something in an agent interaction is off — a tool call isn't firing, a state delta is wrong, or the run ends before the UI settles. The **AG-UI Inspector** sidebar opens a dedicated SSE connection to your runtime's `/cpk-debug-events` endpoint and renders every event in a filterable, color-coded stream. Click any event row to expand the full JSON payload.
+You're running a CopilotKit runtime and something in an agent interaction is off — a tool call isn't firing, a state delta is wrong, or the run ends before the UI settles. The **AG-UI Inspector** sidebar opens a dedicated SSE connection to `{runtimeUrl}/cpk-debug-events` and renders every event in a filterable, color-coded stream. Click any event row to expand the full JSON payload. That path is relative to the base path the runtime is mounted at, so give the panel the full runtime URL rather than just the origin.
 
 <Callout type="info">
   Full walkthrough, event-type color reference, and production guard details: [AG-UI Event Inspector](/troubleshooting/event-inspector).

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -126,7 +126,6 @@ export const ANGULAR_DOC_REDIRECTS: Readonly<Record<string, string>> = {
   "migrate/1.10.X": "using-these-docs",
   "migrate/v2": "using-these-docs",
   "whats-new/v1-50": "using-these-docs",
-  inspector: "guides/troubleshooting",
   "multi-agent-flows": "multi-agent/subagents",
   "ag-ui-protocol": "agentic-protocols/ag-ui",
   "a2a-protocol": "agentic-protocols/a2a",


### PR DESCRIPTION
## What this fixes

The Inspector is `cpk-web-inspector`, a framework-agnostic web component from
`@copilotkit/web-inspector`. `@copilotkit/angular` does not reference that package
and does not mount the element, so an Angular application has to create it
itself. Nothing in the docs said so.

It was worse than a missing paragraph. `ANGULAR_DOC_REDIRECTS` mapped the
`inspector` slug onto `guides/troubleshooting`, so `/angular/*/inspector`
**redirected away from the Inspector**, and the Angular sidebar's
"Observe & Operate" section contained a single entry — the VS Code extension:

```
== Observe & Operate
- VS Code Extension [vs-code-extension]
```

## What I documented

New Angular-owned page, `frontends/angular/inspector.mdx`, sourced from
`examples/integrations/adk-angular/src/app/web-inspector.ts`:

- the Inspector is a web component and `@copilotkit/angular` does not mount it
- the mount component: `afterNextRender`, reuse-or-create, append to `document.body`
- `inspector.core = copilotKit.core` plus `auto-attach-core="false"`, and why —
  given no core the element hunts for development globals such as
  `window.__COPILOTKIT_CORE__`, so turning the search off is what guarantees it
  observes the app's core and never a different one
- anchoring the launcher bottom-left, clear of a chat panel's close button
- keeping it out of production builds via `@defer (when isDev)` + `isDevMode()`
- server rendering (`afterNextRender` + the deferred import vs. `customElements`)
- cleanup through `DestroyRef.onDestroy`

Plus: the redirect is gone so the page is reachable, and
`frontends/angular/guides/troubleshooting.mdx` links to it.

**React's Inspector content is untouched** — not edited, not moved, not gated.

### House style

Checked against the eleven existing Angular-owned pages rather than written to
taste, which changed four things from my first draft:

- **`## Next steps` with a bare link list.** Every Angular guide closes that way;
  I had `## Related` with a prose gloss per link.
- **No `<video>`.** No Angular-owned page embeds media, and none uses `<Callout>`
  or `<Steps>` either — that surface is prose, tables, and fences. I had carried
  the Inspector video over from the shared snippet.
- **Imperative task headings**, matching "Send the current session" /
  "Validate every runtime request" in `auth.mdx`: "Mount the element",
  "Supply the application's core", "Position the launcher". I had
  "Mount it yourself" and "Hand it the application's core".
- **Declarative sentences, no rhetorical fragments.** "The mount is yours, so the
  exclusion is yours as well." and a bare "`DestroyRef.onDestroy` does." are not
  this surface's register; both are now plain statements of mechanism.

Frontmatter (`title`/`description`/`icon`/`doc_type: how-to`), h2-only
structure, ~80-column wrapping, and the `{runtimeUrl}` placeholder convention all
follow the siblings. `<AngularSnippet region=…>` does **not** apply — that
component pulls code extracted from the Angular Showcase at build time, and this
mount component is not in the Showcase. Nav needs no `meta.json` entry either:
`frontends/meta.json` carries only a title, and the Angular sidebar is derived in
`getAngularDocsNavTree`. Verified the entry renders anyway.

### Two deviations from the brief, both deliberate

**1. Structural gating instead of `<FrontendOnly frontend="angular">` in the
shared snippet.** The brief described `snippets/shared/premium/inspector.mdx` as
the real Inspector content with the per-framework pages as shims onto it. On
current `main` that is only half true: `docs/inspector.mdx` is now a 131-line
standalone page that does **not** render `<Inspector />`, and it is what the
Angular root and every `docs_mode: generated` framework resolve to. I built the
`FrontendOnly` version first and it forced the Angular guide to be duplicated
into two files that had already diverged. An Angular-owned page instead matches
how all eleven existing Angular guides work, keeps one source of truth, and
gates by resolution rather than by branch.

The repo's own test agrees on the direction — `angular-docs-content.test.ts`
lists `<FrontendOnly` in `REACT_ONLY_CONTENT`, i.e. it treats the tag as
something that should not reach the Angular surface.

That test also gave me a real mutation check for free. My first attempt leaked
React's `<CopilotKit … enableInspector={false}>` into 19 Angular pages, and the
suite caught every one:

```
× keeps the complete Angular surface free of another frontend's code
+   "inspector: <CopilotKit
+   publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
+   enableInspector={false}
+ >",
× keeps every Angular and backend combination frontend-native
    expected [ …(18) ] to deeply equal []
```

**2. I document the CSS override for positioning, not `setAttribute("anchor", …)`.**
The scaffold sets that attribute, but `cpk-web-inspector` never reads it. Runtime
proof against the built `dist`:

```
observedAttributes: ["auto-attach-core"]
static properties keys: ["core","autoAttachCore","_capabilitiesVersion"]
'anchor' observed? -> false
```

There is no `getAttribute("anchor")` anywhere in the package, and `defaultAnchor`
(the prop React's `CopilotKitInspector` accepts) is not consumed either. What
actually moves the panel is the CSS in the scaffold's own `styles.css` — as its
comment already says: "CSS in styles.css enforces this too." So the docs describe
the mechanism that works. **The scaffold has one dead line** its owner may want
to drop; I did not touch it (see below).

## The adk-angular dependency is discharged

`examples/integrations/adk-angular` is planned for removal, and its
`web-inspector.ts` comment was the only written record of this pattern. That
pattern is now documented. **Whoever removes that scaffold no longer needs to
preserve it.** I only read the scaffold — no file under
`examples/integrations/adk-angular` is modified by this PR.

## The VS Code extension claim: both halves reproduced

The report said Angular users are pointed at a VS Code extension instead, that
its `cpk-debug-events` endpoint is documented at the wrong path, and that it
produced no events for a real run. I verified each independently rather than
acting on the report.

**Pointed at the extension — confirmed.** See the one-entry sidebar above.

**Wrong path — confirmed, and fixed.** The router suffix-matches
`cpk-debug-events`, but a runtime mounted with a `basePath` rejects anything
outside it. Against a real runtime on `basePath: "/api/copilotkit"`:

```
runtime mounted at basePath=/api/copilotkit, NODE_ENV=development
/cpk-debug-events                -> 404  application/json  {"error":"Not found"}
/api/copilotkit/cpk-debug-events -> 200  text/event-stream  ": connected\n\n"
/api/copilotkit/info             -> 200  application/json   {"version":"1.64.1",…}
```

The docs said "available at `GET /cpk-debug-events` on your CopilotKit runtime"
and gave the panel default as the bare origin `http://localhost:4000`, so a
reader supplying their server's origin gets a 404. Now documented as
`GET {runtimeUrl}/cpk-debug-events`, base-path-relative, with the worked
`localhost:8200` example and a `curl` check, in both
`troubleshooting/event-inspector.mdx` and `vs-code-extension.mdx`.

**No events for a real run — confirmed, cause is runtime mode.** The debug bus is
fed from exactly one place, `handlers/shared/sse-response.ts`, reached only by
`handlers/sse/run.ts` and `handlers/sse/connect.ts`. An Intelligence-configured
runtime dispatches to `handlers/intelligence/run.ts` and
`handlers/intelligence/connect.ts`, which return `Response.json` and hand the
browser a realtime connection — no AG-UI event ever passes through the runtime's
SSE layer. Neither file mentions `debugEventBus`. So on an Intelligence-backed
runtime the endpoint connects, emits `: connected`, and then stays silent
forever. That is now a callout on the event-inspector page pointing readers at
the in-app Inspector, which reads the events client-side.

I did not change runtime code for this — it is a docs-accuracy gap, and whether
the Intelligence path *should* feed the bus is a product decision, not mine to
make here.

## Testing

From `showcase/shell-docs`:

**`npm run test`** — 403 passed, 1 failed, and that failure is pre-existing on
`origin/main`. Verified in a pristine `origin/main` worktree with no changes:

```
❯ src/lib/__tests__/channels-docs.test.ts (30 tests | 1 failed)
    × publishes the Channels overview only through provider navigation
```

It asserts `channels-architecture-dark.png` in the Channels overview source and
is unrelated to anything here. The seven `angular-docs-content.test.ts` tests —
the ones that police frontend separation — all pass.

**`npm run typecheck`** — identical output on my branch and on a pristine
`origin/main` worktree (5 pre-existing `@testing-library/react` resolution
errors from my symlinked `node_modules`, all in test files I did not touch). No
new errors.

**`npm run lint`** — exit 0, no warnings in any file I changed.

**`npx oxfmt --check`** on the one `.ts` file — "All matched files use the
correct format."

### Render check, both namespaces

`next dev`, following redirects, checking bodies rather than status codes since
this site soft-404s:

| URL | http | Angular mount content | React `enableInspector` |
| --- | --- | --- | --- |
| `/angular/langgraph-typescript/inspector` | 200 | yes (`afterNextRender`, `auto-attach-core`, `cpk-web-inspector`) | **no** |
| `/langgraph-python/inspector` | 200 | **no** | yes |

Each namespace shows only its own instructions. The only `tsx` string on the
Angular page is Next.js dev chunk filenames, not content.

Before this change `/angular/langgraph-typescript/inspector` answered
`307 -> /angular/langgraph-typescript/guides/troubleshooting`.

Also confirmed 200-with-content, no redirect, and the mount instructions present
on `/angular/inspector`, `/angular/google-adk/inspector`, and
`/angular/mastra/inspector`; the sidebar now carries
`href="/angular/langgraph-typescript/inspector"` under "Observe & Operate"; the
Angular troubleshooting page links to it; and the new event-inspector callouts
render in both the React and Angular namespaces with `/inspector` correctly
rewritten to `/angular/<backend>/inspector`.

## Notes for reviewers

- **OSS-857 stays open** — other defects on it are unresolved.
- No changeset, per this repo's release process.
- Follow-up for the adk-angular owner, not done here:
  `setAttribute("anchor", "bottom-left")` in `web-inspector.ts` is a no-op and
  can be deleted; the `styles.css` rule below it is what positions the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
