### PR TITLE
feat(runtime): add OrcaRouter as a built-in model provider

### DIFF
--- a/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
+++ b/packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts
@@ -3,10 +3,23 @@ import { resolveModel } from "../index";
 
 // Mock the SDK provider factories so we can assert the options resolveModel passes them
 // (the returned LanguageModel does not expose baseURL publicly, so we verify at the factory).
-const createOpenAI = vi.fn((_opts?: unknown) => (modelId: string) => ({
-  modelId,
-  provider: "openai",
-}));
+const createOpenAI = vi.fn((_opts?: unknown) => {
+  // A callable provider factory that also exposes `.chat()` — the OrcaRouter
+  // branch uses `.chat()` (chat completions) while the OpenAI / MiniMax
+  // branches invoke the factory as a plain callable.
+  const callable = ((modelId: string) => ({
+    modelId,
+    provider: "openai",
+  })) as unknown as {
+    (modelId: string): { modelId: string; provider: string };
+    chat(modelId: string): { modelId: string; provider: string };
+  };
+  callable.chat = (modelId: string) => ({
+    modelId,
+    provider: "orcarouter.chat",
+  });
+  return callable;
+});
 const createAnthropic = vi.fn((_opts?: unknown) => (modelId: string) => ({
   modelId,
   provider: "anthropic",
@@ -39,6 +52,8 @@ describe("resolveModel — custom baseURL via env", () => {
     process.env.GOOGLE_API_KEY = "test-google-key";
     process.env.MINIMAX_API_KEY = "test-minimax-key";
     delete process.env.MINIMAX_BASE_URL;
+    process.env.ORCAROUTER_API_KEY = "test-orcarouter-key";
+    delete process.env.ORCAROUTER_BASE_URL;
   });
 
   afterEach(() => {
@@ -99,6 +114,35 @@ describe("resolveModel — custom baseURL via env", () => {
 
     expect(createOpenAI).toHaveBeenCalledWith(
       expect.objectContaining({ baseURL: "https://api.minimaxi.com/v1" }),
+    );
+  });
+
+  it.each(["auto", "fusion", "fusion-flash", "fusion-mini"])(
+    "resolves OrcaRouter model orcarouter/%s with the gateway endpoint",
+    (modelId) => {
+      const model = resolveModel(`orcarouter/${modelId}`);
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        name: "orcarouter",
+        apiKey: "test-orcarouter-key",
+        baseURL: "https://api.orcarouter.ai/v1",
+      });
+      // The gateway expects the fully-namespaced id (`orcarouter/auto`), which
+      // the resolver re-prefixes after stripping the `orcarouter` provider part.
+      expect(model).toMatchObject({
+        modelId: `orcarouter/${modelId}`,
+        provider: "orcarouter.chat",
+      });
+    },
+  );
+
+  it("passes ORCAROUTER_BASE_URL to the OrcaRouter provider", () => {
+    process.env.ORCAROUTER_BASE_URL = "https://orcarouter.internal/v1";
+
+    resolveModel("orcarouter:auto");
+
+    expect(createOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://orcarouter.internal/v1" }),
     );
   });
 });

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -105,6 +105,11 @@ export type BuiltInAgentModel =
   // MiniMax models
   | "minimax/MiniMax-M3"
   | "minimax/MiniMax-M2.7"
+  // OrcaRouter gateway models
+  | "orcarouter/auto"
+  | "orcarouter/fusion"
+  | "orcarouter/fusion-flash"
+  | "orcarouter/fusion-mini"
   // Allow any LanguageModel instance
   | (string & {});
 
@@ -247,6 +252,23 @@ export function resolveModel(
       return minimax(model);
     }
 
+    case "orcarouter": {
+      // OrcaRouter is a gateway that exposes an OpenAI-compatible
+      // chat/completions API with a single key for a routed set of models
+      // (orcarouter/auto, orcarouter/fusion, ...).
+      const orcarouter = createOpenAI({
+        name: "orcarouter",
+        apiKey: apiKey || process.env.ORCAROUTER_API_KEY!,
+        baseURL:
+          process.env.ORCAROUTER_BASE_URL || "https://api.orcarouter.ai/v1",
+      });
+      // OrcaRouter model ids are namespaced (`orcarouter/auto`); the
+      // resolver already stripped the `orcarouter` prefix, so re-prefix it.
+      // Use `.chat()` (chat completions) — the default Responses API path is
+      // not supported by the gateway.
+      return orcarouter.chat(`orcarouter/${model}`);
+    }
+
     case "vertex": {
       const vertex = createVertex();
       return vertex(model);
@@ -254,7 +276,7 @@ export function resolveModel(
 
     default:
       throw new Error(
-        `Unknown provider "${provider}" in "${spec}". Supported: openai, anthropic, google (gemini).`,
+        `Unknown provider "${provider}" in "${spec}". Supported: openai, anthropic, google (gemini), minimax, orcarouter.`,
       );
   }
 }
@@ -828,6 +850,7 @@ export interface BuiltInAgentClassicConfig {
    * - ANTHROPIC_API_KEY for Anthropic models
    * - GOOGLE_API_KEY for Google models
    * - MINIMAX_API_KEY for MiniMax models
+   * - ORCAROUTER_API_KEY for OrcaRouter models
    */
   apiKey?: string;
   /**

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -76,6 +76,27 @@ const agent = new BuiltInAgent({
 });
 ```
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes
+each request to the best model for the task through a single API key. It also runs
+gateway-level, zero-trust security for AI agents on the same endpoint — screening
+every prompt/response and governing every tool call on a default-deny basis, with
+no application code changes.
+
+| Model                     | Specifier                       |
+| ------------------------- | ------------------------------- |
+| OrcaRouter Auto (routed)  | `orcarouter:auto`               |
+| OrcaRouter Fusion         | `orcarouter:fusion`             |
+| OrcaRouter Fusion Flash   | `orcarouter:fusion-flash`       |
+| OrcaRouter Fusion Mini    | `orcarouter:fusion-mini`        |
+
+```typescript
+const agent = new BuiltInAgent({
+  model: "orcarouter:auto",
+});
+```
+
 ## Environment Variables
 
 Set the API key for your chosen provider:
@@ -95,6 +116,11 @@ MINIMAX_API_KEY=...
 
 # Optional: use the China endpoint
 MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+
+# OrcaRouter
+ORCAROUTER_API_KEY=sk-orca-...
+# Optional: custom endpoint (defaults to https://api.orcarouter.ai/v1)
+# ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
 ```
 
 Alternatively, pass the API key directly in your configuration:
@@ -191,6 +217,8 @@ The Built-in Agent resolves model strings to AI SDK provider instances:
 | `"openai:gpt-4.1"` | `@ai-sdk/openai` | `openai("gpt-4.1")` |
 | `"anthropic:claude-sonnet-4-5"` | `@ai-sdk/anthropic` | `anthropic("claude-sonnet-4-5")` |
 | `"google:gemini-2.5-pro"` | `@ai-sdk/google` | `google("gemini-2.5-pro")` |
+| `"minimax:MiniMax-M3"` | `@ai-sdk/openai` | `minimax("MiniMax-M3")` |
+| `"orcarouter:auto"` | `@ai-sdk/openai` | `orcarouter.chat("orcarouter/auto")` |
 
 Both `"provider:model"` and `"provider/model"` separators are supported and work identically.
 


### PR DESCRIPTION
## What does this PR do?

Adds **OrcaRouter** as a named, built-in model provider for the Built-in Agent, mirroring the existing MiniMax gateway wiring in `resolveModel()`.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes each request to the best model for the task through a single API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes:

- `packages/runtime/src/agent/index.ts`:
  - Adds `orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini` to `BuiltInAgentModel`.
  - Adds an `orcarouter` case in `resolveModel()` that builds an `@ai-sdk/openai` provider pointed at `https://api.orcarouter.ai/v1`, keyed by `ORCAROUTER_API_KEY` (overridable via `ORCAROUTER_BASE_URL`).
  - Uses `.chat()` (chat completions) with the re-prefixed `orcarouter/` model id, because the gateway requires the fully-namespaced id and does not expose the Responses API.
  - Updates the supported-provider error message and the `apiKey` doc comment.
- `packages/runtime/src/agent/__tests__/resolve-model-baseurl.test.ts`: adds unit tests for the new provider, mirroring the MiniMax cases.
- `showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx`: documents the new provider (models, specifiers, env vars, resolution table).

## Verification

- `npx vitest run src/agent/` — 365 tests pass (22 files), including 5 new OrcaRouter cases.
- `npx tsc --noEmit` on `@copilotkit/runtime` — no new errors (the 26 pre-existing channel-package resolution errors are identical on a clean checkout).
- `npx oxlint` and `npx oxfmt --check` on changed files — clean.
- Live test against the real gateway through the compiled `resolveModel()` path: `orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini` each returned a 200 chat completion (`ORCA-LIVE-OK`).

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [ ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

---

Disclosure: I'm an engineer on the OrcaRouter team.
