### PR TITLE
fix(showcase): gen-ui-tool-based uses shared pie-chart contract for all slugs

### DIFF
--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.test.ts
@@ -6,12 +6,20 @@ import type {
 } from "../helpers/d5-registry.js";
 
 /**
- * Tests for the D5 gen-UI (custom) script. The script now branches on
- * integrationSlug:
- *   - `langgraph-python` sends "Show me a pie chart..." and asserts
- *     SVG donut chart shape.
- *   - All others send "Write me a haiku about nature" and assert
- *     the HaikuCard rendering.
+ * Tests for the D5 gen-UI (custom) script.
+ *
+ * The probe is a SHARED probe (Showcase iron rule 1): it must run the
+ * SAME contract for every `gen-ui-tool-based` integration — no
+ * per-slug branching. Every integration:
+ *   - sends "Show me a pie chart of revenue by category"
+ *   - asserts the SVG donut/pie chart shape
+ *   - asserts the second-leg narration mentions the chart
+ *
+ * The former slug-allowlist (`CHART_INTEGRATIONS`) that routed a
+ * handful of slugs down the pie-chart path and everyone else down an
+ * obsolete `generate_haiku` / HaikuCard path is GONE. All 21
+ * gen-ui-tool-based pages register `render_bar_chart` +
+ * `render_pie_chart`, so the shared contract is the pie-chart contract.
  *
  * Module-cache caveat: see the headless test file's preamble — same
  * `vi.resetModules()` + dynamic-import dance to keep the registry
@@ -68,6 +76,52 @@ function syntheticCtx(
   return { bubbleIndex, text };
 }
 
+const PIE_CHART_MESSAGE = "Show me a pie chart of revenue by category";
+
+/**
+ * A cross-section of gen-ui-tool-based slugs spanning both families of
+ * the OLD allowlist: chart integrations that were already on the
+ * pie-chart path, and integrations that USED to take the obsolete
+ * haiku path. Every one must now select the SAME (pie-chart) contract.
+ */
+const GEN_UI_SLUGS = [
+  "langgraph-python", // was on the allowlist (chart)
+  "ms-agent-python", // was on the allowlist (chart)
+  "ms-agent-dotnet", // was NOT on the allowlist (formerly haiku)
+  "pydantic-ai", // was NOT on the allowlist (formerly haiku)
+  "langgraph-typescript", // was NOT on the allowlist (formerly haiku)
+  "agno", // was NOT on the allowlist (formerly haiku)
+] as const;
+
+/**
+ * Build a pie-chart-shaped assertion page: first evaluate resolves the
+ * gen-UI component selector, second resolves a healthy SVG shape.
+ */
+function makePieChartPage(shape: {
+  hasSvg: boolean;
+  circleCount: number;
+  pathCount: number;
+  rectCount: number;
+  drawingChildren: number;
+}): Page {
+  let evalCount = 0;
+  return makeAssertionPage({
+    evaluateImpl: () => {
+      evalCount++;
+      if (evalCount === 1) return { selector: '[role="article"] svg' };
+      return shape;
+    },
+  });
+}
+
+const HEALTHY_SVG = {
+  hasSvg: true,
+  circleCount: 5,
+  pathCount: 0,
+  rectCount: 0,
+  drawingChildren: 5,
+};
+
 describe("d5-gen-ui-custom script", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -83,55 +137,54 @@ describe("d5-gen-ui-custom script", () => {
     );
   });
 
