### PR TITLE
fix(runtime): name useSingleEndpoint when a single-route envelope hits a multi-route runtime

### DIFF
--- a/packages/core/src/__tests__/runtime-info-error-detail.test.ts
+++ b/packages/core/src/__tests__/runtime-info-error-detail.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+import { CopilotKitCore, CopilotKitCoreErrorCode } from "../core";
+
+/**
+ * The runtime answers a transport mismatch with a 404 that explains the cause
+ * (the `single_route_envelope_against_multi_route_runtime` diagnostic). That
+ * explanation is only worth emitting if the client surfaces it — before
+ * OSS-882 the response body was discarded and the developer saw nothing but a
+ * status code.
+ */
+describe("runtime info failures surface the server's explanation", () => {
+  const originalFetch = global.fetch;
+  const originalWindow = (globalThis as { window?: unknown }).window;
+
+  const DIAGNOSTIC = {
+    error: "Not found",
+    code: "single_route_envelope_against_multi_route_runtime",
+    message:
+      'Received a single-route request envelope ({ method: "..." }) but this runtime is mounted in multi-route mode. Pass useSingleEndpoint={false}.',
+  };
+
+  const respond = (
+    body: unknown,
+    status = 404,
+    contentType = "application/json",
+  ) =>
+    new Response(typeof body === "string" ? body : JSON.stringify(body), {
+      status,
+      headers: { "content-type": contentType },
+    });
+
+  const mockFetch = (response: Response) => {
+    global.fetch = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(response.clone()),
+      ) as unknown as typeof fetch;
+  };
+
+  beforeEach(() => {
+    (globalThis as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      (globalThis as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  /**
+   * The path the reported failure actually took: the compat provider forces
+   * `useSingleEndpoint`, so the core's startup `/info` handshake POSTs an
+   * envelope and the multi-route runtime 404s it.
+   */
+  const connectAndCaptureError = async (
+    body: unknown,
+    status = 404,
+    contentType?: string,
+  ) => {
+    mockFetch(respond(body, status, contentType));
+
+    const core = new CopilotKitCore({
+      runtimeUrl: "https://runtime.example/api/copilotkit",
+      runtimeTransport: "single",
+    });
+    const errors: Array<{ code: CopilotKitCoreErrorCode; error: Error }> = [];
+    const sub = core.subscribe({
+      onError: (e) => void errors.push(e as never),
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        errors.some(
+          (e) => e.code === CopilotKitCoreErrorCode.RUNTIME_INFO_FETCH_FAILED,
+        ),
+      ).toBe(true);
+    });
+    sub.unsubscribe();
+
+    return errors.find(
+      (e) => e.code === CopilotKitCoreErrorCode.RUNTIME_INFO_FETCH_FAILED,
+    )!.error;
+  };
+
+  describe("core /info handshake", () => {
+    it("names useSingleEndpoint when the runtime diagnoses the mismatch", async () => {
+      const error = await connectAndCaptureError(DIAGNOSTIC);
+      expect(error.message).toContain("useSingleEndpoint");
+    });
+
+    it("keeps the status alongside the explanation", async () => {
+      const error = await connectAndCaptureError(DIAGNOSTIC);
+      expect(error.message).toContain(
+        "Runtime info request failed with status 404",
+      );
+    });
+
+    it("falls back to the bare status when the body carries no message", async () => {
+      const error = await connectAndCaptureError({ error: "Not found" });
+      expect(error.message).toBe("Runtime info request failed with status 404");
+    });
+
+    it("survives a non-JSON error body", async () => {
+      const error = await connectAndCaptureError(
+        "<html>gateway</html>",
+        502,
+        "text/html",
+      );
+      expect(error.message).toBe("Runtime info request failed with status 502");
+    });
+
+    it("ignores a non-string message field", async () => {
+      const error = await connectAndCaptureError({ message: { nested: true } });
+      expect(error.message).toBe("Runtime info request failed with status 404");
+    });
+  });
+
+  describe("ProxiedCopilotRuntimeAgent", () => {
+    it("surfaces the explanation on the auto-detect fallback", async () => {
+      mockFetch(respond(DIAGNOSTIC));
+
+      const agent = new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: "https://runtime.example/api/copilotkit",
+        agentId: "remote",
+        transport: "auto",
+      });
+
+      await expect(agent.runAgent({})).rejects.toThrow(/useSingleEndpoint/);
+    });
+
+    it("leaves a message-less failure as the bare status", async () => {
+      mockFetch(respond({ error: "Not found" }));
+
+      const agent = new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: "https://runtime.example/api/copilotkit",
+        agentId: "remote",
+        transport: "auto",
+      });
+
+      await expect(agent.runAgent({})).rejects.toThrow(
+        "Runtime info request failed with status 404",
+      );
+    });
+  });
+});

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -28,6 +28,7 @@ import type {
 } from "@copilotkit/shared";
 import { IntelligenceAgent } from "./intelligence-agent";
 import type { CopilotRuntimeTransport } from "./types";
