### PR TITLE
chore(showcase): mark CrewAI conversational flows live

### DIFF
--- a/showcase/integrations/crewai-conversational-flows/PARITY_NOTES.md
+++ b/showcase/integrations/crewai-conversational-flows/PARITY_NOTES.md
@@ -29,6 +29,6 @@ backend, runtime routing, and fixtures under
 
 ## Deployment
 
-The manifest remains `deployed: false` until a dedicated Railway service is
-provisioned. Local D6 verification runs through the
-`crewai-conversational-flows` compose service on port 3120.
+The dedicated production Railway service is provisioned and tracked in the
+Railway SSOT, and the manifest is marked `deployed: true`. Local D6 verification
+runs through the `crewai-conversational-flows` compose service on port 3120.

--- a/showcase/integrations/crewai-conversational-flows/manifest.yaml
+++ b/showcase/integrations/crewai-conversational-flows/manifest.yaml
@@ -7,7 +7,7 @@ description: CopilotKit integration with CrewAI Conversational Flows
 partner_docs: null
 repo: https://github.com/CopilotKit/CopilotKit/tree/main/showcase/integrations/crewai-conversational-flows
 copilotkit_version: 2.0.0
-deployed: false
+deployed: true
 docs_mode: hidden
 sort_order: 41
 generative_ui:


### PR DESCRIPTION
## Summary

- mark CrewAI Conversational Flows `deployed: true` now that its production Railway instance is provisioned, SSOT-tracked, promoted, and healthy
- update the parity note so it reflects the live production deployment
- retain `docs_mode: hidden`; Conversational Flows remain documented within the existing CrewAI Flows docs rather than as a separate framework

## Production verification

- `GET https://showcase-crewai-conversational-flows-production.up.railway.app/api/health` returns HTTP 200 with `status: ok`
- post-promotion D5 run `frun_mt2lnj48_t8zh0h_1`, job `o8rkn6b0igh4rxd`: 40/40 cells passed, 0 failed

## Local verification

- `nx run @copilotkit/showcase-scripts:validate-manifests`
- `nx run @copilotkit/showcase-scripts:generate-registry`
- `validate-constraints.ts crewai-conversational-flows`
- formatter check and `git diff --check`
- Nx affected lint, test, and build resolved no affected targets for this manifest/Markdown-only change
