### PR TITLE
docs(langgraph): fix inaccurate "Works the same for create_react_agent" comments (7 sites)

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -232,7 +232,7 @@ This context can then be shared with your LangGraph agent.
                         from langchain.agents import create_agent
                         from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
 
-                        graph = create_agent( # Works the same for "create_react_agent" or similar options
+                        graph = create_agent( # create_agent supersedes the deprecated create_react_agent, which accepts neither middleware= nor system_prompt=
                             model="openai:gpt-5.4",
                             tools=[],  # Backend tools go here
                             middleware=[CopilotKitMiddleware()], # [!code highlight]
@@ -246,7 +246,7 @@ This context can then be shared with your LangGraph agent.
                         import { createAgent } from "langchain";
                         import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
-                        export const agenticChatGraph = createAgent({ // Works the same for "create_react_agent" or similar options
+                        export const agenticChatGraph = createAgent({ // createAgent supersedes the deprecated createReactAgent, which accepts neither middleware nor systemPrompt
                           model: "openai:gpt-5.4",
                           tools: [],  // Backend tools go here
                           middleware: [copilotkitMiddleware], // [!code highlight]

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -146,7 +146,7 @@ The following example shows a data-fetch frontend tool paired with a matching `s
         from langchain.agents import create_agent
         from copilotkit import CopilotKitMiddleware, CopilotKitState
 
-        graph = create_agent( # Works the same for "create_react_agent" or similar options
+        graph = create_agent( # create_agent supersedes the deprecated create_react_agent, which accepts neither middleware= nor system_prompt=
             model="openai:gpt-4o",
             tools=[],  # backend tools go here
             middleware=[CopilotKitMiddleware()],
@@ -168,7 +168,7 @@ The following example shows a data-fetch frontend tool paired with a matching `s
         import { createAgent } from "langchain";
         import { copilotkitMiddleware, CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph";
 
-        export const graph = createAgent({ // Works the same for "create_react_agent" or similar options
+        export const graph = createAgent({ // createAgent supersedes the deprecated createReactAgent, which accepts neither middleware nor systemPrompt
           model: "openai:gpt-4o",
           tools: [],  // backend tools go here
           stateSchema: CopilotKitStateSchema,

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
@@ -190,7 +190,7 @@ function AdminPanel({ isAdmin }: { isAdmin: boolean }) {
 For simple UI-control tools (e.g. toggling a theme), the `description` field is usually enough for a LangGraph agent to discover and call the tool at the right time. For **mandatory** tools — ones where the agent must call the tool before answering rather than reasoning from stale context — pair a clear `description` with an explicit instruction in the agent's `system_prompt`.
 
 ```python title="agent.py — make mandatory tools explicit in system_prompt"
-graph = create_agent( # Works the same for "create_react_agent" or similar options
+graph = create_agent( # create_agent supersedes the deprecated create_react_agent, which accepts neither middleware= nor system_prompt=
     model="openai:gpt-4o",
     tools=[],
     middleware=[CopilotKitMiddleware()],

--- a/showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx
@@ -52,7 +52,7 @@ import {
                 from langchain.agents import create_agent
                 from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
 
-                graph = create_agent( # Works the same for "create_react_agent" or similar options
+                graph = create_agent( # create_agent supersedes the deprecated create_react_agent, which accepts neither middleware= nor system_prompt=
                     model="openai:gpt-5.4",
                     tools=[],  # Backend tools go here
                     middleware=[CopilotKitMiddleware()], # [!code highlight]
@@ -66,7 +66,7 @@ import {
                 import { createAgent } from "langchain";
                 import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
-                export const agenticChatGraph = createAgent({ // Works the same for "create_react_agent" or similar options
+                export const agenticChatGraph = createAgent({ // createAgent supersedes the deprecated createReactAgent, which accepts neither middleware nor systemPrompt
                     model: "openai:gpt-5.4",
                     tools: [],  // Backend tools go here
                     middleware: [copilotkitMiddleware], // [!code highlight]


### PR DESCRIPTION
Closes #6607.

Verified against the pinned `langgraph_prebuilt` (1.1.0): `create_react_agent` has neither `middleware` nor `system_prompt` parameters, rejects `state_schema=CopilotKitState`, and is deprecated in favour of `langchain.agents.create_agent`. Readers following the comment hit an immediate `TypeError`.

All 7 occurrences on `main` are updated (4 sites noted in the issue plus the 3 that landed with #5469):

- `showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx` (Python + TypeScript)
- `showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx` (Python + TypeScript)
- `showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx` (Python + TypeScript)
- `showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx` (Python)

Each comment is replaced with an accurate note (”`create_agent` supersedes the deprecated `create_react_agent`, which accepts neither `middleware=` nor `system_prompt=`”), and the TypeScript snippets now reference `createReactAgent` (camelCase) instead of the Python `create_react_agent` name — the second, smaller problem noted in the issue.