### PR TITLE
feat(shell-docs): inline backend picker opens the current docs page in the chosen backend

### DIFF
--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import { useFramework } from "./framework-provider";
-import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export function IntegrationGrid({
-  path,
   description,
 }: {
+  // `path` and `exclude` are authoring metadata passed by many MDX call
+  // sites (which framework pages exist for this feature). They are not
+  // rendered — the note links to the full backend list instead.
   path?: string;
   exclude?: string[];
   description?: string;
@@ -17,13 +19,6 @@ export function IntegrationGrid({
   // On a framework-scoped route the user already chose a backend — hide.
   if (framework) return null;
 
-  // Shell host is now read at runtime from window.__SHOWCASE_CONFIG__
-  // (set by the root layout) so the rendered <a href> reflects the
-  // current deploy's NEXT_PUBLIC_SHELL_URL without a rebuild. Pulled
-  // after the early-return so we never call into the client reader on
-  // renders that produce no DOM.
-  const shellHost = getRuntimeConfig().shellUrl;
-
   return (
     <>
       <h2>Choose your AI backend</h2>
@@ -32,18 +27,10 @@ export function IntegrationGrid({
       )}
       <div className="shell-docs-radius-surface mb-4 bg-[var(--bg-elevated)] p-4 text-sm text-[var(--text-muted)]">
         See{" "}
-        <a
-          href={`${shellHost}/integrations`}
-          className="text-[var(--accent)]"
-          // shellHost is the SSR placeholder during server-render and the
-          // real value post-hydration (runtime-config.client.ts). React
-          // would otherwise log a hydration mismatch on this href every
-          // pageload; suppression scopes to THIS attribute mismatch only.
-          suppressHydrationWarning
-        >
-          Integrations
-        </a>{" "}
-        for all available frameworks{path ? ` (${path})` : ""}.
+        <Link href="/#backends" className="text-[var(--accent)]">
+          all supported agent frameworks
+        </Link>{" "}
+        to pick your backend.
       </div>
     </>
   );

--- a/showcase/shell-docs/src/components/integration-grid.tsx
+++ b/showcase/shell-docs/src/components/integration-grid.tsx
@@ -1,36 +1,130 @@
 "use client";
 
+// IntegrationGrid — inline backend picker rendered at the bottom of
+// unscoped (framework-agnostic) docs feature pages. Each chip opens THE
+// CURRENT PAGE scoped to that backend, reusing the same path rewriting
+// as the sidebar's backend selector (backendPathForCurrentPath), so the
+// reader keeps their place instead of being bounced to a landing page.
+//
+// Backends listed in `exclude` (authored per call site in MDX) are shown
+// grayed out — the feature genuinely isn't available there. A stale or
+// missing `exclude` is non-fatal: the framework-scoped route already
+// renders a graceful "not available for <framework>" fallback.
+
 import React from "react";
 import Link from "next/link";
-import { useFramework } from "./framework-provider";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import { DEFAULT_FRAMEWORK, useFramework } from "./framework-provider";
+import { FrameworkLogo } from "./icons/framework-icons";
+import { compareByDisplayOrder } from "@/lib/framework-order";
+import { backendPathForCurrentPath } from "@/lib/frontend-options";
+import { getDocsMode, getIntegrations } from "@/lib/registry";
 
 export function IntegrationGrid({
+  exclude,
   description,
 }: {
-  // `path` and `exclude` are authoring metadata passed by many MDX call
-  // sites (which framework pages exist for this feature). They are not
-  // rendered — the note links to the full backend list instead.
+  /** Legacy authoring metadata; no longer rendered. */
   path?: string;
-  exclude?: string[];
+  /**
+   * Backend slugs this page's feature is not available for. MUST be
+   * authored as a comma-separated STRING (`exclude="agno, agent-spec"`):
+   * the MDX pipeline (next-mdx-remote `blockJS`, on by default) strips
+   * expression attributes like `exclude={[...]}` before they reach the
+   * component, so array literals silently arrive as undefined. Arrays
+   * are still accepted for direct TSX consumers.
+   */
+  exclude?: string[] | string;
   description?: string;
 }) {
-  const { framework } = useFramework();
+  const { framework, effectiveFramework, setStoredFramework } = useFramework();
+  const pathname = usePathname() ?? "";
+  const posthog = usePostHog();
 
   // On a framework-scoped route the user already chose a backend — hide.
   if (framework) return null;
 
+  const integrations = getIntegrations()
+    .filter((i) => getDocsMode(i.slug) !== "hidden")
+    .slice()
+    .sort((a, b) => {
+      if (a.slug === "built-in-agent") return -1;
+      if (b.slug === "built-in-agent") return 1;
+      return compareByDisplayOrder(a.slug, b.slug);
+    });
+  const allSlugs = integrations.map((i) => i.slug);
+  const excluded = new Set(
+    (Array.isArray(exclude) ? exclude : (exclude?.split(",") ?? []))
+      .map((slug) => slug.trim())
+      .filter(Boolean),
+  );
+
+  function handleSelect(slug: string) {
+    setStoredFramework(slug);
+    try {
+      posthog?.capture("docs.framework_selected", {
+        framework: slug,
+        from_path: pathname,
+        source: "integration_grid",
+      });
+    } catch {
+      // Swallow - analytics is fire-and-forget.
+    }
+  }
+
+  const chipBase =
+    "shell-docs-radius-control inline-flex items-center gap-1.5 border px-2.5 py-1.5 text-[13px] font-medium";
+
   return (
     <>
       <h2>Choose your AI backend</h2>
-      {description && (
-        <p className="mb-4 text-[var(--text-secondary)]">{description}</p>
-      )}
-      <div className="shell-docs-radius-surface mb-4 bg-[var(--bg-elevated)] p-4 text-sm text-[var(--text-muted)]">
-        See{" "}
-        <Link href="/#backends" className="text-[var(--accent)]">
-          all supported agent frameworks
-        </Link>{" "}
-        to pick your backend.
+      <p className="mb-4 text-[var(--text-secondary)]">
+        {description ?? "Open this page for the backend you're building with."}
+      </p>
+      <div className="not-prose mb-4 flex flex-wrap gap-2">
+        {integrations.map((i) => {
+          const isCurrent = i.slug === effectiveFramework;
+          const name = i.slug === "built-in-agent" ? "CopilotKit" : i.name;
+          if (excluded.has(i.slug)) {
+            return (
+              <span
+                key={i.slug}
+                title={`Not available for ${name} yet`}
+                className={`${chipBase} cursor-not-allowed border-[var(--border)] bg-[var(--bg-elevated)]/40 text-[var(--text-muted)] opacity-60`}
+              >
+                <FrameworkLogo slug={i.slug} fallbackSrc={i.logo} size={15} />
+                {name}
+              </span>
+            );
+          }
+          return (
+            <Link
+              key={i.slug}
+              href={backendPathForCurrentPath(
+                i.slug,
+                pathname,
+                allSlugs,
+                DEFAULT_FRAMEWORK,
+              )}
+              aria-current={isCurrent ? "page" : undefined}
+              onClick={() => handleSelect(i.slug)}
+              className={`${chipBase} no-underline transition-colors ${
+                isCurrent
+                  ? "border-[var(--accent)] bg-[var(--accent-dim)] text-[var(--accent)]"
+                  : "border-[var(--border)] bg-[var(--bg-surface)] text-[var(--text-secondary)] hover:border-[var(--accent)] hover:text-[var(--text)]"
+              }`}
+            >
+              <FrameworkLogo
+                slug={i.slug}
+                fallbackSrc={i.logo}
+                size={15}
+                className={isCurrent ? "text-[var(--accent)]" : undefined}
+              />
+              {name}
+            </Link>
+          );
+        })}
       </div>
     </>
   );

--- a/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/state-rendering.mdx
@@ -40,7 +40,6 @@ token-by-token rather than appearing in one burst between checkpoints.
 
 <Snippet region="state-streaming-middleware" title="backend — state streaming mapping" />
 
-<IntegrationGrid
-  path="generative-ui/state-rendering"
-  exclude={["agno", "agent-spec"]}
-/>
+{/* exclude must be a comma-separated STRING — the MDX pipeline strips
+    expression attributes like exclude={[...]} (next-mdx-remote blockJS). */}
+<IntegrationGrid path="generative-ui/state-rendering" exclude="agno, agent-spec" />

--- a/showcase/shell-docs/src/content/docs/shared-state.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state.mdx
@@ -95,4 +95,6 @@ one-way UI-to-agent channel that auto-unregisters on unmount.
 See **[Agent read-only context](/shared-state/agent-readonly)** for the
 full pattern.
 
-<IntegrationGrid path="shared-state" exclude={["agno", "agent-spec", "spring-ai", "langroid"]} />
+{/* exclude must be a comma-separated STRING — the MDX pipeline strips
+    expression attributes like exclude={[...]} (next-mdx-remote blockJS). */}
+<IntegrationGrid path="shared-state" exclude="agno, agent-spec, spring-ai, langroid" />

--- a/showcase/shell-docs/src/content/docs/shared-state/streaming.mdx
+++ b/showcase/shell-docs/src/content/docs/shared-state/streaming.mdx
@@ -77,4 +77,6 @@ indicator.
 - **[Agent read-only context](/shared-state/agent-readonly)** —
   for the inverse, UI → agent one-way channel.
 
-<IntegrationGrid path="shared-state/streaming" exclude={["agno", "agent-spec", "spring-ai", "langroid"]} />
+{/* exclude must be a comma-separated STRING — the MDX pipeline strips
+    expression attributes like exclude={[...]} (next-mdx-remote blockJS). */}
+<IntegrationGrid path="shared-state/streaming" exclude="agno, agent-spec, spring-ai, langroid" />


### PR DESCRIPTION
## What this does

Unscoped (framework-agnostic) docs feature pages end with a "Choose your AI backend" block. It used to be a note that linked *away* — originally to the showcase demo explorer, which loses the reader's place entirely.

This PR turns it into an **inline backend picker**: a chip per supported backend that opens **the current page** scoped to that backend (e.g. from `/generative-ui/state-rendering`, the Google ADK chip goes to `/google-adk/generative-ui/state-rendering`). It reuses `backendPathForCurrentPath` — the exact path rewriting the sidebar's backend selector already uses — plus the same registry filtering/ordering as the landing page's backend grid. Chip clicks persist the choice via `setStoredFramework` and fire the existing `docs.framework_selected` PostHog event with `source: "integration_grid"`.

<img width="1440" height="900" alt="inline-backend-picker" src="https://github.com/user-attachments/assets/45987e49-e059-47cf-8eb1-6a30514555e8" />

Availability handling:
- Backends listed in the call site's `exclude` prop render grayed out ("Not available for X yet") — see Agno above.
- Anything not excluded but genuinely missing falls back to the framework route's existing graceful handling (`NotAvailableForFrameworkPage` / the "Not available for X yet — try Y" banner), so there are no dead ends.

## Bug found along the way: the MDX pipeline silently drops expression props

`exclude={["agno", "agent-spec"]}` never reached the component. Root cause: **next-mdx-remote v6 defaults `blockJS: true`**, whose remark plugin strips every JSX expression attribute (and `{expression}` node) at compile — only string-literal props survive. This affects all MDX rendered through `MDXRemote` in shell-docs (`<Image width={1000}>`, `<Tabs items={[...]}>` — masked because `DocsTabs` re-derives items from `<Tab value>` children — and the `selected={false}` unreliability already worked around in `page.tsx`).

Flipping `blockJS: false` globally is not safe today: a content scan found 871 expression attributes, 461 with free identifiers (arrow-function handlers, `icon={<Component />}`, `props.components`) that would evaluate and throw. So within this PR, `exclude` is authored as a comma-separated **string** (`exclude="agno, agent-spec"`), the component accepts both string and array, and the three MDX call sites are updated with a warning comment. The systemic audit is spun off as a separate task.

## Where the link used to land vs the page context now preserved

**Before** — `showcase.copilotkit.ai/integrations`, the showcase demo explorer:

<img width="1440" height="900" alt="before-showcase-integrations" src="https://github.com/user-attachments/assets/64d7d06a-bb46-4579-85f7-286ff8eb5669" />

**Intermediate state (first commit)** — linked to the docs' "Build with any agent backend" list (`/#backends`), correct list but loses the current page:

<img width="1440" height="900" alt="after-docs-backends" src="https://github.com/user-attachments/assets/e3bf6c4a-eacf-4f1d-be94-38beb7083bda" />

**Final state (second commit)** — the picker is inline and keeps the reader on the same page in their chosen backend.

## Verification

- `tsc --noEmit` and `oxlint` pass in `showcase/shell-docs`.
- Verified in the browser on the dev server: chips render with correct per-backend hrefs for the current page; CopilotKit (Built-in Agent) is marked current; Agno renders grayed; clicking Google ADK lands on `/google-adk/generative-ui/state-rendering` with the sidebar backend switched; `/claude-sdk-python/generative-ui/state-rendering` (no framework-specific page) renders the root content scoped to Claude SDK — no dead end.
- Vitest: 420/421 pass; the 1 failure (`channels-docs.test.ts`) is pre-existing on main (channels architecture diagram references the light PNG twice) and untouched here — spun off as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
