### PR TITLE
fix(react): preserve caret across textarea measurement in CopilotChatInput

### DIFF
--- a/packages/channels-telegram/src/__tests__/telegram-html.test.ts
+++ b/packages/channels-telegram/src/__tests__/telegram-html.test.ts
@@ -68,3 +68,22 @@ describe("stripHtml", () => {
     expect(stripHtml("&amp;lt;")).toBe("&lt;");
   });
 });
+
+describe("telegramHtml: fenced code language tags (#6602)", () => {
+  it("emits Telegram language- form for tagged fences", () => {
+    expect(telegramHtml("```js\nconst a = 1;\n```")).toBe(
+      '<pre><code class="language-js">const a = 1;</code></pre>',
+    );
+  });
+  it("handles python and escapes code contents", () => {
+    expect(telegramHtml("```python\nif a < b:\n    pass\n```")).toBe(
+      '<pre><code class="language-python">if a &lt; b:\n    pass</code></pre>',
+    );
+  });
+  it("untagged fences stay plain <pre>", () => {
+    expect(telegramHtml("```\nplain\n```")).toBe("<pre>plain</pre>");
+  });
+  it("single-line ```code``` fences become inline <code>", () => {
+    expect(telegramHtml("```code```")).toBe("<code>code</code>");
+  });
+});

