### PR TITLE
fix(showcase): tighten the offsite-expenses beat

### DIFF
--- a/examples/showcases/reskinnable-demo/agent/agent.py
+++ b/examples/showcases/reskinnable-demo/agent/agent.py
@@ -3,9 +3,9 @@
     banking                       gpt-5.4, temp 0
       │  banking's own prompt; the browser's frontend tools and the
       │  Intelligence memory tools; `render_report` for the canvas
-      └─ expense-analyst          gpt-5.6-sol, reasoning_effort=high
+      └─ expense-analyst          gpt-5.6-sol, reasoning_effort=medium
            │  sandboxed shell (LocalShellBackend), `submit_expense_report`
-           └─ merchant-researcher gpt-5.4, streaming OFF, one per merchant
+           └─ merchant-researcher gpt-5.4, own lane, one per merchant
                 `search_merchant` (Tavily)
 
 The nesting is the design, not an accident of growth. Each level exists because
@@ -92,19 +92,30 @@ DO THIS, IN THIS ORDER:
 
 1. Fetch the statement into your working directory:
 
-   curl -sS -o expenses.csv {_app_base_url()}/sample-expenses-offsite.csv
+   curl -sS -o expenses.csv {_app_base_url()}/sample-expenses-offsite.csv && head -3 expenses.csv
 
-   Then check it is really a CSV — `head -3 expenses.csv`. If it came back as an
-   HTML error page, STOP and say so. Analysing a 404 page as if it were the
-   statement wastes minutes and produces a confident, wrong answer.
+   Fetch and check in that ONE command — the `head` is how you confirm it is
+   really a CSV, and there is nothing to decide between the two halves, so
+   splitting them just spends an extra turn to learn nothing. If the head shows
+   an HTML error page rather than a CSV header, STOP and say so. Analysing a 404
+   page as if it were the statement wastes minutes and produces a confident,
+   wrong answer.
 
 2. Write a short python script to parse and group the rows and RUN it with
    python3. Do not eyeball the rows by hand.
 
-3. For every merchant whose nature you cannot determine from its name alone,
-   delegate to the `merchant-researcher` subagent to find out what kind of
-   business it is. "Cardinal & Ash" could be a restaurant or a law firm; find
-   out rather than assume.
+3. Research only the rows where research can still change the answer.
+
+   A row dated outside {OFFSITE_START}..{OFFSITE_END} is already settled by its
+   date: it is not reimbursable whichever kind of business the merchant turns
+   out to be, so do not spend a subagent establishing that a charge a week after
+   the offsite was a bookshop. The exception is travel to or from the offsite,
+   which is in scope on the adjacent days — keep those rows in the running.
+
+   For the rows that survive that test, delegate to the `merchant-researcher`
+   subagent for every merchant whose nature you cannot determine from its name
+   alone. "Cardinal & Ash" could be a restaurant or a law firm; find out rather
+   than assume.
 
    DISPATCH ALL OF THEM IN ONE RESPONSE — emit one task call per merchant in the
    same assistant turn so they run concurrently. Do not wait for one to come
@@ -118,13 +129,30 @@ DO THIS, IN THIS ORDER:
    exactly the three fields `merchant`, `amount` and `note`, nothing else, and
    answers 201 with the new transaction's id:
 
-   curl -sS -X POST {_app_base_url()}/api/banking/v1/transactions \\
-     -H 'content-type: application/json' \\
-     -w '%{{http_code}}' \\
-     -d '{{"merchant":"Hotel Verrano","amount":318.55,"note":"Offsite {OFFSITE_CITY} — reimbursable"}}'
+   POST {_app_base_url()}/api/banking/v1/transactions
+     content-type: application/json
+     {{"merchant":"Hotel Verrano","amount":318.55,"note":"Offsite {OFFSITE_CITY} — reimbursable"}}
 
