### PR TITLE
feat(react-core): add local message inspector links

### DIFF
--- a/examples/v2/react/demo/src/app/page.tsx
+++ b/examples/v2/react/demo/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import {
   CopilotChat,
+  CopilotChatAssistantMessage,
   CopilotKitProvider,
   defineToolCallRenderer,
   useAgentContext,
@@ -313,6 +314,40 @@ function Chat({
         <CopilotChat
           className={theme === "dark" ? "dark" : undefined}
           input={{ toolsMenu }}
+          welcomeScreen={{
+            children: ({ input, suggestionView }) => (
+              <div
+                style={{
+                  flex: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding: "0 16px",
+                }}
+              >
+                <div style={{ width: "100%", maxWidth: 768 }}>
+                  <CopilotChatAssistantMessage
+                    message={{
+                      id: "local-inspector-preview",
+                      role: "assistant",
+                      content:
+                        "This local preview lets you open the CopilotKit Inspector directly from an assistant response. Hover over the CopilotKit mark below, then click it to inspect the current run.",
+                    }}
+                  />
+                  <div style={{ marginTop: 32 }}>{input}</div>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      marginTop: 16,
+                    }}
+                  >
+                    {suggestionView}
+                  </div>
+                </div>
+              </div>
+            ),
+          }}
           threadId={selectedThreadId}
           key={selectedThreadId ?? "stateless"}
         />

--- a/packages/react-core/src/v2/components/CopilotKitInspector.tsx
+++ b/packages/react-core/src/v2/components/CopilotKitInspector.tsx
@@ -1,24 +1,30 @@
 import * as React from "react";
 import { createComponent } from "@lit-labs/react";
 import type { CopilotKitCore } from "@copilotkit/core";
-import type { Anchor } from "@copilotkit/web-inspector";
+import type { Anchor, WebInspectorElement } from "@copilotkit/web-inspector";
+import type { CopilotKitInspectorOpenRequest } from "./CopilotKitInspectorContext";
 
 type CopilotKitInspectorBaseProps = {
   core?: CopilotKitCore | null;
   defaultAnchor?: Anchor;
+  openRequest?: CopilotKitInspectorOpenRequest | null;
   [key: string]: unknown;
 };
 
-type InspectorComponent = React.ComponentType<CopilotKitInspectorBaseProps>;
+type InspectorComponent = React.ComponentType<
+  CopilotKitInspectorBaseProps & React.RefAttributes<WebInspectorElement>
+>;
 
 export interface CopilotKitInspectorProps extends CopilotKitInspectorBaseProps {}
 
 export const CopilotKitInspector: React.FC<CopilotKitInspectorProps> = ({
   core,
+  openRequest,
   ...rest
 }) => {
   const [InspectorComponent, setInspectorComponent] =
     React.useState<InspectorComponent | null>(null);
+  const inspectorRef = React.useRef<WebInspectorElement | null>(null);
 
   React.useEffect(() => {
     let mounted = true;
@@ -43,10 +49,18 @@ export const CopilotKitInspector: React.FC<CopilotKitInspectorProps> = ({
     };
   }, []);
 
+  React.useEffect(() => {
+    if (openRequest) {
+      inspectorRef.current?.openInspector("message_toolbar", openRequest);
+    }
+  }, [InspectorComponent, openRequest]);
+
   // During SSR (and until the client finishes loading), render nothing to keep markup consistent.
   if (!InspectorComponent) return null;
 
-  return <InspectorComponent {...rest} core={core ?? null} />;
+  return (
+    <InspectorComponent ref={inspectorRef} {...rest} core={core ?? null} />
+  );
 };
 
 CopilotKitInspector.displayName = "CopilotKitInspector";

--- a/packages/react-core/src/v2/components/CopilotKitInspectorContext.tsx
+++ b/packages/react-core/src/v2/components/CopilotKitInspectorContext.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as React from "react";
+
+export type CopilotKitInspectorOpenRequest = {
+  messageId: string;
+  threadId?: string;
+  agentId?: string;
+};
+
+type CopilotKitInspectorContextValue = {
+  isLocalInspectorEnabled: boolean;
+  openInspector: (request: CopilotKitInspectorOpenRequest) => void;
+};
+
+const CopilotKitInspectorContext =
+  React.createContext<CopilotKitInspectorContextValue>({
+    isLocalInspectorEnabled: false,
+    openInspector: () => undefined,
+  });
+
+export const CopilotKitInspectorContextProvider =
+  CopilotKitInspectorContext.Provider;
+
+export function useCopilotKitInspector(): CopilotKitInspectorContextValue {
+  return React.useContext(CopilotKitInspectorContext);
+}

--- a/packages/react-core/src/v2/components/chat/CopilotChatAssistantMessage.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAssistantMessage.tsx
@@ -1,5 +1,5 @@
 import type { AssistantMessage, Message } from "@ag-ui/core";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import {
   Copy,
   Check,
@@ -25,12 +25,14 @@ import { renderSlot } from "../../lib/slots";
 import { Streamdown } from "streamdown";
 import { copyToClipboard } from "@copilotkit/shared";
 import CopilotChatToolCallsView from "./CopilotChatToolCallsView";
+import { useCopilotKitInspector } from "../CopilotKitInspectorContext";
 
 export type CopilotChatAssistantMessageProps = WithSlots<
   {
     markdownRenderer: typeof CopilotChatAssistantMessage.MarkdownRenderer;
     toolbar: typeof CopilotChatAssistantMessage.Toolbar;
     copyButton: typeof CopilotChatAssistantMessage.CopyButton;
+    inspectorButton: typeof CopilotChatAssistantMessage.InspectorButton;
     thumbsUpButton: typeof CopilotChatAssistantMessage.ThumbsUpButton;
     thumbsDownButton: typeof CopilotChatAssistantMessage.ThumbsDownButton;
     readAloudButton: typeof CopilotChatAssistantMessage.ReadAloudButton;
@@ -63,6 +65,7 @@ export function CopilotChatAssistantMessage({
   markdownRenderer,
   toolbar,
   copyButton,
+  inspectorButton,
   thumbsUpButton,
   thumbsDownButton,
   readAloudButton,
@@ -73,6 +76,8 @@ export function CopilotChatAssistantMessage({
   ...props
 }: CopilotChatAssistantMessageProps) {
   useKatexStyles();
+  const { isLocalInspectorEnabled, openInspector } = useCopilotKitInspector();
+  const chatConfiguration = useCopilotChatConfiguration();
 
   const boundMarkdownRenderer = renderSlot(
     markdownRenderer,
@@ -100,6 +105,19 @@ export function CopilotChatAssistantMessage({
     CopilotChatAssistantMessage.ThumbsUpButton,
     {
       onClick: onThumbsUp ? () => onThumbsUp(message) : undefined,
+    },
+  );
+
+  const boundInspectorButton = renderSlot(
+    inspectorButton,
+    CopilotChatAssistantMessage.InspectorButton,
+    {
+      onClick: () =>
+        openInspector({
+          messageId: message.id,
+          threadId: chatConfiguration?.threadId,
+          agentId: chatConfiguration?.agentId,
+        }),
     },
   );
 
@@ -134,6 +152,7 @@ export function CopilotChatAssistantMessage({
       children: (
         <div className="cpk:flex cpk:items-center cpk:gap-1">
           {boundCopyButton}
+          {isLocalInspectorEnabled && boundInspectorButton}
           {(onThumbsUp || thumbsUpButton) && boundThumbsUpButton}
           {(onThumbsDown || thumbsDownButton) && boundThumbsDownButton}
           {(onReadAloud || readAloudButton) && boundReadAloudButton}
@@ -169,6 +188,7 @@ export function CopilotChatAssistantMessage({
           toolbar: boundToolbar,
           toolCallsView: boundToolCallsView,
           copyButton: boundCopyButton,
+          inspectorButton: boundInspectorButton,
           thumbsUpButton: boundThumbsUpButton,
           thumbsDownButton: boundThumbsDownButton,
           readAloudButton: boundReadAloudButton,
@@ -207,6 +227,118 @@ export function CopilotChatAssistantMessage({
   );
 }
 
+function CopilotKitColoredIcon() {
+  const gradientId = useId().replace(/:/g, "");
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="cpk:size-5"
+      data-testid="copilot-inspector-icon"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M8.162 7.758c2.093-2.738 3.831-5.445 4.498-7.63a.093.093 0 01.14-.051c2.324 1.539 6.558 2.552 10.301 2.576a.09.09 0 01.085.124c-1.243 3.158-2.765 8.817-2.823 15.28-.001.095-.135.13-.183.046-2.131-3.729-8.955-8.968-11.982-10.205a.09.09 0 01-.036-.14z"
+        fill={`url(#${gradientId}-purple)`}
+      />
+      <path
+        d="M15.223 6.083A61.492 61.492 0 018.25 7.827c-.045.008-.055.071-.012.089 3.05 1.267 9.84 6.492 11.952 10.206a.017.017 0 00.022.007.018.018 0 00.01-.024l-4.999-12.02z"
+        fill={`url(#${gradientId}-blue)`}
+      />
+      <path
+        d="M12.81.07c2.8 1.528 6.037 2.214 10.33 2.575.028.002.036.039.012.051-.55.282-3.695 1.883-6.03 2.74-.626.23-1.256.443-1.876.64a.028.028 0 01-.033-.016L12.746.128c-.017-.04.027-.078.065-.058z"
+        fill={`url(#${gradientId}-light-blue)`}
+      />
+      <path
+        className="cpk:fill-[#513C9F] cpk:dark:fill-[#B99AE8]"
+        d="M12.725.075c.046-.019.1.003.119.05l7.514 17.923a.091.091 0 01-.148.1l-.02-.03L12.675.195a.091.091 0 01.049-.12z"
+      />
+      <path
+        className="cpk:fill-[#513C9F] cpk:dark:fill-[#B99AE8]"
+        d="M23.06 2.66c.044-.025.1-.01.125.034.025.044.009.1-.035.124v.001l-.008.004-.025.015-.1.054a41.384 41.384 0 01-1.811.92A47.05 47.05 0 0116.33 5.82c-1.954.674-3.97 1.197-5.497 1.552a66.27 66.27 0 01-2.38.507l-.138.026-.036.007h-.01l-.002.002a.091.091 0 11-.033-.18l.016.09-.015-.09h.002l.01-.002.035-.007.137-.025a66.16 66.16 0 002.373-.506c1.524-.354 3.533-.876 5.479-1.547a46.857 46.857 0 006.276-2.709c.166-.087.295-.156.381-.204l.099-.054.024-.014.008-.004z"
+      />
+      <path
+        className="cpk:fill-[#ABABAB] cpk:dark:fill-[#D4D4D4]"
+        d="M13.838 2.272a.16.16 0 01.107.2l-2.72 9.055h6.4l.061.013a.16.16 0 010 .295l-.061.013h-6.541L.679 24.099l-.05.04a.16.16 0 01-.194-.245l10.43-12.285 2.773-9.23a.16.16 0 01.2-.107z"
+      />
+      <path
+        d="M7.809 21.461l-1.232.173c.638 1.69 1.949 2.427 3.514 2.427 3.831 0 2.661-4.334 4.883-4.334 1.61 0 .956 3.513 4.423 3.513 2.116 0 2.326-2.131 1.966-3.048l-.008-.016-.567-.868c-.037-.058-.127-.036-.133.032l-.106 1.053a1.01 1.01 0 00.003.219c.088.727.144 2.491-1.155 2.491-1.37 0-1.7-3.467-4.423-3.467-3.196 0-2.785 4.289-4.747 4.289-1.294 0-2.28-1.46-2.418-2.464z"
+        fill={`url(#${gradientId}-tail)`}
+      />
+      <defs>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id={`${gradientId}-purple`}
+          x1="17.852"
+          x2="14.202"
+          y1="1.467"
+          y2="11.504"
+        >
+          <stop className="cpk:[stop-color:#6430AB] cpk:dark:[stop-color:#B792F0]" />
+          <stop
+            className="cpk:[stop-color:#AA89D8] cpk:dark:[stop-color:#D3BDF7]"
+            offset="1"
+          />
+        </linearGradient>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id={`${gradientId}-blue`}
+          x1="15.024"
+          x2="10.324"
+          y1="7.125"
+          y2="16.204"
+        >
+          <stop className="cpk:[stop-color:#005DBB] cpk:dark:[stop-color:#4D9FEF]" />
+          <stop
+            className="cpk:[stop-color:#3D92E8] cpk:dark:[stop-color:#84C0FA]"
+            offset="1"
+          />
+        </linearGradient>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id={`${gradientId}-light-blue`}
+          x1="17.122"
+          x2="15.707"
+          y1="1.467"
+          y2="5.892"
+        >
+          <stop className="cpk:[stop-color:#1B70C4] cpk:dark:[stop-color:#61ACF2]" />
+          <stop
+            className="cpk:[stop-color:#54A4F2] cpk:dark:[stop-color:#9ACDFF]"
+            offset="1"
+          />
+        </linearGradient>
+        <linearGradient
+          gradientUnits="userSpaceOnUse"
+          id={`${gradientId}-tail`}
+          x1="6.577"
+          x2="21.506"
+          y1="21.758"
+          y2="21.758"
+        >
+          <stop className="cpk:[stop-color:#4497EA] cpk:dark:[stop-color:#79BCF5]" />
+          <stop
+            className="cpk:[stop-color:#1463B2] cpk:dark:[stop-color:#4594D8]"
+            offset=".255"
+          />
+          <stop
+            className="cpk:[stop-color:#0A437D] cpk:dark:[stop-color:#347CB7]"
+            offset=".499"
+          />
+          <stop
+            className="cpk:[stop-color:#2476C8] cpk:dark:[stop-color:#58A4E5]"
+            offset=".667"
+          />
+          <stop
+            className="cpk:[stop-color:#0C549A] cpk:dark:[stop-color:#3C87C7]"
+            offset=".973"
+          />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CopilotChatAssistantMessage {
   export const MarkdownRenderer: React.FC<
@@ -236,9 +368,10 @@ export namespace CopilotChatAssistantMessage {
   export const ToolbarButton: React.FC<
     React.ButtonHTMLAttributes<HTMLButtonElement> & {
       title: string;
+      tooltip?: React.ReactNode;
       children: React.ReactNode;
     }
-  > = ({ title, children, ...props }) => {
+  > = ({ title, tooltip, children, ...props }) => {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -252,7 +385,7 @@ export namespace CopilotChatAssistantMessage {
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          <p>{title}</p>
+          {tooltip ?? <p>{title}</p>}
         </TooltipContent>
       </Tooltip>
     );
@@ -307,6 +440,34 @@ export namespace CopilotChatAssistantMessage {
         ) : (
           <Copy className="cpk:size-[18px]" />
         )}
+      </ToolbarButton>
+    );
+  };
+
+  export const InspectorButton: React.FC<
+    React.ButtonHTMLAttributes<HTMLButtonElement>
+  > = ({ title, ...props }) => {
+    const config = useCopilotChatConfiguration();
+    const labels = config?.labels ?? CopilotChatDefaultLabels;
+    const primaryLabel = title || labels.assistantMessageToolbarInspectorLabel;
+    const localOnlyLabel =
+      labels.assistantMessageToolbarInspectorLocalOnlyLabel;
+    const accessibleLabel = `${primaryLabel} (${localOnlyLabel})`;
+    return (
+      <ToolbarButton
+        data-testid="copilot-inspector-button"
+        title={accessibleLabel}
+        tooltip={
+          <div className="cpk:flex cpk:flex-col cpk:gap-0.5">
+            <span>{primaryLabel}</span>
+            <span className="cpk:text-[10px] cpk:opacity-65">
+              {localOnlyLabel}
+            </span>
+          </div>
+        }
+        {...props}
+      >
+        <CopilotKitColoredIcon />
       </ToolbarButton>
     );
   };
@@ -382,6 +543,8 @@ CopilotChatAssistantMessage.Toolbar.displayName =
   "CopilotChatAssistantMessage.Toolbar";
 CopilotChatAssistantMessage.CopyButton.displayName =
   "CopilotChatAssistantMessage.CopyButton";
+CopilotChatAssistantMessage.InspectorButton.displayName =
+  "CopilotChatAssistantMessage.InspectorButton";
 CopilotChatAssistantMessage.ThumbsUpButton.displayName =
   "CopilotChatAssistantMessage.ThumbsUpButton";
 CopilotChatAssistantMessage.ThumbsDownButton.displayName =

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatAssistantMessage.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatAssistantMessage.test.tsx
@@ -4,7 +4,8 @@ import { vi } from "vitest";
 import { CopilotChatAssistantMessage } from "../CopilotChatAssistantMessage";
 import { CopilotChatConfigurationProvider } from "../../../providers/CopilotChatConfigurationProvider";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
-import { AssistantMessage } from "@ag-ui/core";
+import type { AssistantMessage } from "@ag-ui/core";
+import { CopilotKitInspectorContextProvider } from "../../CopilotKitInspectorContext";
 
 // No mocks needed - Vitest handles ES modules natively!
 
@@ -96,6 +97,35 @@ describe("CopilotChatAssistantMessage", () => {
       expect(screen.queryByRole("button", { name: /thumbs down/i })).toBeNull();
       expect(screen.queryByRole("button", { name: /read aloud/i })).toBeNull();
       expect(screen.queryByRole("button", { name: /regenerate/i })).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: /view in inspector/i }),
+      ).toBeNull();
+    });
+
+    it("renders the local Inspector action and opens it from the toolbar", () => {
+      const openInspector = vi.fn();
+
+      renderWithProvider(
+        <CopilotKitInspectorContextProvider
+          value={{ isLocalInspectorEnabled: true, openInspector }}
+        >
+          <CopilotChatAssistantMessage message={basicMessage} />
+        </CopilotKitInspectorContextProvider>,
+      );
+
+      const inspectorButton = screen.getByRole("button", {
+        name: "View in Inspector (Local Only)",
+      });
+      const inspectorIcon = screen.getByTestId("copilot-inspector-icon");
+
+      expect(inspectorIcon.querySelectorAll("linearGradient")).toHaveLength(4);
+      fireEvent.click(inspectorButton);
+
+      expect(openInspector).toHaveBeenCalledWith({
+        messageId: basicMessage.id,
+        threadId: TEST_THREAD_ID,
+        agentId: "default",
+      });
     });
 
     it("renders all buttons when all callbacks provided", () => {

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -24,6 +24,8 @@ export const CopilotChatDefaultLabels = {
   assistantMessageToolbarCopyCodeLabel: "Copy",
   assistantMessageToolbarCopyCodeCopiedLabel: "Copied",
   assistantMessageToolbarCopyMessageLabel: "Copy",
+  assistantMessageToolbarInspectorLabel: "View in Inspector",
+  assistantMessageToolbarInspectorLocalOnlyLabel: "Local Only",
   assistantMessageToolbarThumbsUpLabel: "Good response",
   assistantMessageToolbarThumbsDownLabel: "Bad response",
   assistantMessageToolbarReadAloudLabel: "Read aloud",

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -322,16 +322,18 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
 
     const localhostHosts = new Set(["localhost", "127.0.0.1"]);
     const isLocalhost = localhostHosts.has(window.location?.hostname ?? "");
+    const canShowLocalInspectorAction =
+      process.env.NODE_ENV === "development" && isLocalhost;
 
     if (showDevConsole === true) {
       // Explicitly show the inspector
       setShouldRenderInspector(true);
-      setIsLocalInspectorEnabled(isLocalhost);
+      setIsLocalInspectorEnabled(canShowLocalInspectorAction);
     } else if (showDevConsole === "auto") {
       // Show on localhost or 127.0.0.1 only
       if (isLocalhost) {
         setShouldRenderInspector(true);
-        setIsLocalInspectorEnabled(true);
+        setIsLocalInspectorEnabled(canShowLocalInspectorAction);
       } else {
         setShouldRenderInspector(false);
         setIsLocalInspectorEnabled(false);

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -5,6 +5,7 @@ import type { FrontendTool } from "@copilotkit/core";
 import type React from "react";
 import {
   useMemo,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useReducer,
@@ -19,6 +20,8 @@ export type { CopilotKitContextValue } from "../context";
 export { CopilotKitContext, useLicenseContext } from "../context";
 import { z } from "zod";
 import { CopilotKitInspector } from "../components/CopilotKitInspector";
+import { CopilotKitInspectorContextProvider } from "../components/CopilotKitInspectorContext";
+import type { CopilotKitInspectorOpenRequest } from "../components/CopilotKitInspectorContext";
 import type { Anchor } from "@copilotkit/web-inspector";
 import { LicenseWarningBanner } from "../components/license-warning-banner";
 import { createLicenseContextValue } from "@copilotkit/shared";
@@ -294,6 +297,9 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   debug,
 }) => {
   const [shouldRenderInspector, setShouldRenderInspector] = useState(false);
+  const [isLocalInspectorEnabled, setIsLocalInspectorEnabled] = useState(false);
+  const [inspectorOpenRequest, setInspectorOpenRequest] =
+    useState<CopilotKitInspectorOpenRequest | null>(null);
   const [runtimeA2UIEnabled, setRuntimeA2UIEnabled] = useState(false);
   const [runtimeOpenGenUIEnabled, setRuntimeOpenGenUIEnabled] = useState(false);
   // Bumped by onCatalogComponentsChanged so the filtered catalog re-derives
@@ -314,22 +320,43 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
       return;
     }
 
+    const localhostHosts = new Set(["localhost", "127.0.0.1"]);
+    const isLocalhost = localhostHosts.has(window.location?.hostname ?? "");
+
     if (showDevConsole === true) {
       // Explicitly show the inspector
       setShouldRenderInspector(true);
+      setIsLocalInspectorEnabled(isLocalhost);
     } else if (showDevConsole === "auto") {
       // Show on localhost or 127.0.0.1 only
-      const localhostHosts = new Set(["localhost", "127.0.0.1"]);
-      if (localhostHosts.has(window.location.hostname)) {
+      if (isLocalhost) {
         setShouldRenderInspector(true);
+        setIsLocalInspectorEnabled(true);
       } else {
         setShouldRenderInspector(false);
+        setIsLocalInspectorEnabled(false);
       }
     } else {
       // showDevConsole is false or undefined (default false)
       setShouldRenderInspector(false);
+      setIsLocalInspectorEnabled(false);
     }
   }, [showDevConsole]);
+
+  const requestInspectorOpen = useCallback(
+    (request: CopilotKitInspectorOpenRequest) => {
+      setInspectorOpenRequest({ ...request });
+    },
+    [],
+  );
+
+  const inspectorContextValue = useMemo(
+    () => ({
+      isLocalInspectorEnabled,
+      openInspector: requestInspectorOpen,
+    }),
+    [isLocalInspectorEnabled, requestInspectorOpen],
+  );
 
   // Normalize array props to stable references with clear dev warnings
   const renderToolCallsList = useStableArrayProp<ReactToolCallRenderer<any>>(
@@ -919,13 +946,16 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
               includeSchema={a2ui?.includeSchema}
             />
           )}
-          {children}
-          {shouldRenderInspector ? (
-            <CopilotKitInspector
-              core={copilotkit}
-              defaultAnchor={inspectorDefaultAnchor}
-            />
-          ) : null}
+          <CopilotKitInspectorContextProvider value={inspectorContextValue}>
+            {children}
+            {shouldRenderInspector ? (
+              <CopilotKitInspector
+                core={copilotkit}
+                defaultAnchor={inspectorDefaultAnchor}
+                openRequest={inspectorOpenRequest}
+              />
+            ) : null}
+          </CopilotKitInspectorContextProvider>
           {/* License warnings — driven by server-reported status */}
           {runtimeLicenseStatus === "none" && !resolvedPublicKey && (
             <LicenseWarningBanner type="no_license" />

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.inspectorVisibility.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.inspectorVisibility.test.tsx
@@ -1,0 +1,89 @@
+import type { AssistantMessage } from "@ag-ui/core";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CopilotChatAssistantMessage } from "../../components/chat/CopilotChatAssistantMessage";
+import { CopilotChatConfigurationProvider } from "../CopilotChatConfigurationProvider";
+import { CopilotKitProvider } from "../CopilotKitProvider";
+
+const assistantMessage: AssistantMessage = {
+  id: "assistant-message",
+  role: "assistant",
+  content: "A response to inspect.",
+};
+
+const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+function renderAssistantMessage(
+  hostname: string,
+  showDevConsole: boolean | "auto" = true,
+) {
+  Object.defineProperty(window, "location", {
+    value: { hostname },
+    configurable: true,
+  });
+
+  return render(
+    <CopilotKitProvider
+      runtimeUrl="/api/copilotkit"
+      showDevConsole={showDevConsole}
+    >
+      <CopilotChatConfigurationProvider threadId="thread-id">
+        <CopilotChatAssistantMessage message={assistantMessage} />
+      </CopilotChatConfigurationProvider>
+    </CopilotKitProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+
+  if (originalLocation) {
+    Object.defineProperty(window, "location", originalLocation);
+  }
+});
+
+describe("CopilotKitProvider local Inspector action", () => {
+  it("renders in development on localhost when the Inspector is enabled", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    renderAssistantMessage("localhost");
+    await act(async () => {});
+
+    expect(
+      screen.getByRole("button", { name: /view in inspector/i }),
+    ).toBeDefined();
+  });
+
+  it("does not render in production, even on localhost", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    renderAssistantMessage("localhost");
+    await act(async () => {});
+
+    expect(
+      screen.queryByRole("button", { name: /view in inspector/i }),
+    ).toBeNull();
+  });
+
+  it("does not render on a non-local domain, even in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    renderAssistantMessage("example.com");
+    await act(async () => {});
+
+    expect(
+      screen.queryByRole("button", { name: /view in inspector/i }),
+    ).toBeNull();
+  });
+
+  it("does not render when the Inspector is disabled", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    renderAssistantMessage("localhost", false);
+    await act(async () => {});
+
+    expect(
+      screen.queryByRole("button", { name: /view in inspector/i }),
+    ).toBeNull();
+  });
+});

--- a/packages/web-inspector/src/__tests__/thread-detail.spec.ts
+++ b/packages/web-inspector/src/__tests__/thread-detail.spec.ts
@@ -527,6 +527,94 @@ test("real metadata renders the exact labels, full identity, and supplied option
   }
 });
 
+test("a message focus request scrolls and pulses once per request", async () => {
+  prepareDom();
+  const scrollIntoView = vi.fn();
+  const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollIntoView",
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoView,
+  });
+  const detail = new CpkThreadInspector();
+  detail.threadId = "thread-focused-message";
+  detail.focusMessageId = "assistant-message-1";
+  detail.focusRequestId = 1;
+  detail.provider = {
+    getEvents: vi.fn().mockResolvedValue([
+      {
+        type: "TEXT_MESSAGE_START",
+        timestamp: "2026-06-25T10:00:00.000Z",
+        payload: {
+          messageId: "assistant-message-1",
+          role: "assistant",
+        },
+      },
+      {
+        type: "TEXT_MESSAGE_CONTENT",
+        timestamp: "2026-06-25T10:00:01.000Z",
+        payload: {
+          messageId: "assistant-message-1",
+          delta: "Focused response",
+        },
+      },
+    ]),
+  };
+  document.body.append(detail);
+
+  try {
+    await vi.waitFor(() => {
+      const focusedMessage = detail.shadowRoot?.querySelector<HTMLElement>(
+        '[data-message-id="assistant-message-1"]',
+      );
+      expect(focusedMessage).not.toBeNull();
+      expect(focusedMessage?.classList.contains("cpk-td__focus-pulse")).toBe(
+        true,
+      );
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    });
+
+    const focusedMessage = detail.shadowRoot?.querySelector<HTMLElement>(
+      '[data-message-id="assistant-message-1"]',
+    );
+    focusedMessage?.dispatchEvent(new Event("animationend"));
+    expect(focusedMessage?.classList.contains("cpk-td__focus-pulse")).toBe(
+      false,
+    );
+
+    scrollIntoView.mockClear();
+    detail.agentEventsInput = [...detail.agentEventsInput];
+    await detail.updateComplete;
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    expect(focusedMessage?.classList.contains("cpk-td__focus-pulse")).toBe(
+      false,
+    );
+
+    detail.focusRequestId = 2;
+    await detail.updateComplete;
+    await vi.waitFor(() => {
+      expect(focusedMessage?.classList.contains("cpk-td__focus-pulse")).toBe(
+        true,
+      );
+    });
+  } finally {
+    detail.remove();
+    if (originalScrollIntoView) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "scrollIntoView",
+        originalScrollIntoView,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+    }
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  }
+});
+
 test("missing metadata falls back to Untitled and the full thread ID without optional account facts", async () => {
   prepareDom();
   const threadId = "thread-fallback-full-0987654321-zyxwvutsrqponmlkjihgfedcba";

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -10,6 +10,7 @@ import { CopilotKitCoreRuntimeConnectionStatus } from "@copilotkit/core";
 import type { CopilotKitCoreSubscriber } from "@copilotkit/core";
 import type { Memory } from "@copilotkit/core";
 import type { AbstractAgent, AgentSubscriber } from "@ag-ui/client";
+import type { InspectorOpenSource } from "../lib/telemetry.js";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // --- Types for accessing LitElement-private reactive properties ---
@@ -350,6 +351,38 @@ describe("WebInspectorElement", () => {
       "STEP_FINISHED",
       "STEP_STARTED",
     ]);
+  });
+
+  it("opens the requested message's thread", async () => {
+    const { agent } = createMockAgent("alpha");
+    const { core, emitAgentsChanged } = createMockCore({ alpha: agent });
+    const inspector = createInspectorWithCore(core);
+
+    emitAgentsChanged();
+    await inspector.updateComplete;
+
+    inspector.openInspector("message_toolbar", {
+      threadId: "thread-1",
+      agentId: "alpha",
+      messageId: "assistant-message-1",
+    });
+    await inspector.updateComplete;
+
+    const focusInternals = inspector as unknown as {
+      isOpen: boolean;
+      selectedMenu: string;
+      selectedContext: string;
+      selectedThreadId: string | null;
+      focusedThreadMessageId: string | null;
+      threadFocusRequestId: number;
+    };
+
+    expect(focusInternals.isOpen).toBe(true);
+    expect(focusInternals.selectedMenu).toBe("threads");
+    expect(focusInternals.selectedContext).toBe("alpha");
+    expect(focusInternals.selectedThreadId).toBe("thread-1");
+    expect(focusInternals.focusedThreadMessageId).toBe("assistant-message-1");
+    expect(focusInternals.threadFocusRequestId).toBe(1);
   });
 
   it("normalizes context, persists state, and copies context values", async () => {
@@ -1589,7 +1622,7 @@ type OpenTelemetryInternals = {
   isOpen: boolean;
   announcementTimestamp: string | null;
   fetchAnnouncement: () => Promise<void>;
-  openInspector: (source: "floating_button" | "announcement_preview") => void;
+  openInspector: (source: InspectorOpenSource) => void;
 };
 
 describe("WebInspectorElement open + banner surface telemetry", () => {
@@ -1716,6 +1749,19 @@ describe("WebInspectorElement open + banner surface telemetry", () => {
     expect(eventsNamed("oss.inspector.opened")[0]!.properties).toMatchObject({
       open_source: "announcement_preview",
     });
+  });
+
+  it("attributes an open from an assistant message toolbar", async () => {
+    const { inspector, internals } = mount();
+    await inspector.updateComplete;
+
+    inspector.openInspector("message_toolbar");
+    await inspector.updateComplete;
+
+    expect(eventsNamed("oss.inspector.opened")[0]!.properties).toMatchObject({
+      open_source: "message_toolbar",
+    });
+    expect(internals.isOpen).toBe(true);
   });
 
   it("counts one open per open, and nothing for an already-open panel", async () => {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -110,6 +110,15 @@ export type { Anchor } from "./lib/types.js";
 export { buildCapabilityRows as ɵbuildCapabilityRows };
 export type { CapabilityToolRow as ɵCapabilityToolRow };
 
+export type InspectorOpenOptions = {
+  /** Select the thread that contains the message. */
+  threadId?: string;
+  /** Narrow the Threads view to the agent that owns the thread. */
+  agentId?: string;
+  /** Scroll the selected thread timeline to this message when available. */
+  messageId?: string;
+};
+
 export const WEB_INSPECTOR_TAG = "cpk-web-inspector" as const;
 export const THREAD_INSPECTOR_TAG = "cpk-thread-inspector" as const;
 
@@ -569,6 +578,7 @@ type TimelineItemKind =
 
 type TimelineItem = {
   id: string;
+  messageId?: string;
   kind: TimelineItemKind;
   title: string;
   body?: string;
@@ -1295,6 +1305,8 @@ export class CpkThreadInspector extends LitElement {
     agentStateInput: { attribute: false },
     agentEventsInput: { attribute: false },
     liveMessageVersion: { attribute: false },
+    focusMessageId: { attribute: false },
+    focusRequestId: { attribute: false },
     _tab: { state: true },
     _fetchedMetadata: { state: true },
     _conversation: { state: true },
@@ -1333,6 +1345,8 @@ export class CpkThreadInspector extends LitElement {
    * so the conversation view reflects live streaming output.
    */
   liveMessageVersion = 0;
+  focusMessageId: string | null = null;
+  focusRequestId = 0;
 
   private _tab: ThreadDetailsTab = "timeline";
   private _fetchedMetadata: ThreadDebuggerMetadata | null = null;
@@ -1355,6 +1369,8 @@ export class CpkThreadInspector extends LitElement {
   private _eventsNotAvailable = false;
   /** True when the /state endpoint returned 501 — don't fall back to live data. */
   private _stateNotAvailable = false;
+  private _scrolledFocusRequestId = 0;
+  private _highlightedFocusRequestId = -1;
   /**
    * Briefly true after a tab switch so the active-tab highlight + a generic
    * "Loading…" placeholder paint before the heavy per-tab render runs. Without
@@ -1798,6 +1814,37 @@ export class CpkThreadInspector extends LitElement {
 
     .cpk-td__status--error {
       color: #c0333a;
+    }
+
+    @keyframes cpk-td-focus-pulse {
+      0% {
+        outline-color: rgba(100, 48, 171, 0);
+        box-shadow: 0 0 0 rgba(100, 48, 171, 0);
+        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+      }
+      24%,
+      50% {
+        outline-color: rgba(100, 48, 171, 0.78);
+        box-shadow: 0 7px 20px rgba(100, 48, 171, 0.2);
+      }
+      100% {
+        outline-color: rgba(100, 48, 171, 0);
+        box-shadow: 0 0 0 rgba(100, 48, 171, 0);
+      }
+    }
+
+    .cpk-td__focus-pulse {
+      position: relative;
+      z-index: 1;
+      outline: 2px solid transparent;
+      outline-offset: 3px;
+      animation: cpk-td-focus-pulse 760ms linear;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .cpk-td__focus-pulse {
+        animation-duration: 320ms;
+      }
     }
 
     /* ── Conversation bubbles ────────────────────────────────────────── */
@@ -2353,6 +2400,47 @@ export class CpkThreadInspector extends LitElement {
       this._messagesAbort = null;
       void this.fetchMessages(this.threadId, true);
     }
+
+    const focusedContentChanged =
+      _changed.has("_fetchedEvents") ||
+      _changed.has("agentEventsInput") ||
+      _changed.has("_conversation");
+    if (
+      this.focusMessageId &&
+      (this.focusRequestId > this._scrolledFocusRequestId ||
+        focusedContentChanged)
+    ) {
+      if (this._tab !== "timeline") {
+        this._activatedTabs = new Set([...this._activatedTabs, "timeline"]);
+        this._tab = "timeline";
+        this.requestUpdate();
+      }
+      requestAnimationFrame(() => this.scrollToFocusedMessage());
+    }
+  }
+
+  private scrollToFocusedMessage(): void {
+    if (!this.focusMessageId) return;
+    const message = Array.from(
+      this.shadowRoot?.querySelectorAll<HTMLElement>("[data-message-id]") ?? [],
+    ).find((candidate) => candidate.dataset.messageId === this.focusMessageId);
+    if (!message) return;
+    message.scrollIntoView?.({ block: "center" });
+    this._scrolledFocusRequestId = this.focusRequestId;
+    this.pulseFocusedMessage(message);
+  }
+
+  private pulseFocusedMessage(message: HTMLElement): void {
+    if (this.focusRequestId === this._highlightedFocusRequestId) return;
+    this._highlightedFocusRequestId = this.focusRequestId;
+    message.classList.remove("cpk-td__focus-pulse");
+    void message.offsetWidth;
+    message.classList.add("cpk-td__focus-pulse");
+    message.addEventListener(
+      "animationend",
+      () => message.classList.remove("cpk-td__focus-pulse"),
+      { once: true },
+    );
   }
 
   connectedCallback(): void {
@@ -2822,6 +2910,7 @@ export class CpkThreadInspector extends LitElement {
       if (!item) {
         item = {
           id: `message-${key}`,
+          messageId: key,
           kind: "message",
           title: `${role || "message"} message`,
           body: "",
@@ -3498,6 +3587,7 @@ export class CpkThreadInspector extends LitElement {
         class="cpk-td__timeline-item ${
           isWarning ? "cpk-td__timeline-item--warning" : ""
         }"
+        data-message-id=${item.messageId ?? nothing}
       >
         <div class="cpk-td__timeline-header">
           <span class="cpk-td__timeline-kind"
@@ -3691,6 +3781,7 @@ export class CpkThreadInspector extends LitElement {
         class="cpk-td__bubble ${
           isUser ? "cpk-td__bubble--user" : "cpk-td__bubble--assistant"
         }"
+        data-message-id=${item.id}
       >
         <div
           class="cpk-td__bubble-inner ${
@@ -4832,6 +4923,9 @@ export class WebInspectorElement extends LitElement {
   private selectedThreadId: string | null = null;
   private selectedRealThreadIsExplicit = false;
   private selectedLocalExampleThreadId: string | null = null;
+  private requestedThreadId: string | null = null;
+  private focusedThreadMessageId: string | null = null;
+  private threadFocusRequestId = 0;
   private threadListWidth = 290;
   private threadDividerResizing = false;
   private threadDividerPointerId = -1;
@@ -5421,6 +5515,17 @@ export class WebInspectorElement extends LitElement {
     if (!this.areThreadEndpointsAvailable()) return;
     const { displayThreads } = this.getActiveThreadsState();
     const previousSelectedThreadId = this.selectedThreadId;
+
+    if (this.requestedThreadId !== null) {
+      this.selectedThreadId = this.requestedThreadId;
+      this.selectedRealThreadIsExplicit = true;
+      if (
+        displayThreads.some((thread) => thread.id === this.requestedThreadId)
+      ) {
+        this.requestedThreadId = null;
+      }
+      return;
+    }
 
     if (
       this.selectedLocalExampleThreadId !== null &&
@@ -6326,6 +6431,35 @@ export class WebInspectorElement extends LitElement {
     }
 
     return this.agentEvents.get(this.selectedContext) ?? [];
+  }
+
+  private focusThread(options: InspectorOpenOptions): void {
+    if (!options.threadId) return;
+    this.pendingPersistedMenu = null;
+    this.selectedMenu = "threads";
+    this.settingsOpen = false;
+    this.lastSelectedMenuByGroup.threads = "threads";
+    this.contextMenuOpen = false;
+    this.selectedLocalExampleThreadId = null;
+    this.exampleTourActive = false;
+    this.selectedContext =
+      options.agentId &&
+      this.contextOptions.some((option) => option.key === options.agentId)
+        ? options.agentId
+        : "all-agents";
+    this.requestedThreadId = options.threadId;
+    this.selectedThreadId = options.threadId;
+    this.selectedRealThreadIsExplicit = true;
+    this.focusedThreadMessageId = options.messageId ?? null;
+    this.threadFocusRequestId += 1;
+
+    const { displayThreads } = this.getActiveThreadsState();
+    if (displayThreads.some((thread) => thread.id === options.threadId)) {
+      this.requestedThreadId = null;
+    }
+
+    this.persistState();
+    this.requestUpdate();
   }
 
   private filterEvents(events: InspectorEvent[]): InspectorEvent[] {
@@ -8731,7 +8865,14 @@ ${argsString}</pre
     this.draggedDuringInteraction = false;
   }
 
-  private openInspector(source: InspectorOpenSource): void {
+  public openInspector(
+    source: InspectorOpenSource,
+    options: InspectorOpenOptions = {},
+  ): void {
+    if (options.threadId) {
+      this.focusThread(options);
+    }
+
     if (this.isOpen) {
       return;
     }
@@ -9738,6 +9879,8 @@ ${argsString}</pre
     threadId: string,
     showingExamples: boolean,
   ): void {
+    this.requestedThreadId = null;
+    this.focusedThreadMessageId = null;
     if (
       showingExamples &&
       this.selectedThreadId === threadId &&
@@ -11323,6 +11466,8 @@ ${argsString}</pre
                     .liveMessageVersion=${
                       this.liveMessageVersion.get(selectedThread.id) ?? 0
                     }
+                    .focusMessageId=${this.focusedThreadMessageId}
+                    .focusRequestId=${this.threadFocusRequestId}
                     .agentStateInput=${this.getLatestStateForAgent(
                       selectedThread.agentId,
                     )}

--- a/packages/web-inspector/src/lib/telemetry.ts
+++ b/packages/web-inspector/src/lib/telemetry.ts
@@ -235,7 +235,10 @@ export function trackBannerDismissed(props: {
  * deliberately NOT a source: it is not an open *intent*, and counting it
  * would turn every dev-server hot reload into an "open".
  */
-export type InspectorOpenSource = "floating_button" | "announcement_preview";
+export type InspectorOpenSource =
+  | "floating_button"
+  | "announcement_preview"
+  | "message_toolbar";
 
 export type InspectorOpenedTelemetryProps = {
   open_source: InspectorOpenSource;


### PR DESCRIPTION
## Summary

- Adds a local-only “View in Inspector” action to assistant messages using the colored CopilotKit mark.
- Opens the associated Inspector thread and focuses the selected message.
- Restricts the action to explicit development builds on loopback hosts.
- Adds focused React v2 demo coverage and regression tests.

## Why

Developers need a direct local debugging path from a rendered assistant response to its thread timeline without exposing development tooling in production or on non-local domains.

## How

- Exposes a local Inspector open request through the React provider and context.
- Passes message, thread, and agent identifiers into Web Inspector.
- Selects the matching thread, scrolls to the message, and applies a one-time focus pulse with reduced-motion support.
- Fails closed unless `NODE_ENV === "development"`, the hostname is `localhost` or `127.0.0.1`, and the Inspector is enabled.
- Covers development-local, production-local, development-remote, and disabled-Inspector visibility states.

### Screenshot

_Screenshot ready; attachment pending upload approval._

### Validation

- `pnpm nx test @copilotkit/web-inspector -- --run src/__tests__/web-inspector.spec.ts src/__tests__/thread-detail.spec.ts`
- `pnpm nx test @copilotkit/react-core` — 1,508 tests passed
- `pnpm nx check-types @copilotkit/web-inspector`
- `pnpm nx check-types @copilotkit/react-core`
- `NODE_ENV=production pnpm nx build @copilotkit/react-core`
- Pre-commit package tests, `publint`, and `attw`
