### PR TITLE
fix(runtime): stop emitting a require() statement in published .d.cts

### DIFF
--- a/.github/workflows/static_quality.yml
+++ b/.github/workflows/static_quality.yml
@@ -273,7 +273,10 @@ jobs:
             echo "NX_NO_CLOUD=true"
           } >> "$GITHUB_ENV"
 
-      - name: Run publint and attw
+      - name: Test the declaration-file validator
+        run: pnpm exec vitest run scripts/__tests__/validate-dts-ambient.test.ts
+
+      - name: Run publint, attw, and check-dts
         run: pnpm run check:packages
 
   check-types:

--- a/nx.json
+++ b/nx.json
@@ -92,6 +92,11 @@
       "dependsOn": ["build"],
       "inputs": ["{projectRoot}/package.json", "{projectRoot}/dist/**"],
       "cache": true
+    },
+    "check-dts": {
+      "dependsOn": ["build"],
+      "inputs": ["{projectRoot}/package.json", "{projectRoot}/dist/**"],
+      "cache": true
     }
   },
   "parallel": 14,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "graph": "nx graph",
     "publint": "nx run-many -t publint --projects=packages/**",
     "attw": "nx run-many -t attw --projects=packages/**",
-    "check:packages": "nx run-many -t publint,attw --projects=packages/**",
+    "check:packages": "nx run-many -t publint,attw,check-dts --projects=packages/**",
     "validate:model-names": "tsx scripts/validate-doc-model-names.ts",
     "check:intelligence-env-names": "tsx scripts/validate-intelligence-env-names.ts",
     "check:plugin-skills": "tsx scripts/sync-plugin-skills.ts --check",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -73,6 +73,7 @@
     "generate-graphql-schema": "node -e \"const fs=require('fs');fs.rmSync('__snapshots__',{recursive:true,force:true})\" && ts-node --transpile-only ./scripts/generate-gql-schema.ts",
     "link:global": "pnpm link --global",
     "unlink:global": "pnpm unlink --global",
