### PR TITLE
fix(showcase): register CrewAI flows production instance

### DIFF
--- a/.github/workflows/showcase_promote.yml
+++ b/.github/workflows/showcase_promote.yml
@@ -39,6 +39,7 @@ on:
           - built-in-agent
           - claude-sdk-python
           - claude-sdk-typescript
+          - crewai-conversational-flows
           - crewai-crews
           - google-adk
           - langgraph-fastapi

--- a/showcase/RAILWAY.md
+++ b/showcase/RAILWAY.md
@@ -91,7 +91,10 @@ so it validates the staging instance and canonical GHCR image without requiring
 a prod instance. Older staging-first entries used a temporary `gateIgnore`
 exemption; do not copy that historical pattern.
 
-`showcase-crewai-conversational-flows` is the current worked example.
+`showcase-crewai-conversational-flows` followed this staging-first path before
+its prod instance was provisioned and recorded in the SSOT. Treat it as a
+completed example; its current dual-environment entry is not a staging-only
+template.
 
 ### The critical gotcha (read this first)
 

--- a/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
+++ b/showcase/bin/spec/test_promote_single_service_fleet_invariants.rb
@@ -251,6 +251,23 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
         Railway::PromoteCommand.new(argv + ["--non-interactive", "--yes"])
     end
 
+    # No live service is single-environment today. Inject a minimal synthetic
+    # SSOT record so the parity behavior for future staging-first rollouts stays
+    # covered without coupling this unit test to whichever slug is currently in
+    # that rollout phase.
+    def build_cmd_with_staging_only_ssot_service(service)
+        cmd = build_cmd([])
+        live_ssot_lookup = cmd.method(:ssot_service)
+        cmd.define_singleton_method(:ssot_service) do |name|
+            if name == service
+                { "name" => name, "onlyEnvironment" => "staging" }
+            else
+                live_ssot_lookup.call(name)
+            end
+        end
+        cmd
+    end
+
     # Zero the promote retry back-off for the duration of the block so the 3x
     # eventual-consistency retry loop in pin_and_verify doesn't add real wall
     # time. RETRY_DELAY_SEC is a process-global constant, so this is a global
@@ -429,12 +446,14 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
     # by the SSOT. This keeps a staging-first rollout from blocking the documented
     # no-argument promote path without hiding unknown fleet drift.
     def test_full_fleet_parity_tolerates_ssot_declared_staging_only_service
+        service = "showcase-staging-only-fixture"
         staging = {
-            "services" => [{ "name" => "showcase-crewai-conversational-flows" }],
+            "services" => [{ "name" => service }],
         }
         prod = { "services" => [] }
 
-        findings = build_cmd([]).check_service_set_parity(staging, prod)
+        cmd = build_cmd_with_staging_only_ssot_service(service)
+        findings = cmd.check_service_set_parity(staging, prod)
 
         assert_empty findings
     end
@@ -449,11 +468,12 @@ class PromoteSingleServiceFleetInvariantsTest < Minitest::Test
     end
 
     def test_targeted_promote_still_refuses_ssot_declared_staging_only_service
-        service = "showcase-crewai-conversational-flows"
+        service = "showcase-staging-only-fixture"
         staging = { "services" => [{ "name" => service }] }
         prod = { "services" => [] }
 