-  it("buildTurns sends pie chart message for langgraph-python", async () => {
+  // --- Shared contract: EVERY slug gets the pie-chart prompt ---
+
+  it("buildTurns sends the pie chart message for a formerly-non-allowlisted slug (ms-agent-dotnet)", async () => {
     const { script } = await loadFreshRegistry();
     const turns = script.buildTurns({
-      integrationSlug: "langgraph-python",
+      integrationSlug: "ms-agent-dotnet",
       featureType: "gen-ui-custom",
-      baseUrl: "https://showcase-langgraph-python.example.com",
+      baseUrl: "https://showcase-ms-agent-dotnet.example.com",
     });
     expect(turns).toHaveLength(1);
-    expect(turns[0]!.input).toBe("Show me a pie chart of revenue by category");
+    expect(turns[0]!.input).toBe(PIE_CHART_MESSAGE);
     expect(typeof turns[0]!.assertions).toBe("function");
   });
 
-  it("buildTurns sends haiku message for non-langgraph-python integrations", async () => {
+  it("NO slug selects a different probe contract — every gen-ui-tool-based slug sends the pie chart message", async () => {
     const { script } = await loadFreshRegistry();
-    const turns = script.buildTurns({
-      integrationSlug: "agno",
-      featureType: "gen-ui-custom",
-      baseUrl: "https://showcase-agno.example.com",
-    });
-    expect(turns).toHaveLength(1);
-    expect(turns[0]!.input).toBe("Write me a haiku about nature");
-    expect(typeof turns[0]!.assertions).toBe("function");
+    for (const slug of GEN_UI_SLUGS) {
+      const turns = script.buildTurns({
+        integrationSlug: slug,
+        featureType: "gen-ui-custom",
+        baseUrl: `https://showcase-${slug}.example.com`,
+      });
+      expect(turns, `slug ${slug} should build exactly one turn`).toHaveLength(
+        1,
+      );
+      expect(
+        turns[0]!.input,
+        `slug ${slug} must send the shared pie chart message`,
+      ).toBe(PIE_CHART_MESSAGE);
+    }
   });
 
-  // --- Pie chart path (langgraph-python) ---
+  // --- Pie chart shape + narration assertions run for EVERY slug ---
 
-  it("pie chart: assertion FAILS when the rendered component has no <svg>", async () => {
+  it("pie chart: assertion FAILS when the rendered component has no <svg> (ms-agent-dotnet)", async () => {
     const { script } = await loadFreshRegistry();
     const turn = script.buildTurns({
-      integrationSlug: "langgraph-python",
+      integrationSlug: "ms-agent-dotnet",
       featureType: "gen-ui-custom",
       baseUrl: "https://example.com",
     })[0]!;
 
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) {
-          return { selector: '[data-testid="gen-ui-card"]' };
-        }
-        return {
-          hasSvg: false,
-          circleCount: 0,
-          pathCount: 0,
-          rectCount: 0,
-          drawingChildren: 0,
-        };
-      },
+    const page = makePieChartPage({
+      hasSvg: false,
+      circleCount: 0,
+      pathCount: 0,
+      rectCount: 0,
+      drawingChildren: 0,
     });
 
     await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
@@ -139,27 +192,20 @@ describe("d5-gen-ui-custom script", () => {
     );
   });
 
-  it("pie chart: assertion FAILS when SVG has too few drawing children", async () => {
+  it("pie chart: assertion FAILS when SVG has too few drawing children (pydantic-ai)", async () => {
     const { script } = await loadFreshRegistry();
     const turn = script.buildTurns({
-      integrationSlug: "langgraph-python",
+      integrationSlug: "pydantic-ai",
       featureType: "gen-ui-custom",
       baseUrl: "https://example.com",
     })[0]!;
 
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) return { selector: '[role="article"] svg' };
-        return {
-          hasSvg: true,
-          circleCount: 1,
-          pathCount: 0,
-          rectCount: 0,
-          drawingChildren: 1,
-        };
-      },
+    const page = makePieChartPage({
+      hasSvg: true,
+      circleCount: 1,
+      pathCount: 0,
+      rectCount: 0,
+      drawingChildren: 1,
     });
 
     await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
@@ -167,31 +213,15 @@ describe("d5-gen-ui-custom script", () => {
     );
   });
 
-  it("pie chart: assertion FAILS when assistant follow-up is missing expected tokens", async () => {
+  it("pie chart: assertion FAILS when assistant follow-up is missing expected tokens (ms-agent-dotnet)", async () => {
     const { script } = await loadFreshRegistry();
     const turn = script.buildTurns({
-      integrationSlug: "langgraph-python",
+      integrationSlug: "ms-agent-dotnet",
       featureType: "gen-ui-custom",
       baseUrl: "https://example.com",
     })[0]!;
 
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) return { selector: '[role="article"] svg' };
-        if (evalCount === 2) {
-          return {
-            hasSvg: true,
-            circleCount: 5,
-            pathCount: 0,
-            rectCount: 0,
-            drawingChildren: 5,
-          };
-        }
-        return "Done — let me know if you want anything else.";
-      },
-    });
+    const page = makePieChartPage(HEALTHY_SVG);
 
     await expect(
       turn.assertions!(
@@ -201,31 +231,15 @@ describe("d5-gen-ui-custom script", () => {
     ).rejects.toThrow(/missing tokens/);
   });
 
-  it("pie chart: assertion PASSES on a healthy donut render with full narration", async () => {
+  it("pie chart: assertion PASSES on a healthy donut render with full narration (ms-agent-dotnet)", async () => {
     const { script } = await loadFreshRegistry();
     const turn = script.buildTurns({
-      integrationSlug: "langgraph-python",
+      integrationSlug: "ms-agent-dotnet",
       featureType: "gen-ui-custom",
       baseUrl: "https://example.com",
     })[0]!;
 
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) return { selector: '[role="article"] svg' };
-        if (evalCount === 2) {
-          return {
-            hasSvg: true,
-            circleCount: 5,
-            pathCount: 0,
-            rectCount: 0,
-            drawingChildren: 5,
-          };
-        }
-        return "Pie chart rendered above — Electronics is the largest slice, followed by Clothing, Food, and Books.";
-      },
-    });
+    const page = makePieChartPage(HEALTHY_SVG);
 
     await expect(
       turn.assertions!(
@@ -237,136 +251,23 @@ describe("d5-gen-ui-custom script", () => {
     ).resolves.toBeUndefined();
   });
 
-  // --- Haiku card path (all non-LGP integrations) ---
-
-  it("haiku: assertion FAILS when no card or component renders", async () => {
+  it("pie chart: assertion PASSES for the langgraph-python control (chart integration)", async () => {
     const { script } = await loadFreshRegistry();
     const turn = script.buildTurns({
-      integrationSlug: "agno",
+      integrationSlug: "langgraph-python",
       featureType: "gen-ui-custom",
       baseUrl: "https://example.com",
     })[0]!;
 
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) {
-          // Cascade matched a generic selector
-          return { selector: '[data-message-role="assistant"]' };
-        }
-        // No haiku card or rendered component found
-        return { found: false };
-      },
-    });
-
-    await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
-      /no haiku card or rendered component/,
-    );
-  });
-
-  it("haiku: assertion FAILS when haiku card has zero children (empty wrapper)", async () => {
-    const { script } = await loadFreshRegistry();
-    const turn = script.buildTurns({
-      // agno is a genuine haiku integration; mastra was moved to
-      // CHART_INTEGRATIONS (it's an LGP-style useComponent chart demo), so it
-      // no longer takes the haiku path here.
-      integrationSlug: "agno",
-      featureType: "gen-ui-custom",
-      baseUrl: "https://example.com",
-    })[0]!;
-
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) {
-          return { selector: '[data-testid="haiku-card"]' };
-        }
-        // Haiku card found but empty
-        return {
-          found: true,
-          selector: '[data-testid="haiku-card"]',
-          childCount: 0,
-          hasText: false,
-          japaneseLineCount: 0,
-          englishLineCount: 0,
-        };
-      },
-    });
-
-    await expect(turn.assertions!(page, syntheticCtx())).rejects.toThrow(
-      /zero children/,
-    );
-  });
-
-  it("haiku: assertion PASSES on a healthy haiku card render (no narration check)", async () => {
-    // Haiku integrations use `useFrontendTool` with `followUp: false`,
-    // so there is no second-leg narration. Only the structural check
-    // (card rendered with children + text) is asserted.
-    const { script } = await loadFreshRegistry();
-    const turn = script.buildTurns({
-      integrationSlug: "agno",
-      featureType: "gen-ui-custom",
-      baseUrl: "https://example.com",
-    })[0]!;
-
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) {
-          return { selector: '[data-testid="haiku-card"]' };
-        }
-        // assertHaikuCardShape: card found with children and text
-        return {
-          found: true,
-          selector: '[data-testid="haiku-card"]',
-          childCount: 3,
-          hasText: true,
-          japaneseLineCount: 3,
-          englishLineCount: 3,
-        };
-      },
-    });
+    const page = makePieChartPage(HEALTHY_SVG);
 
     await expect(
-      turn.assertions!(page, syntheticCtx()),
-    ).resolves.toBeUndefined();
-  });
-
-  it("haiku: assertion PASSES with fallback selector (no testid)", async () => {
-    // Some integrations might render the component without testids.
-    // The probe falls back to generic assistant message selectors.
-    const { script } = await loadFreshRegistry();
-    const turn = script.buildTurns({
-      integrationSlug: "langgraph-typescript",
-      featureType: "gen-ui-custom",
-      baseUrl: "https://example.com",
-    })[0]!;
-
-    let evalCount = 0;
-    const page = makeAssertionPage({
-      evaluateImpl: () => {
-        evalCount++;
-        if (evalCount === 1) {
-          return { selector: '[data-message-role="assistant"]' };
-        }
-        // Fallback: no haiku-card testid, but assistant message
-        // wrapper has children and text
-        return {
-          found: true,
-          selector: '[data-message-role="assistant"]',
-          childCount: 2,
-          hasText: true,
-          japaneseLineCount: 0,
-          englishLineCount: 0,
-        };
-      },
-    });
-
-    await expect(
-      turn.assertions!(page, syntheticCtx()),
+      turn.assertions!(
+        page,
+        syntheticCtx(
+          "Here is your pie chart of revenue by category — Electronics leads.",
+        ),
+      ),
     ).resolves.toBeUndefined();
   });
 });