--- a/packages/channels-telegram/src/telegram-html.ts
+++ b/packages/channels-telegram/src/telegram-html.ts
@@ -44,10 +44,25 @@ export function telegramHtml(input: string): string {
   // ── 1. Pull code regions out so we don't touch them. ──
   const codeRegions: string[] = [];
 
-  // Fenced code blocks first (```…```)
-  let body = input.replace(/```([\s\S]*?)```/g, (_match, inner: string) => {
-    const escaped = escapeHtml(inner.replace(/^\n/, "").replace(/\n$/, ""));
-    codeRegions.push(`<pre>${escaped}</pre>`);
+  // Fenced code blocks with an info string (```lang\n…```)
+  let body = input.replace(
+    /```([^\n`]*)\n([\s\S]*?)```/g,
+    (_match, info: string, inner: string) => {
+      const lang = info.trim().split(/\s+/)[0] ?? "";
+      const escaped = escapeHtml(inner.replace(/\n$/, ""));
+      codeRegions.push(
+        lang
+          ? `<pre><code class="language-${escapeHtml(lang)}">${escaped}</code></pre>`
+          : `<pre>${escaped}</pre>`,
+      );
+      return codePlaceholder(codeRegions.length - 1);
+    },
+  );
+
+  // Single-line ``` ```code``` ``` fences (no info string by definition)
+  body = body.replace(/```([^`\n]*)```/g, (_match, inner: string) => {
+    const escaped = escapeHtml(inner);
+    codeRegions.push(`<code>${escaped}</code>`);
     return codePlaceholder(codeRegions.length - 1);
   });
 

--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -665,6 +665,11 @@ export function CopilotChatInput({
 
     const previousValue = textarea.value;
     const previousHeight = textarea.style.height;
+    // Setting .value resets the caret to the end of the textarea, so
+    // save and restore the selection around the measurement swap.
+    const previousSelectionStart = textarea.selectionStart;
+    const previousSelectionEnd = textarea.selectionEnd;
+    const previousDirection = textarea.selectionDirection;
 
     textarea.style.height = "auto";
 
@@ -677,6 +682,17 @@ export function CopilotChatInput({
     textarea.value = "";
     const singleLineHeight = textarea.scrollHeight;
     textarea.value = previousValue;
+    if (
+      document.activeElement === textarea &&
+      previousSelectionStart !== null &&
+      previousSelectionEnd !== null
+    ) {
+      textarea.setSelectionRange(
+        previousSelectionStart,
+        previousSelectionEnd,
+        previousDirection ?? undefined,
+      );
+    }
 
     const contentHeight = singleLineHeight - paddingTop - paddingBottom;
     const maxHeight = contentHeight * 5 + paddingTop + paddingBottom;

--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -210,6 +210,7 @@ function CopilotPopupViewInternal({
       data-copilotkit
       className={cn(
         "cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch",
+        "cpk:bg-transparent",
         "cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4",
       )}
     >

--- a/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
+++ b/packages/vue/src/v2/components/chat/CopilotPopupViewInternal.vue
@@ -366,7 +366,7 @@ onBeforeUnmount(() => {
   <div
     v-if="isRendered"
     data-copilotkit
-    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
+    class="cpk:fixed cpk:inset-0 cpk:z-[1200] cpk:flex cpk:max-w-full cpk:flex-col cpk:items-stretch cpk:bg-transparent cpk:md:inset-auto cpk:md:bottom-24 cpk:md:right-6 cpk:md:items-end cpk:md:gap-4"
   >
     <div
       ref="containerRef"

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -232,7 +232,7 @@ This context can then be shared with your LangGraph agent.
                         from langchain.agents import create_agent
                         from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
 
-                        graph = create_agent( # Works the same for "create_react_agent" or similar options
+                        graph = create_agent(
                             model="openai:gpt-5.4",
                             tools=[],  # Backend tools go here
                             middleware=[CopilotKitMiddleware()], # [!code highlight]
@@ -246,7 +246,7 @@ This context can then be shared with your LangGraph agent.
                         import { createAgent } from "langchain";
                         import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
-                        export const agenticChatGraph = createAgent({ // Works the same for "create_react_agent" or similar options
+                        export const agenticChatGraph = createAgent({
                           model: "openai:gpt-5.4",
                           tools: [],  // Backend tools go here
                           middleware: [copilotkitMiddleware], // [!code highlight]

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/frontend-tools.mdx
@@ -146,7 +146,7 @@ The following example shows a data-fetch frontend tool paired with a matching `s
         from langchain.agents import create_agent
         from copilotkit import CopilotKitMiddleware, CopilotKitState
 
-        graph = create_agent( # Works the same for "create_react_agent" or similar options
+        graph = create_agent(
             model="openai:gpt-4o",
             tools=[],  # backend tools go here
             middleware=[CopilotKitMiddleware()],
@@ -168,7 +168,7 @@ The following example shows a data-fetch frontend tool paired with a matching `s
         import { createAgent } from "langchain";
         import { copilotkitMiddleware, CopilotKitStateSchema } from "@copilotkit/sdk-js/langgraph";
 
-        export const graph = createAgent({ // Works the same for "create_react_agent" or similar options
+        export const graph = createAgent({
           model: "openai:gpt-4o",
           tools: [],  // backend tools go here
           stateSchema: CopilotKitStateSchema,

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
@@ -190,7 +190,7 @@ function AdminPanel({ isAdmin }: { isAdmin: boolean }) {
 For simple UI-control tools (e.g. toggling a theme), the `description` field is usually enough for a LangGraph agent to discover and call the tool at the right time. For **mandatory** tools — ones where the agent must call the tool before answering rather than reasoning from stale context — pair a clear `description` with an explicit instruction in the agent's `system_prompt`.
 
 ```python title="agent.py — make mandatory tools explicit in system_prompt"
-graph = create_agent( # Works the same for "create_react_agent" or similar options
+graph = create_agent(
     model="openai:gpt-4o",
     tools=[],
     middleware=[CopilotKitMiddleware()],

--- a/showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/langgraph/frontend-tools.mdx
@@ -52,7 +52,7 @@ import {
                 from langchain.agents import create_agent
                 from copilotkit import CopilotKitMiddleware, CopilotKitState # [!code highlight]
 
-                graph = create_agent( # Works the same for "create_react_agent" or similar options
+                graph = create_agent(
                     model="openai:gpt-5.4",
                     tools=[],  # Backend tools go here
                     middleware=[CopilotKitMiddleware()], # [!code highlight]
@@ -66,7 +66,7 @@ import {
                 import { createAgent } from "langchain";
                 import { copilotkitMiddleware } from "@copilotkit/sdk-js/langgraph"; // [!code highlight]
 
-                export const agenticChatGraph = createAgent({ // Works the same for "create_react_agent" or similar options
+                export const agenticChatGraph = createAgent({
                     model: "openai:gpt-5.4",
                     tools: [],  // Backend tools go here
                     middleware: [copilotkitMiddleware], // [!code highlight]


### PR DESCRIPTION
Fixes #6167

`ensureMeasurements()` in `CopilotChatInput` temporarily sets `textarea.value = ""` (then restores it) to measure the single-line height. Assigning `.value` resets the caret to the end of the textarea. In expanded mode the layout evaluation runs on every keystroke, so placing the cursor mid-text and typing made it jump to the end.

The fix saves `selectionStart`/`selectionEnd`/`selectionDirection` before the measurement swap and restores them afterwards (only when the textarea is focused).
