### PR TITLE
feat(react-core): make intelligence indicator auto-mount configurable

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatMessageView.tsx
@@ -437,7 +437,7 @@ export function CopilotChatMessageView({
 }: CopilotChatMessageViewProps) {
   const renderCustomMessage = useRenderCustomMessages();
   const { renderActivityMessage } = useRenderActivityMessage();
-  const { copilotkit } = useCopilotKit();
+  const { copilotkit, autoMountIntelligenceIndicator } = useCopilotKit();
   const config = useCopilotChatConfiguration();
   const [, forceUpdate] = useReducer((x) => x + 1, 0);
 
@@ -706,7 +706,10 @@ export function CopilotChatMessageView({
     // moves with the anchor across a hand-off without remounting, and past
     // turns keep their own indicator.
     const intelligenceTurnId = intelligenceTurnAnchors.get(message.id);
-    if (intelligenceTurnId !== undefined) {
+    if (
+      autoMountIntelligenceIndicator !== false &&
+      intelligenceTurnId !== undefined
+    ) {
       elements.push(
         <IntelligenceIndicator
           key={`intelligence-${intelligenceTurnId}`}

--- a/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/intelligence-indicator/__tests__/IntelligenceIndicator.e2e.test.tsx
@@ -195,18 +195,26 @@ const RunAgentHarness: React.FC<{ withIntelligence: boolean }> = ({
 interface RenderOptions {
   withIntelligence?: boolean;
   intelligenceIndicator?: IndicatorSlot;
+  autoMountIntelligenceIndicator?: boolean;
 }
 
 const renderForIndicator = (
   agent: MockStepwiseAgent,
   options: RenderOptions = {},
 ): void => {
-  const { withIntelligence = true, intelligenceIndicator } = options;
+  const {
+    withIntelligence = true,
+    intelligenceIndicator,
+    autoMountIntelligenceIndicator,
+  } = options;
 
   // No `renderCustomMessages` prop is passed — the indicator
   // auto-mounts when intelligence is configured.
   render(
-    <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+    <CopilotKitProvider
+      agents__unsafe_dev_only={{ default: agent }}
+      autoMountIntelligenceIndicator={autoMountIntelligenceIndicator}
+    >
       <CopilotChatConfigurationProvider agentId="default" threadId="t">
         <RunAgentHarness withIntelligence={withIntelligence} />
         <div style={{ height: 400 }}>
@@ -437,6 +445,32 @@ describe('IntelligenceIndicator — "CopilotKit Intelligence" (auto-mounted)', (
 
     await waitFor(() => expectIndicatorOn("m1"));
     expectIndicatorCount(1);
+  });
+
+  it("provider opt-out: does not auto-mount the indicator when disabled", async () => {
+    const agent = makeAgent();
+    renderForIndicator(agent, { autoMountIntelligenceIndicator: false });
+    await screen.findByTestId("trigger-run");
+
+    await triggerRun(agent);
+    startRun(agent);
+    emitAssistantMessageWithToolCalls(agent, "m_opt_out", [
+      { id: "tc_opt_out", arg: "{}" },
+    ]);
+
+    await waitFor(() =>
+      expect(agent.messages.some((message) => message.id === "m_opt_out")).toBe(
+        true,
+      ),
+    );
+
+    // The normal indicator leaves its hidden phase after a 100ms grace window.
+    // Waiting past that threshold makes this regression assertion meaningful:
+    // a mistakenly auto-mounted indicator would be visible by now.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    expectNoIndicatorAnywhere();
   });
 
   // NOTE: replay-flash suppression (a tool call + result that resolve before

--- a/packages/react-core/src/v2/context.ts
+++ b/packages/react-core/src/v2/context.ts
@@ -17,6 +17,13 @@ export interface CopilotKitContextValue {
    * are captured even before child components mount.
    */
   executingToolCallIds: ReadonlySet<string>;
+  /**
+   * Whether chat views should automatically mount the IntelligenceIndicator
+   * for Intelligence-using turns. Defaults to true when omitted.
+   *
+   * Providers that do not render this indicator may omit the value.
+   */
+  autoMountIntelligenceIndicator?: boolean;
 }
 
 export const EMPTY_SET: ReadonlySet<string> = new Set();

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -175,6 +175,15 @@ export interface CopilotKitProviderProps {
   };
   showDevConsole?: boolean | "auto";
   /**
+   * Whether to automatically mount the IntelligenceIndicator for
+   * Intelligence-using chat turns.
+   *
+   * Set to false when rendering your own Intelligence status UI.
+   *
+   * @default true
+   */
+  autoMountIntelligenceIndicator?: boolean;
+  /**
    * Error handler called when CopilotKit encounters an error.
    * Fires for all error types (runtime connection failures, agent errors, tool errors).
    */
@@ -289,6 +298,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   humanInTheLoop,
   openGenerativeUI,
   showDevConsole = false,
+  autoMountIntelligenceIndicator = true,
   useSingleEndpoint,
   onError,
   a2ui,
@@ -927,8 +937,12 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   }, [copilotkit, sandboxFunctionsDescriptors, openGenUIActive]);
 
   const contextValue = useMemo<CopilotKitContextValue>(
-    () => ({ copilotkit, executingToolCallIds }),
-    [copilotkit, executingToolCallIds],
+    () => ({
+      copilotkit,
+      executingToolCallIds,
+      autoMountIntelligenceIndicator,
+    }),
+    [copilotkit, executingToolCallIds, autoMountIntelligenceIndicator],
   );
 
   // License context — driven by server-reported status via /info endpoint

--- a/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
@@ -127,6 +127,23 @@ Defaults to `false` for production safety.
 
 </PropertyReference>
 
+<PropertyReference name="autoMountIntelligenceIndicator" type="boolean">
+Controls whether CopilotKit automatically mounts the CopilotKit Intelligence
+indicator for Intelligence-using chat turns. Defaults to `true`.
+
+Set this to `false` when you render your own Intelligence status UI.
+
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  autoMountIntelligenceIndicator={false}
+>
+  {children}
+</CopilotKit>
+```
+
+</PropertyReference>
+
 <PropertyReference name="a2ui" type="{ theme?: Theme }">
 Configuration for the A2UI (Agent-to-UI) renderer.
 


### PR DESCRIPTION
## What does this PR do?

Closes #5126.

Adds an opt-out for CopilotKit's automatic `IntelligenceIndicator` mount while preserving the current behavior by default.

- adds `autoMountIntelligenceIndicator?: boolean` to the web provider API, defaulting to `true`
- threads the setting through the shared context without making it mandatory for React Native providers
- gates only the automatic mount in `CopilotChatMessageView`, leaving the indicator component and custom slot behavior unchanged
- adds e2e regression coverage for the `false` opt-out, including a wait beyond the indicator's 100ms grace window
- documents the new provider prop

## Backward compatibility

Existing users are unchanged: omitting the prop keeps automatic mounting enabled.

```tsx
<CopilotKit
  runtimeUrl="/api/copilotkit"
  autoMountIntelligenceIndicator={false}
>
  {children}
</CopilotKit>
```

## Testing

Validated from the fork against the current monorepo:

- `pnpm nx run @copilotkit/react-core:test` — PASS (including 17 dependent tasks)
- `pnpm nx run @copilotkit/react-core:check-types` — PASS
- `pnpm exec oxfmt --check <changed files>` — PASS
- `pnpm exec oxlint <changed TS/TSX files>` — PASS
- `pnpm run build` — PASS for the full packages monorepo build

A push-triggered `pkg-pr-new / build` run on the fork previously reported a failure, but the exact same full build command was reproduced successfully afterward. The upstream PR workflows still show `action_required` until a maintainer approves Actions for the fork contribution; they have not produced a code/test failure on this PR.

## Checklist

- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] No changeset/version bump was added
- [x] Allow edits by maintainers is enabled
