### PR TITLE
fix(showcase): make the A2UI fixed-schema guide followable (OSS-901)

### DIFF
--- a/showcase/integrations/mastra/manifest.yaml
+++ b/showcase/integrations/mastra/manifest.yaml
@@ -334,6 +334,7 @@ demos:
       - src/app/demos/a2ui-fixed-schema/a2ui/catalog.ts
       - src/app/demos/a2ui-fixed-schema/a2ui/definitions.ts
       - src/app/demos/a2ui-fixed-schema/a2ui/renderers.tsx
+      - src/mastra/tools/a2ui-generate.ts
       - src/mastra/tools/index.ts
       - src/app/api/copilotkit/route.ts
   - id: headless-complete

--- a/showcase/integrations/mastra/src/mastra/tools/a2ui-context.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/a2ui-context.ts
@@ -26,3 +26,17 @@ export function readForwardedA2uiContext(
     ? (context as Array<Record<string, unknown>>)
     : [];
 }
+
+/**
+ * Flatten forwarded context entries into the system prompt for the inner
+ * `render_a2ui` call. Entries without a non-empty string `value` are dropped,
+ * so an empty (ungrounded) prompt is `""` rather than a string of blanks.
+ */
+export function systemPromptFrom(
+  contextEntries: Array<Record<string, unknown>> | undefined,
+): string {
+  return (contextEntries ?? [])
+    .map((entry) => entry?.value)
+    .filter((value): value is string => typeof value === "string" && !!value)
+    .join("\n\n");
+}

--- a/showcase/integrations/mastra/src/mastra/tools/a2ui-generate.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/a2ui-generate.ts
@@ -1,0 +1,192 @@
+/**
+ * Mastra `generate-a2ui` tool — the LLM-driven A2UI pattern.
+ *
+ * This file is the doc-facing source for `/mastra/generative-ui/a2ui/fixed-schema`
+ * (the `backend-render-operations` region below is what the guide renders), so it
+ * is deliberately SELF-CONTAINED: the A2UI operation builder is defined here
+ * rather than imported from the showcase's shared tools, exactly as the reference
+ * TypeScript cell does in
+ * `showcase/integrations/langgraph-typescript/src/agent/a2ui-fixed.ts`.
+ * A reader can copy the region into their own project and have it compile
+ * (OSS-901: the guide previously called `generateA2uiImpl` /
+ * `buildA2uiOperationsFromToolCall` from `@copilotkit/showcase-shared-tools`,
+ * which is a tsconfig path alias inside this repo and not an installable
+ * package).
+ *
+ * Two imports below are showcase plumbing, and both have a one-line
+ * equivalent in a real app — see the comments at each import.
+ */
+
+// @region[backend-render-operations]
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { generateText, tool as aiTool } from "ai";
+// In your own app this is `import { openai } from "@ai-sdk/openai"`. The
+// showcase wraps it so this backend tool's own LLM call carries the inbound
+// request's aimock headers — see `_header_forwarding.ts`.
+import { openai } from "@/mastra/_header_forwarding";
+// Reads the catalog schema + generation guidelines the AG-UI bridge forwards
+// onto Mastra's request context, and flattens them into the inner call's system
+// prompt. In your own app, hand the inner call whatever description of your
+// catalog you want it to render against.
+import { readForwardedA2uiContext, systemPromptFrom } from "./a2ui-context";
+
+/** Catalog the surface is pinned to when the model omits `catalogId`. */
+const DEFAULT_CATALOG_ID = "copilotkit://app-dashboard-catalog";
+const DEFAULT_SURFACE_ID = "dynamic-surface";
+
+/**
+ * A2UI v0.9 operations are NESTED (`{ createSurface: {...} }`), not flat
+ * (`{ type: "create_surface", ... }`): a consumer dispatches on the operation
+ * key, so a flat shape is silently ignored and the surface never paints.
+ */
+type A2UIOperation =
+  | { version: "v0.9"; createSurface: { surfaceId: string; catalogId: string } }
+  | {
+      version: "v0.9";
+      updateComponents: {
+        surfaceId: string;
+        components: Array<Record<string, unknown>>;
+      };
+    }
+  | {
+      version: "v0.9";
+      updateDataModel: {
+        surfaceId: string;
+        path: string;
+        value: Record<string, unknown>;
+      };
+    };
+
+/**
+ * Turn the inner model's `render_a2ui` arguments into the `a2ui_operations`
+ * container the A2UI middleware detects in a tool result.
+ */
+function buildA2uiOperations(args: Record<string, unknown>): {
+  a2ui_operations: A2UIOperation[];
+} {
+  const surfaceId = (args.surfaceId as string) ?? DEFAULT_SURFACE_ID;
+  const catalogId = (args.catalogId as string) ?? DEFAULT_CATALOG_ID;
+  const components = (args.components as Array<Record<string, unknown>>) ?? [];
+  const data = args.data as Record<string, unknown> | undefined;
+
+  if (components.length === 0) {
+    console.warn("generate-a2ui: empty components for surface", surfaceId);
+  }
+
+  const operations: A2UIOperation[] = [
+    { version: "v0.9", createSurface: { surfaceId, catalogId } },
+    { version: "v0.9", updateComponents: { surfaceId, components } },
+  ];
+
+  // Emit `updateDataModel` only when there is data to seed. An empty object is
+  // truthy in JS, so guard on key count to stay in step with the Python
+  // reference (`if data:`), which skips the op for `{}`.
+  if (
+    data != null &&
+    typeof data === "object" &&
+    Object.keys(data).length > 0
+  ) {
+    operations.push({
+      version: "v0.9",
+      updateDataModel: { surfaceId, path: "/", value: data },
+    });
+  }
+
+  return { a2ui_operations: operations };
+}
+
+/**
+ * Normalize an incoming message role to the `user`/`assistant` pair
+ * `generateText` accepts. An unsound `as "user" | "assistant"` cast would let a
+ * `system`/`tool` role slip through mis-typed (a `??` only guards
+ * null/undefined), so map explicitly: anything that is not `assistant`
+ * collapses to `user`.
+ */
+function toRole(role: unknown): "user" | "assistant" {
+  return role === "assistant" ? "assistant" : "user";
+}
+
+// The `generate-a2ui` tool runs a secondary LLM call with a forced
+// `render_a2ui` tool, then converts that tool call's args into the
+// A2UI `a2ui_operations` container that the middleware forwards to
+// the frontend renderer. Mastra returns the operations as a JSON
+// string from the tool body; the catalog resolves component names to
+// React renderers on the client.
+export const generateA2uiTool = createTool({
+  id: "generate-a2ui",
+  description: "Generate dynamic A2UI surface components",
+  inputSchema: z.object({
+    messages: z.array(z.record(z.unknown())).describe("Chat messages"),
+    contextEntries: z
+      .array(z.record(z.unknown()))
+      .optional()
+      .describe("Context entries"),
+  }),
+  execute: async ({ messages, contextEntries }, executionContext) => {
+    // The outer model leaves `contextEntries` empty — it has no basis to hand
+    // the catalog schema back through a tool arg — so on a live LLM the inner
+    // `render_a2ui` subagent would run with an EMPTY system prompt: ungrounded,
+    // it emits invalid/misnamed components (or none), and the surface fails to
+    // render, varying run to run. (aimock hides it: the recorded fixture
+    // returns a valid envelope regardless of the empty context.) The bridge
+    // already forwards the catalog schema + generation guidelines onto the
+    // request context, so read them server-side and ground the render there
+    // rather than trusting the model-supplied arg.
+    const forwardedContext = readForwardedA2uiContext(executionContext);
+    const systemPrompt = systemPromptFrom(
+      forwardedContext.length > 0 ? forwardedContext : contextEntries,
+    );
+
+    const result = await generateText({
+      model: openai("gpt-4.1"),
+      system: systemPrompt,
+      messages: messages.map((m) => ({
+        role: toRole(m.role),
+        content: (m.content as string) ?? "",
+      })),
+      tools: {
+        render_a2ui: aiTool({
+          description: "Render a dynamic A2UI v0.9 surface.",
+          // AI SDK v5 renamed the tool schema key from `parameters` to
+          // `inputSchema`; under v5 a `parameters` key is ignored, so the
+          // render_a2ui schema would never reach the model.
+          inputSchema: z.object({
+            surfaceId: z.string().describe("Unique surface identifier."),
+            catalogId: z.string().describe("The catalog ID."),
+            components: z
+              .array(z.record(z.unknown()))
+              .describe("A2UI v0.9 component array."),
+            data: z
+              .record(z.unknown())
+              .optional()
+              .describe("Optional initial data model."),
+          }),
+        }),
+      },
+      toolChoice: { type: "tool", toolName: "render_a2ui" },
+    });
+
+    const toolCall = result.toolCalls?.[0];
+    if (!toolCall) {
+      // The forced `render_a2ui` tool was not called, so there are no
+      // operations to forward. Returning a `{ error }` JSON string would look
+      // like a successful tool result to the frontend/runtime, which cannot
+      // then distinguish it from a real A2UI payload. Throw instead so the
+      // Mastra runtime surfaces this as a genuine tool error.
+      const message = "generate-a2ui: LLM did not call render_a2ui";
+      console.error(message, { finishReason: result.finishReason });
+      throw new Error(message);
+    }
+
+    // AI SDK v5 renamed the typed tool-call arguments from `.args` to
+    // `.input` (the `ai` v4 shape was `toolCall.args`). Read `.input` so the
+    // a2ui builder gets the render_a2ui arguments instead of `undefined`.
+    return JSON.stringify(
+      buildA2uiOperations(toolCall.input as Record<string, unknown>),
+    );
+  },
+});
+// @endregion[backend-render-operations]
+
+export { buildA2uiOperations };

