### PR TITLE
fix(react,vue): make popup positioning wrapper transparent

### DIFF
--- a/packages/channels-telegram/src/__tests__/telegram-html.test.ts
+++ b/packages/channels-telegram/src/__tests__/telegram-html.test.ts
@@ -68,3 +68,22 @@ describe("stripHtml", () => {
     expect(stripHtml("&amp;lt;")).toBe("&lt;");
   });
 });
+
+describe("telegramHtml: fenced code language tags (#6602)", () => {
+  it("emits Telegram language- form for tagged fences", () => {
+    expect(telegramHtml("```js\nconst a = 1;\n```")).toBe(
+      '<pre><code class="language-js">const a = 1;</code></pre>',
+    );
+  });
+  it("handles python and escapes code contents", () => {
+    expect(telegramHtml("```python\nif a < b:\n    pass\n```")).toBe(
+      '<pre><code class="language-python">if a &lt; b:\n    pass</code></pre>',
+    );
+  });
+  it("untagged fences stay plain <pre>", () => {
+    expect(telegramHtml("```\nplain\n```")).toBe("<pre>plain</pre>");
+  });
+  it("single-line ```code``` fences become inline <code>", () => {
+    expect(telegramHtml("```code```")).toBe("<code>code</code>");
+  });
+});

--- a/packages/channels-telegram/src/telegram-html.ts
+++ b/packages/channels-telegram/src/telegram-html.ts
@@ -44,10 +44,25 @@ export function telegramHtml(input: string): string {
   // ── 1. Pull code regions out so we don't touch them. ──
   const codeRegions: string[] = [];
 
-  // Fenced code blocks first (```…```)
-  let body = input.replace(/```([\s\S]*?)```/g, (_match, inner: string) => {
-    const escaped = escapeHtml(inner.replace(/^\n/, "").replace(/\n$/, ""));
-    codeRegions.push(`<pre>${escaped}</pre>`);
+  // Fenced code blocks with an info string (```lang\n…```)
+  let body = input.replace(
+    /```([^\n`]*)\n([\s\S]*?)```/g,
+    (_match, info: string, inner: string) => {
+      const lang = info.trim().split(/\s+/)[0] ?? "";
+      const escaped = escapeHtml(inner.replace(/\n$/, ""));
+      codeRegions.push(
+        lang
+          ? `<pre><code class="language-${escapeHtml(lang)}">${escaped}</code></pre>`
+          : `<pre>${escaped}</pre>`,
+      );
+      return codePlaceholder(codeRegions.length - 1);
+    },
+  );
+
+  // Single-line ``` ```code``` ``` fences (no info string by definition)
+  body = body.replace(/```([^`\n]*)```/g, (_match, inner: string) => {
+    const escaped = escapeHtml(inner);
+    codeRegions.push(`<code>${escaped}</code>`);
     return codePlaceholder(codeRegions.length - 1);
   });
 

--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -210,6 +210,7 @@ function CopilotPopupViewInternal({
       data-copilotkit
       className={cn(
         "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch",
+        "cpk:bg-transparent",
         "cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4",
       )}
     >

--- a/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
+++ b/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
@@ -366,7 +366,7 @@ onBeforeUnmount(() => {
   <div
     v-if="isRendered"
     data-copilotkit
-    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
+    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
   >
     <div
       ref="containerRef"


### PR DESCRIPTION
## Summary
- The fixed outer popup wrapper (`[data-copilotkit]`) now sets `cpk:bg-transparent` in both React and Vue v2 `CopilotPopupView`
- Previously the default theme background on `[data-copilotkit]` showed square white corners around the rounded-2xl inner dialog
- Fixes #6472

## Test plan
- Render an open v2 popup on a non-white page background at desktop width; corners are transparent and host page shows through
