### PR TITLE
fix(world): preserve LangGraph assistant config

### DIFF
--- a/examples/showcases/chatkit-studio/apps/world/e2e/migration-contract.test.cjs
+++ b/examples/showcases/chatkit-studio/apps/world/e2e/migration-contract.test.cjs
@@ -1,0 +1,17 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { test } = require("node:test");
+
+const routeSource = readFileSync(
+  join(__dirname, "../src/app/api/copilotkit/route.ts"),
+  "utf8",
+);
+
+test("forwards the browser OpenAI key through LangGraph assistant config", () => {
+  assert.match(routeSource, /req\.headers\.get\("x-openai-api-key"\)/);
+  assert.match(
+    routeSource,
+    /assistantConfig:\s*\{\s*configurable:\s*\{\s*openai_api_key:\s*userApiKey \|\| undefined,/s,
+  );
+});

--- a/examples/showcases/chatkit-studio/apps/world/src/app/api/copilotkit/route.ts
+++ b/examples/showcases/chatkit-studio/apps/world/src/app/api/copilotkit/route.ts
@@ -20,7 +20,7 @@ export const POST = async (req: NextRequest) => {
           process.env.LANGGRAPH_DEPLOYMENT_URL || "http://localhost:8125",
         graphId: process.env.LANGGRAPH_GRAPH_ID || "world_agent",
         langsmithApiKey: process.env.LANGSMITH_API_KEY || "",
-        config: {
+        assistantConfig: {
           configurable: {
             openai_api_key: userApiKey || undefined,
           },


### PR DESCRIPTION
# fix(world): preserve LangGraph assistant config

## Summary

- restore the World demo's browser-supplied OpenAI key under `assistantConfig`
- preserve the behavior of the authoritative legacy World commit
- add a dependency-free migration contract test

## Verification

- rebased cleanly onto current `main` at `c2abbea9cf6a48c22b1dcd19e9dc469d5cfd458f`
- verified the authoritative legacy source still uses `assistantConfig` at `markmdev/copilotkit-world@7a27a37b628b9e339d1284ec42382008e67884f5`
- verified `@ag-ui/langgraph@0.0.7` declares, stores, and merges `assistantConfig`
- regression check against current `main` failed for the expected missing-`assistantConfig` reason; the branch's dependency-free Node test passed (`1/1`)
- `oxfmt --write` plus `oxfmt --check` passed on both changed files
- Nx reported no affected lint targets; direct `oxlint` completed with `0` errors and one pre-existing `NextRequest` type-import warning on the unchanged import line
- root dependency bootstrap passed with the repository-pinned pnpm `10.33.4` and `--frozen-lockfile --ignore-scripts`
- `nx run @copilotkit/runtime-client-gql:build` and its 13 dependency builds passed; this does not make that package resolvable from the independently managed nested ChatKit Studio workspace
- exact-base and branch World typechecks used the same pnpm `9.15.0` provisioning: base reports seven diagnostics, branch reports six, and the branch-only diagnostic count is zero
- the removed base diagnostic is the changed route's invalid `config` property; all six remaining diagnostics are identical current-`main` errors in unchanged `page.tsx`, `useCountryData.ts`, and `countryData.ts`
- both production builds compiled the optimized application source; base then failed on the invalid `config`, while the branch advanced past the changed route and stopped on the pre-existing undeclared `@copilotkit/runtime-client-gql` import
- Python agent compilation passed
- worktree is clean; commit `a25941f9017fcd2a0a8e7660fe768c69cfaa28b6` changes only the World route and its migration contract test

## Existing baseline debt

The branch introduces no type or production-build regression and removes the route error it targets. Six unrelated current-`main` type diagnostics remain:

```text
src/app/page.tsx(14,42): error TS2307: Cannot find module '@copilotkit/runtime-client-gql'
src/hooks/useCountryData.ts(2,50): error TS2307: Cannot find module 'geojson'
src/hooks/useCountryData.ts(4,51): error TS2307: Cannot find module 'topojson-specification'
src/hooks/useCountryData.ts(32,27): error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string'.
src/hooks/useCountryData.ts(43,12): error TS7006: Parameter 'country' implicitly has an 'any' type.
src/utils/countryData.ts(1,40): error TS2307: Cannot find module 'geojson'
```

The nested ChatKit Studio frozen install also reproduces the separate current-`main` Playground importer drift covered by D006. D007 no longer changes `package.json`, so it does not duplicate that lockfile fix.

Legacy source: `markmdev/copilotkit-world` at `7a27a37b628b9e339d1284ec42382008e67884f5`.
