### PR TITLE
fix(runtime): normalize nested LangGraph tool metadata

### DIFF
--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts
@@ -303,6 +303,32 @@ describe("langGraphDefaultMergeState", () => {
     expect(result.copilotkit.actions).toEqual(expect.arrayContaining(tools));
   });
 
+  it("exposes nested function metadata at the action top level", () => {
+    const { agent } = createAgent();
+    const tool = {
+      type: "function",
+      function: {
+        name: "lookupWeather",
+        description: "Look up the weather",
+        parameters: { type: "object", properties: {} },
+      },
+    };
+
+    withMockedParentMerge(agent, {
+      "ag-ui": { tools: [tool], context: [] },
+      tools: [],
+      messages: [],
+    });
+
+    const result = agent.langGraphDefaultMergeState({} as any, [], {} as any);
+    expect(result.copilotkit.actions[0]).toMatchObject({
+      name: "lookupWeather",
+      description: "Look up the weather",
+      parameters: { type: "object", properties: {} },
+    });
+    expect(result.copilotkit.actions[0].function).toEqual(tool.function);
+  });
+
   it("merges copilotkit context from ag-ui", () => {
     const { agent } = createAgent();
     const context = [{ description: "user info", value: "test" }];

--- a/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
+++ b/packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts
@@ -35,6 +35,25 @@ import type {
 import { CustomEventNames } from "./consts";
 export { CustomEventNames };
 
+function normalizeLangGraphTool(tool: any): any {
+  if (!tool || typeof tool !== "object") return tool;
+
+  const functionSpec = tool.function;
+  if (!functionSpec || typeof functionSpec !== "object") return tool;
+
+  const normalized = { ...tool };
+
+  // LangGraph can expose OpenAI-style { function: { ... } } descriptors,
+  // while Python consumers commonly read the canonical fields at the top level.
+  for (const key of ["name", "description", "parameters"] as const) {
+    if (!(key in normalized) && key in functionSpec) {
+      normalized[key] = functionSpec[key];
+    }
+  }
+
+  return normalized;
+}
+
 export class LangGraphAgent extends AGUILangGraphAgent {
   constructor(config: LangGraphAgentConfig) {
     super(config);
@@ -228,10 +247,16 @@ export class LangGraphAgent extends AGUILangGraphAgent {
     ];
     const combinedTools = Array.from(
       new Map(
-        rawCombinedTools.map((t: any) => [
-          t?.id ?? t?.name ?? t?.key ?? JSON.stringify(t),
-          t,
-        ]),
+        rawCombinedTools.map((tool: any) => {
+          const normalizedTool = normalizeLangGraphTool(tool);
+          return [
+            normalizedTool?.id ??
+              normalizedTool?.name ??
+              normalizedTool?.key ??
+              JSON.stringify(normalizedTool),
+            normalizedTool,
+          ] as const;
+        }),
       ).values(),
     );
 


### PR DESCRIPTION
## Summary

- normalize OpenAI-style nested LangGraph tool descriptors when building `copilotkit.actions`
- preserve the original `function` object while exposing `name`, `description`, and `parameters` at the action top level
- add regression coverage for the nested descriptor shape

Fixes #6570

## Validation

- `nx run @copilotkit/runtime:test --skip-nx-cache -- src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts`
- `nx run @copilotkit/runtime:check-types --skip-nx-cache`
- `oxfmt --check packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts`
- `oxlint packages/runtime/src/lib/runtime/agent-integrations/langgraph/agent.ts packages/runtime/src/lib/runtime/agent-integrations/langgraph/__tests__/dispatch-event-filtering.test.ts`
