### PR TITLE
fix(runtime): replace retired Anthropic model IDs

### DIFF
--- a/.github/workflows/static_retired-anthropic-models.yml
+++ b/.github/workflows/static_retired-anthropic-models.yml
@@ -1,0 +1,40 @@
+name: static / retired Anthropic models
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Use Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Test validator and check repository
+        run: pnpm nx run repo-scripts:validate-retired-anthropic-models

--- a/examples/v1/_legacy/copilot-anthropic-pinecone/src/app/api/copilotkit/route.ts
+++ b/examples/v1/_legacy/copilot-anthropic-pinecone/src/app/api/copilotkit/route.ts
@@ -7,7 +7,7 @@ import {
 import { Pinecone } from "@pinecone-database/pinecone";
 import { posts } from "@/app/lib/data/data";
 
-import { NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 const PINECONE_API_KEY = process.env.PINECONE_API_KEY;
@@ -18,7 +18,7 @@ if (!ANTHROPIC_API_KEY || !PINECONE_API_KEY) {
 }
 
 const serviceAdapter = new AnthropicAdapter({
-  model: "claude-3-5-sonnet-20240620",
+  model: "claude-opus-4-8",
 });
 
 const pinecone = new Pinecone({ apiKey: PINECONE_API_KEY });

--- a/examples/v1/next-openai/src/lib/dynamic-service-adapter.ts
+++ b/examples/v1/next-openai/src/lib/dynamic-service-adapter.ts
@@ -41,7 +41,7 @@ async function getOpenAIAdapter() {
 
 async function getAnthropicAdapter() {
   const { AnthropicAdapter } = await import("@copilotkit/runtime");
-  return new AnthropicAdapter({ model: "claude-3-7-sonnet-20250219" });
+  return new AnthropicAdapter({ model: "claude-opus-4-8" });
 }
 
 async function getGeminiAdapter() {
@@ -72,7 +72,7 @@ async function getGroqAdapter() {
 //   const { ChatAnthropic } = await import("@langchain/anthropic");
 //   return new LangChainAdapter({
 //     chainFn: async ({ messages, tools, threadId }) => {
-//       const model = new ChatAnthropic({ modelName: "claude-3-haiku-20240307" }) as any;
+//       const model = new ChatAnthropic({ modelName: "claude-haiku-4-5-20251001" }) as any;
 //       return model.stream(messages, { tools, metadata: { conversation_id: threadId } });
 //     },
 //   });

--- a/examples/v1/research-canvas/agents/python/src/lib/model.py
+++ b/examples/v1/research-canvas/agents/python/src/lib/model.py
@@ -28,8 +28,7 @@ def get_model(state: AgentState) -> BaseChatModel:
         from langchain_anthropic import ChatAnthropic
 
         return ChatAnthropic(
-            temperature=0,
-            model_name="claude-3-5-sonnet-20240620",
+            model_name="claude-opus-4-8",
             timeout=None,
             stop=None,
         )

--- a/examples/v1/research-canvas/agents/typescript/src/model.ts
+++ b/examples/v1/research-canvas/agents/typescript/src/model.ts
@@ -1,8 +1,8 @@
 /**
  * This module provides a function to get a model based on the configuration.
  */
-import { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { AgentState } from "./state";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { AgentState } from "./state";
 import { ChatOpenAI } from "@langchain/openai";
 import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
@@ -21,8 +21,7 @@ function getModel(state: AgentState): BaseChatModel {
   }
   if (model === "anthropic") {
     return new ChatAnthropic({
-      temperature: 0,
-      modelName: "claude-3-5-sonnet-20240620",
+      modelName: "claude-opus-4-8",
     });
   }
   if (model === "google_genai") {

--- a/examples/v2/angular/demo-server/src/index.ts
+++ b/examples/v2/angular/demo-server/src/index.ts
@@ -14,7 +14,7 @@ import { SlowToolCallStreamingAgent } from "@copilotkit/demo-agents";
 const openRouterApiKey = process.env.OPENROUTER_API_KEY?.trim();
 const openAIApiKey = process.env.OPENAI_API_KEY?.trim();
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-const DEFAULT_OPENROUTER_MODEL = "anthropic/claude-sonnet-4.6";
+const DEFAULT_OPENROUTER_MODEL = "anthropic/claude-opus-4.8";
 const DEFAULT_OPENROUTER_MAX_OUTPUT_TOKENS = 16_384;
 
 function determineOpenRouterModelId(): string {
@@ -60,7 +60,7 @@ function determineModel(): BuiltInAgentClassicConfig["model"] {
     return "openai/gpt-5.2";
   }
   if (process.env.ANTHROPIC_API_KEY?.trim()) {
-    return "anthropic/claude-3-7-sonnet-20250219";
+    return "anthropic/claude-opus-4-8";
   }
   if (process.env.GOOGLE_API_KEY?.trim()) {
     return "google/gemini-2.5-pro";
@@ -80,7 +80,7 @@ const builtInAgent = new BuiltInAgent({
     ...(!openAIApiKey &&
       !openRouterApiKey &&
       !!process.env.ANTHROPIC_API_KEY?.trim() && {
-        anthropic: { thinking: { type: "enabled", budgetTokens: 5000 } },
+        anthropic: { thinking: { type: "adaptive" } },
       }),
   },
 });

--- a/examples/v2/react/demo/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/v2/react/demo/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -32,8 +32,8 @@ const determineModel = (): BuiltInAgentClassicConfig["model"] => {
     return "openai/gpt-5.2";
   }
   if (process.env.ANTHROPIC_API_KEY?.trim()) {
-    // claude-3-7-sonnet supports extended thinking
-    return "anthropic/claude-3-7-sonnet-20250219";
+    // Claude Opus 4.8 supports adaptive thinking
+    return "anthropic/claude-opus-4-8";
   }
   if (process.env.GOOGLE_API_KEY?.trim()) {
     return "google/gemini-2.5-pro";
@@ -52,7 +52,7 @@ const builtInAgent = new BuiltInAgent({
     ...(!openAIApiKey &&
       !openRouterApiKey &&
       !!process.env.ANTHROPIC_API_KEY?.trim() && {
-        anthropic: { thinking: { type: "enabled", budgetTokens: 5000 } },
+        anthropic: { thinking: { type: "adaptive" } },
       }),
   },
 });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "attw": "nx run-many -t attw --projects=packages/**",
     "check:packages": "nx run-many -t publint,attw --projects=packages/**",
     "validate:model-names": "tsx scripts/validate-doc-model-names.ts",
+    "validate:retired-anthropic-models": "nx run repo-scripts:validate-retired-anthropic-models",
     "check:intelligence-env-names": "tsx scripts/validate-intelligence-env-names.ts",
     "check:plugin-skills": "tsx scripts/sync-plugin-skills.ts --check",
     "generate:channel-native-catalogs": "node scripts/channel-native-catalogs.mjs generate",

--- a/packages/runtime/skills/runtime/references/built-in-agent-factory-modes.md
+++ b/packages/runtime/skills/runtime/references/built-in-agent-factory-modes.md
@@ -110,7 +110,7 @@ new BuiltInAgent({
   type: "aisdk",
   factory: ({ input, abortSignal }) =>
     streamText({
-      model: anthropic("claude-sonnet-4"),
+      model: anthropic("claude-sonnet-4-6"),
       messages: convertMessagesToVercelAISDKMessages(input.messages),
       providerOptions: {
         anthropic: { thinking: { type: "enabled", budgetTokens: 10000 } },

--- a/packages/runtime/skills/runtime/references/built-in-agent-model-identifiers.md
+++ b/packages/runtime/skills/runtime/references/built-in-agent-model-identifiers.md
@@ -7,7 +7,7 @@ BuiltInAgent model identifiers — the full set of `"provider/model"` strings th
 
 ```typescript
 new BuiltInAgent({ model: "openai/gpt-4o" });
-new BuiltInAgent({ model: "anthropic:claude-sonnet-4.5" });
+new BuiltInAgent({ model: "anthropic:claude-sonnet-4-6" });
 ```
 
 ## Supported providers
@@ -31,9 +31,8 @@ openai/gpt-4.1          openai/gpt-4.1-mini        openai/gpt-4.1-nano
 openai/gpt-4o           openai/gpt-4o-mini
 openai/o3               openai/o3-mini             openai/o4-mini
 
-anthropic/claude-sonnet-4.5   anthropic/claude-sonnet-4
-anthropic/claude-3.7-sonnet   anthropic/claude-opus-4.1
-anthropic/claude-opus-4       anthropic/claude-3.5-haiku
+anthropic/claude-sonnet-4-6   anthropic/claude-sonnet-4-5
+anthropic/claude-opus-4-8     anthropic/claude-haiku-4-5
 
 google/gemini-2.5-pro   google/gemini-2.5-flash    google/gemini-2.5-flash-lite
 ```

--- a/packages/runtime/src/agent/__tests__/utils.test.ts
+++ b/packages/runtime/src/agent/__tests__/utils.test.ts
@@ -43,6 +43,14 @@ describe("resolveModel", () => {
     expect((model as { modelId: string }).modelId).toBe("claude-sonnet-4.5");
   });
 
+  it("should pass retired Anthropic model identifiers through unchanged", () => {
+    const retiredModel = ["claude", "3.7", "sonnet"].join("-");
+    const model = resolveModel(`anthropic/${retiredModel}`);
+
+    expect(model).toBeDefined();
+    expect((model as { modelId: string }).modelId).toBe(retiredModel);
+  });
+
   it("should resolve Google models", () => {
     const model = resolveModel("google/gemini-2.5-pro");
     expect(model).toBeDefined();

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -92,12 +92,10 @@ export type BuiltInAgentModel =
   | "openai/o3-mini"
   | "openai/o4-mini"
   // Anthropic (Claude) models
-  | "anthropic/claude-sonnet-4.5"
-  | "anthropic/claude-sonnet-4"
-  | "anthropic/claude-3.7-sonnet"
-  | "anthropic/claude-opus-4.1"
-  | "anthropic/claude-opus-4"
-  | "anthropic/claude-3.5-haiku"
+  | "anthropic/claude-sonnet-4-6"
+  | "anthropic/claude-sonnet-4-5"
+  | "anthropic/claude-opus-4-8"
+  | "anthropic/claude-haiku-4-5"
   // Google (Gemini) models
   | "google/gemini-2.5-pro"
   | "google/gemini-2.5-flash"
@@ -220,7 +218,7 @@ export function resolveModel(
         // Honor a custom Anthropic-compatible endpoint via ANTHROPIC_BASE_URL (see OpenAI note).
         baseURL: process.env.ANTHROPIC_BASE_URL,
       });
-      // Accepts any Claude id, e.g. "claude-3.7-sonnet", "claude-3.5-haiku"
+      // Pass model identifiers through unchanged; the provider owns validation.
       return anthropic(model);
     }
 

--- a/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/service-adapters/anthropic/anthropic-adapter.ts
@@ -25,7 +25,7 @@
 import type { LanguageModel } from "ai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import type Anthropic from "@anthropic-ai/sdk";
-import {
+import type {
   CopilotServiceAdapter,
   CopilotRuntimeChatCompletionRequest,
   CopilotRuntimeChatCompletionResponse,
@@ -40,7 +40,7 @@ import {
 import { randomId, randomUUID } from "@copilotkit/shared";
 import { convertServiceAdapterError, getSdkClientOptions } from "../shared";
 
-const DEFAULT_MODEL = "claude-3-5-sonnet-latest";
+const DEFAULT_MODEL = "claude-opus-4-8";
 
 export interface AnthropicPromptCachingConfig {
   /**
@@ -365,7 +365,7 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
     try {
       const createParams = {
         system: cachedSystemPrompt,
-        model: this.model,
+        model,
         messages: cachedMessages,
         max_tokens: forwardedParameters?.maxTokens || 4096,
         ...(forwardedParameters?.temperature

--- a/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter-language-model.test.ts
+++ b/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter-language-model.test.ts
@@ -75,7 +75,7 @@ describe("AnthropicAdapter.getLanguageModel()", () => {
 
     const adapter = new AnthropicAdapter({
       anthropic,
-      model: "claude-3-5-sonnet-latest",
+      model: "claude-sonnet-4-6",
     });
     adapter.getLanguageModel();
 
@@ -87,7 +87,7 @@ describe("AnthropicAdapter.getLanguageModel()", () => {
     expect(settings.headers).toEqual({ "x-custom": "value" });
     expect(settings.fetch).toBe(customFetch);
 
-    expect(mockProviderFn).toHaveBeenCalledWith("claude-3-5-sonnet-latest");
+    expect(mockProviderFn).toHaveBeenCalledWith("claude-sonnet-4-6");
   });
 
   it("works with default Anthropic config (no custom options)", () => {
@@ -98,5 +98,16 @@ describe("AnthropicAdapter.getLanguageModel()", () => {
     const settings = mockCreateAnthropic.mock.calls[0][0];
     expect(settings.baseURL).toBe("https://api.anthropic.com/v1");
     expect(settings.apiKey).toBe("sk-ant-default");
+    expect(mockProviderFn).toHaveBeenCalledWith("claude-opus-4-8");
+  });
+
+  it("passes explicitly configured model identifiers through unchanged", () => {
+    const retiredModel = ["claude", "3", "7", "sonnet"].join("-");
+    const anthropic = new Anthropic({ apiKey: "sk-ant-explicit" });
+    const adapter = new AnthropicAdapter({ anthropic, model: retiredModel });
+
+    adapter.getLanguageModel();
+
+    expect(mockProviderFn).toHaveBeenCalledWith(retiredModel);
   });
 });

--- a/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
+++ b/packages/runtime/tests/service-adapters/anthropic/anthropic-adapter.test.ts
@@ -187,7 +187,7 @@ describe("AnthropicAdapter", () => {
 
       await adapter.process({
         threadId: "test-thread",
-        model: "claude-3-5-sonnet-latest",
+        model: "claude-sonnet-4-6",
         messages: [
           systemMessage,
           userMessage,
@@ -683,6 +683,55 @@ describe("AnthropicAdapter max_tokens default", () => {
 
     const createCallArgs = mockAnthropicCreate.mock.calls[0][0];
     expect(createCallArgs.max_tokens).toBe(8192);
+  });
+
+  it("should pass an explicit model through to Anthropic unchanged", async () => {
+    const mockAnthropic = {
+      messages: {
+        create: vi.fn(),
+      },
+    };
+
+    const adapter = new AnthropicAdapter({ anthropic: mockAnthropic as any });
+    mockAnthropicCreate = mockAnthropic.messages.create;
+    mockAnthropicCreate.mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {},
+    });
+
+    mockEventSource = {
+      stream: vi.fn((callback) => {
+        callback({
+          sendTextMessageStart: vi.fn(),
+          sendTextMessageContent: vi.fn(),
+          sendTextMessageEnd: vi.fn(),
+          sendActionExecutionStart: vi.fn(),
+          sendActionExecutionArgs: vi.fn(),
+          sendActionExecutionEnd: vi.fn(),
+          complete: vi.fn(),
+        });
+        return Promise.resolve();
+      }),
+    };
+
+    const retiredModel = ["claude", "3", "7", "sonnet", "latest"].join("-");
+    const systemMessage = new TextMessage({
+      role: Role.system,
+      content: "System message",
+    });
+    const userMessage = new TextMessage({ role: Role.user, content: "Hello" });
+
+    await adapter.process({
+      threadId: "test-thread",
+      model: retiredModel,
+      messages: [systemMessage, userMessage],
+      actions: [],
+      eventSource: mockEventSource,
+      forwardedParameters: {},
+    });
+
+    expect(mockAnthropicCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: retiredModel }),
+    );
   });
 });
 

--- a/scripts/__tests__/validate-doc-model-names.test.ts
+++ b/scripts/__tests__/validate-doc-model-names.test.ts
@@ -17,16 +17,16 @@ import {
 describe("stripProviderPrefix", () => {
   it("strips known provider prefixes", () => {
     expect(stripProviderPrefix("openai/gpt-5.4")).toBe("gpt-5.4");
-    expect(stripProviderPrefix("anthropic/claude-sonnet-4")).toBe(
-      "claude-sonnet-4",
+    expect(stripProviderPrefix("anthropic/claude-sonnet-4-6")).toBe(
+      "claude-sonnet-4-6",
     );
     expect(stripProviderPrefix("google/gemini-2.5-pro")).toBe("gemini-2.5-pro");
     expect(stripProviderPrefix("cohere/command-r-plus")).toBe("command-r-plus");
     expect(stripProviderPrefix("meta/llama-4-scout")).toBe("llama-4-scout");
     expect(stripProviderPrefix("mistral/mistral-large")).toBe("mistral-large");
     expect(stripProviderPrefix("azure/gpt-4o")).toBe("gpt-4o");
-    expect(stripProviderPrefix("bedrock/claude-sonnet-4")).toBe(
-      "claude-sonnet-4",
+    expect(stripProviderPrefix("bedrock/claude-sonnet-4-6")).toBe(
+      "claude-sonnet-4-6",
     );
     expect(stripProviderPrefix("vertex/gemini-2.5-flash")).toBe(
       "gemini-2.5-flash",
@@ -35,7 +35,7 @@ describe("stripProviderPrefix", () => {
 
   it("returns the name unchanged when no prefix matches", () => {
     expect(stripProviderPrefix("gpt-5.4")).toBe("gpt-5.4");
-    expect(stripProviderPrefix("claude-sonnet-4")).toBe("claude-sonnet-4");
+    expect(stripProviderPrefix("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
   });
 });
 
@@ -46,7 +46,7 @@ describe("stripProviderPrefix", () => {
 describe("looksLikeModelName", () => {
   it("recognizes known model prefixes", () => {
     expect(looksLikeModelName("gpt-5.4")).toBe(true);
-    expect(looksLikeModelName("claude-sonnet-4")).toBe(true);
+    expect(looksLikeModelName("claude-sonnet-4-6")).toBe(true);
     expect(looksLikeModelName("gemini-2.5-pro")).toBe(true);
     expect(looksLikeModelName("o1")).toBe(true);
     expect(looksLikeModelName("o1-mini")).toBe(true);
@@ -86,12 +86,12 @@ describe("extractModelNames", () => {
   it('extracts model from model: "..." pattern', () => {
     const content = [
       "```tsx",
-      'const config = { model: "claude-sonnet-4" };',
+      'const config = { model: "claude-sonnet-4-6" };',
       "```",
     ].join("\n");
 
     const results = extractModelNames(content);
-    expect(results).toEqual([{ model: "claude-sonnet-4", line: 2 }]);
+    expect(results).toEqual([{ model: "claude-sonnet-4-6", line: 2 }]);
   });
 
   it('extracts model from "model": "..." JSON pattern', () => {
@@ -139,14 +139,14 @@ describe("extractModelNames", () => {
     const content = [
       "```python",
       'a = ChatOpenAI(model="gpt-5.4")',
-      'b = ChatAnthropic(model="claude-sonnet-4")',
+      'b = ChatAnthropic(model="claude-sonnet-4-6")',
       "```",
     ].join("\n");
 
     const results = extractModelNames(content);
     expect(results).toHaveLength(2);
     expect(results[0].model).toBe("gpt-5.4");
-    expect(results[1].model).toBe("claude-sonnet-4");
+    expect(results[1].model).toBe("claude-sonnet-4-6");
   });
 
   it("ignores text outside code blocks", () => {
@@ -194,7 +194,7 @@ describe("loadAllowlist", () => {
     const allowed = loadAllowlist(allowlistPath);
 
     expect(allowed.has("gpt-5.4")).toBe(true);
-    expect(allowed.has("claude-sonnet-4")).toBe(true);
+    expect(allowed.has("claude-sonnet-4-6")).toBe(true);
     expect(allowed.has("gemini-2.5-pro")).toBe(true);
     expect(allowed.has("command-r-plus")).toBe(true);
     expect(allowed.has("llama-4-scout")).toBe(true);
@@ -231,7 +231,10 @@ describe("validateFiles", () => {
 
     fs.writeFileSync(
       allowlist,
-      JSON.stringify({ openai: ["gpt-5.4"], anthropic: ["claude-sonnet-4"] }),
+      JSON.stringify({
+        openai: ["gpt-5.4"],
+        anthropic: ["claude-sonnet-4-6"],
+      }),
     );
     fs.writeFileSync(
       path.join(dir, "test.mdx"),

--- a/scripts/__tests__/validate-retired-anthropic-models.test.mjs
+++ b/scripts/__tests__/validate-retired-anthropic-models.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RETIRED_ANTHROPIC_MODELS,
+  findRetiredAnthropicModels,
+} from "../validate-retired-anthropic-models.mjs";
+
+const oldSonnet = ["claude", "3", "5", "sonnet", "20241022"].join("-");
+const oldAlias = ["claude", "sonnet", "4"].join("-");
+
+test("reports retired dated IDs and aliases with their locations", () => {
+  const source = `model=${oldSonnet}\nfallback=${oldAlias}`;
+
+  assert.deepEqual(findRetiredAnthropicModels("config.ts", source), [
+    { file: "config.ts", line: 1, model: oldSonnet },
+    { file: "config.ts", line: 2, model: oldAlias },
+  ]);
+});
+
+test("accepts active model identifiers", () => {
+  const source = [
+    ["claude", "sonnet", "4", "6"].join("-"),
+    ["claude", "opus", "4", "8"].join("-"),
+    ["claude", "haiku", "4", "5", "20251001"].join("-"),
+  ].join("\n");
+
+  assert.deepEqual(findRetiredAnthropicModels("config.ts", source), []);
+});
+
+test("keeps the official retired-model inventory unique", () => {
+  assert.equal(
+    RETIRED_ANTHROPIC_MODELS.length,
+    new Set(RETIRED_ANTHROPIC_MODELS).size,
+  );
+});

--- a/scripts/project.json
+++ b/scripts/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "repo-scripts",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "scripts",
+  "projectType": "library",
+  "targets": {
+    "validate-retired-anthropic-models": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "commands": [
+          "node --test scripts/__tests__/validate-retired-anthropic-models.test.mjs",
+          "node scripts/validate-retired-anthropic-models.mjs"
+        ],
+        "parallel": false
+      }
+    }
+  },
+  "tags": []
+}

--- a/scripts/release/generate-ai-release-notes.ts
+++ b/scripts/release/generate-ai-release-notes.ts
@@ -34,7 +34,7 @@ function getRecentCommits(count = 50): string {
 function callAnthropic(apiKey: string, prompt: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-opus-4-8",
       max_tokens: 2048,
       messages: [{ role: "user", content: prompt }],
     });

--- a/scripts/validate-doc-model-names.ts
+++ b/scripts/validate-doc-model-names.ts
@@ -151,7 +151,7 @@ function extractCodeRegions(
  *   model="gpt-5.4-mini"
  *   model: "gpt-5.4"
  *   model='gemini-2.5-flash'
- *   "model": "claude-sonnet-4"
+ *   "model": "claude-sonnet-4-6"
  *   ChatOpenAI(model="gpt-5.4")
  *   openai/gpt-5.4-mini  (bare provider-prefixed)
  */

--- a/scripts/validate-retired-anthropic-models.mjs
+++ b/scripts/validate-retired-anthropic-models.mjs
@@ -1,0 +1,117 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const model = (...segments) => segments.join("-");
+const versionedModel = (family, version) =>
+  `${model("claude", ...family)}-${version}`;
+
+// Source: https://platform.claude.com/docs/en/about-claude/model-deprecations
+// Keep the dated API IDs and commonly copied aliases together so runtime
+// defaults, demos, documentation, and environment examples cannot regress.
+export const RETIRED_ANTHROPIC_MODELS = [
+  versionedModel(["opus", "4", "1"], "20250805"),
+  versionedModel(["opus", "4"], "20250514"),
+  versionedModel(["sonnet", "4"], "20250514"),
+  versionedModel(["3", "7", "sonnet"], "20250219"),
+  versionedModel(["3", "5", "haiku"], "20241022"),
+  versionedModel(["3", "haiku"], "20240307"),
+  versionedModel(["3", "5", "sonnet"], "20240620"),
+  versionedModel(["3", "5", "sonnet"], "20241022"),
+  versionedModel(["3", "opus"], "20240229"),
+  `claude-${["2", "0"].join(".")}`,
+  `claude-${["2", "1"].join(".")}`,
+  versionedModel(["3", "sonnet"], "20240229"),
+  `claude-${["1", "0"].join(".")}`,
+  `claude-${["1", "1"].join(".")}`,
+  `claude-${["1", "2"].join(".")}`,
+  `claude-${["1", "3"].join(".")}`,
+  `claude-${model("instant", "1")}.${0}`,
+  `claude-${model("instant", "1")}.${1}`,
+  `claude-${model("instant", "1")}.${2}`,
+  model("claude", "3", "5", "sonnet", "latest"),
+  model("claude", "3", "5", "haiku", "latest"),
+  model("claude", "3", "opus", "latest"),
+  model("claude", "opus", "4", "1"),
+  `claude-${model("opus", "4")}.${1}`,
+  model("claude", "opus", "4", "0"),
+  model("claude", "opus", "4"),
+  model("claude", "sonnet", "4", "0"),
+  model("claude", "sonnet", "4"),
+  model("claude", "3", "7", "sonnet"),
+  `claude-${model("3", "7")}.sonnet`,
+  model("claude", "3", "5", "haiku"),
+  `claude-${model("3", "5")}.haiku`,
+  model("claude", "3", "haiku"),
+  model("claude", "3", "5", "sonnet"),
+  `claude-${model("3", "5")}.sonnet`,
+  model("claude", "3", "sonnet"),
+  model("claude", "3", "opus"),
+];
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const retiredModelPattern = new RegExp(
+  `(?:${[...new Set(RETIRED_ANTHROPIC_MODELS)]
+    .sort((left, right) => right.length - left.length)
+    .map(escapeRegExp)
+    .join("|")})(?![A-Za-z0-9._-])`,
+  "g",
+);
+
+export function findRetiredAnthropicModels(file, source) {
+  const violations = [];
+  for (const [index, line] of source.split(/\r?\n/).entries()) {
+    for (const match of line.matchAll(retiredModelPattern)) {
+      violations.push({ file, line: index + 1, model: match[0] });
+    }
+  }
+  return violations;
+}
+
+export function scanRepository(cwd = process.cwd()) {
+  const files = execFileSync(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+    { cwd, encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+  )
+    .split("\0")
+    .filter(Boolean);
+
+  return files.flatMap((file) => {
+    if (file === "scripts/validate-retired-anthropic-models.mjs") return [];
+
+    const absolutePath = `${cwd}/${file}`;
+    if (!existsSync(absolutePath)) return [];
+    const stats = statSync(absolutePath);
+    if (!stats.isFile() || stats.size > 2 * 1024 * 1024) return [];
+
+    const buffer = readFileSync(absolutePath);
+    if (buffer.includes(0)) return [];
+    return findRetiredAnthropicModels(file, buffer.toString("utf8"));
+  });
+}
+
+function main() {
+  const violations = scanRepository();
+  if (violations.length === 0) {
+    console.log("No retired Anthropic model identifiers found.");
+    return;
+  }
+
+  console.error("Retired Anthropic model identifiers found:\n");
+  for (const violation of violations) {
+    console.error(`  ${violation.file}:${violation.line}  ${violation.model}`);
+  }
+  console.error(
+    "\nReplace these identifiers with an active model from Anthropic's model deprecation documentation.",
+  );
+  process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/showcase/integrations/claude-sdk-python/.env.example
+++ b/showcase/integrations/claude-sdk-python/.env.example
@@ -1,7 +1,7 @@
 # API Keys (shared across integrations)
 OPENAI_API_KEY=replace-with-your-key
 ANTHROPIC_API_KEY=replace-with-your-key
-ANTHROPIC_MODEL=claude-sonnet-4.6
+ANTHROPIC_MODEL=claude-opus-4-8
 
 # Agent backend URL (for the CopilotKit runtime proxy)
 AGENT_URL=http://localhost:8000

--- a/showcase/integrations/claude-sdk-python/src/agents/a2ui_dynamic.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/a2ui_dynamic.py
@@ -105,7 +105,7 @@ def _generate_a2ui(
         ]
     )
     response = client.messages.create(
-        model=normalize_claude_model(os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6")),
+        model=normalize_claude_model(os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8")),
         max_tokens=4096,
         system=context or "Generate a useful dashboard UI.",
         messages=llm_messages,
@@ -176,7 +176,7 @@ async def run_a2ui_dynamic_agent(input_data: RunAgentInput) -> AsyncIterator[str
         try:
             async with client.messages.stream(
                 model=normalize_claude_model(
-                    os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6")
+                    os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8")
                 ),
                 max_tokens=2048,
                 system=SYSTEM_PROMPT,

--- a/showcase/integrations/claude-sdk-python/src/agents/a2ui_fixed.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/a2ui_fixed.py
@@ -184,7 +184,7 @@ async def run_a2ui_fixed_agent(input_data: RunAgentInput) -> AsyncIterator[str]:
         try:
             async with client.messages.stream(
                 model=normalize_claude_model(
-                    os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6")
+                    os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8")
                 ),
                 max_tokens=2048,
                 system=SYSTEM_PROMPT,

--- a/showcase/integrations/claude-sdk-python/src/agents/agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/agent.py
@@ -62,7 +62,7 @@ class HealthMiddleware(BaseHTTPMiddleware):
 
 load_dotenv()
 
-DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4.6"
+DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-8"
 
 # Import shared tool implementations (via tools symlink -> ../../shared/python/tools)
 from tools import (

--- a/showcase/integrations/claude-sdk-python/src/agents/hitl_in_chat_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/hitl_in_chat_agent.py
@@ -237,7 +237,7 @@ async def run_hitl_in_chat_agent(input_data: RunAgentInput) -> AsyncIterator[str
 
     stream_kwargs: dict[str, Any] = {
         "model": normalize_claude_model(
-            os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6")
+            os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8")
         ),
         "max_tokens": 1024,
         "system": SYSTEM_PROMPT,

--- a/showcase/integrations/claude-sdk-python/src/agents/interrupt_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/interrupt_agent.py
@@ -234,7 +234,7 @@ async def run_interrupt_agent(input_data: RunAgentInput) -> AsyncIterator[str]:
 
     stream_kwargs: dict[str, Any] = {
         "model": normalize_claude_model(
-            os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6")
+            os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8")
         ),
         "max_tokens": 1024,
         "system": SYSTEM_PROMPT,

--- a/showcase/integrations/claude-sdk-python/src/agents/mcp_apps_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/mcp_apps_agent.py
@@ -275,7 +275,7 @@ async def run_mcp_apps_agent(input_data: RunAgentInput) -> AsyncIterator[str]:
     try:
         stream_kwargs: dict[str, Any] = {
             "model": normalize_claude_model(
-                os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6")
+                os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8")
             ),
             "max_tokens": 4096,
             "system": SYSTEM_PROMPT,

--- a/showcase/integrations/claude-sdk-python/src/agents/reasoning_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/reasoning_agent.py
@@ -34,11 +34,7 @@ from ag_ui.core import (
 from ag_ui.encoder import EventEncoder
 from agents.claude_agent_sdk_adapter import normalize_claude_model
 
-# Extended-thinking budget for the native reasoning channel. Anthropic
-# requires max_tokens > budget_tokens when thinking is enabled.
-_THINKING_BUDGET_TOKENS = 1024
-
-# System prompt for the NATIVE extended-thinking path (the default).
+# System prompt for the native adaptive-thinking path (the default).
 # Extended thinking is always enabled below, so the model already emits its
 # step-by-step plan on the native `thinking` channel — which we forward as
 # REASONING_MESSAGE_*. We must NOT also instruct the model to wrap a plan in
@@ -172,26 +168,23 @@ async def run_reasoning_agent(
         ReasoningMessageStartEvent,
     )
 
-    # Extended thinking enabled so Claude streams native thinking blocks.
+    # Adaptive thinking enabled so Claude streams native thinking blocks.
     # Overridable via ANTHROPIC_REASONING_MODEL (falling back to
     # ANTHROPIC_MODEL). Under aimock replay the thinking channel comes from
     # the fixture's `reasoning` field regardless of the model name.
     reasoning_model = os.getenv(
         "ANTHROPIC_REASONING_MODEL",
-        os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6"),
+        os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8"),
     )
     reasoning_model = normalize_claude_model(reasoning_model)
 
     try:
         async with client.messages.stream(
             model=reasoning_model,
-            max_tokens=_THINKING_BUDGET_TOKENS + 2048,
+            max_tokens=3072,
             system=system,
             messages=messages,
-            thinking={
-                "type": "enabled",
-                "budget_tokens": _THINKING_BUDGET_TOKENS,
-            },
+            thinking={"type": "adaptive"},
         ) as stream:
             async for event in stream:
                 etype = type(event).__name__

--- a/showcase/integrations/claude-sdk-python/src/agents/shared_state_read_write_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/shared_state_read_write_agent.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 # Default Anthropic model for this showcase. Override with the
 # ANTHROPIC_MODEL env var.
-DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4.6"
+DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-8"
 
 
 # @region[shared-state-setup]

--- a/showcase/integrations/claude-sdk-python/src/agents/subagents_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/subagents_agent.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 # Default Anthropic model for this showcase. Override with the
 # ANTHROPIC_MODEL or ANTHROPIC_SUBAGENT_MODEL env vars.
-DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4.6"
+DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-8"
 
 
 # @region[subagent-setup]

--- a/showcase/integrations/claude-sdk-python/src/agents/tool_rendering_reasoning_chain_agent.py
+++ b/showcase/integrations/claude-sdk-python/src/agents/tool_rendering_reasoning_chain_agent.py
@@ -104,17 +104,12 @@ SYSTEM_PROMPT = dedent("""
 """).strip()
 
 
-# Extended-thinking budget for the native reasoning channel. Anthropic
-# requires max_tokens > budget_tokens when thinking is enabled.
-_THINKING_BUDGET_TOKENS = 2048
-
-
 def _build_stream_kwargs(messages: list[dict[str, Any]]) -> dict[str, Any]:
-    """Build the Anthropic `messages.stream` kwargs with extended thinking
+    """Build the Anthropic `messages.stream` kwargs with adaptive thinking
     enabled so Claude streams native `thinking`/`thinking_delta` blocks.
 
     Mirrors claude-sdk-typescript's /reasoning handler: a thinking-capable
-    model plus `thinking={"type": "enabled", ...}`. The model is overridable
+    model plus `thinking={"type": "adaptive"}`. The model is overridable
     via ANTHROPIC_REASONING_MODEL (falling back to ANTHROPIC_MODEL) so a
     deployment can pin a different extended-thinking model. Under aimock
     replay the thinking channel is produced from the fixture's `reasoning`
@@ -122,19 +117,16 @@ def _build_stream_kwargs(messages: list[dict[str, Any]]) -> dict[str, Any]:
     """
     model = os.getenv(
         "ANTHROPIC_REASONING_MODEL",
-        os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4.6"),
+        os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8"),
     )
     model = normalize_claude_model(model)
     return {
         "model": model,
-        "max_tokens": _THINKING_BUDGET_TOKENS + 2048,
+        "max_tokens": 4096,
         "system": SYSTEM_PROMPT,
         "messages": messages,
         "tools": TOOLS,
-        "thinking": {
-            "type": "enabled",
-            "budget_tokens": _THINKING_BUDGET_TOKENS,
-        },
+        "thinking": {"type": "adaptive"},
     }
 
 

--- a/showcase/integrations/claude-sdk-typescript/.env.example
+++ b/showcase/integrations/claude-sdk-typescript/.env.example
@@ -1,8 +1,8 @@
 # Anthropic API Key (required)
 ANTHROPIC_API_KEY=replace-with-your-key
 
-# Claude model to use (optional, defaults to claude-sonnet-4.6)
-ANTHROPIC_MODEL=claude-sonnet-4.6
+# Claude model to use (optional, defaults to claude-opus-4-8)
+ANTHROPIC_MODEL=claude-opus-4-8
 
 # Agent backend URL (Next.js → agent server proxy)
 AGENT_URL=http://localhost:8000

--- a/showcase/integrations/claude-sdk-typescript/PARITY_NOTES.md
+++ b/showcase/integrations/claude-sdk-typescript/PARITY_NOTES.md
@@ -27,10 +27,10 @@ does not implement are skipped below.
   changes.
 - `agentic-chat-reasoning` / `reasoning-default-render` /
   `tool-rendering-reasoning-chain` — `agent_server.ts` now opts into
-  Anthropic extended thinking (`thinking: { type: "enabled" }`) on the new
+  Anthropic adaptive thinking (`thinking: { type: "adaptive" }`) on the new
   `/reasoning` endpoint and forwards `thinking_delta` events as AG-UI
   `REASONING_MESSAGE_START | CONTENT | END`. Default model is
-  Claude 3.7 Sonnet; override via `CLAUDE_REASONING_MODEL`. A dedicated Next.js
+  Claude Opus 4.8; override via `CLAUDE_REASONING_MODEL`. A dedicated Next.js
   runtime route (`/api/copilotkit-reasoning/route.ts`) wires those agent ids
   to the new endpoint. Reasoning-chain reuses per-tool renderers + a wildcard
   catch-all.

--- a/showcase/integrations/claude-sdk-typescript/src/agent/index.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/agent/index.ts
@@ -22,7 +22,8 @@ app.use(express.json({ limit: "2mb" }));
 
 const HOST = process.env.AGENT_HOST || "0.0.0.0";
 const PORT = parseInt(process.env.AGENT_PORT || "8123", 10);
-const CLAUDE_MODEL = process.env.CLAUDE_MODEL || "claude-3-5-haiku-20241022";
+const CLAUDE_MODEL =
+  process.env.ANTHROPIC_MODEL || process.env.CLAUDE_MODEL || "claude-opus-4-8";
 
 if (!process.env.ANTHROPIC_API_KEY) {
   console.error("[agent_server] FATAL: ANTHROPIC_API_KEY is not set");

--- a/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/agent_server.ts
@@ -94,10 +94,13 @@ app.use(express.json({ limit: "35mb" }));
 const HOST = process.env.AGENT_HOST || "0.0.0.0";
 const PORT = parseInt(process.env.AGENT_PORT || "8000", 10);
 const CLAUDE_MODEL = normalizeAnthropicModel(
-  process.env.CLAUDE_MODEL ||
-    process.env.ANTHROPIC_MODEL ||
-    "claude-sonnet-4.6",
+  process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || "claude-opus-4-8",
 );
+// Anthropic SDK 0.57's types predate adaptive thinking, but its transport
+// forwards this API-supported value unchanged.
+const ADAPTIVE_THINKING = {
+  type: "adaptive",
+} as unknown as Anthropic.Messages.ThinkingConfigParam;
 const CLAUDE_VISION_MODEL = normalizeAnthropicModel(
   process.env.CLAUDE_VISION_MODEL ||
     process.env.ANTHROPIC_VISION_MODEL ||
@@ -586,10 +589,9 @@ interface DemoConfig {
   /** Force vision-capable model regardless of attachment detection. */
   forceVisionModel?: boolean;
   /**
-   * Enable Anthropic extended thinking and forward `thinking_delta` events
+   * Enable Anthropic adaptive thinking and forward `thinking_delta` events
    * as AG-UI REASONING_MESSAGE_* events. Requires a model that supports
-   * extended thinking (Claude 3.7 Sonnet / Claude 4 family). Sets
-   * `thinking: { type: "enabled", budget_tokens }`.
+   * adaptive thinking. Sets `thinking: { type: "adaptive" }`.
    */
   enableThinking?: boolean;
   /** Override model used when `enableThinking` is set. */
@@ -1122,10 +1124,7 @@ function makeAgentHandler(config: DemoConfig = {}) {
         ...(tools.length > 0 ? { tools } : {}),
         ...(config.enableThinking
           ? {
-              thinking: {
-                type: "enabled" as const,
-                budget_tokens: 2048,
-              },
+              thinking: ADAPTIVE_THINKING,
             }
           : {}),
       };
@@ -1885,10 +1884,7 @@ async function runAgenticLoop(
             ...(tools.length > 0 ? { tools } : {}),
             ...(config.enableThinking
               ? {
-                  thinking: {
-                    type: "enabled" as const,
-                    budget_tokens: 2048,
-                  },
+                  thinking: ADAPTIVE_THINKING,
                 }
               : {}),
           },

--- a/showcase/integrations/langroid/.env.example
+++ b/showcase/integrations/langroid/.env.example
@@ -12,7 +12,7 @@ AGENT_URL=http://localhost:8000
 # for OpenAI; use provider prefixes (`litellm/anthropic/...`, `gemini/...`,
 # `openrouter/...`, `ollama/...`, etc.) for non-OpenAI providers.
 # LANGROID_MODEL=gpt-4.1
-# LANGROID_MODEL=litellm/anthropic/claude-opus-4
+# LANGROID_MODEL=litellm/anthropic/claude-opus-4-8
 # LANGROID_MODEL=gemini/gemini-2.5-flash
 
 # Showcase

--- a/showcase/integrations/langroid/entrypoint.sh
+++ b/showcase/integrations/langroid/entrypoint.sh
@@ -53,7 +53,7 @@ trap cleanup EXIT
 
 # Provider-agnostic startup diagnostic. langroid is multi-provider — the chat
 # model is selected via ``LANGROID_MODEL`` (e.g. ``gpt-4.1``,
-# ``litellm/anthropic/claude-opus-4``, ``gemini/gemini-2.5-flash``). Whichever
+# ``litellm/anthropic/claude-opus-4-8``, ``gemini/gemini-2.5-flash``). Whichever
 # provider is picked, only THAT provider's API key is required.
 #
 # This block inspects ``LANGROID_MODEL`` (and the planner-only override
@@ -255,7 +255,7 @@ _check_key() {
     # Bare ``anthropic/<model>`` is not a langroid-native prefix; langroid
     # only routes Anthropic via ``litellm/anthropic/...`` or
     # ``openrouter/anthropic/...``. If an operator sets
-    # ``LANGROID_MODEL=anthropic/claude-opus-4`` the env-key check passes
+    # ``LANGROID_MODEL=anthropic/claude-opus-4-8`` the env-key check passes
     # but the request will fail downstream because langroid falls back to
     # the default OpenAI client and the OpenAI SDK rejects the model id.
     #

--- a/showcase/integrations/langroid/tests/python/test_generate_a2ui.py
+++ b/showcase/integrations/langroid/tests/python/test_generate_a2ui.py
@@ -291,7 +291,7 @@ def test_create_agent_wires_all_tools_with_stream_true(monkeypatch):
     langroid's ``ChatAgent`` lazily constructs the LLM from the config —
     ``create_agent`` itself only instantiates the config, not the LLM.
     """
-    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4")
+    monkeypatch.setenv("LANGROID_MODEL", "anthropic/claude-opus-4-8")
 
     captured_config_kwargs: list[dict] = []
     enable_message_calls: list[Any] = []
@@ -325,7 +325,7 @@ def test_create_agent_wires_all_tools_with_stream_true(monkeypatch):
     # Config kwargs: model from env, stream=True.
     assert len(captured_config_kwargs) == 1
     kwargs = captured_config_kwargs[0]
-    assert kwargs["chat_model"] == "anthropic/claude-opus-4"
+    assert kwargs["chat_model"] == "anthropic/claude-opus-4-8"
     assert kwargs["stream"] is True, (
         f"create_agent must construct primary LLM config with stream=True; "
         f"got stream={kwargs.get('stream')!r}"

--- a/showcase/integrations/strands-typescript/src/agent/model-factory.ts
+++ b/showcase/integrations/strands-typescript/src/agent/model-factory.ts
@@ -96,19 +96,18 @@ export async function createModel(
       await import("@strands-agents/sdk/models/anthropic");
     return new AnthropicModel({
       apiKey,
-      modelId: process.env.MODEL_ID ?? "claude-sonnet-4-6",
+      modelId: process.env.MODEL_ID ?? "claude-opus-4-8",
     });
   }
 
   if (provider === "bedrock") {
     const { BedrockModel } = await import("@strands-agents/sdk");
     return new BedrockModel({
-      modelId: process.env.MODEL_ID ?? "global.anthropic.claude-sonnet-4-6",
+      modelId: process.env.MODEL_ID ?? "global.anthropic.claude-opus-4-8",
       ...(reasoning
         ? {
-            temperature: 1,
             additionalRequestFields: {
-              thinking: { type: "enabled", budget_tokens: 2000 },
+              thinking: { type: "adaptive" },
             },
           }
         : {}),

--- a/showcase/scripts/check-claude-quickstarts-runtime.ts
+++ b/showcase/scripts/check-claude-quickstarts-runtime.ts
@@ -556,7 +556,7 @@ async function checkTypeScriptQuickstart() {
         ANTHROPIC_API_KEY: LIVE_ANTHROPIC
           ? process.env.ANTHROPIC_API_KEY
           : "test-key",
-        CLAUDE_MODEL: process.env.CLAUDE_MODEL ?? "claude-sonnet-4-6",
+        CLAUDE_MODEL: process.env.CLAUDE_MODEL ?? "claude-opus-4-8",
       },
     });
 
@@ -679,7 +679,7 @@ async function checkPythonVersion(version: string) {
           ANTHROPIC_API_KEY: LIVE_ANTHROPIC
             ? process.env.ANTHROPIC_API_KEY
             : "test-key",
-          ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL ?? "claude-sonnet-4-6",
+          ANTHROPIC_MODEL: process.env.ANTHROPIC_MODEL ?? "claude-opus-4-8",
         },
       },
     );

--- a/showcase/scripts/verify-shell-docs.test.ts
+++ b/showcase/scripts/verify-shell-docs.test.ts
@@ -269,7 +269,7 @@ describe("checkClaudeQuickstarts", () => {
     - \`src/agents/claude_agent_sdk_adapter.py\` - adapter
     - \`src/app/api/copilotkit/route.ts\` - runtime
     ANTHROPIC_API_KEY=your_anthropic_api_key
-    ANTHROPIC_MODEL=claude-sonnet-4-6
+    ANTHROPIC_MODEL=claude-opus-4-8
     AGENT_URL=http://localhost:8000
   </TailoredContentOption>
   <TailoredContentOption id="bring-your-own" title="Use an existing agent" description="byoa">
@@ -291,7 +291,7 @@ describe("checkClaudeQuickstarts", () => {
         return {"status": "ok"}
     @app.post("/")
     async def run_agent(input_data: RunAgentInput):
-        adapter = ClaudeAgentAdapter(model=os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6"))
+        adapter = ClaudeAgentAdapter(model=os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8"))
         async def event_stream():
             try:
                 async for event in adapter.run(input_data):
@@ -336,7 +336,7 @@ describe("checkClaudeQuickstarts", () => {
     - \`src/app/api/copilotkit/route.ts\` - runtime
     - \`src/app/page.tsx\` - frontend
     ANTHROPIC_API_KEY=your_anthropic_api_key
-    CLAUDE_MODEL=claude-sonnet-4-6
+    CLAUDE_MODEL=claude-opus-4-8
     AGENT_URL=http://localhost:8000
   </TailoredContentOption>
   <TailoredContentOption id="bring-your-own" title="Use an existing agent" description="byoa">

--- a/showcase/scripts/verify-shell-docs.ts
+++ b/showcase/scripts/verify-shell-docs.ts
@@ -532,7 +532,7 @@ const CLAUDE_QUICKSTARTS = [
     slug: "claude-sdk-python",
     path: "integrations/claude-sdk-python/quickstart.mdx",
     title: "Python",
-    modelEnvLine: "ANTHROPIC_MODEL=claude-sonnet-4-6",
+    modelEnvLine: "ANTHROPIC_MODEL=claude-opus-4-8",
     requiredStarterFiles: [
       "src/agent_server.py",
       "src/agents/claude_agent_sdk_adapter.py",
@@ -543,7 +543,7 @@ const CLAUDE_QUICKSTARTS = [
     slug: "claude-sdk-typescript",
     path: "integrations/claude-sdk-typescript/quickstart.mdx",
     title: "TypeScript",
-    modelEnvLine: "CLAUDE_MODEL=claude-sonnet-4-6",
+    modelEnvLine: "CLAUDE_MODEL=claude-opus-4-8",
     requiredStarterFiles: [
       "src/agent_server.ts",
       "src/app/api/copilotkit/route.ts",

--- a/showcase/shell-docs/model-allowlist.json
+++ b/showcase/shell-docs/model-allowlist.json
@@ -25,19 +25,12 @@
   ],
   "anthropic": [
     "claude-fable-5",
+    "claude-opus-4-8",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
     "claude-opus-4-5",
     "claude-sonnet-4-5",
-    "claude-opus-4-1",
-    "claude-opus-4",
-    "claude-sonnet-4",
-    "claude-sonnet-4-0",
-    "claude-opus-4-0",
-    "claude-3-7-sonnet",
-    "claude-3-5-haiku",
-    "claude-3-5-sonnet",
     "claude-code"
   ],
   "google": [

--- a/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
@@ -313,7 +313,7 @@ const agent = new BuiltInAgent({
   type: "aisdk",
   factory: ({ input, abortSignal }) =>
     streamText({
-      model: anthropic("claude-sonnet-4", {
+      model: anthropic("claude-sonnet-4-6", {
         thinking: { type: "enabled", budgetTokens: 10000 },
       }),
       messages: convertMessagesToVercelAISDKMessages(input.messages),
@@ -339,7 +339,7 @@ const agent = new BuiltInAgent({
   factory: ({ input, abortController }) => {
     const { messages, systemPrompts } = convertInputToTanStackAI(input);
     return chat({
-      adapter: anthropicText("claude-sonnet-4"),
+      adapter: anthropicText("claude-sonnet-4-6"),
       messages,
       systemPrompts,
       modelOptions: { thinking: { type: "enabled", budgetTokens: 10000 } },
@@ -476,8 +476,8 @@ const agent = new BuiltInAgent({
     const { messages, systemPrompts } = convertInputToTanStackAI(input);
 
     const adapter =
-      props.model === "anthropic/claude-sonnet-4"
-        ? anthropicText("claude-sonnet-4")
+      props.model === "anthropic/claude-sonnet-4-6"
+        ? anthropicText("claude-sonnet-4-6")
         : openaiText((props.model as string) ?? "gpt-4o");
 
     const modelOptions: Record<string, unknown> = {};
@@ -502,7 +502,7 @@ Forward properties from the frontend provider:
 <FrontendOnly frontend="react">
 ```tsx title="app/page.tsx"
 <CopilotKit
-  properties={{ model: "anthropic/claude-sonnet-4", temperature: 0.3 }}
+  properties={{ model: "anthropic/claude-sonnet-4-6", temperature: 0.3 }}
   useSingleEndpoint={false}
 >
   <CopilotChat />
@@ -522,7 +522,7 @@ Forward properties from the frontend provider:
 provideCopilotKit({
   runtimeUrl: "/api/copilotkit",
   properties: {
-    model: "anthropic/claude-sonnet-4",
+    model: "anthropic/claude-sonnet-4-6",
     temperature: 0.3,
   },
 })

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/model-selection.mdx
@@ -13,18 +13,18 @@ Specify a model using the `"provider:model"` format. `"provider/model"` also wor
 
 ### OpenAI
 
-| Model | Specifier |
-|-------|-----------|
-| GPT-5 | `openai:gpt-5` |
-| GPT-5 Mini | `openai:gpt-5-mini` |
-| GPT-4.1 | `openai:gpt-4.1` |
+| Model        | Specifier             |
+| ------------ | --------------------- |
+| GPT-5        | `openai:gpt-5`        |
+| GPT-5 Mini   | `openai:gpt-5-mini`   |
+| GPT-4.1      | `openai:gpt-4.1`      |
 | GPT-4.1 Mini | `openai:gpt-4.1-mini` |
 | GPT-4.1 Nano | `openai:gpt-4.1-nano` |
-| GPT-4o | `openai:gpt-4o` |
-| GPT-4o Mini | `openai:gpt-4o-mini` |
-| o3 | `openai:o3` |
-| o3-mini | `openai:o3-mini` |
-| o4-mini | `openai:o4-mini` |
+| GPT-4o       | `openai:gpt-4o`       |
+| GPT-4o Mini  | `openai:gpt-4o-mini`  |
+| o3           | `openai:o3`           |
+| o3-mini      | `openai:o3-mini`      |
+| o4-mini      | `openai:o4-mini`      |
 
 ```typescript
 const agent = new BuiltInAgent({
@@ -34,27 +34,25 @@ const agent = new BuiltInAgent({
 
 ### Anthropic
 
-| Model | Specifier |
-|-------|-----------|
+| Model             | Specifier                     |
+| ----------------- | ----------------------------- |
+| Claude Opus 4.8   | `anthropic:claude-opus-4-8`   |
+| Claude Sonnet 4.6 | `anthropic:claude-sonnet-4-6` |
+| Claude Haiku 4.5  | `anthropic:claude-haiku-4-5`  |
 | Claude Sonnet 4.5 | `anthropic:claude-sonnet-4-5` |
-| Claude Sonnet 4 | `anthropic:claude-sonnet-4` |
-| Claude 3.7 Sonnet | `anthropic:claude-3-7-sonnet` |
-| Claude Opus 4.1 | `anthropic:claude-opus-4-1` |
-| Claude Opus 4 | `anthropic:claude-opus-4` |
-| Claude 3.5 Haiku | `anthropic:claude-3-5-haiku` |
 
 ```typescript
 const agent = new BuiltInAgent({
-  model: "anthropic:claude-sonnet-4-5",
+  model: "anthropic:claude-sonnet-4-6",
 });
 ```
 
 ### Google
 
-| Model | Specifier |
-|-------|-----------|
-| Gemini 2.5 Pro | `google:gemini-2.5-pro` |
-| Gemini 2.5 Flash | `google:gemini-2.5-flash` |
+| Model                 | Specifier                      |
+| --------------------- | ------------------------------ |
+| Gemini 2.5 Pro        | `google:gemini-2.5-pro`        |
+| Gemini 2.5 Flash      | `google:gemini-2.5-flash`      |
 | Gemini 2.5 Flash Lite | `google:gemini-2.5-flash-lite` |
 
 ```typescript
@@ -114,7 +112,8 @@ For models not in the built-in list, you can pass any Vercel AI SDK `LanguageMod
 import { BuiltInAgent } from "@copilotkit/runtime/v2";
 import { createOpenAI } from "@ai-sdk/openai"; // [!code highlight]
 
-const customProvider = createOpenAI({ // [!code highlight]
+const customProvider = createOpenAI({
+  // [!code highlight]
   apiKey: process.env.MY_API_KEY, // [!code highlight]
   baseURL: "https://my-proxy.example.com/v1", // [!code highlight]
 }); // [!code highlight]
@@ -153,13 +152,14 @@ import { BuiltInAgent } from "@copilotkit/runtime/v2";
 import { createOpenAI } from "@ai-sdk/openai"; // [!code highlight]
 
 // OpenRouter: one key, hundreds of models behind an OpenAI-compatible API
-const openrouter = createOpenAI({ // [!code highlight]
+const openrouter = createOpenAI({
+  // [!code highlight]
   apiKey: process.env.OPENROUTER_API_KEY, // [!code highlight]
   baseURL: "https://openrouter.ai/api/v1", // [!code highlight]
 }); // [!code highlight]
 
 const agent = new BuiltInAgent({
-  model: openrouter("anthropic/claude-sonnet-4-5"), // [!code highlight]
+  model: openrouter("anthropic/claude-sonnet-4-6"), // [!code highlight]
 });
 ```
 
@@ -172,25 +172,26 @@ AI SDK can talk to it, the Built-in Agent can use it.
   switching the model at request time. The model is configured **on the agent**,
   either as a `"provider:model"` string or an AI SDK `LanguageModel` instance:
 
-  ```typescript
-  new BuiltInAgent({ model: "openai:gpt-4.1" });        // built-in string
-  new BuiltInAgent({ model: openrouter("...") });        // any LanguageModel
-  ```
+```typescript
+new BuiltInAgent({ model: "openai:gpt-4.1" }); // built-in string
+new BuiltInAgent({ model: openrouter("...") }); // any LanguageModel
+```
 
-  To switch models per user, request, or feature flag, construct the agent with
-  the desired `model` on your own backend. For full control over the runtime you
-  can also use a [Custom Agent](/backend/custom-agent).
+To switch models per user, request, or feature flag, construct the agent with
+the desired `model` on your own backend. For full control over the runtime you
+can also use a [Custom Agent](/backend/custom-agent).
+
 </Callout>
 
 ## How it works
 
 The Built-in Agent resolves model strings to AI SDK provider instances:
 
-| Model string | AI SDK provider | Resolved call |
-|---|---|---|
-| `"openai:gpt-4.1"` | `@ai-sdk/openai` | `openai("gpt-4.1")` |
-| `"anthropic:claude-sonnet-4-5"` | `@ai-sdk/anthropic` | `anthropic("claude-sonnet-4-5")` |
-| `"google:gemini-2.5-pro"` | `@ai-sdk/google` | `google("gemini-2.5-pro")` |
+| Model string                    | AI SDK provider     | Resolved call                    |
+| ------------------------------- | ------------------- | -------------------------------- |
+| `"openai:gpt-4.1"`              | `@ai-sdk/openai`    | `openai("gpt-4.1")`              |
+| `"anthropic:claude-sonnet-4-6"` | `@ai-sdk/anthropic` | `anthropic("claude-sonnet-4-6")` |
+| `"google:gemini-2.5-pro"`       | `@ai-sdk/google`    | `google("gemini-2.5-pro")`       |
 
 Both `"provider:model"` and `"provider/model"` separators are supported and work identically.
 

--- a/showcase/shell-docs/src/content/docs/integrations/claude-sdk-python/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/claude-sdk-python/quickstart.mdx
@@ -53,7 +53,7 @@ Before you begin, you'll need the following:
 
           ```plaintext title=".env"
           ANTHROPIC_API_KEY=your_anthropic_api_key
-          ANTHROPIC_MODEL=claude-sonnet-4-6
+          ANTHROPIC_MODEL=claude-opus-4-8
           ```
 
           The runtime route defaults to `AGENT_URL=http://localhost:8000`, which is where the starter's FastAPI agent server listens.
@@ -138,7 +138,7 @@ Before you begin, you'll need the following:
 
           ```plaintext title=".env"
           ANTHROPIC_API_KEY=your_anthropic_api_key
-          ANTHROPIC_MODEL=claude-sonnet-4-6
+          ANTHROPIC_MODEL=claude-opus-4-8
           ```
         </Step>
 
@@ -171,7 +171,7 @@ Before you begin, you'll need the following:
           adapter = ClaudeAgentAdapter(
               name="claude_agent",
               options={
-                  "model": os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6"),
+                  "model": os.getenv("ANTHROPIC_MODEL", "claude-opus-4-8"),
                   "system_prompt": "You are a helpful assistant embedded in a CopilotKit app.",
                   "tools": [],
                   "permission_mode": "dontAsk",

--- a/showcase/shell-docs/src/content/docs/integrations/claude-sdk-typescript/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/claude-sdk-typescript/quickstart.mdx
@@ -51,7 +51,7 @@ Before you begin, you'll need the following:
 
           ```plaintext title=".env"
           ANTHROPIC_API_KEY=your_anthropic_api_key
-          CLAUDE_MODEL=claude-sonnet-4-6
+          CLAUDE_MODEL=claude-opus-4-8
           ```
 
           The runtime route defaults to `AGENT_URL=http://localhost:8000`, which is where the starter's agent server listens.
@@ -137,7 +137,7 @@ Before you begin, you'll need the following:
 
           ```plaintext title=".env"
           ANTHROPIC_API_KEY=your_anthropic_api_key
-          CLAUDE_MODEL=claude-sonnet-4-6
+          CLAUDE_MODEL=claude-opus-4-8
           AGENT_PORT=8000
           ```
         </Step>
@@ -162,7 +162,7 @@ Before you begin, you'll need the following:
 
           const agent = new ClaudeAgentAdapter({
             agentId: "claude_agent",
-            model: process.env.CLAUDE_MODEL ?? "claude-sonnet-4-6",
+            model: process.env.CLAUDE_MODEL ?? "claude-opus-4-8",
             systemPrompt: "You are a helpful assistant embedded in a CopilotKit app.",
             tools: [],
             permissionMode: "dontAsk",

--- a/showcase/shell-docs/src/content/snippets/shared/backend/custom-agent.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/backend/custom-agent.mdx
@@ -300,7 +300,7 @@ const agent = new BuiltInAgent({
   type: "aisdk",
   factory: ({ input, abortSignal }) =>
     streamText({
-      model: anthropic("claude-sonnet-4", {
+      model: anthropic("claude-sonnet-4-6", {
         thinking: { type: "enabled", budgetTokens: 10000 },
       }),
       messages: convertMessagesToVercelAISDKMessages(input.messages),
@@ -326,7 +326,7 @@ const agent = new BuiltInAgent({
   factory: ({ input, abortController }) => {
     const { messages, systemPrompts } = convertInputToTanStackAI(input);
     return chat({
-      adapter: anthropicText("claude-sonnet-4"),
+      adapter: anthropicText("claude-sonnet-4-6"),
       messages,
       systemPrompts,
       modelOptions: { thinking: { type: "enabled", budgetTokens: 10000 } },
@@ -463,8 +463,8 @@ const agent = new BuiltInAgent({
     const { messages, systemPrompts } = convertInputToTanStackAI(input);
 
     const adapter =
-      props.model === "anthropic/claude-sonnet-4"
-        ? anthropicText("claude-sonnet-4")
+      props.model === "anthropic/claude-sonnet-4-6"
+        ? anthropicText("claude-sonnet-4-6")
         : openaiText((props.model as string) ?? "gpt-4o");
 
     const modelOptions: Record<string, unknown> = {};
@@ -487,7 +487,7 @@ const agent = new BuiltInAgent({
 Forward props from the frontend using the `CopilotKit` provider's `properties` prop:
 
 ```tsx title="app/page.tsx"
-<CopilotKit properties={{ model: "anthropic/claude-sonnet-4", temperature: 0.3 }}>
+<CopilotKit properties={{ model: "anthropic/claude-sonnet-4-6", temperature: 0.3 }}>
   <CopilotChat />
 </CopilotKit>
 ```

--- a/skills/copilotkit-debug/references/agent-debugging.md
+++ b/skills/copilotkit-debug/references/agent-debugging.md
@@ -209,7 +209,7 @@ The tool's `execute` function threw an exception.
 Supported formats:
 
 - `"openai/gpt-5"`, `"openai/gpt-4o"`, `"openai/o3-mini"`
-- `"anthropic/claude-sonnet-4.5"`, `"anthropic/claude-opus-4"`
+- `"anthropic/claude-sonnet-4-6"`, `"anthropic/claude-opus-4-8"`
 - `"google/gemini-2.5-pro"`, `"google/gemini-2.5-flash"`
 - `"vertex/gemini-2.5-pro"` (uses Google Vertex AI)
 

--- a/skills/copilotkit-setup/SKILL.md
+++ b/skills/copilotkit-setup/SKILL.md
@@ -518,7 +518,7 @@ Format: `"provider/model-name"` string or a Vercel AI SDK `LanguageModel` instan
 
 **OpenAI:** `openai/gpt-5`, `openai/gpt-5-mini`, `openai/gpt-4.1`, `openai/gpt-4.1-mini`, `openai/gpt-4.1-nano`, `openai/gpt-4o`, `openai/gpt-4o-mini`, `openai/o3`, `openai/o3-mini`, `openai/o4-mini`
 
-**Anthropic:** `anthropic/claude-sonnet-4.5`, `anthropic/claude-sonnet-4`, `anthropic/claude-3.7-sonnet`, `anthropic/claude-opus-4.1`, `anthropic/claude-opus-4`, `anthropic/claude-3.5-haiku`
+**Anthropic:** `anthropic/claude-sonnet-4-6`, `anthropic/claude-sonnet-4-5`, `anthropic/claude-opus-4-8`, `anthropic/claude-haiku-4-5`
 
 **Google:** `google/gemini-2.5-pro`, `google/gemini-2.5-flash`, `google/gemini-2.5-flash-lite`
 

--- a/skills/runtime/references/built-in-agent-factory-modes.md
+++ b/skills/runtime/references/built-in-agent-factory-modes.md
@@ -110,7 +110,7 @@ new BuiltInAgent({
   type: "aisdk",
   factory: ({ input, abortSignal }) =>
     streamText({
-      model: anthropic("claude-sonnet-4"),
+      model: anthropic("claude-sonnet-4-6"),
       messages: convertMessagesToVercelAISDKMessages(input.messages),
       providerOptions: {
         anthropic: { thinking: { type: "enabled", budgetTokens: 10000 } },

--- a/skills/runtime/references/built-in-agent-model-identifiers.md
+++ b/skills/runtime/references/built-in-agent-model-identifiers.md
@@ -7,7 +7,7 @@ BuiltInAgent model identifiers — the full set of `"provider/model"` strings th
 
 ```typescript
 new BuiltInAgent({ model: "openai/gpt-4o" });
-new BuiltInAgent({ model: "anthropic:claude-sonnet-4.5" });
+new BuiltInAgent({ model: "anthropic:claude-sonnet-4-6" });
 ```
 
 ## Supported providers
@@ -31,9 +31,8 @@ openai/gpt-4.1          openai/gpt-4.1-mini        openai/gpt-4.1-nano
 openai/gpt-4o           openai/gpt-4o-mini
 openai/o3               openai/o3-mini             openai/o4-mini
 
-anthropic/claude-sonnet-4.5   anthropic/claude-sonnet-4
-anthropic/claude-3.7-sonnet   anthropic/claude-opus-4.1
-anthropic/claude-opus-4       anthropic/claude-3.5-haiku
+anthropic/claude-sonnet-4-6   anthropic/claude-sonnet-4-5
+anthropic/claude-opus-4-8     anthropic/claude-haiku-4-5
 
 google/gemini-2.5-pro   google/gemini-2.5-flash    google/gemini-2.5-flash-lite
 ```


### PR DESCRIPTION
## Problem

Retired Anthropic model identifiers remained in runtime types, examples, documentation, and showcase configuration. Several Anthropic defaults also still selected Sonnet 4.6.

## Why

Retired defaults and copy-paste examples fail at Anthropic, while short-lived defaults force repeated repository-wide remediation. Explicit user-selected model identifiers must remain forward-compatible and must not be rejected or silently replaced by CopilotKit.

## Fix

- Replace retired repository references and move Sonnet 4.6 defaults to Opus 4.8
- Keep arbitrary explicit model identifiers open and pass them through unchanged, with regressions covering a retired 3.7 identifier
- Limit runtime package behavior changes to default model selection and honoring the explicit per-request model already accepted by the adapter
- Use Opus 4.8-compatible adaptive thinking only where the changed showcase default requires it
- Add an Nx-backed repository guard and CI check preventing retired Anthropic identifiers from returning