+import { runtimeInfoError } from "./utils/runtime-info-error";
 
 type ResolvedRuntimeMode = RuntimeMode | "pending";
 
@@ -564,9 +565,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       ...(this.credentials ? { credentials: this.credentials } : {}),
     });
     if (!response.ok) {
-      throw new Error(
-        `Runtime info request failed with status ${response.status}`,
-      );
+      throw await runtimeInfoError(response);
     }
     return (await response.json()) as RuntimeInfo;
   }
@@ -603,9 +602,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       ...(this.credentials ? { credentials: this.credentials } : {}),
     });
     if (!response.ok) {
-      throw new Error(
-        `Runtime info request failed with status ${response.status}`,
-      );
+      throw await runtimeInfoError(response);
     }
     this.transport = "single";
     this.singleEndpointUrl = this.runtimeUrl;

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -21,6 +21,7 @@ import {
   CopilotKitCoreRuntimeConnectionStatus,
 } from "./core";
 import type { CopilotRuntimeTransport } from "../types";
+import { runtimeInfoError } from "../utils/runtime-info-error";
 
 type ResolvedCopilotRuntimeTransport = Exclude<CopilotRuntimeTransport, "auto">;
 
@@ -937,9 +938,7 @@ export class AgentRegistry {
       ...(credentials ? { credentials } : {}),
     });
     if (!response.ok) {
-      throw new Error(
-        `Runtime info request failed with status ${response.status}`,
-      );
+      throw await runtimeInfoError(response);
     }
     return {
       runtimeInfo: (await response.json()) as RuntimeInfo,
@@ -959,9 +958,7 @@ export class AgentRegistry {
       ...(credentials ? { credentials } : {}),
     });
     if (!response.ok) {
-      throw new Error(
-        `Runtime info request failed with status ${response.status}`,
-      );
+      throw await runtimeInfoError(response);
     }
     return (await response.json()) as RuntimeInfo;
   }

--- a/packages/core/src/utils/runtime-info-error.ts
+++ b/packages/core/src/utils/runtime-info-error.ts
@@ -1,0 +1,29 @@
+/**
+ * Build the error for a failed runtime `/info` response, folding in whatever
+ * explanation the runtime sent back.
+ *
+ * The status alone cannot distinguish a wrong `runtimeUrl` from a transport
+ * mismatch, so the runtime answers the latter with a body naming the cause
+ * (see the handler's `single_route_envelope_against_multi_route_runtime`
+ * diagnostic). Discarding that body — as every `/info` caller used to — left
+ * the developer with a bare 404 and nothing to act on (OSS-882).
+ *
+ * A body that isn't JSON, or carries no string `message`, contributes nothing:
+ * the status is then the whole error.
+ */
+export async function runtimeInfoError(response: Response): Promise<Error> {
+  const base = `Runtime info request failed with status ${response.status}`;
+
+  let detail: string | undefined;
+  try {
+    const body: unknown = await response.clone().json();
+    const message = (body as { message?: unknown } | null)?.message;
+    if (typeof message === "string" && message.trim().length > 0) {
+      detail = message.trim();
+    }
+  } catch {
+    // Unparseable or already-consumed body — fall back to the status.
+  }
+
+  return new Error(detail ? `${base}: ${detail}` : base);
+}

