### PR TITLE
fix(react-core): gate CopilotChat submission on runtime readiness (empty assistant response)

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -120,7 +120,7 @@ export function CopilotChat({
   const hasExplicitThreadId =
     !!threadId || !!existingConfig?.hasExplicitThreadId;
 
-  const { agent } = useAgent({
+  const { agent, isReady } = useAgent({
     agentId: resolvedAgentId,
     throttleMs,
   });
@@ -1047,7 +1047,14 @@ export function CopilotChat({
     ...mergedProps,
     messages,
     // Input behavior props
-    onSubmitMessage: onSubmitInput,
+    // Gate submission on runtime readiness. While `isReady` is false the
+    // `agent` returned by useAgent is a provisional stand-in that `/info` will
+    // swap out; a message committed to it (and the composer cleared) is lost
+    // on that swap, surfacing as an empty assistant response. Withholding
+    // `onSubmitMessage` disables the send control (canSend keys off it) and
+    // makes Enter a no-op that preserves the composer text until the real
+    // agent is bound.
+    onSubmitMessage: isReady ? onSubmitInput : undefined,
     onStop: effectiveStopHandler,
     inputMode: effectiveMode,
     inputValue,

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -952,15 +952,20 @@ export function CopilotChat({
   // stability we just established for stableMessageView and other slot values.
   const mergedProps: Partial<CopilotChatViewProps> = {
     isRunning: agent.isRunning,
-    suggestions: autoSuggestions,
-    // Gate suggestion submission on runtime readiness, mirroring the
+    // HIDE suggestion pills until the runtime is ready, mirroring the
     // `onSubmitMessage` gate below. Static `available:"always"` pills render
     // during the provisional window (before `/info` swaps the real agent in),
     // so a click before `isReady` would commit `suggestion.message` to the
     // doomed provisional agent and run against it — the same empty-assistant
     // loss the typed-message gate prevents. Withholding `onSelectSuggestion`
-    // makes the pill click a no-op until the real agent is bound; the pill
-    // becomes live again once `isReady` flips true.
+    // alone leaves the pill VISUALLY ENABLED but inert (a click silently drops
+    // the user's intent), so instead we do not surface the pills at all until
+    // the real agent is bound: passing an empty list keeps `hasSuggestions`
+    // false in the view (the same mechanism that hides pills while connecting /
+    // running). Once `isReady` flips true the real suggestions appear and the
+    // handler goes live. The `onSelectSuggestion` gate is retained as
+    // defense-in-depth for any custom chatView slot that renders its own pills.
+    suggestions: isReady ? autoSuggestions : [],
     onSelectSuggestion: isReady ? handleSelectSuggestion : undefined,
     suggestionView: stableSuggestionView,
     ...restProps,

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -953,7 +953,15 @@ export function CopilotChat({
   const mergedProps: Partial<CopilotChatViewProps> = {
     isRunning: agent.isRunning,
     suggestions: autoSuggestions,
-    onSelectSuggestion: handleSelectSuggestion,
+    // Gate suggestion submission on runtime readiness, mirroring the
+    // `onSubmitMessage` gate below. Static `available:"always"` pills render
+    // during the provisional window (before `/info` swaps the real agent in),
+    // so a click before `isReady` would commit `suggestion.message` to the
+    // doomed provisional agent and run against it — the same empty-assistant
+    // loss the typed-message gate prevents. Withholding `onSelectSuggestion`
+    // makes the pill click a no-op until the real agent is bound; the pill
+    // becomes live again once `isReady` flips true.
+    onSelectSuggestion: isReady ? handleSelectSuggestion : undefined,
     suggestionView: stableSuggestionView,
     ...restProps,
   };

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../../__tests__/utils/test-helpers";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 import type { CopilotKitCore } from "@copilotkit/core";
+import { useConfigureSuggestions } from "../../../hooks/use-configure-suggestions";
 
 /**
  * Regression coverage for the fleet-wide "empty assistant response" bug.
@@ -170,5 +171,278 @@ describe("CopilotChat readiness gate (empty-assistant-response race)", () => {
       expect(document.body.textContent).toContain("Hi there! How can I help?");
     });
     expect(document.body.textContent).toContain("Hello during provisional");
+  });
+});
+
+/**
+ * Companion coverage for the suggestion-submission arm of the readiness gate.
+ *
+ * The same provisional-agent window that dropped a typed message also affects
+ * static `available:"always"` suggestion pills: they render on the welcome
+ * screen BEFORE `/info` resolves, so a pill selected during that window would
+ * commit `suggestion.message` to the doomed provisional agent (and run against
+ * it) — lost on the swap, surfacing as an empty assistant response. The fix
+ * withholds `onSelectSuggestion` until `isReady`, making the pill click a
+ * no-op during the provisional window and live once the real agent is bound.
+ */
+describe("CopilotChat readiness gate — suggestion submission", () => {
+  const originalFetch = global.fetch;
+  let resolveInfo: ((value: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    HTMLElement.prototype.scrollTo = vi.fn();
+    resolveInfo = undefined;
+    const infoPromise = new Promise((resolve) => {
+      resolveInfo = resolve;
+    });
+    global.fetch = vi.fn((url: RequestInfo | URL) => {
+      if (String(url).includes("/info")) return infoPromise;
+      return new Promise(() => {});
+    }) as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  function CaptureCore({ onCore }: { onCore: (c: CopilotKitCore) => void }) {
+    const { copilotkit } = useCopilotKit();
+    onCore(copilotkit);
+    return null;
+  }
+
+  const STATIC_SUGGESTIONS = [{ title: "Say hello", message: "Hello there!" }];
+
+  function ChatWithAlwaysSuggestions() {
+    useConfigureSuggestions({
+      suggestions: STATIC_SUGGESTIONS,
+      available: "always",
+      consumerAgentId: DEFAULT_AGENT_ID,
+    });
+    return <CopilotChat />;
+  }
+
+  it("does not commit a suggestion selected during the provisional window; it works once ready", async () => {
+    const realAgent = new MockStepwiseAgent();
+    let core: CopilotKitCore | undefined;
+
+    render(
+      <CopilotKitProvider runtimeUrl="http://localhost:59998/api">
+        <CaptureCore onCore={(c) => (core = c)} />
+        <div style={{ height: 400 }}>
+          <ChatWithAlwaysSuggestions />
+        </div>
+      </CopilotKitProvider>,
+    );
+
+    // --- Provisional window (isReady=false): the static pill is rendered ---
+    const pill = await screen.findByText("Say hello");
+
+    // A user click on the suggestion DURING the provisional window. The fix
+    // withholds onSelectSuggestion, so the click is a no-op and nothing is
+    // committed to the doomed provisional agent. The buggy build commits
+    // `suggestion.message` to the provisional agent (which is the agent
+    // currently rendered by CopilotChat), so its text appears in the DOM.
+    fireEvent.click(pill);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Discriminator: the suggestion's MESSAGE ("Hello there!", distinct from
+    // the pill's TITLE "Say hello") must NOT have been committed. In the buggy
+    // build it renders as a user message on the provisional agent → present.
+    expect(document.body.textContent).not.toContain("Hello there!");
+
+    // --- Runtime becomes ready (real agent swapped in) ---
+    act(() => {
+      core!.addAgent__unsafe_dev_only({
+        id: DEFAULT_AGENT_ID,
+        agent: realAgent,
+      });
+    });
+    await act(async () => {
+      resolveInfo!({
+        status: 200,
+        ok: true,
+        json: async () => ({
+          version: "1.0.0",
+          audioFileTranscriptionEnabled: false,
+          agents: {},
+        }),
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Now ready: the pill is live. Selecting it commits to the REAL agent and
+    // runs, producing a rendered response.
+    const readyPill = await screen.findByText("Say hello");
+    fireEvent.click(readyPill);
+
+    await waitFor(() => expect(realAgent.messages.length).toBeGreaterThan(0), {
+      timeout: 2000,
+    });
+
+    const messageId = testId("assistant");
+    realAgent.emit(runStartedEvent());
+    realAgent.emit(textChunkEvent(messageId, "Hi from suggestion!"));
+    realAgent.emit(runFinishedEvent());
+    realAgent.complete();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Hi from suggestion!");
+    });
+    // The suggestion's message survived to the real agent as a user message.
+    expect(document.body.textContent).toContain("Hello there!");
+  });
+});
+
+/**
+ * Production-shaped regression for the readiness gate that crosses the real
+ * network → SSE transport boundary (rather than injecting a controllable agent
+ * and emitting events directly). A public `<CopilotKit runtimeUrl=...>` drives
+ * the single-endpoint transport: a mocked `fetch` serves runtime `info` and
+ * `agent/run`, and `agent/run` streams a real `text/event-stream` body of
+ * AG-UI frames (RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT →
+ * TEXT_MESSAGE_END → RUN_FINISHED). This exercises the same provisional-window
+ * race end-to-end: with the gate absent the send committed to the provisional
+ * agent (clearing the composer), so the second click — against an empty
+ * composer whose send control is disabled — never runs and the assistant
+ * container stays empty. With the gate, the first click is a no-op that
+ * preserves the composer text, and the second (post-`/info`) click runs over
+ * the real transport, rendering the streamed assistant message.
+ */
+describe("CopilotChat readiness gate — production-shaped SSE transport", () => {
+  const RUNTIME_URL = "http://localhost:59997/api/copilotkit";
+  const originalFetch = global.fetch;
+  let resolveInfo: ((value: Response) => void) | undefined;
+  let agentRunCalls = 0;
+
+  const encoder = new TextEncoder();
+
+  function makeSseResponse(): Response {
+    const messageId = "assistant-sse-1";
+    const events = [
+      { type: "RUN_STARTED", threadId: "mock-thread-id", runId: "run-1" },
+      { type: "TEXT_MESSAGE_START", messageId, role: "assistant" },
+      { type: "TEXT_MESSAGE_CONTENT", messageId, delta: "Hi there! " },
+      { type: "TEXT_MESSAGE_CONTENT", messageId, delta: "How can I help?" },
+      { type: "TEXT_MESSAGE_END", messageId },
+      {
+        type: "RUN_FINISHED",
+        threadId: "mock-thread-id",
+        runId: "run-1",
+        result: { newMessages: [] },
+      },
+    ];
+    const payload = events
+      .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+      .join("");
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(payload));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }
+
+  beforeEach(() => {
+    HTMLElement.prototype.scrollTo = vi.fn();
+    resolveInfo = undefined;
+    agentRunCalls = 0;
+    // Hold the single-endpoint `info` handshake open so the runtime stays
+    // Connecting and useAgent returns a provisional agent (isReady=false).
+    const infoPromise = new Promise<Response>((resolve) => {
+      resolveInfo = resolve;
+    });
+    global.fetch = vi.fn((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method;
+      // Auto-detect tries REST GET /info first; 404 forces the single-endpoint
+      // POST transport the reviewer asked us to exercise.
+      if (u.endsWith("/info") && method !== "POST") {
+        return Promise.resolve(new Response("Not Found", { status: 404 }));
+      }
+      if (u === RUNTIME_URL && method === "POST") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          method?: string;
+        };
+        if (body.method === "info") return infoPromise;
+        if (body.method === "agent/run") {
+          agentRunCalls += 1;
+          return Promise.resolve(makeSseResponse());
+        }
+      }
+      // Any other request (e.g. a provisional-agent run in the buggy build)
+      // hangs harmlessly.
+      return new Promise(() => {});
+    }) as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("streams the assistant response over the real transport after a send during the provisional window", async () => {
+    render(
+      <CopilotKitProvider runtimeUrl={RUNTIME_URL}>
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      </CopilotKitProvider>,
+    );
+
+    // --- Provisional window (isReady=false): user types and sends ---
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Hello during provisional" } });
+    // Buggy build: commits to the provisional agent AND clears the composer.
+    // Fixed build: gated no-op that preserves the composer text.
+    fireEvent.click(screen.getByTestId("copilot-send-button"));
+
+    // --- Resolve the single-endpoint `info` → runtime Connected, real agent
+    // discovered from `agents: { default }`, isReady flips true. ---
+    await act(async () => {
+      resolveInfo!(
+        new Response(
+          JSON.stringify({
+            version: "1.0.0",
+            audioFileTranscriptionEnabled: false,
+            agents: { [DEFAULT_AGENT_ID]: { description: "Default agent" } },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Second click WITHOUT re-typing. In the fixed build the composer still
+    // holds the text (canSend is true) so this runs over the real transport;
+    // in the buggy build the composer was cleared, the send control is disabled,
+    // and nothing runs.
+    fireEvent.click(screen.getByTestId("copilot-send-button"));
+
+    // The user message must have survived and produced a rendered assistant
+    // message streamed over the real SSE transport.
+    await waitFor(
+      () => {
+        const el = document.querySelector(
+          '[data-testid="copilot-assistant-message"]',
+        );
+        expect(el?.textContent ?? "").toContain("Hi there! How can I help?");
+      },
+      { timeout: 3000 },
+    );
+    expect(document.body.textContent).toContain("Hello during provisional");
+    // Proves the run crossed the transport boundary (not a directly-emitted
+    // event): exactly one agent/run POST reached the mocked runtime.
+    expect(agentRunCalls).toBe(1);
   });
 });

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { useCopilotKit } from "../../../context";
+import { CopilotChat } from "../CopilotChat";
+import {
+  MockStepwiseAgent,
+  runStartedEvent,
+  runFinishedEvent,
+  textChunkEvent,
+  testId,
+} from "../../../__tests__/utils/test-helpers";
+import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
+import type { CopilotKitCore } from "@copilotkit/core";
+
+/**
+ * Regression coverage for the fleet-wide "empty assistant response" bug.
+ *
+ * #5801 (first shipped 1.63.0) deferred the runtime `/info` handshake to a
+ * React effect, widening the "provisional agent" window. `useAgent` exposes an
+ * `isReady` flag (1.63.2) that is `false` while the provisional stand-in is
+ * live and flips `true` once `/info` swaps in the real agent. `CopilotChat`
+ * never consumed `isReady`, so a message SENT during the provisional window was
+ * committed to the provisional agent (and the composer cleared) and then LOST
+ * when `/info` swapped the `agent` reference — surfacing as an empty assistant
+ * response.
+ *
+ * This exercises the real readiness race against the real `CopilotChat` submit
+ * path: it holds the runtime in the Connecting/provisional state, sends during
+ * that window, then resolves `/info` (the actual status-change re-render that
+ * flips `isReady`), and asserts the message survives to produce a rendered
+ * assistant response.
+ */
+describe("CopilotChat readiness gate (empty-assistant-response race)", () => {
+  const originalFetch = global.fetch;
+  let resolveInfo: ((value: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    resolveInfo = undefined;
+    // Hold the `/info` handshake open so the runtime stays Connecting and
+    // useAgent returns a provisional agent (isReady=false). Any other fetch
+    // (e.g. a run dispatched against the provisional agent) hangs harmlessly.
+    const infoPromise = new Promise((resolve) => {
+      resolveInfo = resolve;
+    });
+    global.fetch = vi.fn((url: RequestInfo | URL) => {
+      if (String(url).includes("/info")) return infoPromise;
+      return new Promise(() => {});
+    }) as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  function CaptureCore({ onCore }: { onCore: (c: CopilotKitCore) => void }) {
+    const { copilotkit } = useCopilotKit();
+    onCore(copilotkit);
+    return null;
+  }
+
+  it("does not drop a message sent during the provisional window; the assistant response renders once ready", async () => {
+    const realAgent = new MockStepwiseAgent();
+    let core: CopilotKitCore | undefined;
+
+    render(
+      <CopilotKitProvider runtimeUrl="http://localhost:59999/api">
+        <CaptureCore onCore={(c) => (core = c)} />
+        {/* No explicit threadId -> isConnecting stays false, so the input
+            overlay does not confound the readiness gate under test. */}
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      </CopilotKitProvider>,
+    );
+
+    // --- Provisional window (isReady=false): user types and sends ---
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "Hello during provisional" } });
+
+    // A user click on the send control DURING the provisional window. The fix
+    // gates this so nothing is committed to the doomed provisional agent and the
+    // composer text is preserved; the buggy build commits it (clearing the
+    // composer), losing it on the swap below.
+    fireEvent.click(screen.getByTestId("copilot-send-button"));
+
+    // --- Runtime becomes ready ---
+    // Register the controllable agent under the resolved id, then resolve
+    // `/info` (with no remote agents). Resolving flips the runtime
+    // Connecting -> Connected, whose status-change event re-renders the tree;
+    // useAgent then finds the real agent via getAgent() and flips isReady=true,
+    // swapping out the provisional stand-in — the real `/info` swap.
+    act(() => {
+      core!.addAgent__unsafe_dev_only({
+        id: DEFAULT_AGENT_ID,
+        agent: realAgent,
+      });
+    });
+    await act(async () => {
+      resolveInfo!({
+        // `status` (not just `ok`) is required: the default "auto" transport
+        // treats a 2xx GET /info as the REST runtime; without a 2xx status it
+        // falls through to the single-endpoint POST and never connects.
+        status: 200,
+        ok: true,
+        json: async () => ({
+          version: "1.0.0",
+          audioFileTranscriptionEnabled: false,
+          agents: {},
+        }),
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Send control is enabled now. Click send again WITHOUT re-typing: this
+    // relies on the composer still holding the text (the fix's message-
+    // preservation guarantee). In the buggy build the composer was cleared on
+    // the provisional commit, so this second click sends nothing.
+    fireEvent.click(screen.getByTestId("copilot-send-button"));
+
+    // Wait until the message is committed onto the REAL agent (addMessage runs
+    // just before onSubmitInput awaits copilotkit.runAgent, so this is a
+    // reliable signal that the run is about to subscribe to the agent stream).
+    // Body text alone is unreliable here: the textarea's auto-resize mirror
+    // echoes the composer contents, so it would report the text before any
+    // message is committed.
+    //
+    // In the BUGGY build this never happens: the provisional click already
+    // consumed and cleared the composer, so the second click sends nothing and
+    // the real agent never receives the message. Tolerate that here (bounded)
+    // so the failure surfaces on the empty-container assertion below rather
+    // than on this intermediate wait.
+    try {
+      await waitFor(
+        () => expect(realAgent.messages.length).toBeGreaterThan(0),
+        { timeout: 2000 },
+      );
+    } catch {
+      // Buggy build: message was dropped on the provisional->ready swap.
+    }
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Drive the real agent's assistant response. emit() wraps each event in
+    // act() internally; a trailing flush lets the batched re-render commit.
+    const messageId = testId("assistant");
+    realAgent.emit(runStartedEvent());
+    realAgent.emit(textChunkEvent(messageId, "Hi there! "));
+    realAgent.emit(textChunkEvent(messageId, "How can I help?"));
+    realAgent.emit(runFinishedEvent());
+    realAgent.complete();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    // The user's message must have survived the provisional->ready swap and
+    // produced a rendered assistant response (non-empty container). The streamed
+    // markdown text renders across multiple inline leaf nodes, so assert against
+    // the rendered container's text rather than a single-element getByText.
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Hi there! How can I help?");
+    });
+    expect(document.body.textContent).toContain("Hello during provisional");
+  });
+});

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
@@ -8,6 +8,10 @@ import {
 } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+// Real public customer-surface wrapper (the same one exercised by
+// CopilotListeners.defaultAgentAbsent.test.tsx / v1-explicit-threadid-bridge.test.tsx
+// and used by Showcase). Its normal default is `useSingleEndpoint=true`.
+import { CopilotKit } from "../../../../components/copilot-provider/copilotkit";
 import { useCopilotKit } from "../../../context";
 import { CopilotChat } from "../CopilotChat";
 import {
@@ -181,9 +185,11 @@ describe("CopilotChat readiness gate (empty-assistant-response race)", () => {
  * static `available:"always"` suggestion pills: they render on the welcome
  * screen BEFORE `/info` resolves, so a pill selected during that window would
  * commit `suggestion.message` to the doomed provisional agent (and run against
- * it) — lost on the swap, surfacing as an empty assistant response. The fix
- * withholds `onSelectSuggestion` until `isReady`, making the pill click a
- * no-op during the provisional window and live once the real agent is bound.
+ * it) — lost on the swap, surfacing as an empty assistant response. Merely
+ * withholding `onSelectSuggestion` would leave the pill VISUALLY ENABLED but
+ * inert (a click silently drops the user's intent), so the fix HIDES the pills
+ * until `isReady`: they are not rendered during the provisional window and
+ * appear (live) only once the real agent is bound.
  */
 describe("CopilotChat readiness gate — suggestion submission", () => {
   const originalFetch = global.fetch;
@@ -223,7 +229,7 @@ describe("CopilotChat readiness gate — suggestion submission", () => {
     return <CopilotChat />;
   }
 
-  it("does not commit a suggestion selected during the provisional window; it works once ready", async () => {
+  it("hides the suggestion pill during the provisional window; it appears and works once ready", async () => {
     const realAgent = new MockStepwiseAgent();
     let core: CopilotKitCore | undefined;
 
@@ -236,23 +242,19 @@ describe("CopilotChat readiness gate — suggestion submission", () => {
       </CopilotKitProvider>,
     );
 
-    // --- Provisional window (isReady=false): the static pill is rendered ---
-    const pill = await screen.findByText("Say hello");
-
-    // A user click on the suggestion DURING the provisional window. The fix
-    // withholds onSelectSuggestion, so the click is a no-op and nothing is
-    // committed to the doomed provisional agent. The buggy build commits
-    // `suggestion.message` to the provisional agent (which is the agent
-    // currently rendered by CopilotChat), so its text appears in the DOM.
-    fireEvent.click(pill);
+    // --- Provisional window (isReady=false): the input renders, but the fix
+    // HIDES the static pill so it cannot be a visually-enabled-but-inert
+    // control that silently drops a click. Wait for the composer to mount so
+    // this is a real "rendered chat, no pill" state (not just a pre-mount
+    // frame). The buggy build renders the pill enabled here.
+    await screen.findByRole("textbox");
     await act(async () => {
       await new Promise((r) => setTimeout(r, 50));
     });
 
-    // Discriminator: the suggestion's MESSAGE ("Hello there!", distinct from
-    // the pill's TITLE "Say hello") must NOT have been committed. In the buggy
-    // build it renders as a user message on the provisional agent → present.
-    expect(document.body.textContent).not.toContain("Hello there!");
+    // Discriminator: the pill (its TITLE "Say hello") is NOT in the DOM while
+    // the runtime is provisional. Pre-fix the pill renders visually enabled.
+    expect(screen.queryByText("Say hello")).toBeNull();
 
     // --- Runtime becomes ready (real agent swapped in) ---
     act(() => {
@@ -303,20 +305,30 @@ describe("CopilotChat readiness gate — suggestion submission", () => {
 /**
  * Production-shaped regression for the readiness gate that crosses the real
  * network → SSE transport boundary (rather than injecting a controllable agent
- * and emitting events directly). A public `<CopilotKit runtimeUrl=...>` drives
- * the single-endpoint transport: a mocked `fetch` serves runtime `info` and
- * `agent/run`, and `agent/run` streams a real `text/event-stream` body of
- * AG-UI frames (RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT →
- * TEXT_MESSAGE_END → RUN_FINISHED). This exercises the same provisional-window
- * race end-to-end: with the gate absent the send committed to the provisional
- * agent (clearing the composer), so the second click — against an empty
- * composer whose send control is disabled — never runs and the assistant
- * container stays empty. With the gate, the first click is a no-op that
- * preserves the composer text, and the second (post-`/info`) click runs over
- * the real transport, rendering the streamed assistant message.
+ * and emitting events directly). It renders the REAL public customer-surface
+ * wrapper — `<CopilotKit runtimeUrl=... agent="agentic_chat">` imported from
+ * `components/copilot-provider/copilotkit`, the same wrapper Showcase uses and
+ * that `CopilotListeners.defaultAgentAbsent.test.tsx` /
+ * `v1-explicit-threadid-bridge.test.tsx` exercise — so it drives the same
+ * provider chain, agent selection, and single-endpoint POST `info` / `agent/run`
+ * path used in production. The wrapper's normal default is
+ * `useSingleEndpoint=true`, so the runtime info handshake is a POST
+ * `{ method: "info" }` (no REST GET `/info` probe — hence no synthetic 404
+ * fallback), and `agent/run` streams a real `text/event-stream` body of AG-UI
+ * frames (RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT →
+ * TEXT_MESSAGE_END → RUN_FINISHED).
+ *
+ * This exercises the same provisional-window race end-to-end: with the gate
+ * absent the send committed to the provisional agent (clearing the composer),
+ * so the second click — against an empty composer whose send control is
+ * disabled — never runs and the assistant container stays empty. With the gate,
+ * the first click is a no-op that preserves the composer text, and the second
+ * (post-`info`) click runs over the real transport, rendering the streamed
+ * assistant message.
  */
 describe("CopilotChat readiness gate — production-shaped SSE transport", () => {
   const RUNTIME_URL = "http://localhost:59997/api/copilotkit";
+  const AGENT_ID = "agentic_chat";
   const originalFetch = global.fetch;
   let resolveInfo: ((value: Response) => void) | undefined;
   let agentRunCalls = 0;
@@ -365,11 +377,9 @@ describe("CopilotChat readiness gate — production-shaped SSE transport", () =>
     global.fetch = vi.fn((url: RequestInfo | URL, init?: RequestInit) => {
       const u = String(url);
       const method = init?.method;
-      // Auto-detect tries REST GET /info first; 404 forces the single-endpoint
-      // POST transport the reviewer asked us to exercise.
-      if (u.endsWith("/info") && method !== "POST") {
-        return Promise.resolve(new Response("Not Found", { status: 404 }));
-      }
+      // The wrapper defaults to single-endpoint transport, so the runtime `info`
+      // handshake and the run both arrive as POSTs to the runtime URL — there is
+      // NO REST GET `/info` probe to fall back from.
       if (u === RUNTIME_URL && method === "POST") {
         const body = JSON.parse(String(init?.body ?? "{}")) as {
           method?: string;
@@ -393,11 +403,18 @@ describe("CopilotChat readiness gate — production-shaped SSE transport", () =>
 
   it("streams the assistant response over the real transport after a send during the provisional window", async () => {
     render(
-      <CopilotKitProvider runtimeUrl={RUNTIME_URL}>
+      // `showDevConsole={false}` mirrors a production deploy (Showcase runs with
+      // the dev console off) and keeps the jsdom-unbacked web-inspector
+      // localStorage hydration out of this transport-boundary test.
+      <CopilotKit
+        runtimeUrl={RUNTIME_URL}
+        agent={AGENT_ID}
+        showDevConsole={false}
+      >
         <div style={{ height: 400 }}>
           <CopilotChat welcomeScreen={false} />
         </div>
-      </CopilotKitProvider>,
+      </CopilotKit>,
     );
 
     // --- Provisional window (isReady=false): user types and sends ---
@@ -407,15 +424,16 @@ describe("CopilotChat readiness gate — production-shaped SSE transport", () =>
     // Fixed build: gated no-op that preserves the composer text.
     fireEvent.click(screen.getByTestId("copilot-send-button"));
 
-    // --- Resolve the single-endpoint `info` → runtime Connected, real agent
-    // discovered from `agents: { default }`, isReady flips true. ---
+    // --- Resolve the single-endpoint `info` → runtime Connected, the real
+    // `agentic_chat` agent discovered from the advertised `agents` map, isReady
+    // flips true. ---
     await act(async () => {
       resolveInfo!(
         new Response(
           JSON.stringify({
             version: "1.0.0",
             audioFileTranscriptionEnabled: false,
-            agents: { [DEFAULT_AGENT_ID]: { description: "Default agent" } },
+            agents: { [AGENT_ID]: { description: "Agentic chat agent" } },
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         ),

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -8,6 +8,7 @@ import {
   CvdiagProbeSession,
   wirePlaywrightPage,
   FIRST_TOKEN_GRACE_MS,
+  SEND_ENABLED_SELECTOR,
 } from "./d4-chat-roundtrip.js";
 import { filterEdgeHeaders } from "../../cvdiag/index.js";
 import { computeAbReport } from "../../cvdiag/ab-report.js";
@@ -3631,5 +3632,118 @@ describe("wirePlaywrightPage attach-fault telemetry (finding 3)", () => {
     await wired.goto("https://x.example.com/demos/agentic-chat", {});
     const st = await wired.readTurnState!();
     expect(st.sseAttachFailed).toBe(false);
+  });
+});
+
+// ── Readiness gate: send-control ordering ────────────────────────────────────
+//
+// react-core now gates chat submission on runtime readiness: while
+// `useAgent().isReady` is false, `CopilotChat` withholds `onSubmitMessage`,
+// which flips `canSend` false, renders `[data-testid="copilot-send-button"]`
+// with the HTML `disabled` attribute, and makes an Enter keypress a SILENT
+// no-op (the composer text is preserved, no turn starts, the assistant
+// response stays empty). A probe that types and immediately presses Enter
+// inside that provisional window sends into the void and the cell FALSELY reds.
+//
+// The driver's `sendTurn` therefore WAITS for the send control to become
+// ENABLED (`SEND_ENABLED_SELECTOR`, i.e. `:not([disabled])`) AFTER typing and
+// BEFORE pressing Enter. These tests pin that ordering with a fake page that
+// models the readiness gate: `press("Enter")` only COMMITS the turn (making the
+// assistant text observable) if the enabled-send wait happened first. Without
+// the wait (pre-fix driver) the Enter no-ops, the turn stays empty, and BOTH
+// the ordering assertion (the enabled-send wait is absent) and the green
+// assertion (empty response → red) fail — the local RED. With the wait the
+// ordering holds and the turn commits — the local GREEN.
+describe("d4 driver — readiness send-control ordering", () => {
+  interface OrderingProbe {
+    page: E2ePage;
+    /** Ordered log of page interactions: `type:*`, `waitForSelector:*`, `press:*`. */
+    calls: string[];
+  }
+
+  /**
+   * Fake page modelling the react-core readiness gate. The send control starts
+   * `disabled`; `waitForSelector(SEND_ENABLED_SELECTOR)` models Playwright
+   * blocking until the button is enabled — resolving it flips the internal
+   * "enabled" latch. `press("Enter")` commits the turn (makes `assistantText`
+   * observable through `evaluate`) ONLY if that latch is set, i.e. only if the
+   * driver waited for the enabled send control before pressing.
+   */
+  function makeOrderingPage(assistantText: string): OrderingProbe {
+    const calls: string[] = [];
+    let sendEnabledWaited = false;
+    let committed = false;
+    const page: E2ePage = {
+      async goto() {},
+      async type(sel, text) {
+        calls.push(`type:${sel}:${text}`);
+      },
+      async waitForSelector(sel) {
+        calls.push(`waitForSelector:${sel}`);
+        if (sel === SEND_ENABLED_SELECTOR) {
+          sendEnabledWaited = true;
+        }
+      },
+      async press(sel, key) {
+        calls.push(`press:${sel}:${key}`);
+        // Enter is a no-op unless the enabled-send wait happened first — the
+        // exact production behaviour of the readiness gate.
+        if (sendEnabledWaited) {
+          committed = true;
+        }
+      },
+      async textContent() {
+        return "";
+      },
+      async evaluate<R>(): Promise<R> {
+        return (committed ? assistantText : "") as unknown as R;
+      },
+      async close() {},
+    };
+    return { page, calls };
+  }
+
+  it("waits for the enabled send control BEFORE pressing Enter (type → wait-enabled → Enter)", async () => {
+    const probe = makeOrderingPage("Hello! Nice to meet you.");
+    const browser: E2eBrowser = {
+      async newContext(): Promise<E2eBrowserContext> {
+        return {
+          async newPage(): Promise<E2ePage> {
+            return probe.page;
+          },
+          async close() {},
+        };
+      },
+      async close() {},
+    };
+    const driver = createE2eSmokeDriver({
+      launcher: async () => browser,
+      // Keep the empty-response poll short so the pre-fix RED path fails fast
+      // (empty assistant text) instead of spinning the full page timeout.
+      textPollTimeoutMs: 100,
+    });
+    const writer = new CapturingWriter();
+
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+    });
+
+    // Ordering: the enabled-send wait must exist AND precede the Enter press.
+    const enabledWaitIdx = probe.calls.findIndex(
+      (c) => c === `waitForSelector:${SEND_ENABLED_SELECTOR}`,
+    );
+    const enterPressIdx = probe.calls.findIndex(
+      (c) => c === "press:textarea:Enter",
+    );
+    expect(enabledWaitIdx).toBeGreaterThanOrEqual(0);
+    expect(enterPressIdx).toBeGreaterThanOrEqual(0);
+    expect(enabledWaitIdx).toBeLessThan(enterPressIdx);
+
+    // And the readiness-gated turn actually commits → green (an early Enter
+    // would no-op, leaving an empty response → red).
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eSmokeSignal;
+    expect(sig.l3).toBe("green");
   });
 });

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.test.ts
@@ -2442,6 +2442,18 @@ function makeLateTokenBrowser(opts: {
    */
   firstTypeDelayMs?: number;
   /**
+   * Model the react-core readiness wait (`waitForSelector(SEND_ENABLED_SELECTOR)`,
+   * item-2/item-3): when set, that wait AWAITS this many ms before resolving
+   * (the send control settling from `disabled` → enabled). Draining wall-clock
+   * DURING the wait — rather than during `type` — is how the press-guard
+   * (`send-budget-exhausted`) path is exercised WITHOUT tripping the earlier
+   * readiness-budget guard (`delayed-readiness`): `type` completes with budget
+   * above `SEND_READY_MIN_BUDGET_MS`, the wait then drains the remaining budget
+   * below `SEND_PRESS_MIN_BUDGET_MS`. Only the readiness selector is delayed; the
+   * nav `waitForSelector("textarea")` is untouched.
+   */
+  sendEnableDelayMs?: number;
+  /**
    * Model an SSE-ONLY completion: the turn completes via the `runsFinished`
    * transport counter bumping past baseline, but NO fresh DOM `true→false`
    * stop-edge fires for THIS turn, so `lastStoppedAtMs` keeps holding a STALE
@@ -2573,7 +2585,32 @@ function makeLateTokenBrowser(opts: {
         const perSend = opts.responsesPerSend?.[sendCount - 1];
         if (perSend !== undefined) respHandler?.(perSend);
       },
-      async waitForSelector() {},
+      async waitForSelector(sel?: string, o?: { timeout?: number }) {
+        // Model the react-core readiness wait. Only the enabled-send selector is
+        // special-cased; the nav `waitForSelector("textarea")` stays a no-op.
+        if (sel === SEND_ENABLED_SELECTOR) {
+          // A doomed ~1ms readiness wait (budget drained before the wait) —
+          // Playwright rejects it, which pre-guard mis-classifies as a generic
+          // level-error. Mirrors the type/press timeout modelling.
+          if (
+            opts.throwWhenTimeoutAtMost !== undefined &&
+            o?.timeout !== undefined &&
+            o.timeout <= opts.throwWhenTimeoutAtMost
+          ) {
+            throw new Error(
+              `page.waitForSelector: Timeout ${o.timeout}ms exceeded waiting for selector "${sel}"`,
+            );
+          }
+          // A healthy wait that CONSUMES wall-clock (send control settling) so a
+          // test can drain the press budget during the wait itself.
+          if (
+            opts.sendEnableDelayMs !== undefined &&
+            opts.sendEnableDelayMs > 0
+          ) {
+            await new Promise((r) => setTimeout(r, opts.sendEnableDelayMs));
+          }
+        }
+      },
       async textContent() {
         return "";
       },
@@ -3165,21 +3202,23 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     expect(typeAttempts).toBe(1);
   }, 10000);
 
-  it("FIRST-SEND cap: a near-hang first `type` does NOT floor `press` to ~1ms → classified send-budget-exhausted, not a generic level-error", async () => {
-    // Item-1 first-send fold: the FIRST `type` near-hangs (awaits past the whole
-    // 2000ms envelope), so by the time `press` is reached the remaining budget
-    // has fully drained — below `RETRY_MIN_BUDGET_MS` (750ms) AND to the ~1ms
-    // pre-fix floor. `pageTimeoutMs` (2000ms) exceeds `RETRY_MIN_BUDGET_MS` so the
-    // FIRST `type` itself clears the guard (a fresh envelope) — only `press`,
-    // reached after the hang, trips it. The fake rejects any `type`/`press` whose
-    // action timeout is <= 5ms (Playwright's ~1ms rejection).
+  it("PRESS cap: the readiness wait drains the envelope so `press` would floor to ~1ms → classified send-budget-exhausted, not a generic level-error", async () => {
+    // Press-guard fold: `type` completes on a fresh envelope (budget well above
+    // `SEND_READY_MIN_BUDGET_MS`, so the item-2 readiness-budget guard does NOT
+    // fire), then the readiness wait (`waitForSelector(SEND_ENABLED_SELECTOR)`)
+    // CONSUMES nearly the whole 4000ms envelope, so by the time `press` is
+    // reached the remaining budget has drained below `SEND_PRESS_MIN_BUDGET_MS`
+    // (50ms) and to the ~1ms pre-fix floor. Draining during the WAIT (not during
+    // `type`) is what isolates the press guard from the earlier readiness guard.
+    // The fake rejects any `type`/`press` whose action timeout is <= 5ms
+    // (Playwright's ~1ms rejection).
     //
     // RED (pre-fix): `sendTurn` floored `press`'s timeout to `Math.max(1,
     // hardCeiling - now)` ≈ 1ms; the fake threw a page-fault-shaped "Timeout 1ms
     // exceeded…", the driver's outer catch red-classified it as a GENERIC
     // `level-error` — a self-inflicted 1ms floor masquerading as a real page
     // fault (spurious-red flap).
-    // GREEN (post-fix): the first-send min-budget guard throws a distinctly
+    // GREEN (post-fix): the press min-budget guard throws a distinctly
     // classified `SendBudgetExhaustedError` BEFORE issuing the doomed `press`, so
     // the red carries `errorDesc: send-budget-exhausted` (observable + specific),
     // never the catch-all `level-error`.
@@ -3189,8 +3228,55 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
         makeLateTokenBrowser({
           assistantText: "",
           firstTokenDelayMs: 100,
-          // First `type` eats the whole envelope so `press` drains below
-          // RETRY_MIN_BUDGET_MS (750ms) and to the ~1ms pre-fix floor.
+          // `type` is instant (fresh envelope clears the readiness guard); the
+          // readiness wait then eats almost the whole 4000ms envelope so `press`
+          // drains below SEND_PRESS_MIN_BUDGET_MS (50ms) and to the ~1ms floor.
+          sendEnableDelayMs: 3980,
+          throwWhenTimeoutAtMost: 5,
+        }) as unknown as E2eBrowser,
+      textPollTimeoutMs: 4000,
+      pageTimeoutMs: 4000,
+    });
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+      demos: [],
+    });
+    expect(result.state).toBe("red");
+    const chat = writer.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("red");
+    const errorDesc = (chat?.signal as { errorDesc?: string } | undefined)
+      ?.errorDesc;
+    // The discriminator: a distinct, observable classification — NOT the generic
+    // `level-error` a floored-1ms `press` throw produced pre-fix.
+    expect(errorDesc).toBe("send-budget-exhausted");
+  }, 10000);
+
+  // ── ITEM 2: readiness-budget guard (delayed-readiness classification) ────────
+  it("READINESS cap: a near-hang first `type` drains the envelope BEFORE the readiness wait → classified delayed-readiness, not a generic level-error", async () => {
+    // Item-2: react-core gates submission on `isReady`, so `sendTurn` waits for
+    // the send control to become ENABLED between `type` and `press`. When a
+    // near-hang first `type` drains the whole 2000ms envelope, that readiness
+    // wait would floor to `Math.max(1, hardCeiling - now)` ≈ 1ms — a doomed
+    // action Playwright rejects. The fake rejects a `waitForSelector` on the
+    // enabled-send selector whose timeout is <= 5ms (Playwright's ~1ms
+    // rejection), reproducing the exact reported bug.
+    //
+    // RED (pre-fix, no readiness-budget guard): the doomed ~1ms readiness
+    // `waitForSelector` threw a page-fault-shaped "Timeout 1ms exceeded…", which
+    // the driver's outer catch red-classified as a GENERIC `level-error` —
+    // indistinguishable from a real page fault (a spurious-red flap).
+    // GREEN (post-fix): the readiness min-budget guard throws a distinctly
+    // classified `ReadinessBudgetExhaustedError` BEFORE issuing the doomed wait,
+    // so the red carries `errorDesc: delayed-readiness` (observable + specific).
+    const writer = new CapturingWriter();
+    const driver = createE2eSmokeDriver({
+      launcher: async () =>
+        makeLateTokenBrowser({
+          assistantText: "",
+          firstTokenDelayMs: 100,
+          // First `type` eats the whole envelope so the readiness wait budget
+          // drains below SEND_READY_MIN_BUDGET_MS (100ms) and to the ~1ms floor.
           firstTypeDelayMs: 2100,
           throwWhenTimeoutAtMost: 5,
         }) as unknown as E2eBrowser,
@@ -3208,8 +3294,10 @@ describe("d4 L4 first-token wait hardening (readTurnState-driven)", () => {
     const errorDesc = (chat?.signal as { errorDesc?: string } | undefined)
       ?.errorDesc;
     // The discriminator: a distinct, observable classification — NOT the generic
-    // `level-error` a floored-1ms `press` throw produced pre-fix.
-    expect(errorDesc).toBe("send-budget-exhausted");
+    // `level-error` a floored-1ms readiness `waitForSelector` throw produced
+    // pre-fix, and NOT `send-budget-exhausted` (the readiness wait is reached
+    // BEFORE the press guard).
+    expect(errorDesc).toBe("delayed-readiness");
   }, 10000);
 });
 
@@ -3746,4 +3834,139 @@ describe("d4 driver — readiness send-control ordering", () => {
     const sig = result.signal as E2eSmokeSignal;
     expect(sig.l3).toBe("green");
   });
+});
+
+// ── ITEM 3: per-attempt baseline taken AFTER the readiness wait ──────────────
+// The driver captures the turn-lifecycle BASELINE (the page-global monotonic
+// `runsFinished` / `runStartCount` edge counters) that scopes "did THIS turn
+// complete?" to strictly-new edges past it. Taking that snapshot too early —
+// before the readiness wait — lets a DIFFERENT run that completes DURING the
+// wait (an auto-greeting / initial-mount run that finishes while the send
+// control is still settling) land its finished/started edge AFTER the snapshot.
+// The poll's `> baseline` gate then mistakes that unrelated completion for THIS
+// submitted turn finishing; with the assistant text not yet rendered the poll
+// fast-fails "empty assistant response" — a FALSE red on a turn that was about
+// to render correctly. Capturing the baseline AFTER `type` + the enabled-send
+// wait and immediately before Enter folds the during-wait edge into the
+// baseline, so only an edge that lands AFTER Enter counts.
+describe("d4 driver — per-attempt baseline captured after the readiness wait", () => {
+  /**
+   * Fake page modelling a run that completes DURING the readiness wait. A prior
+   * run has already finished (`prior = 1`). When the driver issues the readiness
+   * `waitForSelector(SEND_ENABLED_SELECTOR)`, a PHANTOM run (an auto/greeting run
+   * kicked off as the runtime becomes ready) both STARTS and FINISHES — bumping
+   * `runStartCount` and `runsFinished` past `prior` and settling `runningNow`
+   * false. The user's SUBMITTED turn then starts ~`submittedStartDelayMs` after
+   * Enter and finishes (rendering `assistantText`) at `submittedCompleteDelayMs`.
+   *
+   * With the baseline taken BEFORE the wait (pre-fix), it misses the phantom's
+   * edges, so the very first poll after Enter sees `runStartCount`/`runsFinished`
+   * already past baseline with `runningNow === false` → reads THIS turn as
+   * complete-and-empty and fast-fails RED before the real content lands. With the
+   * baseline taken AFTER the wait (post-fix) the phantom is folded in, so the
+   * poll waits for the submitted turn's OWN new edge and reads its content →
+   * GREEN.
+   */
+  function makeCounterAdvancesDuringWaitBrowser(opts: {
+    assistantText: string;
+    submittedStartDelayMs: number;
+    submittedCompleteDelayMs: number;
+  }): E2eBrowser {
+    const prior = 1;
+    const makeContaminatedPage = (): E2ePage => {
+      let phantomDone = false;
+      let pressed = false;
+      let pressAtMs = 0;
+      const page: E2ePage = {
+        async goto() {
+          return null;
+        },
+        async type() {},
+        async waitForSelector(sel?: string) {
+          // The phantom run starts+finishes DURING the readiness wait.
+          if (sel === SEND_ENABLED_SELECTOR) {
+            phantomDone = true;
+          }
+        },
+        async press(_sel, _key) {
+          pressed = true;
+          pressAtMs = Date.now();
+        },
+        async textContent() {
+          return "";
+        },
+        async evaluate<R>(): Promise<R> {
+          const submittedFinished =
+            pressed && Date.now() - pressAtMs >= opts.submittedCompleteDelayMs;
+          return (submittedFinished ? opts.assistantText : "") as unknown as R;
+        },
+        async readTurnState() {
+          const elapsed = pressed ? Date.now() - pressAtMs : 0;
+          const submittedStarted =
+            pressed && elapsed >= opts.submittedStartDelayMs;
+          const submittedFinished =
+            pressed && elapsed >= opts.submittedCompleteDelayMs;
+          const phantom = phantomDone ? 1 : 0;
+          return {
+            runsFinished: prior + phantom + (submittedFinished ? 1 : 0),
+            attrPresent: true,
+            sawRunningTrue: true,
+            runningNow: submittedStarted && !submittedFinished,
+            runStartCount: prior + phantom + (submittedStarted ? 1 : 0),
+            lastStoppedAtMs: 0,
+            sseAttachFailed: false,
+          };
+        },
+        async close() {},
+      };
+      return page;
+    };
+    return {
+      async newContext(): Promise<E2eBrowserContext> {
+        return {
+          async newPage(): Promise<E2ePage> {
+            return makeContaminatedPage();
+          },
+          async close() {},
+        };
+      },
+      async close() {},
+    };
+  }
+
+  it("does not false-red when a run completes during the readiness wait (baseline taken after the wait)", async () => {
+    // Content lands at 3000ms after Enter — PAST the 2000ms completed-empty grace
+    // window a pre-fix (contaminated-baseline) poll fast-fails within, so a
+    // pre-fix baseline reds before the content; the post-fix baseline waits for
+    // the submitted turn's own edge and reads the content → GREEN. Margins are
+    // deliberately wide (start 300ms « base floor 2000ms; content 3000ms « ceiling
+    // ~5000ms) so the wall-clock assertions are robust under machine load.
+    const writer = new CapturingWriter();
+    const driver = createE2eSmokeDriver({
+      launcher: async () =>
+        makeCounterAdvancesDuringWaitBrowser({
+          assistantText: "Hello! Nice to meet you.",
+          submittedStartDelayMs: 300,
+          submittedCompleteDelayMs: 3000,
+        }),
+      // Wide enough that the pre-start gap (300ms) does not fast-fail as a
+      // "never observed" run before the submitted turn's start edge appears, and
+      // that (pre-fix) the completed-empty grace deadline (2000ms) elapses with
+      // the DOM still empty (content at 3000ms).
+      textPollTimeoutMs: 2000,
+      // Attempt-0 ceiling ≈ pageTimeoutMs/2 ≈ 5000ms > 3000ms content arrival.
+      pageTimeoutMs: 10000,
+    });
+
+    const result = await driver.run(baseCtx({ writer }), {
+      key: "e2e-smoke:foo",
+      backendUrl: "https://x.example.com",
+    });
+
+    expect(result.state).toBe("green");
+    const sig = result.signal as E2eSmokeSignal;
+    expect(sig.l3).toBe("green");
+    const chat = writer.results.find((r) => r.key === "chat:foo");
+    expect(chat?.state).toBe("green");
+  }, 15000);
 });

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -603,6 +603,29 @@ const RETRY_MIN_BUDGET_MS = 750;
 const SEND_PRESS_MIN_BUDGET_MS = 50;
 
 /**
+ * Minimum wall-clock budget (ms) required to ATTEMPT the readiness
+ * `waitForSelector(SEND_ENABLED_SELECTOR)` that sits BETWEEN `type` and `press`.
+ * react-core now gates submission on runtime readiness, so `sendTurn` waits for
+ * the send control to become ENABLED before pressing Enter. A near-hang `type`
+ * (or a late resend) can drain the first-token envelope so that, by the time the
+ * readiness wait is reached, `Math.max(1, hardCeiling - now)` would floor that
+ * wait's timeout to ~1ms — a doomed action Playwright rejects with a
+ * page-fault-shaped "Timeout 1ms exceeded…" message that the outer catch then
+ * mis-classifies as a GENERIC `level-error`, indistinguishable from a real page
+ * fault (a spurious-red flap source). Below this floor `sendTurn` throws a
+ * distinctly-classified `ReadinessBudgetExhaustedError` (`errorDesc:
+ * delayed-readiness`) instead of issuing the doomed wait, so a send that could
+ * not observe readiness within its drained budget reds as an OBSERVABLE
+ * delayed-readiness case rather than a self-inflicted 1ms floor masquerading as
+ * a page fault.
+ *
+ * Sized ABOVE `SEND_PRESS_MIN_BUDGET_MS` (the readiness wait must observe an
+ * async DOM state transition, not just issue a keypress) yet small enough that a
+ * legitimately-small envelope with a fresh first send still attempts the wait.
+ */
+const SEND_READY_MIN_BUDGET_MS = 100;
+
+/**
  * Thrown by `sendTurn` when too little wall-clock budget remains to issue a
  * `type`/`press` action with a MEANINGFUL timeout — i.e. the remaining budget
  * to `hardCeiling` has dropped below `RETRY_MIN_BUDGET_MS`, so
@@ -648,6 +671,53 @@ function sendBudgetErrorDesc(
     (err as { errorDesc?: unknown }).errorDesc === "send-budget-exhausted"
   ) {
     return "send-budget-exhausted";
+  }
+  return undefined;
+}
+
+/**
+ * Thrown by `sendTurn` when too little wall-clock budget remains to ATTEMPT the
+ * readiness `waitForSelector(SEND_ENABLED_SELECTOR)` with a MEANINGFUL timeout
+ * — i.e. the remaining budget to `hardCeiling` has dropped below
+ * `SEND_READY_MIN_BUDGET_MS`, so `Math.max(1, hardCeiling - now)` would floor
+ * the wait to ~1ms. A ~1ms readiness wait is a doomed action Playwright rejects
+ * with a page-fault-shaped "Timeout 1ms exceeded…" message; the driver's outer
+ * catch would otherwise red-classify it as a GENERIC `level-error`,
+ * indistinguishable from a real page fault. Carrying a distinct `errorDesc`
+ * (duck-typed in the outer catch, mirroring `SendBudgetExhaustedError` /
+ * `TurnNotCompleteError.reason`) classifies the failure as `delayed-readiness`
+ * — an OBSERVABLE, non-`level-error` red for a send whose control never became
+ * enabled within its drained budget.
+ */
+class ReadinessBudgetExhaustedError extends Error {
+  readonly errorDesc = "delayed-readiness" as const;
+  constructor(remainingMs: number, minMs: number) {
+    super(
+      `send-turn readiness wait skipped: ${remainingMs}ms budget remaining ` +
+        `(< ${minMs}ms min) would floor the readiness waitForSelector timeout ` +
+        `to ~1ms (send never became enabled within budget)`,
+    );
+    this.name = "ReadinessBudgetExhaustedError";
+  }
+}
+
+/**
+ * Duck-typed extractor for a `ReadinessBudgetExhaustedError`'s distinct
+ * `errorDesc` (`delayed-readiness`), returning `undefined` for any other throw.
+ * Kept structural (a `readonly errorDesc` field check) rather than an
+ * `instanceof` so the outer catch stays decoupled from the concrete class — the
+ * SAME decoupling rationale as `sendBudgetErrorDesc`.
+ */
+function readinessBudgetErrorDesc(
+  err: unknown,
+): "delayed-readiness" | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "errorDesc" in err &&
+    (err as { errorDesc?: unknown }).errorDesc === "delayed-readiness"
+  ) {
+    return "delayed-readiness";
   }
   return undefined;
 }
@@ -1905,7 +1975,10 @@ async function runLevel(opts: {
     // is called; this in-send guard covers the type→press drain the retry check
     // can't see. `type` keeps the plain `Math.max(1, remaining)` floor
     // (Playwright treats 0 as "no timeout").
-    const sendTurn = async (): Promise<void> => {
+    const sendTurn = async (): Promise<{
+      runsFinished: number;
+      runStartCount: number;
+    }> => {
       const typeBudget = Math.max(1, hardCeiling - Date.now());
       await pg.type("textarea", message, { timeout: typeBudget });
       // READINESS GATE (react-core `isReady`): after typing, the send control is
@@ -1916,11 +1989,38 @@ async function runLevel(opts: {
       // (`:not([disabled])`) BEFORE pressing Enter so the send lands on the real
       // (bound) agent. Bounded by the remaining first-token envelope so a page
       // that never becomes ready reds on its own terms rather than hanging.
-      const readyBudget = Math.max(1, hardCeiling - Date.now());
+      //
+      // MIN-BUDGET GUARD (item-2) — BEFORE the readiness wait: a near-hang
+      // `type` (or a late resend) can drain the envelope so the wait's
+      // `Math.max(1, hardCeiling - now)` would floor to ~1ms — a doomed action
+      // Playwright rejects, which the outer catch then mis-classifies as a
+      // generic `level-error`. Once the budget for the readiness wait has drained
+      // below the floor, throw a DISTINCTLY-classified
+      // `ReadinessBudgetExhaustedError` (`errorDesc: delayed-readiness`) so a
+      // send whose control never became enabled within its drained budget reds as
+      // an observable delayed-readiness case, not a self-inflicted 1ms floor.
+      const readyRemaining = hardCeiling - Date.now();
+      if (readyRemaining < SEND_READY_MIN_BUDGET_MS) {
+        throw new ReadinessBudgetExhaustedError(
+          Math.max(0, readyRemaining),
+          SEND_READY_MIN_BUDGET_MS,
+        );
+      }
       await pg.waitForSelector(SEND_ENABLED_SELECTOR, {
         state: "visible",
-        timeout: readyBudget,
+        timeout: readyRemaining,
       });
+      // Per-attempt turn-lifecycle BASELINE (item-3): snapshot the page-global
+      // monotonic edge counters AFTER `type` + the enabled-send wait and
+      // IMMEDIATELY before the Enter press. Taking it earlier (before the
+      // readiness wait) let a run that COMPLETES DURING the wait — e.g. an
+      // auto-greeting / initial-mount run that finishes while the send control is
+      // still settling — land its finished/started edge AFTER the snapshot, so
+      // the poll's `> baseline` gate mistook that unrelated completion for THIS
+      // submitted turn finishing (empty DOM → false red). Snapshotting here folds
+      // any during-wait edge into the baseline, so only an edge that lands AFTER
+      // the Enter press counts as THIS turn's completion.
+      const baseline = await readBaseline();
       const pressRemaining = hardCeiling - Date.now();
       if (pressRemaining < SEND_PRESS_MIN_BUDGET_MS) {
         throw new SendBudgetExhaustedError(
@@ -1932,6 +2032,7 @@ async function runLevel(opts: {
       await pg.press("textarea", "Enter", {
         timeout: Math.max(1, pressRemaining),
       });
+      return baseline;
     };
     // ── ONE guarded `readTurnState()` wrapper (harmonized error handling) ─────
     // ALL three turn-state consumers below (`readBaseline`, `readTurnComplete`,
@@ -2015,11 +2116,11 @@ async function runLevel(opts: {
       }
       return { runsFinished: st.runsFinished, runStartCount: st.runStartCount };
     };
-    // Baseline snapshot for attempt 0, taken BEFORE the send so the agent
-    // provably cannot have fired RUN_STARTED / RUN_FINISHED for THIS turn yet —
-    // the completion gate then tests strictly-new edges past this baseline.
-    let attemptBaseline = await readBaseline();
-    await sendTurn();
+    // Baseline snapshot for attempt 0. `sendTurn` captures it AFTER `type` + the
+    // enabled-send wait and IMMEDIATELY before the Enter press (item-3), so a run
+    // that completes DURING the readiness wait is folded into the baseline and
+    // the completion gate tests strictly-new edges past THIS turn's actual send.
+    let attemptBaseline = await sendTurn();
 
     // probe.message.send is NOT emitted here: at press time the agent-message
     // POST has only just been ISSUED — its response (and thus its edge headers)
@@ -2352,11 +2453,6 @@ async function runLevel(opts: {
           if (hardCeiling - Date.now() < RETRY_MIN_BUDGET_MS) break;
           // Non-completion retry: the prior attempt's turn was observed
           // in-flight but never signalled completion (stalled/dropped stream).
-          // Re-baseline BEFORE the resend (SAME ordering rationale as attempt 0)
-          // so the retried attempt's completion gate tests strictly-new edges
-          // past the STALL's already-latched counters — a stale prior edge can
-          // never satisfy the retry.
-          attemptBaseline = await readBaseline();
           // Re-arm the message-POST edge-header capture for THIS (winning)
           // attempt: `messageSendEdge` / `lastMessagePostResp` were latched to
           // the FIRST (stalled) attempt's POST response, so a retry-rescued GREEN
@@ -2369,7 +2465,13 @@ async function runLevel(opts: {
           messageSendEdge = undefined;
           lastMessagePostResp = undefined;
           messageSendEmitted = false;
-          await sendTurn();
+          // Re-baseline for the resend — captured INSIDE `sendTurn`, after `type`
+          // + the enabled-send wait and immediately before the Enter press (item-3,
+          // SAME ordering as attempt 0). This tests strictly-new edges past the
+          // STALL's already-latched counters AND past any run that completes during
+          // THIS resend's readiness wait, so a stale prior edge can never satisfy
+          // the retry.
+          attemptBaseline = await sendTurn();
         }
         // Split the REMAINING budget evenly across the remaining attempts so the
         // retry can never push total wall-clock past `pageTimeoutMs`.
@@ -2621,12 +2723,17 @@ async function runLevel(opts: {
           failureSummary: truncateUtf8(msg, 1200),
           // Duck-type a distinct `errorDesc` off the thrown error (mirroring the
           // `TurnNotCompleteError.reason` decoupling): a `SendBudgetExhaustedError`
-          // is a self-inflicted min-budget skip (item-1), NOT a generic page
-          // fault, so it reports `send-budget-exhausted` rather than the catch-all
-          // `level-error`. An external abort still wins (the driver's hard-timeout).
+          // is a self-inflicted min-budget skip, NOT a generic page fault, so it
+          // reports `send-budget-exhausted`; a `ReadinessBudgetExhaustedError`
+          // (item-2) is a send whose control never became enabled within its
+          // drained budget, so it reports `delayed-readiness` — both preferred over
+          // the catch-all `level-error`. An external abort still wins (the driver's
+          // hard-timeout).
           errorDesc: abortSignal.aborted
             ? "abort"
-            : (sendBudgetErrorDesc(err) ?? "level-error"),
+            : (readinessBudgetErrorDesc(err) ??
+              sendBudgetErrorDesc(err) ??
+              "level-error"),
         },
         observedAt: now().toISOString(),
       },

--- a/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
+++ b/showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts
@@ -483,6 +483,28 @@ export const D4_PROBED_DEMO_ROUTES = [
 ] as const;
 export type D4ProbedDemoRoute = (typeof D4_PROBED_DEMO_ROUTES)[number];
 
+/**
+ * Selector for the chat send control in its ENABLED state. `sendTurn` waits on
+ * this AFTER typing the message and BEFORE pressing Enter.
+ *
+ * WHY the wait exists: react-core now gates submission on runtime readiness —
+ * `CopilotChat` withholds `onSubmitMessage` while `useAgent().isReady` is false
+ * (the `agent` is a provisional stand-in `/info` will swap out). Withholding the
+ * handler flips `canSend` false, which renders the `[data-testid="copilot-send-button"]`
+ * with the HTML `disabled` attribute, and makes an Enter keypress a SILENT no-op:
+ * the composer text is preserved (not committed to the doomed provisional agent),
+ * so no turn starts and the assistant response stays empty. A probe that types
+ * and immediately presses Enter inside that provisional window sends into the
+ * void and the cell FALSELY reds. Waiting for the button to lose `disabled`
+ * (`:not([disabled])`) parks the send until the real agent is bound, so the Enter
+ * lands a real turn. The `data-testid` matches
+ * `CopilotChatInput.SendButton` (react-core `CopilotChatInput.tsx`); the
+ * `:not([disabled])` refinement matches only once `canSend` is true (readiness +
+ * non-empty composer), so it resolves precisely at the moment Enter will work.
+ */
+export const SEND_ENABLED_SELECTOR =
+  '[data-testid="copilot-send-button"]:not([disabled])' as const;
+
 // `PendingSseEvent`, `CvdiagProbeSession`, `defaultCvdiagBufferDir`, and
 // `nowMonoMs` were extracted to `../../cvdiag/probe-session.js` so the d5/d6
 // probe path can reuse the SAME probe-layer session. They are imported at the
@@ -1886,6 +1908,19 @@ async function runLevel(opts: {
     const sendTurn = async (): Promise<void> => {
       const typeBudget = Math.max(1, hardCeiling - Date.now());
       await pg.type("textarea", message, { timeout: typeBudget });
+      // READINESS GATE (react-core `isReady`): after typing, the send control is
+      // still `disabled` until the runtime reports ready — and an Enter keypress
+      // during that provisional window is a SILENT no-op (the message is never
+      // committed, the turn never starts, the assistant response stays empty →
+      // false red). Wait for the send button to become ENABLED
+      // (`:not([disabled])`) BEFORE pressing Enter so the send lands on the real
+      // (bound) agent. Bounded by the remaining first-token envelope so a page
+      // that never becomes ready reds on its own terms rather than hanging.
+      const readyBudget = Math.max(1, hardCeiling - Date.now());
+      await pg.waitForSelector(SEND_ENABLED_SELECTOR, {
+        state: "visible",
+        timeout: readyBudget,
+      });
       const pressRemaining = hardCeiling - Date.now();
       if (pressRemaining < SEND_PRESS_MIN_BUDGET_MS) {
         throw new SendBudgetExhaustedError(


### PR DESCRIPTION
## Problem

Fleet-wide "empty assistant response": the assistant-message container mounts but never receives text. #5801 (first released 1.63.0) deferred the runtime `/info` call to a React effect, widening the "provisional agent" window; 1.63.2 exposed an `isReady` signal on `useAgent` but `CopilotChat` never consumed it. A chat submitted during the provisional window is committed to the provisional agent and then lost when `/info` swaps in the real agent — the user message and streamed assistant text disappear, so the assistant bubble renders empty.

This was confirmed with a controlled SSE A/B: stock 1.68.1 does forward `TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT → TEXT_MESSAGE_END` (the runtime is fine — not the in-memory runner / #5837), but the `/info` agent swap drops the rendered messages; restoring a readiness guard makes the identical SSE render correctly.

## Fix

`CopilotChat` now consumes `isReady` from `useAgent` and withholds `onSubmitMessage` until the runtime is ready:

```
- const { agent } = useAgent({ ... });
+ const { agent, isReady } = useAgent({ ... });
...
- onSubmitMessage: onSubmitInput,
+ onSubmitMessage: isReady ? onSubmitInput : undefined,
```

`CopilotChatInput` already derives `canSend` (and its Enter handler) from `onSubmitMessage`, so withholding it while not-ready (a) disables the send control and (b) makes Enter a no-op that **preserves** the composer text — the message can't be committed to the doomed provisional agent. No runtime/runner changes; no fixture re-recording.

## Red–green proof

New test `CopilotChat.readinessGate.test.tsx` drives the real readiness race against the real `CopilotChat` submit path: holds the runtime in Connecting (deferred `/info`), sends during the provisional window, then resolves `/info` (the real status-change re-render that flips `isReady`) and asserts the message survives to render an assistant response.

- **RED** (fix reverted): the chat body contains only chrome text — no user message, no assistant response (the empty-container symptom).
- **GREEN** (fix applied): assistant text renders; passes 3× consecutively (deterministic).
- Mutation-verified: reverting the fix reproduces RED.

## Verification

- react-core: **1468 tests pass** (0 regressions; 3 pre-existing web-inspector `localStorage` jsdom-env file errors are unrelated and present with and without this change).
- react-ui: **69 tests pass**.
- react-core typecheck (`tsc --noEmit`): **0 errors**.

## Follow-up (not in this PR)

The showcase D4 probe driver (`showcase/harness/src/probes/drivers/d4-chat-roundtrip.ts`) should wait for the send control to be enabled before pressing Enter (poll `[data-testid="copilot-send-button"]` `disabled === false` after typing). Omitted here because it can't be red-green'd without a live showcase backend. Note this fix makes the follow-up more relevant: with send gated, a probe that types + Enters during the provisional window now silently no-ops.

Ref: #5801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017t7HsmM31NHNmUQrHF47pm
