### PR TITLE
refactor(showcase): retire the v1 runtime adapter across every integration

### DIFF
--- a/showcase/integrations/ag2/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -7,12 +7,12 @@
 // - showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
 // - src/agents/a2ui_fixed.py (the AG2 backend)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -36,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-agent-config/route.ts
@@ -24,12 +24,12 @@
 // - src/agents/agent_config_agent.py — the AG2 agent + AGUIStream sub-app
 // - src/app/demos/agent-config/page.tsx — the provider config
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 // Shape of the AG-UI run input we care about. We avoid a direct import of
@@ -169,17 +169,17 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+        // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full details server-side (operators grep `errorId` to correlate),
     // but never echo `err.message` / `err.stack` back to the HTTP client —

--- a/showcase/integrations/ag2/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -21,9 +21,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -58,12 +57,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -7,12 +7,12 @@
 // system prompt tuned to emit that shape — see
 // `src/agents/byoc_hashbrown_agent.py`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -31,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -1,11 +1,11 @@
 // Dedicated runtime for the BYOC json-render demo (AG2).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -24,12 +24,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -41,12 +40,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-mcp-apps/route.ts
@@ -9,12 +9,12 @@
 // - showcase/integrations/langgraph-python/src/app/api/copilotkit-mcp-apps/route.ts
 // - src/agents/mcp_apps_agent.py (the AG2 backend, no bespoke tools)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -57,12 +57,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-multimodal/route.ts
@@ -6,12 +6,12 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"` (the slug registered below).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -25,15 +25,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published agents type generic mismatch.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit-ogui/route.ts
@@ -5,12 +5,12 @@
 // causes the CopilotKit provider's setTools effect to wipe per-demo
 // `useFrontendTool`/`useComponent` registrations in the default runtime.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -27,9 +27,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[advanced-runtime-config]
       // @region[minimal-runtime-flag]
       // Server-side config is identical for the minimal and advanced cells —
@@ -47,9 +45,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[minimal-runtime-flag]
-      // @endregion[advanced-runtime-config]
+      // @endregion[advanced-runtime-config],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ag2/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ag2/src/app/api/copilotkit/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // The agent backend runs as a separate process on port 8000.
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
@@ -116,16 +117,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/agno/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -8,12 +8,12 @@
 // - showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
 // - src/agents/a2ui_fixed_agent.py (the Agno backend)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -23,7 +23,7 @@ const a2uiFixedSchemaAgent = new HttpAgent({
 });
 
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts
+  // @ts-ignore -- see main route.ts
   agents: { "a2ui-fixed-schema": a2uiFixedSchemaAgent },
   a2ui: {
     // The backend agent emits its own `a2ui_operations` container inside
@@ -37,12 +37,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-agent-config/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -27,21 +26,21 @@ const agentConfigAgent = new HttpAgent({
 
 const runtime = new CopilotRuntime({
   agents: {
-    // @ts-expect-error -- see main route.ts
+    // @ts-ignore -- see main route.ts
     "agent-config-demo": agentConfigAgent,
-    // @ts-expect-error -- see main route.ts
+    // @ts-ignore -- see main route.ts
     default: agentConfigAgent,
   },
 });
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -36,7 +35,7 @@ const agents: Record<string, AbstractAgent> = {
 };
 
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts
+  // @ts-ignore -- see main route.ts
   agents,
   openGenerativeUI: true,
   a2ui: {
@@ -55,12 +54,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/agno/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -1,12 +1,13 @@
 // Dedicated runtime for the byoc-hashbrown demo (Agno).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -40,15 +41,15 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts
+        // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(
         `[copilotkit-byoc-hashbrown/route] Response status: ${response.status}`,

--- a/showcase/integrations/agno/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -1,11 +1,11 @@
 // Dedicated runtime for the byoc-json-render demo (Agno).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -15,18 +15,18 @@ const byocJsonRenderAgent = new HttpAgent({
 });
 
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts
+  // @ts-ignore -- see main route.ts
   agents: { byoc_json_render: byocJsonRenderAgent },
 });
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -25,7 +24,7 @@ const declarativeGenUiAgent = new HttpAgent({
 });
 
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts
+  // @ts-ignore -- see main route.ts
   agents: { "declarative-gen-ui": declarativeGenUiAgent },
   a2ui: {
     // The backend agent owns `generate_a2ui` explicitly (see
@@ -46,12 +45,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -5,13 +5,14 @@
 // agent still mounts at `/byoc-hashbrown/agui` (see src/agent_server.py).
 // The demo page mounts <CopilotKit agent="declarative-hashbrown-demo">.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -45,15 +46,15 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts
+        // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(
         `[copilotkit-declarative-hashbrown/route] Response status: ${response.status}`,

--- a/showcase/integrations/agno/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -7,13 +7,14 @@
 // `declarative-json-render`; the agent ID retains its legacy
 // `byoc_json_render` name.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -29,18 +30,18 @@ const agents: Record<string, AbstractAgent> = {
 };
 
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts
+  // @ts-ignore -- see main route.ts
   agents,
 });
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/agno/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-mcp-apps/route.ts
@@ -14,12 +14,12 @@
 // Reference:
 // https://docs.copilotkit.ai/integrations/agno/generative-ui/mcp-apps
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -43,7 +43,7 @@ const headlessCompleteAgent = new HttpAgent({ url: `${AGENT_URL}/agui` });
 // built-in `MCPAppsActivityRenderer` renders inline in the chat.
 const runtime = new CopilotRuntime({
   agents: {
-    // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+    // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
     // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
     // plain Records. Fixed in source, pending release.
     "headless-complete": headlessCompleteAgent,
@@ -66,12 +66,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-multimodal/route.ts
@@ -8,12 +8,12 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"` (resolved below).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -29,15 +29,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts
+        // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit-ogui/route.ts
@@ -11,12 +11,12 @@
 // `open-generative-ui` activity event the built-in renderer mounts inside a
 // sandboxed iframe.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -33,9 +33,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -44,16 +42,18 @@ export const POST = async (req: NextRequest) => {
       // the provider. The single `openGenerativeUI` flag below turns on
       // Open Generative UI for the listed agent(s).
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts
+        // @ts-ignore -- see main route.ts
         agents,
         openGenerativeUI: {
           agents: ["open-gen-ui", "open-gen-ui-advanced"],
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/agno/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/agno/src/app/api/copilotkit/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // The agent backend runs as a separate process on port 8000.
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
@@ -136,16 +137,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -10,9 +10,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
 
@@ -37,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-a2ui-fixed-schema",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-agent-config/route.ts
@@ -15,9 +15,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import { claudeHttpAgentConfig } from "@/app/api/_shared/claude-http-agent";
@@ -148,15 +147,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-agent-config", error);
   }

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -6,9 +6,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -41,12 +40,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-beautiful-chat",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -10,9 +10,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -30,15 +29,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-byoc-hashbrown",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -12,9 +12,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -35,17 +34,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts: CopilotRuntime agents type is
         // stricter than a plain Record but fixed in source, pending
         // release.
         agents,
       }),
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-byoc-json-render",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -11,9 +11,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
 
@@ -46,12 +45,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-declarative-gen-ui",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -9,9 +9,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -31,12 +30,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-declarative-hashbrown",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -9,9 +9,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -31,12 +30,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-declarative-json-render",

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-mcp-apps/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import crypto from "node:crypto";
@@ -59,12 +58,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error instanceof Error ? error : new Error(String(error));
     const errorId = crypto.randomUUID();

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-multimodal/route.ts
@@ -17,9 +17,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -37,15 +36,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-multimodal", error);
   }

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit-ogui/route.ts
@@ -1,9 +1,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -28,9 +27,7 @@ for (const name of agentNames) {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for minimal and advanced cells —
@@ -48,9 +45,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-ogui", error);
   }

--- a/showcase/integrations/claude-sdk-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/claude-sdk-python/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import crypto from "node:crypto";
@@ -121,16 +120,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -10,9 +10,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
 
@@ -37,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-a2ui-fixed-schema",

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-agent-config/route.ts
@@ -14,9 +14,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -37,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-agent-config", error);
   }

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -61,12 +60,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-beautiful-chat",

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -7,9 +7,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
 