--- a/packages/runtime/src/v2/runtime/__tests__/single-route-envelope-diagnostic.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/single-route-envelope-diagnostic.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import type { AbstractAgent } from "@ag-ui/client";
+import { createCopilotEndpoint } from "../endpoints";
+import { CopilotRuntime } from "../core/runtime";
+
+/**
+ * A single-route client (`useSingleEndpoint`) POSTs a `{ method }` envelope at
+ * the base path. Against a multi-route runtime that path matches no route, so
+ * the request 404s with nothing pointing at the cause — the failure mode behind
+ * OSS-882. These tests pin the diagnostic the handler returns instead, and the
+ * ordinary 404 it must keep returning for everything else.
+ */
+describe("single-route envelope against a multi-route runtime", () => {
+  const createMockAgent = (): AbstractAgent => {
+    const agent: unknown = { execute: async () => ({ events: [] }) };
+    (agent as { clone: () => unknown }).clone = () => createMockAgent();
+    return agent as AbstractAgent;
+  };
+
+  const createEndpoint = () =>
+    createCopilotEndpoint({
+      runtime: new CopilotRuntime({ agents: { default: createMockAgent() } }),
+      basePath: "/api/copilotkit",
+    });
+
+  const postEnvelope = (body: unknown, contentType = "application/json") =>
+    createEndpoint().fetch(
+      new Request("https://example.com/api/copilotkit", {
+        method: "POST",
+        headers: { "Content-Type": contentType },
+        body: JSON.stringify(body),
+      }),
+    );
+
+  it("names useSingleEndpoint when the envelope is an info call", async () => {
+    const response = await postEnvelope({ method: "info" });
+    expect(response.status).toBe(404);
+
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.code).toBe("single_route_envelope_against_multi_route_runtime");
+    expect(body.message).toContain("useSingleEndpoint");
+    expect(body.message).toContain("single-route");
+  });
+
+  it("diagnoses every method the single-route envelope accepts", async () => {
+    for (const method of [
+      "info",
+      "agent/run",
+      "agent/suggest",
+      "agent/connect",
+      "agent/stop",
+      "transcribe",
+    ]) {
+      const response = await postEnvelope({ method, params: { agentId: "x" } });
+      const body = (await response.json()) as Record<string, string>;
+      expect(body.code, `expected method "${method}" to be diagnosed`).toBe(
+        "single_route_envelope_against_multi_route_runtime",
+      );
+    }
+  });
+
+  it("leaves an ordinary unmatched route as a plain 404", async () => {
+    const response = await createEndpoint().fetch(
+      new Request("https://example.com/api/copilotkit/nope", { method: "GET" }),
+    );
+    expect(response.status).toBe(404);
+
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.code).toBeUndefined();
+    expect(body.error).toBe("Not found");
+  });
+
+  it("leaves a JSON POST that is not an envelope as a plain 404", async () => {
+    const response = await postEnvelope({ threadId: "t1", messages: [] });
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.code).toBeUndefined();
+    expect(body.error).toBe("Not found");
+  });
+
+  it("leaves an unrecognized method name as a plain 404", async () => {
+    const response = await postEnvelope({ method: "definitely/not/a/method" });
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.code).toBeUndefined();
+  });
+
+  it("does not diagnose a non-JSON POST", async () => {
+    const response = await postEnvelope({ method: "info" }, "text/plain");
+    const body = (await response.json()) as Record<string, string>;
+    expect(body.code).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/v2/runtime/__tests__/single-route-envelope-diagnostic.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/single-route-envelope-diagnostic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createCopilotEndpoint } from "../endpoints";
 import { CopilotRuntime } from "../core/runtime";
+import { detectSingleRouteEnvelope } from "../endpoints/single-route-helpers";
 
 /**
  * A single-route client (`useSingleEndpoint`) POSTs a `{ method }` envelope at
@@ -81,6 +82,20 @@ describe("single-route envelope against a multi-route runtime", () => {
     const response = await postEnvelope({ method: "definitely/not/a/method" });
     const body = (await response.json()) as Record<string, string>;
     expect(body.code).toBeUndefined();
+  });
+
+  it("degrades to a plain 404 when middleware already drained the body", async () => {
+    // `clone()` throws TypeError("unusable") once the body has been read, so a
+    // before-request middleware that consumed it must cost us the diagnostic,
+    // never turn a 404 into a 500.
+    const request = new Request("https://example.com/api/copilotkit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ method: "info" }),
+    });
+    await request.json();
+
+    await expect(detectSingleRouteEnvelope(request)).resolves.toBeNull();
   });
 
   it("does not diagnose a non-JSON POST", async () => {

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -111,10 +111,26 @@ import {
   parseMethodCall,
   createJsonRequest,
   expectString,
+  detectSingleRouteEnvelope,
 } from "../endpoints/single-route-helpers";
 import type { MethodCall } from "../endpoints/single-route-helpers";
 import { logger } from "@copilotkit/shared";
 import { fireInstanceCreatedTelemetry } from "../telemetry/instance-created";
+
+/**
+ * Emitted when a single-route client's JSON envelope reaches a runtime mounted
+ * in multi-route mode. Named so callers can branch on the cause rather than
+ * string-matching the prose.
+ */
+const SINGLE_ROUTE_ENVELOPE_CODE =
+  "single_route_envelope_against_multi_route_runtime";
+
+const SINGLE_ROUTE_ENVELOPE_MESSAGE =
+  'Received a single-route request envelope ({ method: "..." }) but this ' +
+  "runtime is mounted in multi-route mode, so the request matched no route. " +
+  "If the frontend uses <CopilotKit> from @copilotkit/react-core/v2, pass " +
+  "useSingleEndpoint={false} — that provider defaults it to true. Otherwise " +
+  'mount the runtime with mode: "single-route" to serve this envelope.';
 
 /* ------------------------------------------------------------------------------------------------
  * Public types
@@ -383,6 +399,25 @@ export function createCopilotRuntimeHandler(
         // Multi-route: match URL pattern
         const matched = matchRoute(path, basePath);
         if (!matched) {
+          // A single-endpoint client POSTing `{ method }` at the base path
+          // matches no route here. Say so, rather than leaving the developer
+          // with a bare 404 and no way to tell a transport mismatch from a
+          // wrong `basePath` (issue OSS-882).
+          const envelopeMethod = await detectSingleRouteEnvelope(request);
+          if (envelopeMethod) {
+            logger.warn(
+              { url: request.url, path, method: envelopeMethod },
+              SINGLE_ROUTE_ENVELOPE_MESSAGE,
+            );
+            throw jsonResponse(
+              {
+                error: "Not found",
+                code: SINGLE_ROUTE_ENVELOPE_CODE,
+                message: SINGLE_ROUTE_ENVELOPE_MESSAGE,
+              },
+              404,
+            );
+          }
           throw jsonResponse({ error: "Not found" }, 404);
         }
 

--- a/packages/runtime/src/v2/runtime/endpoints/single-route-helpers.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/single-route-helpers.ts
@@ -22,6 +22,46 @@ export interface MethodCall {
   body?: unknown;
 }
 
+/**
+ * Detect a single-route JSON envelope on a request the multi-route router
+ * could not match.
+ *
+ * A single-endpoint client (`useSingleEndpoint` on the frontend provider)
+ * POSTs `{ method, params, body }` at the base path. A multi-route runtime
+ * matches no route for that path and would otherwise answer a bare 404, giving
+ * the developer nothing to go on. Recognising the envelope here lets the
+ * handler name the actual cause instead.
+ *
+ * Deliberately conservative: it reports a method only for a POST carrying a
+ * JSON body whose `method` is one the single-route endpoint actually accepts.
+ * Anything else is a genuine 404 and must stay one.
+ *
+ * @returns The envelope's method name, or `null` if this is not an envelope.
+ */
+export async function detectSingleRouteEnvelope(
+  request: Request,
+): Promise<EndpointMethod | null> {
+  if (request.method !== "POST") return null;
+
+  const contentType = request.headers.get("content-type") || "";
+  if (!contentType.includes("application/json")) return null;
+
+  let envelope: unknown;
+  try {
+    envelope = await request.clone().json();
+  } catch {
+    return null;
+  }
+
+  if (typeof envelope !== "object" || envelope === null) return null;
+
+  const method = (envelope as JsonEnvelope).method;
+  if (typeof method !== "string") return null;
+  if (!(METHOD_NAMES as readonly string[]).includes(method)) return null;
+
+  return method as EndpointMethod;
+}
+
 export async function parseMethodCall(request: Request): Promise<MethodCall> {
   const contentType = request.headers.get("content-type") || "";
 

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -32,10 +32,19 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
   headers={{
     Authorization: `Bearer ${userToken}`,
   }}
+  useSingleEndpoint={false}
 >
   <YourApp />
 </CopilotKit>
 ```
+
+<Callout type="warn" title="Why the explicit useSingleEndpoint">
+  The `createCopilotRuntimeHandler` route below serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
+  asks for single-route transport unless told otherwise, so without this prop
+  its startup `/info` call 404s and no agents are discovered.
+  `<CopilotKitProvider>` detects the transport and needs no prop. See
+  [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+</Callout>
 
 ## Backend
 

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -79,6 +79,16 @@ see [Runtime HTTP endpoints](/backend/runtime-endpoints).
   Both styles work in v1.50. For new projects, use the v2 handlers. See [Deploy to any runtime](/runtime-server-adapter).
 </Callout>
 
+<FrontendOnly frontend="react">
+<Callout type="warn" title="Switching to a v2 handler also switches the transport">
+  The legacy factories are single-route; the v2 handlers are multi-route by
+  default. The `<CopilotKit>` above asks for single-route unless told otherwise,
+  so add `useSingleEndpoint={false}` when you switch — or move to
+  `<CopilotKitProvider>`, which detects the transport. See
+  [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+</Callout>
+</FrontendOnly>
+
 ## Agents
 
 The runtime supports multiple agent types. `BuiltInAgent` is the primary agent class:

--- a/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
@@ -501,10 +501,21 @@ Forward properties from the frontend provider:
 
 <FrontendOnly frontend="react">
 ```tsx title="app/page.tsx"
-<CopilotKit properties={{ model: "anthropic/claude-sonnet-4", temperature: 0.3 }}>
+<CopilotKit
+  properties={{ model: "anthropic/claude-sonnet-4", temperature: 0.3 }}
+  useSingleEndpoint={false}
+>
   <CopilotChat />
 </CopilotKit>
 ```
+
+<Callout type="warn" title="Why the explicit useSingleEndpoint">
+  `createCopilotEndpoint` serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
+  asks for single-route transport unless told otherwise, so without this prop
+  its startup `/info` call 404s and no agents are discovered.
+  `<CopilotKitProvider>` detects the transport and needs no prop. See
+  [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+</Callout>
 </FrontendOnly>
 
 <FrontendOnly frontend="angular">

--- a/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
@@ -207,7 +207,9 @@ The Function URL is the origin; `basePath` is appended to it.
   The Function URL handler above serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
   asks for single-route transport unless told otherwise, so without this prop
   its startup `/info` call 404s and no agents are discovered.
-  `<CopilotKitProvider>` detects the transport and needs no prop. See
+  `<CopilotKitProvider>` detects the transport and needs no prop. Drop the prop
+  if you took the buffered front door below and mounted the handler with
+  `mode: "single-route"`. See
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
 </Callout>
 </FrontendOnly>

--- a/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
@@ -195,10 +195,21 @@ The Function URL is the origin; `basePath` is appended to it.
 
 <FrontendOnly frontend="react">
 ```tsx
-<CopilotKit runtimeUrl="https://<url-id>.lambda-url.<region>.on.aws/api/copilotkit">
+<CopilotKit
+  runtimeUrl="https://<url-id>.lambda-url.<region>.on.aws/api/copilotkit"
+  useSingleEndpoint={false}
+>
   <YourApp />
 </CopilotKit>
 ```
+
+<Callout type="warn" title="Why the explicit useSingleEndpoint">
+  The Function URL handler above serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
+  asks for single-route transport unless told otherwise, so without this prop
+  its startup `/info` call 404s and no agents are discovered.
+  `<CopilotKitProvider>` detects the transport and needs no prop. See
+  [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+</Callout>
 </FrontendOnly>
 
 <FrontendOnly frontend="angular">

--- a/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
+++ b/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
@@ -38,9 +38,9 @@ Single-route mode is useful when your platform only allows a single route handle
 <FrontendOnly frontend="react">
 <Callout type="warn" title="The mode you pick here binds the frontend">
   The v1 `<CopilotKit>` wrapper defaults to single-route transport, so it needs
-  `useSingleEndpoint={false}` against every multi-route handler on this page —
-  and no prop at all once you pass `mode: "single-route"`.
-  `<CopilotKitProvider>` detects the mode either way. The full mapping is in
+  `useSingleEndpoint={false}` against a multi-route handler — and no prop at all
+  once you pass `mode: "single-route"`. `<CopilotKitProvider>` detects the mode
+  either way. The full mapping is in
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
 </Callout>
 </FrontendOnly>
@@ -1002,13 +1002,19 @@ Once your runtime is running, point your frontend at it:
 
 <FrontendOnly frontend="react">
 ```tsx
-<CopilotKit
-  runtimeUrl="http://localhost:4000/api/copilotkit"
-  useSingleEndpoint={false}
->
+<CopilotKit runtimeUrl="http://localhost:4000/api/copilotkit" useSingleEndpoint={false}>
   <YourApp />
 </CopilotKit>
 ```
+
+<Callout type="warn" title="Match the prop to the mode you chose">
+  `useSingleEndpoint={false}` is what a **multi-route** handler needs — the
+  default, and what every example above uses unless you passed
+  `mode: "single-route"`. If you did choose single-route, drop the prop: the v1
+  `<CopilotKit>` wrapper already defaults to that transport. `<CopilotKitProvider>`
+  detects the mode and needs no prop either way. Getting this wrong 404s the
+  startup `/info` call, and the runtime will say so in your server logs.
+</Callout>
 </FrontendOnly>
 
 <FrontendOnly frontend="angular">

--- a/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
+++ b/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
@@ -35,6 +35,16 @@ The runtime supports two endpoint modes:
 
 Single-route mode is useful when your platform only allows a single route handler (e.g. a single serverless function), or when you prefer a simpler URL structure.
 
+<FrontendOnly frontend="react">
+<Callout type="warn" title="The mode you pick here binds the frontend">
+  The v1 `<CopilotKit>` wrapper defaults to single-route transport, so it needs
+  `useSingleEndpoint={false}` against every multi-route handler on this page —
+  and no prop at all once you pass `mode: "single-route"`.
+  `<CopilotKitProvider>` detects the mode either way. The full mapping is in
+  [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+</Callout>
+</FrontendOnly>
+
 ## Fetch-Native Runtimes
 
 If your platform supports the Fetch API natively (Bun, Deno, Cloudflare Workers, etc.), you can use `createCopilotRuntimeHandler` directly — no adapter needed.
@@ -992,7 +1002,10 @@ Once your runtime is running, point your frontend at it:
 
 <FrontendOnly frontend="react">
 ```tsx
-<CopilotKit runtimeUrl="http://localhost:4000/api/copilotkit">
+<CopilotKit
+  runtimeUrl="http://localhost:4000/api/copilotkit"
+  useSingleEndpoint={false}
+>
   <YourApp />
 </CopilotKit>
 ```
@@ -1017,7 +1030,7 @@ provideCopilotKit({
 <FrontendOnly frontend="react">
 For same-origin deployments, use a relative path:
 ```tsx
-<CopilotKit runtimeUrl="/api/copilotkit">
+<CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
   <YourApp />
 </CopilotKit>
 ```


### PR DESCRIPTION
Closes [OSS-882](https://linear.app/copilotkit/issue/OSS-882/add-to-existing-journeys-reach-for-the-v1-compat-copilotkit-wrapper).

## The failure

The v1-compatible `<CopilotKit>` provider pins `useSingleEndpoint` to `true` ([`copilotkit.tsx:108`](https://github.com/CopilotKit/CopilotKit/blob/main/packages/react-core/src/components/copilot-provider/copilotkit.tsx#L108)), so its startup handshake POSTs `{ method: "info" }` at the base path. A multi-route runtime — the default — matches no route for that path and answered a bare `{"error":"Not found"}`, indistinguishable from a wrong `basePath` or an unmounted handler.

Two independent onboarding validation runs hit this on their first browser attempt and each had to guess the cause. Both were *add-to-existing-app* journeys; the greenfield one reached for `CopilotKitProvider` and never saw it.

## What changed

**The runtime says what happened.** `detectSingleRouteEnvelope` recognises a POST whose JSON body carries a `method` the single-route endpoint accepts, and the multi-route handler uses it at the one point routing gives up. The 404 now carries a `code` and a message naming the prop, plus a `logger.warn` so it lands in the dev-server terminal too. Deliberately conservative — wrong verb, non-JSON, unknown method, or a JSON POST that isn't an envelope all stay ordinary 404s, unchanged in status and shape.

**The client stops discarding it.** All four `/info` callers (two in `agent-registry.ts`, two in `agent.ts`) threw away the response body and reported only the status, so a server-side diagnosis reached nobody. They now go through `runtimeInfoError`, which folds a string `message` from the body into the thrown error. Any future server-side diagnosis reaches the developer for free.

**Docs.** Five pages paired a v2 multi-route handler with `<CopilotKit>` and never mentioned the prop. Rather than a warning under a snippet that is still wrong to copy, the snippets themselves now pass `useSingleEndpoint={false}`, with a short callout linking to the provider/handler mapping.

Two pages were deliberately left alone: `backend/runtime-endpoints.mdx` already documents the pairing in full, and `cookbook/arcade.mdx` uses `mode: "single-route"` on purpose and already explains it. `backend/copilot-runtime.mdx` keeps its snippet as-is — it pairs with the v1 endpoint, where the default is correct — and gains the caveat only on its "switch to v2 handlers" note.

Option 3 in the issue (reconsidering the compat default) is **not** in this PR.

## Testing

### Both halves connect, end to end

Real `createCopilotRuntimeHandler` + real `CopilotKitCore` configured the way the v1 wrapper configures it — no mocks on either side:

```
code   : runtime_info_fetch_failed
message: Runtime info request failed with status 404: Received a single-route
         request envelope ({ method: "..." }) but this runtime is mounted in
         multi-route mode, so the request matched no route. If the frontend uses
         <CopilotKit> from @copilotkit/react-core/v2, pass useSingleEndpoint={false}
         — that provider defaults it to true. Otherwise mount the runtime with
         mode: "single-route" to serve this envelope.

PASS — the diagnostic reached the client
```

The server-side `logger.warn` fired in the same run, carrying `{ url, path, method: 'info' }`.

### Unit tests

`packages/runtime` — `single-route-envelope-diagnostic.test.ts` (2 positive, 5 control):

```
 ✓ src/v2/runtime/__tests__/single-route-envelope-diagnostic.test.ts (7 tests) 26ms
      Tests  7 passed (7)
```

`packages/core` — `runtime-info-error-detail.test.ts` (2 positive, 5 control):

```
 ✓ src/__tests__/runtime-info-error-detail.test.ts (7 tests) 267ms
      Tests  7 passed (7)
```

### Mutation checks

Every new test was verified to fail when its mechanism is broken, in both directions.

Detector forced to `return null` — the two positives die, the four controls hold:

```
   × names useSingleEndpoint when the envelope is an info call
   × diagnoses every method the single-route envelope accepts
   ✓ leaves an ordinary unmatched route as a plain 404
   ✓ leaves a JSON POST that is not an envelope as a plain 404
   ✓ leaves an unrecognized method name as a plain 404
   ✓ does not diagnose a non-JSON POST
```

Detector forced to `return "info"` — the controls die instead, proving they are not vacuous:

```
   ✓ names useSingleEndpoint when the envelope is an info call
   ✓ diagnoses every method the single-route envelope accepts
   × leaves an ordinary unmatched route as a plain 404
   × leaves a JSON POST that is not an envelope as a plain 404
   × leaves an unrecognized method name as a plain 404
   × does not diagnose a non-JSON POST
```

`runtimeInfoError` with the detail dropped, then with the `typeof message === "string"` guard removed — each kills a different pair:

```
mutation: detail dropped              → 2 failed | 5 passed
mutation: accept any message field    → 2 failed | 5 passed
restored                              → 7 passed
```

### Full suites, builds, docs

| Check | Result |
|---|---|
| `packages/core` full suite | `Test Files 60 passed (60)` / `Tests 662 passed (662)` |
| `packages/runtime` full suite | `Test Files 142 passed (142)` / `Tests 2067 passed (2067)` |
| `packages/core` `tsc --noEmit` | clean |
| `packages/runtime` `tsdown` | `416 files` — build complete |
| MDX compile, 5 edited pages | all `OK` |
| pre-commit `nx run-many -t test,publint,attw` | passed across affected projects |
| CI on `f94d1ab0` | 72 pass, 3 skipping, 0 fail |

Both suites are fully green. An earlier revision of this description reported 6
runtime failures as pre-existing on `main`; they were not. They were artifacts
of a worktree whose `node_modules` had been assembled by hand, and a proper
`pnpm install` cleared all of them along with the inspector-metadata failures
from a stale `@copilotkit/shared` dist. `main` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