-        findings = build_cmd([service]).check_service_set_parity(
+        cmd = build_cmd_with_staging_only_ssot_service(service)
+        findings = cmd.check_service_set_parity(
             staging, prod, target: service,
         )
 

--- a/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
+++ b/showcase/scripts/__tests__/fixtures/railway-envs.golden.json
@@ -208,6 +208,13 @@
     }
   },
   "showcase-crewai-conversational-flows": {
+    "prod": {
+      "instanceId": "209031fe-2e02-4fbb-8f12-1276457d1916",
+      "domain": "showcase-crewai-conversational-flows-production.up.railway.app",
+      "probe": true,
+      "driver": "agent",
+      "repoName": "showcase-crewai-conversational-flows"
+    },
     "staging": {
       "instanceId": "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
       "domain": "showcase-crewai-conversational-flows-staging.up.railway.app",

--- a/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
+++ b/showcase/scripts/__tests__/verify-railway-image-refs.test.ts
@@ -270,40 +270,49 @@ describe("WS-C: all gate-managed services gateValidated, with correct overrides"
   it("findMissingServices treats every gateValidated service as a target, per the envs it declares", () => {
     // With nothing "present", every gateValidated service should appear in
     // the missing set for each env it DECLARES. All dual-env gateValidated
-    // services (the 29 showcase/infra + 12 starters that carry both prod and
-    // staging) are demanded in BOTH envs. The lone single-env gateValidated
-    // service — showcase-crewai-conversational-flows, live in staging only —
-    // is demanded ONLY in staging, so the counts are intentionally asymmetric:
-    //   prod    = 41 (the dual-env services; the staging-only one is skipped)
-    //   staging = 42 (the dual-env services PLUS the staging-only one)
+    // services (the 30 showcase/infra + 12 starters) now carry both prod and
+    // staging and are demanded in BOTH envs.
     const missingProd = findMissingServices("prod", new Set<string>());
     const missingStaging = findMissingServices("staging", new Set<string>());
-    expect(missingProd).toHaveLength(41);
+    expect(missingProd).toHaveLength(42);
     expect(missingStaging).toHaveLength(42);
-    // The staging-only service is required in staging but NOT prod.
+    // CrewAI Conversational Flows is now required in both envs.
     expect(missingStaging).toContain("showcase-crewai-conversational-flows");
-    expect(missingProd).not.toContain("showcase-crewai-conversational-flows");
+    expect(missingProd).toContain("showcase-crewai-conversational-flows");
     // The 12 starters are still demanded in BOTH envs.
     expect(missingProd).toContain("starter-adk");
     expect(missingStaging).toContain("starter-mastra");
   });
 
-  it("validates the staging-only CrewAI service against its canonical GHCR tag", () => {
+  it("validates dual-env CrewAI image refs against its canonical GHCR repo", () => {
     const service = "showcase-crewai-conversational-flows";
-    const repo = repoNameFor(service, "staging");
+    const stagingRepo = repoNameFor(service, "staging");
+    const prodRepo = repoNameFor(service, "prod");
 
     expect(
-      validateImage(`ghcr.io/copilotkit/${repo}:latest`, {
+      validateImage(`ghcr.io/copilotkit/${stagingRepo}:latest`, {
         env: "staging",
-        repoName: repo,
+        repoName: stagingRepo,
       }),
     ).toBeNull();
     expect(
       validateImage("ghcr.io/copilotkit/showcase-wrong:latest", {
         env: "staging",
-        repoName: repo,
+        repoName: stagingRepo,
       })?.reason,
     ).toMatch(/repo name mismatches expected/);
+    expect(
+      validateImage(`ghcr.io/copilotkit/${prodRepo}@sha256:${"a".repeat(64)}`, {
+        env: "prod",
+        repoName: prodRepo,
+      }),
+    ).toBeNull();
+    expect(
+      validateImage(`ghcr.io/copilotkit/${prodRepo}:latest`, {
+        env: "prod",
+        repoName: prodRepo,
+      })?.reason,
+    ).toMatch(/prod must be pinned/);
   });
 });
 

--- a/showcase/scripts/emit-railway-envs-json.test.ts
+++ b/showcase/scripts/emit-railway-envs-json.test.ts
@@ -91,7 +91,7 @@ describe("emit-railway-envs-json closure block", () => {
     expect(agent?.promoteTier).toBe(2);
   });
 
-  it("marks only single-environment services with their declared environment", () => {
+  it("omits onlyEnvironment after CrewAI conversational flows becomes dual-env", () => {
     const services = parsed.services as Array<{
       name: string;
       onlyEnvironment?: string;
@@ -101,7 +101,7 @@ describe("emit-railway-envs-json closure block", () => {
       services.find(
         (service) => service.name === "showcase-crewai-conversational-flows",
       )?.onlyEnvironment,
-    ).toBe("staging");
+    ).toBeUndefined();
     expect(
       services.find((service) => service.name === "showcase-crewai-crews")
         ?.onlyEnvironment,

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -437,19 +437,18 @@
     {
       "name": "showcase-crewai-conversational-flows",
       "serviceId": "11859593-da4e-486c-a810-6cdffeff9750",
-      "prodInstanceId": "11859593-da4e-486c-a810-6cdffeff9750",
+      "prodInstanceId": "209031fe-2e02-4fbb-8f12-1276457d1916",
       "stagingInstanceId": "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
       "ciBuilt": true,
       "gateValidated": true,
-      "onlyEnvironment": "staging",
       "dispatchName": "crewai-conversational-flows",
       "domains": {
         "staging": "showcase-crewai-conversational-flows-staging.up.railway.app",
-        "prod": ""
+        "prod": "showcase-crewai-conversational-flows-production.up.railway.app"
       },
       "probe": {
         "staging": true,
-        "prod": false,
+        "prod": true,
         "driver": "agent"
       },
       "promoteTier": 2,
@@ -461,6 +460,7 @@
         }
       ],
       "healthcheckPath": {
+        "prod": "/api/health",
         "staging": "/api/health"
       },
       "autoUpdates": {
@@ -1474,6 +1474,10 @@
         "tier": 2
       },
       {
+        "name": "showcase-crewai-conversational-flows",
+        "tier": 2
+      },
+      {
         "name": "showcase-crewai-crews",
         "tier": 2
       },
@@ -1582,11 +1586,6 @@
         "tier": 2
       }
     ],
-    "skipped": [
-      {
-        "name": "showcase-crewai-conversational-flows",
-        "reason": "no \"prod\" environment in the SSOT — cannot be promoted (it exists in: staging)."
-      }
-    ]
+    "skipped": []
   }
 }

--- a/showcase/scripts/railway-envs.test.ts
+++ b/showcase/scripts/railway-envs.test.ts
@@ -112,7 +112,7 @@ describe("railway-envs SSOT", () => {
     expect(names.length).toBe(42);
   });
 
-  it("models CrewAI conversational flows as a staging-first showcase deployment", () => {
+  it("models CrewAI conversational flows as a dual-environment showcase deployment", () => {
     const name = "showcase-crewai-conversational-flows";
     const entry = SERVICES[name];
 
@@ -127,7 +127,12 @@ describe("railway-envs SSOT", () => {
     expect(entry.serviceRefs).toEqual([
       { key: "OPENAI_BASE_URL", target: "aimock" },
     ]);
-    expect(envsFor(name)).toEqual(["staging"]);
+    expect(envsFor(name)).toEqual(["prod", "staging"]);
+    expect(domainFor(name, "prod")).toBe(
+      "showcase-crewai-conversational-flows-production.up.railway.app",
+    );
+    expect(healthcheckPathFor(name, "prod")).toBe("/api/health");
+    expect(probeEnabled(name, "prod")).toBe(true);
     expect(domainFor(name, "staging")).toBe(
       "showcase-crewai-conversational-flows-staging.up.railway.app",
     );
@@ -248,10 +253,10 @@ describe("railway-envs SSOT", () => {
   });
 
   it("CI_BUILT_SERVICES contains exactly 40 services (incl. pocketbase + 12 starters) and excludes webhooks", () => {
-    // 28 showcase/infra CI-built (incl. the staging-only
-    // showcase-crewai-conversational-flows) + 12 starter-<slug> (S2 brought them under
-    // the gate; they ARE built+pushed by showcase_build.yml's `build-starters`
-    // job to ghcr.io/copilotkit/starter-<slug>:latest).
+    // 28 showcase/infra CI-built (including conversational flows) + 12
+    // starter-<slug> (S2 brought them under the gate; they ARE built+pushed by
+    // showcase_build.yml's `build-starters` job to
+    // ghcr.io/copilotkit/starter-<slug>:latest).
     expect(CI_BUILT_SERVICES.size).toBe(40);
     // pocketbase is now CI-built (showcase_build.yml `pocketbase` slot,
     // gated to showcase/pocketbase/** changes).

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -1065,13 +1065,18 @@ export const SERVICES: Record<
     // closure — same wiring as its `showcase-crewai-crews` sibling.
     runtimeDeps: ["aimock"],
     serviceRefs: [{ key: "OPENAI_BASE_URL", target: "aimock" }],
-    // STAGING-ONLY: the live Railway service currently has a serviceInstance in
-    // staging only (no prod instance is provisioned). The env-map schema models
-    // a single-env service by declaring only the env that exists — the image-ref
-    // gate then requires it in staging (findMissingServices) and never demands a
-    // (non-existent) prod instance. All values below are read verbatim from the
-    // live Railway service, not derived.
+    // The production serviceInstance was provisioned from staging via Railway
+    // environment sync, then deployed and health-verified. Both env entries
+    // below are read verbatim from the live Railway service so the image-ref
+    // gate and promote workflow now manage the integration in both envs.
     environments: {
+      prod: {
+        instanceId: "209031fe-2e02-4fbb-8f12-1276457d1916",
+        healthcheckPath: "/api/health",
+        domain:
+          "showcase-crewai-conversational-flows-production.up.railway.app",
+        probe: true,
+      },
       staging: {
         instanceId: "3d44daba-b417-4c6c-a366-d1b94e5fe8fa",
         healthcheckPath: "/api/health",

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -68,7 +68,7 @@ describe("runRedeploy", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    // 40 CI-built (28 showcase/infra incl. staging-only conversational flows,
+    // 40 CI-built (28 showcase/infra incl. conversational flows,
     // + 12 starters) + harness-workers (imageOf consumer of showcase-harness)
     // = 41. All 40 declare staging, so the env-aware
     // default scope keeps every one of them.
@@ -143,14 +143,15 @@ describe("runRedeploy", () => {
     ]);
   });
 
-  it("default prod scope includes the dual-env worker (harness-workers) and dual-env showcase-strands-typescript", async () => {
+  it("default prod scope includes the dual-env worker, Strands TS, and CrewAI conversational flows", async () => {
     // The default scope is env-aware: a service joins the prod scope when it
     // declares a prod env. harness-workers is now dual-env (the prod worker was
     // backfilled into the SSOT), so the env-aware imageOf expansion pulls it
     // into the prod scope as a showcase-harness consumer. showcase-strands-typescript
-    // is also dual-env and joins. The prod default = the 40 services that
-    // declare prod (27 CI-built showcase/infra incl. showcase-strands-typescript
-    // + 12 starters + the imageOf-consumer harness-workers).
+    // is also dual-env and joins. CrewAI Conversational Flows now has a prod
+    // instance and joins too. The prod default = the 41 services that declare
+    // prod (28 CI-built showcase/infra + 12 starters + the imageOf-consumer
+    // harness-workers).
     const seenNames: string[] = [];
     const redeploy = vi.fn(async (serviceId: string) => {
       const name = Object.entries(SERVICES).find(
@@ -164,15 +165,14 @@ describe("runRedeploy", () => {
       redeploy,
       appendSummary,
     });
-    expect(result.attempted).toBe(40);
+    expect(result.attempted).toBe(41);
     // harness-workers is now dual-env, so a prod redeploy of its showcase-harness
     // image bounces the prod worker too (it used to be silently skipped).
     expect(seenNames).toContain("harness-workers");
     // showcase-strands-typescript is dual-env, so it joins the prod scope.
     expect(seenNames).toContain("showcase-strands-typescript");
-    // CrewAI Conversational Flows is staging-only until its prod instance is
-    // provisioned, so env-aware default redeploys must not target it in prod.
-    expect(seenNames).not.toContain("showcase-crewai-conversational-flows");
+    // CrewAI Conversational Flows is now dual-env, so it joins the prod scope.
+    expect(seenNames).toContain("showcase-crewai-conversational-flows");
     // S2: starters ARE in the default prod scope (CI-built, dual-env).
     expect(seenNames).toContain("starter-adk");
   });
@@ -579,7 +579,7 @@ describe("resolveTargetServices", () => {
 
   it("returns the CI_BUILT_SERVICES set sorted when given undefined", () => {
     const resolved = resolveTargetServices(undefined);
-    // 28 showcase/infra CI-built (incl. staging-only conversational flows) +
+    // 28 showcase/infra CI-built (incl. conversational flows) +
     // 12 starters = 40. resolveTargetServices returns the FULL CI_BUILT set;
     // the env-aware narrowing happens later in runRedeploy, not here.
     expect(resolved.length).toBe(40);


### PR DESCRIPTION
## Summary

- register the provisioned `showcase-crewai-conversational-flows` production Railway service instance, domain, health path, and probe in the Railway SSOT
- regenerate the promotion closure and workflow service selector so the integration can be promoted through the standard runbook path
- update SSOT, image-reference, generator, and environment-aware redeploy tests for dual-environment coverage
- recast the staging-only runbook reference as a completed staging-to-production example

This deliberately does not mark the integration manifest as deployed or perform another Railway mutation. It only reconciles the already-running production instance into source control.

## Live verification

- production `/api/health` returns HTTP 200
- production and staging run the same image digest: `sha256:e6f38a9454f8ae9410239bb3cc75d21b0d2ccecbbbfe789b25a9f2d9f03139b4`
- all 84 environment-scoped Railway image refs verified
- `autoUpdates` verified disabled across all 84 service/environment checks
- promotion dry-run resolves the production target to the pinned digest above

## Local verification

- `pnpm exec tsc --noEmit -p showcase/scripts/tsconfig.json`
- uncached Nx test run: 77 files, 2,519 tests passed
- Railway Ruby suite: 188 runs, 723 assertions passed
- `pnpm lint` (0 errors)
- `actionlint .github/workflows/showcase_promote.yml`
- `pnpm exec tsx showcase/scripts/emit-railway-envs-json.ts --check`
- `pnpm exec tsx showcase/scripts/sync-promote-service-options.ts --check`