+    "check-dts": "tsx ../../scripts/validate-dts-ambient.ts dist",
     "publint": "publint .",
     "attw": "attw --pack . --profile node16"
   },

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -15,17 +15,28 @@ export default defineConfig({
   target: "es2022",
   outDir: "dist",
   unbundle: true,
-  banner: ({ format, fileName }) => {
-    // tsdown/rolldown reorders bare side-effect imports to the end of the entry chunk,
-    // breaking type-graphql which needs reflect-metadata at load time.
-    // The _virtual/_rolldown/runtime banner propagates to all output files per format,
-    // ensuring reflect-metadata is always the first thing that runs.
-    if (fileName.includes("_virtual/_rolldown/runtime")) {
-      return format === "cjs"
+  // tsdown/rolldown reorders bare side-effect imports to the end of the entry
+  // chunk, breaking type-graphql, which needs reflect-metadata at load time. So
+  // every JS output gets reflect-metadata prepended, guaranteeing it runs first.
+  //
+  // Return an OBJECT, not a string. tsdown routes an object banner by chunk kind
+  // (`js` / `dts` / `css`) but applies a string banner to *every* chunk, including
+  // declarations -- which put `require("reflect-metadata");` at line 1 of all 87
+  // published `.d.cts` files and cost consumers 71 x TS1036 "Statements are not
+  // allowed in ambient contexts" under `skipLibCheck: false` (OSS-899).
+  //
+  // Nor is this keyed off `fileName` any more. tsdown's `resolveChunkAddon`
+  // reassigns its own closure variable on the first call, so a function banner is
+  // evaluated once and its result reused for every later chunk -- meaning a
+  // fileName condition silently decided the banner for the whole build based on
+  // whichever chunk happened to be emitted first. Keying on `format` alone is
+  // order-independent, and `format` is fixed per build.
+  banner: ({ format }) => ({
+    js:
+      format === "cjs"
         ? 'require("reflect-metadata");'
-        : 'import "reflect-metadata";';
-    }
-  },
+        : 'import "reflect-metadata";',
+  }),
   external: [
     "@ag-ui/langgraph",
     "@langchain/core",

--- a/scripts/__tests__/validate-dts-ambient.test.ts
+++ b/scripts/__tests__/validate-dts-ambient.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  findAmbientViolations,
+  formatViolations,
+  listDeclarationFiles,
+} from "../validate-dts-ambient.js";
+
+function setupDist(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "validate-dts-"));
+  for (const [relative, contents] of Object.entries(files)) {
+    const full = path.join(root, relative);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  }
+  return root;
+}
+
+describe("findAmbientViolations", () => {
+  let dist: string;
+
+  afterEach(() => {
+    if (dist) fs.rmSync(dist, { recursive: true, force: true });
+  });
+
+  it("flags the reflect-metadata require banner that shipped in OSS-899", () => {
+    dist = setupDist({
+      "index.d.cts": [
+        'require("reflect-metadata");',
+        'import { Foo } from "./foo.cjs";',
+        "export { Foo };",
+      ].join("\n"),
+    });
+
+    expect(findAmbientViolations(dist)).toEqual([
+      { file: "index.d.cts", line: 1, snippet: 'require("reflect-metadata");' },
+    ]);
+  });
+
+  it("accepts the ESM form of the same banner, which is a legal side-effect import", () => {
+    dist = setupDist({
+      "index.d.mts": [
+        'import "reflect-metadata";',
+        "export type A = string;",
+      ].join("\n"),
+    });
+
+    expect(findAmbientViolations(dist)).toEqual([]);
+  });
+
+  it("accepts every declaration form a real .d.ts uses", () => {
+    dist = setupDist({
+      "index.d.ts": [
+        'import type { X } from "./x.js";',
+        'import Y = require("./y");',
+        "type A = X;",
+        "interface B { a: A }",
+        "declare enum C { One }",
+        "declare class D {}",
+        "declare function e(): void;",
+        "declare const f: number;",
+        'declare module "g" {}',
+        "declare global {}",
+        "export { A, B, C, D, e, f };",
+        "export default Y;",
+        "export * from './h.js';",
+        "export as namespace pkg;",
+        ";",
+      ].join("\n"),
+    });
+
+    expect(findAmbientViolations(dist)).toEqual([]);
+  });
+
+  it("reports control flow and assignment statements with their line numbers", () => {
+    dist = setupDist({
+      "a.d.ts": ["type A = 1;", "if (A) {}"].join("\n"),
+      "nested/b.d.mts": ["export type B = 2;", "", "globalThis.x = 1;"].join(
+        "\n",
+      ),
+    });
+
+    expect(findAmbientViolations(dist)).toEqual([
+      { file: "a.d.ts", line: 2, snippet: "if (A) {}" },
+      {
+        file: path.join("nested", "b.d.mts"),
+        line: 3,
+        snippet: "globalThis.x = 1;",
+      },
+    ]);
+  });
+
+  it("ignores non-declaration files that sit next to the declarations", () => {
+    dist = setupDist({
+      "index.cjs": 'require("reflect-metadata");',
+      "index.d.cts": "export type A = string;",
+      "index.d.cts.map": '{"version":3}',
+    });
+
+    expect(listDeclarationFiles(dist)).toEqual([
+      path.join(dist, "index.d.cts"),
+    ]);
+    expect(findAmbientViolations(dist)).toEqual([]);
+  });
+});
+
+describe("formatViolations", () => {
+  it("returns an empty string when there is nothing to report", () => {
+    expect(formatViolations([], "dist")).toBe("");
+  });
+
+  it("names the file, line, and offending source", () => {
+    const message = formatViolations(
+      [
+        {
+          file: "lib/logger.d.cts",
+          line: 1,
+          snippet: 'require("reflect-metadata");',
+        },
+      ],
+      "dist",
+    );
+
+    expect(message).toContain("Found 1 statement(s)");
+    expect(message).toContain("TS1036");
+    expect(message).toContain(
+      `${path.join("dist", "lib/logger.d.cts")}:1  require("reflect-metadata");`,
+    );
+  });
+});

