### PR TITLE
test(react-core): isolate feedback memoization rerender

### DIFF
--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.raw-event-feedback.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChat.raw-event-feedback.test.tsx
@@ -210,7 +210,7 @@ describe("CopilotChatMessageView feedback raw event", () => {
     view.unmount();
   });
 
-  it("keeps assistant slot props stable across unrelated configuration changes", () => {
+  it("keeps assistant slot props stable across unrelated message-view rerenders", () => {
     thumbsUpButtonRenderCount = 0;
     const agent = new FeedbackAgent();
     const onThumbsUp = vi.fn();
@@ -223,9 +223,9 @@ describe("CopilotChatMessageView feedback raw event", () => {
         <CopilotChatConfigurationProvider
           agentId="feedback-agent"
           threadId="feedback-thread"
-          labels={{ chatInputPlaceholder: "first" }}
         >
           <CopilotChatMessageView
+            className="first"
             messages={[
               { id: "assistant-1", role: "assistant", content: "Answer" },
             ]}
@@ -243,9 +243,9 @@ describe("CopilotChatMessageView feedback raw event", () => {
         <CopilotChatConfigurationProvider
           agentId="feedback-agent"
           threadId="feedback-thread"
-          labels={{ chatInputPlaceholder: "second" }}
         >
           <CopilotChatMessageView
+            className="second"
             messages={[
               { id: "assistant-1", role: "assistant", content: "Answer" },
             ]}


### PR DESCRIPTION
## Summary

- replace the configuration-context update in the assistant slot-prop stability test with an unrelated message-view prop update
- preserve coverage that the raw-event feedback adapter does not churn ordinary assistant render props
- leave production behavior and the callback-only raw-event boundary unchanged

## Root cause

The test changed chatInputPlaceholder, which changes the memoized chat-configuration context value. CopilotChatAssistantMessage consumes that context, so React correctly rerenders it independently of the message-view memo comparator. The configuration update was therefore not an unrelated proxy for feedback-adapter churn.

## Test plan

- [x] reproduce the original expected 1 / received 2 failure
- [x] prove the corrected test fails when className is temporarily added to the feedback adapter memo dependencies
- [x] raw-event feedback test file
- [x] React-core memoization/performance tests
- [x] complete React-core suite on React 19
- [x] complete React-core suite on React 18 compatibility overrides
- [x] React-core build and normal typecheck
- [x] changed-file format and lint checks