--- a/showcase/integrations/mastra/src/mastra/tools/index.ts
+++ b/showcase/integrations/mastra/src/mastra/tools/index.ts
@@ -1,19 +1,10 @@
-// @region[backend-render-operations]
-// @region[weather-tool-backend]
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
-// Use the header-forwarding `openai` so backend tool LLM calls (e.g.
-// generateText inside generateA2ui) carry the inbound aimock context
-// headers. See `_header_forwarding.ts`.
-import { openai } from "@/mastra/_header_forwarding";
-import { generateText, tool as aiTool } from "ai";
 import {
   getWeatherImpl,
   queryDataImpl,
   scheduleMeetingImpl,
   searchFlightsImpl,
-  generateA2uiImpl,
-  buildA2uiOperationsFromToolCall,
 } from "@copilotkit/showcase-shared-tools";
 
 // `manage_todos` writes the todo list into working memory so the Beautiful
@@ -23,9 +14,10 @@ import {
   writeTodosToWorkingMemory,
   readTodosFromWorkingMemory,
 } from "./working-memory";
-// Grounds the dynamic `generate_a2ui` render on the catalog schema the bridge
-// forwards onto Mastra's request context (the outer model sends it empty).
-import { readForwardedA2uiContext } from "./a2ui-context";
+// Single A2UI operation builder for this integration: the doc-facing
+// `a2ui-generate.ts` owns it so its snippet stays self-contained (OSS-901),
+// and the fixed-flight tool below emits the same envelope shape.
+import { buildA2uiOperations } from "./a2ui-generate";
 
 // Re-export the dedicated tool sets defined in their own modules so the
 // barrel keeps a single import surface for callers under `@/mastra/tools`.
@@ -39,7 +31,9 @@ export {
   writingAgentTool,
   critiqueAgentTool,
 } from "./subagents";
+export { generateA2uiTool } from "./a2ui-generate";
 