--- a/scripts/validate-dts-ambient.ts
+++ b/scripts/validate-dts-ambient.ts
@@ -1,0 +1,146 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import ts from "typescript";
+
+// A `.d.ts` file is an ambient context: TypeScript only permits declarations,
+// imports, and exports at its top level. Anything else is TS1036 ("Statements
+// are not allowed in ambient contexts") for every consumer compiling with
+// `skipLibCheck: false`.
+//
+// Bundlers are the usual way this breaks. tsdown applies a *string* `banner` to
+// every emitted chunk including declarations, so a JS-shaped banner such as
+// `require("reflect-metadata");` silently lands at line 1 of each published
+// `.d.cts`. That shipped in @copilotkit/runtime and cost consumers 71 errors
+// (OSS-899) -- invisible to us because every scaffolder sets
+// `skipLibCheck: true`. This validator is the guard that makes it visible.
+
+/** Top-level node kinds a declaration file is allowed to contain. */
+const ALLOWED_KINDS = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.ImportDeclaration,
+  ts.SyntaxKind.ImportEqualsDeclaration,
+  ts.SyntaxKind.ExportDeclaration,
+  ts.SyntaxKind.ExportAssignment,
+  ts.SyntaxKind.NamespaceExportDeclaration,
+  ts.SyntaxKind.InterfaceDeclaration,
+  ts.SyntaxKind.TypeAliasDeclaration,
+  ts.SyntaxKind.EnumDeclaration,
+  ts.SyntaxKind.ClassDeclaration,
+  ts.SyntaxKind.FunctionDeclaration,
+  ts.SyntaxKind.ModuleDeclaration,
+  ts.SyntaxKind.VariableStatement,
+  ts.SyntaxKind.EmptyStatement,
+  ts.SyntaxKind.MissingDeclaration,
+]);
+
+const DTS_SUFFIXES = [".d.ts", ".d.mts", ".d.cts"];
+
+export interface AmbientViolation {
+  /** Path to the declaration file, relative to the scanned directory. */
+  file: string;
+  /** 1-based line number of the offending statement. */
+  line: number;
+  /** Source text of the offending statement, trimmed to one line. */
+  snippet: string;
+}
+
+/** Collect every `.d.ts`/`.d.mts`/`.d.cts` file under `dir`, recursively. */
+export function listDeclarationFiles(dir: string): string[] {
+  const found: string[] = [];
+
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (DTS_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) {
+        found.push(full);
+      }
+    }
+  };
+
+  walk(dir);
+  return found.sort();
+}
+
+/**
+ * Find top-level statements that are illegal in a declaration file.
+ *
+ * @param dir Directory of built declarations to scan (e.g. a package's `dist`).
+ * @returns One violation per offending statement, in file then line order.
+ */
+export function findAmbientViolations(dir: string): AmbientViolation[] {
+  const violations: AmbientViolation[] = [];
+
+  for (const file of listDeclarationFiles(dir)) {
+    const text = fs.readFileSync(file, "utf8");
+    const source = ts.createSourceFile(
+      file,
+      text,
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ false,
+      ts.ScriptKind.TS,
+    );
+
+    for (const statement of source.statements) {
+      if (ALLOWED_KINDS.has(statement.kind)) continue;
+      const { line } = source.getLineAndCharacterOfPosition(
+        statement.getStart(source),
+      );
+      violations.push({
+        file: path.relative(dir, file),
+        line: line + 1,
+        snippet: statement.getText(source).split("\n")[0].trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function formatViolations(
+  violations: AmbientViolation[],
+  dir: string,
+): string {
+  if (violations.length === 0) return "";
+  const lines = violations.map(
+    (v) => `  ${path.join(dir, v.file)}:${v.line}  ${v.snippet}`,
+  );
+  return [
+    `Found ${violations.length} statement(s) in published declarations.`,
+    "A .d.ts is an ambient context: only declarations, imports, and exports are",
+    "allowed. Each of these is a TS1036 error for consumers on skipLibCheck: false.",
+    "",
+    ...lines,
+  ].join("\n");
+}
+
+function main(argv: string[]): number {
+  const dirs = argv.length > 0 ? argv : ["dist"];
+  let failed = false;
+
+  for (const dir of dirs) {
+    const resolved = path.resolve(dir);
+    if (!fs.existsSync(resolved)) {
+      console.error(
+        `validate-dts-ambient: ${dir} does not exist -- build the package first.`,
+      );
+      return 1;
+    }
+
+    const violations = findAmbientViolations(resolved);
+    if (violations.length > 0) {
+      console.error(formatViolations(violations, dir));
+      failed = true;
+    } else {
+      const count = listDeclarationFiles(resolved).length;
+      console.log(`validate-dts-ambient: ${dir} clean (${count} files).`);
+    }
+  }
+
+  return failed ? 1 : 0;
+}
+
+// Guard the CLI path so the exported helpers stay importable from tests.
+if (process.argv[1] && process.argv[1].endsWith("validate-dts-ambient.ts")) {
+  process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
Fixes the part of OSS-899 that is hard to defend: every `.d.cts` file we publish from `@copilotkit/runtime` starts with a `require()` call.

## The bug

A consumer whose only source file is `import { CopilotRuntime } from "@copilotkit/runtime";`, compiled with `strict` and `skipLibCheck: false`, gets **81 errors** on a bare install of 1.68.3. **71 of them are `TS1036` "Statements are not allowed in ambient contexts"**, raised inside our own shipped declarations.

Cause is in `packages/runtime/tsdown.config.ts`. The banner that guarantees `reflect-metadata` loads before `type-graphql` was returned as a **string**. tsdown's `resolveChunkAddon` routes an *object* return by chunk kind (`js` / `dts` / `css`) but applies a *string* return to **every** emitted chunk — declarations included. So all 87 published `.d.cts` files began:

```ts
require("reflect-metadata");
import { CopilotRuntimeLogger, ... } from "./lib/logger.cjs";
```

A `require()` call is a statement, and a `.d.ts` is an ambient context. One error per file.

Two reasons this went unnoticed for so long:

- Every scaffolder sets `skipLibCheck: true`. Verified in genuine `ng new` and `create-next-app` output. A developer who scaffolds normally never sees it.
- The `.d.mts` flavour got `import "reflect-metadata";`, which is a legal side-effect import in a declaration file. **ESM-resolving consumers saw zero `TS1036`.** Only CJS resolution is affected.

## The fix

Return an object so tsdown routes by chunk kind — JS keeps its `reflect-metadata` prologue, declarations get nothing.

The `fileName.includes("_virtual/_rolldown/runtime")` condition is dropped as well, and that is the more interesting half. `resolveChunkAddon` reassigns its own closure variable on the first call:

```js
if (typeof chunkAddon === "function") chunkAddon = chunkAddon({ format, fileName: chunk.fileName });
```

so a function banner is evaluated **once** and its result reused for every later chunk. The old config's comment ("propagates to all output files per format") described that as intended behaviour, but it was really a condition deciding the banner for the entire build based on whichever chunk happened to be emitted first. Keying on `format` alone — fixed per build — is order-independent.

The object form is tsdown's declared API, not a workaround: `ChunkAddonFunction` returns `ChunkAddonObject | string | undefined` where `ChunkAddonObject` is `{ js?, css?, dts? }`. `tsc --noEmit --strict` on `tsdown.config.ts` against tsdown's own types is clean — worth stating because the config is in no tsconfig `include`, so nothing else typechecks it.

## The guard

`scripts/validate-dts-ambient.ts` parses each built declaration with the TypeScript compiler API and fails on any top-level node that is not a declaration, import, or export. Wired as a `check-dts` nx target shaped exactly like the existing `publint` / `attw` / `compat-check` targets (`dependsOn: ["build"]`, `inputs` on `dist/**`), and folded into the `check:packages` script that the `package-quality` CI job already runs. That job already builds runtime for `publint`, so the added cost is one 177-file parse.

Only `@copilotkit/runtime` opts in, because it is the only offender. Running the validator itself over the built declarations of all 32 packages: **87 of runtime's 177** bad on the published 1.68.3 artifact, and **0** in every other package. Others can opt in with the same one-line script.

## Testing

**1. Reproduce the reported defect on the published package.** Bare `npm install @copilotkit/runtime@1.68.3 typescript`, `probe.ts` importing only `CopilotRuntime`, tsconfig with `strict`, `skipLibCheck: false`, `module`/`moduleResolution` `nodenext`:

```
$ npx tsc --noEmit ; echo exit=$?
exit=1
$ grep -oE 'error TS[0-9]+' tsc.out | sort | uniq -c | sort -rn
  71 error TS1036
   5 error TS2416
   2 error TS7016
   2 error TS2307
   1 error TS2694
```

81 errors, matching the issue. All 71 `TS1036` are at line 1, column 1 of a `.d.cts`.

**2. Confirm the mechanism.** Every published declaration's first line, before the fix:

```
-- *.d.cts --  total: 87
  87 require("reflect-metadata");
-- *.d.mts --  total: 90
  90 import "reflect-metadata";
```

**3. Same probe across every public subpath, before and after.** Built `packages/runtime` at 1.68.3 with this change and swapped the result into the probe's `node_modules`. `total` is all errors; `1036` is the subset this PR addresses.

| subpath | CJS before | CJS after | ESM before | ESM after |
| --- | --- | --- | --- | --- |
| `@copilotkit/runtime` | 81 (71×1036) | **10** (0) | 10 (0) | 10 (0) |
| `/v2` | 32 (29×1036) | **3** (0) | 3 (0) | 3 (0) |
| `/langgraph` | 15 (4×1036) | **7** (0) | 7 (0) | 7 (0) |
| `/v2/express` | 21 (18×1036) | **3** (0) | 3 (0) | 3 (0) |
| `/v2/hono` | 21 (19×1036) | **2** (0) | 2 (0) | 2 (0) |
| `/v2/node` | 22 (20×1036) | **2** (0) | 2 (0) | 2 (0) |

Zero `TS1036` on every subpath in both module modes, and **after the fix each subpath's CJS count equals its ESM count** — the CJS-only penalty is gone and nothing else moved. Every ESM column is untouched, which is the expected result since `.d.mts` never carried the bad banner.

The errors that remain are the separate items catalogued on OSS-899 (optional-peer SDK types, `@types/cors`, a `lru-cache` variance error from `graphql-yoga`, a zod namespace skew in `@copilotkit/license-verifier`) and are not touched here.

**4. `reflect-metadata` still runs first in every JS output.** This is what the banner exists for, so it is the thing most at risk from the change:

```
cjs files with require("reflect-metadata") as line 1: 131  / total 131
mjs files with import "reflect-metadata" as line 1: 132  / total 132
```

**5. Nothing but the banner line changed.** Diffed every one of the 87 built `.d.cts` files against the published 1.68.3 artifact from line 2 onward. Exactly one file differs, and it is unrelated source drift — a JSDoc env-var rename from `6f58b2c6a4` (`COPILOTKIT_API_KEY` → `INTELLIGENCE_API_KEY`, refs OSS-881) that landed on main after 1.68.3 shipped. Line counts are also identical, so declaration sourcemaps do not shift.

The `_virtual/_rolldown` reference count in declarations is 2 before and 2 after — that item is deliberately out of scope here.

**6. The guard catches the regression it exists for.** Reverted the banner to its pre-fix string form, rebuilt, and ran the new target:

```
$ pnpm exec tsx ../../scripts/validate-dts-ambient.ts dist
Found 87 statement(s) in published declarations.
A .d.ts is an ambient context: only declarations, imports, and exports are
allowed. Each of these is a TS1036 error for consumers on skipLibCheck: false.

  dist/agent/converters/aisdk.d.cts:1  require("reflect-metadata");
  ...
exit=1
```

Restored the fix and rebuilt:

```
$ pnpm exec tsx ../../scripts/validate-dts-ambient.ts dist
validate-dts-ambient: dist clean (177 files).
exit=0
```

**7. Validator unit tests, mutation-checked.** `scripts/__tests__/validate-dts-ambient.test.ts`, 7 tests covering the exact OSS-899 banner, the legal ESM form, every declaration form a real `.d.ts` uses, line-number reporting, and ignoring sibling `.cjs`/`.map` files.

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Then broke the mechanism three ways to confirm the tests are not self-fulfilling:

| mutation | result |
|---|---|
| allow `ExpressionStatement` in the kind allowlist | 2 failed / 5 passed |
| drop the `line + 1` conversion | 2 failed / 5 passed |
| scan only `.d.ts`, not `.d.mts` / `.d.cts` | 3 failed / 4 passed |
| restored | 7 passed |

**8. Runtime suite and packaging targets, on a clean `pnpm install --frozen-lockfile` in this worktree.**

```
$ nx run @copilotkit/runtime:test
 Test Files  143 passed (143)
      Tests  2073 passed (2073)

$ nx run-many -t publint,attw,check-dts --projects=@copilotkit/runtime
NX   Successfully ran targets publint, attw, check-dts for project @copilotkit/runtime
```

`attw --profile node16` reports 🟢 from both CJS and ESM; the `node10` failure is pre-existing and ignored by the profile.

**9. Formatting and types.** `oxfmt --check` clean on all three source files; `tsc --noEmit --strict` clean on the new script.

## Overlap with #6476

#6476 (`adopt TypeScript 7 and tsdown 0.22`) bumps tsdown to 0.22.14 but does **not** touch `packages/runtime/tsdown.config.ts`, so it does not fix this. The two PRs conflict only textually — both add lines to runtime's `scripts` block and to the root `package.json`. This fix uses tsdown's documented object-banner form, so it holds whether or not 0.22 changed `resolveChunkAddon`'s memoization.

No changeset: this ships through the normal release scopes.
