### PR TITLE
fix(showcase): complete HITL probe on modal mount

### DIFF
--- a/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.test.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.test.ts
@@ -53,6 +53,20 @@ describe("d5-hitl-approve-deny script", () => {
     expect(turns[0]!.assertions).toBeTypeOf("function");
   });
 
+  it("completes the tool-only first leg when the approval modal mounts", async () => {
+    const mod = await import("./d5-hitl-approve-deny.js");
+    const script = mod.__d5HitlApproveDenyScript;
+    const turns = script.buildTurns({
+      integrationSlug: "langgraph-python",
+      featureType: "hitl-approve-deny",
+      baseUrl: "https://example.test",
+    });
+
+    expect(turns[0]!.completeOnMount).toEqual({
+      testIds: ["approval-dialog-overlay"],
+    });
+  });
+
   it("assertion clicks approve and passes when the follow-up message contains $50 and 12345", async () => {
     const mod = await import("./d5-hitl-approve-deny.js");
     const script = mod.__d5HitlApproveDenyScript;

--- a/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.ts
+++ b/showcase/harness/src/probes/scripts/d5-hitl-approve-deny.ts
@@ -58,12 +58,15 @@ const script: D5Script = {
   buildTurns: () => [
     {
       input: "Issue a $50 refund to customer #12345",
-      // Generous timeout: the first leg waits for the agent to
-      // tool-call AND the modal to render. The conversation-runner's
-      // settle window measures assistant-message stability — the modal
-      // appears as a side effect of the tool call landing in the
-      // conversation, so settle fires once the assistant message
-      // (which carries the toolCall) has streamed in.
+      // The first fixture leg is intentionally tool-call-only: its meaningful
+      // output is the app-level approval modal, not assistant prose. Unhandled
+      // tool calls also intentionally render no default chat card, so a text-
+      // stability gate cannot converge. Complete on the modal mount instead;
+      // the shared runner still requires a finished run and a new assistant
+      // bubble before it executes the approval assertions below.
+      completeOnMount: {
+        testIds: ["approval-dialog-overlay"],
+      },
       responseTimeoutMs: 60_000,
       assertions: async (page: ConversationPage) => {
         // Runtime guard: HitlPage extends ConversationPage with `click`,


### PR DESCRIPTION
## Summary

- complete the tool-only HITL approval leg when the app-level approval modal mounts
- retain the shared runner's finished-run/new-assistant-bubble gates and the existing approval/follow-up assertions
- add a contract test that pins the modal completion selector to the first turn

## Why

Unhandled tool calls intentionally render no default chat card. The HITL fixture's first leg therefore produces an empty assistant bubble plus the approval modal, so text-stability completion cannot converge even though the app and fixture are healthy.

## Verification

- focused red/green contract: 8 tests passed after failing on missing `completeOnMount`
- showcase harness: 177 test files / 3,722 tests passed; typecheck and build passed
- isolated fleet-control-plane D5 cells passed for LangGraph Python, CrewAI Conversational Flows, and Mastra

## Deployment scope

This changes only the shared showcase harness image. Promote the harness control-plane and harness pool-worker roles together; no integration service image changes are required for this fix.
