### PR TITLE
docs(a2ui): require a literal-or-binding union for bound props (refs OSS-857)

### DIFF
--- a/packages/a2ui-renderer/src/react-renderer/index.ts
+++ b/packages/a2ui-renderer/src/react-renderer/index.ts
@@ -87,6 +87,27 @@ export type { ReactComponentImplementation } from "./a2ui-react/adapter";
 export { basicCatalog } from "./a2ui-react/catalog/basic";
 export { Catalog } from "@a2ui/web_core/v0_9";
 
+// Prop schemas for catalog definitions. A prop the A2UI schema binds to the
+// data model (`{ path: "/origin" }`) must use one of these unions rather than a
+// plain literal type: the binder classifies a prop as dynamic by inspecting its
+// Zod type, so a plain type leaves the raw `{ path }` object unresolved. These
+// live in `@a2ui/web_core`, a transitive dependency here that app code cannot
+// rely on importing — hence the re-export.
+export {
+  DynamicStringSchema,
+  DynamicNumberSchema,
+  DynamicBooleanSchema,
+  DynamicStringListSchema,
+  DataBindingSchema,
+} from "@a2ui/web_core/v0_9";
+export type {
+  DynamicString,
+  DynamicNumber,
+  DynamicBoolean,
+  DynamicStringList,
+  DataBinding,
+} from "@a2ui/web_core/v0_9";
+
 // Backward compat: no-op functions for initializeDefaultCatalog
 export function registerDefaultCatalog() {
   /* v0.9: catalog is built-in */

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -63,8 +63,11 @@ without data bindings (like `Title` or `Arrow`) carry their value
 inline; components bound to the LLM's data (like `Airport`) reference
 fields via JSON Pointer paths such as `{ "path": "/origin" }`. The
 A2UI binder resolves those paths *before* the React renderer runs, so
-renderer props are typed as their resolved values (plain `z.string()`,
-not a path-or-literal union).
+your renderer receives the resolved value and never sees the path — but
+the *definition* still has to declare that prop as a literal-or-binding
+union, because that union is the only signal the binder has that the
+prop is bindable. See [Declare the component
+definitions](#declare-the-component-definitions).
 
 ## The 5-component custom catalog
 
@@ -89,8 +92,44 @@ npm install @copilotkit/a2ui-renderer zod
 <Step>
 ### Declare the component definitions
 
-Each component declares its props as a Zod schema. Props are the
-*resolved* values, never the path expressions:
+Each component declares its props as a Zod schema. Any prop the schema
+binds to the data model — anything that can arrive as
+`{ "path": "/origin" }` rather than a literal — **must** be declared as a
+union of the literal type and the binding object. That is what the
+`DynString` helper below is for, and why `Airport`'s `code` uses it
+rather than a plain `z.string()`.
+
+The binder decides whether to resolve a prop by *inspecting its Zod
+type*: a union with a `{ path }` member is treated as dynamic and
+resolved against the data model, while a plain literal type is treated
+as static and passed through untouched. So declaring a bound prop as
+`z.string()` does not merely lose type precision — it tells the binder
+not to resolve it, and the raw `{ path: "/origin" }` object reaches your
+renderer.
+
+<Callout type="warn" title="Plain `z.string()` on a bound prop crashes the render">
+  Because the unresolved object reaches the renderer, the first thing
+  that renders it as text throws React's
+  [error #31](https://react.dev/errors/31):
+  `Objects are not valid as a React child (found: object with keys {path})`.
+  Nothing in that message points at the schema, so it reads as a renderer
+  bug rather than a missing union. If you hit it, check the prop's
+  declared type first.
+
+  Props that are never bound (`Arrow`, or a `variant` enum) are fine as
+  plain types. This applies only to props the schema binds.
+</Callout>
+
+Once the union is declared, the binder resolves the path before your
+renderer runs, so the renderer still receives a plain string — the union
+describes what the *schema* may send, not what the renderer must handle.
+`@copilotkit/a2ui-renderer` re-exports A2UI's canonical
+`DynamicStringSchema` (plus `DynamicNumberSchema`, `DynamicBooleanSchema`
+and the matching types) if you would rather not hand-roll the union:
+
+```ts
+import { DynamicStringSchema } from "@copilotkit/a2ui-renderer";
+```
 
 <Snippet region="definitions-types" />
 </Step>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -559,7 +559,16 @@ Before you begin, you'll need the following:
 
         <Accordions className="mb-4">
             <Accordion title="Troubleshooting">
-                - If you're having connection issues, try using `0.0.0.0` or `127.0.0.1` instead of `localhost`
+                - **Connection issues? Keep `localhost`, don't swap in a literal IP.** Which loopback address reaches the agent depends on the runtime, and `0.0.0.0` is a bind-all address for a server, never a valid target in a client URL.
+
+                  <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
+                    <Tab value="Python">
+                      `langgraph dev` (the Python CLI) defaults to `--host 127.0.0.1`, so both `http://127.0.0.1:8123` and `http://localhost:8123` reach it. `http://[::1]:8123` does not — the server is not listening on IPv6.
+                    </Tab>
+                    <Tab value="TypeScript">
+                      `@langchain/langgraph-cli` (the `langgraphjs` binary) defaults to `--host localhost`, which Node resolves to IPv6 on a dual-stack machine, binding `::1` **only**. So `http://localhost:8123` and `http://[::1]:8123` reach it, while `http://127.0.0.1:8123` is refused by that same running server — switching to `127.0.0.1` is what breaks it. If you need IPv4, bind it explicitly with `langgraphjs dev --host 127.0.0.1`.
+                    </Tab>
+                  </Tabs>
                 - Make sure your agent folder contains a `langgraph.json` file
                 - In the `langgraph.json` file, reference the path to a `.env` file
                 - Check that your OpenAI API key is correctly set in the `.env` file


### PR DESCRIPTION
Four defects were reported from a LangGraph TypeScript + Next.js onboarding run. Two
were unverified and one was unsound as stated, so each was reproduced or traced to
source before anything was written. Two needed a fix, one needed a fix plus a package
re-export, and one turned out to be correct as documented.

## Per-defect findings

**Defect 1 — bound props need a literal-or-binding union schema. REAL, and the page said the opposite.**
Confirmed, with the mechanism. `scrapeSchemaBehavior` in `@a2ui/web_core`'s
`GenericBinder` decides whether to resolve a `{ path }` binding by inspecting the prop's
Zod type: a `ZodUnion` containing an object with a `path` key (and no `componentId`)
becomes `DYNAMIC`; everything else falls through to `STATIC`, whose handler is
`case 'STATIC': return value;`. So a bound prop declared as a plain `z.string()` is never
resolved and the raw `{ path: "/origin" }` object reaches the renderer, where the first
thing that renders it as text throws React error #31.

The page was not merely silent about this — it asserted the opposite:

> The A2UI binder resolves those paths *before* the React renderer runs, so renderer
> props are typed as their resolved values (plain `z.string()`, not a path-or-literal union).

The reference cell has declared the union all along and carries a comment naming the exact
React error, but that comment sits *outside* the `@region[definitions-types]` marker, and
`extractRegion` returns only the lines between the markers — so it never reaches the page.
The rule is now stated where the reader declares the prop, with the failure mode.

**Defect 2 — `DynamicStringSchema` is not re-exported. Explanation 2: the symbol exists in a package that had not been searched.**
It is real and it is not a wished-for helper. It lives in `@a2ui/web_core` at
`src/v0_9/schema/common-types`, reachable on the export map as `@a2ui/web_core/v0_9`, and
it is a three-member union (`z.string()`, `DataBindingSchema`, `FunctionCallSchema`) —
slightly wider than the two-member `DynString` the reference cells hand-roll. The earlier
search was correct that it appears nowhere under `packages/`; it is a dependency symbol.

It is also genuinely unreachable for users: `@a2ui/web_core` is a plain `dependency` of
`@copilotkit/a2ui-renderer`, so application code cannot rely on importing it. Re-exported
from `@copilotkit/a2ui-renderer` with its numeric/boolean/list siblings and their types,
and noted in the docs as an alternative to hand-rolling the union.

**Defect 3 — the quickstart recommended the host form that fails. REAL, verified independently for both runtimes.**
The advice was *"try using `0.0.0.0` or `127.0.0.1` instead of `localhost`"*, in shared prose.
For the Node runtime that is exactly backwards, and it was verified from source and by
running it, not taken on report. Rewritten and split across the page's existing
Python/TypeScript language tabs so neither runtime sees the other's advice. Also corrected
the `0.0.0.0` half, which is wrong for both: it is a bind-all address for a server, not a
target for a client URL.

**Defect 4 — `useSingleEndpoint` guidance for the compat component. NOT A DEFECT. Nothing changed.**
The docs are right. The compat wrapper resolves its default at
`packages/react-core/src/components/copilot-provider/copilotkit.tsx:108`:

```tsx
useSingleEndpoint={props.useSingleEndpoint ?? true}
```

and the v2 provider maps `true → "single"`, `false → "rest"`, `undefined → "auto"`
(`CopilotKitProvider.tsx:616-620`, again at `777-781`). So omitting the prop really does
keep a single-route default, and `useSingleEndpoint={false}` really is what a multi-route
Runtime needs. The same `CopilotKit` component is exported from both `@copilotkit/react-core`
and `@copilotkit/react-core/v2`, so the guidance holds for either import. Reported as one
observation from one run rather than an established finding — it did not survive checking.

## Two things worth flagging

**The URL is served by the root page, not the LangGraph one.** Both
`generative-ui/a2ui/fixed-schema.mdx` and
`integrations/langgraph/generative-ui/a2ui/fixed-schema.mdx` exist, and the resolution is the
opposite of what the directory layout suggests: all three langgraph slugs are
`docs_mode: generated` in their manifests, and in that branch root MDX wins
(`[framework]/[[...slug]]/page.tsx:836-841`). Confirmed live — the LangGraph-scoped copy is a
thinner, older duplicate that is **not served at that URL for any framework**. Left in place,
but it is a trap for the next person and probably wants deleting separately.

**Overlap with #6569.** That PR is still open and edits both files this one touches.
`git merge-tree` against its head merges clean, so no action needed, but the two should be
read together.

## Testing

Worktree off `origin/main` (which already contains #6566 and #6568).

**Defect 1 — mechanism, against the locked `@a2ui/web_core@0.10.4`.** Schema classification:

```
plain z.string()  -> {"type":"STATIC"}
literal|binding   -> {"type":"DYNAMIC"}
```

End-to-end through the real `GenericBinder`, feeding `{ path: "/origin" }` against a data
model of `{ origin: "SFO" }`:

```
z.string()      : typeof=object value={"path":"/origin"}
literal|binding : typeof=string value="SFO"
z.string() -> renderable as a React child? NO — React throws: Objects are not valid as a
              React child (found: object with keys {path})
literal|binding -> renderable as a React child? yes
```

**Defect 2 — the re-export works from the built entry point**, and behaves identically to the
hand-rolled union in the binder (it has a third union member, so this needed checking):

```
DynamicStringSchema parses a literal: "SFO"
DynamicStringSchema parses a binding: {"path":"/origin"}
hand-rolled union   -> {"type":"DYNAMIC"}
DynamicStringSchema -> {"type":"DYNAMIC"}
plain z.string()    -> {"type":"STATIC"}
```

**Defect 3 — both runtimes verified from CLI source, and the Node binding reproduced.**
`@langchain/langgraph-cli@1.4.4` `dist/cli/dev.mjs:19` defaults `--host` to `"localhost"`
and passes it to `serve({ hostname })`; `langgraph_cli-0.4.31` `cli.py:664-666` defaults
`--host` to `"127.0.0.1"`. Reproducing what Node does with `{ host: "localhost" }` on this
dual-stack machine:

```
node version: v22.14.0
bound to: {"address":"::1","family":"IPv6","port":42024}
  localhost   -> CONNECTED
  127.0.0.1   -> ECONNREFUSED
  ::1         -> CONNECTED
  0.0.0.0     -> ECONNREFUSED
```

`127.0.0.1` is refused by the very server `localhost` reaches — so the old advice broke a
working setup.

**Rendered checks (`next dev`, body-inspected — this site soft-404s, so no status codes were trusted).**
`/langgraph-typescript/...` and `/langgraph-python/generative-ui/a2ui/fixed-schema`: root-file
marker present, LangGraph-file marker absent, new prose and the React-error callout present,
old wrong sentence gone. The `{path}` braces render literally inside `<code>` and the
`#declare-the-component-definitions` anchor resolves to a real heading id.

Quickstart troubleshooting tabs resolve per framework, so the gating is right:

```
/langgraph-typescript/quickstart   Python selected=false   TypeScript selected=true
/langgraph-python/quickstart       Python selected=true    TypeScript selected=false
/langgraph-fastapi/quickstart      Python selected=true    TypeScript selected=false
```

The `<Tabs>` nested in a list item renders as a real `<ul><li>` with a working tablist, not
broken MDX.

**Suites.**

| Check | Result |
| --- | --- |
| `packages/a2ui-renderer` `tsc --noEmit` | pass |
| `packages/a2ui-renderer` build (`tsdown`) | pass, 143 files |
| `packages/a2ui-renderer` `vitest run` | 4 files, 22 tests passed |
| `oxlint` on the changed source | 0 warnings, 0 errors |
| `shell-docs` `npm run typecheck` | pass (exit 0) |
| `shell-docs` `npm run lint` | pass (exit 0) |
| `shell-docs` `npm run test` | 58/59 files, 420/421 tests |

The one failing test is `channels-docs.test.ts > publishes the Channels overview only through
provider navigation`. It is **pre-existing on `origin/main`** and unrelated to these files —
verified by reverting all three changes to a pristine checkout and re-running it, where it
fails identically (`1 failed | 29 passed`).

## Conventions pass

Checked the added prose against the docs tree's actual conventions rather than by ear, which
turned up four things worth changing:

- **`Callout type="warn"`** is the house spelling (84 uses vs 11 `warning`) — already correct.
- **Code identifiers in Callout titles are backticked** (95-odd precedents, e.g.
  ``title="`identifyUser` is not an authentication gate"``). Mine wasn't; fixed. Note these
  render as *literal* backticks — verified that existing titles behave identically on `/auth`,
  so this matches the site rather than diverging from it.
- **Dropped a hand-written code fence.** The first draft illustrated the union with a synthetic
  `ts` block that (a) wasn't valid TypeScript — an orphaned object property with no enclosing
  object — and (b) duplicated the `<Snippet region="definitions-types" />` rendered immediately
  below it. Hand-copied code next to the generated snippet is exactly the drift the snippet
  architecture exists to prevent, so the prose now names `DynString` and `Airport`'s `code` and
  lets the snippet carry the code. Confirmed those two names are present in **all 21**
  integration cells that feed this page, since the root page serves every framework.
- **Matched local line-style.** The quickstart's other troubleshooting bullets are single
  unwrapped lines, so the new bullet's prose is too; the a2ui page wraps at ~70–80 columns and
  the new paragraphs match that.

Also tightened two things for accuracy over emphasis: the binder rule now says "a union with a
`{ path }` member" rather than "a union containing an object with a `path` key", which was
over-broad (a `{ componentId, path }` member is classified `STRUCTURAL`, not `DYNAMIC`), and
the package comment was cut from nine lines to six to sit better among that file's one-line
section labels.

Re-verified after the rewrite: `tsc` pass, `vitest` 22 passed, `oxlint` clean, `oxfmt` clean,
shell-docs typecheck/lint pass, tests unchanged at 420/421 with the same pre-existing channels
failure, and both pages re-rendered — anchor still resolves, tabs still resolve per framework
(`langgraph-python` → Python, `langgraph-typescript` → TypeScript).

Out of scope and untouched: `snippets/shared/premium/inspector.mdx`. No changeset added.
Does not close OSS-857.

