### PR TITLE
fix(runtime): apply the run path's request-header merge to the v2 connect clone

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/connect-header-parity.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/connect-header-parity.test.ts
@@ -1,0 +1,142 @@
+import { Observable } from "rxjs";
+import { describe, expect, it } from "vitest";
+import type { AbstractAgent, BaseEvent } from "@ag-ui/client";
+import type { CopilotRuntime } from "../core/runtime";
+import { handleConnectAgent } from "../handlers/handle-connect";
+import { resolveForwardHeadersPolicy } from "../handlers/header-utils";
+import { configureAgentForRequest } from "../handlers/shared/agent-utils";
+
+const input = {
+  threadId: "thread-1",
+  runId: "run-1",
+  state: {},
+  messages: [],
+  tools: [],
+  context: [],
+  forwardedProps: {},
+};
+
+function createRuntime(agent: AbstractAgent): CopilotRuntime {
+  return {
+    agents: Promise.resolve({ "test-agent": agent }),
+    forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
+    runner: {
+      connect: () =>
+        new Observable<BaseEvent>((subscriber) => subscriber.complete()),
+    },
+  } as unknown as CopilotRuntime;
+}
+
+describe("connect request-header parity", () => {
+  it("configures the connect clone with the /run merge", async () => {
+    const clones: Array<AbstractAgent & { headers?: Record<string, string> }> =
+      [];
+    const registeredAgent = {
+      headers: undefined,
+      clone: () => {
+        const clone = {
+          headers: undefined,
+          use: () => {},
+        } as unknown as AbstractAgent & { headers?: Record<string, string> };
+        clones.push(clone);
+        return clone;
+      },
+    };
+    const runtime = createRuntime(registeredAgent as unknown as AbstractAgent);
+    const request = new Request(
+      "https://example.com/agent/test-agent/connect",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer forwarded-token",
+          "X-Tenant-Id": "acme",
+          "X-Forwarded-For": "203.0.113.7",
+          "X-CopilotCloud-Public-Api-Key": "ck_test",
+        },
+        body: JSON.stringify(input),
+      },
+    );
+
+    await handleConnectAgent({ runtime, request, agentId: "test-agent" });
+
+    const runClone = {
+      headers: undefined,
+      use: () => {},
+    } as AbstractAgent & { headers?: Record<string, string> };
+    configureAgentForRequest({
+      runtime,
+      request,
+      agentId: "test-agent",
+      agent: runClone,
+    });
+
+    expect(clones[0].headers).toEqual(runClone.headers);
+    expect(clones[0].headers).toEqual({
+      authorization: "Bearer forwarded-token",
+      "x-tenant-id": "acme",
+    });
+    expect(clones[0].headers).not.toHaveProperty("x-forwarded-for");
+    expect(clones[0].headers).not.toHaveProperty(
+      "x-copilotcloud-public-api-key",
+    );
+    expect(registeredAgent.headers).toBeUndefined();
+  });
+
+  it("keeps server Authorization on the clone without a duplicate key", async () => {
+    let clone!: AbstractAgent & { headers?: Record<string, string> };
+    const registeredAgent = {
+      headers: { Authorization: "Bearer service-token" },
+      clone: () => {
+        clone = {
+          headers: { Authorization: "Bearer service-token" },
+          use: () => {},
+        } as unknown as AbstractAgent & { headers?: Record<string, string> };
+        return clone;
+      },
+    };
+
+    await handleConnectAgent({
+      runtime: createRuntime(registeredAgent as unknown as AbstractAgent),
+      request: new Request("https://example.com/agent/test-agent/connect", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer inbound-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(input),
+      }),
+      agentId: "test-agent",
+    });
+
+    expect(clone.headers).toEqual({ Authorization: "Bearer service-token" });
+    expect(clone.headers).not.toHaveProperty("authorization");
+  });
+
+  it("sets an empty clone header object when nothing is forwardable", async () => {
+    let clone!: AbstractAgent & { headers?: Record<string, string> };
+    const registeredAgent = {
+      clone: () => {
+        clone = { use: () => {} } as AbstractAgent & {
+          headers?: Record<string, string>;
+        };
+        return clone;
+      },
+    };
+
+    await handleConnectAgent({
+      runtime: createRuntime(registeredAgent as unknown as AbstractAgent),
+      request: new Request("https://example.com/agent/test-agent/connect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://example.com",
+        },
+        body: JSON.stringify(input),
+      }),
+      agentId: "test-agent",
+    });
+
+    expect(clone.headers).toEqual({});
+  });
+});

