### PR TITLE
fix(react-core): stop the compat CopilotKit wrapper pinning useSingleEndpoint

### DIFF
--- a/packages/react-core/skills/react-core/references/provider-setup.md
+++ b/packages/react-core/skills/react-core/references/provider-setup.md
@@ -6,7 +6,28 @@ near the root of the React tree. Every CopilotKit hook (`useAgent`,
 (`CopilotChat`, `CopilotPopup`, `CopilotSidebar`) must be rendered inside
 this provider.
 
-> **Which provider component?** Always use `CopilotKit` imported from `@copilotkit/react-core/v2`. It is the compatibility bridge across v1 and v2 and a strict superset of the other provider APIs. Do **not** use `CopilotKit` from the package root (`@copilotkit/react-core`, legacy v1) or `CopilotKitProvider` from `/v2` (a subset of the functionality).
+> **Which provider component?** Use `CopilotKit` imported from `@copilotkit/react-core/v2`. It is the compatibility bridge across v1 and v2 and a superset of `CopilotKitProvider`, which is also exported from `/v2` and is a perfectly good choice if you do not need the v1 bridge. Do **not** use `CopilotKit` from the package root (`@copilotkit/react-core`) — that is the legacy v1 entry point and will not work with v2 hooks or components.
+
+## Transport
+
+You do not normally configure the transport. Both providers leave
+`useSingleEndpoint` unset by default, and the client then negotiates: it probes
+`GET {runtimeUrl}/info` and falls back to the single-route `POST` envelope. That
+works against a multi-route handler (the default for every `createCopilot*`
+handler) and a single-route one alike.
+
+Set the prop only to pin one mode deliberately:
+
+| `useSingleEndpoint`       | Transport                    | Requires                                      |
+| ------------------------- | ---------------------------- | --------------------------------------------- |
+| omitted (**recommended**) | negotiated                   | either handler mode                           |
+| `{true}`                  | single-route `POST` envelope | a handler mounted with `mode: "single-route"` |
+| `{false}`                 | multi-route REST routes      | a handler in the default multi-route mode     |
+
+Pinning the wrong one is the classic first-run failure: a single-route envelope
+sent to a multi-route runtime matches no route, so the runtime 404s while
+`GET /info` still returns 200 and the app looks connected. If you see that, drop
+the prop rather than guessing the other value.
 
 All v2 imports use the `@copilotkit/react-core/v2` subpath. Imports from the
 package root are v1 and will not work with v2 hooks or components.

--- a/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-transport-default.test.tsx
+++ b/packages/react-core/src/components/copilot-provider/__tests__/copilotkit-transport-default.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopilotKit } from "../../../v2";
+import { CopilotKit } from "../copilotkit";
+
+/**
+ * The compatibility `<CopilotKit>` wrapper is re-exported from
+ * `@copilotkit/react-core/v2`, so it is the provider most integrations reach
+ * for. It used to pin `useSingleEndpoint` to `true`, which overrode the core's
+ * `"auto"` negotiation and made every first request 404 against a multi-route
+ * runtime — the default handler mode. See OSS-888.
+ *
+ * Omitting the prop must therefore resolve to `"auto"`, which probes
+ * `GET /info` and falls back to the single-route envelope, so the wrapper works
+ * against either handler mode. An explicit prop must still win.
+ */
+describe("CopilotKit (compat wrapper) transport default", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  function wrapperWith(props: { useSingleEndpoint?: boolean }) {
+    return ({ children }: { children?: React.ReactNode }) => (
+      <CopilotKit runtimeUrl="/api/copilotkit" {...props}>
+        {children}
+      </CopilotKit>
+    );
+  }
+
+  it("resolves an omitted useSingleEndpoint to 'auto' transport", () => {
+    const { result } = renderHook(() => useCopilotKit(), {
+      wrapper: wrapperWith({}),
+    });
+
+    expect(result.current.copilotkit.runtimeTransport).toBe("auto");
+  });
+
+  it("still maps an explicit useSingleEndpoint={true} to 'single'", () => {
+    const { result } = renderHook(() => useCopilotKit(), {
+      wrapper: wrapperWith({ useSingleEndpoint: true }),
+    });
+
+    expect(result.current.copilotkit.runtimeTransport).toBe("single");
+  });
+
+  it("still maps an explicit useSingleEndpoint={false} to 'rest'", () => {
+    const { result } = renderHook(() => useCopilotKit(), {
+      wrapper: wrapperWith({ useSingleEndpoint: false }),
+    });
+
+    expect(result.current.copilotkit.runtimeTransport).toBe("rest");
+  });
+});

