### PR TITLE
feat(runtime): project Intelligence marketplace entitlement

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -59,30 +59,44 @@ describe("handleGetRuntimeInfo", () => {
     }) as unknown as CopilotRuntimeLike;
   const createIntelligenceRuntimeLike = (
     overrides: Partial<CopilotIntelligenceRuntimeLike> = {},
-  ): CopilotIntelligenceRuntimeLike => ({
-    agents: {},
-    transcriptionService: undefined,
-    beforeRequestMiddleware: undefined,
-    afterRequestMiddleware: undefined,
-    runner: createRunner(),
-    a2ui: undefined,
-    mcpApps: undefined,
-    openGenerativeUI: undefined,
-    mode: "intelligence",
-    debug: { enabled: false, events: false, lifecycle: false, verbose: false },
-    forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
-    intelligence: new CopilotKitIntelligence({
+  ): CopilotIntelligenceRuntimeLike => {
+    const intelligence = new CopilotKitIntelligence({
       apiUrl: "https://runtime.example",
       wsUrl: "wss://runtime.example",
       apiKey: "test-key",
-    }),
-    identifyUser: vi.fn().mockResolvedValue({ id: "user-1", name: "User One" }),
-    generateThreadNames: true,
-    lockTtlSeconds: 20,
-    lockHeartbeatIntervalSeconds: 15,
-    channels: [],
-    ...overrides,
-  });
+    });
+    vi.spyOn(intelligence, "getRuntimeEntitlement").mockResolvedValue({
+      kind: "notSupported",
+    });
+
+    return {
+      agents: {},
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: createRunner(),
+      a2ui: undefined,
+      mcpApps: undefined,
+      openGenerativeUI: undefined,
+      mode: "intelligence",
+      debug: {
+        enabled: false,
+        events: false,
+        lifecycle: false,
+        verbose: false,
+      },
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
+      intelligence,
+      identifyUser: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", name: "User One" }),
+      generateThreadNames: true,
+      lockTtlSeconds: 20,
+      lockHeartbeatIntervalSeconds: 15,
+      channels: [],
+      ...overrides,
+    };
+  };
 
   it("should return runtime info with audioFileTranscriptionEnabled=false when no transcription service", async () => {
     const runtime = new CopilotRuntime({
@@ -579,6 +593,61 @@ describe("handleGetRuntimeInfo", () => {
       message: "Failed to get agents",
     });
   });
+
+  test.each([
+    [{ kind: "ok", entitlement: { active: true } }, "valid"],
+    [{ kind: "ok", entitlement: { active: false } }, "invalid"],
+    [{ kind: "unavailable" }, "unknown"],
+  ] as const)(
+    "projects Intelligence entitlement result %# into licenseStatus=%s",
+    async (result, expectedStatus) => {
+      const runtime = createIntelligenceRuntimeLike();
+      vi.mocked(runtime.intelligence.getRuntimeEntitlement).mockResolvedValue(
+        result.kind === "ok"
+          ? {
+              kind: "ok",
+              entitlement: {
+                organizationId: "7",
+                source: "awsMarketplaceDeploymentLicense",
+                active: result.entitlement.active,
+                features: { msteams: true },
+                limits: { "threads.max_count": 25_000 },
+                planCode: "team_deployment",
+                entitlementSource: "must-not-reach-browser",
+              },
+            }
+          : result,
+      );
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.licenseStatus).toBe(expectedStatus);
+      expect(JSON.stringify(data)).not.toMatch(
+        /organizationId|source|features|limits|planCode|entitlementSource|awsMarketplace/iu,
+      );
+    },
+  );
+
+  it("falls back to the unchanged local checker only when Intelligence lacks the endpoint", async () => {
+    const runtime = createIntelligenceRuntimeLike({
+      licenseChecker: {
+        getStatus: () => ({ warningSeverity: "none" }),
+      } as CopilotIntelligenceRuntimeLike["licenseChecker"],
+    });
+
+    const response = await handleGetRuntimeInfo({
+      runtime,
+      request: mockRequest,
+    });
+    const data = await response.json();
+
+    expect(data.licenseStatus).toBe("valid");
+  });
 });
 
 test("get-runtime-info advertises inspector metadata without fetching it", async () => {
@@ -588,6 +657,9 @@ test("get-runtime-info advertises inspector metadata without fetching it", async
     apiKey: "server-api-key",
   });
   const getInspectorMetadata = vi.spyOn(intelligence, "getInspectorMetadata");
+  vi.spyOn(intelligence, "getRuntimeEntitlement").mockResolvedValue({
+    kind: "notSupported",
+  });
   const runtime = new CopilotRuntime({
     agents: {},
     intelligence,

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -10,6 +10,7 @@ import { CopilotKitIntelligence } from "../intelligence-platform";
 import { TranscriptionService } from "../transcription-service/transcription-service";
 import { describe, it, expect, test, vi, beforeEach, afterEach } from "vitest";
 import type { AbstractAgent } from "@ag-ui/client";
+import { createLicenseContextValue } from "@copilotkit/shared";
 
 // Mock transcription service
 class MockTranscriptionService extends TranscriptionService {
@@ -597,7 +598,7 @@ describe("handleGetRuntimeInfo", () => {
   test.each([
     [{ kind: "ok", entitlement: { active: true } }, "valid"],
     [{ kind: "ok", entitlement: { active: false } }, "invalid"],
-    [{ kind: "unavailable" }, "unknown"],
+    [{ kind: "unavailable" }, "invalid"],
   ] as const)(
     "projects Intelligence entitlement result %# into licenseStatus=%s",
     async (result, expectedStatus) => {
@@ -627,6 +628,9 @@ describe("handleGetRuntimeInfo", () => {
 
       expect(response.status).toBe(200);
       expect(data.licenseStatus).toBe(expectedStatus);
+      expect(
+        createLicenseContextValue(data.licenseStatus).checkFeature("msteams"),
+      ).toBe(expectedStatus === "valid");
       expect(JSON.stringify(data)).not.toMatch(
         /organizationId|source|features|limits|planCode|entitlementSource|awsMarketplace/iu,
       );

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -15,7 +15,7 @@ import { VERSION } from "../core/runtime";
 import { isTelemetryDisabled } from "../telemetry/telemetry-client";
 import { supportsLocalThreadEndpoints } from "../runner/agent-runner";
 
-function resolveLicenseStatus(
+function resolveLocalLicenseStatus(
   runtime: CopilotRuntimeLike,
 ): RuntimeLicenseStatus {
   if (!runtime.licenseChecker) return "none";
@@ -26,6 +26,27 @@ function resolveLicenseStatus(
   if (status.error) return "invalid";
   if (status.warningSeverity === "info") return "none";
   return "unknown";
+}
+
+async function resolveLicenseStatus(
+  runtime: CopilotRuntimeLike,
+): Promise<RuntimeLicenseStatus> {
+  if (!isIntelligenceRuntime(runtime)) {
+    return resolveLocalLicenseStatus(runtime);
+  }
+
+  try {
+    const result = await runtime.intelligence.getRuntimeEntitlement();
+    if (result.kind === "ok") {
+      return result.entitlement.active ? "valid" : "invalid";
+    }
+    if (result.kind === "unavailable") {
+      return "unknown";
+    }
+    return resolveLocalLicenseStatus(runtime);
+  } catch {
+    return "unknown";
+  }
 }
 
 interface HandleGetRuntimeInfoParameters {
@@ -76,6 +97,9 @@ export async function handleGetRuntimeInfo({
 
     const agentsDict: Record<string, AgentDescription> =
       Object.fromEntries(agentEntries);
+    const licenseStatus = isIntelligenceRuntime(runtime)
+      ? await resolveLicenseStatus(runtime)
+      : undefined;
 
     const runtimeInfo: RuntimeInfo = {
       version: VERSION,
@@ -115,9 +139,7 @@ export async function handleGetRuntimeInfo({
           }
         : {}),
       openGenerativeUIEnabled: webEnabled && !!runtime.openGenerativeUI,
-      ...(isIntelligenceRuntime(runtime)
-        ? { licenseStatus: resolveLicenseStatus(runtime) }
-        : {}),
+      ...(isIntelligenceRuntime(runtime) ? { licenseStatus } : {}),
       telemetryDisabled: isTelemetryDisabled(),
     };
 

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -41,11 +41,11 @@ async function resolveLicenseStatus(
       return result.entitlement.active ? "valid" : "invalid";
     }
     if (result.kind === "unavailable") {
-      return "unknown";
+      return "invalid";
     }
     return resolveLocalLicenseStatus(runtime);
   } catch {
-    return "unknown";
+    return "invalid";
   }
 }
 

--- a/packages/runtime/src/v2/runtime/index.ts
+++ b/packages/runtime/src/v2/runtime/index.ts
@@ -17,6 +17,8 @@ export {
   type SubscribeToThreadsRequest,
   type SubscribeToThreadsResponse,
   type UpdateThreadRequest,
+  type RuntimeEntitlement,
+  type RuntimeEntitlementResult,
 } from "./intelligence-platform";
 
 // Re-export `@ai-sdk/mcp` stable types so consumers don't need to depend on

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -1383,3 +1383,21 @@ test("runtime-entitlement client aborts and fails closed when authority stalls",
     vi.useRealTimers();
   }
 });
+
+test("runtime-entitlement client aborts and fails closed when the response body stalls", async () => {
+  vi.useFakeTimers();
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockResolvedValue(new Response(new ReadableStream<Uint8Array>()));
+
+  try {
+    const request = client.getRuntimeEntitlement();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(request).resolves.toEqual({ kind: "unavailable" });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.signal.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -1287,3 +1287,99 @@ test("inspector-metadata client rejects invalid and unknown schemas", async () =
   await expect(client.getInspectorMetadata()).resolves.toBeUndefined();
   await expect(client.getInspectorMetadata()).resolves.toBeUndefined();
 });
+
+const activeRuntimeEntitlement = {
+  organizationId: "7",
+  source: "awsMarketplaceDeploymentLicense" as const,
+  active: true,
+  features: { msteams: true, deployment_via_helm_chart: true },
+  limits: { "threads.max_count": 25_000 },
+  planCode: "team_deployment",
+};
+
+test("runtime-entitlement client authenticates and accepts only the sanitized contract", async () => {
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify(activeRuntimeEntitlement), { status: 200 }),
+  );
+
+  await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+    kind: "ok",
+    entitlement: activeRuntimeEntitlement,
+  });
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://api.example.com/api/entitlements/runtime",
+    {
+      method: "GET",
+      headers: { Authorization: "Bearer server-api-key" },
+      signal: expect.any(AbortSignal),
+    },
+  );
+});
+
+test("runtime-entitlement client treats 404 as compatible absence", async () => {
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+  await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+    kind: "notSupported",
+  });
+});
+
+test("runtime-entitlement client fails closed without retaining provider bodies", async () => {
+  const { client } = setupInspectorMetadataClient();
+  const sensitiveMarker = "aws-secret-provider-body-9a77";
+  const loggerError = vi
+    .spyOn(logger, "error")
+    .mockImplementation(() => undefined);
+
+  try {
+    fetchMock
+      .mockResolvedValueOnce(new Response(sensitiveMarker, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ...activeRuntimeEntitlement,
+            consumptionToken: sensitiveMarker,
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("{", { status: 200 }));
+
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+
+    expect(JSON.stringify(loggerError.mock.calls)).not.toContain(
+      sensitiveMarker,
+    );
+  } finally {
+    loggerError.mockRestore();
+  }
+});
+
+test("runtime-entitlement client aborts and fails closed when authority stalls", async () => {
+  vi.useFakeTimers();
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockImplementation(() => new Promise<Response>(() => undefined));
+
+  try {
+    const request = client.getRuntimeEntitlement();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(request).resolves.toEqual({ kind: "unavailable" });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.signal.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -49,6 +49,33 @@ const MANAGED_INTELLIGENCE_WS_URL = "wss://realtime.intelligence.copilotkit.ai";
 /** Maximum time spent on the optional Inspector metadata provider request. */
 const INSPECTOR_METADATA_REQUEST_TIMEOUT_MS = 5_000;
 
+/** Maximum time spent consulting the deployment entitlement authority. */
+const RUNTIME_ENTITLEMENT_REQUEST_TIMEOUT_MS = 5_000;
+
+const RUNTIME_ENTITLEMENT_SOURCES = new Set([
+  "managedOrgSubscription",
+  "selfHostedDeploymentLicense",
+  "awsMarketplaceDeploymentLicense",
+] as const);
+
+export interface RuntimeEntitlement {
+  organizationId: string;
+  source:
+    | "managedOrgSubscription"
+    | "selfHostedDeploymentLicense"
+    | "awsMarketplaceDeploymentLicense";
+  active: boolean;
+  features: Record<string, boolean>;
+  limits: Record<string, number>;
+  planCode?: string;
+  entitlementSource?: string;
+}
+
+export type RuntimeEntitlementResult =
+  | { kind: "ok"; entitlement: RuntimeEntitlement }
+  | { kind: "notSupported" }
+  | { kind: "unavailable" };
+
 /**
  * Error thrown when an Intelligence platform HTTP request returns a non-2xx
  * status. Carries the HTTP {@link status} code so callers can branch on
@@ -674,6 +701,74 @@ export class CopilotKitIntelligence {
         );
       }
       throw error;
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  /**
+   * Read the deployment's server-authoritative runtime entitlement.
+   *
+   * A 404 preserves compatibility with Intelligence deployments predating the
+   * endpoint. Every other failure returns `unavailable`, allowing callers to
+   * fail closed without exposing provider response bodies or identifiers.
+   */
+  async getRuntimeEntitlement(): Promise<RuntimeEntitlementResult> {
+    const path = "/api/entitlements/runtime";
+    const abortController = new AbortController();
+    const timeoutMarker = Symbol("runtime-entitlement-timeout");
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(timeoutMarker);
+        abortController.abort();
+      }, RUNTIME_ENTITLEMENT_REQUEST_TIMEOUT_MS);
+    });
+
+    try {
+      const response = await Promise.race([
+        fetch(`${this.#apiUrl}${path}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${this.#apiKey}` },
+          signal: abortController.signal,
+        }),
+        timeout,
+      ]);
+
+      if (response.status === 404) {
+        return { kind: "notSupported" };
+      }
+
+      if (!response.ok) {
+        logger.error(
+          { status: response.status, path },
+          "Intelligence runtime entitlement request failed",
+        );
+        return { kind: "unavailable" };
+      }
+
+      const body = await Promise.race([response.text(), timeout]);
+      const entitlement = parseRuntimeEntitlement(JSON.parse(body) as unknown);
+      if (!entitlement) {
+        logger.error(
+          { path, reason: "invalid-contract" },
+          "Intelligence runtime entitlement request failed",
+        );
+        return { kind: "unavailable" };
+      }
+
+      return { kind: "ok", entitlement };
+    } catch (error) {
+      logger.warn(
+        {
+          path,
+          reason: error === timeoutMarker ? "timeout" : "request-failed",
+        },
+        "Intelligence runtime entitlement request unavailable",
+      );
+      return { kind: "unavailable" };
     } finally {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
@@ -1337,6 +1432,72 @@ export class CopilotKitIntelligence {
 function configuredUrl(url: string | undefined): string | undefined {
   const trimmed = url?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function parseRuntimeEntitlement(input: unknown): RuntimeEntitlement | null {
+  if (!isRecord(input)) return null;
+
+  const allowedKeys = new Set([
+    "organizationId",
+    "source",
+    "active",
+    "features",
+    "limits",
+    "planCode",
+    "entitlementSource",
+  ]);
+  if (Object.keys(input).some((key) => !allowedKeys.has(key))) return null;
+
+  const source = input.source;
+  if (
+    typeof input.organizationId !== "string" ||
+    input.organizationId.length === 0 ||
+    typeof source !== "string" ||
+    !RUNTIME_ENTITLEMENT_SOURCES.has(source as RuntimeEntitlement["source"]) ||
+    typeof input.active !== "boolean" ||
+    !isBooleanRecord(input.features) ||
+    !isNumberRecord(input.limits) ||
+    !isOptionalNonEmptyString(input.planCode) ||
+    !isOptionalNonEmptyString(input.entitlementSource)
+  ) {
+    return null;
+  }
+
+  return {
+    organizationId: input.organizationId,
+    source: source as RuntimeEntitlement["source"],
+    active: input.active,
+    features: input.features,
+    limits: input.limits,
+    ...(input.planCode === undefined ? {} : { planCode: input.planCode }),
+    ...(input.entitlementSource === undefined
+      ? {}
+      : { entitlementSource: input.entitlementSource }),
+  };
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function isBooleanRecord(input: unknown): input is Record<string, boolean> {
+  return (
+    isRecord(input) &&
+    Object.values(input).every((value) => typeof value === "boolean")
+  );
+}
+
+function isNumberRecord(input: unknown): input is Record<string, number> {
+  return (
+    isRecord(input) &&
+    Object.values(input).every(
+      (value) => typeof value === "number" && Number.isFinite(value),
+    )
+  );
+}
+
+function isOptionalNonEmptyString(input: unknown): input is string | undefined {
+  return input === undefined || (typeof input === "string" && input.length > 0);
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/intelligence-platform/index.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/index.ts
@@ -7,4 +7,6 @@ export {
   type SubscribeToThreadsRequest,
   type SubscribeToThreadsResponse,
   type UpdateThreadRequest,
+  type RuntimeEntitlement,
+  type RuntimeEntitlementResult,
 } from "./client";

--- a/showcase/shell-docs/superpowers/plans/2026-08-20-aws-marketplace-runtime-entitlement.md
+++ b/showcase/shell-docs/superpowers/plans/2026-08-20-aws-marketplace-runtime-entitlement.md
@@ -34,7 +34,7 @@ type RuntimeEntitlement = {
     | "selfHostedDeploymentLicense"
     | "awsMarketplaceDeploymentLicense";
   active: boolean;
-  features: string[];
+  features: Record<string, boolean>;
   limits: Record<string, number>;
   planCode?: string;
   entitlementSource?: string;
@@ -68,7 +68,7 @@ Expected: FAIL because `getRuntimeEntitlement()` does not exist.
 | -------------------------------------------- | ------------------------------- |
 | Intelligence entitlement active              | `valid`                         |
 | Intelligence entitlement inactive            | `invalid`                       |
-| Intelligence authority unavailable/malformed | `unknown`                       |
+| Intelligence authority unavailable/malformed | `invalid`                       |
 | Intelligence endpoint 404                    | current local checker result    |
 | Non-Intelligence runtime                     | current local checker result    |
 

--- a/showcase/shell-docs/superpowers/plans/2026-08-20-aws-marketplace-runtime-entitlement.md
+++ b/showcase/shell-docs/superpowers/plans/2026-08-20-aws-marketplace-runtime-entitlement.md
@@ -1,0 +1,96 @@
+# AWS Marketplace Runtime Entitlement Projection Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for each behavior change and superpowers:verification-before-completion before any completion claim. Execute this plan after the Intelligence runtime-entitlement JSON contract is fixed.
+
+**Goal:** Make the CopilotKit runtime's existing `/info` response reflect the server-authenticated Intelligence deployment entitlement so AWS Marketplace Team deployments enter the existing valid/locked states without exposing seller or AWS license material.
+
+**Architecture:** Extend the existing Intelligence client with one authenticated, schema-checked read of `/api/entitlements/runtime`. The asynchronous `/info` handler prefers this server authority in Intelligence mode, maps active/inactive/unavailable to the existing license status vocabulary, and retains the local offline checker for non-Intelligence deployments and compatibility with an older Intelligence server that returns 404.
+
+**Tech Stack:** TypeScript, fetch, Zod/current repository validation utilities, Vitest, pnpm/Nx.
+
+---
+
+## Execution rules
+
+- Work only in `/Users/maxk/.config/superpowers/worktrees/CopilotKit/aws-marketplace-team-helm-v1-20260820`.
+- Do not add Marketplace UI, AWS SDKs, direct AWS calls, token exchange, new browser DTO fields, or changes to normal offline token verification.
+- Never surface or retain consumption tokens, client tokens, SKU, key fingerprint, license ARN, or App API internal token in the `/info` payload or error text.
+- Add one failing behavior test, run it red for the intended reason, implement minimally, run focused and full runtime suites, then commit and push. Do not amend or force-push.
+
+### Task 1: Add the authenticated Intelligence entitlement read
+
+**Files:**
+
+- Modify: `packages/runtime/src/v2/runtime/intelligence-platform/client.ts`
+- Test: `packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts`
+
+- [ ] **RED:** Assert a new `getRuntimeEntitlement()` sends the existing server Authorization credential to `/api/entitlements/runtime`, applies the client's normal timeout/abort behavior, and accepts only the sanitized contract:
+
+```ts
+type RuntimeEntitlement = {
+  organizationId: string;
+  source:
+    | "managedOrgSubscription"
+    | "selfHostedDeploymentLicense"
+    | "awsMarketplaceDeploymentLicense";
+  active: boolean;
+  features: string[];
+  limits: Record<string, number>;
+  planCode?: string;
+  entitlementSource?: string;
+};
+```
+
+Assert a 404 returns a typed `notSupported` result, non-2xx errors fail closed, malformed/extra credential-shaped fields are rejected or stripped, and no response body containing a secret is copied into thrown messages.
+
+Run:
+
+```bash
+fnm exec --using=22 pnpm nx test @copilotkit/runtime -- client.test.ts
+```
+
+Expected: FAIL because `getRuntimeEntitlement()` does not exist.
+
+- [ ] **GREEN:** Reuse the client's private request/auth machinery. Parse the narrow DTO defensively and return a discriminated result that distinguishes `ok`, `notSupported`, and `unavailable` without including raw bodies.
+- [ ] **VERIFY:** Run the focused client tests and runtime typecheck.
+- [ ] **COMMIT:** `git add packages/runtime/src/v2/runtime/intelligence-platform && git commit -m "Read Intelligence runtime entitlement" && git push`.
+
+### Task 2: Project server authority into `/info`
+
+**Files:**
+
+- Modify: `packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts`
+- Test: `packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts`
+
+- [ ] **RED:** Cover these exact cases:
+
+| Runtime mode/result                          | Existing `/info` license status |
+| -------------------------------------------- | ------------------------------- |
+| Intelligence entitlement active              | `valid`                         |
+| Intelligence entitlement inactive            | `invalid`                       |
+| Intelligence authority unavailable/malformed | `unknown`                       |
+| Intelligence endpoint 404                    | current local checker result    |
+| Non-Intelligence runtime                     | current local checker result    |
+
+Also assert that plan/features/limits and all provider/AWS identifiers are absent from the browser-facing `/info` response; the PRD requests the existing locked experience, not a new Marketplace UI contract.
+
+Run:
+
+```bash
+fnm exec --using=22 pnpm nx test @copilotkit/runtime -- get-runtime-info.test.ts
+```
+
+Expected: FAIL because runtime info is resolved only from the local checker.
+
+- [ ] **GREEN:** Make license resolution asynchronous, call the Intelligence client only when that mode is configured, map the server result to the existing status enum, and use local verification only for `notSupported` or non-Intelligence paths. Do not catch authority failures into a permissive fallback.
+- [ ] **VERIFY:** Run focused tests, then `fnm exec --using=22 pnpm nx test @copilotkit/runtime`, the runtime typecheck/build targets, and `git diff --check`.
+- [ ] **COMMIT:** Commit and push as `Project Intelligence entitlement into runtime info`.
+
+### Task 3: Contract and delivery verification
+
+- [ ] Run the same sanitized JSON fixture against the Intelligence App API route test and this client's parser test.
+- [ ] Confirm ordinary offline licensed, offline invalid, and no-license `/info` snapshots are unchanged.
+- [ ] Inspect the complete diff for secrets, raw response logging, unrelated API changes, and changes outside runtime scope.
+- [ ] Fetch `origin/main`; create a new final-delivery branch at that exact commit, cherry-pick the reviewed commits, and rerun the full runtime suite and build. Push the new branch normally, replace the draft PR, and close the superseded draft so repository history remains truly rebased without force-pushing.
+- [ ] Push and open/update a draft PR linked to the Intelligence PR. Watch all required GitHub checks until green; diagnose any failure with superpowers:systematic-debugging and add a failing regression test before the fix.
+- [ ] Verify on GitHub that the PR merge base equals current `origin/main` and the branch head is the locally verified commit.


### PR DESCRIPTION
## Summary

Projects the server-authenticated Intelligence deployment entitlement into the existing runtime /info license status.

This linked draft currently contains the executable TDD plan. It intentionally adds no Marketplace UI or AWS client behavior to the runtime.