-   CHECK EVERY SINGLE CALL BEFORE MOVING ON. If a call does not come back 201
-   with an `id`, then for that row you must:
+   FILE THEM ALL IN ONE COMMAND. Write a short python script that walks your
+   expensable rows, POSTs each one, and prints a line per row with the merchant,
+   the status code and the id it read back — then run that script. One `curl`
+   per row is the same N requests dressed as N round-trips through the model,
+   and on a statement this size that serial shuttling is most of the time the
+   whole analysis takes.
+
+   THE SCRIPT MUST REFUSE TO FILE TWICE. Have it write the ids it collected to
+   `filed.json`, and on startup, if that file already exists, print the ids from
+   it and exit WITHOUT posting anything. This is not defensive padding — the
+   batched form made a real duplicate-filing bug: the script got run a second
+   time and every charge was filed twice, so the report card said six filings
+   while the ledger held twelve. A duplicate here is a reimbursement claimed
+   twice. The marker makes a second run free and harmless, and it means you can
+   re-read the ids without risking the ledger.
+
+   Batching the REQUESTS does not batch the CHECKING. The script must print each
+   row's own status and id, and you must read that output row by row before
+   moving on. If a row did not come back 201 with an `id`, then for that row you
+   must:
      - NOT invent, guess, pattern-match, or reuse a transaction id;
      - leave `filedTransactionId` absent from that row entirely;
      - state in that row's `reason` that the filing failed, with the status code.
@@ -196,7 +224,7 @@ def search_merchant(query: str) -> list[dict]:
 
     results = TavilyClient(api_key=api_key).search(
         query=query,
-        max_results=5,
+        max_results=3,
         include_raw_content=False,
         topic="general",
     )
@@ -204,8 +232,11 @@ def search_merchant(query: str) -> list[dict]:
         {
             "url": r.get("url", ""),
             "title": r.get("title", ""),
-            # Truncated: five untrimmed pages per merchant across seven
-            # concurrent subagents is a lot of context for "is this a hotel".
+            # Truncated, and only three results asked for: untrimmed pages per
+            # merchant across several concurrent subagents is a lot of context
+            # for "is this a hotel". Results four and five never changed a
+            # verdict — the first hits already say what the business is — and
+            # every one of them is tokens the researcher has to read first.
             "content": (r.get("content") or "")[:2000],
         }
         for r in results.get("results", [])
@@ -365,6 +396,16 @@ def _run_key_from_request(request) -> str:
     return _run_key_from_config(cfg)
 
 
+def _workspace_path() -> pathlib.Path:
+    """The analyst's sandbox directory.
+
+    Module-level because TWO places need it: the shell backend that runs inside
+    it, and the per-run reset below that clears the previous run's filing marker
+    out of it.
+    """
+    return pathlib.Path(os.environ.get("AGENT_WORKSPACE", "/tmp/expense-agent"))
+
+
 @wrap_model_call
 async def _stamp_run_start(request, handler):
     """Record when this run's first model call happened.
@@ -381,6 +422,22 @@ async def _stamp_run_start(request, handler):
     key = _run_key_from_request(request)
     if key not in _RUN_STARTS:
         _RUN_STARTS[key] = time.time()
+
+        # Clear the PREVIOUS run's filing marker.
+        #
+        # `filed.json` is how the filing script refuses to post twice within a
+        # run (prompt step 5), and it has to exist because the batched form
+        # really did double-file once: the script was run a second time and the
+        # ledger ended up with twelve rows behind a report card claiming six.
+        #
+        # But the workspace is a FIXED directory shared by every run, so a
+        # marker left in place would convince the next demo it had already
+        # filed and it would post nothing at all — the same bug wearing the
+        # opposite mask, and a quieter one, because a run that files nothing
+        # still produces a confident report. Clearing it here, in the branch
+        # that fires exactly once per run, is what keeps "cannot double-file"
+        # from turning into "never files again".
+        (_workspace_path() / "filed.json").unlink(missing_ok=True)
 
     # An ALARM, not a trace.
     #
@@ -589,7 +646,7 @@ def _build_expense_analyst():
     reaching `astream_events`, which is what `ag_ui_langgraph` builds AG-UI
     events from. So the console still draws the whole journey.
     """
-    workspace = pathlib.Path(os.environ.get("AGENT_WORKSPACE", "/tmp/expense-agent"))
+    workspace = _workspace_path()
     workspace.mkdir(parents=True, exist_ok=True)
 
     # The sandbox. `virtual_mode=False` so the agent's shell sees real paths it
