### PR TITLE
fix(web-inspector): stop Agent tab messages from showing template indent

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -329,6 +329,33 @@ describe("WebInspectorElement", () => {
     );
   });
 
+  it("renders Agent tab message text without template indent", async () => {
+    const { agent } = createMockAgent("alpha", {
+      messages: [{ id: "m1", role: "user", content: "test" }],
+    });
+    const { core, emitAgentsChanged } = createMockCore({ alpha: agent });
+    const inspector = createInspectorWithCore(core);
+
+    emitAgentsChanged();
+    await inspector.updateComplete;
+
+    const internals = inspector as unknown as {
+      isOpen: boolean;
+      selectedMenu: string;
+      selectedContext: string;
+    };
+    internals.isOpen = true;
+    internals.selectedMenu = "agents";
+    internals.selectedContext = "alpha";
+    inspector.requestUpdate();
+    await inspector.updateComplete;
+
+    const content = inspector.shadowRoot?.querySelector(
+      ".cpk-agent-view .whitespace-pre-wrap",
+    );
+    expect(content?.textContent).toBe("test");
+  });
+
   it("records step lifecycle events", async () => {
     const { agent, controller } = createMockAgent("alpha");
     const { core, emitAgentsChanged } = createMockCore({ alpha: agent });

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -13746,9 +13746,7 @@ ${prettyEvent}</pre
                                 hasContent
                                   ? html`<div
                                     class="whitespace-pre-wrap break-words text-gray-700"
-                                  >
-                                    ${rawContent}
-                                  </div>`
+                                  >${rawContent}</div>`
                                   : html`<div class="italic text-gray-400">
                                     ${contentFallback}
                                   </div>`


### PR DESCRIPTION
## What does this PR do?

The Agent tab Current Messages list used `whitespace-pre-wrap` around the message text.
The Lit template also had extra spaces and newlines around that value.
As a result, a short message such as `test` rendered with a large empty block.

This change puts the message text on the same line as the opening tag, so only the real message text is shown.

Verified in the browser: the user row is now the exact string `test` (one line, 16px high).
Inspector tests: 485 passed, including a new regression test.

## Related PRs and Issues

None. Found while testing Playground on the react-router example.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked
