### PR TITLE
feat(web-inspector): copy stored threads into Playground from Threads

### DIFF
--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -625,6 +625,67 @@ test("Try from here copies a stored thread into Playground without changing the 
   }
 });
 
+test("Try from here discards a stale copy after leaving Threads", async () => {
+  const context = await setup({
+    agent: true,
+    agentIds: ["default"],
+    threads: [SAVED_THREAD],
+  });
+  try {
+    await context.open();
+    await context.selectLeaf("threads");
+    await selectSavedThread(context.inspector);
+
+    const pendingFetch = globalThis.fetch;
+    let releaseMessages!: () => void;
+    let messagesResolved = false;
+    const messagesGate = new Promise<void>((resolve) => {
+      releaseMessages = resolve;
+    });
+    vi.stubGlobal(
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const isMessages = url.endsWith("/threads/thread-1/messages");
+        if (isMessages) {
+          await messagesGate;
+        }
+        const response = await pendingFetch(input, init);
+        if (isMessages) {
+          messagesResolved = true;
+        }
+        return response;
+      },
+    );
+
+    const root = requireElement(
+      context.inspector.shadowRoot,
+      "Web Inspector shadow root was not rendered",
+    );
+    const button = requireElement(
+      tryFromHereButton(root),
+      "Try from here was not rendered",
+    );
+    button.click();
+    await context.selectLeaf("home");
+    expectCurrentNavigation(root, "home", "home");
+
+    releaseMessages();
+    await waitFor(() => messagesResolved, "stale Try from here load");
+    await context.inspector.updateComplete;
+
+    expectCurrentNavigation(root, "home", "home");
+    await context.selectLeaf("playground");
+    expect(root.textContent).not.toContain("Earlier answer");
+    expect(
+      root.querySelector<HTMLSelectElement>("#cpk-playground-thread-source")
+        ?.value ?? "",
+    ).not.toBe("thread-1");
+  } finally {
+    context.teardown();
+  }
+});
+
 test("Try from here stays on Threads when messages fail", async () => {
   const context = await setup({
     agent: true,

--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -36,6 +36,7 @@ type SetupOptions = {
   };
   runtimeMode?: "sse" | "intelligence";
   threads?: ɵThread[];
+  failThreadMessages?: boolean;
 };
 
 /** Build the trusted account metadata fixture used by the shell test. */
@@ -137,6 +138,9 @@ async function setup(
         return jsonResponse({ threads: options.threads ?? [], joinCode: null });
       }
       if (url.endsWith("/threads/thread-1/messages")) {
+        if (options.failThreadMessages) {
+          return new Response("missing thread", { status: 500 });
+        }
         return jsonResponse({
           messages: [
             { id: "message-1", role: "user", content: "Earlier question" },
@@ -356,6 +360,53 @@ function expectVisibleFocus(root: ShadowRoot, control: HTMLElement): void {
   expect(Number.parseFloat(styles.outlineWidth)).toBeGreaterThanOrEqual(2);
 }
 
+const SAVED_THREAD: ɵThread = {
+  id: "thread-1",
+  organizationId: "organization-1",
+  agentId: "default",
+  createdById: "user-1",
+  name: "Saved conversation",
+  archived: false,
+  createdAt: "2026-08-19T12:00:00.000Z",
+  updatedAt: "2026-08-19T12:01:00.000Z",
+};
+
+async function selectSavedThread(
+  inspector: WebInspectorElement,
+): Promise<void> {
+  const root = requireElement(
+    inspector.shadowRoot,
+    "Web Inspector shadow root was not rendered",
+  );
+  await waitFor(() => {
+    const list = root.querySelector("cpk-thread-list");
+    return Boolean(list?.shadowRoot?.querySelector(".cpk-tl__item"));
+  }, "saved thread row");
+  const list = requireElement(
+    root.querySelector("cpk-thread-list"),
+    "Thread list was not rendered",
+  );
+  const row = requireElement(
+    list.shadowRoot?.querySelector<HTMLButtonElement>(".cpk-tl__item"),
+    "Saved thread row was not rendered",
+  );
+  row.click();
+  await inspector.updateComplete;
+  await waitFor(
+    () => root.querySelector("cpk-thread-details") !== null,
+    "thread details",
+  );
+}
+
+function tryFromHereButton(root: ShadowRoot): HTMLButtonElement | null {
+  const details = root.querySelector("cpk-thread-details");
+  return (
+    details?.shadowRoot?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Try from here"]',
+    ) ?? null
+  );
+}
+
 function sidebarLeaves(root: ShadowRoot): string[] {
   const navigation = requireElement(
     root.querySelector<HTMLElement>('nav[aria-label="Inspector"]'),
@@ -532,6 +583,109 @@ test("Playground forks saved thread history without changing the app agent", asy
     );
     expect(root.textContent).toContain("Earlier question");
     expect(context.core.getAgent("default")?.messages).toEqual([]);
+  } finally {
+    context.teardown();
+  }
+});
+
+test("Try from here copies a stored thread into Playground without changing the app agent", async () => {
+  const context = await setup({
+    agent: true,
+    agentIds: ["default"],
+    threads: [SAVED_THREAD],
+  });
+  try {
+    await context.open();
+    await context.selectLeaf("threads");
+    await selectSavedThread(context.inspector);
+
+    const root = requireElement(
+      context.inspector.shadowRoot,
+      "Web Inspector shadow root was not rendered",
+    );
+    const button = requireElement(
+      tryFromHereButton(root),
+      "Try from here was not rendered",
+    );
+    button.click();
+
+    await waitFor(
+      () => root.textContent?.includes("Earlier answer") === true,
+      "copied thread messages",
+    );
+    expectCurrentNavigation(root, "workbench", "playground");
+    expect(root.textContent).toContain("Earlier question");
+    expect(context.core.getAgent("default")?.messages).toEqual([]);
+    expect(
+      root.querySelector<HTMLSelectElement>("#cpk-playground-thread-source")
+        ?.value,
+    ).toBe("thread-1");
+  } finally {
+    context.teardown();
+  }
+});
+
+test("Try from here stays on Threads when messages fail", async () => {
+  const context = await setup({
+    agent: true,
+    agentIds: ["default"],
+    threads: [SAVED_THREAD],
+    failThreadMessages: true,
+  });
+  try {
+    await context.open();
+    await context.selectLeaf("threads");
+    await selectSavedThread(context.inspector);
+    const root = requireElement(
+      context.inspector.shadowRoot,
+      "Web Inspector shadow root was not rendered",
+    );
+    const button = requireElement(
+      tryFromHereButton(root),
+      "Try from here was not rendered",
+    );
+    button.click();
+    await waitFor(() => {
+      const details = root.querySelector("cpk-thread-details");
+      return (
+        details?.shadowRoot?.textContent?.includes("Failed to load thread") ===
+        true
+      );
+    }, "Try from here error");
+    expectCurrentNavigation(root, "workbench", "threads");
+  } finally {
+    context.teardown();
+  }
+});
+
+test("Try from here is hidden on example tour threads", async () => {
+  const context = await setup({ agent: true, threads: [] });
+  try {
+    await context.open();
+    await context.selectLeaf("threads");
+    const root = requireElement(
+      context.inspector.shadowRoot,
+      "Web Inspector shadow root was not rendered",
+    );
+    await waitFor(() => {
+      const list = root.querySelector("cpk-thread-list");
+      return Boolean(list?.shadowRoot?.querySelector(".cpk-tl__item"));
+    }, "example thread row");
+    const list = requireElement(
+      root.querySelector("cpk-thread-list"),
+      "Thread list was not rendered",
+    );
+    const row = requireElement(
+      list.shadowRoot?.querySelector<HTMLButtonElement>(".cpk-tl__item"),
+      "Example thread row was not rendered",
+    );
+    row.click();
+    await context.inspector.updateComplete;
+    await waitFor(
+      () => root.querySelector("cpk-thread-details") !== null,
+      "example thread details",
+    );
+    expect(tryFromHereButton(root)).toBeNull();
   } finally {
     context.teardown();
   }

--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -607,6 +607,8 @@ test("Try from here copies a stored thread into Playground without changing the 
       tryFromHereButton(root),
       "Try from here was not rendered",
     );
+    expect(button.closest(".cpk-td__timeline-toolbar")).not.toBeNull();
+    expect(button.querySelector("svg")).not.toBeNull();
     button.click();
 
     await waitFor(

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -125,6 +125,7 @@ import {
   trackMemoriesTabClicked,
   trackThreadsTabClicked,
   trackThreadsTalkToEngineerClicked,
+  trackThreadsTryFromHereClicked,
   trackWhatsNewClicked,
   trackWhatsNewSignalViewed,
   trackWhatsNewViewed,
@@ -2081,6 +2082,9 @@ export class CpkThreadInspector extends PortableLitElement {
     viewInAppError: { attribute: false },
     focusMessageId: { attribute: false },
     focusRequestId: { attribute: false },
+    tryFromHereAvailable: { attribute: false },
+    tryFromHereBusy: { attribute: false },
+    tryFromHereError: { attribute: false },
     _tab: { state: true },
     _fetchedMetadata: { state: true },
     _conversation: { state: true },
@@ -2128,6 +2132,9 @@ export class CpkThreadInspector extends PortableLitElement {
   viewInAppError: string | null = null;
   focusMessageId: string | null = null;
   focusRequestId = 0;
+  tryFromHereAvailable = false;
+  tryFromHereBusy = false;
+  tryFromHereError: string | null = null;
 
   private _tab: ThreadDetailsTab = "timeline";
   private _fetchedMetadata: ThreadDebuggerMetadata | null = null;
@@ -2614,6 +2621,41 @@ export class CpkThreadInspector extends PortableLitElement {
       .cpk-td__view-in-app:active {
         transform: none;
       }
+    }
+
+    .cpk-td__try-from-here {
+      display: inline-flex;
+      align-items: center;
+      margin-left: auto;
+      padding: 4px 8px;
+      border: 1px solid #d8d9e3;
+      border-radius: 6px;
+      background: #ffffff;
+      color: #3f3f46;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .cpk-td__try-from-here:hover:not(:disabled) {
+      border-color: #c4c5d4;
+      background: #f7f7fb;
+    }
+
+    .cpk-td__try-from-here:focus-visible {
+      outline: 2px solid #a78bfa;
+      outline-offset: 1px;
+    }
+
+    .cpk-td__try-from-here:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .cpk-td__try-from-here-error {
+      color: #c0333a;
+      font-size: 11px;
+      line-height: 1.4;
     }
 
     /*
@@ -3342,6 +3384,7 @@ export class CpkThreadInspector extends PortableLitElement {
     :host([data-color-scheme="dark"]) .cpk-td__panel-toggle,
     :host([data-color-scheme="dark"]) .cpk-td__metadata-strip,
     :host([data-color-scheme="dark"]) .cpk-td__metadata-pill,
+    :host([data-color-scheme="dark"]) .cpk-td__try-from-here,
     :host([data-color-scheme="dark"]) .cpk-td__tool-block,
     :host([data-color-scheme="dark"]) .cpk-td__tool-header,
     :host([data-color-scheme="dark"]) .cpk-td__tool-body,
@@ -3359,6 +3402,7 @@ export class CpkThreadInspector extends PortableLitElement {
     }
 
     :host([data-color-scheme="dark"]) .cpk-td__metadata-pill,
+    :host([data-color-scheme="dark"]) .cpk-td__try-from-here,
     :host([data-color-scheme="dark"]) .cpk-td__bubble-inner--assistant,
     :host([data-color-scheme="dark"]) .cpk-td__tool-block,
     :host([data-color-scheme="dark"]) .cpk-td__event,
@@ -3517,6 +3561,7 @@ export class CpkThreadInspector extends PortableLitElement {
     :host([data-color-scheme="dark"]) .cpk-td__timeline-title,
     :host([data-color-scheme="dark"]) .cpk-td__timeline-bulk-toggle,
     :host([data-color-scheme="dark"]) .cpk-td__timeline-details-toggle,
+    :host([data-color-scheme="dark"]) .cpk-td__try-from-here,
     :host([data-color-scheme="dark"]) .cpk-tdp__value {
       color: #f3f4f8;
     }
@@ -4707,6 +4752,7 @@ export class CpkThreadInspector extends PortableLitElement {
             `,
           )}
         </div>
+        ${this.renderTryFromHereControl()}
       </div>
     `;
   }
@@ -4744,6 +4790,42 @@ export class CpkThreadInspector extends PortableLitElement {
       }
     `;
   }
+
+  private renderTryFromHereControl() {
+    if (!this.tryFromHereAvailable) return nothing;
+    return html`
+      <button
+        type="button"
+        class="cpk-td__try-from-here"
+        aria-label="Try from here"
+        ?disabled=${this.tryFromHereBusy}
+        @click=${this.onTryFromHere}
+      >
+        ${this.tryFromHereBusy ? "Loading…" : "Try from here"}
+      </button>
+      ${
+        this.tryFromHereError
+          ? html`<span
+              class="cpk-td__try-from-here-error"
+              role="alert"
+              >${this.tryFromHereError}</span
+            >`
+          : nothing
+      }
+    `;
+  }
+
+  private onTryFromHere = (event: Event): void => {
+    event.preventDefault();
+    if (!this.tryFromHereAvailable || this.tryFromHereBusy) return;
+    this.dispatchEvent(
+      new CustomEvent("tryFromHere", {
+        detail: this.threadId,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
 
   private renderTimelineBulkControls() {
     if (this._eventsNotAvailable) return nothing;
@@ -6391,6 +6473,8 @@ export class WebInspectorElement extends LitElement {
   private playgroundError: string | null = null;
   private playgroundSourceThreadId: string | null = null;
   private playgroundShowEphemeralNotice = false;
+  private tryFromHereBusy = false;
+  private tryFromHereError: string | null = null;
   private threadCapabilityEnabled: boolean | null = null;
   private threadCapabilityGeneration = 0;
   private contextMenuOpen = false;
@@ -14607,6 +14691,56 @@ export class WebInspectorElement extends LitElement {
     return mapped;
   }
 
+  private async loadThreadSnapshot(thread: ɵThread): Promise<{
+    messages: Message[];
+    state: unknown;
+  }> {
+    const core = this._core;
+    if (!core?.runtimeUrl) {
+      throw new Error("Failed to load thread.");
+    }
+    const baseUrl = core.runtimeUrl.replace(/\/+$/, "");
+    const encodedThreadId = encodeURIComponent(thread.id);
+    const [messagesResponse, stateResponse] = await Promise.all([
+      fetch(`${baseUrl}/threads/${encodedThreadId}/messages`, {
+        headers: { ...core.headers },
+      }),
+      fetch(`${baseUrl}/threads/${encodedThreadId}/state`, {
+        headers: { ...core.headers },
+      }),
+    ]);
+    if (!messagesResponse.ok) {
+      throw new Error(
+        `Failed to load thread (HTTP ${messagesResponse.status}).`,
+      );
+    }
+    const messagesBody = (await messagesResponse.json()) as {
+      messages?: ThreadDebuggerMessage[];
+    };
+    const stateBody = stateResponse.ok
+      ? ((await stateResponse.json()) as { state?: unknown })
+      : { state: {} };
+    return {
+      messages: this.mapThreadMessagesToPlayground(
+        messagesBody.messages ?? [],
+      ),
+      state: stateBody.state ?? {},
+    };
+  }
+
+  private applyThreadSnapshotToPlayground(
+    thread: ɵThread,
+    snapshot: { messages: Message[]; state: unknown },
+  ): void {
+    this.startPlaygroundSession(
+      false,
+      snapshot.messages,
+      snapshot.state,
+      thread.agentId,
+    );
+    this.playgroundSourceThreadId = thread.id;
+  }
+
   private handlePlaygroundThreadSourceChange = async (
     event: Event,
   ): Promise<void> => {
@@ -14616,48 +14750,56 @@ export class WebInspectorElement extends LitElement {
       return;
     }
 
-    const core = this._core;
     const thread = this._threads.find((candidate) => candidate.id === threadId);
-    if (!core?.runtimeUrl || !thread) return;
+    if (!thread) return;
 
     this.playgroundIsLoadingThread = true;
     this.playgroundError = null;
     this.requestUpdate();
 
     try {
-      const baseUrl = core.runtimeUrl.replace(/\/+$/, "");
-      const encodedThreadId = encodeURIComponent(threadId);
-      const [messagesResponse, stateResponse] = await Promise.all([
-        fetch(`${baseUrl}/threads/${encodedThreadId}/messages`, {
-          headers: { ...core.headers },
-        }),
-        fetch(`${baseUrl}/threads/${encodedThreadId}/state`, {
-          headers: { ...core.headers },
-        }),
-      ]);
-      if (!messagesResponse.ok) {
-        throw new Error(
-          `Failed to load thread (HTTP ${messagesResponse.status}).`,
-        );
-      }
-      const messagesBody = (await messagesResponse.json()) as {
-        messages?: ThreadDebuggerMessage[];
-      };
-      const stateBody = stateResponse.ok
-        ? ((await stateResponse.json()) as { state?: unknown })
-        : { state: {} };
-      this.startPlaygroundSession(
-        false,
-        this.mapThreadMessagesToPlayground(messagesBody.messages ?? []),
-        stateBody.state ?? {},
-        thread.agentId,
-      );
-      this.playgroundSourceThreadId = threadId;
+      const snapshot = await this.loadThreadSnapshot(thread);
+      this.applyThreadSnapshotToPlayground(thread, snapshot);
     } catch (error) {
       this.playgroundError =
         error instanceof Error ? error.message : "Failed to load thread.";
     } finally {
       this.playgroundIsLoadingThread = false;
+      this.requestUpdate();
+    }
+  };
+
+  private handleTryFromHere = async (threadId: string | null): Promise<void> => {
+    if (!threadId || this.tryFromHereBusy) return;
+    const thread =
+      this._threads.find((candidate) => candidate.id === threadId) ?? null;
+    if (!thread) return;
+
+    this.tryFromHereBusy = true;
+    this.tryFromHereError = null;
+    this.requestUpdate();
+
+    try {
+      const snapshot = await this.loadThreadSnapshot(thread);
+      this.applyThreadSnapshotToPlayground(thread, snapshot);
+      if (!this.core?.telemetryDisabled) {
+        trackThreadsTryFromHereClicked({
+          ...this.getThreadsTelemetryProps(),
+          outcome: "success",
+        });
+      }
+      this.handleMenuSelect("playground");
+    } catch (error) {
+      this.tryFromHereError =
+        error instanceof Error ? error.message : "Failed to load thread.";
+      if (!this.core?.telemetryDisabled) {
+        trackThreadsTryFromHereClicked({
+          ...this.getThreadsTelemetryProps(),
+          outcome: "failure",
+        });
+      }
+    } finally {
+      this.tryFromHereBusy = false;
       this.requestUpdate();
     }
   };
@@ -14997,10 +15139,20 @@ export class WebInspectorElement extends LitElement {
                       ?disabled=${busy}
                       @change=${this.handlePlaygroundThreadSourceChange}
                     >
-                      <option value="">Load a thread...</option>
+                      <option
+                        value=""
+                        ?selected=${!this.playgroundSourceThreadId}
+                      >
+                        Load a thread...
+                      </option>
                       ${sourceThreads.map(
                         (thread) => html`
-                          <option value=${thread.id}>
+                          <option
+                            value=${thread.id}
+                            ?selected=${
+                              this.playgroundSourceThreadId === thread.id
+                            }
+                          >
                             ${
                               thread.name?.trim() ||
                               `Thread ${thread.id.slice(0, 8)}`
@@ -16044,6 +16196,7 @@ export class WebInspectorElement extends LitElement {
       return;
     }
 
+    this.tryFromHereError = null;
     this.selectedThreadId = threadId;
     if (showingExamples && this.isExampleThreadId(threadId)) {
       this.selectedRealThreadIsExplicit = false;
@@ -17360,6 +17513,18 @@ export class WebInspectorElement extends LitElement {
                             ? EMPTY_INSPECTOR_MESSAGES
                             : this.getLiveAgentMessagesForThread(selectedThread)
                         }
+                        .tryFromHereAvailable=${
+                          !selectedThreadIsLocalExample &&
+                          this.areThreadEndpointsAvailable() &&
+                          this._core?.threadEndpoints?.inspect !== false
+                        }
+                        .tryFromHereBusy=${this.tryFromHereBusy}
+                        .tryFromHereError=${this.tryFromHereError}
+                        @tryFromHere=${(
+                          event: CustomEvent<string | null>,
+                        ) => {
+                          void this.handleTryFromHere(event.detail);
+                        }}
                       ></cpk-thread-details>
                       ${
                         selectedThreadIsLocalExample

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -2273,7 +2273,9 @@ export class CpkThreadInspector extends PortableLitElement {
   }
 
   private renderTabContent(id: ThreadDetailsTab): TemplateResult {
-    if (id === "timeline") return this.renderTimeline();
+    if (id === "timeline") {
+      return this.withMessagesToolbar(this.renderTimeline());
+    }
     if (id === "state") return this.renderState();
     return this.renderEvents();
   }
@@ -2626,20 +2628,33 @@ export class CpkThreadInspector extends PortableLitElement {
     .cpk-td__try-from-here {
       display: inline-flex;
       align-items: center;
-      margin-left: auto;
-      padding: 4px 8px;
-      border: 1px solid #d8d9e3;
-      border-radius: 6px;
+      gap: 4px;
+      margin-inline-start: auto;
+      padding: 6px 10px;
+      border: 1px solid #dbdbe5;
+      border-radius: 8px;
       background: #ffffff;
-      color: #3f3f46;
+      color: #36363a;
+      font-family: "Spline Sans Mono", monospace;
       font-size: 11px;
       font-weight: 600;
+      line-height: 1.2;
       cursor: pointer;
     }
 
+    .cpk-td__try-from-here-icon {
+      display: block;
+      flex-shrink: 0;
+    }
+
+    :host([dir="rtl"]) .cpk-td__try-from-here-icon {
+      scale: -1 1;
+    }
+
     .cpk-td__try-from-here:hover:not(:disabled) {
-      border-color: #c4c5d4;
-      background: #f7f7fb;
+      border-color: rgba(85, 88, 178, 0.38);
+      background: #f7f7ff;
+      color: #010507;
     }
 
     .cpk-td__try-from-here:focus-visible {
@@ -2653,6 +2668,7 @@ export class CpkThreadInspector extends PortableLitElement {
     }
 
     .cpk-td__try-from-here-error {
+      flex-basis: 100%;
       color: #c0333a;
       font-size: 11px;
       line-height: 1.4;
@@ -3042,6 +3058,8 @@ export class CpkThreadInspector extends PortableLitElement {
 
     .cpk-td__timeline-toolbar {
       display: flex;
+      flex-wrap: wrap;
+      align-items: center;
       gap: 6px;
     }
 
@@ -4752,7 +4770,6 @@ export class CpkThreadInspector extends PortableLitElement {
             `,
           )}
         </div>
-        ${this.renderTryFromHereControl()}
       </div>
     `;
   }
@@ -4802,6 +4819,21 @@ export class CpkThreadInspector extends PortableLitElement {
         @click=${this.onTryFromHere}
       >
         ${this.tryFromHereBusy ? "Loading…" : "Try from here"}
+        <svg
+          class="cpk-td__try-from-here-icon"
+          aria-hidden="true"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 7h10v10" />
+          <path d="M7 17 17 7" />
+        </svg>
       </button>
       ${
         this.tryFromHereError
@@ -4828,6 +4860,15 @@ export class CpkThreadInspector extends PortableLitElement {
   };
 
   private renderTimelineBulkControls() {
+    const bulk = this.renderTimelineBulkButtons();
+    const tryFromHere = this.renderTryFromHereControl();
+    if (bulk === nothing && tryFromHere === nothing) return nothing;
+    return html`<div class="cpk-td__timeline-toolbar">
+      ${bulk}${tryFromHere}
+    </div>`;
+  }
+
+  private renderTimelineBulkButtons() {
     if (this._eventsNotAvailable) return nothing;
 
     const detailIds = this.timelineItemsForEvents(this.activeEvents)
@@ -4842,7 +4883,7 @@ export class CpkThreadInspector extends PortableLitElement {
       (id) => !this._expandedTimelineDetails.has(id),
     );
 
-    return html`<div class="cpk-td__timeline-toolbar">
+    return html`
       <button
         type="button"
         class="cpk-td__timeline-bulk-toggle"
@@ -4859,7 +4900,7 @@ export class CpkThreadInspector extends PortableLitElement {
       >
         Collapse all
       </button>
-    </div>`;
+    `;
   }
 
   private renderRawEventBulkControls() {
@@ -4903,6 +4944,10 @@ export class CpkThreadInspector extends PortableLitElement {
     });
   }
 
+  private withMessagesToolbar(content: unknown) {
+    return html`${this.renderTimelineBulkControls()}${content}`;
+  }
+
   private renderTimeline() {
     if (this._loadingEvents) {
       return html`
@@ -4910,13 +4955,19 @@ export class CpkThreadInspector extends PortableLitElement {
       `;
     }
     if (this._eventsError) {
-      return html`<div class="cpk-td__status cpk-td__status--error">
+      return html`<div
+        class="cpk-td__status cpk-td__status--error"
+      >
         ${this._eventsError}
       </div>`;
     }
     if (this._eventsNotAvailable) {
-      if (this._conversation.length > 0) return this.renderConversation();
-      if (this._loadingMessages) return this.renderConversation();
+      if (this._conversation.length > 0) {
+        return this.renderConversation();
+      }
+      if (this._loadingMessages) {
+        return this.renderConversation();
+      }
       return html`
         <div class="cpk-td__empty-state">
           <span>Timeline event history not available</span>
@@ -4939,8 +4990,12 @@ export class CpkThreadInspector extends PortableLitElement {
 
     const timelineItems = this.timelineItemsForEvents(events);
     if (timelineItems.length === 0) {
-      if (this._conversation.length > 0) return this.renderConversation();
-      if (this._loadingMessages) return this.renderConversation();
+      if (this._conversation.length > 0) {
+        return this.renderConversation();
+      }
+      if (this._loadingMessages) {
+        return this.renderConversation();
+      }
       return html`
         <div class="cpk-td__empty-state">
           <span>No timeline events captured</span>
@@ -4960,10 +5015,7 @@ export class CpkThreadInspector extends PortableLitElement {
         this.agentMessagesInput,
         this._expandedTimelineDetails,
       ],
-      () =>
-        html`${this.renderTimelineBulkControls()}${timelineItems.map((item) =>
-          this.renderTimelineItem(item),
-        )}`,
+      () => html`${timelineItems.map((item) => this.renderTimelineItem(item))}`,
     );
   }
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -14721,9 +14721,7 @@ export class WebInspectorElement extends LitElement {
       ? ((await stateResponse.json()) as { state?: unknown })
       : { state: {} };
     return {
-      messages: this.mapThreadMessagesToPlayground(
-        messagesBody.messages ?? [],
-      ),
+      messages: this.mapThreadMessagesToPlayground(messagesBody.messages ?? []),
       state: stateBody.state ?? {},
     };
   }
@@ -14769,7 +14767,9 @@ export class WebInspectorElement extends LitElement {
     }
   };
 
-  private handleTryFromHere = async (threadId: string | null): Promise<void> => {
+  private handleTryFromHere = async (
+    threadId: string | null,
+  ): Promise<void> => {
     if (!threadId || this.tryFromHereBusy) return;
     const thread =
       this._threads.find((candidate) => candidate.id === threadId) ?? null;
@@ -17520,9 +17520,7 @@ export class WebInspectorElement extends LitElement {
                         }
                         .tryFromHereBusy=${this.tryFromHereBusy}
                         .tryFromHereError=${this.tryFromHereError}
-                        @tryFromHere=${(
-                          event: CustomEvent<string | null>,
-                        ) => {
+                        @tryFromHere=${(event: CustomEvent<string | null>) => {
                           void this.handleTryFromHere(event.detail);
                         }}
                       ></cpk-thread-details>

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -14779,19 +14779,28 @@ export class WebInspectorElement extends LitElement {
     this.tryFromHereError = null;
     this.requestUpdate();
 
+    const isCurrentTryFromHereRequest = (): boolean =>
+      this.selectedThreadId === threadId && this.selectedMenu === "threads";
+
     try {
       const snapshot = await this.loadThreadSnapshot(thread);
-      this.applyThreadSnapshotToPlayground(thread, snapshot);
+      // A later thread or pane change owns the UI. Keep the fetch outcome
+      // for telemetry, but do not replace Playground or leave Threads.
+      if (isCurrentTryFromHereRequest()) {
+        this.applyThreadSnapshotToPlayground(thread, snapshot);
+        this.handleMenuSelect("playground");
+      }
       if (!this.core?.telemetryDisabled) {
         trackThreadsTryFromHereClicked({
           ...this.getThreadsTelemetryProps(),
           outcome: "success",
         });
       }
-      this.handleMenuSelect("playground");
     } catch (error) {
-      this.tryFromHereError =
-        error instanceof Error ? error.message : "Failed to load thread.";
+      if (isCurrentTryFromHereRequest()) {
+        this.tryFromHereError =
+          error instanceof Error ? error.message : "Failed to load thread.";
+      }
       if (!this.core?.telemetryDisabled) {
         trackThreadsTryFromHereClicked({
           ...this.getThreadsTelemetryProps(),

--- a/packages/web-inspector/src/lib/__tests__/telemetry.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/telemetry.test.ts
@@ -20,6 +20,7 @@ import {
   trackThreadsLockedViewed,
   trackThreadsTabClicked,
   trackThreadsTalkToEngineerClicked,
+  trackThreadsTryFromHereClicked,
   trackWhatsNewClicked,
   trackWhatsNewSignalViewed,
   trackWhatsNewViewed,
@@ -345,6 +346,33 @@ describe("typed helpers", () => {
     });
   });
 
+  it("trackThreadsTryFromHereClicked sends outcome without thread ids", async () => {
+    trackThreadsTryFromHereClicked({
+      intelligence_status: "intelligence_enabled",
+      thread_service_status: "available",
+      runtime_mode: "sse",
+      runtime_url_type: "localhost",
+      license_status: "valid",
+      telemetry_disabled: false,
+      leaf_key: "threads",
+      outcome: "success",
+    });
+    await Promise.resolve();
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init?.body as string) ?? "{}") as {
+      event: string;
+      properties: Record<string, unknown>;
+    };
+    expect(body.event).toBe(TELEMETRY_EVENTS.threadsTryFromHereClicked);
+    expect(body.properties).toMatchObject({
+      outcome: "success",
+      leaf_key: "threads",
+      runtime_mode: "sse",
+    });
+    expect(body.properties).not.toHaveProperty("thread_id");
+    expect(body.properties).not.toHaveProperty("message");
+  });
+
   it("sends required threads CTA and viewed events", async () => {
     trackThreadsLockedViewed({
       intelligence_status: "intelligence_not_enabled",
@@ -464,10 +492,10 @@ describe("event catalogue", () => {
     ]);
   });
 
-  it("holds twenty-six event names, all under the owned oss.inspector prefix", () => {
+  it("holds twenty-seven event names, all under the owned oss.inspector prefix", () => {
     const names = Object.values(TELEMETRY_EVENTS) as string[];
 
-    expect(names).toHaveLength(26);
+    expect(names).toHaveLength(27);
     expect(names.filter((name) => !name.startsWith("oss.inspector."))).toEqual(
       [],
     );

--- a/packages/web-inspector/src/lib/__tests__/thread-telemetry-privacy.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/thread-telemetry-privacy.test.ts
@@ -21,6 +21,7 @@ import {
   trackThreadsLockedViewed,
   trackThreadsTabClicked,
   trackThreadsTalkToEngineerClicked,
+  trackThreadsTryFromHereClicked,
 } from "../telemetry.js";
 import type {
   InspectorMetadataActionClickedTelemetryProps,
@@ -61,7 +62,8 @@ type ThreadEventKey =
   | "example_kind"
   | "tour_step"
   | "tour_tab"
-  | "dismiss_method";
+  | "dismiss_method"
+  | "outcome";
 
 type ThreadEventFields = Required<
   Pick<InspectorThreadTelemetryProps, ThreadEventKey>
@@ -233,6 +235,7 @@ function createThreadFixture(
     tour_step: overrides.tour_step ?? 1,
     tour_tab: overrides.tour_tab ?? "timeline",
     dismiss_method: overrides.dismiss_method ?? "skip",
+    outcome: overrides.outcome ?? "success",
     ...forbidden,
   };
 
@@ -293,6 +296,13 @@ test.each<ThreadHelperCase>([
     invoke: trackThreadsTabClicked,
     expectedEvent: "oss.inspector.threads_tab_clicked",
     expectedProperties: {},
+  },
+  {
+    name: "threads try from here clicked",
+    invoke: trackThreadsTryFromHereClicked,
+    expectedEvent: "oss.inspector.threads_try_from_here_clicked",
+    eventOverrides: { outcome: "success" },
+    expectedProperties: { outcome: "success" },
   },
   {
     name: "threads locked viewed",

--- a/packages/web-inspector/src/lib/telemetry.ts
+++ b/packages/web-inspector/src/lib/telemetry.ts
@@ -34,6 +34,7 @@ export const TELEMETRY_EVENTS = {
   errorSignalViewed: "oss.inspector.error_signal_viewed",
   whatsNewClicked: "oss.inspector.whats_new_clicked",
   threadsTabClicked: "oss.inspector.threads_tab_clicked",
+  threadsTryFromHereClicked: "oss.inspector.threads_try_from_here_clicked",
   threadsLockedViewed: "oss.inspector.threads_locked_viewed",
   threadsIntelligenceSignupClicked:
     "oss.inspector.threads_intelligence_signup_clicked",
@@ -375,6 +376,7 @@ export type InspectorThreadTelemetryProps = Readonly<{
   tour_step?: ExampleTourStep;
   tour_tab?: ExampleTourTab;
   dismiss_method?: "skip" | "done";
+  outcome?: "success" | "failure";
 }>;
 
 /** Rebuild the common Thread payload from its closed coarse allowlist. */
@@ -459,6 +461,15 @@ export function trackThreadsTabClicked(
   props: InspectorThreadTelemetryProps = {},
 ): void {
   track(TELEMETRY_EVENTS.threadsTabClicked, threadCommonProperties(props));
+}
+
+export function trackThreadsTryFromHereClicked(
+  props: InspectorThreadTelemetryProps,
+): void {
+  track(TELEMETRY_EVENTS.threadsTryFromHereClicked, {
+    ...threadCommonProperties(props),
+    ...(props.outcome === undefined ? {} : { outcome: props.outcome }),
+  });
 }
 
 export function trackThreadsLockedViewed(

--- a/prds/oss-873-try-from-here.md
+++ b/prds/oss-873-try-from-here.md
@@ -1,0 +1,151 @@
+# Try from here (Threads to Playground)
+
+Linear: [OSS-873](https://linear.app/copilotkit/issue/OSS-873/new-features-add-a-new-fork-from-here-action-to-the-the-threads-view)
+
+## Problem Statement
+
+A developer opens a past thread in Inspector to see what the agent did. They want to try a follow-up, or retry the same conversation, without changing that stored thread.
+
+Today they can read the thread. They cannot start a safe experiment from it on the Threads view. If they keep chatting in the app, they risk writing into the real thread. Playground can load a whole thread from its own header. The developer who is already on Threads must leave the thread, open Playground, and pick the thread again.
+
+## Solution
+
+The developer opens a real stored thread. The thread detail header shows **Try from here**.
+
+A click copies the whole conversation (messages and thread state) into a new Playground scratch session. Inspector then opens Playground. The stored thread does not change.
+
+The scratch session uses a new local thread id. Later Playground messages do not write back to the original thread.
+
+If Playground already has a scratch chat, this click replaces it. There is no confirm dialog. If the copy fails, the developer stays on Threads. The old scratch session stays. An error appears next to the button.
+
+The button is hidden on example tour threads and when thread inspect cannot load.
+
+## User Stories
+
+1. As a developer, I want a **Try from here** control on the thread I am viewing, so that I can experiment without leaving the conversation I just read.
+2. As a developer, I want the control in the thread detail header, so that I do not hunt through the thread list.
+3. As a developer, I want the label to read **Try from here**, so that the action sounds like a safe experiment, not a Git fork.
+4. As a developer, I want one click to copy the whole thread, so that I do not pick messages one by one.
+5. As a developer, I want the copy to include every stored message, so that the scratch chat matches the original conversation.
+6. As a developer, I want the copy to include thread state, so that a retry can use the same agent state as that thread.
+7. As a developer, I want the scratch session to use the thread's agent, so that the wrong agent does not answer.
+8. As a developer, I want Inspector to switch to Playground after a successful copy, so that I can type the next message at once.
+9. As a developer, I want the stored thread to stay unchanged after I chat in Playground, so that history stays a record of what happened.
+10. As a developer, I want Playground to use a new scratch thread id, so that the runtime does not treat the copy as the original thread.
+11. As a developer who already has a Playground scratch chat, I want Try from here to replace that scratch, so that I am not stuck with two sessions and no UI for a second one.
+12. As a developer, I do not want a confirm dialog, so that the path matches Playground **Load a thread**.
+13. As a developer, I want the copy to finish before Playground is replaced, so that a failed load does not wipe my current scratch.
+14. As a developer whose copy fails, I want to stay on Threads, so that I am not sent to an empty Playground.
+15. As a developer whose copy fails, I want an error next to **Try from here**, so that I know why nothing happened.
+16. As a developer whose copy fails, I want to click **Try from here** again, so that a later success still works.
+17. As a developer looking at an example tour thread, I do not want **Try from here**, so that a demo thread is not treated as a stored conversation.
+18. As a developer whose Threads view is locked, I do not want **Try from here**, so that I am not offered an action that cannot load messages.
+19. As a developer on a thread that cannot inspect, I do not want **Try from here**, so that a dead button does not sit in the header.
+20. As a developer with no thread selected, I do not want **Try from here**, so that the empty detail pane stays empty.
+21. As a developer, I want a loading state on the button while the copy runs, so that a double click does not start two loads.
+22. As a developer who double-clicks, I want the second click to do nothing while the first load is in flight, so that Playground is replaced once.
+23. As a developer whose Playground agent is mid-run, I want a successful Try from here to stop that run and then open the copy, so that the old scratch does not keep streaming.
+24. As a developer, I want Playground **Load a thread** to keep working, so that I can still start from Playground without opening Threads.
+25. As a developer, I want Playground **New thread** to keep working after Try from here, so that I can drop the copy and start empty.
+26. As a developer, I want the Playground source-thread control to show this thread after a successful copy, so that I can see which thread I started from.
+27. As a developer, I want Inspector agent scope to match the thread's agent after a successful copy, so that Playground and the header agree.
+28. As a developer on **All Agents**, I want Try from here to still copy that one thread's agent, so that I do not have to change the dropdown first.
+29. As a developer with two agents, I want a thread from agent B to open Playground on agent B, so that agent A does not receive the copy.
+30. As a developer on an empty stored thread, I want Try from here to still run, so that I get an empty scratch with that thread's state.
+31. As a developer whose messages request fails, I want the action to fail, so that Playground is not opened with a partial copy.
+32. As a developer whose state request fails, I want messages to still copy and state to be empty, so that the path matches Playground **Load a thread**.
+33. As a developer with no runtime URL, I want the action to fail with a visible error, so that I know the copy cannot load.
+34. As a developer, I want core request headers to go with the load, so that authenticated runtimes still return messages and state.
+35. As a keyboard user, I want **Try from here** to be a real button I can tab to, so that I do not need a pointer.
+36. As a screen-reader user, I want the button name to be **Try from here**, so that the action is clear.
+37. As a screen-reader user, I want a failed copy to expose the error next to the button, so that the failure is not silent.
+38. As a developer in a popped-out Inspector, I want Try from here to work in that window, so that I do not have to dock back first.
+39. As a developer using React, Vue, or the web component, I want the same control, so that the feature lives in Inspector, not in each wrapper.
+40. As a developer on dark or light Inspector, I want the button to follow the current color scheme, so that the header stays readable.
+41. As a developer, I want tool calls and tool results in the copy when the thread has them, so that the scratch conversation stays complete.
+42. As a developer, I want later Playground runs to write only to the scratch session, so that Threads still shows the original messages.
+43. As a QA tester, I want a successful copy to be assertable from the UI (Playground leaf open, original messages visible, new thread id), so that tests do not read private fields when public UI is enough.
+44. As a QA tester, I want a failed copy to keep the Playground leaf unselected (or unchanged) and keep prior scratch messages, so that the no-wipe rule is testable.
+45. As a telemetry reviewer, I want one coarse event with `outcome` success or failure, so that we can see if people use the control.
+46. As a telemetry reviewer, I want no thread id and no message text in that event, so that Threads privacy rules still hold.
+47. As a developer who opted out of telemetry, I want the click to still copy, so that analytics never block the action.
+48. As a docs reader, I want Threads docs to mention **Try from here** after it ships, so that I can find the action without a Linear ticket.
+
+## Implementation Decisions
+
+- This work lives in the web Inspector. No new public React or Vue API. No new runtime route. No new package.
+- Playground is a hard dependency. Try from here is an entry on Threads into the existing scratch Playground session.
+- Reuse the Playground load contract:
+  - `GET {runtimeUrl}/threads/{threadId}/messages` must succeed.
+  - `GET {runtimeUrl}/threads/{threadId}/state` is best-effort. If it fails, use empty state.
+  - Send the same core headers as Playground load.
+  - Map stored thread messages onto Playground agent messages (user, assistant, tool), then `clone()` the source agent, assign a new Playground thread id, `setMessages`, `setState`.
+- Fetch the snapshot first. Replace the scratch session only after a successful messages load. This is the control flow from the grill (not a demo):
+
+```
+snapshot = loadThread(threadId)
+if snapshot.messagesFailed:
+  showErrorOnThreads(error)
+  return
+replaceScratch(snapshot)  // clone agent, new thread id, messages + state
+openLeaf("playground")
+```
+
+- After success, set the Playground source-thread id to this thread, switch Inspector leaf to Playground, and set agent scope to `thread.agentId`.
+- While the load runs, disable **Try from here** and ignore extra clicks.
+- On success, if a Playground run is active, abort it as part of replacing the scratch session (same teardown Playground already uses).
+- Button placement: thread detail header only. Not on list rows. Not on messages.
+- Visibility: real stored thread, thread inspect available, not an example tour thread, a thread is selected.
+- Failure UI: stay on Threads. Keep the current Playground scratch. Show the error next to the button. Do not open Playground.
+- Telemetry: one event in the existing Inspector Threads family, for example `oss.inspector.threads_try_from_here_clicked`, with `outcome: "success" | "failure"` plus the same coarse Threads fields (`leaf_key`, `runtime_mode`, license and usage buckets). No thread id. No message text. No runtime URL. Honor `telemetryDisabled`.
+- Playground **Load a thread** and **New thread** stay as they are.
+- Docs: this is an Inspector overlay action, not a new pane. When the button ships, update the Inspector pane map and the Threads Callout so they name **Try from here**. Do not add a Callout before the button ships.
+
+## Testing Decisions
+
+- Good tests assert what the developer sees and what the stored thread does not do. They do not assert private field names when a heading, button, or message list is enough.
+- A good success test: open a real thread, click **Try from here**, see Playground, see the copied messages, see a different thread id, then send a Playground message and still see the original thread unchanged when returning to Threads.
+- A good failure test: messages HTTP fails, the developer is still on Threads, the error is visible, Playground still has the previous scratch messages.
+- A good visibility test: example tour thread has no **Try from here**. Locked Threads has no **Try from here**.
+- A good privacy test: the telemetry payload has `outcome` and does not include thread id, message text, or runtime URL.
+- Modules to test: web Inspector (thread detail header, copy flow, navigation to Playground, telemetry).
+- Prior art:
+  - Playground navigation and **Load a thread** tests in Inspector navigation specs.
+  - Threads state, locked, and example-thread tests.
+  - Threads telemetry privacy tests (forbidden fields and coarse buckets).
+
+## Manual Testing Plan
+
+Use the v2 react-router example with Inspector open (`showDevConsole="auto"`). Runtime must expose thread inspect (messages and, if present, state).
+
+1. **Happy path.** Send two chat turns in the app. Open Inspector, open Threads, select that thread. Click **Try from here**. Confirm Inspector is on Playground, the messages match, and the Playground source control names that thread. Send a new Playground message. Return to Threads and confirm the stored thread does not include the new Playground message.
+2. **Replace scratch.** In Playground, send a unique scratch message. Open Threads, select a different real thread, click **Try from here**. Confirm Playground shows the stored thread, not the unique scratch message.
+3. **Fail and keep scratch.** Repeat step 2 so Playground has a unique scratch message. Break the messages request (stop the runtime, or block `/threads/.../messages`). Click **Try from here**. Confirm you stay on Threads, an error is next to the button, and Playground still has the unique scratch message.
+4. **Hidden on examples.** Use a runtime with no real threads so the example tour list shows. Select an example thread. Confirm **Try from here** is absent.
+5. **Hidden when locked.** Use a runtime with Threads locked. Confirm **Try from here** is absent.
+6. **Empty thread.** If you can open a stored thread with no messages, click **Try from here**. Confirm Playground opens empty (or with state only) and does not error.
+7. **Keyboard.** Tab to **Try from here** and activate it with Enter. Confirm the same success path as step 1.
+8. **Two agents.** If the example exposes two agents, fork a thread that belongs to the non-default agent. Confirm Playground header shows that agent.
+
+## Out of Scope
+
+- Per-message fork (copy only up to a chosen message).
+- A **Try from here** control on thread list rows.
+- A confirm dialog before replacing Playground.
+- A second concurrent Playground session.
+- Copy from example tour threads.
+- Edit, rename, delete, or append to the stored thread from this action.
+- New runtime endpoints.
+- New public frontend APIs or new Inspector panes.
+- Sending thread ids or message bodies in telemetry.
+
+## Further Notes
+
+- Ticket title says "Fork from here". Shipped label is **Try from here**.
+- Playground landed in CopilotKit/CopilotKit#6580. This spec assumes that Playground load and clone path is on main.
+- State fetch failure is empty state, not a hard failure. That matches Playground **Load a thread** today.
+- Suggested git branch from Linear: `alem/oss-873-new-features-add-a-new-fork-from-here-action-to-the-the`.
+- Documentation impact (product docs, after the button ships, not in this file's job):
+  - Reader: a developer who already uses Inspector Threads and wants to retry a conversation.
+  - Update the Threads Inspector Callout and the Inspector pane map. Move **Try from here** out of Unshipped. Do not invent a new docs section unless Threads overview cannot hold one short Callout line.
+  - Readers who do not use the web overlay (React Native, Channels) get no Open Inspector step for this action.

--- a/prds/oss-873-try-from-here.md
+++ b/prds/oss-873-try-from-here.md
@@ -82,7 +82,7 @@ The button is hidden on example tour threads and when thread inspect cannot load
   - Map stored thread messages onto Playground agent messages (user, assistant, tool), then `clone()` the source agent, assign a new Playground thread id, `setMessages`, `setState`.
 - Fetch the snapshot first. Replace the scratch session only after a successful messages load. This is the control flow from the grill (not a demo):
 
-```
+```text
 snapshot = loadThread(threadId)
 if snapshot.messagesFailed:
   showErrorOnThreads(error)

--- a/showcase/shell-docs/src/content/snippets/shared/inspector/open-inspector-pane-threads.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/inspector/open-inspector-pane-threads.mdx
@@ -1,6 +1,7 @@
 <Callout type="info" title="See this in Inspector">
   Open Inspector on localhost. Stay on **Threads** (it is the default).
   Real threads appear when Intelligence is on. Enable Intelligence appears when it is off.
+  Open a real thread and use **Try from here** to copy it into a Playground scratch session. The stored thread does not change.
 
   More detail: [Inspector](/inspector).
 </Callout>

--- a/skills/inspector-docs/references/pane-map.md
+++ b/skills/inspector-docs/references/pane-map.md
@@ -7,7 +7,9 @@ Update this file in the same change that adds or removes a pane.
 | ----------------- | --------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------- |
 | Agent             | Default web quickstart step                   | `snippets/shared/inspector/open-inspector-step.mdx`          | First check in the quickstart step                                    |
 | AG-UI Events      | Default web quickstart step                   | `snippets/shared/inspector/open-inspector-step.mdx`          | Second check, after a chat message                                    |
-| Threads           | Default web quickstart step, Threads overview | `open-inspector-step.mdx`, `open-inspector-pane-threads.mdx` | Unlocked or Enable Intelligence both count                            |
+| Threads           | Default web quickstart step, Threads overview | `open-inspector-step.mdx`, `open-inspector-pane-threads.mdx` | Unlocked or Enable Intelligence both count. Callout also names **Try from here**. |
+| Playground        | no page yet                                   |                                                              | Workbench leaf. Threads **Try from here** copies into this scratch session. |
+| Try from here     | Threads overview                              | `open-inspector-pane-threads.mdx`                            | Overlay action on a real stored thread detail header.                 |
 | Frontend Tools    | Frontend tools, human-in-the-loop overview    | `open-inspector-pane-frontend-tools.mdx`                     | HITL tools appear here when registered                                |
 | State             | Shared state                                  | `open-inspector-pane-state.mdx`                              | Thread detail tab                                                     |
 | Context           | `useAgentContext` / agent-readonly            | `open-inspector-pane-context.mdx`                            | Agents group                                                          |
@@ -15,11 +17,9 @@ Update this file in the same change that adds or removes a pane.
 | Capabilities      | no page yet                                   |                                                              | Client tool and catalog toggles. No dedicated docs page in this slice |
 | Messages          | no page yet                                   |                                                              | Thread detail tab. Covered by Threads Callout                         |
 | Angular Inspector | Angular frontend getting-started              | `open-inspector-step-angular.mdx`                            | Install page first                                                    |
-| Playground        | no page yet                                   |                                                              | Workbench scratch chat. No dedicated docs page in this slice          |
 
 ## Unshipped (no Callout)
 
-- Fork from here
 - Emit events
 - Pop-out window
 

--- a/skills/inspector-docs/references/pane-map.md
+++ b/skills/inspector-docs/references/pane-map.md
@@ -3,20 +3,20 @@
 Source of truth for which shipped Inspector pane has a docs Callout.
 Update this file in the same change that adds or removes a pane.
 
-| Shipped pane      | Docs page                                     | Callout snippet                                              | Notes                                                                 |
-| ----------------- | --------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------- |
-| Agent             | Default web quickstart step                   | `snippets/shared/inspector/open-inspector-step.mdx`          | First check in the quickstart step                                    |
-| AG-UI Events      | Default web quickstart step                   | `snippets/shared/inspector/open-inspector-step.mdx`          | Second check, after a chat message                                    |
+| Shipped pane      | Docs page                                     | Callout snippet                                              | Notes                                                                             |
+| ----------------- | --------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Agent             | Default web quickstart step                   | `snippets/shared/inspector/open-inspector-step.mdx`          | First check in the quickstart step                                                |
+| AG-UI Events      | Default web quickstart step                   | `snippets/shared/inspector/open-inspector-step.mdx`          | Second check, after a chat message                                                |
 | Threads           | Default web quickstart step, Threads overview | `open-inspector-step.mdx`, `open-inspector-pane-threads.mdx` | Unlocked or Enable Intelligence both count. Callout also names **Try from here**. |
-| Playground        | no page yet                                   |                                                              | Workbench leaf. Threads **Try from here** copies into this scratch session. |
-| Try from here     | Threads overview                              | `open-inspector-pane-threads.mdx`                            | Overlay action on a real stored thread detail header.                 |
-| Frontend Tools    | Frontend tools, human-in-the-loop overview    | `open-inspector-pane-frontend-tools.mdx`                     | HITL tools appear here when registered                                |
-| State             | Shared state                                  | `open-inspector-pane-state.mdx`                              | Thread detail tab                                                     |
-| Context           | `useAgentContext` / agent-readonly            | `open-inspector-pane-context.mdx`                            | Agents group                                                          |
-| Learning          | CopilotKit Intelligence overview              | `open-inspector-pane-learning.mdx`                           | Primary nav                                                           |
-| Capabilities      | no page yet                                   |                                                              | Client tool and catalog toggles. No dedicated docs page in this slice |
-| Messages          | no page yet                                   |                                                              | Thread detail tab. Covered by Threads Callout                         |
-| Angular Inspector | Angular frontend getting-started              | `open-inspector-step-angular.mdx`                            | Install page first                                                    |
+| Playground        | no page yet                                   |                                                              | Workbench leaf. Threads **Try from here** copies into this scratch session.       |
+| Try from here     | Threads overview                              | `open-inspector-pane-threads.mdx`                            | Overlay action on a real stored thread detail header.                             |
+| Frontend Tools    | Frontend tools, human-in-the-loop overview    | `open-inspector-pane-frontend-tools.mdx`                     | HITL tools appear here when registered                                            |
+| State             | Shared state                                  | `open-inspector-pane-state.mdx`                              | Thread detail tab                                                                 |
+| Context           | `useAgentContext` / agent-readonly            | `open-inspector-pane-context.mdx`                            | Agents group                                                                      |
+| Learning          | CopilotKit Intelligence overview              | `open-inspector-pane-learning.mdx`                           | Primary nav                                                                       |
+| Capabilities      | no page yet                                   |                                                              | Client tool and catalog toggles. No dedicated docs page in this slice             |
+| Messages          | no page yet                                   |                                                              | Thread detail tab. Covered by Threads Callout                                     |
+| Angular Inspector | Angular frontend getting-started              | `open-inspector-step-angular.mdx`                            | Install page first                                                                |
 
 ## Unshipped (no Callout)
 


### PR DESCRIPTION
Inspector Threads now has **Try from here**. One click copies a stored thread into a Playground scratch session. The stored thread does not change.

If the copy fails, Inspector stays on Threads and keeps the current Playground scratch. Example tour threads and locked Threads do not show the button.

## What does this PR do?

Adds **Try from here** on a real stored thread in Inspector Threads. One click copies messages and thread state into a Playground scratch session. The stored thread does not change.

If the copy fails, Inspector stays on Threads and keeps the current Playground scratch. Example tour threads and locked Threads do not show the button.

## Related PRs and Issues

- Linear: OSS-873
- Playground base: https://github.com/CopilotKit/CopilotKit/pull/6580 (merged)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

## Testing

**Commands run**

1. Rebased `feat/oss-873-try-from-here` onto `origin/main` and resolved 6 conflict files.
2. `npx nx run @copilotkit/web-inspector:test` — 626 tests passed (after the stale-result guard).
3. `npx nx run @copilotkit/web-inspector:check-types` — passed.

**Manual test**

1. Open Inspector on localhost with Intelligence on, so a real stored thread exists.
2. Open that thread. Confirm **Try from here** is in the thread header.
3. Click **Try from here**. Confirm Inspector opens Playground with the copied messages and the stored thread is unchanged.
4. Open an example tour thread. Confirm **Try from here** is not shown.
5. Force a copy failure (disconnect runtime). Confirm Inspector stays on Threads and the prior Playground scratch is unchanged.

**How this PR makes testing easy**

- `packages/web-inspector/src/__tests__/inspector-navigation.spec.ts` covers the button, copy path, failure path, and a stale click that must not overwrite Playground.
- `packages/web-inspector/src/lib/__tests__/telemetry.test.ts` covers `oss.inspector.threads_try_from_here_clicked`.

## Risk / rollback

Risk is limited to Inspector Threads and Playground. A revert of this PR removes the button and the new telemetry event. No runtime protocol change.

## Public API change

New Inspector telemetry export and event name:

**Before**

```ts
trackThreadsTabClicked(props);
```

**After**

```ts
trackThreadsTabClicked(props);
trackThreadsTryFromHereClicked({ ...props, outcome: "success" });
```

`CpkThreadInspector` also emits a `tryFromHere` custom event when the user clicks the button.