@@ -32,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-declarative-gen-ui",

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -10,9 +10,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -32,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-declarative-hashbrown",

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -10,9 +10,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -30,12 +29,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-declarative-json-render",

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-headless-complete/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-headless-complete/route.ts
@@ -9,9 +9,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
 
@@ -28,12 +27,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-headless-complete",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-headless-complete",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse(
       "/api/copilotkit-headless-complete",

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-mcp-apps/route.ts
@@ -12,9 +12,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -52,12 +51,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-mcp-apps", error);
   }

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-multimodal/route.ts
@@ -10,9 +10,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -33,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-multimodal", error);
   }

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-ogui/route.ts
@@ -12,9 +12,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
 
@@ -27,9 +26,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
@@ -40,9 +37,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-ogui", error);
   }

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-reasoning/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-reasoning/route.ts
@@ -12,9 +12,8 @@
 import type { NextRequest } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -46,12 +45,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-reasoning",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-reasoning",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     return internalRuntimeErrorResponse("/api/copilotkit-reasoning", error);
   }

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -15,9 +15,8 @@ import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 
@@ -39,12 +38,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-shared-state-read-write",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-shared-state-read-write",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full stack server-side, return only an opaque error id to the
     // client. Returning `error.message` / `error.stack` over the wire leaks

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-subagents/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit-subagents/route.ts
@@ -16,9 +16,8 @@ import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 
@@ -38,12 +37,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-subagents",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-subagents",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full stack server-side, return only an opaque error id to the
     // client. Returning `error.message` / `error.stack` over the wire leaks

--- a/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/claude-sdk-typescript/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { createClaudeHttpAgent } from "@/app/api/_shared/claude-http-agent";
 import { internalRuntimeErrorResponse } from "@/app/api/_shared/route-error";
