### PR TITLE
fix(telemetry): install registry outside parent workspace

### DIFF
--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -83,7 +83,8 @@ jobs:
 
       # Regenerate the canonical alongside the fragment — the registry's reconcile
       # CI rejects a stale telemetry-events.json, so a fragment-only PR fails.
-      # Use the registry's own pnpm (its packageManager field).
+      # This checkout is nested in CopilotKit's pnpm workspace, so explicitly
+      # bypass that parent workspace and use the registry's own lockfile.
       - name: Setup pnpm for registry
         if: steps.token.outputs.token != ''
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -94,8 +95,8 @@ jobs:
         if: steps.token.outputs.token != ''
         working-directory: p2p
         run: |
-          pnpm install --frozen-lockfile
-          pnpm reconcile
+          pnpm --ignore-workspace install --frozen-lockfile
+          pnpm --ignore-workspace run reconcile
 
       - name: Open fragment PR
         if: steps.token.outputs.token != ''

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -84,7 +84,8 @@ jobs:
 
       # Regenerate the canonical alongside the fragment — the registry's reconcile
       # CI rejects a stale telemetry-events.json, so a fragment-only PR fails.
-      # Use the registry's own pnpm (its packageManager field).
+      # This checkout is nested in CopilotKit's pnpm workspace, so explicitly
+      # bypass that parent workspace and use the registry's own lockfile.
       - name: Setup pnpm for registry
         if: steps.token.outputs.token != ''
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -95,8 +96,8 @@ jobs:
         if: steps.token.outputs.token != ''
         working-directory: p2p
         run: |
-          pnpm install --frozen-lockfile
-          pnpm reconcile
+          pnpm --ignore-workspace install --frozen-lockfile
+          pnpm --ignore-workspace run reconcile
 
       - name: Open fragment PR
         if: steps.token.outputs.token != ''


### PR DESCRIPTION
## Problem

Telemetry fragment workflows install the nested oss-path-to-production checkout through CopilotKit's parent pnpm workspace. The checkout's own dependencies, including Node type declarations, are therefore not installed and reconciliation fails during TypeScript compilation.

## Why

pnpm discovers the parent workspace from p2p, reports the 70 CopilotKit workspace projects, and ignores the external registry's lockfile.

## Fix

Run install and reconciliation with the ignore-workspace option in both telemetry workflows, forcing pnpm to use the checked-out registry's package metadata and lockfile. Verified with a clean oss-path-to-production checkout.