### PR TITLE
fix(runtime): surface AI SDK tool errors

### DIFF
--- a/packages/runtime/src/agent/__tests__/agent-test-helpers.ts
+++ b/packages/runtime/src/agent/__tests__/agent-test-helpers.ts
@@ -27,6 +27,7 @@ export {
   toolCallDelta,
   toolCall,
   toolResult,
+  toolError,
   reasoningStart,
   reasoningDelta,
   reasoningEnd,

--- a/packages/runtime/src/agent/__tests__/basic-agent.test.ts
+++ b/packages/runtime/src/agent/__tests__/basic-agent.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { z } from "zod";
 import { BasicAgent, defineTool } from "../index";
-import type { ToolDefinition } from "../index";
 import { EventType } from "@ag-ui/client";
 import type {
   BaseEvent,
@@ -21,6 +20,7 @@ import {
   toolCallDelta,
   toolCall,
   toolResult,
+  toolError,
   reasoningStart,
   reasoningDelta,
   reasoningEnd,
@@ -275,6 +275,43 @@ describe("BasicAgent", () => {
         role: "tool",
         toolCallId: "call1",
       });
+    });
+
+    it("should emit a visible tool result when execution throws", async () => {
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([
+          toolCall("call-error", "getCats", { limit: 1 }),
+          toolError("call-error", "getCats", new Error("Missing API key")),
+          finish(),
+        ]) as any,
+      );
+
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+      };
+
+      const events = await collectEvents(agent["run"](input));
+      const resultEvent = events.find(
+        (event) => event.type === EventType.TOOL_CALL_RESULT,
+      );
+
+      expect(resultEvent).toMatchObject({
+        type: EventType.TOOL_CALL_RESULT,
+        toolCallId: "call-error",
+        content: "Error: Missing API key",
+      });
+      expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/runtime/src/agent/__tests__/converter-aisdk.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-aisdk.test.ts
@@ -14,6 +14,7 @@ import {
   toolCallDelta,
   toolCall,
   toolResult,
+  toolError,
   reasoningStart,
   reasoningDelta,
   reasoningEnd,
@@ -277,6 +278,32 @@ describe("AI SDK Converter", () => {
       );
       expect(JSON.parse(eventField<string>(resultsB[0], "content"))).toBe(
         "resultB",
+      );
+    });
+
+    it("tool errors emit a visible result instead of silently succeeding", async () => {
+      const agent = createAgent("aisdk", [
+        toolCall("tc-error", "getCats", { limit: 1 }),
+        toolError("tc-error", "getCats", new Error("Missing API key")),
+        finish(),
+      ]);
+      const input = createDefaultInput();
+      const events = await collectEvents(agent.run(input));
+
+      expectLifecycleWrapped(events);
+
+      const resultEvents = events.filter(
+        (event) => event.type === EventType.TOOL_CALL_RESULT,
+      );
+      expect(resultEvents).toHaveLength(1);
+      expect(eventField<string>(resultEvents[0], "toolCallId")).toBe(
+        "tc-error",
+      );
+      expect(eventField<string>(resultEvents[0], "content")).toBe(
+        "Error: Missing API key",
+      );
+      expect(events.some((event) => event.type === EventType.RUN_ERROR)).toBe(
+        false,
       );
     });
   });