+// @region[weather-tool-backend]
 export const weatherTool = createTool({
   id: "get_weather",
   description: "Get current weather for a location",
@@ -336,100 +330,6 @@ export const searchFlightsTool = createTool({
   },
 });
 
-// The `generate-a2ui` tool runs a secondary LLM call with a forced
-// `render_a2ui` tool, then converts that tool call's args into the
-// A2UI `a2ui_operations` container that the middleware forwards to
-// the frontend renderer. Mastra returns the operations as a JSON
-// string from the tool body; the catalog resolves component names to
-// React renderers on the client.
-export const generateA2uiTool = createTool({
-  id: "generate-a2ui",
-  description: "Generate dynamic A2UI surface components",
-  inputSchema: z.object({
-    messages: z.array(z.record(z.unknown())).describe("Chat messages"),
-    contextEntries: z
-      .array(z.record(z.unknown()))
-      .optional()
-      .describe("Context entries"),
-  }),
-  execute: async ({ messages, contextEntries }, executionContext) => {
-    // The outer model leaves `contextEntries` empty — it has no basis to hand
-    // the catalog schema back through a tool arg — so on a live LLM the inner
-    // `render_a2ui` subagent would run with an EMPTY system prompt: ungrounded,
-    // it emits invalid/misnamed components (or none), and the surface fails to
-    // render, varying run to run. (aimock hides it: the recorded fixture
-    // returns a valid envelope regardless of the empty context.) The bridge
-    // already forwards the catalog schema + generation guidelines onto the
-    // request context, so read them server-side and ground the render there
-    // rather than trusting the model-supplied arg.
-    const forwardedContext = readForwardedA2uiContext(executionContext);
-    const prep = generateA2uiImpl({
-      messages,
-      contextEntries:
-        forwardedContext.length > 0 ? forwardedContext : contextEntries,
-    });
-
-    // Normalize each incoming message role to the `user`/`assistant` pair
-    // `generateText` accepts here. An unsound `as "user" | "assistant"` cast
-    // would let a `system`/`tool` role slip through mis-typed (the `??` only
-    // guards null/undefined), so map explicitly: anything that is not
-    // `assistant` collapses to `user`.
-    const toRole = (role: unknown): "user" | "assistant" =>
-      role === "assistant" ? "assistant" : "user";
-
-    const result = await generateText({
-      model: openai("gpt-4.1"),
-      system: prep.systemPrompt,
-      messages: prep.messages.map((m) => ({
-        role: toRole(m.role),
-        content: (m.content as string) ?? "",
-      })),
-      tools: {
-        render_a2ui: aiTool({
-          description: "Render a dynamic A2UI v0.9 surface.",
-          // AI SDK v5 renamed the tool schema key from `parameters` to
-          // `inputSchema`; under v5 a `parameters` key is ignored, so the
-          // render_a2ui schema would never reach the model.
-          inputSchema: z.object({
-            surfaceId: z.string().describe("Unique surface identifier."),
-            catalogId: z.string().describe("The catalog ID."),
-            components: z
-              .array(z.record(z.unknown()))
-              .describe("A2UI v0.9 component array."),
-            data: z
-              .record(z.unknown())
-              .optional()
-              .describe("Optional initial data model."),
-          }),
-        }),
-      },
-      toolChoice: { type: "tool", toolName: "render_a2ui" },
-    });
-
-    const toolCall = result.toolCalls?.[0];
-    if (!toolCall) {
-      // The forced `render_a2ui` tool was not called, so there are no
-      // operations to forward. Returning a `{ error }` JSON string would look
-      // like a successful tool result to the frontend/runtime, which cannot
-      // then distinguish it from a real A2UI payload. Throw instead so the
-      // Mastra runtime surfaces this as a genuine tool error.
-      const message = "generate-a2ui: LLM did not call render_a2ui";
-      console.error(message, { finishReason: result.finishReason });
-      throw new Error(message);
-    }
-
-    // AI SDK v5 renamed the typed tool-call arguments from `.args` to
-    // `.input` (the `ai` v4 shape was `toolCall.args`). Read `.input` so the
-    // a2ui builder gets the render_a2ui arguments instead of `undefined`.
-    return JSON.stringify(
-      buildA2uiOperationsFromToolCall(
-        toolCall.input as Record<string, unknown>,
-      ),
-    );
-  },
-});
-// @endregion[backend-render-operations]
-
 // @region[beautiful-chat-fixed-flights]
 // Fixed-schema A2UI flight search for the Beautiful Chat cell. Mirrors
 // langgraph-python `beautiful_chat.py::search_flights`: the tool RESULT is a
@@ -495,7 +395,7 @@ export const searchFlightsA2uiTool = createTool({
   // tool result once for the wire, so a single-encoded `a2ui_operations`
   // container is what the A2UI middleware detects and paints.
   execute: async ({ flights }) =>
-    buildA2uiOperationsFromToolCall({
+    buildA2uiOperations({
       surfaceId: FLIGHT_SURFACE_ID,
       catalogId: FLIGHT_CATALOG_ID,
       components: buildFlightCardComponents(flights),

--- a/showcase/integrations/mastra/tests/vitest/a2ui-context.test.ts
+++ b/showcase/integrations/mastra/tests/vitest/a2ui-context.test.ts
@@ -17,8 +17,10 @@
  * the resulting system prompt is actually grounded, mirroring the live shape.
  */
 import { describe, it, expect } from "vitest";
-import { generateA2uiImpl } from "@copilotkit/showcase-shared-tools";
-import { readForwardedA2uiContext } from "@/mastra/tools/a2ui-context";
+import {
+  readForwardedA2uiContext,
+  systemPromptFrom,
+} from "@/mastra/tools/a2ui-context";
 
 /** The context array the bridge forwards, captured live from staging. */
 const forwardedContext = [
@@ -70,18 +72,16 @@ describe("readForwardedA2uiContext", () => {
 describe("generate_a2ui grounding source", () => {
   it("the empty ARG the outer model sends yields an UNGROUNDED prompt (the bug)", () => {
     // Reproduces the live payload: contextEntries === [].
-    const prep = generateA2uiImpl({ messages: [], contextEntries: [] });
-    expect(prep.systemPrompt).toBe("");
+    expect(systemPromptFrom([])).toBe("");
   });
 
   it("the forwarded request context yields a GROUNDED prompt (the fix)", () => {
-    const prep = generateA2uiImpl({
-      messages: [],
-      contextEntries: readForwardedA2uiContext(execCtx(forwardedContext)),
-    });
-    expect(prep.systemPrompt.length).toBeGreaterThan(0);
-    expect(prep.systemPrompt).toContain("copilotkit://app-dashboard-catalog");
-    expect(prep.systemPrompt).toContain("FlightCard");
-    expect(prep.systemPrompt).toContain("A2UI Protocol Instructions");
+    const systemPrompt = systemPromptFrom(
+      readForwardedA2uiContext(execCtx(forwardedContext)),
+    );
+    expect(systemPrompt.length).toBeGreaterThan(0);
+    expect(systemPrompt).toContain("copilotkit://app-dashboard-catalog");
+    expect(systemPrompt).toContain("FlightCard");
+    expect(systemPrompt).toContain("A2UI Protocol Instructions");
   });
 });

--- a/showcase/integrations/strands/manifest.yaml
+++ b/showcase/integrations/strands/manifest.yaml
@@ -332,6 +332,10 @@ demos:
     route: /demos/a2ui-fixed-schema
     animated_preview_url:
     highlight:
+      - src/agents/a2ui_generate.py
+      # Shared (symlinked) helper the tool above calls to build the
+      # `a2ui_operations` envelope — bundled so the guide shows it too.
+      - tools/generate_a2ui.py
       - src/agents/agent.py
       - src/app/demos/a2ui-fixed-schema/page.tsx
       - src/app/demos/a2ui-fixed-schema/a2ui/catalog.ts

--- a/showcase/integrations/strands/src/agents/a2ui_generate.py
+++ b/showcase/integrations/strands/src/agents/a2ui_generate.py
@@ -1,0 +1,189 @@
+"""A2UI dynamic generation — Strands ``generate_a2ui`` tool.
+
+Mirrors the per-demo specialization pattern used by ``gen_ui_agent.py`` and
+``a2ui_dynamic.py``: this module owns the tool definition and its structured
+error shape, and ``agent.py`` wires it into the shared ``StrandsAgent``
+instance.
+
+It also keeps this integration's slice of the A2UI docs honest. The
+``backend-render-operations`` region below is what
+`/aws-strands/generative-ui/a2ui/fixed-schema` renders, and a region starts at
+the top of its file so the snippet carries its own imports (see the
+marker-hoist sweep in 34b6418). While the tool lived in ``agent.py`` that made
+the published snippet the whole 1688-line module; here the snippet is just the
+tool (OSS-901).
+"""
+
+# @region[backend-render-operations]
+import json
+import logging
+from typing import TypedDict
+
+from strands import tool
+
+# Shared tool implementations, symlinked at the project root
+# (→ ../../shared/python/tools). ``build_a2ui_operations_from_tool_call`` wraps
+# the inner model's ``render_a2ui`` arguments in the nested A2UI v0.9
+# ``a2ui_operations`` envelope the middleware detects in a tool result.
+from tools import build_a2ui_operations_from_tool_call
+
+logger = logging.getLogger(__name__)
+
+
+class _A2uiError(TypedDict):
+    """Shape of the structured error dict returned by generate_a2ui branches.
+
+    Mirrors the google-adk and langroid sibling agents' error shape — keep
+    all three in sync. Every error branch MUST populate all three keys so
+    callers (and the LLM summarizing the tool result) see a consistent
+    surface.
+    """
+
+    error: str
+    message: str
+    remediation: str
+
+
+
+# The `generate_a2ui` tool runs a secondary LLM call with a forced
+# `render_a2ui` tool, then converts that tool call's args into the
+# A2UI `a2ui_operations` container via
+# `build_a2ui_operations_from_tool_call`. The ag_ui_strands middleware
+# detects the container in the tool result and forwards the ops to
+# the frontend, which resolves component names through the registered
+# catalog (`copilotkit://generative-catalog`).
+@tool
+def generate_a2ui(context: str) -> str:
+    """Generate dynamic A2UI components based on the conversation.
+
+    A secondary LLM designs the UI schema and data. The result is
+    returned as an a2ui_operations container for the middleware to detect.
+
+    Error branches return a JSON-serialized ``_A2uiError`` dict rather
+    than raising, so OpenAI transport / quota / auth failures surface to
+    the LLM as a structured tool result (not an uncaught exception in the
+    strands tool machinery). See ``_A2uiError`` above.
+
+    Args:
+        context: Conversation context to generate UI from
+
+    Returns:
+        A2UI operations (or ``_A2uiError``) as JSON string
+    """
+    tool_schema = {
+        "type": "function",
+        "function": {
+            "name": "render_a2ui",
+            "description": "Render a dynamic A2UI v0.9 surface.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "surfaceId": {"type": "string"},
+                    "catalogId": {"type": "string"},
+                    "components": {"type": "array", "items": {"type": "object"}},
+                    "data": {"type": "object"},
+                },
+                "required": ["surfaceId", "catalogId", "components"],
+            },
+        },
+    }
+
+    # Wrap the OpenAI call so raw SDK / transport failures do NOT bubble up
+    # through the strands tool machinery as uncaught exceptions. Return a
+    # structured error with remediation instead — the LLM can surface this
+    # to the user. Mirrors the google-adk and langroid sibling agents'
+    # error-handling shape — keep all three in sync.
+    #
+    # Exception scope is broad on the SDK side but still bounded:
+    #   * ``openai.OpenAIError`` covers config-time failures (e.g. from
+    #     ``OpenAI()`` constructor when ``OPENAI_API_KEY`` is unset).
+    #     ``APIError`` subclasses (RateLimitError, APIConnectionError,
+    #     AuthenticationError, BadRequestError, etc.) are also caught via
+    #     the broader ``except`` tuple. Verified against ``openai>=1.0`` —
+    #     re-check hierarchy on major version bumps.
+    #   * ``httpx.HTTPError`` covers transport failures (ConnectError,
+    #     ReadTimeout, RemoteProtocolError) that can escape below the SDK's
+    #     wrap layer in rare cases.
+    # Programmer errors (AttributeError, NameError, TypeError from bad
+    # kwargs, etc.) still propagate so bugs are not silently swallowed as
+    # "LLM error". Note the client construction itself is inside the try
+    # block for the same reason.
+    import openai as _openai_mod
+    import httpx as _httpx_mod
+
+    try:
+        client = _openai_mod.OpenAI()
+        response = client.chat.completions.create(
+            model="gpt-4.1",
+            messages=[
+                {
+                    "role": "system",
+                    "content": context or "Generate a useful dashboard UI.",
+                },
+                {
+                    "role": "user",
+                    "content": "Generate a dynamic A2UI dashboard based on the conversation.",
+                },
+            ],
+            tools=[tool_schema],
+            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
+        )
+    except (_openai_mod.OpenAIError, _httpx_mod.HTTPError) as exc:
+        logger.exception("generate_a2ui: OpenAI API call failed")
+        return json.dumps(
+            _A2uiError(
+                error="a2ui_llm_error",
+                message=f"Secondary A2UI LLM call failed: {exc.__class__.__name__}",
+                remediation=(
+                    "Verify OPENAI_API_KEY is set and the OpenAI service is reachable. "
+                    "See server logs for the full traceback."
+                ),
+            )
+        )
+
+    if not response.choices:
+        logger.warning("generate_a2ui: OpenAI response contained no choices")
+        return json.dumps(
+            _A2uiError(
+                error="a2ui_empty_response",
+                message="Secondary A2UI LLM returned no choices.",
+                remediation="Retry; if this persists, check OpenAI status.",
+            )
+        )
+
+    tool_calls = response.choices[0].message.tool_calls
+    if not tool_calls:
+        logger.warning(
+            "generate_a2ui: OpenAI response had no tool_calls despite forced tool_choice"
+        )
+        return json.dumps(
+            _A2uiError(
+                error="a2ui_no_tool_call",
+                message="Secondary A2UI LLM did not call render_a2ui.",
+                remediation=(
+                    "Retry the request. If this persists, verify the tool_choice "
+                    "schema matches the OpenAI API contract."
+                ),
+            )
+        )
+
+    tool_call = tool_calls[0]
+    try:
+        args = json.loads(tool_call.function.arguments)
+    except (ValueError, TypeError) as exc:
+        logger.exception(
+            "generate_a2ui: failed to parse render_a2ui tool arguments as JSON"
+        )
+        return json.dumps(
+            _A2uiError(
+                error="a2ui_invalid_arguments",
+                message=f"Could not parse render_a2ui arguments: {exc}",
+                remediation="Retry the request; the secondary LLM emitted malformed JSON.",
+            )
+        )
+
+    result = build_a2ui_operations_from_tool_call(args)
+    return json.dumps(result)
+
+
+# @endregion[backend-render-operations]

--- a/showcase/integrations/strands/src/agents/a2ui_generate.py
+++ b/showcase/integrations/strands/src/agents/a2ui_generate.py
@@ -44,7 +44,6 @@ class _A2uiError(TypedDict):
     remediation: str
 
 
-
 # The `generate_a2ui` tool runs a secondary LLM call with a forced
 # `render_a2ui` tool, then converts that tool call's args into the
 # A2UI `a2ui_operations` container via

--- a/showcase/integrations/strands/src/agents/agent.py
+++ b/showcase/integrations/strands/src/agents/agent.py
@@ -10,7 +10,6 @@ so import failures are localized and testable.
 
 # @region[supervisor-delegation-tools]
 # @region[subagent-setup]
-# @region[backend-render-operations]
 # @region[weather-tool-backend]
 import json
 import logging
@@ -18,7 +17,7 @@ import os
 import threading
 import uuid
 from collections.abc import AsyncIterator, Mapping
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional
 
 from ag_ui.core.events import (
     EventType,
@@ -63,7 +62,6 @@ from tools import (
     roll_dice_impl,
     schedule_meeting_impl,
     search_flights_impl,
-    build_a2ui_operations_from_tool_call,
 )
 
 # gen-ui-agent specialization (set_steps tool + state hook + prompt addendum).
@@ -75,6 +73,11 @@ from agents.gen_ui_agent import (
     set_steps,
     steps_state_from_args,
 )
+
+# Dynamic A2UI generation (`generate_a2ui` + its structured error shape). Its
+# own module for the same reason as gen_ui_agent above — and so the docs'
+# `backend-render-operations` snippet is that tool rather than all of agent.py.
+from agents.a2ui_generate import generate_a2ui
 
 logger = logging.getLogger(__name__)
 
@@ -315,20 +318,6 @@ class _MessagesSnapshotWrapper:
                 continue
 
 
-class _A2uiError(TypedDict):
-    """Shape of the structured error dict returned by generate_a2ui branches.
-
-    Mirrors the google-adk and langroid sibling agents' error shape — keep
-    all three in sync. Every error branch MUST populate all three keys so
-    callers (and the LLM summarizing the tool result) see a consistent
-    surface.
-    """
-
-    error: str
-    message: str
-    remediation: str
-
-
 # ---- Tools --------------------------------------------------------------
 
 
@@ -460,150 +449,6 @@ def search_flights(flights: list[dict]):
     """
     result = search_flights_impl(flights)
     return json.dumps(result)
-
-
-# The `generate_a2ui` tool runs a secondary LLM call with a forced
-# `render_a2ui` tool, then converts that tool call's args into the
-# A2UI `a2ui_operations` container via
-# `build_a2ui_operations_from_tool_call`. The ag_ui_strands middleware
-# detects the container in the tool result and forwards the ops to
-# the frontend, which resolves component names through the registered
-# catalog (`copilotkit://generative-catalog`).
-@tool
-def generate_a2ui(context: str) -> str:
-    """Generate dynamic A2UI components based on the conversation.
-
-    A secondary LLM designs the UI schema and data. The result is
-    returned as an a2ui_operations container for the middleware to detect.
-
-    Error branches return a JSON-serialized ``_A2uiError`` dict rather
-    than raising, so OpenAI transport / quota / auth failures surface to
-    the LLM as a structured tool result (not an uncaught exception in the
-    strands tool machinery). See ``_A2uiError`` above.
-
-    Args:
-        context: Conversation context to generate UI from
-
-    Returns:
-        A2UI operations (or ``_A2uiError``) as JSON string
-    """
-    tool_schema = {
-        "type": "function",
-        "function": {
-            "name": "render_a2ui",
-            "description": "Render a dynamic A2UI v0.9 surface.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "surfaceId": {"type": "string"},
-                    "catalogId": {"type": "string"},
-                    "components": {"type": "array", "items": {"type": "object"}},
-                    "data": {"type": "object"},
-                },
-                "required": ["surfaceId", "catalogId", "components"],
-            },
-        },
-    }
-
-    # Wrap the OpenAI call so raw SDK / transport failures do NOT bubble up
-    # through the strands tool machinery as uncaught exceptions. Return a
-    # structured error with remediation instead — the LLM can surface this
-    # to the user. Mirrors the google-adk and langroid sibling agents'
-    # error-handling shape — keep all three in sync.
-    #
-    # Exception scope is broad on the SDK side but still bounded:
-    #   * ``openai.OpenAIError`` covers config-time failures (e.g. from
-    #     ``OpenAI()`` constructor when ``OPENAI_API_KEY`` is unset).
-    #     ``APIError`` subclasses (RateLimitError, APIConnectionError,
-    #     AuthenticationError, BadRequestError, etc.) are also caught via
-    #     the broader ``except`` tuple. Verified against ``openai>=1.0`` —
-    #     re-check hierarchy on major version bumps.
-    #   * ``httpx.HTTPError`` covers transport failures (ConnectError,
-    #     ReadTimeout, RemoteProtocolError) that can escape below the SDK's
-    #     wrap layer in rare cases.
-    # Programmer errors (AttributeError, NameError, TypeError from bad
-    # kwargs, etc.) still propagate so bugs are not silently swallowed as
-    # "LLM error". Note the client construction itself is inside the try
-    # block for the same reason.
-    import openai as _openai_mod
-    import httpx as _httpx_mod
-
-    try:
-        client = _openai_mod.OpenAI()
-        response = client.chat.completions.create(
-            model="gpt-4.1",
-            messages=[
-                {
-                    "role": "system",
-                    "content": context or "Generate a useful dashboard UI.",
-                },
-                {
-                    "role": "user",
-                    "content": "Generate a dynamic A2UI dashboard based on the conversation.",
-                },
-            ],
-            tools=[tool_schema],
-            tool_choice={"type": "function", "function": {"name": "render_a2ui"}},
-        )
-    except (_openai_mod.OpenAIError, _httpx_mod.HTTPError) as exc:
-        logger.exception("generate_a2ui: OpenAI API call failed")
-        return json.dumps(
-            _A2uiError(
-                error="a2ui_llm_error",
-                message=f"Secondary A2UI LLM call failed: {exc.__class__.__name__}",
-                remediation=(
-                    "Verify OPENAI_API_KEY is set and the OpenAI service is reachable. "
-                    "See server logs for the full traceback."
-                ),
-            )
-        )
-
-    if not response.choices:
-        logger.warning("generate_a2ui: OpenAI response contained no choices")
-        return json.dumps(
-            _A2uiError(
-                error="a2ui_empty_response",
-                message="Secondary A2UI LLM returned no choices.",
-                remediation="Retry; if this persists, check OpenAI status.",
-            )
-        )
-
-    tool_calls = response.choices[0].message.tool_calls
-    if not tool_calls:
-        logger.warning(
-            "generate_a2ui: OpenAI response had no tool_calls despite forced tool_choice"
-        )
-        return json.dumps(
-            _A2uiError(
-                error="a2ui_no_tool_call",
-                message="Secondary A2UI LLM did not call render_a2ui.",
-                remediation=(
-                    "Retry the request. If this persists, verify the tool_choice "
-                    "schema matches the OpenAI API contract."
-                ),
-            )
-        )
-
-    tool_call = tool_calls[0]
-    try:
-        args = json.loads(tool_call.function.arguments)
-    except (ValueError, TypeError) as exc:
-        logger.exception(
-            "generate_a2ui: failed to parse render_a2ui tool arguments as JSON"
-        )
-        return json.dumps(
-            _A2uiError(
-                error="a2ui_invalid_arguments",
-                message=f"Could not parse render_a2ui arguments: {exc}",
-                remediation="Retry the request; the secondary LLM emitted malformed JSON.",
-            )
-        )
-
-    result = build_a2ui_operations_from_tool_call(args)
-    return json.dumps(result)
-
-
-# @endregion[backend-render-operations]
 
 
 @tool

--- a/showcase/integrations/strands/tests/python/test_generate_a2ui_errors.py
+++ b/showcase/integrations/strands/tests/python/test_generate_a2ui_errors.py
@@ -1,5 +1,8 @@
 """Tests for the hardened ``generate_a2ui`` error-handling surface.
 
+The tool lives in ``agents/a2ui_generate.py``; ``agents/agent.py`` imports it
+into the shared agent's tool list, so importing it from either module works.
+
 Mirrors the google-adk sibling agent's hardening pattern: every failure
 branch returns a structured ``{error, message, remediation}`` dict
 (JSON-serialized, since the strands tool returns a string) instead of
@@ -336,10 +339,12 @@ def test_happy_path_returns_a2ui_operations(monkeypatch):
 
     # Stub build_a2ui_operations_from_tool_call to return a marker payload
     # so we don't depend on the shared tool's real implementation shape.
-    import agents.agent as agent_mod
+    # The tool (and this name) live in `agents.a2ui_generate`; `agents.agent`
+    # only re-exports the tool for the agent's tool list.
+    import agents.a2ui_generate as a2ui_mod
 
     monkeypatch.setattr(
-        agent_mod,
+        a2ui_mod,
         "build_a2ui_operations_from_tool_call",
         lambda args: {"a2ui_marker": True, "surfaceId": args.get("surfaceId")},
     )

--- a/showcase/scripts/bundle-demo-content.ts
+++ b/showcase/scripts/bundle-demo-content.ts
@@ -58,7 +58,15 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import yaml from "yaml";
-import { findUnexpectedMultiFileRegions } from "./lib/demo-region-guard.js";
+import {
+  findUnexpectedMultiFileRegions,
+  findOversizeRegions,
+  findWorkspaceOnlyImportRegions,
+} from "./lib/demo-region-guard.js";
+import type {
+  RegionBodyFinding,
+  RegionBodySource,
+} from "./lib/demo-region-guard.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -363,12 +371,20 @@ function collectDemoFiles(
   return { readme, files: out, perFileRegions };
 }
 
+function describeRegionFinding(finding: RegionBodyFinding): string {
+  return `  ${finding.demoKey}: region "${finding.regionName}" (${finding.file}) ${finding.detail}`;
+}
+
 function main() {
   console.log("Bundling demo content...\n");
 
   const bundle: BundledContent = {
     demos: {},
   };
+
+  // Every published region body, checked once at the end so one run reports
+  // every unfollowable snippet instead of only the first.
+  const regionBodies: RegionBodySource[] = [];
 
   if (!fs.existsSync(PACKAGES_DIR)) {
     console.log("No packages directory found.");
@@ -568,6 +584,15 @@ function main() {
         }
 
         bundle.demos[key] = { readme, files, backend_files: [], regions };
+
+        for (const [regionName, region] of Object.entries(regions)) {
+          regionBodies.push({
+            demoKey: key,
+            regionName,
+            file: region.file,
+            code: region.code,
+          });
+        }
         const hlCount = files.filter((f) => f.highlighted).length;
         const regionCount = Object.keys(regions).length;
         console.log(
@@ -581,6 +606,29 @@ function main() {
         { cause: err },
       );
     }
+  }
+
+  // Guard the published snippets before writing: a region a reader cannot
+  // follow is a docs bug, and it is invisible in review because the bodies are
+  // assembled here rather than authored. See demo-region-guard.ts.
+  const workspaceOnly = findWorkspaceOnlyImportRegions(regionBodies);
+  const oversize = findOversizeRegions(regionBodies);
+  if (workspaceOnly.length > 0 || oversize.length > 0) {
+    throw new Error(
+      [
+        workspaceOnly.length > 0
+          ? `Region bodies importing repo-only modules:\n${workspaceOnly.map(describeRegionFinding).join("\n")}`
+          : null,
+        oversize.length > 0
+          ? `Region bodies over the published-snippet limit:\n${oversize.map(describeRegionFinding).join("\n")}`
+          : null,
+        "Move the @region marker so it wraps only the code the page is about, " +
+          "splitting the file if the snippet needs its own imports (see " +
+          "mastra/src/mastra/tools/a2ui-generate.ts).",
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
+    );
   }
 
   const json = JSON.stringify(bundle, null, 2) + "\n";

--- a/showcase/scripts/lib/__tests__/demo-region-guard.test.ts
+++ b/showcase/scripts/lib/__tests__/demo-region-guard.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_REGION_LINES,
+  OVERSIZE_REGION_BASELINE,
+  findOversizeRegions,
+  findWorkspaceOnlyImportRegions,
+  regionBodyKey,
+} from "../demo-region-guard.js";
+import type { RegionBodySource } from "../demo-region-guard.js";
+
+function region(over: Partial<RegionBodySource> = {}): RegionBodySource {
+  return {
+    demoKey: "mastra::a2ui-fixed-schema",
+    regionName: "backend-render-operations",
+    file: "src/mastra/tools/a2ui-generate.ts",
+    code: "export const generateA2uiTool = createTool({});",
+    ...over,
+  };
+}
+
+describe("findWorkspaceOnlyImportRegions", () => {
+  it("flags the OSS-901 import that only resolves through tsconfig paths", () => {
+    const findings = findWorkspaceOnlyImportRegions([
+      region({
+        code: [
+          "import { createTool } from '@mastra/core/tools';",
+          "import { generateA2uiImpl } from '@copilotkit/showcase-shared-tools';",
+        ].join("\n"),
+      }),
+    ]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toContain("@copilotkit/showcase-shared-tools");
+  });
+
+  it("passes a body whose imports are all installable or file-local", () => {
+    expect(
+      findWorkspaceOnlyImportRegions([
+        region({
+          code: [
+            "import { createTool } from '@mastra/core/tools';",
+            "import { generateText } from 'ai';",
+            "import { readForwardedA2uiContext } from './a2ui-context';",
+          ].join("\n"),
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("catches any showcase-only alias, not just the shared-tools one", () => {
+    expect(
+      findWorkspaceOnlyImportRegions([
+        region({ code: "import x from '@copilotkit/showcase-frontend';" }),
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it("does not mistake a published package for a workspace alias", () => {
+    expect(
+      findWorkspaceOnlyImportRegions([
+        region({
+          code: "import { CopilotKit } from '@copilotkit/react-core';",
+        }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("findOversizeRegions", () => {
+  const oversizeCode = Array.from(
+    { length: MAX_REGION_LINES + 1 },
+    (_, i) => `const line${i} = ${i};`,
+  ).join("\n");
+
+  it("flags a region that publishes more than the limit", () => {
+    const findings = findOversizeRegions([region({ code: oversizeCode })]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].detail).toContain(`${MAX_REGION_LINES + 1} lines`);
+  });
+
+  it("passes a region exactly at the limit", () => {
+    const atLimit = Array.from(
+      { length: MAX_REGION_LINES },
+      (_, i) => `const line${i} = ${i};`,
+    ).join("\n");
+
+    expect(findOversizeRegions([region({ code: atLimit })])).toEqual([]);
+  });
+
+  it("exempts a baselined region so known debt does not block the build", () => {
+    expect(
+      findOversizeRegions([
+        region({
+          demoKey: "strands::subagents",
+          regionName: "supervisor-delegation-tools",
+          file: "src/agents/agent.py",
+          code: oversizeCode,
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("still flags a baselined region name when a different file grows", () => {
+    const findings = findOversizeRegions([
+      region({
+        demoKey: "strands::subagents",
+        regionName: "supervisor-delegation-tools",
+        file: "src/agents/some_new_module.py",
+        code: oversizeCode,
+      }),
+    ]);
+
+    expect(findings).toHaveLength(1);
+  });
+
+  it("keys the baseline by integration slug, not by demo", () => {
+    // The same backend file feeds every demo of an integration, so an entry
+    // written for one demo must cover the rest.
+    expect(
+      OVERSIZE_REGION_BASELINE.has(
+        regionBodyKey(
+          "strands",
+          "supervisor-delegation-tools",
+          "src/agents/agent.py",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not baseline the regions this change fixed", () => {
+    for (const key of [
+      regionBodyKey(
+        "mastra",
+        "backend-render-operations",
+        "src/mastra/tools/index.ts",
+      ),
+      regionBodyKey(
+        "mastra",
+        "backend-render-operations",
+        "src/mastra/tools/a2ui-generate.ts",
+      ),
+      regionBodyKey(
+        "strands",
+        "backend-render-operations",
+        "src/agents/agent.py",
+      ),
+      regionBodyKey(
+        "strands",
+        "backend-render-operations",
+        "src/agents/a2ui_generate.py",
+      ),
+      regionBodyKey(
+        "mastra",
+        "weather-tool-backend",
+        "src/mastra/tools/index.ts",
+      ),
+    ]) {
+      expect(OVERSIZE_REGION_BASELINE.has(key)).toBe(false);
+    }
+  });
+});

--- a/showcase/scripts/lib/demo-region-guard.ts
+++ b/showcase/scripts/lib/demo-region-guard.ts
@@ -65,3 +65,157 @@ export function findUnexpectedMultiFileRegions(
       ),
   );
 }
+
+// ---------------------------------------------------------------------------
+// Published-snippet guards
+//
+// A `@region[...]` body is rendered verbatim on a docs page, so a reader is
+// expected to be able to read it — and, for a backend tool, copy it. Two
+// failure modes have shipped to docs.copilotkit.ai unnoticed, both introduced
+// by the marker-hoist sweep (34b6418) that moved region starts above the
+// imports: hoisting to the top of a *god-file* makes the published snippet the
+// whole file, and any workspace-only import in that file becomes an
+// uninstallable line in the guide.
+//
+// OSS-901: `/mastra/generative-ui/a2ui/fixed-schema` rendered all 432 lines of
+// mastra's tools barrel, including `@copilotkit/showcase-shared-tools` — a
+// tsconfig path alias to a symlink in this repo, not a package anyone can
+// install. An onboarding run stopped there rather than invent an API.
+// ---------------------------------------------------------------------------
+
+export interface RegionBodySource {
+  demoKey: string;
+  regionName: string;
+  /** Bundled path of the file the region was extracted from. */
+  file: string;
+  /** The region body as it will be published. */
+  code: string;
+}
+
+export interface RegionBodyFinding extends RegionBodySource {
+  detail: string;
+}
+
+/**
+ * Import specifiers that only resolve inside this repo (tsconfig `paths` to a
+ * symlinked directory under `showcase/shared/`). They are fine in showcase
+ * code and wrong in a published snippet.
+ */
+const WORKSPACE_ONLY_SPECIFIER_RE = /@copilotkit\/showcase-[a-z0-9-]+/;
+
+/**
+ * Ceiling on a published region. Chosen from the corpus: the median region is
+ * 28 lines and p90 is 125, so 200 flags the god-file cases without arguing
+ * about genuinely long single-purpose files (a 344-line renderers.tsx is the
+ * whole point of that page).
+ */
+export const MAX_REGION_LINES = 200;
+
+export function regionBodyKey(
+  slug: string,
+  regionName: string,
+  file: string,
+): string {
+  return `${slug}::${regionName}::${file}`;
+}
+
+/**
+ * Regions already over `MAX_REGION_LINES` when this guard was added. Each is a
+ * page rendering more than a reader can follow; the list only shrinks. Do NOT
+ * add an entry to make a build pass — split the file the way
+ * `mastra/src/mastra/tools/a2ui-generate.ts` and
+ * `strands/src/agents/a2ui_generate.py` were split for OSS-901.
+ */
+export const OVERSIZE_REGION_BASELINE = new Set([
+  "ag2::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "ag2::supervisor-delegation-tools::src/agents/subagents.py",
+  "agno::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "agno::supervisor-delegation-tools::src/agents/subagents.py",
+  "built-in-agent::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "claude-sdk-python::backend-demo-tool-sets::src/agents/agent.py",
+  "claude-sdk-python::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "claude-sdk-typescript::backend-tool-execution::src/agent_server.ts",
+  "claude-sdk-typescript::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "crewai-conversational-flows::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "crewai-conversational-flows::supervisor-delegation-tools::src/agents/subagents.py",
+  "crewai-crews::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "crewai-crews::supervisor-delegation-tools::src/agents/subagents.py",
+  "google-adk::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "google-adk::subagent-setup::src/agents/subagents_agent.py",
+  "google-adk::supervisor-delegation-tools::src/agents/subagents_agent.py",
+  "langgraph-fastapi::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "langgraph-python::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "langgraph-python::supervisor-delegation-tools::src/agents/subagents.py",
+  "langgraph-typescript::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "langgraph-typescript::supervisor-delegation-tools::src/agent/subagents.ts",
+  "langroid::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "langroid::supervisor-delegation-tools::src/agents/subagents.py",
+  "llamaindex::backend-render-operations::src/agents/a2ui_fixed.py",
+  "llamaindex::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "llamaindex::supervisor-delegation-tools::src/agents/subagents_agent.py",
+  "mastra::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "mastra::supervisor-delegation-tools::src/mastra/tools/subagents.ts",
+  "ms-agent-dotnet::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "ms-agent-dotnet::subagent-setup::agent/SubagentsAgent.cs",
+  "ms-agent-dotnet::supervisor-delegation-tools::agent/SubagentsAgent.cs",
+  "ms-agent-dotnet::weather-tool-backend::agent/Program.cs",
+  "ms-agent-harness-dotnet::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "ms-agent-harness-dotnet::subagent-setup::agent/SubagentsAgent.cs",
+  "ms-agent-harness-dotnet::supervisor-delegation-tools::agent/SubagentsAgent.cs",
+  "ms-agent-python::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "ms-agent-python::supervisor-delegation-tools::src/agents/subagents_agent.py",
+  "pydantic-ai::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "pydantic-ai::supervisor-delegation-tools::src/agents/subagents.py",
+  "spring-ai::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "spring-ai::state-streaming-middleware::src/main/java/com/copilotkit/showcase/springai/SharedStateStreamingController.java",
+  "spring-ai::supervisor-delegation-tools::src/main/java/com/copilotkit/showcase/springai/SubagentsController.java",
+  "strands::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "strands::subagent-setup::src/agents/agent.py",
+  "strands::supervisor-delegation-tools::src/agents/agent.py",
+  "strands::weather-tool-backend::src/agents/agent.py",
+  "strands-typescript::renderers-react::src/app/demos/declarative-gen-ui/a2ui/renderers.tsx",
+  "strands-typescript::subagent-setup::src/agent/tools.ts",
+]);
+
+/**
+ * Regions whose published body imports something only this repo can resolve.
+ * There is no baseline: the list was empty once OSS-901 was fixed, and a new
+ * one means a docs page just became unfollowable.
+ */
+export function findWorkspaceOnlyImportRegions(
+  sources: RegionBodySource[],
+): RegionBodyFinding[] {
+  const findings: RegionBodyFinding[] = [];
+  for (const source of sources) {
+    const match = source.code.match(WORKSPACE_ONLY_SPECIFIER_RE);
+    if (!match) continue;
+    findings.push({
+      ...source,
+      detail: `imports "${match[0]}", which resolves only through this repo's tsconfig paths`,
+    });
+  }
+  return findings;
+}
+
+export function findOversizeRegions(
+  sources: RegionBodySource[],
+): RegionBodyFinding[] {
+  const findings: RegionBodyFinding[] = [];
+  for (const source of sources) {
+    const lineCount = source.code.split("\n").length;
+    if (lineCount <= MAX_REGION_LINES) continue;
+    const slug = source.demoKey.split("::")[0];
+    if (
+      OVERSIZE_REGION_BASELINE.has(
+        regionBodyKey(slug, source.regionName, source.file),
+      )
+    ) {
+      continue;
+    }
+    findings.push({
+      ...source,
+      detail: `publishes ${lineCount} lines (limit ${MAX_REGION_LINES}) — the region marker probably sits above unrelated code`,
+    });
+  }
+  return findings;
+}

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -269,7 +269,14 @@ Mastra and Strands take a different route: the agent tool runs a
 operations container per-request. The frontend catalog is still fixed
 (same `Title`/`Airport`/`Arrow`/`AirlineBadge`/`PriceTag` primitives),
 but the schema is built on the fly. Schema construction and render
-emission happen in the same tool call:
+emission happen in the same tool call.
+
+Neither SDK ships an `a2ui.render(...)` equivalent here, so the tool
+assembles the `a2ui_operations` envelope itself — the operation builder
+below is part of what you copy. Note the operations are *nested*
+(`{ createSurface: {...} }`): a consumer dispatches on the operation
+key, so a flat `{ type: "create_surface" }` shape is ignored and the
+surface never paints.
 
 <Snippet region="backend-render-operations" />
 </Step>

--- a/showcase/shell-docs/src/content/snippets/shared/generative-ui/a2ui.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/generative-ui/a2ui.mdx
@@ -51,17 +51,27 @@ Enable A2UI in `CopilotRuntime` by passing `a2ui: {}`:
 ```ts title="app/api/copilotkit/route.ts"
 import {
   CopilotRuntime,
-  ExperimentalEmptyAdapter,
-  copilotRuntimeNextJSAppRouterEndpoint,
-} from "@copilotkit/runtime";
+  createCopilotRuntimeHandler,
+} from "@copilotkit/runtime/v2";
 
 const runtime = new CopilotRuntime({
   agents: { default: myAgent },
   a2ui: {},
 });
+
+// Single-route: only POST needed, no catch-all [...path] required
+const handler = createCopilotRuntimeHandler({
+  runtime,
+  basePath: "/api/copilotkit",
+  mode: "single-route",
+});
+
+export { handler as POST };
 ```
 
 This automatically applies `A2UIMiddleware` to all registered agents. To scope it to specific agents, you can specify agents with the `agents` property: `a2ui: { agents: ["my-agent"] }`.
+
+Both halves of this page are v2 entry points: `@copilotkit/runtime/v2` on the server, `@copilotkit/react-core/v2` in the browser. If you are on the legacy `@copilotkit/runtime` root import with `copilotRuntimeNextJSAppRouterEndpoint`, A2UI still works — that class forwards `a2ui` straight to the v2 runtime — but the v2 handler is the current API, and our own showcase integrations moved to it (#6618). See [Deploy to any runtime](/runtime-server-adapter) for the other hosts.
 
 Once configured, any A2UI output returned from your agent will automatically be rendered in the chat interface — no additional frontend code required.
 


### PR DESCRIPTION
Closes OSS-901.

## Problem

`/mastra/generative-ui/a2ui/fixed-schema` could not be followed. A Mastra onboarding run on Codex stopped there rather than invent an API, reporting that the guide "depends on unbundled showcase helpers."

That is true, and the mechanism is worse than the report. Region bodies are assembled at bundle time, so what ships is invisible in a source diff. The `backend-render-operations` marker sits on **line 1** of `mastra/src/mastra/tools/index.ts` — put there by the marker-hoist sweep in 34b6418 so snippets would carry their imports — and the closing marker is at the bottom of the file. The page therefore published **all 432 lines** of the tools barrel: weather, stock price, dice, d20, query-data, schedule-meeting, search-flights, the aimock header-forwarding import, and

```ts
import { generateA2uiImpl, buildA2uiOperationsFromToolCall } from "@copilotkit/showcase-shared-tools";
```

`@copilotkit/showcase-shared-tools` is not a package. It is a tsconfig `paths` entry (`mastra/tsconfig.json:23`) pointing at `./shared-tools`, a symlink to `showcase/shared/typescript/tools`. There is nothing for a reader to install.

Same defect on the strands page from the same sweep: 586 lines of a 1688-line `agents/agent.py`.

## What changed

**The two cells get a dedicated module for the A2UI tool**, so hoisting the marker to the top of the file yields exactly the tool plus its own imports. This is the shape of the reference cell (`langgraph-typescript/src/agent/a2ui-fixed.ts`, which likewise builds A2UI operations locally) and, on the Python side, of `gen_ui_agent.py` / `a2ui_dynamic.py`.

| page | before | after |
| --- | --- | --- |
| mastra fixed-schema | 432 lines, 16.5 KB | 166 lines |
| strands fixed-schema | 586 lines | 171 lines |

Every line in the new snippets either installs from npm or is a visibly local `./` / `@/` module carrying a comment about what a real app uses instead. Mastra keeps a single operation builder — the beautiful-chat flight tool now calls the same one. The strands cell also highlights `tools/generate_a2ui.py` so the guide shows the helper the tool calls.

**A guard in the bundler**, because neither failure mode shows up in review:

- any `@copilotkit/showcase-*` specifier in a published body fails the build (corpus is at zero after this change, so no baseline);
- over 200 lines fails the build (median region is 28, p90 is 125; the 48 already over the line are baselined by `slug::region::file` and the list only shrinks).

**The entrypoint half of the issue lands differently than I first read it.** OSS-901 flagged `@copilotkit/runtime` + `@copilotkit/react-core/v2` on the shared A2UI page as a v1/v2 trap. It is not a broken pairing — v1's `CopilotRuntime` forwards `a2ui` (and `mcpApps` / `openGenerativeUI`) straight to the v2 runtime (`packages/runtime/src/lib/runtime/copilot-runtime.ts:414`). But #6618 landed while this branch was open and retired the v1 runtime adapter across every showcase integration, so the page's v1 root import *was* the stale half. The block also imported `ExperimentalEmptyAdapter` and `copilotRuntimeNextJSAppRouterEndpoint` and used neither, so it was a route a reader could not run. It now shows `createCopilotRuntimeHandler` from `@copilotkit/runtime/v2` in the single-route form, matching the rebased showcase route and `/runtime-server-adapter`, with a note that the legacy form still works.

**On the systemic question.** A separate sweep counted ~50 regions whose marker sits on line 1 with a matching close at end-of-file, and proposed failing a region that spans >=90% of its file. That rule does not survive contact with the published bodies: of 141 regions at >=90% span, only **2** publish more than 200 lines, and 98 publish under 100 — dedicated single-purpose files whose whole content *is* the intended snippet. It would also flag this PR's own fix (`strands/a2ui_generate.py` is 171/188 = 91%) and the langgraph reference cells. Published size is the signal that separates the defect from the pattern, which is what the guard here measures.

## Testing

**Guard catches the pre-fix tree** (restored HEAD sources, moved the new modules aside, ran the bundler):

```
REAL EXIT=1
Region bodies importing repo-only modules:
  mastra::agentic-chat: region "weather-tool-backend" (src/mastra/tools/index.ts) imports "@copilotkit/showcase-shared-tools", ...
  mastra::agentic-chat: region "backend-render-operations" (src/mastra/tools/index.ts) imports "@copilotkit/showcase-shared-tools", ...
Region bodies over the published-snippet limit:
  strands::a2ui-fixed-schema: region "backend-render-operations" (src/agents/agent.py) publishes 586 lines (limit 200) ...
```

and passes on this branch (`bundler exit=0`, 801 demos bundled).

**Guard unit tests** — `showcase/scripts/lib/__tests__/demo-region-guard.test.ts`, 10 passed. Mutation-checked: raising `MAX_REGION_LINES` and short-circuiting the alias scan fails exactly 2 of them; restoring passes 10/10.

**Showcase script suites** — `demo-region-guard`, `bundle-demo-content`, `validate-parity`, `verify-shell-docs`, `validate-shared-symlinks`: **151 passed (5 files)**.

**Mastra vitest** — `tests/vitest/a2ui-context.test.ts`, 5 passed. The prompt builder lives in the dependency-free `a2ui-context.ts` so this regression test still runs without the Mastra SDK installed, as it did before. Mutation-checked: breaking the join fails 1 of 5.

**Strands pytest** — `tests/python/test_generate_a2ui_errors.py` 11 passed (was 1 failed / 10 passed after the move, because the happy-path test patched `agents.agent.build_a2ui_operations_from_tool_call`; retargeted at the new module). Whole runnable suite: **40 passed** across `test_generate_a2ui_errors`, `test_hook_injection`, `test_sales_state_from_args`, `test_tool_call_cap`. Mutation-checked: stubbing out the builder call fails the happy-path test. `test_cvdiag_boundaries` / `test_instrumentor_patch` need `starlette` / `opentelemetry-instrumentation-threading`, absent from this venv — unrelated to this change.

**Published snippet, rendered** (`demo-content.json` after bundling):

```
mastra snippet lines: 166 | file: src/mastra/tools/a2ui-generate.ts
import { createTool } from "@mastra/core/tools";
import { z } from "zod";
import { generateText, tool as aiTool } from "ai";
// In your own app this is `import { openai } from "@ai-sdk/openai"`. ...
```

**Docs verification** — `verify-shell-docs.ts` produces a byte-identical finding set with my two MDX edits toggled on and off (empty diff), so the edits add no new findings. `component-imports`, `essential-content` and the rest are unchanged; the suite's pre-existing failures are untouched.

**Lint / format** — `oxfmt` on all changed TS, `oxlint` clean on the new and edited files.

## Follow-ups (not in this PR)

- The 48 baselined regions are the same class of defect on other pages — `strands::supervisor-delegation-tools` publishes 795 lines, `strands::subagent-setup` 625, `ms-agent-dotnet::weather-tool-backend` 549. Each wants the same split.
- `claude-sdk-typescript/shared-tools/` and `langgraph-typescript/shared-tools/` are real directories where symlinks belong — the erosion `showcase/AGENTS.md` documents. Untouched here.
- Dropping the strands commit (`14c7351`) is safe on its own; it only requires adding `strands::backend-render-operations::src/agents/agent.py` to the guard baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