--- a/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
+++ b/showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts
@@ -1,20 +1,12 @@
 /**
  * D5 — gen-UI (custom) script.
  *
- * Probes the showcase's `/demos/gen-ui-tool-based` page against
- * whichever frontend-defined tool the integration registers:
- *
- *   - **langgraph-python**, **ms-agent-python**, and **spring-ai** register
- *     chart tools (`render_pie_chart` / `render_bar_chart`) via `useComponent`
- *     (renders donut/bar SVG charts).
- *   - **All other integrations** register `generate_haiku` via
- *     `useFrontendTool` (renders a HaikuCard with Japanese/English text
- *     and an optional image).
- *
- * The fixture (`fixtures/d5/gen-ui-custom.json`) carries BOTH tool
- * patterns keyed by different user messages. The probe branches on
- * `integrationSlug` to send the correct message and assert the matching
- * rendering shape.
+ * Probes the showcase's `/demos/gen-ui-tool-based` page. Every
+ * `gen-ui-tool-based` integration registers the SAME chart tools
+ * (`render_bar_chart` + `render_pie_chart`) via `useComponent`, so this
+ * is a SHARED probe with ONE contract (Showcase iron rule 1): send the
+ * pie-chart prompt and assert the pie-chart rendering shape for EVERY
+ * integration — no per-slug branching.
  *
  * Why "custom" is stricter than "headless":
  *   - `headless` checks that *some* component rendered with
@@ -22,41 +14,13 @@
  *   - `custom` additionally asserts the rendered shape MATCHES the
  *     expected structure for the recorded tool:
  *       - `render_pie_chart`: `<svg>` with multiple drawing elements
- *       - `generate_haiku`: `[data-testid="haiku-card"]` or any
- *         card-like element with text children
+ *       - the second-leg narration mentions the chart
  */
 
 import { registerD5Script } from "../helpers/d5-registry.js";
 import type { D5BuildContext } from "../helpers/d5-registry.js";
 import type { ConversationTurn, Page } from "../helpers/conversation-runner.js";
 import { readSvgChartShape, waitForGenUiComponent } from "./_gen-ui-shared.js";