--- a/packages/react-core/src/components/copilot-provider/copilotkit.tsx
+++ b/packages/react-core/src/components/copilot-provider/copilotkit.tsx
@@ -101,11 +101,20 @@ export function CopilotKit({ children, ...props }: CopilotKitProps) {
         showUsageBanner={enabled}
       >
         <ThreadsProvider threadId={props.threadId}>
+          {/*
+            `useSingleEndpoint` is deliberately NOT defaulted here — it arrives
+            through `v2Props` and stays `undefined` when the caller omits it, so
+            the core negotiates the transport (`"auto"`: probe `GET /info`, fall
+            back to the single-route envelope). This wrapper is re-exported from
+            `@copilotkit/react-core/v2`, so it is the provider most integrations
+            reach for; pinning the flag to `true` here overrode that negotiation
+            and 404'd every first request against a multi-route runtime — the
+            default handler mode. See OSS-888.
+          */}
           <CopilotKitV2Provider
             {...v2Props}
             showDevConsole={showInspector}
             renderCustomMessages={renderArr}
-            useSingleEndpoint={props.useSingleEndpoint ?? true}
           >
             <CopilotKitInternal {...props}>{children}</CopilotKitInternal>
           </CopilotKitV2Provider>

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.readinessGate.test.tsx
@@ -10,7 +10,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
 // Real public customer-surface wrapper (the same one exercised by
 // CopilotListeners.defaultAgentAbsent.test.tsx / v1-explicit-threadid-bridge.test.tsx
-// and used by Showcase). Its normal default is `useSingleEndpoint=true`.
+// and used by Showcase). It defaults to negotiated (`"auto"`) transport, so the
+// single-endpoint suite below pins `useSingleEndpoint` explicitly.
 import { CopilotKit } from "../../../../components/copilot-provider/copilotkit";
 import { useCopilotKit } from "../../../context";
 import { CopilotChat } from "../CopilotChat";
@@ -311,8 +312,9 @@ describe("CopilotChat readiness gate — suggestion submission", () => {
  * that `CopilotListeners.defaultAgentAbsent.test.tsx` /
  * `v1-explicit-threadid-bridge.test.tsx` exercise — so it drives the same
  * provider chain, agent selection, and single-endpoint POST `info` / `agent/run`
- * path used in production. The wrapper's normal default is
- * `useSingleEndpoint=true`, so the runtime info handshake is a POST
+ * path used in production. Single-endpoint transport is a precondition of this
+ * fixture rather than the behaviour under test, so it is pinned explicitly with
+ * `useSingleEndpoint` below: the runtime info handshake is then a POST
  * `{ method: "info" }` (no REST GET `/info` probe — hence no synthetic 404
  * fallback), and `agent/run` streams a real `text/event-stream` body of AG-UI
  * frames (RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT →
@@ -377,9 +379,9 @@ describe("CopilotChat readiness gate — production-shaped SSE transport", () =>
     global.fetch = vi.fn((url: RequestInfo | URL, init?: RequestInit) => {
       const u = String(url);
       const method = init?.method;
-      // The wrapper defaults to single-endpoint transport, so the runtime `info`
-      // handshake and the run both arrive as POSTs to the runtime URL — there is
-      // NO REST GET `/info` probe to fall back from.
+      // `useSingleEndpoint` is pinned on the provider below, so the runtime
+      // `info` handshake and the run both arrive as POSTs to the runtime URL —
+      // there is NO REST GET `/info` probe to fall back from.
       if (u === RUNTIME_URL && method === "POST") {
         const body = JSON.parse(String(init?.body ?? "{}")) as {
           method?: string;
@@ -410,6 +412,7 @@ describe("CopilotChat readiness gate — production-shaped SSE transport", () =>
         runtimeUrl={RUNTIME_URL}
         agent={AGENT_ID}
         showDevConsole={false}
+        useSingleEndpoint
       >
         <div style={{ height: 400 }}>
           <CopilotChat welcomeScreen={false} />

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -128,9 +128,9 @@ const SINGLE_ROUTE_ENVELOPE_CODE =
 const SINGLE_ROUTE_ENVELOPE_MESSAGE =
   'Received a single-route request envelope ({ method: "..." }) but this ' +
   "runtime is mounted in multi-route mode, so the request matched no route. " +
-  "If the frontend uses <CopilotKit> from @copilotkit/react-core/v2, pass " +
-  "useSingleEndpoint={false} — that provider defaults it to true. Otherwise " +
-  'mount the runtime with mode: "single-route" to serve this envelope.';
+  "Either drop useSingleEndpoint from the frontend provider so it negotiates " +
+  'the transport, or mount the runtime with mode: "single-route" to serve ' +
+  "this envelope.";
 
 /* ------------------------------------------------------------------------------------------------
  * Public types

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -38,11 +38,10 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 </CopilotKit>
 ```
 
-<Callout type="warn" title="Why the explicit useSingleEndpoint">
-  The `createCopilotRuntimeHandler` route below serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
-  asks for single-route transport unless told otherwise, so without this prop
-  its startup `/info` call 404s and no agents are discovered.
-  `<CopilotKitProvider>` detects the transport and needs no prop. See
+<Callout type="info" title="About the explicit useSingleEndpoint">
+  The `createCopilotRuntimeHandler` route below serves multi-route, the default. Both `<CopilotKit>` and `<CopilotKitProvider>` negotiate the transport when the
+  prop is omitted, so this `{false}` is optional: it pins the multi-route REST
+  routes rather than probing for them. See
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
 </Callout>
 

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -82,9 +82,9 @@ see [Runtime HTTP endpoints](/backend/runtime-endpoints).
 <FrontendOnly frontend="react">
 <Callout type="warn" title="Switching to a v2 handler also switches the transport">
   The legacy factories are single-route; the v2 handlers are multi-route by
-  default. The `<CopilotKit>` above asks for single-route unless told otherwise,
-  so add `useSingleEndpoint={false}` when you switch — or move to
-  `<CopilotKitProvider>`, which detects the transport. See
+  default. The `<CopilotKit>` above sets no transport, so it detects the switch
+  on its own — but if you have pinned `useSingleEndpoint={true}` anywhere, drop
+  it or flip it to `{false}` when you move to a v2 handler. See
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
 </Callout>
 </FrontendOnly>

--- a/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
@@ -509,11 +509,10 @@ Forward properties from the frontend provider:
 </CopilotKit>
 ```
 
-<Callout type="warn" title="Why the explicit useSingleEndpoint">
-  `createCopilotEndpoint` serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
-  asks for single-route transport unless told otherwise, so without this prop
-  its startup `/info` call 404s and no agents are discovered.
-  `<CopilotKitProvider>` detects the transport and needs no prop. See
+<Callout type="info" title="About the explicit useSingleEndpoint">
+  `createCopilotEndpoint` serves multi-route, the default. Both `<CopilotKit>` and `<CopilotKitProvider>` negotiate the transport when the
+  prop is omitted, so this `{false}` is optional: it pins the multi-route REST
+  routes rather than probing for them. See
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
 </Callout>
 </FrontendOnly>

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -25,15 +25,28 @@ mapping:
 
 | Provider | `useSingleEndpoint` | Transport | Needs handler | Route file |
 | --- | --- | --- | --- | --- |
-| `<CopilotKit>` (v1 wrapper) | omitted → defaults to `true` | `single` | single-route | `route.ts`, `POST` |
-| `<CopilotKit>` (v1 wrapper) | `{false}` | `rest` | multi-route | `[[...slug]]/route.ts`, 4 verbs |
-| `<CopilotKitProvider>` (v2) | omitted | `auto` — detected from `/info` | either | matches the handler |
-| `<CopilotKitProvider>` (v2) | `{true}` | `single` | single-route | `route.ts`, `POST` |
+| `<CopilotKit>` or `<CopilotKitProvider>` | omitted | `auto` — detected from `/info` | either | matches the handler |
+| `<CopilotKit>` or `<CopilotKitProvider>` | `{true}` | `single` | single-route | `route.ts`, `POST` |
+| `<CopilotKit>` or `<CopilotKitProvider>` | `{false}` | `rest` | multi-route | `[[...slug]]/route.ts`, 4 verbs |
 
 `<CopilotKit>` is a backward-compatible wrapper that renders
-`<CopilotKitProvider>` internally and pins `useSingleEndpoint` to `true` unless
-you pass the prop. **The v1 wrapper therefore asks for single-route transport
-even when your Runtime is multi-route.**
+`<CopilotKitProvider>` internally. Both are exported from
+`@copilotkit/react-core/v2` and both leave `useSingleEndpoint` unset by default,
+so **omitting the prop is the safe choice on either** — the client probes
+`GET /info` and falls back to the single-route envelope, matching whichever mode
+your Runtime serves.
+
+<Callout type="warn" title="Pinning the wrong mode 404s silently">
+  Passing `useSingleEndpoint={true}` to a multi-route Runtime sends an envelope
+  that matches no route, so the Runtime 404s while `GET /info` still returns 200
+  and the app looks connected. Drop the prop rather than guessing the other
+  value.
+
+  Older releases pinned `useSingleEndpoint` to `true` inside `<CopilotKit>`, so
+  code written against those versions may pass `{false}` explicitly to
+  compensate. That is still correct against a multi-route handler — it is just no
+  longer required.
+</Callout>
 
 Both ship from the same package entry point, so moving between them is an import
 change, not a migration.
@@ -222,9 +235,9 @@ import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 </CopilotKitProvider>
 ```
 
-If you still use the v1 `<CopilotKit>` wrapper from `@copilotkit/react-core`,
-set `useSingleEndpoint={false}`. Omitting that prop keeps the v1 wrapper's
-single-route default.
+The `<CopilotKit>` wrapper behaves the same way — omitting the prop lets it
+detect the multi-route Runtime. Passing `useSingleEndpoint={false}` is also
+correct here; it just pins what detection would have found anyway.
 </FrontendOnly>
 
 <FrontendOnly frontend="angular">
@@ -378,8 +391,8 @@ envelope:
 Its response and failure rules match `GET {basePath}/inspector-metadata`.
 
 <FrontendOnly frontend="react">
-On the frontend, opt into the matching transport with the `useSingleEndpoint`
-prop:
+The frontend detects this mode on its own, so no prop is required. To pin it
+explicitly, pass `useSingleEndpoint`:
 
 ```tsx
 import { CopilotKit } from '@copilotkit/react-core/v2';
@@ -392,8 +405,9 @@ import { CopilotKit } from '@copilotkit/react-core/v2';
 <Callout type="warn">
 The frontend transport must match the runtime mode. If the runtime is in
 single-route mode but the frontend is making multi-route requests (or vice
-versa), every call 404s. Set `useSingleEndpoint` on `<CopilotKit>` whenever the
-runtime uses `mode: "single-route"`.
+versa), every call 404s. Omitting the prop avoids that by construction, since
+the client then probes for the mode the runtime actually serves — so pin
+`useSingleEndpoint` only when you want to skip that probe.
 </Callout>
 </FrontendOnly>
 

--- a/showcase/shell-docs/src/content/docs/cookbook/arcade.mdx
+++ b/showcase/shell-docs/src/content/docs/cookbook/arcade.mdx
@@ -238,11 +238,11 @@ export const OPTIONS = handler;
 ```
 
 <Callout type="info" title="Single-route transport">
-  CopilotKit's `<CopilotKit>` provider defaults to `useSingleEndpoint`, so the client POSTs every
+  This recipe pins `useSingleEndpoint` on the provider, so the client POSTs every
   call as a `{ method, params, body }` envelope to the base path. Mount a single-route handler to
   match (`createCopilotRuntimeHandler({ mode: "single-route" })`), and `createCopilotRuntimeHandler`
   is the preferred primitive, so avoid the deprecated `createCopilotEndpointSingleRoute` / hono
-  adapters.
+  adapters. Omitting the prop would let the client detect the mode instead.
 </Callout>
 
 ## Render the authorization step as generative UI

--- a/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/aws-lambda.mdx
@@ -203,11 +203,10 @@ The Function URL is the origin; `basePath` is appended to it.
 </CopilotKit>
 ```
 
-<Callout type="warn" title="Why the explicit useSingleEndpoint">
-  The Function URL handler above serves multi-route, the default. `<CopilotKit>` is the v1 wrapper and
-  asks for single-route transport unless told otherwise, so without this prop
-  its startup `/info` call 404s and no agents are discovered.
-  `<CopilotKitProvider>` detects the transport and needs no prop. Drop the prop
+<Callout type="info" title="About the explicit useSingleEndpoint">
+  The Function URL handler above serves multi-route, the default. Both `<CopilotKit>` and `<CopilotKitProvider>` negotiate the transport when the
+  prop is omitted, so this `{false}` is optional: it pins the multi-route REST
+  routes rather than probing for them. Drop the prop
   if you took the buffered front door below and mounted the handler with
   `mode: "single-route"`. See
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -128,11 +128,10 @@ Before you begin, you'll need the following:
         Wrap your application with the CopilotKit provider:
 
         <Callout type="info" title="Which provider goes with which handler?">
-          `<CopilotKit>` here is the backward-compatible wrapper: it defaults
-          `useSingleEndpoint` to `true`, which is the matching half of the
-          single-route `copilotRuntimeNextJSAppRouterEndpoint` above. `<CopilotKitProvider>`
-          is the v2 provider from the same package and detects the transport from
-          `/info` instead. They are not aliases — see
+          `<CopilotKit>` here is the backward-compatible wrapper. It sets no transport
+          by default, so it detects the single-route `copilotRuntimeNextJSAppRouterEndpoint`
+          above on its own. `<CopilotKitProvider>` is the v2 provider from the same
+          package and detects the transport the same way. They are not aliases — see
           [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
         </Callout>
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -429,11 +429,10 @@ Before you begin, you'll need the following:
               Wrap your application with the CopilotKit provider:
 
               <Callout type="info" title="Which provider goes with which handler?">
-                `<CopilotKit>` here is the backward-compatible wrapper: it defaults
-                `useSingleEndpoint` to `true`, which is the matching half of the
-                single-route `copilotRuntimeNextJSAppRouterEndpoint` above. `<CopilotKitProvider>`
-                is the v2 provider from the same package and detects the transport from
-                `/info` instead. They are not aliases — see
+                `<CopilotKit>` here is the backward-compatible wrapper. It sets no transport
+                by default, so it detects the single-route `copilotRuntimeNextJSAppRouterEndpoint`
+                above on its own. `<CopilotKitProvider>` is the v2 provider from the same
+                package and detects the transport the same way. They are not aliases — see
                 [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
               </Callout>
 

--- a/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
+++ b/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
@@ -37,10 +37,10 @@ Single-route mode is useful when your platform only allows a single route handle
 
 <FrontendOnly frontend="react">
 <Callout type="warn" title="The mode you pick here binds the frontend">
-  The v1 `<CopilotKit>` wrapper defaults to single-route transport, so it needs
-  `useSingleEndpoint={false}` against a multi-route handler — and no prop at all
-  once you pass `mode: "single-route"`. `<CopilotKitProvider>` detects the mode
-  either way. The full mapping is in
+  Both `<CopilotKit>` and `<CopilotKitProvider>` detect the mode when you pass
+  no transport prop, so either one follows whichever mode you pick here. Pin it
+  with `useSingleEndpoint` only if you want to skip that detection — and then it
+  has to match. The full mapping is in
   [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
 </Callout>
 </FrontendOnly>

--- a/skills/copilotkit-develop/SKILL.md
+++ b/skills/copilotkit-develop/SKILL.md
@@ -66,10 +66,10 @@ import { CopilotKit } from "@copilotkit/react-core/v2";
 
 function App() {
   return (
-    // useSingleEndpoint={false} matches the multi-route backend above. The
-    // v1-compat CopilotKit bridge defaults it to true (single transport),
-    // which would 404 against a multi-route handler.
-    <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
+    // No useSingleEndpoint: the provider negotiates the transport, so this
+    // works against a multi-route handler (the default) and a single-route one
+    // alike. Pass the prop only to pin one mode deliberately.
+    <CopilotKit runtimeUrl="/api/copilotkit">
       <YourApp />
     </CopilotKit>
   );

--- a/skills/copilotkit-integrations/SKILL.md
+++ b/skills/copilotkit-integrations/SKILL.md
@@ -85,7 +85,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-The provider component is `CopilotKit` (imported from `@copilotkit/react-core/v2`). There is no `agent` prop -- agents are selected per-hook via `agentId` (matching a key from `CopilotRuntime({ agents: { ... } })`). Set `useSingleEndpoint={false}` so the v1-compat bridge uses multi-route transport against the catch-all backend route below; omitting it defaults to single-route, which a multi-route backend 404s.
+The provider component is `CopilotKit` (imported from `@copilotkit/react-core/v2`). There is no `agent` prop -- agents are selected per-hook via `agentId` (matching a key from `CopilotRuntime({ agents: { ... } })`). `useSingleEndpoint={false}` pins multi-route transport against the catch-all backend route below. It is optional — omitting it lets the provider detect the mode — but pinning it skips the detection probe.
 
 ### API Route Pattern (route.ts)
 

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -221,7 +221,7 @@ const app = createCopilotHonoHandler({
 export const POST = handle(app);
 ```
 
-When using single-route, the frontend must set `useSingleEndpoint` on the provider (see Step 3).
+The frontend provider negotiates this automatically; set `useSingleEndpoint` on it only to pin single-route transport explicitly (see Step 3).
 
 #### Standalone Express Server
 
@@ -316,10 +316,10 @@ import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
 
 export default function Home() {
   return (
-    // useSingleEndpoint={false} matches the multi-route backend above.
-    // The v1-compat CopilotKit bridge defaults useSingleEndpoint to true,
-    // which would 404 against multi-route endpoints.
-    <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
+    // No useSingleEndpoint: the provider negotiates the transport, so it
+    // matches the multi-route backend above (the default) or a single-route
+    // one. Pass the prop only to pin one mode deliberately.
+    <CopilotKit runtimeUrl="/api/copilotkit">
       <div style={{ height: "100vh" }}>
         <CopilotChat />
       </div>
@@ -338,14 +338,14 @@ When the runtime runs on a separate server (e.g., Express on port 4000):
 </CopilotKit>
 ```
 
-Set `useSingleEndpoint` when the backend uses single-route endpoints (`createCopilotHonoHandler` or `createCopilotExpressHandler` with `mode: "single-route"`).
+Omitting `useSingleEndpoint` lets the provider negotiate the transport, which works against either handler mode. Set it to `true` only to pin single-route transport (`createCopilotHonoHandler` or `createCopilotExpressHandler` with `mode: "single-route"`), or to `false` to pin the multi-route REST routes.
 
 #### CopilotKit key props
 
 | Prop                | Type                                                       | Description                                                                                                          |
 | ------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `runtimeUrl`        | `string`                                                   | URL of the CopilotKit runtime endpoint                                                                               |
-| `useSingleEndpoint` | `boolean`                                                  | Set to `true` when using single-route endpoints                                                                      |
+| `useSingleEndpoint` | `boolean`                                                  | Omit to negotiate the transport (works with either handler mode); `true` pins single-route, `false` pins multi-route |
 | `headers`           | `Record<string, string> \| (() => Record<string, string>)` | Custom headers sent with every request. The function form is evaluated per-request (useful for dynamic auth tokens). |
 | `credentials`       | `RequestCredentials`                                       | Fetch credentials mode (e.g., `"include"` for cookies)                                                               |
 | `publicLicenseKey`  | `string`                                                   | CopilotKit Intelligence public license key (`publicApiKey` is a deprecated alias)                                    |

--- a/skills/copilotkit-setup/references/framework-detection.md
+++ b/skills/copilotkit-setup/references/framework-detection.md
@@ -42,7 +42,7 @@ Detect the project's framework before generating any setup code. The detection o
 - **Frontend connects to external URL:** `runtimeUrl` points to the Express server (e.g., `http://localhost:4000/api/copilotkit`)
 - **Stylesheet import:** In `pages/_app.tsx` or `styles/globals.css`: `import "@copilotkit/react-core/v2/styles.css"`
 - **Env file:** `.env.local`
-- **Key prop:** `useSingleEndpoint` must be set on the provider when using single-route Express endpoints
+- **Key prop:** `useSingleEndpoint` may be set on the provider to pin single-route transport for single-route Express endpoints; omitting it lets the provider detect the mode
 
 ### Angular
 

--- a/skills/react-core/references/provider-setup.md
+++ b/skills/react-core/references/provider-setup.md
@@ -6,7 +6,28 @@ near the root of the React tree. Every CopilotKit hook (`useAgent`,
 (`CopilotChat`, `CopilotPopup`, `CopilotSidebar`) must be rendered inside
 this provider.
 
-> **Which provider component?** Always use `CopilotKit` imported from `@copilotkit/react-core/v2`. It is the compatibility bridge across v1 and v2 and a strict superset of the other provider APIs. Do **not** use `CopilotKit` from the package root (`@copilotkit/react-core`, legacy v1) or `CopilotKitProvider` from `/v2` (a subset of the functionality).
+> **Which provider component?** Use `CopilotKit` imported from `@copilotkit/react-core/v2`. It is the compatibility bridge across v1 and v2 and a superset of `CopilotKitProvider`, which is also exported from `/v2` and is a perfectly good choice if you do not need the v1 bridge. Do **not** use `CopilotKit` from the package root (`@copilotkit/react-core`) — that is the legacy v1 entry point and will not work with v2 hooks or components.
+
+## Transport
+
+You do not normally configure the transport. Both providers leave
+`useSingleEndpoint` unset by default, and the client then negotiates: it probes
+`GET {runtimeUrl}/info` and falls back to the single-route `POST` envelope. That
+works against a multi-route handler (the default for every `createCopilot*`
+handler) and a single-route one alike.
+
+Set the prop only to pin one mode deliberately:
+
+| `useSingleEndpoint`       | Transport                    | Requires                                      |
+| ------------------------- | ---------------------------- | --------------------------------------------- |
+| omitted (**recommended**) | negotiated                   | either handler mode                           |
+| `{true}`                  | single-route `POST` envelope | a handler mounted with `mode: "single-route"` |
+| `{false}`                 | multi-route REST routes      | a handler in the default multi-route mode     |
+
+Pinning the wrong one is the classic first-run failure: a single-route envelope
+sent to a multi-route runtime matches no route, so the runtime 404s while
+`GET /info` still returns 200 and the app looks connected. If you see that, drop
+the prop rather than guessing the other value.
 
 All v2 imports use the `@copilotkit/react-core/v2` subpath. Imports from the
 package root are v1 and will not work with v2 hooks or components.


### PR DESCRIPTION
Refs [OSS-888](https://linear.app/copilotkit/issue/OSS-888).

## The failure

A correctly assembled v2 integration 404s on its first browser request while every static check passes and `GET /info` returns 200.

`packages/react-core/src/v2/index.ts:28` re-exports the **v1-compat** `CopilotKit` wrapper, so it is the provider most integrations reach for. That wrapper pinned:

```tsx
useSingleEndpoint={props.useSingleEndpoint ?? true}
```

which overrode the core's `"auto"` negotiation and forced single-route transport. But **every** v2 handler defaults to `mode: "multi-route"` (`endpoints/hono.ts:95`; `createCopilotEndpoint` is an alias at `:90`). Nothing serves the single-route envelope the client sends, so the runtime 404s while the provider looks connected.

## What this is *not*

The library defaults do not actually disagree. `CopilotKitProvider` (the real v2 provider) leaves the flag undefined → `"auto"`, which probes `GET /info` and falls back to the single-route envelope (`core/agent-registry.ts` `fetchRuntimeInfoAutoDetect`) — it works against **either** handler mode. Only the compat wrapper defeated that.

So this is one line of override, not a defaults mismatch needing a direction chosen.

## Why four onboarding runs hit it, not one

The library bug alone doesn't explain a 100% failure rate. The shipped `react-core` skill does:

`packages/react-core/skills/react-core/references/provider-setup.md` — bundled in the npm tarball (`files: ["dist","skills"]`) — **mandated** the compat wrapper, **forbade** `CopilotKitProvider` as "a subset of the functionality", and mentioned `useSingleEndpoint` **zero times** across ~10 code samples. An agent following it wrote the 404 configuration every time.

Meanwhile `skills/copilotkit-setup/SKILL.md` got it right, so the two shipped skills contradicted each other and nothing gated either against the code.

## The change

**Commit 1 — the library fix.** The prop already arrives through `v2Props`, so dropping the override lets it stay `undefined` and inherit `"auto"`. An explicit `useSingleEndpoint` still wins in both directions.

**Commit 2 — the docs and skills.** Correcting the default made ~15 pages' explanations false. Code samples that pass `{false}` stay valid (they pin what negotiation would find anyway), so this corrects the *explanations* rather than the samples — keeping every page true both before and after release. Includes dropping the now-false causal claim from the single-route-envelope diagnostic added in #6579.

## Compatibility

Safe for existing v1 apps. A v1 app on a single-route-only handler (`copilotRuntimeNextJSAppRouterEndpoint` and friends) now does one `GET /info` that 404s, then falls back to single-route and works. Cost is one extra request on connect.

One edge case worth a reviewer's eye: if a deployment's `runtimeUrl` + `/info` returns 200 from something that is *not* a multi-route CopilotKit runtime (a catch-all proxy serving HTML, say), `"auto"` would resolve to `rest`. Setting `useSingleEndpoint` explicitly remains the escape hatch.

Conventional-commit note: this lands as `fix`, but it *does* change a public default. Flag if you'd rather it carried a minor bump.

## Tests

- New `copilotkit-transport-default.test.tsx` — omitted → `"auto"`, `{true}` → `"single"`, `{false}` → `"rest"`. Confirmed RED first (`expected 'single' to be 'auto'`).
- `CopilotChat.readinessGate.test.tsx` depended on the old default to avoid a REST probe. Single-route transport is a **precondition of that fixture**, not the behaviour under test, so it now pins the flag explicitly and its stale comments are corrected. Its coverage (readiness gate across the real SSE boundary) is unchanged.
- `react-core` 1512 passed · `runtime` 2073 passed · `core` 668 passed.
- `pnpm check:plugin-skills` in sync (`skills/react-core/` is the generated mirror).

`showcase/shell-docs`'s own vitest suite fails to load 35 files with `Cannot find package 'react/jsx-dev-runtime'` — reproduced identically on unmodified `origin/main`, so it is environmental in this checkout and unrelated. All 183 tests that do run pass.

## Not addressed here

Nothing gates a shipped skill against the code it documents, which is why `provider-setup.md` could contradict both the library and the sibling skill indefinitely. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)