--- a/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
@@ -4,6 +4,7 @@ import { isIntelligenceRuntime } from "../core/runtime";
 import { telemetry } from "../telemetry";
 import type { RunAgentParameters as ConnectAgentParameters } from "./shared/agent-utils";
 import {
+  applyForwardedRequestHeaders,
   parseConnectRequest,
   cloneAgentForRequest,
 } from "./shared/agent-utils";
@@ -40,6 +41,8 @@ export async function handleConnectAgent({
       return agent;
     }
 
+    applyForwardedRequestHeaders({ runtime, request, agent });
+
     const connectRequest = await parseConnectRequest(request);
     if (connectRequest instanceof Response) {
       return connectRequest;
@@ -59,10 +62,9 @@ export async function handleConnectAgent({
       request,
       agentId,
       threadId: connectRequest.input.threadId,
-      // Pass the per-request clone so its server-configured `agent.headers` are
-      // folded into the merged header set threaded into `runner.connect`. That
-      // merge is forward-looking plumbing — no shipped runner consumes
-      // connect-path headers yet; see the note in `sse/connect.ts`.
+      // Pass the per-request clone whose headers were merged by
+      // applyForwardedRequestHeaders, the single owner of request-header
+      // forwarding shared with configureAgentForRequest.
       agent,
     });
   } catch (error) {

--- a/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-connect.ts
@@ -62,6 +62,7 @@ export async function handleConnectAgent({
       request,
       agentId,
       threadId: connectRequest.input.threadId,
+      headersApplied: true,
       // Pass the per-request clone whose headers were merged by
       // applyForwardedRequestHeaders, the single owner of request-header
       // forwarding shared with configureAgentForRequest.

--- a/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
+++ b/packages/runtime/src/v2/runtime/handlers/shared/agent-utils.ts
@@ -78,6 +78,34 @@ export async function cloneAgentForRequest(
   return (agents[agentId] as AbstractAgent).clone() as AbstractAgent;
 }
 
+export function applyForwardedRequestHeaders(params: {
+  runtime: CopilotRuntimeLike;
+  request: Request;
+  agent: AbstractAgent;
+}): void {
+  const { runtime, request } = params;
+  const agent = params.agent as MiddlewareCapableAgent;
+
+  // Forward eligible inbound headers onto the outgoing agent call under the
+  // runtime's resolved forwarding policy (`authorization` / custom `x-*`, with
+  // known infra/proxy/platform headers stripped by the default denylist —
+  // #5712), but let headers the server explicitly configured on the agent WIN
+  // on collision (case-insensitively): a server-set service-to-service token
+  // (e.g. an IAM bearer) must never be silently overridden by a
+  // browser/edge/platform-injected inbound header. See `mergeForwardableHeaders`
+  // for the casing/duplicate-key rationale and `shouldForwardHeader` for breadth.
+  agent.headers = mergeForwardableHeaders(
+    agent.headers,
+    request,
+    // `forwardHeadersPolicy` is optional on the published `CopilotRuntimeLike`
+    // interface (non-breaking minor release). Concrete runtimes always set it;
+    // a policy-less external implementor falls back to the default resolved
+    // policy (default-on denylist) so behavior stays identical and never derefs
+    // undefined.
+    runtime.forwardHeadersPolicy ?? resolveForwardHeadersPolicy(undefined),
+  );
+}
+
 export function configureAgentForRequest(params: {
   runtime: CopilotRuntimeLike;
   request: Request;
@@ -141,24 +169,7 @@ export function configureAgentForRequest(params: {
     }
   }
 
-  // Forward eligible inbound headers onto the outgoing agent call under the
-  // runtime's resolved forwarding policy (`authorization` / custom `x-*`, with
-  // known infra/proxy/platform headers stripped by the default denylist —
-  // #5712), but let headers the server explicitly configured on the agent WIN
-  // on collision (case-insensitively): a server-set service-to-service token
-  // (e.g. an IAM bearer) must never be silently overridden by a
-  // browser/edge/platform-injected inbound header. See `mergeForwardableHeaders`
-  // for the casing/duplicate-key rationale and `shouldForwardHeader` for breadth.
-  agent.headers = mergeForwardableHeaders(
-    agent.headers,
-    request,
-    // `forwardHeadersPolicy` is optional on the published `CopilotRuntimeLike`
-    // interface (non-breaking minor release). Concrete runtimes always set it;
-    // a policy-less external implementor falls back to the default resolved
-    // policy (default-on denylist) so behavior stays identical and never derefs
-    // undefined.
-    runtime.forwardHeadersPolicy ?? resolveForwardHeadersPolicy(undefined),
-  );
+  applyForwardedRequestHeaders({ runtime, request, agent });
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -1,10 +1,6 @@
 import type { AbstractAgent } from "@ag-ui/client";
 import type { CopilotRuntimeLike } from "../../core/runtime";
 import { createSseEventResponse } from "../shared/sse-response";
-import {
-  mergeForwardableHeaders,
-  resolveForwardHeadersPolicy,
-} from "../header-utils";
 
 /**
  * `headers` lives on the HTTP-backed agent configs (e.g. `HttpAgent`), not on
@@ -23,9 +19,8 @@ interface HandleSseConnectParams {
   threadId: string;
   /**
    * The per-request agent clone, carrying any server-configured `agent.headers`
-   * (e.g. service-to-service auth). Used only to compute the merged header set
-   * threaded into `runner.connect` below — see the note there for why that
-   * merge is forward-looking plumbing rather than active outbound auth today.
+   * (e.g. service-to-service auth). The merged headers are computed once by
+   * `applyForwardedRequestHeaders` in `handle-connect.ts` and read below.
    */
   agent?: AgentWithHeaders;
 }
@@ -47,27 +42,12 @@ export function handleSseConnect({
       runtime.runner.connect({
         threadId,
         agentId,
-        // Forward-looking plumbing: we compute the merged header set (server
-        // `agent.headers` win on collision, case-insensitively; non-colliding
-        // inbound headers still forward — see `mergeForwardableHeaders`, #5712)
-        // and thread it into `runner.connect`. NO shipped runner consumes the
-        // `headers` field of `AgentRunnerConnectRequest` today — every runner
-        // (in-memory, intelligence, telemetry, sqlite) reads only `threadId`.
-        // The real outbound header forwarding is the /run path, where
-        // `cloneAgentForRequest` mutates `agent.headers` directly
-        // (agent-utils.ts). This wiring exists so a future outbound-connecting
-        // runner can pick the merged headers up without a route change; the
-        // collision precedence noted here is purely about that merge, not about
-        // middleware/mutation parity with /run.
-        headers: mergeForwardableHeaders(
-          agent?.headers,
-          request,
-          // Optional on `CopilotRuntimeLike` (non-breaking minor release);
-          // coalesce a policy-less external implementor to the default resolved
-          // policy (default-on denylist) instead of dereffing undefined.
-          runtime.forwardHeadersPolicy ??
-            resolveForwardHeadersPolicy(undefined),
-        ),
+        // `applyForwardedRequestHeaders` computed this once on the connect
+        // clone. Server-configured headers win case-insensitively (#5712/#5782).
+        // No shipped runner consumes AgentRunnerConnectRequest.headers today;
+        // every runner reads threadId/agentId only. This remains forward-looking
+        // plumbing for a future outbound-connecting runner.
+        headers: agent?.headers ?? {},
       }),
   });
 }

--- a/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/sse/connect.ts
@@ -1,6 +1,7 @@
 import type { AbstractAgent } from "@ag-ui/client";
 import type { CopilotRuntimeLike } from "../../core/runtime";
 import { createSseEventResponse } from "../shared/sse-response";
+import { applyForwardedRequestHeaders } from "../shared/agent-utils";
 
 /**
  * `headers` lives on the HTTP-backed agent configs (e.g. `HttpAgent`), not on
@@ -23,6 +24,8 @@ interface HandleSseConnectParams {
    * `applyForwardedRequestHeaders` in `handle-connect.ts` and read below.
    */
   agent?: AgentWithHeaders;
+  /** True when the route already applied the shared merge to `agent`. */
+  headersApplied?: boolean;
 }
 
 export function handleSseConnect({
@@ -31,7 +34,20 @@ export function handleSseConnect({
   agentId,
   threadId,
   agent,
+  headersApplied = false,
 }: HandleSseConnectParams): Response {
+  // Keep direct callers compatible with the pre-parity helper contract. The
+  // route caller marks its clone as already configured, so this fallback only
+  // serves direct callers; the merge implementation remains shared.
+  const connectAgent = agent ?? ({} as AgentWithHeaders);
+  if (!headersApplied) {
+    applyForwardedRequestHeaders({
+      runtime,
+      request,
+      agent: connectAgent,
+    });
+  }
+
   return createSseEventResponse({
     request,
     debugEventBus: runtime.debugEventBus,
@@ -47,7 +63,7 @@ export function handleSseConnect({
         // No shipped runner consumes AgentRunnerConnectRequest.headers today;
         // every runner reads threadId/agentId only. This remains forward-looking
         // plumbing for a future outbound-connecting runner.
-        headers: agent?.headers ?? {},
+        headers: connectAgent.headers ?? {},
       }),
   });
 }

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -236,7 +236,7 @@ Per-tool filtering belongs to `@ag-ui/mcp-apps-middleware`. The runtime currentl
 
 ## Forwarding request headers to your agent
 
-When a request reaches the runtime, some inbound headers are forwarded onto the outgoing call to your agent (the `/run` path that actually dispatches the agent). This is how a token configured by the frontend provider reaches a self-hosted agent — see [Authentication](/auth).
+When a request reaches the runtime, some inbound headers are forwarded onto the outgoing call to your agent (both `/run` and `/connect` apply the same policy to the per-request agent, but no shipped runner consumes connect-path headers yet, so today only `/run` produces an outbound agent call). This is how a token configured by the frontend provider reaches a self-hosted agent — see [Authentication](/auth).
 
 By default the runtime forwards `authorization` and any `x-*` header, **minus** a built-in denylist of infrastructure, proxy, and platform headers that no legitimate agent integration needs forwarded from the edge. The denylist strips, among others:
 


### PR DESCRIPTION
## Summary

The v2 connect route cloned an agent per request, then passed that clone into SSE handling without applying the request-header forwarding policy. The `/run` path applies that policy to its clone, so connect and run followed different header paths. The SSE helper also repeated the merge logic, leaving two owners for the same behavior.

## Changes

- Extract the forwarding step into `applyForwardedRequestHeaders`, shared by `configureAgentForRequest` and the connect route.
- Apply the shared step in `handleConnectAgent` immediately after cloning the agent, before the intelligence/SSE branch split.
- Keep direct `handleSseConnect` callers compatible with a fallback; the route marks its clone as already configured, so the merge runs once on the normal path.
- Add connect-header parity coverage and retain the existing handler, header-policy, and direct-SSE coverage.
- Correct the shell documentation and runtime comments so they describe the connect path accurately.

## Scope

This PR doesn't change runners or the `AgentRunnerConnectRequest` contract. `headers` remains available to `runner.connect`, but shipped runners don't consume connect-path headers yet.

It doesn't change MCP Apps middleware, forwarding-policy rules, or `@ag-ui/a2a`. CopilotKit's connect-side preparation is fixed here; downstream A2A outbound header consumption remains outside this repository. `Refs #3170`.

## Test plan

- [x] Connect-header parity tests, 3 passed. The base reproduction failed because the cloned agent had no forwarded headers; the head passes.
- [x] Connect handler regression tests, 17 passed. Existing handler behavior remains covered without modifying the handler test fixture.
- [x] Header precedence, forwarding-policy, and direct-SSE tests, 50 passed.
- [x] Runtime type checking, formatting, lint, and diff checks passed.
- [ ] CI green, including `static / quality`, `test / unit`, and `static / compat`.