-
-/**
- * Integrations that register chart tools (`render_pie_chart` and/or
- * `render_bar_chart`) via `useComponent`. All others use the
- * `generate_haiku` / HaikuCard pattern via `useFrontendTool`.
- *
- *   - langgraph-python: `render_pie_chart` only
- *   - ms-agent-python:  `render_bar_chart` + `render_pie_chart`
- *   - spring-ai:        `render_bar_chart` + `render_pie_chart`
- */
-const CHART_INTEGRATIONS = new Set([
-  "langgraph-python",
-  "ms-agent-python",
-  "spring-ai",
-  // google-adk's gen-ui-tool-based page was ported from langgraph-python
-  // verbatim during the D5 parity push, so it registers
-  // `render_pie_chart` + `render_bar_chart` via `useComponent` like LGP
-  // does, not the legacy `generate_haiku` shape.
-  "google-adk",
-  // mastra's gen-ui-tool-based page is the same LGP-style `useComponent`
-  // chart demo (render_pie_chart / render_bar_chart), not the haiku shape.
-  // Without this entry the probe sent the haiku prompt and looked for a
-  // haiku card the demo can't produce, so the assistant bubble came back
-  // empty ("rendered but has no text content"). Surfaced once OSS-381 took
-  // the cell out of not_supported. Pairs with aimock/d6/mastra/gen-ui-custom.json.
-  "mastra",
-]);
 
 /**
  * Lower-bound for the donut chart's drawing-child count (pie chart path).
@@ -67,35 +31,24 @@ const MIN_CHART_DRAWING_CHILDREN = 2;
  * Follow-up tokens for the pie chart path. Token-level check guards
  * against a silent regression where the chart renders but the second
  * LLM leg never fires.
- *
- * The haiku path has no follow-up tokens because `useFrontendTool`
- * with `followUp: false` skips the second-leg narration entirely.
  */
 const PIE_CHART_FOLLOWUP_TOKENS = ["pie", "chart"] as const;
 
 /**
- * User messages per rendering path. Must match the fixture's
- * `match.userMessage` entries exactly.
+ * User message for the shared pie-chart contract. Must match the
+ * fixture's `match.userMessage` entry exactly.
  */
 const PIE_CHART_USER_MESSAGE = "Show me a pie chart of revenue by category";