@@ -742,30 +769,27 @@ describe("AI SDK Converter", () => {
   // ---------------------------------------------------------------------------
 
   describe("Edge Cases", () => {
-    it("unknown event types are silently ignored", async () => {
+    it("unknown event types fail the run instead of being silently ignored", async () => {
       const agent = createAgent("aisdk", [
         { type: "some-unknown-event", data: "hello" },
         textDelta("text after unknown"),
-        { type: "another-mystery-event" },
-        finish(),
       ]);
       const input = createDefaultInput();
-      const events = await collectEvents(agent.run(input));
-
-      expectLifecycleWrapped(events);
-
-      // Should still have the text chunk
-      const textChunks = events.filter(
-        (e) => e.type === EventType.TEXT_MESSAGE_CHUNK,
+      const { events, errored } = await collectEventsIncludingErrors(
+        agent.run(input),
       );
-      expect(textChunks).toHaveLength(1);
 
-      // No events for unknown types — only RUN_STARTED, TEXT_MESSAGE_CHUNK, RUN_FINISHED
-      expectEventSequence(events, [
-        EventType.RUN_STARTED,
-        EventType.TEXT_MESSAGE_CHUNK,
-        EventType.RUN_FINISHED,
-      ]);
+      expect(errored).toBe(true);
+      const errorEvents = events.filter(
+        (event) => event.type === EventType.RUN_ERROR,
+      );
+      expect(errorEvents).toHaveLength(1);
+      expect(eventField<string>(errorEvents[0], "message")).toBe(
+        "Unsupported AI SDK stream part: some-unknown-event",
+      );
+      expect(
+        events.some((event) => event.type === EventType.RUN_FINISHED),
+      ).toBe(false);
     });
 
     it("large text deltas (100k chars) are passed through", async () => {

--- a/packages/runtime/src/agent/__tests__/test-helpers.ts
+++ b/packages/runtime/src/agent/__tests__/test-helpers.ts
@@ -110,6 +110,23 @@ export function toolResult(
 }
 
 /**
+ * Helper to create a tool error event emitted when a tool's execute function
+ * throws.
+ */
+export function toolError(
+  toolCallId: string,
+  toolName: string,
+  toolErrorValue: unknown,
+): MockStreamEvent {
+  return {
+    type: "tool-error",
+    toolCallId,
+    toolName,
+    error: toolErrorValue,
+  };
+}
+
+/**
  * Helper to create a reasoning-start event
  */
 export function reasoningStart(id?: string): MockStreamEvent {

--- a/packages/runtime/src/agent/converters/aisdk.ts
+++ b/packages/runtime/src/agent/converters/aisdk.ts
@@ -18,6 +18,27 @@ import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
 import { createStateEventNormalizer } from "../state-delta";
 
+export function formatToolError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  if (typeof error === "string") return error;
+  if (error === undefined || error === null) return "Unknown tool error";
+
+  try {
+    const serialized = JSON.stringify(error);
+    return serialized === undefined ? String(error) : serialized;
+  } catch {
+    return String(error);
+  }
+}
+
 /**
  * Converts an AI SDK `fullStream` into AG-UI `BaseEvent` objects.
  *
@@ -322,6 +343,49 @@ export async function* convertAISDKStream(
           break;
         }
 
+        case "tool-error": {
+          const toolCallId = p.toolCallId as string | undefined;
+          if (!toolCallId) {
+            throw new Error("AI SDK tool-error is missing toolCallId");
+          }
+
+          // Prefer the name captured from the preceding tool-call part because
+          // some providers omit toolName on the error part.
+          const toolName =
+            ("toolName" in p
+              ? (p.toolName as string | undefined)
+              : undefined) ??
+            toolCallStates.get(toolCallId)?.toolName ??
+            "";
+
+          // Interrupt tools do not execute on the server. Their result is
+          // supplied by the human on the resume run, so suppress this part just
+          // like a normal tool-result.
+          if (
+            toolName &&
+            pendingInterrupts?.some(
+              (interrupt) => interrupt.toolCallId === toolCallId,
+            )
+          ) {
+            toolCallStates.delete(toolCallId);
+            break;
+          }
+
+          toolCallStates.delete(toolCallId);
+          const resultEvent: ToolCallResultEvent = {
+            type: EventType.TOOL_CALL_RESULT,
+            role: "tool",
+            messageId: randomUUID(),
+            toolCallId,
+            // A tool exception is a tool result from the model's perspective.
+            // Keeping the Error prefix consistent with the core tool runner
+            // lets both the client and the next model step see the failure.
+            content: `Error: ${formatToolError(p.error)}`,
+          };
+          yield resultEvent;
+          break;
+        }
+
         case "tool-result": {
           // AI SDK tool-result uses "output"; older versions used "result" — check both
           const toolResult =
@@ -400,9 +464,21 @@ export async function* convertAISDKStream(
           );
         }
 
-        default:
-          // Unknown event types are silently ignored
+        // These AI SDK fullStream parts carry metadata that has no AG-UI event
+        // equivalent. They are known and intentionally ignored; keeping them
+        // explicit lets the default branch catch genuinely new parts.
+        case "start":
+        case "start-step":
+        case "finish-step":
+        case "text-end":
+        case "source":
+        case "file":
+        case "tool-output-denied":
+        case "raw":
           break;
+
+        default:
+          throw new Error(`Unsupported AI SDK stream part: ${String(p.type)}`);
       }
     }
   } finally {

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -49,7 +49,7 @@ import { z } from "zod";
 import type { StandardSchemaV1, InferSchemaOutput } from "@copilotkit/shared";
 import { schemaToJsonSchema } from "@copilotkit/shared";
 import { jsonSchema as aiJsonSchema } from "ai";
-import { convertAISDKStream } from "./converters/aisdk";
+import { convertAISDKStream, formatToolError } from "./converters/aisdk";
 import { convertTanStackStream } from "./converters/tanstack";
 import { createStateEventNormalizer } from "./state-delta";
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -1737,6 +1737,34 @@ export class BuiltInAgent extends AbstractAgent {
                 break;
               }
 
+              case "tool-error": {
+                const toolCallId = part.toolCallId;
+                const toolName =
+                  ("toolName" in part && part.toolName) ||
+                  toolCallStates.get(toolCallId)?.toolName ||
+                  "";
+
+                // Interrupt tools do not execute on the server. Their result
+                // is supplied by the human on the resume run.
+                if (toolName && interruptToolNames.has(toolName)) {
+                  toolCallStates.delete(toolCallId);
+                  break;
+                }
+
+                toolCallStates.delete(toolCallId);
+                const resultEvent: ToolCallResultEvent = {
+                  type: EventType.TOOL_CALL_RESULT,
+                  role: "tool",
+                  messageId: randomUUID(),
+                  toolCallId,
+                  // Keep tool exceptions as tool results so the client and the
+                  // next model step both receive the failure.
+                  content: `Error: ${formatToolError(part.error)}`,
+                };
+                subscriber.next(resultEvent);
+                break;
+              }
+
               case "finish": {
                 // Emit run finished event
                 const finishedEvent: RunFinishedEvent = {
@@ -1794,6 +1822,24 @@ export class BuiltInAgent extends AbstractAgent {
                   );
                 break;
               }
+
+              // These AI SDK fullStream parts carry metadata that has no AG-UI
+              // event equivalent. They are known and intentionally ignored;
+              // the default branch catches genuinely new parts.
+              case "start":
+              case "start-step":
+              case "finish-step":
+              case "text-end":
+              case "source":
+              case "file":
+              case "tool-output-denied":
+              case "raw":
+                break;
+
+              default:
+                throw new Error(
+                  `Unsupported AI SDK stream part: ${String(part.type)}`,
+                );
             }
           }
 


### PR DESCRIPTION
## What does this PR do?

### Problem

When a tool's `execute` function throws under the AI SDK 6 stream format, CopilotKit can report a successful run with no tool result or error. This is the failure reported in #3510.

### Root cause

The `fullStream` handling in both the AI SDK converter and the classic `BuiltInAgent` path handled `tool-call`, `tool-result`, and `error`, but not the sibling `tool-error` part emitted when tool execution throws. There was also no default branch, so unknown stream parts could disappear silently.

### Change

- Convert `tool-error` into a `TOOL_CALL_RESULT` containing a readable error for the client and next model step.
- Preserve interrupt-tool suppression and tool-call state cleanup.
- Explicitly ignore known AI SDK metadata parts and throw on an unrecognized part so the run surfaces `RUN_ERROR`.
- Add regression coverage for both converter and classic `BuiltInAgent` paths, plus unknown-part handling.

### Red / green proof

- Red condition covered by the regression: before this change, the existing switches had no `tool-error` or `default` case, so a synthetic thrown-tool stream produced neither a tool result nor an error and could finish normally.
- Green: the focused suite now asserts `Error: Missing API key` as a `TOOL_CALL_RESULT`, asserts no false success error path for tool failures, and asserts `RUN_ERROR` for an unknown stream part.

### Validation

- Focused Vitest: 4 files, 75 tests passed (`converter-aisdk`, `basic-agent`, AI SDK v6 compatibility, native interrupt).
- Focused TypeScript check: 0 errors using source aliases for the local workspace package.
- Oxfmt check: passed on all 6 changed files.
- Oxlint: 0 errors; 3 existing shadowing warnings in untouched logic.
- `git diff --check`: passed.
- Full runtime Vitest: 129 files / 1,940 tests passed; 14 collection failures were caused by unavailable workspace `@copilotkit/channels` and `@copilotkit/channels-core` build entries after an unrelated Node 26 `better-sqlite3` install failure. No changed test failed.

### Scope

Runtime AI SDK stream conversion only; no provider, network, or public API changes.

### AI assistance

AI-assisted implementation. Reproduction, root-cause analysis, test design, and validation were checked against the live issue, current `main`, repository guidance, and focused local test evidence.

## Related PRs and Issues

- Fixes #3510

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md)
- [x] No documentation update is needed for this runtime bug fix.
- [x] Allow edits by maintainers is enabled.
