### PR TITLE
fix(channels-telegram): emit language- form for tagged code fences

### DIFF
--- a/packages/channels-telegram/src/__tests__/telegram-html.test.ts
+++ b/packages/channels-telegram/src/__tests__/telegram-html.test.ts
@@ -68,3 +68,22 @@ describe("stripHtml", () => {
     expect(stripHtml("&amp;lt;")).toBe("&lt;");
   });
 });
+
+describe("telegramHtml: fenced code language tags (#6602)", () => {
+  it("emits Telegram language- form for tagged fences", () => {
+    expect(telegramHtml("```js\nconst a = 1;\n```")).toBe(
+      '<pre><code class="language-js">const a = 1;</code></pre>',
+    );
+  });
+  it("handles python and escapes code contents", () => {
+    expect(telegramHtml("```python\nif a < b:\n    pass\n```")).toBe(
+      '<pre><code class="language-python">if a &lt; b:\n    pass</code></pre>',
+    );
+  });
+  it("untagged fences stay plain <pre>", () => {
+    expect(telegramHtml("```\nplain\n```")).toBe("<pre>plain</pre>");
+  });
+  it("single-line ```code``` fences become inline <code>", () => {
+    expect(telegramHtml("```code```")).toBe("<code>code</code>");
+  });
+});

--- a/packages/channels-telegram/src/__tests__/telegram-html.test.ts
+++ b/packages/channels-telegram/src/__tests__/telegram-html.test.ts
@@ -86,4 +86,21 @@ describe("telegramHtml: fenced code language tags (#6602)", () => {
   it("single-line ```code``` fences become inline <code>", () => {
     expect(telegramHtml("```code```")).toBe("<code>code</code>");
   });
+  it("keeps language tokens that contain +, -, . or #", () => {
+    expect(telegramHtml("```c++\nx\n```")).toBe(
+      '<pre><code class="language-c++">x</code></pre>',
+    );
+    expect(telegramHtml("```objective-c\nx\n```")).toBe(
+      '<pre><code class="language-objective-c">x</code></pre>',
+    );
+    expect(telegramHtml("```asp.net\nx\n```")).toBe(
+      '<pre><code class="language-asp.net">x</code></pre>',
+    );
+  });
+  it("falls back to plain <pre> when the info string is not a language token", () => {
+    // An arbitrary info string must not become a class name. It is escaped
+    // either way, so this is about not emitting a meaningless attribute.
+    expect(telegramHtml("```<script>\nx\n```")).toBe("<pre>x</pre>");
+    expect(telegramHtml('```a"b\nx\n```')).toBe("<pre>x</pre>");
+  });
 });

--- a/packages/channels-telegram/src/telegram-html.ts
+++ b/packages/channels-telegram/src/telegram-html.ts
@@ -44,10 +44,25 @@ export function telegramHtml(input: string): string {
   // ── 1. Pull code regions out so we don't touch them. ──
   const codeRegions: string[] = [];
 
-  // Fenced code blocks first (```…```)
-  let body = input.replace(/```([\s\S]*?)```/g, (_match, inner: string) => {
-    const escaped = escapeHtml(inner.replace(/^\n/, "").replace(/\n$/, ""));
-    codeRegions.push(`<pre>${escaped}</pre>`);
+  // Fenced code blocks with an info string (```lang\n…```)
+  let body = input.replace(
+    /```([^\n`]*)\n([\s\S]*?)```/g,
+    (_match, info: string, inner: string) => {
+      const lang = info.trim().split(/\s+/)[0] ?? "";
+      const escaped = escapeHtml(inner.replace(/\n$/, ""));
+      codeRegions.push(
+        lang
+          ? `<pre><code class="language-${escapeHtml(lang)}">${escaped}</code></pre>`
+          : `<pre>${escaped}</pre>`,
+      );
+      return codePlaceholder(codeRegions.length - 1);
+    },
+  );
+
+  // Single-line ``` ```code``` ``` fences (no info string by definition)
+  body = body.replace(/```([^`\n]*)```/g, (_match, inner: string) => {
+    const escaped = escapeHtml(inner);
+    codeRegions.push(`<code>${escaped}</code>`);
     return codePlaceholder(codeRegions.length - 1);
   });
 

--- a/packages/channels-telegram/src/telegram-html.ts
+++ b/packages/channels-telegram/src/telegram-html.ts
@@ -14,7 +14,9 @@
  *   [text](url)      →  <a href="url">text</a>
  *   - bullet         →  •  bullet
  *   `code`           →  <code>code</code>
- *   ```…```          →  <pre>…</pre>
+ *   ```\n…```         →  <pre>…</pre>
+ *   ```lang\n…```     →  <pre><code class="language-lang">…</code></pre>
+ *   ```…``` (1 line)  →  <code>…</code>
  */
 
 /** Escape & < > " for use inside Telegram HTML text nodes and attributes. */
@@ -48,7 +50,11 @@ export function telegramHtml(input: string): string {
   let body = input.replace(
     /```([^\n`]*)\n([\s\S]*?)```/g,
     (_match, info: string, inner: string) => {
-      const lang = info.trim().split(/\s+/)[0] ?? "";
+      const rawLang = info.trim().split(/\s+/)[0] ?? "";
+      // Only a plausible language token becomes a class name. An arbitrary
+      // info string would otherwise land in the attribute (escaped, so not
+      // injectable, but meaningless to Telegram).
+      const lang = /^[\w+#.-]+$/.test(rawLang) ? rawLang : "";
       const escaped = escapeHtml(inner.replace(/\n$/, ""));
       codeRegions.push(
         lang


### PR DESCRIPTION
## Summary
- Tagged fenced code blocks (```js ... ```) now emit Telegram's `<pre><code class="language-js">` form instead of leaking the language token into the code body
- Untagged fences stay plain `<pre>`; single-line ``` ```code``` ``` fences become inline `<code>`
- Fixes #6602

## Test plan
- New vitest cases in `telegram-html.test.ts` (tagged/untagged/inline fences)
- Verified standalone via `node --experimental-strip-types`