-const HAIKU_USER_MESSAGE = "Write me a haiku about nature";
-
-function isChartIntegration(slug: string): boolean {
-  return CHART_INTEGRATIONS.has(slug);
-}
 
 export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
-  const usePieChart = isChartIntegration(ctx.integrationSlug);
   console.debug("[d5-gen-ui-custom] buildTurns", {
     slug: ctx.integrationSlug,
-    usePieChart,
-    inputLength: (usePieChart ? PIE_CHART_USER_MESSAGE : HAIKU_USER_MESSAGE)
-      .length,
+    inputLength: PIE_CHART_USER_MESSAGE.length,
   });
 
   return [
     {
-      input: usePieChart ? PIE_CHART_USER_MESSAGE : HAIKU_USER_MESSAGE,
+      input: PIE_CHART_USER_MESSAGE,
       assertions: async (page, assertionCtx) => {
         // 1. Cascade-find the rendered component. Gen-UI components
         //    surface through the same selector hooks regardless of which
@@ -106,49 +59,36 @@ export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
           matchedSelector,
         });
 
-        if (usePieChart) {
-          // --- Pie chart path (chart integrations) ---
-          console.debug("[d5-gen-ui-custom] asserting pie chart shape");
-          await assertPieChartShape(page, matchedSelector);
+        console.debug("[d5-gen-ui-custom] asserting pie chart shape");
+        await assertPieChartShape(page, matchedSelector);
 
-          // Narration check: the second-leg LLM response must
-          // mention the chart. Token-level so wording drift doesn't
-          // fail the probe.
-          //
-          // `ctx.text` is the SAME turn-scoped text resolved by the
-          // runner's settle path — the values returned by
-          // `waitForTurnComplete` (turn-indexed bubble lookup, defect-2
-          // safe). We no longer read `readLastAssistantText` here
-          // because that returned `list[list.length - 1]` and could
-          // leak a later turn's bubble into THIS turn's assertions.
-          //
-          // `ctx` is REQUIRED on the runner's `ConversationTurn` type;
-          // unit tests driving `turn.assertions` directly must supply
-          // a synthetic ctx (`{ bubbleIndex, text }`).
-          const text = assertionCtx.text.toLowerCase();
-          console.debug("[d5-gen-ui-custom] pie chart follow-up text check", {
-            expectedTokenCount: PIE_CHART_FOLLOWUP_TOKENS.length,
-            assistantTextLength: text.length,
-          });
-          const missing = PIE_CHART_FOLLOWUP_TOKENS.filter(
-            (tok) => !text.includes(tok),
+        // Narration check: the second-leg LLM response must mention the
+        // chart. Token-level so wording drift doesn't fail the probe.
+        //
+        // `assertionCtx.text` is the SAME turn-scoped text resolved by
+        // the runner's settle path — the values returned by
+        // `waitForTurnComplete` (turn-indexed bubble lookup, defect-2
+        // safe). We no longer read `readLastAssistantText` here because
+        // that returned `list[list.length - 1]` and could leak a later
+        // turn's bubble into THIS turn's assertions.
+        //
+        // `ctx` is REQUIRED on the runner's `ConversationTurn` type;
+        // unit tests driving `turn.assertions` directly must supply a
+        // synthetic ctx (`{ bubbleIndex, text }`).
+        const text = assertionCtx.text.toLowerCase();
+        console.debug("[d5-gen-ui-custom] pie chart follow-up text check", {
+          expectedTokenCount: PIE_CHART_FOLLOWUP_TOKENS.length,
+          assistantTextLength: text.length,
+        });
+        const missing = PIE_CHART_FOLLOWUP_TOKENS.filter(
+          (tok) => !text.includes(tok),
+        );
+        if (missing.length > 0) {
+          throw new Error(
+            `gen-ui-custom: assistant follow-up missing tokens [${missing.join(
+              ", ",
+            )}]; last assistant text: ${text.slice(0, 200)}`,
           );
-          if (missing.length > 0) {
-            throw new Error(
-              `gen-ui-custom: assistant follow-up missing tokens [${missing.join(
-                ", ",
-              )}]; last assistant text: ${text.slice(0, 200)}`,
-            );
-          }
-        } else {
-          // --- Haiku card path (all other integrations) ---
-          // The haiku integrations use `useFrontendTool` with
-          // `followUp: false`, so there is no second-leg narration.
-          // The structural check alone (card rendered with children
-          // + text) is sufficient for the custom tier.
-          console.debug("[d5-gen-ui-custom] asserting haiku card shape");
-          await assertHaikuCardShape(page, matchedSelector);
-          console.debug("[d5-gen-ui-custom] haiku card assertion passed");
         }
       },
     },
@@ -156,7 +96,7 @@ export function buildTurns(ctx: D5BuildContext): ConversationTurn[] {
 }
 
 /**
- * Assert the SVG chart shape (chart integrations' `render_pie_chart`).
+ * Assert the SVG chart shape (`render_pie_chart`).
  */
 async function assertPieChartShape(
   page: Page,
@@ -176,95 +116,6 @@ async function assertPieChartShape(
   if (shape.circleCount === 0 && shape.pathCount === 0) {
     throw new Error(
       `gen-ui-custom: SVG has neither <circle> nor <path> elements (rects=${shape.rectCount}); shape doesn't match a chart`,
-    );
-  }
-}
-
-/**
- * Assert the haiku card shape (all non-chart integrations' `generate_haiku`).
- *
- * The HaikuCard component renders:
- *   - `[data-testid="haiku-card"]` wrapper div
- *   - Inside: `[data-testid="haiku-japanese-line"]` and
- *     `[data-testid="haiku-english-line"]` text elements
- *
- * The structural assertion checks that:
- *   1. A haiku card (or any non-trivial rendered component) is present
- *   2. It has visible text children (not an empty wrapper)
- */
-async function assertHaikuCardShape(
-  page: Page,
-  matchedSelector: string,
-): Promise<void> {
-  const cardInfo = await page.evaluate(() => {
-    const win = globalThis as unknown as {
-      document: {
-        querySelector(sel: string): {
-          childElementCount: number;
-          textContent: string | null;
-        } | null;
-        querySelectorAll(sel: string): { length: number };
-      };
-    };
-
-    // Try the specific haiku testid first, then fall back to any
-    // rendered component with children.
-    const haikuCard = win.document.querySelector('[data-testid="haiku-card"]');
-    if (haikuCard) {
-      return {
-        found: true as const,
-        selector: '[data-testid="haiku-card"]',
-        childCount: haikuCard.childElementCount,
-        hasText: (haikuCard.textContent ?? "").trim().length > 0,
-        japaneseLineCount: win.document.querySelectorAll(
-          '[data-testid="haiku-japanese-line"]',
-        ).length,
-        englishLineCount: win.document.querySelectorAll(
-          '[data-testid="haiku-english-line"]',
-        ).length,
-      };
-    }
-
-    // Fallback: look for any rendered component from the gen-UI
-    // cascade selectors that has non-trivial content (the component
-    // registered via useFrontendTool's render callback).
-    const fallbackSelectors = [
-      '[data-testid="copilot-assistant-message"]',
-      '[data-message-role="assistant"]',
-      '[role="article"]',
-    ];
-    for (const sel of fallbackSelectors) {
-      const el = win.document.querySelector(sel);
-      if (el && el.childElementCount > 0) {
-        return {
-          found: true as const,
-          selector: sel,
-          childCount: el.childElementCount,
-          hasText: (el.textContent ?? "").trim().length > 0,
-          japaneseLineCount: 0,
-          englishLineCount: 0,
-        };
-      }
-    }
-
-    return { found: false as const };
-  });
-
-  if (!cardInfo.found) {
-    throw new Error(
-      `gen-ui-custom: matched cascade selector ${matchedSelector} but no haiku card or rendered component found in DOM`,
-    );
-  }
-
-  if (cardInfo.childCount === 0) {
-    throw new Error(
-      `gen-ui-custom: haiku card ${cardInfo.selector} rendered but has zero children (empty wrapper)`,
-    );
-  }
-
-  if (!cardInfo.hasText) {
-    throw new Error(
-      `gen-ui-custom: haiku card ${cardInfo.selector} rendered but has no text content`,
     );
   }
 }


### PR DESCRIPTION
## The bug (shared-probe-rule violation)

`showcase/harness/src/probes/scripts/d5-gen-ui-custom.ts` branched on `integrationSlug` via a stale `CHART_INTEGRATIONS` allowlist: only ~5 slugs (langgraph-python, ms-agent-python, spring-ai, google-adk, mastra) got the pie-chart prompt + assertions. Every other `gen-ui-tool-based` slug got an **obsolete** `generate_haiku` prompt + `HaikuCard` assertion.

This violates Showcase **iron rule 1** (one shared probe, no per-slug `if slug === …` branch in the test) and no longer matches the product:

- All **21** `gen-ui-tool-based` pages register `render_bar_chart` + `render_pie_chart` via `useComponent`.
- Every committed D6 `render-a2ui.json` fixture already carries the chart exchange.
- On staging the non-allowlisted cells failed: the assistant container renders but the `HaikuCard` assertion reports "rendered but has no text content". Routing the cell through the pie-chart path greens it (SVG renders, pie validated, narration appears).

## The change (probe only)

- Every `gen-ui-tool-based` integration now sends `PIE_CHART_USER_MESSAGE` ("Show me a pie chart of revenue by category").
- The pie-chart SVG shape assertions + second-leg narration token check run for **every** slug.
- Removed the slug-dependent `CHART_INTEGRATIONS` set / `isChartIntegration` branch.
- Removed the obsolete haiku prompt + `HaikuCard` fallback (verified no other usage anywhere in `showcase/harness/src`).

No allowlist was substituted with a larger allowlist. **No** fixture re-record, backend, frontend, npm, or aimock change. Net `-248` lines across the probe + its unit test.

## Red → Green (local proof)

The unit test was updated **before** the implementation so a formerly-non-allowlisted slug (`ms-agent-dotnet`) fails pre-fix.

**RED (test updated, old implementation):** 6 failed / 2 passed
```
× buildTurns sends the pie chart message for a formerly-non-allowlisted slug (ms-agent-dotnet)
  → expected 'Write me a haiku about nature' to be 'Show me a pie chart of revenue by category'
× NO slug selects a different probe contract — every gen-ui-tool-based slug sends the pie chart message
  → slug ms-agent-dotnet must send the shared pie chart message: expected 'Write me a haiku about nature' to be 'Show me a pie chart of revenue by category'
× pie chart: assertion FAILS when the rendered component has no <svg> (ms-agent-dotnet)
  → got 'gen-ui-custom: matched cascade selector … but no haiku card or rendered component found in DOM'
× pie chart: assertion FAILS when SVG has too few drawing children (pydantic-ai)
× pie chart: assertion FAILS when assistant follow-up is missing expected tokens (ms-agent-dotnet)
× pie chart: assertion PASSES on a healthy donut render with full narration (ms-agent-dotnet)
```

**GREEN (after implementation):** 8 passed / 8
```
✓ src/probes/scripts/d5-gen-ui-custom.test.ts (8 tests) 23ms
Test Files  1 passed (1)
     Tests  8 passed (8)
```

**Mutation-verified:** setting `PIE_CHART_USER_MESSAGE = "MUTANT"` fails the two contract tests; disabling the narration token check (`if (false)`) fails the missing-tokens test. Clean restore confirmed by diff.

## Command results (from a fresh worktree off origin/main)

| Command | Result |
| --- | --- |
| `nx run @copilotkit/showcase-harness:test` (target file) | ✅ 8 passed |
| `nx run @copilotkit/showcase-harness:test` (full) | ✅ 177 files / 3721 tests passed, 2 skipped, 0 failed |
| `nx run @copilotkit/showcase-harness:typecheck` | ✅ clean |
| `nx run @copilotkit/showcase-harness:build` | ✅ success |
| `showcase/bin/showcase fixtures validate` | ✅ exit 0, "All fixtures valid" |

> Note: the full suite / typecheck initially reported failures in `frontend-matrix.test.ts` and `d0-gone-predicate.test.ts`. These are **pre-existing** and depend on gitignored generated artifacts (`frontend-catalog.json`, `registry.json`) absent from a fresh worktree — confirmed by reproducing them on pristine `origin/main` with my changes stashed. After running the repo's `generate-registry` step they pass. Neither file references gen-ui-custom.

## Value tests — HANDED OFF (control-plane unreachable here)

The production-shaped control-plane value tests must run **without** `--direct`. Docker is not reachable in my environment (`docker info` / `docker ps` exit 1; `--isolate` fails at `docker compose … ps`), so I did **not** run them and did **not** substitute `--direct`. Please run live:

```
showcase/bin/showcase test ms-agent-dotnet:gen-ui-tool-based --d5 --isolate --verbose
showcase/bin/showcase test pydantic-ai:gen-ui-tool-based --d5 --isolate --verbose
showcase/bin/showcase test langgraph-typescript:gen-ui-tool-based --d5 --isolate --verbose
showcase/bin/showcase test langgraph-python:gen-ui-tool-based --d5 --isolate --verbose   # control
```

Expect: RED on the formerly-haiku cells (ms-agent-dotnet, pydantic-ai, langgraph-typescript) before this change, GREEN after; langgraph-python stays GREEN.

## Rollout

Needs a harness / control-plane deploy + a D5 sweep rerun to flip the affected `gen-ui-tool-based` cells. **No** npm publish, backend, aimock, or fixture re-record required.

Refs the `gen-ui-tool-based` shared-probe contract. Separate/unrelated: LlamaIndex `done-signal-missing` (not touched here).