@@ -202,16 +201,16 @@ const copilotkitPost = async (req: NextRequest): Promise<Response> => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -41,12 +40,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -33,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-agent-config/route.ts
@@ -7,9 +7,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -31,12 +30,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -52,12 +51,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -40,12 +39,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -39,12 +38,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -50,12 +49,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-mcp-apps/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -67,12 +66,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-multimodal/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -33,17 +32,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-ogui/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -28,9 +27,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
@@ -41,9 +38,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
@@ -58,12 +57,12 @@ function logRouteError(err: unknown): string {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-shared-state-read-write",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-shared-state-read-write",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const errorId = logRouteError(error);
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-subagents/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-subagents/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
@@ -60,12 +59,12 @@ function logRouteError(err: unknown): string {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-subagents",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-subagents",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const errorId = logRouteError(error);
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-tool-rendering/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit-tool-rendering/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
@@ -55,12 +54,12 @@ function logRouteError(err: unknown): string {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-tool-rendering",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-tool-rendering",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const errorId = logRouteError(error);
     return NextResponse.json(

--- a/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/crewai-conversational-flows/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -139,16 +138,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -8,13 +8,14 @@
 // Agent URL points at the dedicated `/a2ui-fixed-schema` FastAPI endpoint
 // mounted by `agent_server.py`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -37,12 +38,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -31,12 +30,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-agent-config/route.ts
@@ -3,13 +3,14 @@
 // expertise / responseLength to the CrewAI crew (which simply passes them
 // through as agent context).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -29,12 +30,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -50,12 +49,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -10,13 +10,14 @@
 // Agent URL points at the dedicated `/byoc-hashbrown` FastAPI endpoint
 // mounted by `agent_server.py`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -36,12 +37,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -9,13 +9,14 @@
  * mounted by `agent_server.py`.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -35,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -48,12 +47,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-mcp-apps/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -65,12 +64,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-multimodal/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -33,17 +32,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-ogui/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -26,9 +25,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
@@ -39,9 +36,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -8,13 +8,14 @@
 // `src/agents/shared_state_read_write.py` for the full rationale on why
 // this demo cannot share the `LatestAiDevelopment` crew on "/".
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -54,12 +55,12 @@ function logRouteError(err: unknown): string {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-shared-state-read-write",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-shared-state-read-write",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const errorId = logRouteError(error);
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-subagents/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-subagents/route.ts
@@ -12,13 +12,14 @@
 // final crew output through the AG-UI bridge, with no per-delegation
 // visibility for the frontend).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -58,12 +59,12 @@ function logRouteError(err: unknown): string {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-subagents",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-subagents",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const errorId = logRouteError(error);
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit-tool-rendering/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit-tool-rendering/route.ts
@@ -8,13 +8,14 @@
 // these events for backend-executed tools, which is why the catch-all
 // crew endpoint cannot serve tool-rendering.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -51,12 +52,12 @@ function logRouteError(err: unknown): string {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-tool-rendering",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-tool-rendering",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const errorId = logRouteError(error);
     return NextResponse.json(

--- a/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/crewai-crews/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -143,16 +142,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -7,12 +7,12 @@
 // - showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
 // - src/agents/a2ui_fixed_agent.py (the ADK backend)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -41,13 +41,13 @@ export const POST = async (req: NextRequest) => {
       },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -44,13 +43,13 @@ export const POST = async (req: NextRequest) => {
       },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-agent-config/route.ts
@@ -19,9 +19,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -52,12 +51,12 @@ export const POST = async (req: NextRequest) => {
       agents,
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
@@ -78,13 +77,13 @@ export const POST = async (req: NextRequest) => {
       },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -20,9 +20,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -42,13 +41,13 @@ export const POST = async (req: NextRequest) => {
       agents: { "declarative-gen-ui": declarativeGenUiAgent },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -3,12 +3,12 @@
 // the HttpAgent + AGENT_URL pattern that talks to the Python ADK backend
 // process (mounted at /declarative-hashbrown by agent_server.py).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -28,13 +28,13 @@ export const POST = async (req: NextRequest) => {
       agents: { "declarative-hashbrown-demo": declarativeHashbrownAgent },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -10,12 +10,12 @@
  * slug, route, and frontend folder were renamed.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -35,13 +35,13 @@ export const POST = async (req: NextRequest) => {
       agents: { byoc_json_render: byocJsonRenderAgent },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-mcp-apps/route.ts
@@ -9,13 +9,14 @@
 // Reference:
 // https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -69,13 +70,13 @@ export const POST = async (req: NextRequest) => {
     });
     // @endregion[runtime-mcpapps-config]
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-multimodal/route.ts
@@ -10,12 +10,12 @@
 // ADK's HttpAgent + AGENT_URL backend pattern (see copilotkit-byoc-hashbrown
 // for the same pattern).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -41,13 +41,13 @@ export const POST = async (req: NextRequest) => {
       },
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit-ogui/route.ts
@@ -2,12 +2,12 @@
 // Both demos share this endpoint but differ on the agent name they pass via
 // `<CopilotKit agent="...">`. Mirrors langgraph-python's /api/copilotkit-ogui.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
 
@@ -44,13 +44,13 @@ export const POST = async (req: NextRequest) => {
     // @endregion[advanced-runtime-config]
     // @endregion[minimal-runtime-flag]
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/google-adk/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/google-adk/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import { extractForwardedHeaders } from "@/lib/header-forwarding";
@@ -81,7 +80,7 @@ const agentNames = [
 // Build agents per-request so we can inject inbound x-* headers (e.g.
 // x-aimock-context) into the outbound HTTP call to the Python agent_server.
 // HttpAgent's `requestInit` spreads `this.headers` into the outbound fetch,
-// so populating `headers` from `req.headers` before `handleRequest` runs
+// so populating `headers` from `req.headers` before `copilotHandler` runs
 // is sufficient to convey the header to the Python backend, where
 // HeaderForwardingHTTPMiddleware then propagates it to Gemini via the
 // httpx/aiohttp event hooks installed at import time. See
@@ -109,13 +108,13 @@ export const POST = async (req: NextRequest) => {
       agents,
     });
 
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full details server-side (operators grep `errorId` to correlate),
     // but never echo `err.message` / `err.stack` back to the HTTP client —

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -7,12 +7,12 @@
 // - src/app/api/copilotkit/route.ts (LF main runtime)
 // - src/agents/src/a2ui_fixed.py (the backend graph)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8123";
@@ -37,12 +37,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8123";
@@ -41,12 +40,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-agent-config/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -52,12 +51,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -72,12 +71,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -4,9 +4,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8123";
@@ -26,12 +25,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -13,12 +13,12 @@
 // - src/app/api/copilotkit-a2ui-fixed-schema/route.ts (topology this mirrors)
 // - src/agents/src/byoc_hashbrown_agent.py (the backend graph)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -48,12 +48,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -10,12 +10,12 @@
  * folder were renamed. Mirrors langgraph-python.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -38,12 +38,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-mcp-apps/route.ts
@@ -13,12 +13,12 @@
 // Reference:
 // https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8123";
@@ -62,12 +62,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-multimodal/route.ts
@@ -13,12 +13,12 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"` (the slug registered below).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8123";
@@ -40,17 +40,17 @@ const agents: Record<string, LangGraphAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit-ogui/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 // Dedicated runtime for the Open Generative UI demos.
@@ -39,9 +39,7 @@ const agents: Record<string, LangGraphAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -59,9 +57,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: any) {
     return NextResponse.json(
       { error: error.message, stack: error.stack },

--- a/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-fastapi/src/app/api/copilotkit/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 import crypto from "node:crypto";
 
@@ -160,16 +160,16 @@ console.log(
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -7,12 +7,12 @@
 // - src/app/api/copilotkit-beautiful-chat/route.ts (topology this mirrors)
 // - src/agents/a2ui_fixed.py (the backend graph)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -39,12 +39,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -42,12 +41,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-agent-config/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -50,12 +49,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -63,12 +62,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -4,9 +4,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -28,12 +27,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -10,12 +10,12 @@
 // produces the hashbrown shape lives in
 // `src/agents/byoc_hashbrown_prompt.py`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -34,12 +34,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -10,12 +10,12 @@
  * slug, route, and frontend folder were renamed.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -36,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -65,12 +64,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-multimodal/route.ts
@@ -13,12 +13,12 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"` (the slug registered below).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -42,17 +42,17 @@ const agents: Record<string, LangGraphAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit-ogui/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 // Dedicated runtime for the Open Generative UI demos.
@@ -33,9 +33,7 @@ const agents: Record<string, LangGraphAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -53,9 +51,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: any) {
     return NextResponse.json(
       { error: error.message, stack: error.stack },

--- a/showcase/integrations/langgraph-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-python/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -127,9 +126,7 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -145,9 +142,11 @@ export const POST = async (req: NextRequest) => {
         // OpenGenerativeUI lives in /api/copilotkit-ogui for the same reason.
         // MCP Apps is in /api/copilotkit-mcp-apps.
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -2,12 +2,12 @@
 // endpoint lets us set `a2ui.injectA2UITool: false` — the backend agent owns
 // the `display_flight` tool which emits its own `a2ui_operations` container.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -33,12 +33,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -42,12 +41,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-agent-config/route.ts
@@ -15,9 +15,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -48,12 +47,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -61,12 +60,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -4,9 +4,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -28,12 +27,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -8,12 +8,12 @@
 // graph ID retains the legacy name; only the user-facing slug, route, and
 // frontend folder were renamed).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -32,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -9,12 +9,12 @@
  * name; only the user-facing slug, route, and frontend folder were renamed.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -35,12 +35,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
@@ -12,13 +12,13 @@
 // Reference:
 // https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -67,12 +67,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full error details server-side with a correlation id, but only
     // return the id (not the message or stack) to the client. Returning

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-multimodal/route.ts
@@ -12,12 +12,12 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"` (the slug registered below).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 const LANGGRAPH_URL =
@@ -41,17 +41,17 @@ const agents: Record<string, LangGraphAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit-ogui/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 
 // Dedicated runtime for the Open Generative UI demos.
@@ -33,9 +33,7 @@ const agents: Record<string, LangGraphAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -53,9 +51,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: any) {
     return NextResponse.json(
       { error: error.message, stack: error.stack },

--- a/showcase/integrations/langgraph-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langgraph-typescript/src/app/api/copilotkit/route.ts
@@ -3,9 +3,8 @@ import { NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { LangGraphAgent } from "@copilotkit/runtime/langgraph";
 // CVDIAG backend instrumentation (L1-E). No-op pass-through unless
 // CVDIAG_BACKEND_EMITTER is set truthy (default OFF).
@@ -116,15 +115,15 @@ const copilotkitPost = async (req: NextRequest): Promise<Response> => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/langroid/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -9,12 +9,12 @@
 // - showcase/integrations/ag2/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
 // - src/agents/a2ui_fixed_agent.py (the Langroid backend)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -38,12 +38,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-agent-config/route.ts
@@ -27,12 +27,12 @@
 // this repack and so the Playwright spec can assert request-body
 // propagation against exactly one URL.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import type { RunAgentInput } from "@ag-ui/client";
 
@@ -153,12 +153,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -54,12 +53,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -7,12 +7,12 @@
 // `${AGENT_URL}/byoc-hashbrown` whose system prompt is tuned to emit the
 // hashbrown JSON envelope (see `src/agents/byoc_hashbrown_agent.py`).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -31,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -6,12 +6,12 @@
  * `@json-render/react`) renders against a Zod-validated catalog.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -30,12 +30,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -39,12 +38,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -10,12 +10,12 @@
 // canonical `declarative-hashbrown` surface; the page mounts
 // <CopilotKit agent="declarative-hashbrown-demo">.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -34,12 +34,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -8,12 +8,12 @@
 // `declarative-json-render`; the agent ID retains its legacy
 // `byoc_json_render` name.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -32,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-mcp-apps/route.ts
@@ -15,12 +15,12 @@
 // Reference:
 // https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -35,7 +35,7 @@ const headlessCompleteAgent = new HttpAgent({ url: `${AGENT_URL}/` });
 
 // @region[runtime-mcpapps-config]
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+  // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
   // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
   // plain Records. Fixed in source, pending release.
   agents: {
@@ -60,12 +60,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-multimodal/route.ts
@@ -10,12 +10,12 @@
 // The page at `src/app/demos/multimodal/page.tsx` points its `runtimeUrl`
 // here and sets `agent="multimodal-demo"`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -31,15 +31,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-ogui/route.ts
@@ -1,9 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 // Dedicated runtime for the Open Generative UI demos (Langroid).
@@ -21,9 +21,7 @@ const agents: Record<string, HttpAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -41,9 +39,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/langroid/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -7,12 +7,12 @@
 // endpoint (POST /shared-state-read-write) that implements its own AG-UI
 // SSE pipeline with full state support.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
 
@@ -34,12 +34,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-shared-state-read-write",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-shared-state-read-write",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full error details server-side (with a correlation id) but do
     // NOT leak `error.message` / `error.stack` to the client — those can

--- a/showcase/integrations/langroid/src/app/api/copilotkit-subagents/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit-subagents/route.ts
@@ -6,12 +6,12 @@
 // state["delegations"] and surfaced to the UI via STATE_SNAPSHOT events
 // so the live delegation log can render running -> completed transitions.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
 
@@ -31,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-subagents",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-subagents",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     // Log full error details server-side (with a correlation id) but do
     // NOT leak `error.message` / `error.stack` to the client — those can

--- a/showcase/integrations/langroid/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/langroid/src/app/api/copilotkit/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // The agent backend runs as a separate process on port 8000.
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
@@ -118,16 +119,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -40,12 +39,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-agent-config/route.ts
@@ -29,9 +29,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -174,12 +173,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -55,12 +54,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -4,13 +4,14 @@
 // parses progressively. The runtime just proxies to the LlamaIndex agent at
 // the /byoc-hashbrown subpath.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -25,12 +26,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -4,13 +4,14 @@
 // `@json-render/react` on the frontend parses progressively. The runtime
 // just proxies to the LlamaIndex agent at the /byoc-json-render subpath.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -25,12 +26,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -15,9 +15,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -41,12 +40,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -6,13 +6,14 @@
 // renamed from `byoc-hashbrown` to the canonical `declarative-hashbrown`
 // surface; the page mounts <CopilotKit agent="declarative-hashbrown-demo">.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -32,12 +33,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -7,13 +7,14 @@
 // `declarative-json-render`; the agent ID retains its legacy
 // `byoc_json_render` name.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -33,12 +34,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-mcp-apps/route.ts
@@ -10,13 +10,14 @@
 // at `/mcp-apps/run` has no bespoke tools — MCP tools are injected by the
 // runtime middleware at request time.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -35,7 +36,7 @@ const headlessCompleteAgent = new HttpAgent({ url: `${AGENT_URL}/run` });
 // event the built-in `MCPAppsActivityRenderer` renders inline in the
 // chat. No app-side renderer registration required.
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+  // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
   // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
   // plain Records. Fixed in source, pending release.
   agents: {
@@ -58,12 +59,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-multimodal/route.ts
@@ -4,13 +4,14 @@
 // runtime keeps the cost of the vision model isolated to the one demo that
 // exercises it.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -28,12 +29,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit-ogui/route.ts
@@ -5,13 +5,14 @@
 // per-demo `useFrontendTool` / `useComponent` registrations on the default
 // runtime to be wiped.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -27,9 +28,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -47,9 +46,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/llamaindex/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/llamaindex/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -119,18 +118,18 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+        // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/mastra/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -22,9 +22,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -61,12 +60,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-a2ui-fixed-schema",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-a2ui-fixed-schema",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -11,9 +11,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -50,12 +49,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-a2ui-recovery",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-a2ui-recovery",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-agent-config/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -49,12 +48,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-agent-config",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-agent-config",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-background-agents/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-background-agents/route.ts
@@ -25,12 +25,12 @@
 // demo's tool, renderer, and e2e document. See
 // `src/mastra/tools/background-research.ts` and `tests/e2e/background-agents.spec.ts`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -58,12 +58,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-background-agents",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-background-agents",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -11,9 +11,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -60,12 +59,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-beautiful-chat",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-beautiful-chat",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-browser-use/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-browser-use/route.ts
@@ -10,9 +10,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -41,12 +40,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-browser-use",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-browser-use",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -10,12 +10,12 @@
 // weatherAgent produces plain text that `useJsonParser` parses as `null`,
 // leaving the dashboard empty — which is why D5 probes time out.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -40,12 +40,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-byoc-hashbrown",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-byoc-hashbrown",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -6,12 +6,12 @@
 // Mastra port we reuse the shared weatherAgent — the dashboard shape is
 // enforced entirely on the frontend by the catalog and the renderer.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -36,12 +36,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-byoc-json-render",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-byoc-json-render",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -21,9 +21,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -60,12 +59,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-declarative-gen-ui",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-declarative-gen-ui",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-mcp-apps/route.ts
@@ -6,12 +6,12 @@
 // built-in `MCPAppsActivityRenderer` (registered by CopilotKit internally)
 // renders in the chat as a sandboxed iframe.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -45,7 +45,7 @@ if (!headlessCompleteAgent) {
 // `activity` event that the built-in `MCPAppsActivityRenderer` renders
 // inline in the chat.
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+  // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
   // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
   // plain Records. Fixed in source, pending release.
   agents: {
@@ -71,12 +71,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-mcp-apps",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-mcp-apps",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-multimodal/route.ts
@@ -9,12 +9,12 @@
 // exactly the cell that exercises it, matching the pattern used by
 // `/api/copilotkit-beautiful-chat`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -42,12 +42,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-multimodal",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-multimodal",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-observational-memory/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-observational-memory/route.ts
@@ -13,12 +13,12 @@
 // returned record (keyed by the Mastra registration key,
 // `observationalMemoryAgent`).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgents } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -51,12 +51,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-observational-memory",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-observational-memory",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit-ogui/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { getLocalAgent } from "@ag-ui/mastra";
 import { mastra } from "@/mastra";
 import { withForwardedHeaders } from "@/mastra/_header_forwarding";
@@ -76,12 +75,12 @@ const runtime = new CopilotRuntime({
 export const POST = async (req: NextRequest) =>
   withForwardedHeaders(req, async () => {
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit-ogui",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
+        basePath: "/api/copilotkit-ogui",
+        mode: "single-route",
       });
-      return await handleRequest(req);
+      return await copilotHandler(req);
     } catch (error: unknown) {
       const e = error as { message?: string; stack?: string };
       return NextResponse.json(

--- a/showcase/integrations/mastra/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/mastra/src/app/api/copilotkit/route.ts
@@ -1,8 +1,7 @@
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { MastraAgent, getLocalAgent } from "@ag-ui/mastra";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
@@ -17,18 +16,10 @@ import { withForwardedHeaders } from "@/mastra/_header_forwarding";
 // CVDIAG_BACKEND_EMITTER is set truthy (default OFF).
 import { withCvdiagBackend } from "@/cvdiag-backend";
 
-// We use ExperimentalEmptyAdapter because Mastra agents drive the LLM
-// themselves — the CopilotKit runtime only brokers AG-UI events between
-// the frontend and the agent. A real adapter (OpenAI/Anthropic/etc.) would
-// try to issue its own LLM calls and conflict with the agent's own loop.
-const serviceAdapter = new ExperimentalEmptyAdapter();
-
-// Startup log: make the adapter choice visible in boot logs so operators
-// debugging "why is the runtime not calling the LLM?" can find the answer
-// without reading source.
-console.log(
-  "[copilotkit route] init: serviceAdapter=ExperimentalEmptyAdapter (Mastra agents drive the LLM)",
-);
+// The V2 runtime has no service adapters: Mastra agents drive the LLM
+// themselves and the runtime only brokers AG-UI events between the frontend
+// and the agent. Under V1 this route passed `ExperimentalEmptyAdapter` to say
+// exactly that; there is now no adapter to choose, so nothing to configure.
 
 // The Mastra config registers a single local agent (`weatherAgent`), but the
 // demo pages request a variety of agent names (`agentic_chat`,
@@ -439,7 +430,7 @@ export function __resetAgentsCacheForTests(): void {
 // regardless of where the failure occurred. Phases:
 //   - "setup": everything that happens BEFORE headers flush. Covers agent
 //     cache construction, runtime instantiation, and synchronous failures
-//     inside `wrapStreamingResponse` (malformed Response from handleRequest,
+//     inside `wrapStreamingResponse` (malformed Response from copilotHandler,
 //     etc.) — all of which still allow us to return a 500 JSON envelope.
 //   - "stream": mid-stream failures observed by the body wrapper AFTER
 //     headers have been committed — we can no longer change the status, only
@@ -464,7 +455,7 @@ function logRouteError(err: unknown, phase: "setup" | "stream"): string {
 
 // Wrap a streaming Response body with a TransformStream that forwards chunks
 // verbatim but catches any error thrown by the upstream source AFTER headers
-// have been flushed. Without this, a rejection inside handleRequest's SSE
+// have been flushed. Without this, a rejection inside copilotHandler's SSE
 // loop escapes every try/catch and leaves the frontend with a mute aborted
 // stream — no log, no errorId, no way to correlate.
 //
@@ -524,10 +515,10 @@ function wrapStreamingResponse(response: Response): Response {
 //   1. Synchronous construction errors (bad mastra config, missing
 //      weatherAgent, etc.) — caught by the outer try/catch, 500 returned.
 //   2. Synchronous wrap-time errors (e.g. malformed Response from
-//      handleRequest that makes `wrapStreamingResponse` itself throw) —
+//      copilotHandler that makes `wrapStreamingResponse` itself throw) —
 //      caught separately so we can cancel the upstream body before the 500
 //      goes out. Without this cancel, the ReadableStream returned by
-//      handleRequest leaks (no consumer ever reads it).
+//      copilotHandler leaks (no consumer ever reads it).
 //   3. Mid-stream errors (thrown after response headers have been flushed)
 //      — caught inside the TransformStream in `wrapStreamingResponse`.
 const copilotkitPost = async (req: NextRequest): Promise<Response> =>
@@ -541,13 +532,13 @@ const copilotkitPost = async (req: NextRequest): Promise<Response> =>
         agents: getAgents(),
       });
 
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime,
-        serviceAdapter,
-        endpoint: "/api/copilotkit",
+        basePath: "/api/copilotkit",
+        mode: "single-route",
       });
 
-      response = await handleRequest(req);
+      response = await copilotHandler(req);
     } catch (err) {
       const errorId = logRouteError(err, "setup");
       return NextResponse.json(

--- a/showcase/integrations/mastra/tests/vitest/builtAgents.types.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/builtAgents.types.test.ts
@@ -13,12 +13,11 @@ vi.mock("@ag-ui/mastra", () => ({
   MastraAgent: { getLocalAgents: vi.fn() },
   getLocalAgent: vi.fn(),
 }));
-vi.mock("@copilotkit/runtime", () => ({
+vi.mock("@copilotkit/runtime/v2", () => ({
   CopilotRuntime: vi.fn(),
-  ExperimentalEmptyAdapter: vi.fn(),
-  copilotRuntimeNextJSAppRouterEndpoint: vi.fn(() => ({
-    handleRequest: vi.fn(async () => new Response("ok")),
-  })),
+  createCopilotRuntimeHandler: vi.fn(() =>
+    vi.fn(async () => new Response("ok")),
+  ),
 }));
 vi.mock("next/server", () => ({
   NextRequest: class {},
@@ -31,8 +30,8 @@ vi.mock("next/server", () => ({
   },
 }));
 
+import type { buildAgents } from "../../src/app/api/copilotkit/route";
 import {
-  buildAgents,
   demoAgentNames,
   type BuiltAgents,
   type DemoAgentName,

--- a/showcase/integrations/mastra/tests/vitest/demoAgentNames.parity.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/demoAgentNames.parity.test.ts
@@ -26,12 +26,11 @@ vi.mock("@ag-ui/mastra", () => ({
   MastraAgent: { getLocalAgents: vi.fn() },
   getLocalAgent: vi.fn(),
 }));
-vi.mock("@copilotkit/runtime", () => ({
+vi.mock("@copilotkit/runtime/v2", () => ({
   CopilotRuntime: vi.fn(),
-  ExperimentalEmptyAdapter: vi.fn(),
-  copilotRuntimeNextJSAppRouterEndpoint: vi.fn(() => ({
-    handleRequest: vi.fn(async () => new Response("ok")),
-  })),
+  createCopilotRuntimeHandler: vi.fn(() =>
+    vi.fn(async () => new Response("ok")),
+  ),
 }));
 vi.mock("next/server", () => ({
   NextRequest: class {},

--- a/showcase/integrations/mastra/tests/vitest/route.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/route.test.ts
@@ -40,12 +40,11 @@ vi.mock("@ag-ui/mastra", () => {
 
 // Stub @copilotkit/runtime so the route module can import without pulling
 // the real runtime into the test env.
-vi.mock("@copilotkit/runtime", () => ({
+vi.mock("@copilotkit/runtime/v2", () => ({
   CopilotRuntime: vi.fn().mockImplementation(({ agents }) => ({ agents })),
-  ExperimentalEmptyAdapter: vi.fn(),
-  copilotRuntimeNextJSAppRouterEndpoint: vi.fn(() => ({
-    handleRequest: vi.fn(async () => new Response("ok")),
-  })),
+  createCopilotRuntimeHandler: vi.fn(() =>
+    vi.fn(async () => new Response("ok")),
+  ),
 }));
 
 // next/server has no special behavior we need here, but route.ts imports types.
@@ -63,13 +62,13 @@ vi.mock("next/server", () => ({
 import { MastraAgent, getLocalAgent } from "@ag-ui/mastra";
 import {
   CopilotRuntime,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const mockedGetLocalAgents = vi.mocked(MastraAgent.getLocalAgents);
 const mockedGetLocalAgent = vi.mocked(getLocalAgent);
 const mockedCopilotRuntime = vi.mocked(CopilotRuntime);
-const mockedEndpointFactory = vi.mocked(copilotRuntimeNextJSAppRouterEndpoint);
+const mockedHandlerFactory = vi.mocked(createCopilotRuntimeHandler);
 
 // Dynamic import AFTER vi.mock calls so the module sees the mocks.
 async function importRoute() {
@@ -530,9 +529,11 @@ describe("POST error handling", () => {
       },
     });
 
-    mockedEndpointFactory.mockReturnValueOnce({
-      handleRequest: vi.fn(async () => malformed),
-    } as unknown as ReturnType<typeof copilotRuntimeNextJSAppRouterEndpoint>);
+    mockedHandlerFactory.mockReturnValueOnce(
+      vi.fn(async () => malformed) as unknown as ReturnType<
+        typeof createCopilotRuntimeHandler
+      >,
+    );
 
     const consoleErrorSpy = vi
       .spyOn(console, "error")
@@ -560,13 +561,13 @@ describe("POST error handling", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  // Regression guard: when handleRequest returns a streaming Response that
+  // Regression guard: when copilotHandler returns a streaming Response that
   // errors AFTER headers flush (typical SSE / AG-UI failure mode), the error
   // must be logged server-side with an errorId even though we can no longer
   // turn the response into a 500. Without the streaming wrapper this test
   // fails silently: the error is swallowed by the ReadableStream and never
   // reaches console.error.
-  it("logs mid-stream handleRequest errors with an errorId (SSE/AG-UI failure path)", async () => {
+  it("logs mid-stream copilotHandler errors with an errorId (SSE/AG-UI failure path)", async () => {
     mockedGetLocalAgents.mockReturnValue({
       weatherAgent: makeAgent("weather", "mastra-weatherAgent"),
       headlessCompleteAgent: makeAgent(
@@ -605,9 +606,11 @@ describe("POST error handling", () => {
       status: 200,
       headers: { "content-type": "text/event-stream" },
     });
-    mockedEndpointFactory.mockReturnValueOnce({
-      handleRequest: vi.fn(async () => erroringResponse),
-    } as unknown as ReturnType<typeof copilotRuntimeNextJSAppRouterEndpoint>);
+    mockedHandlerFactory.mockReturnValueOnce(
+      vi.fn(async () => erroringResponse) as unknown as ReturnType<
+        typeof createCopilotRuntimeHandler
+      >,
+    );
 
     const consoleErrorSpy = vi
       .spyOn(console, "error")

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -6,12 +6,12 @@
 // The .NET backend exposes this agent at `AGENT_URL/a2ui-fixed-schema`
 // (see agent/Program.cs).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -35,12 +35,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -12,12 +12,12 @@
 // catalogId). The .NET backend exposes this agent at `AGENT_URL/a2ui-recovery`
 // (see agent/Program.cs).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -42,12 +42,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-agent-config/route.ts
@@ -8,13 +8,14 @@
 // - showcase/integrations/ms-agent-dotnet/agent/AgentConfigAgent.cs
 // - showcase/integrations/ms-agent-dotnet/src/app/demos/agent-config/page.tsx
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -32,17 +33,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in
         // MaybePromise<NonEmptyRecord<...>> which rejects plain Records;
         // fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -61,12 +60,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -11,9 +11,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -43,12 +42,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -36,12 +35,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -32,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -63,12 +62,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-multimodal/route.ts
@@ -11,13 +11,14 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"`.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent, type RunAgentInput } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent, type RunAgentInput } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -44,15 +45,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit-ogui/route.ts
@@ -1,16 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import {
-  AbstractAgent,
-  HttpAgent,
-  type BaseEvent,
-  type RunAgentInput,
-} from "@ag-ui/client";
-import { map, type Observable } from "rxjs";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent, type BaseEvent, type RunAgentInput } from "@ag-ui/client";
+import { map } from "rxjs";
+import type { Observable } from "rxjs";
 
 // Dedicated runtime for the Open Generative UI demos, mirroring the
 // LangGraph-Python `copilotkit-ogui` route.
@@ -123,9 +120,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // Server-side config is identical for the minimal and advanced cells —
       // the advanced behaviour (sandbox -> host function calls) is wired
       // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
@@ -143,9 +138,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     console.error(`[copilotkit-ogui/route] ERROR: ${err.message}`);

--- a/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-dotnet/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent, BaseEvent } from "@ag-ui/client";
 import { EventType, FunctionMiddleware, HttpAgent } from "@ag-ui/client";
 import { Observable } from "rxjs";
@@ -960,16 +959,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -10,9 +10,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -36,12 +35,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-agent-config/route.ts
@@ -12,9 +12,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -34,17 +33,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in
         // MaybePromise<NonEmptyRecord<...>> which rejects plain Records;
         // fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -61,12 +60,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -11,9 +11,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -43,12 +42,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -36,12 +35,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -32,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -63,12 +62,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-multimodal/route.ts
@@ -15,9 +15,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import type { RunAgentInput } from "@ag-ui/client";
@@ -47,15 +46,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit-ogui/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
@@ -122,9 +121,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // Server-side config is identical for the minimal and advanced cells —
       // the advanced behaviour (sandbox -> host function calls) is wired
       // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
@@ -142,9 +139,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     console.error(`[copilotkit-ogui/route] ERROR: ${err.message}`);

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent, BaseEvent } from "@ag-ui/client";
 import { EventType, FunctionMiddleware, HttpAgent } from "@ag-ui/client";
 import { Observable } from "rxjs";
@@ -776,16 +775,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -7,12 +7,12 @@
 // - showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
 // - src/agents/a2ui_fixed.py (backend agent, mounted at `/a2ui_fixed`)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -36,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-agent-config/route.ts
@@ -10,13 +10,14 @@
 // - src/agents/agent_config_agent.py (backend graph)
 // - src/app/demos/agent-config/page.tsx (provider properties source)
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -34,17 +35,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in
         // MaybePromise<NonEmptyRecord<...>> which rejects plain Records;
         // fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -71,12 +70,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -13,9 +13,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 // The MS Agent backend runs as a separate process on port 8000. This runtime
@@ -48,12 +47,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -16,9 +16,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -36,12 +35,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -32,12 +31,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-mcp-apps/[[...slug]]/route.ts
@@ -18,9 +18,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -68,12 +67,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-multimodal/route.ts
@@ -11,13 +11,14 @@
 // The page at src/app/demos/multimodal/page.tsx points its `runtimeUrl` at
 // this endpoint and sets `agent="multimodal-demo"` (the slug registered below).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -33,17 +34,17 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit-ogui/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // Dedicated runtime for the Open Generative UI demos.
 //
@@ -29,9 +30,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // Server-side config is identical for the minimal and advanced cells --
       // the advanced behaviour (sandbox -> host function calls) is wired
       // entirely on the frontend via `openGenerativeUI.sandboxFunctions` on
@@ -49,9 +48,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/ms-agent-python/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/ms-agent-python/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent, BaseEvent } from "@ag-ui/client";
 import { EventType, FunctionMiddleware, HttpAgent } from "@ag-ui/client";
 import { Observable } from "rxjs";
@@ -696,16 +695,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -5,12 +5,12 @@
 //
 // Mirrors showcase/integrations/langgraph-python/src/app/api/copilotkit-a2ui-fixed-schema/route.ts.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -34,12 +34,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-agent-config/route.ts
@@ -23,9 +23,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -138,12 +137,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -11,9 +11,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -45,12 +44,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -10,9 +10,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -42,12 +41,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -6,13 +6,14 @@
 // `src/agent_server.py`); only the user-facing slug + route surface were
 // renamed to match the LGP canonical demo.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -32,12 +33,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -6,12 +6,12 @@
 // agent ID retains its legacy name). PydanticAI backend mounts the
 // underlying agent at `/byoc_json_render/` (see `src/agent_server.py`).
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -29,12 +29,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-mcp-apps/route.ts
@@ -13,13 +13,14 @@
 // Reference:
 // https://docs.copilotkit.ai/integrations/langgraph/generative-ui/mcp-apps
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -64,12 +65,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-multimodal/route.ts
@@ -6,13 +6,14 @@
 // model (gpt-4o) scoped to this one demo so other cells keep their
 // cheaper, text-only models.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -23,15 +24,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit-ogui/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // Dedicated runtime for the Open Generative UI demos.
 // Isolated here because the `openGenerativeUI` runtime flag sets
@@ -45,12 +46,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     return NextResponse.json(

--- a/showcase/integrations/pydantic-ai/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/pydantic-ai/src/app/api/copilotkit/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 import crypto from "node:crypto";
 
 // The agent backend runs as a separate process on port 8000.
@@ -130,16 +131,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -6,13 +6,14 @@
 // pins the Title, Airport, Arrow, AirlineBadge, PriceTag, and Button
 // components to React renderers.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -31,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-agent-config/route.ts
@@ -4,13 +4,14 @@
 // forwardedProps (tone, expertise, responseLength) off the AG-UI envelope
 // and rebuilds the SpringAIAgent's system prompt per request.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -31,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -54,12 +53,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -5,13 +5,14 @@
 // dedicated controller at /byoc-json-render/run whose system prompt instructs
 // the LLM to emit a flat-spec JSON object matching the catalog's schema.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -32,12 +33,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -10,9 +10,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 
@@ -28,9 +27,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- see main route.ts
         agents,
@@ -42,8 +39,10 @@ export const POST = async (req: NextRequest) => {
           defaultCatalogId: "declarative-gen-ui-catalog",
         },
       }),
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -9,13 +9,14 @@
 // this route proxies to it rather than the generic "/" agent. The page
 // mounts <CopilotKit agent="declarative-hashbrown-demo">.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -31,15 +32,15 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts
+        // @ts-ignore -- see main route.ts
         agents,
       }),
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -8,13 +8,14 @@
 // canonical `declarative-json-render`; the agent ID retains its legacy
 // `byoc_json_render` name.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -29,18 +30,18 @@ const agents: Record<string, AbstractAgent> = {
 };
 
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts
+  // @ts-ignore -- see main route.ts
   agents,
 });
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-mcp-apps/route.ts
@@ -11,13 +11,14 @@
 // tools via the standard `tools` field in the AG-UI request; the MCP
 // activity rendering is driven entirely by the runtime + frontend.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -52,12 +53,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-multimodal/route.ts
@@ -8,13 +8,14 @@
 // `UserMessage.media` list is integration-dependent — see PARITY_NOTES.md
 // for the current state.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -35,12 +36,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-ogui/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // Dedicated runtime for Open Generative UI demos.
 //
@@ -33,9 +34,7 @@ const agents: Record<string, AbstractAgent> = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       // Server-side config is identical for the minimal and advanced cells —
@@ -53,9 +52,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const err = error as Error;
     console.error(`[copilotkit-ogui/route] ERROR: ${err.message}`);

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-shared-state-read-write/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-shared-state-read-write/route.ts
@@ -5,13 +5,14 @@
 // to compose its system prompt and exposes a `set_notes` tool that mutates
 // the `notes` slot of state and emits a STATE_SNAPSHOT back to the frontend.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -32,12 +33,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-shared-state-read-write",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-shared-state-read-write",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-shared-state-streaming/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-shared-state-streaming/route.ts
@@ -4,13 +4,14 @@
 // tool-call arguments for write_document and emits STATE_SNAPSHOT events with
 // the growing document text so the frontend sees per-token updates.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -31,12 +32,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-shared-state-streaming",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-shared-state-streaming",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit-subagents/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit-subagents/route.ts
@@ -5,13 +5,14 @@
 // sub-agents (each its own ChatClient call) and emits STATE_SNAPSHOT events
 // after every delegation so the live "delegation log" panel updates.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
 
@@ -32,12 +33,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-subagents",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-subagents",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/spring-ai/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/spring-ai/src/app/api/copilotkit/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // The Spring AI agent backend runs as a separate Java process.
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
@@ -132,18 +133,18 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+        // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
         // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
         // plain Records. Fixed in source, pending release.
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -4,9 +4,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -28,9 +27,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -46,8 +43,10 @@ export const POST = async (req: NextRequest) => {
           defaultCatalogId: "copilotkit://flight-fixed-catalog",
         },
       }),
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -5,9 +5,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -30,9 +29,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -42,8 +39,10 @@ export const POST = async (req: NextRequest) => {
         // Strands adapter then auto-injects `generate_a2ui` and runs the
         // recovery loop the A2UIMiddleware renders.
       }),
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-agent-config/route.ts
@@ -9,9 +9,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -28,15 +27,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -58,12 +57,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -5,9 +5,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -29,9 +28,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -41,8 +38,10 @@ export const POST = async (req: NextRequest) => {
         // Strands adapter then auto-injects `generate_a2ui` from the forwarded
         // flag and drives the render planner the A2UIMiddleware paints.
       }),
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -33,15 +32,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -14,9 +14,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -33,15 +32,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-mcp-apps/route.ts
@@ -19,9 +19,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -48,7 +47,7 @@ const agents = {
 // `activity` event that the built-in `MCPAppsActivityRenderer` renders
 // inline in the chat.
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+  // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
   // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
   // plain Records. Fixed in source, pending release.
   agents,
@@ -69,12 +68,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-multimodal/route.ts
@@ -10,9 +10,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -29,15 +28,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit-ogui/route.ts
@@ -9,9 +9,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -31,9 +30,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
@@ -44,9 +41,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands-typescript/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/strands-typescript/src/app/api/copilotkit/route.ts
@@ -2,9 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import type { AbstractAgent, HttpAgentConfig } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -144,16 +143,16 @@ export const POST = async (req: NextRequest) =>
     }
 
     try {
-      const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-        endpoint: "/api/copilotkit",
-        serviceAdapter: new ExperimentalEmptyAdapter(),
+      const copilotHandler = createCopilotRuntimeHandler({
         runtime: new CopilotRuntime({
           // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
           agents,
         }),
+        basePath: "/api/copilotkit",
+        mode: "single-route",
       });
 
-      const response = await handleRequest(req);
+      const response = await copilotHandler(req);
       if (!response.ok) {
         console.log(`[copilotkit/route] Response status: ${response.status}`);
       } else if (ROUTE_DEBUG) {

--- a/showcase/integrations/strands/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-a2ui-fixed-schema/route.ts
@@ -4,9 +4,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -28,9 +27,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-fixed-schema",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -46,8 +43,10 @@ export const POST = async (req: NextRequest) => {
           defaultCatalogId: "copilotkit://flight-fixed-catalog",
         },
       }),
+      basePath: "/api/copilotkit-a2ui-fixed-schema",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-a2ui-recovery/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-a2ui-recovery/route.ts
@@ -5,9 +5,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -30,9 +29,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-a2ui-recovery",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -42,8 +39,10 @@ export const POST = async (req: NextRequest) => {
         // Strands adapter then auto-injects `generate_a2ui` and runs the
         // recovery loop the A2UIMiddleware renders.
       }),
+      basePath: "/api/copilotkit-a2ui-recovery",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-agent-config/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-agent-config/route.ts
@@ -5,12 +5,12 @@
 // its own endpoint so the Playwright spec can assert propagation against a
 // single URL.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -27,15 +27,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-agent-config",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-agent-config",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-beautiful-chat/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-beautiful-chat/route.ts
@@ -17,9 +17,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -58,12 +57,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-beautiful-chat",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-beautiful-chat",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/strands/src/app/api/copilotkit-byoc-hashbrown/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-byoc-hashbrown/route.ts
@@ -12,12 +12,12 @@
 // sub-paths (e.g. /byoc_hashbrown/), this route will swap to an HttpAgent
 // pointing at that sub-path.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -34,15 +34,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-byoc-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-byoc-json-render/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-byoc-json-render/route.ts
@@ -1,11 +1,11 @@
 // Dedicated runtime for the BYOC json-render demo.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -22,15 +22,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-byoc-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-byoc-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-gen-ui/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-gen-ui/route.ts
@@ -5,9 +5,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -29,9 +28,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-gen-ui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
@@ -41,8 +38,10 @@ export const POST = async (req: NextRequest) => {
         // Strands adapter then auto-injects `generate_a2ui` from the forwarded
         // flag and drives the render planner the A2UIMiddleware paints.
       }),
+      basePath: "/api/copilotkit-declarative-gen-ui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-hashbrown/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-hashbrown/route.ts
@@ -10,12 +10,12 @@
 // the canonical `declarative-hashbrown` surface; the page mounts
 // <CopilotKit agent="declarative-hashbrown-demo">.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -32,15 +32,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-hashbrown",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-declarative-hashbrown",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/strands/src/app/api/copilotkit-declarative-json-render/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-declarative-json-render/route.ts
@@ -10,12 +10,12 @@
 // `declarative-json-render`; the agent ID retains its legacy
 // `byoc_json_render` name.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -32,15 +32,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-declarative-json-render",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
-        // @ts-expect-error -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
+        // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-declarative-json-render",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     console.error(

--- a/showcase/integrations/strands/src/app/api/copilotkit-mcp-apps/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-mcp-apps/route.ts
@@ -15,12 +15,12 @@
 // Reference (langgraph-python sibling):
 // showcase/integrations/langgraph-python/src/app/api/copilotkit-mcp-apps/route.ts
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -47,7 +47,7 @@ const agents = {
 // `activity` event that the built-in `MCPAppsActivityRenderer` renders
 // inline in the chat.
 const runtime = new CopilotRuntime({
-  // @ts-expect-error -- see main route.ts; published CopilotRuntime's `agents`
+  // @ts-ignore -- see main route.ts; published CopilotRuntime's `agents`
   // type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects
   // plain Records. Fixed in source, pending release.
   agents,
@@ -68,12 +68,12 @@ const runtime = new CopilotRuntime({
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-mcp-apps",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime,
+      basePath: "/api/copilotkit-mcp-apps",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-multimodal/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-multimodal/route.ts
@@ -6,12 +6,12 @@
 // (served by agent_server.py on port 8000); this route just registers the
 // demo's slug against the same HttpAgent proxy as the main route.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -28,15 +28,15 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-multimodal",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit-multimodal",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit-ogui/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit-ogui/route.ts
@@ -5,12 +5,12 @@
 // causes the CopilotKit provider's setTools effect to wipe per-demo
 // `useFrontendTool`/`useComponent` registrations in the default runtime.
 
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 import { HttpAgent } from "@ag-ui/client";
 
 const AGENT_URL = process.env.AGENT_URL || "http://localhost:8000";
@@ -30,9 +30,7 @@ const agents = {
 
 export const POST = async (req: NextRequest) => {
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit-ogui",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       // @region[minimal-runtime-flag]
       // @region[advanced-runtime-config]
       runtime: new CopilotRuntime({
@@ -43,9 +41,11 @@ export const POST = async (req: NextRequest) => {
         },
       }),
       // @endregion[advanced-runtime-config]
-      // @endregion[minimal-runtime-flag]
+      // @endregion[minimal-runtime-flag],
+      basePath: "/api/copilotkit-ogui",
+      mode: "single-route",
     });
-    return await handleRequest(req);
+    return await copilotHandler(req);
   } catch (error: unknown) {
     const e = error as { message?: string; stack?: string };
     return NextResponse.json(

--- a/showcase/integrations/strands/src/app/api/copilotkit/route.ts
+++ b/showcase/integrations/strands/src/app/api/copilotkit/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
-import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
+import type { AbstractAgent } from "@ag-ui/client";
+import { HttpAgent } from "@ag-ui/client";
 
 // The agent backend runs as a separate process on port 8000.
 // This runtime proxies CopilotKit requests to it via AG-UI protocol.
@@ -106,16 +107,16 @@ export const POST = async (req: NextRequest) => {
   }
 
   try {
-    const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
-      endpoint: "/api/copilotkit",
-      serviceAdapter: new ExperimentalEmptyAdapter(),
+    const copilotHandler = createCopilotRuntimeHandler({
       runtime: new CopilotRuntime({
         // @ts-ignore -- Published CopilotRuntime agents type wraps Record in MaybePromise<NonEmptyRecord<...>> which rejects plain Records; fixed in source, pending release
         agents,
       }),
+      basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    const response = await handleRequest(req);
+    const response = await copilotHandler(req);
     if (!response.ok) {
       console.log(`[copilotkit/route] Response status: ${response.status}`);
     } else if (ROUTE_DEBUG) {


### PR DESCRIPTION
Retires the v1 runtime adapter from `showcase/integrations/`. After this, **no code under `showcase/integrations/` calls `copilotRuntimeNextJSAppRouterEndpoint`** — 239 routes across 20 integrations.

This is the cheap path we discussed: single-route mode, which is a genuine drop-in. **No demo page changes, no route path changes, no `GET` exports, no new dependencies.**

## The shape

```ts
const copilotHandler = createCopilotRuntimeHandler({
  runtime,
  basePath: "/api/copilotkit-x",
  mode: "single-route",
});
...
return await copilotHandler(req);
```

**Why single-route:** these demos' frontends are `<CopilotKit runtimeUrl="/api/copilotkit-x">` with no transport prop, and every released provider pins the single-route transport. So single-route mode is what the v1 adapter was already serving. Migrating to multi-route instead would have meant editing every demo page in lockstep, for no functional gain — nothing in the showcase probes `/info`.

**Why `createCopilotRuntimeHandler`** rather than `createCopilotEndpointSingleRoute`: that helper is itself deprecated in favour of the `mode` option (per the deprecated-aliases table in `docs/backend/runtime-endpoints.mdx`), and the fetch handler needs no `hono` dependency and composes directly with the wrappers these routes already have.

The statement is rewritten **in place**, inside whatever wrapper it already sat in, so `withForwardedHeaders`, the try/catch envelopes, `wrapStreamingResponse` and `withCvdiagBackend` are untouched. 75 of these routes construct the runtime inline in the call; rewriting in place preserves that per-request construction exactly as v1 did. No `runner` is added — it's optional and none of these routes passed one.

13 `copilotkit-auth/[[...slug]]` routes already use the v2 fetch handler and are left alone; they only name v1 in comments.

## Verified

The shape was proved end-to-end **before** the rollout, in a real running app with an untouched provider (aimock as the model backend): `POST /api/copilotkit` → 200 twice, chat turn rendered in the browser. It also typechecks against the exact version these integrations pin (1.68.2).

`mastra` is the integration installed and exercised locally — 19 routes, the `withCvdiagBackend` main route, and the only vitest suites that touch routes. Measured against `origin/main` **in the same tree**:

| | baseline (`origin/main`) | after |
| --- | --- | --- |
| `tsc --noEmit` | errors in 10 files | errors in **9** |
| `vitest run` | 2 files / 13 tests failed, 21 passed | 2 files / 13 tests failed, 21 passed |

- **New type errors introduced: none.**
- **Fixed:** `src/app/api/copilotkit-mcp-apps/route.ts`, whose `@ts-expect-error` was *already* unused on `main`.
- **Test-neutral:** those 13 failures are pre-existing on `main` (mostly `extractXHeaders` dereferencing `req.headers` on a `{}` fake request).

Structural audit over all 239 routes, re-run after the pre-commit formatter: none still imports the v1 root, calls the v1 adapter, references `ExperimentalEmptyAdapter` or `handleRequest` in code, or is missing `createCopilotRuntimeHandler` / `basePath` / `mode: "single-route"`.

**CI has now built all 21 integrations green** — `showcase_build_check` Docker-builds each changed integration and `next build` typechecks inside it. That covers the ones I could not stand up locally, including the non-JS backends (`spring-ai`, `ms-agent-dotnet`, `ms-agent-python`, `ms-agent-harness-dotnet`, `langroid`, `strands`). Full run: 41 pass / 3 skip / 0 fail.

To be precise about what each gate proves: CI proves these 21 apps still **build and typecheck**. It does not exercise a chat turn per integration — that came from the pre-rollout live proof of the shape itself, plus mastra's local test suite.

## Runtime verification on real cells

Docker is not running on my machine, and `bin/showcase test --d6 --direct` requires it
(`--direct` only swaps the in-process driver for the fleet control-plane; the containers are
not optional). **So the sanctioned Iron Rule 4 probe has NOT been run** — that gap is real and
a reviewer should weigh it. What I did instead was run a real integration directly.

`showcase/integrations/mastra` on this branch, `npm run dev`, aimock as the model backend.
Probing eight migrated routes with the exact envelope the released provider sends
(`POST {basePath}` with `{"method":"info"}`) — all **200** with real runtime payloads:

    copilotkit-multimodal          200   agents: multimodal-demo
    copilotkit-mcp-apps            200   agents: headless-complete
    copilotkit-a2ui-fixed-schema   200   agents: a2ui-fixed-schema
    copilotkit-beautiful-chat      200   agents: beautiful-chat
    copilotkit-agent-config        200   agents: agent-config-demo
    copilotkit-ogui                200   agents: open-gen-ui
    copilotkit-declarative-gen-ui  200   agents: declarative-gen-ui
    copilotkit-background-agents   200   agents: background-agents

Then three real demo cells driven in a browser, each rendering and completing a chat turn
through its migrated route (two POSTs, both 200, assistant message rendered):

    /demos/beautiful-chat      -> POST /api/copilotkit-beautiful-chat     200, 200
    /demos/a2ui-fixed-schema   -> POST /api/copilotkit-a2ui-fixed-schema  200, 200
    /demos/multimodal          -> POST /api/copilotkit-multimodal         200, 200

Deliberately spread across different route configs — plain, `a2ui`, and a dedicated
vision-model route — rather than three variations of the same one.

### One route is 500, and it is pre-existing

`POST /api/copilotkit` (mastra's main route) returns 500 in dev: `module-not-found` on
`./schema.js` from `src/cvdiag/cvdiag-emitter.ts`. `schema.ts` **is** tracked and present —
Turbopack in dev just does not resolve the ESM-style `.js` specifier to it. Proven
pre-existing by restoring **only** that file to `origin/main` and re-probing: same 500 on the
v1 code. Its Docker build passes, which is why CI is green.

### A mistake in my own verification, recorded

My first pass at the above ran against the wrong branch — I was still on the docs branch,
where these routes are v1, so the first six 200s I collected were the **v1** routes. Caught it,
switched to this branch, and re-ran everything above against the migrated code. The accidental
run was not wasted: it independently confirms the premise of this PR, that the v1 adapter and
v2 single-route mode answer the same envelope the same way.

## Judgement call worth reviewing

27 `@ts-expect-error` directives guarded the **v1** `CopilotRuntime` agents type ("wraps `Record` in `MaybePromise<NonEmptyRecord<...>>`"). Under `/v2` that hole is gone, which makes the directive *unused* — a hard compile error.

I demoted them to `@ts-ignore`, which compiles whether or not the mismatch survives in a given integration. The honest reason at the time: 19 of these apps can't be built locally, so I couldn't prove per-file which still need a suppression, and `@ts-ignore` is what 190 sibling files already use.

Now that CI has built all 21 green, that constraint is gone — the ~220 now-stale suppressions (all of which cite a **v1** type hole that no longer applies) can be removed and verified by the same 21 builds. I've left them in place here to keep this PR mechanical and reviewable; say the word and I'll do it as a second pass.

## Two pre-existing problems found on the way

- **`npm ci` fails in `showcase/integrations/mastra`**: `Missing: @types/http-errors@2.0.5 from lock file`. The Dockerfile uses `npm ci --legacy-peer-deps`, which *does* succeed, so the image still builds — but a plain `npm ci` doesn't. No manifest or lockfile is in this diff.
- **`mastra`'s vitest suite is red on `main`** — 13 failures, as tabled above.

## What's left of the v1 entrypoint

| Surface | Before | After |
| --- | --- | --- |
| `showcase/integrations/**` | 239 | **0** |
| `examples/v1/**` | 12 | 12 (deliberately v1, never in scope) |
| everything else in `examples/` | ~61 | ~61 (not in this PR) |

Stacks cleanly with #6617 (docs) — no file overlap. It also **unblocks the two Claude SDK quickstart pages** I had to revert there: single-route keeps the starter file at the plain `route.ts` path, so those pages' prose claims and `verify-shell-docs.ts` starter-path checks stay valid, and only the fence body needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
