### PR TITLE
fix(runtime): align pino declaration with tested version

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
       "path-to-regexp@<=0.1.12": "0.1.13",
       "serve-static@<=1.16.0": "1.16.0",
       "prismjs@<=1.30.0": "1.30.0",
-      "pino@<=10.1.1": "10.1.1",
       "@copilotkit/license-verifier": "~0.5.0",
       "next": "^16.0.10",
       "defu@<=6.1.4": ">=6.1.5",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -112,7 +112,7 @@
     "openai": "^4.85.1 || >=5.0.0",
     "partial-json": "^0.1.7",
     "phoenix": "^1.8.4",
-    "pino": "^9.2.0",
+    "pino": "^10.1.1",
     "pino-pretty": "^11.2.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "7.8.1",


### PR DESCRIPTION
Fixes #6423 (the pino part)

`pnpm.overrides` pinned `pino@<=10.1.1` to 10.1.1, so CI tested `@copilotkit/runtime` against pino 10 while the published manifest declared `^9.2.0` — npm consumers ran a different major than what was tested.

This bumps `packages/runtime` to `pino: ^10.1.1` and drops the override, so the declaration matches what CI exercises. (`pino-pretty` has no peer dependency on pino — it receives the stream directly — so no change needed there.)

The bare `next` override from the same issue is left untouched here; it spans many example apps and deserves its own reviewed change.
