### PR TITLE
feat(runtime): let a caller name itself on the telemetry it already sends

### DIFF
--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -166,6 +166,16 @@ interface BaseCopilotRuntimeOptions extends CopilotRuntimeMiddlewares {
   afterRequestMiddleware?: AfterRequestMiddleware;
   /** Signed license token for server-side feature verification. Falls back to COPILOTKIT_LICENSE_TOKEN env var. */
   licenseToken?: string;
+  /**
+   * Properties added to every telemetry event this runtime sends.
+   *
+   * For what is true of the whole process rather than of one event. A product
+   * built on this runtime can name itself here and then be told apart in the
+   * events that already go, rather than sending events of its own.
+   *
+   * No effect when telemetry is off: nothing is sent, so nothing carries this.
+   */
+  telemetryProperties?: Record<string, unknown>;
   /** Enable debug logging for the event pipeline. */
   debug?: DebugConfig;
   /**
@@ -401,6 +411,13 @@ abstract class BaseCopilotRuntime implements CopilotRuntimeLike {
     // runtime events even with a license token configured.
     if (this.resolvedLicenseToken) {
       telemetry.setLicenseToken(this.resolvedLicenseToken);
+    }
+
+    // Set here rather than per event, beside the license token and for the same
+    // reason: it describes the caller, not the call, and every event should
+    // carry it whichever handler fired.
+    if (options.telemetryProperties) {
+      telemetry.setGlobalProperties(options.telemetryProperties);
     }
 
     if (process.env.NODE_ENV !== "production") {

--- a/packages/runtime/src/v2/runtime/telemetry/__tests__/global-properties.test.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/__tests__/global-properties.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { lambdaClient } from "@copilotkit/shared";
+import { TelemetryClient } from "../telemetry-client";
+
+/**
+ * Properties that describe the caller rather than the call.
+ *
+ * A product built on this runtime needs to be tellable apart in the events that
+ * already go, and the alternative to one carried field is a second set of
+ * events describing the same runs.
+ *
+ * Asserted at the send boundary rather than on the instance, because a field
+ * held correctly and dropped on the way out is the failure that matters.
+ */
+describe("telemetry global properties", () => {
+  let send: ReturnType<typeof vi.spyOn>;
+
+  function client() {
+    // Sample rate 1 so nothing is dropped by the anonymous gate; these assert
+    // what a sent event carries, not whether it was sampled.
+    return new TelemetryClient({ sampleRate: 1 });
+  }
+
+  beforeEach(() => {
+    send = vi.spyOn(lambdaClient, "send").mockResolvedValue(undefined as never);
+  });
+
+  /**
+   * The properties the one sent event carried.
+   *
+   * Asserted through a helper rather than by indexing the mock inline, so a
+   * missing call fails as a missing call rather than as a property read on
+   * undefined two lines later.
+   */
+  function sentProperties(): Record<string, unknown> {
+    expect(send).toHaveBeenCalledTimes(1);
+    const [payload] = send.mock.calls[0] as [
+      { properties: Record<string, unknown> },
+    ];
+    return payload.properties;
+  }
+
+  afterEach(() => {
+    send.mockRestore();
+  });
+
+  it("carries them on an event that sets none of its own", async () => {
+    const telemetry = client();
+    telemetry.setGlobalProperties({ accessibility_title: "OpenBot" });
+
+    await telemetry.capture("oss.runtime.agent_execution_stream_started", {});
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toMatchObject({
+      event: "oss.runtime.agent_execution_stream_started",
+      properties: { accessibility_title: "OpenBot" },
+    });
+  });
+
+  it("carries them alongside an event's own properties", async () => {
+    const telemetry = client();
+    telemetry.setGlobalProperties({ accessibility_title: "OpenBot" });
+
+    await telemetry.capture("oss.runtime.instance_created", {
+      actionsAmount: 0,
+      endpointTypes: [],
+      endpointsAmount: 0,
+      agentsAmount: 3,
+      "cloud.api_key_provided": false,
+    });
+
+    expect(send.mock.calls[0]?.[0]).toMatchObject({
+      properties: { accessibility_title: "OpenBot", agentsAmount: 3 },
+    });
+  });
+
+  it("merges successive calls rather than replacing", async () => {
+    const telemetry = client();
+    telemetry.setGlobalProperties({ accessibility_title: "OpenBot" });
+    telemetry.setGlobalProperties({ deployment_shape: "self-hosted" });
+
+    await telemetry.capture("oss.runtime.agent_execution_stream_ended", {});
+
+    expect(send.mock.calls[0]?.[0]).toMatchObject({
+      properties: {
+        accessibility_title: "OpenBot",
+        deployment_shape: "self-hosted",
+      },
+    });
+  });
+
+  /*
+   * The specific beats the general. A caller describing one event knows more
+   * than a value set once at construction, so a global must not overwrite it.
+   */
+  it("lets an event's own property win on conflict", async () => {
+    const telemetry = client();
+    telemetry.setGlobalProperties({ agentsAmount: 99 });
+
+    await telemetry.capture("oss.runtime.instance_created", {
+      actionsAmount: 0,
+      endpointTypes: [],
+      endpointsAmount: 0,
+      agentsAmount: 3,
+      "cloud.api_key_provided": false,
+    });
+
+    expect(sentProperties().agentsAmount).toBe(3);
+  });
+
+  it("sends nothing at all when telemetry is disabled", async () => {
+    const telemetry = new TelemetryClient({
+      telemetryDisabled: true,
+      sampleRate: 1,
+    });
+    telemetry.setGlobalProperties({ accessibility_title: "OpenBot" });
+
+    await telemetry.capture("oss.runtime.agent_execution_stream_started", {});
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("adds nothing when none are set", async () => {
+    await client().capture("oss.runtime.agent_execution_stream_started", {});
+
+    expect(sentProperties()).toEqual({});
+  });
+});

--- a/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
@@ -31,6 +31,18 @@ export class TelemetryClient {
   // anonymous without re-parsing per event. Null when the token is
   // absent or yielded no telemetry_id.
   private telemetryId: string | null = null;
+  // Properties merged into every event this client sends.
+  //
+  // For facts about the caller that are true for the whole process rather than
+  // for one event: which product is embedding the runtime, for instance. A
+  // distribution built on top of this can then be told apart in the existing
+  // events instead of sending its own, which is the difference between one
+  // extra field and a second pipeline nobody asked for.
+  //
+  // Per-event properties win on conflict. A caller describing one event knows
+  // more than a value set once at construction, and silently overriding the
+  // specific with the general would be the wrong way round.
+  private globalProperties: Record<string, unknown> = {};
 
   constructor({
     telemetryDisabled,
@@ -46,6 +58,17 @@ export class TelemetryClient {
   private shouldSendEvent() {
     if (this.sampleRate >= 1) return true;
     return Math.random() < this.sampleRate;
+  }
+
+  /**
+   * Add properties carried by every subsequent event.
+   *
+   * Merged rather than replaced, so two callers setting different fields do not
+   * erase each other. Set once at runtime construction in practice; nothing
+   * here is per-request.
+   */
+  setGlobalProperties(properties: Record<string, unknown>) {
+    this.globalProperties = { ...this.globalProperties, ...properties };
   }
 
   setLicenseToken(licenseToken: string) {
@@ -64,7 +87,10 @@ export class TelemetryClient {
 
     await lambdaClient.send({
       event,
-      properties: properties as Record<string, unknown>,
+      properties: {
+        ...this.globalProperties,
+        ...(properties as Record<string, unknown>),
+      },
       packageName: packageJson.name,
       packageVersion: packageJson.version,
       licenseToken: this.licenseToken ?? undefined,


### PR DESCRIPTION
## The problem

The v2 telemetry client sends exactly the properties each call site passes. There is no way for a product built on this runtime to be told apart in the events that already go.

That leaves one option open to such a product: send its own events. Which means a second pipeline describing the same runs, a second namespace at the ingest gate, and two sources of truth for "how much traffic came through us".

## What this adds

`telemetryProperties` on the runtime, merged into every event the client sends.

```ts
new CopilotRuntime({
  agents,
  telemetryProperties: { accessibility_title: "OpenBot" },
});
```

Set beside the license token, in the shared base, for the same reason that is: it describes the caller rather than the call, so every event carries it whichever handler fired, `instance_created`, `copilot_request_created` or any of the `agent_execution_stream_*`.

## Two decisions worth naming

**Per-event properties win on conflict.** A call site describing one event knows more than a value set once at construction, so the general must not overwrite the specific. Tested.

**No egress on its own.** Unset, nothing changes. Telemetry off, nothing is sent, so nothing carries this. It adds a field to existing events rather than adding events.

## Why

OpenBot needs to be separable from other runtime traffic in the existing OSS analytics, and the ask there was explicitly *one field, no new events, no new pipeline, no new namespace*. Without a seam here, the only way to answer "which requests came through OpenBot" is to build the thing nobody wanted.

The client is a private module singleton and the package `exports` map does not expose it, which is correct, so a consumer cannot reach it to set this itself. Verified by probing the deep import from a consuming package: blocked.

## Tests

Six new, at the send boundary rather than on the instance, because a field held correctly and dropped on the way out is the failure that matters:

- carried on an event that sets none of its own
- carried alongside an event's own properties
- successive calls merge rather than replace
- an event's own property wins on conflict
- nothing sent at all when telemetry is disabled
- nothing added when none are set

`packages/runtime`: 11 telemetry tests pass, 1270 v2 tests pass, 0 failures. Build clean, `telemetryProperties` present in the emitted `.d.mts`. Pre-commit gate green (lint 0 warnings, monorepo tests, commitlint).