@@ -603,12 +660,18 @@ def _build_expense_analyst():
 
     analyst_model = ChatOpenAI(
         model=os.environ.get("BANKING_EXPENSE_MODEL", "gpt-5.6-sol"),
-        # High effort is not padding. The judgement calls here are the genuinely
-        # hard part — whether a resolved merchant kind makes a charge
-        # reimbursable under the offsite's dates — and it is also the honest way
-        # to make a run take minutes: it thinks longer because there is more
-        # thinking to do, rather than waiting on a timer.
-        reasoning_effort=os.environ.get("BANKING_EXPENSE_EFFORT", "high"),
+        # The effort is real work, not padding: the judgement calls here are the
+        # genuinely hard part — whether a resolved merchant kind makes a charge
+        # reimbursable under the offsite's dates — so the run takes as long as it
+        # takes to think, rather than waiting on a timer.
+        #
+        # MEDIUM, not high. This was `high`, on the reasoning that a longer run
+        # was an honest one. It is, but the beat is watched, and high spent that
+        # length on the easy majority of the statement as well as the two or
+        # three rows that are actually arguable. Medium reaches the same verdicts
+        # on this statement in appreciably less wall-clock. Put `high` back via
+        # BANKING_EXPENSE_EFFORT if a harder statement ever needs it.
+        reasoning_effort=os.environ.get("BANKING_EXPENSE_EFFORT", "medium"),
         # REQUIRED with the two settings above, and the failure is a hard 400 on
         # the first model call inside the analyst:
         #

--- a/examples/showcases/reskinnable-demo/src/shell/chat/tool-activity.tsx
+++ b/examples/showcases/reskinnable-demo/src/shell/chat/tool-activity.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   defineToolCallRenderer,
   ToolCallStatus,
@@ -60,6 +66,117 @@ function resolveToolLabel(
 }
 
 /**
+ * How many tool-activity lines stay on screen. Older ones are REMOVED, not
+ * collapsed or scrolled.
+ *
+ * The offsite-expenses beat emits ten to fourteen tool calls, and one line per
+ * call turned the transcript into a changelog: the report card it all built
+ * toward was pushed off the screen by a stack of finished `Execute` rows nobody
+ * reads. A rolling window keeps the run legible as "what is happening now"
+ * rather than "everything that has ever happened".
+ */
+const VISIBLE_TOOL_ACTIVITY = 2;
+
+/**
+ * Ordered ids of the tool activity currently mounted, oldest first.
+ *
+ * ## Why a shared registry and not something simpler
+ *
+ * CopilotKit renders ONE component per tool call and owns the container, so
+ * there is no parent here that can see the list and slice it. Two simpler
+ * options are both dead ends, measured on a real run:
+ *
+ *   - CSS (`:nth-last-child`) needs the lines to be siblings. They are not —
+ *     ten lines sat under ten different parents, one wrapper each.
+ *   - Mount-order counters drift, because a `MESSAGES_SNAPSHOT` at the end of a
+ *     run remounts every line at once.
+ *
+ * So each line registers its AG-UI `toolCallId` — stable, unique per call, and
+ * assigned in emission order — and reads back whether it is still among the
+ * last few. `useSyncExternalStore` is what makes the OLDER lines re-render (and
+ * so disappear) when a NEW one arrives; a plain module variable would leave
+ * them on screen until something else happened to re-render them.
+ */
+const activityOrder: string[] = [];
+const activityListeners = new Set<() => void>();
+
+const subscribeActivity = (onChange: () => void) => {
+  activityListeners.add(onChange);
+  return () => {
+    activityListeners.delete(onChange);
+  };
+};
+
+const notifyActivityChanged = () => {
+  for (const listener of activityListeners) listener();
+};
+
+/**
+ * Whether this line is recent enough to still be shown.
+ *
+ * An id that is not registered YET counts as visible: registration happens in
+ * an effect, so a line is not in the list during its own first render, and
+ * treating that as hidden would make every new line appear one frame late.
+ *
+ * Unregistered-means-visible is only safe because registration is a LAYOUT
+ * effect. Read this together with `useIsRecentToolActivity` — the two halves
+ * are one mechanism, and splitting them is what caused the flash.
+ */
+const isRecentActivity = (toolCallId: string): boolean => {
+  const index = activityOrder.indexOf(toolCallId);
+  return index === -1 || index >= activityOrder.length - VISIBLE_TOOL_ACTIVITY;
+};
+
+/**
+ * `useLayoutEffect`, except on the server where React warns that it does
+ * nothing. Registration MUST be a layout effect (see below), and this component
+ * is server-rendered as part of the chat, so the plain hook would log a warning
+ * on every render pass in dev.
+ */
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+function useIsRecentToolActivity(toolCallId: string, track: boolean): boolean {
+  /**
+   * LAYOUT effect, not a passive one, and this is load-bearing.
+   *
+   * A new line renders visible before it is registered (it cannot know its own
+   * position yet), and registering is what evicts the oldest line. With a
+   * passive `useEffect` those two things land in different frames, so the
+   * browser paints the in-between state: the list grows to three rows and then
+   * snaps back to two. That is the flash — one extra row for one frame on every
+   * single tool call, and again when the end-of-run `MESSAGES_SNAPSHOT`
+   * remounts every line at once.
+   *
+   * React flushes state updates scheduled inside a layout effect before the
+   * browser paints, so the eviction happens in the SAME frame as the insertion:
+   * the painted row count goes 2 → 2 and never through 3.
+   */
+  useIsomorphicLayoutEffect(() => {
+    // Internal tools must not take a slot: two filtered `agui` calls would
+    // otherwise fill the window and blank out the real activity behind them.
+    if (!track) return;
+    if (!activityOrder.includes(toolCallId)) {
+      activityOrder.push(toolCallId);
+      notifyActivityChanged();
+    }
+    return () => {
+      const index = activityOrder.indexOf(toolCallId);
+      if (index === -1) return;
+      activityOrder.splice(index, 1);
+      notifyActivityChanged();
+    };
+  }, [toolCallId, track]);
+
+  return useSyncExternalStore(
+    subscribeActivity,
+    () => isRecentActivity(toolCallId),
+    // Server render: nothing has registered, so every line is "newest".
+    () => true,
+  );
+}
+
+/**
  * Tool activity for EVERY tool the agent calls — the wildcard ("*") tool-call
  * renderer. CopilotKit only falls back to this for tool calls with no exact
  * renderer of their own, so it surfaces the otherwise invisible ones
@@ -73,11 +190,13 @@ function resolveToolLabel(
  * with a check.
  */
 function ToolCallChip({
+  toolCallId,
   name,
   status,
   args,
   result,
 }: {
+  toolCallId: string;
   name: string;
   status: ToolCallStatus;
   args?: unknown;
@@ -88,6 +207,7 @@ function ToolCallChip({
   const label = resolveToolLabel(name, skin.toolLabels);
   const done = status === ToolCallStatus.Complete;
   const hidden = isInternalTool(name);
+  const recent = useIsRecentToolActivity(toolCallId, !hidden);
 
   const detail = useMemo(() => {
     const lines: string[] = [`tool: ${name}`];
@@ -101,6 +221,11 @@ function ToolCallChip({
   }, [name, args, result]);
 
   if (hidden) return <></>;
+  // Aged out of the window. Returning nothing REMOVES the line rather than
+  // hiding it, which is the point: the transcript should not keep growing a
+  // stack of finished steps behind the thing they produced. The full sequence
+  // is still in the run's own events (and the harness console renders them).
+  if (!recent) return <></>;
 
   return (
     <div data-testid="tool-activity" className="my-1.5">
@@ -144,8 +269,14 @@ function ToolCallChip({
 export const TOOL_CALL_RENDERERS: ReactToolCallRenderer<unknown>[] = [
   defineToolCallRenderer({
     name: "*",
-    render: ({ name, status, args, result }) => (
-      <ToolCallChip name={name} status={status} args={args} result={result} />
+    render: ({ toolCallId, name, status, args, result }) => (
+      <ToolCallChip
+        toolCallId={toolCallId}
+        name={name}
+        status={status}
+        args={args}
+        result={result}
+      />
     ),
   }),
 ];

--- a/examples/showcases/reskinnable-demo/src/skins/banking/components/harness-console.tsx
+++ b/examples/showcases/reskinnable-demo/src/skins/banking/components/harness-console.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSubagentActivity } from "@/shell/subagents/subagent-activity";
 
 /**
  * The live console for the offsite-expenses run — a CLI window in the
- * transcript showing everything the coding harness does, as it does it.
+ * transcript showing what the coding harness is doing, as it does it.
  *
  * ## It reads EVENTS, not messages
  *
@@ -18,19 +18,33 @@ import { useSubagentActivity } from "@/shell/subagents/subagent-activity";
  * `src/shell/subagents/subagent-activity.tsx` owns that subscription and the
  * measurements behind it.
  *
- * ## Everything the harness does lands HERE
+ * ## Closed by default, and a WINDOW when open
  *
- * Deliberately including the prose. The analyst narrates as it works ("The
- * download has a valid CSV header, not an HTML error page — I'll now parse it
- * programmatically…"), and that narration is the most readable thing in the
- * whole run. It used to render as separate chat messages ABOVE a console that
- * was still empty, which read as two disconnected things happening. The chat now
- * declines to render subagent-tagged messages inline (see `chat-panel.tsx`) so
- * this pane is the single place the run is visible.
+ * The pane starts collapsed to its status strip. A run takes tens of seconds and
+ * the transcript around it — the report card it produces, the cards above it —
+ * is the point of the beat; an always-open terminal streaming for the whole run
+ * pushed that off the screen. The strip still carries the live state ("3 agents
+ * working"), so the run reads as alive while closed, and one click opens it.
+ *
+ * Open, it is the FULL log of the run, and deliberately so. The rolling
+ * "last two steps" window lives on the transcript's activity lines instead
+ * (`src/shell/chat/tool-activity.tsx`) — that is the surface that was growing
+ * unboundedly next to the report card. Windowing both left the detail view with
+ * two lines in it and nowhere to read the rest, so this pane is the place the
+ * whole run stays available, one click away.
  *
  * Nested activity is indented: the analyst's own commands sit at one level and
- * its researchers' work one deeper, which is what makes ten concurrent merchant
+ * its researchers' work one deeper, which is what makes concurrent merchant
  * lookups legible as a fan-out rather than a jumble.
+ *
+ * ## Colours come from the SKIN's tokens
+ *
+ * Every colour here is semantic (`bg-surface-muted`, `text-ink`,
+ * `text-ink-muted`, `border-hairline`). It used to be a hardcoded `bg-ink` with
+ * `text-white/45`-style overlays — an authentic terminal, and a black slab in
+ * the middle of a light-mode transcript. The tokens re-value under
+ * `.dark .theme-banking` (see `../theme.css`), so the console now follows the
+ * app into either mode with no `dark:` variants of its own.
  */
 
 /** How close to the tail still counts as "following the run". */
@@ -43,10 +57,15 @@ const isNearBottom = (el: HTMLDivElement | null): boolean =>
 export const HarnessConsole = () => {
   const { lines: allLines, subagents, isRunning } = useSubagentActivity();
 
+  const [open, setOpen] = useState(false);
+
   // The report tool renders as the REPORT CARD in the transcript, so drawing it
   // here as well would show the same result twice — once as a terminal line,
   // once as the component it produced.
-  const lines = allLines.filter((l) => l.toolName !== "submit_expense_report");
+  const lines = useMemo(
+    () => allLines.filter((l) => l.toolName !== "submit_expense_report"),
+    [allLines],
+  );
 
   const scrollRef = useRef<HTMLDivElement>(null);
   /**
@@ -65,86 +84,105 @@ export const HarnessConsole = () => {
 
   // Follow BOTH a new line and a growing one: text and tool arguments stream as
   // deltas, so the last line keeps getting longer without the count changing.
-  // Watching only `lines.length` leaves the view frozen mid-command.
+  // Watching only the line count leaves the view frozen mid-command.
+  //
+  // `open` is a dependency because the scroll container does not exist while
+  // closed: without it, opening mid-run shows the pane scrolled to the top of
+  // the window until the next delta happens to arrive.
   const tailText = lines.length > 0 ? lines[lines.length - 1].text : "";
   useEffect(() => {
     if (stick.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [lines.length, tailText]);
+  }, [lines.length, tailText, open]);
 
   const running = Array.from(subagents.values()).filter(
     (s) => s.status === "running",
   ).length;
 
   return (
-    <div className="overflow-hidden rounded-[--radius] border border-hairline bg-ink shadow-soft">
-      <div className="flex items-center gap-2 border-b border-white/10 px-3 py-1.5">
-        <span className="text-[11px] font-medium tracking-wide text-white/50">
+    <div className="overflow-hidden rounded-[--radius] border border-hairline bg-surface-muted shadow-soft">
+      <button
+        type="button"
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-hairline/40"
+      >
+        <span
+          aria-hidden
+          className={`text-[9px] text-ink-muted transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        >
+          ▶
+        </span>
+        <span className="text-[11px] font-medium tracking-wide text-ink-muted">
           expense analysis
         </span>
         {isRunning ? (
-          <span className="ml-auto flex items-center gap-1.5 text-[11px] text-white/50">
+          <span className="ml-auto flex items-center gap-1.5 text-[11px] text-ink-muted">
             <span className="size-1.5 animate-pulse rounded-full bg-positive" />
             {running > 1 ? `${running} agents working` : "running"}
           </span>
         ) : (
-          <span className="ml-auto text-[11px] text-white/40">done</span>
+          <span className="ml-auto text-[11px] text-ink-muted">done</span>
         )}
-      </div>
+      </button>
 
-      <div
-        ref={scrollRef}
-        onScroll={onScroll}
-        // Bounded height on purpose: a window onto a long run, not a transcript
-        // that pushes the report card off the screen.
-        className="max-h-80 overflow-y-auto px-3 py-2 font-mono text-[11.5px] leading-relaxed"
-      >
-        {lines.length === 0 ? (
-          <div className="text-white/40">starting…</div>
-        ) : (
-          lines.map((line) => {
-            const pad = line.depth > 0 ? `pl-${line.depth * 3}` : "";
-            if (line.kind === "started") {
+      {open ? (
+        <div
+          ref={scrollRef}
+          onScroll={onScroll}
+          // Bounded height on purpose: a window onto a long run, not a
+          // transcript that pushes the report card off the screen.
+          className="max-h-80 overflow-y-auto border-t border-hairline px-3 py-2 font-mono text-[11.5px] leading-relaxed"
+        >
+          {lines.length === 0 ? (
+            <div className="text-ink-muted">starting…</div>
+          ) : (
+            lines.map((line) => {
+              const pad = line.depth > 0 ? `pl-${line.depth * 3}` : "";
+              if (line.kind === "started") {
+                return (
+                  <div key={line.key} className={`py-0.5 text-brand ${pad}`}>
+                    ┌ {line.text}
+                  </div>
+                );
+              }
+              if (line.kind === "text") {
+                return (
+                  <div
+                    key={line.key}
+                    className={`py-0.5 italic text-ink-muted ${pad}`}
+                  >
+                    {line.text}
+                  </div>
+                );
+              }
+              if (line.kind === "tool") {
+                return (
+                  <div key={line.key} className={`py-0.5 text-ink ${pad}`}>
+                    {line.text}
+                  </div>
+                );
+              }
               return (
-                <div key={line.key} className={`py-0.5 text-brand ${pad}`}>
-                  ┌ {line.text}
-                </div>
-              );
-            }
-            if (line.kind === "text") {
-              return (
-                <div
+                <pre
                   key={line.key}
-                  className={`py-0.5 italic text-white/45 ${pad}`}
+                  className={`whitespace-pre-wrap break-all pb-1 ${pad} ${
+                    line.failed ? "text-negative" : "text-ink-muted"
+                  }`}
                 >
                   {line.text}
-                </div>
+                </pre>
               );
-            }
-            if (line.kind === "tool") {
-              return (
-                <div key={line.key} className={`py-0.5 text-white/90 ${pad}`}>
-                  {line.text}
-                </div>
-              );
-            }
-            return (
-              <pre
-                key={line.key}
-                className={`whitespace-pre-wrap break-all pb-1 ${pad} ${
-                  line.failed ? "text-negative" : "text-white/50"
-                }`}
-              >
-                {line.text}
-              </pre>
-            );
-          })
-        )}
-        {isRunning ? (
-          <span className="inline-block h-3 w-1.5 animate-pulse bg-white/70 align-middle" />
-        ) : null}
-      </div>
+            })
+          )}
+          {isRunning ? (
+            <span className="inline-block h-3 w-1.5 animate-pulse bg-ink align-middle" />
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
The "Sort out my offsite expenses" beat had three problems on stage: the harness console was a black slab in a light-mode transcript, the tool activity grew a stack of finished steps that pushed the report card off the screen, and the run took a full minute.

## Console (banking skin)

- Every colour is now a semantic token, so the pane follows the app into dark or light. It was `bg-ink` with `text-white/45`-style overlays, which only ever looked right in one mode.
- **Collapsed by default.** The status strip still carries the live state ("3 agents working"), so the run reads as alive while closed.
- Still the **full** log when open. It is the detail view, and windowing it as well left two lines and nowhere to read the rest.

## Tool activity (shell, affects all skins)

- Rolls to the last two lines; older ones are **removed**, not collapsed.
- Registration is a **layout** effect, and that is load-bearing. A new line renders before it is registered, and registering is what evicts the oldest, so with a passive effect the browser painted the in-between state: three rows for one frame on every tool call, and again when the end-of-run `MESSAGES_SNAPSHOT` remounts every line at once. Measured per animation frame over a full run — 12,734 frames, never more than two, one `1->2` transition.
- A shared registry rather than something simpler because CopilotKit renders one component per tool call and owns the container. CSS `:nth-last-child` needs siblings and the lines had one parent each; mount-order counters drift across the snapshot remount.

Reviewers should know this one is **not** scoped to banking. Most beats emit one or two tool calls so it is a no-op for them, but a beat emitting three or four would now show only its last two. `VISIBLE_TOOL_ACTIVITY` is a single constant if we want it higher.

## Agent: 1m 0s -> ~45s

- **Research is gated on the offsite dates.** A charge dated outside the window is settled by its date whatever the merchant turns out to be, so half the researcher dispatches were buying nothing. Travel on the adjacent days is still kept in scope.
- **Filings go out in one command** instead of one `curl` per row. The researchers already ran concurrently, so halving them bought almost nothing — the serial per-row round-trips through the model were most of the wall clock.
- Fetch and verify are one command; there is nothing to decide between the halves.
- Analyst reasoning effort defaults to `medium`, overridable with `BANKING_EXPENSE_EFFORT`.

## Filing is idempotent

The batching made this necessary rather than optional: the script got run twice and every charge was filed twice, so the report card claimed six filings while the ledger held twelve. A duplicate here is a reimbursement claimed twice.

The script now writes `filed.json` and exits early if it already exists. That marker is cleared once per run, because the workspace is a fixed directory shared by every run and a stale marker would convince the next demo it had already filed and post nothing at all — the same bug wearing the opposite mask, and a quieter one, since a run that files nothing still writes a confident report.

Deduping server-side on merchant+amount would have been wrong: **Hotel Verrano legitimately appears twice at the identical $318.55** for the two nights of the offsite.

## Verification

Run against a live Intelligence stack, not unit tests alone:

- Six rows filed, all `status=pending`, stable across 60s of polling.
- Present in the Pending Approval queue with their notes and approve/decline actions.
- Report card: 14 rows read, 6 merchants researched, $2,377.15 reimbursable.
- Console checked in both themes (panel `#f9f8fc` light / `#1f1c2c` dark, text inverting with it).

`lint`, `typecheck`, `test:unit` (2460 passed) and `build` all green, re-run after rebasing onto current main.

Does this change make anything in `.claude/skills/reskin/` wrong, incomplete, or misleading? No — nothing there documents the harness console, the tool-activity renderer, or the analyst prompt.
