### PR TITLE
fix(runtime): send global telemetry properties on the field the sink reads

### DIFF
--- a/packages/runtime/src/v2/runtime/telemetry/__tests__/global-properties.test.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/__tests__/global-properties.test.ts
@@ -10,7 +10,10 @@ import { TelemetryClient } from "../telemetry-client";
  * events describing the same runs.
  *
  * Asserted at the send boundary rather than on the instance, because a field
- * held correctly and dropped on the way out is the failure that matters.
+ * held correctly and dropped on the way out is the failure that matters. And
+ * asserted on `globalProperties` specifically: the sink reads that field as the
+ * pass-through bag for `oss.runtime.*`, so landing them in `properties` instead
+ * would send them somewhere nothing downstream looks for them.
  */
 describe("telemetry global properties", () => {
   let send: ReturnType<typeof vi.spyOn>;
@@ -32,12 +35,18 @@ describe("telemetry global properties", () => {
    * missing call fails as a missing call rather than as a property read on
    * undefined two lines later.
    */
-  function sentProperties(): Record<string, unknown> {
+  function sent(): {
+    properties: Record<string, unknown>;
+    globalProperties: Record<string, unknown>;
+  } {
     expect(send).toHaveBeenCalledTimes(1);
     const [payload] = send.mock.calls[0] as [
-      { properties: Record<string, unknown> },
+      {
+        properties: Record<string, unknown>;
+        globalProperties: Record<string, unknown>;
+      },
     ];
-    return payload.properties;
+    return payload;
   }
 
   afterEach(() => {
@@ -50,10 +59,9 @@ describe("telemetry global properties", () => {
 
     await telemetry.capture("oss.runtime.agent_execution_stream_started", {});
 
-    expect(send).toHaveBeenCalledTimes(1);
-    expect(send.mock.calls[0]?.[0]).toMatchObject({
+    expect(sent()).toMatchObject({
       event: "oss.runtime.agent_execution_stream_started",
-      properties: { accessibility_title: "OpenBot" },
+      globalProperties: { accessibility_title: "OpenBot" },
     });
   });
 
@@ -69,8 +77,10 @@ describe("telemetry global properties", () => {
       "cloud.api_key_provided": false,
     });
 
-    expect(send.mock.calls[0]?.[0]).toMatchObject({
-      properties: { accessibility_title: "OpenBot", agentsAmount: 3 },
+    // Separate fields, and both arrive. The sink spreads them together.
+    expect(sent()).toMatchObject({
+      globalProperties: { accessibility_title: "OpenBot" },
+      properties: { agentsAmount: 3 },
     });
   });
 
@@ -81,8 +91,8 @@ describe("telemetry global properties", () => {
 
     await telemetry.capture("oss.runtime.agent_execution_stream_ended", {});
 
-    expect(send.mock.calls[0]?.[0]).toMatchObject({
-      properties: {
+    expect(sent()).toMatchObject({
+      globalProperties: {
         accessibility_title: "OpenBot",
         deployment_shape: "self-hosted",
       },
@@ -90,10 +100,14 @@ describe("telemetry global properties", () => {
   });
 
   /*
-   * The specific beats the general. A caller describing one event knows more
-   * than a value set once at construction, so a global must not overwrite it.
+   * Kept apart on the wire, so a shared key is not resolved here at all.
+   *
+   * It resolves in the sink, which spreads the global bag last for
+   * `oss.runtime.*` and therefore lets the global win. That is worth pinning:
+   * it is the opposite of what the name "global" suggests to most readers, and
+   * it is why the field docs say not to reuse an event's own key.
    */
-  it("lets an event's own property win on conflict", async () => {
+  it("keeps a shared key on both fields rather than resolving it", async () => {
     const telemetry = client();
     telemetry.setGlobalProperties({ agentsAmount: 99 });
 
@@ -105,7 +119,8 @@ describe("telemetry global properties", () => {
       "cloud.api_key_provided": false,
     });
 
-    expect(sentProperties().agentsAmount).toBe(3);
+    expect(sent().properties.agentsAmount).toBe(3);
+    expect(sent().globalProperties.agentsAmount).toBe(99);
   });
 
   it("sends nothing at all when telemetry is disabled", async () => {
@@ -123,6 +138,6 @@ describe("telemetry global properties", () => {
   it("adds nothing when none are set", async () => {
     await client().capture("oss.runtime.agent_execution_stream_started", {});
 
-    expect(sentProperties()).toEqual({});
+    expect(sent().globalProperties).toEqual({});
   });
 });

--- a/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
@@ -39,9 +39,12 @@ export class TelemetryClient {
   // events instead of sending its own, which is the difference between one
   // extra field and a second pipeline nobody asked for.
   //
-  // Per-event properties win on conflict. A caller describing one event knows
-  // more than a value set once at construction, and silently overriding the
-  // specific with the general would be the wrong way round.
+  // Sent as `global_properties`, a field of its own, so these stay separable
+  // from an event's own properties all the way to the sink.
+  //
+  // Do not reuse a key an event already sets: the fanout spreads this bag last
+  // for `oss.runtime.*`, so a collision resolves in favour of the global and
+  // does so silently. Names here should describe the caller, not the call.
   private globalProperties: Record<string, unknown> = {};
 
   constructor({
@@ -87,10 +90,14 @@ export class TelemetryClient {
 
     await lambdaClient.send({
       event,
-      properties: {
-        ...this.globalProperties,
-        ...(properties as Record<string, unknown>),
-      },
+      properties: properties as Record<string, unknown>,
+      // Its own field on the wire rather than folded into `properties`, which
+      // is what the sink expects: for `oss.runtime.*` the fanout treats
+      // `global_properties` as the SDK's pass-through bag and spreads it into
+      // the analytics event, and v1's client sends package name and version the
+      // same way. Folding it in would work and would put a process-level fact
+      // in the per-event slot, where nothing downstream expects to find one.
+      globalProperties: this.globalProperties,
       packageName: packageJson.name,
       packageVersion: packageJson.version,
       licenseToken: this.licenseToken ?? undefined,


### PR DESCRIPTION
Follow-up to #6599. My correction to that PR never got pushed before it merged, so this is the half that got left behind. Flagging because a release is being cut from `main` right now.

## Not broken, wrong slot

#6599 folds global properties into `properties`. That does work end to end: the sink's fanout spreads both bags for `oss.runtime.*`, so the field still arrives and is still filterable. Nothing is lost today.

It is the wrong slot though:

- The wire body is `{ event, properties, global_properties, package, ts }`, and for `oss.runtime.*` the fanout treats `global_properties` as **the SDK's pass-through bag**. That is the field built for exactly this.
- v1's client already sends package name and version there.
- As merged, v2 never populates `global_properties` at all, so a process-level fact sits in the per-event slot and the field meant for it stays empty.

## Also moves where a conflict resolves

Two separate fields cannot collide inside the SDK, so a shared key now survives on both and the sink decides. It spreads the global bag last, so the global wins.

That is the opposite of what #6599's description said and the opposite of what most readers expect from the word "global", so the field docs now say not to reuse a key an event already sets, and the test pins the behaviour rather than leaving it to be discovered.

## Tests

The six from #6599, updated to assert `globalProperties` rather than `properties`, since a field landing where nothing downstream looks for it is the failure this guards. 11 telemetry tests pass.

## Release note

If it is easier to ship the release as-is, nothing is broken and this can follow. Worth taking first if the timing is convenient, so v2 starts on the field it should stay on rather than moving later.