### PR TITLE
docs(react-core): fix agent-access skill docs to match shipped useAgent thread-scoping API

### DIFF
--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -29,13 +29,19 @@ export function ChatDriver({
 }) {
   const { agent } = useAgent({
     agentId: "default",
-    threadId: "main",
     updates: [
       UseAgentUpdate.OnMessagesChanged,
       UseAgentUpdate.OnRunStatusChanged,
     ],
     throttleMs: 100,
   });
+
+  // Thread-scoped private agent (all three required):
+  // const { agent: threadAgent } = useAgent({
+  //   agentId: "chat-1",
+  //   runtimeAgentId: "default",
+  //   threadId: "main",
+  // });
 
   const context = useMemo(() => ({ route, userId }), [route, userId]);
   useAgentContext({ description: "app context", value: context });
@@ -120,11 +126,14 @@ class MyAgent extends AbstractAgent {
 }
 ```
 
-`useAgent` calls `source.clone()` to build a per-thread clone and throws
-`clone() must return a new, independent object` if the clone is the same
-instance. This guards per-thread isolation.
+`useAgent` with `threadId` registers a private proxied agent via
+`CopilotKitCore.registerProxiedAgent` (`agentId` → `runtimeAgentId`) with
+`threadId` pinned, rather than cloning. The per-thread instance is owned by
+that registration (see the `registerProxiedAgent` effect). `clone()` is only
+relevant for custom `AbstractAgent` subclasses used directly — it must still
+return a new, independent object.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:237-252`
 
 ### HIGH — Mutating `agent.messages` directly
 
@@ -256,16 +265,16 @@ sees.
 
 Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx` (no `agentId` parameter); `packages/core/src/core/context-store.ts:26-31`
 
-### MEDIUM — Two components using the same `(agentId, threadId)` expecting isolation
+### MEDIUM — Two components using the same `runtimeAgentId` + `threadId` expecting isolation
 
 Wrong:
 
 ```tsx
 function A() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+  const { agent } = useAgent({ agentId: "chat-a", runtimeAgentId: "default", threadId: "t1" });
 }
 function B() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
+  const { agent } = useAgent({ agentId: "chat-b", runtimeAgentId: "default", threadId: "t1" });
 }
 ```
 
@@ -273,16 +282,17 @@ Correct:
 
 ```tsx
 function A() {
-  useAgent({ agentId: "default", threadId: "a" });
+  useAgent({ agentId: "chat-a", runtimeAgentId: "default", threadId: "a" });
 }
 function B() {
-  useAgent({ agentId: "default", threadId: "b" });
+  useAgent({ agentId: "chat-b", runtimeAgentId: "default", threadId: "b" });
 }
 ```
 
-Per-thread clones are cached in a module-level WeakMap keyed by
-`(registryAgent, threadId)`. Two consumers of the same `(agentId,
-threadId)` observe the same state. Give each surface a distinct `threadId`
-when isolation is intentional.
+Thread-scoped agents are registered via `CopilotKitCore.registerProxiedAgent`
+under a distinct local `agentId` routing to `runtimeAgentId` with `threadId`
+pinned. Two consumers that share the same `runtimeAgentId` and `threadId`
+— even with different local `agentId`s — address the same backend thread.
+Give each surface a distinct `threadId` when isolation is intentional.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:237-252`


### PR DESCRIPTION
Fixes #6125 (doc part) — bundled react-core skill documented a threadId param that doesn't exist.

Current doc in `agent-access.md` shows `useAgent({ agentId: "default", threadId: "main" })` and describes per-thread clones cached in a module-level WeakMap (`use-agent.tsx:78-119`).

Shipped `useAgent` requires the triple `{ agentId, runtimeAgentId, threadId }` via `CopilotKitCore.registerProxiedAgent`; a lone `threadId` is a type error and throws at runtime (`useAgent: threadId requires runtimeAgentId`).

Changes:
- Setup example: remove lone `threadId`, add commented triple example
- Update clone->proxied-agent description and source to 237-252
- Fix isolation example to use `{ agentId, runtimeAgentId, threadId }` triple and correct explanation

Verified: `packages/react-core/src/v2/hooks/use-agent.tsx` still validates the triple at runtime and via types; doc now matches.
