### PR TITLE
fix(core): notify subscribers when agent threads change

### DIFF
--- a/.changeset/observe-agent-thread-transitions.md
+++ b/.changeset/observe-agent-thread-transitions.md
@@ -1,0 +1,8 @@
+---
+"@copilotkit/core": patch
+"@copilotkit/angular": patch
+---
+
+fix(core): notify subscribers when agent threads change
+
+Notify framework subscribers when an observed agent changes threads and clear Angular interrupts retained from the previous thread.

--- a/packages/angular/src/lib/active-thread-connector.spec.ts
+++ b/packages/angular/src/lib/active-thread-connector.spec.ts
@@ -6,12 +6,15 @@ import {
 } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { test, expect, vi } from "vitest";
-import { HttpAgent } from "@ag-ui/client";
+import { AbstractAgent, HttpAgent } from "@ag-ui/client";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { Observable } from "rxjs";
+import { CopilotKitCore } from "@copilotkit/core";
 import {
   injectChatConfiguration,
   provideCopilotChatConfiguration,
 } from "./chat-configuration";
-import type { AgentStore } from "./agent";
+import { AgentStore } from "./agent";
 import { connectActiveThread } from "./active-thread-connector";
 
 /**
@@ -59,6 +62,46 @@ test("explicit switch connects the agent to the picked thread", async () => {
   expect(connect).toHaveBeenCalledWith(
     expect.objectContaining({ agent: fake.agent }),
   );
+});
+
+test("notifies the store when the active thread changes", async () => {
+  class ProductionAgent extends AbstractAgent {
+    run(_input: RunAgentInput): Observable<BaseEvent> {
+      return new Observable();
+    }
+  }
+
+  const core = new CopilotKitCore({});
+  const agent = new ProductionAgent({
+    agentId: "agent-1",
+    threadId: "thread-a",
+  });
+  agent.pendingInterrupts = [{ id: "approve-refund" } as never];
+  const store = new AgentStore(
+    agent,
+    { onDestroy: vi.fn(() => vi.fn()) } as never,
+    core.subscribeToAgentWithOptions.bind(core),
+  );
+  const agentStore = signal(store);
+  const connect = vi.fn();
+
+  TestBed.configureTestingModule({
+    providers: [provideCopilotChatConfiguration()],
+  });
+  const config = TestBed.runInInjectionContext(() => {
+    const cfg = injectChatConfiguration();
+    connectActiveThread(cfg, agentStore, connect);
+    return cfg;
+  });
+
+  expect(store.interruptController.hasInterrupt()).toBe(true);
+  config.setActiveThreadId("thread-b", { explicit: true });
+  TestBed.flushEffects();
+  await Promise.resolve();
+
+  expect(agent.threadId).toBe("thread-b");
+  expect(store.interruptController.hasInterrupt()).toBe(false);
+  expect(connect).toHaveBeenCalledTimes(1);
 });
 
 test("initial mount does not clear messages", async () => {

--- a/packages/angular/src/lib/agent.spec.ts
+++ b/packages/angular/src/lib/agent.spec.ts
@@ -768,6 +768,18 @@ describe("AgentStore.interruptController", () => {
     expect(store.interruptController.hasInterrupt()).toBe(true);
   });
 
+  it("clears the store interrupt when its agent loses its thread", () => {
+    const agent = new MockAgent("agent-1");
+    agent.threadId = "thread-a";
+    agent.pendingInterrupts = [interrupt("approve-refund")];
+    const { store } = hostFor(agent);
+
+    (agent as MockAgent & { threadId: string | undefined }).threadId =
+      undefined;
+
+    expect(store.interruptController.hasInterrupt()).toBe(false);
+  });
+
   it("unregisters manual teardown and runs cleanup only once", () => {
     const agent = new MockAgent("agent-1");
     const unregisterDestroy = vi.fn();

--- a/packages/angular/src/lib/agent.spec.ts
+++ b/packages/angular/src/lib/agent.spec.ts
@@ -744,7 +744,7 @@ describe("AgentStore.interruptController", () => {
     ]);
   });
 
-  it.skip("clears the store interrupt as soon as its agent changes threads", () => {
+  it("clears the store interrupt as soon as its agent changes threads", () => {
     const agent = new MockAgent("agent-1");
     agent.threadId = "thread-a";
     agent.pendingInterrupts = [interrupt("approve-refund")];
@@ -755,6 +755,17 @@ describe("AgentStore.interruptController", () => {
     agent.threadId = "thread-b";
 
     expect(store.interruptController.hasInterrupt()).toBe(false);
+  });
+
+  it("preserves the store interrupt when its agent keeps the same thread", () => {
+    const agent = new MockAgent("agent-1");
+    agent.threadId = "thread-a";
+    agent.pendingInterrupts = [interrupt("approve-refund")];
+    const { store } = hostFor(agent);
+
+    agent.threadId = "thread-a";
+
+    expect(store.interruptController.hasInterrupt()).toBe(true);
   });
 
   it("unregisters manual teardown and runs cleanup only once", () => {

--- a/packages/angular/src/lib/agent.ts
+++ b/packages/angular/src/lib/agent.ts
@@ -101,6 +101,11 @@ export class AgentStore {
       onRunErrorEvent: () => {
         this.#isRunning.set(false);
       },
+      onThreadIdChanged: ({ threadId }) => {
+        if (threadId !== undefined) {
+          this.interruptController.setThreadId(threadId);
+        }
+      },
     });
     // Preserve the store projection as the agent's first subscriber so its
     // synchronous message/state updates keep their existing timing.

--- a/packages/angular/src/lib/agent.ts
+++ b/packages/angular/src/lib/agent.ts
@@ -102,9 +102,7 @@ export class AgentStore {
         this.#isRunning.set(false);
       },
       onThreadIdChanged: ({ threadId }) => {
-        if (threadId !== undefined) {
-          this.interruptController.setThreadId(threadId);
-        }
+        this.interruptController.setThreadId(threadId);
       },
     });
     // Preserve the store projection as the agent's first subscriber so its

--- a/packages/angular/src/lib/interrupt.ts
+++ b/packages/angular/src/lib/interrupt.ts
@@ -221,7 +221,7 @@ export class InterruptController<TValue = unknown, TResult = never> {
   }
 
   /** Clear pending decisions when the host changes threads. */
-  setThreadId(threadId: string): void {
+  setThreadId(threadId: string | undefined): void {
     if (this.#threadId === undefined) {
       this.#threadId = threadId;
       return;

--- a/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
+++ b/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
@@ -1136,7 +1136,7 @@ describe("CopilotKitCore.subscribeToAgentWithOptions", () => {
         },
       });
       const onThreadIdChanged = vi.fn();
-      const previousThreadId = agent.threadId;
+      const initialThreadId = agent.threadId;
 
       core.subscribeToAgentWithOptions(agent, { onThreadIdChanged });
       agent.threadId = "thread-b";
@@ -1146,6 +1146,35 @@ describe("CopilotKitCore.subscribeToAgentWithOptions", () => {
         previousThreadId,
         threadId: "thread-b",
       });
+    });
+
+    it("queues re-entrant assignments behind the current transition", () => {
+      const events: string[] = [];
+      const previousThreadId = agent.threadId;
+      let reentered = false;
+      core.subscribeToAgentWithOptions(agent, {
+        onThreadIdChanged: ({ previousThreadId: previous, threadId }) => {
+          events.push(`first:${previous}->${threadId}`);
+          if (!reentered) {
+            reentered = true;
+            agent.threadId = "thread-c";
+          }
+        },
+      });
+      core.subscribeToAgentWithOptions(agent, {
+        onThreadIdChanged: ({ previousThreadId: previous, threadId }) => {
+          events.push(`second:${previous}->${threadId}`);
+        },
+      });
+
+      agent.threadId = "thread-b";
+
+      expect(events).toEqual([
+        `first:${initialThreadId}->thread-b`,
+        `second:${initialThreadId}->thread-b`,
+        "first:thread-b->thread-c",
+        "second:thread-b->thread-c",
+      ]);
     });
   });
 });

--- a/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
+++ b/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
@@ -1053,4 +1053,76 @@ describe("CopilotKitCore.subscribeToAgentWithOptions", () => {
     // Both fire immediately — no throttling
     expect(onMessagesUnthrottled).toHaveBeenCalledTimes(2);
   });
+  describe("threadId observation", () => {
+    it("notifies changed assignments synchronously with ordered payloads", () => {
+      const onThreadIdChanged = vi.fn();
+      core.subscribeToAgentWithOptions(agent, { onThreadIdChanged });
+
+      agent.threadId = "thread-a";
+      expect(agent.threadId).toBe("thread-a");
+      agent.threadId = "thread-b";
+      agent.threadId = "thread-a";
+
+      expect(onThreadIdChanged).toHaveBeenCalledTimes(3);
+      expect(
+        onThreadIdChanged.mock.calls.map(([event]) => [
+          event.previousThreadId,
+          event.threadId,
+        ]),
+      ).toEqual([
+        [expect.any(String), "thread-a"],
+        ["thread-a", "thread-b"],
+        ["thread-b", "thread-a"],
+      ]);
+    });
+
+    it("same threadId assignments are silent and remain immediate during throttling", () => {
+      const onMessagesChanged = vi.fn();
+      const onThreadIdChanged = vi.fn();
+      core.subscribeToAgentWithOptions(
+        agent,
+        { onMessagesChanged, onThreadIdChanged },
+        { throttleMs: 100 },
+      );
+
+      agent.messages = [userMsg("1", "a")];
+      notifyMessagesChanged(agent);
+      const sameThreadId = agent.threadId;
+      agent.threadId = sameThreadId;
+      expect(onThreadIdChanged).not.toHaveBeenCalled();
+      agent.threadId = "thread-b";
+      expect(onThreadIdChanged).toHaveBeenCalledTimes(1);
+      expect(onMessagesChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it("threadId callback failures are isolated across subscribers and unsubscribe", async () => {
+      const first = vi.fn(() => {
+        throw new Error("sync failure");
+      });
+      const second = vi.fn(() => Promise.reject(new Error("async failure")));
+      const third = vi.fn();
+      const firstSub = core.subscribeToAgentWithOptions(agent, {
+        onThreadIdChanged: first,
+      });
+      core.subscribeToAgentWithOptions(agent, { onThreadIdChanged: second });
+      const thirdSub = core.subscribeToAgentWithOptions(agent, {
+        onThreadIdChanged: third,
+      });
+      const error = silenceConsoleError();
+
+      agent.threadId = "thread-b";
+      await Promise.resolve();
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(third).toHaveBeenCalledTimes(1);
+
+      thirdSub.unsubscribe();
+      firstSub.unsubscribe();
+      agent.threadId = "thread-c";
+      await Promise.resolve();
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(third).toHaveBeenCalledTimes(1);
+      error.mockRestore();
+    });
+  });
 });

--- a/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
+++ b/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
@@ -1143,14 +1143,14 @@ describe("CopilotKitCore.subscribeToAgentWithOptions", () => {
 
       expect(onThreadIdChanged).toHaveBeenCalledWith({
         agent,
-        previousThreadId,
+        previousThreadId: initialThreadId,
         threadId: "thread-b",
       });
     });
 
     it("queues re-entrant assignments behind the current transition", () => {
       const events: string[] = [];
-      const previousThreadId = agent.threadId;
+      const initialThreadId = agent.threadId;
       let reentered = false;
       core.subscribeToAgentWithOptions(agent, {
         onThreadIdChanged: ({ previousThreadId: previous, threadId }) => {

--- a/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
+++ b/packages/core/src/__tests__/core-subscribe-to-agent.test.ts
@@ -1124,5 +1124,28 @@ describe("CopilotKitCore.subscribeToAgentWithOptions", () => {
       expect(third).toHaveBeenCalledTimes(1);
       error.mockRestore();
     });
+
+    it("supports an accessor already installed on the agent", () => {
+      let currentThreadId = agent.threadId;
+      Object.defineProperty(agent, "threadId", {
+        configurable: true,
+        enumerable: true,
+        get: () => currentThreadId,
+        set: (threadId: string) => {
+          currentThreadId = threadId;
+        },
+      });
+      const onThreadIdChanged = vi.fn();
+      const previousThreadId = agent.threadId;
+
+      core.subscribeToAgentWithOptions(agent, { onThreadIdChanged });
+      agent.threadId = "thread-b";
+
+      expect(onThreadIdChanged).toHaveBeenCalledWith({
+        agent,
+        previousThreadId,
+        threadId: "thread-b",
+      });
+    });
   });
 });

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -267,15 +267,15 @@ const SUBSCRIBE_TO_AGENT_KEYS = [
 const ALLOWED_KEYS: ReadonlySet<(typeof SUBSCRIBE_TO_AGENT_KEYS)[number]> =
   new Set(SUBSCRIBE_TO_AGENT_KEYS);
 
-const OBSERVED_AGENTS = new WeakSet<AbstractAgent>();
+const THREAD_ID_OBSERVER = Symbol.for("copilotkit.agent.threadIdObserver");
 
 /**
  * The subset of `AgentSubscriber` callbacks accepted by
  * {@link CopilotKitCore.subscribeToAgentWithOptions}. Only the callbacks
  * listed in {@link SUBSCRIBE_TO_AGENT_KEYS} are supported:
- * `onMessagesChanged`, `onStateChanged`, and the four run lifecycle
+ * `onMessagesChanged`, `onStateChanged`, the four run lifecycle
  * callbacks (`onRunInitialized`, `onRunFinalized`, `onRunFailed`,
- * `onRunErrorEvent`).
+ * `onRunErrorEvent`), and `onThreadIdChanged`.
  *
  * Two categories of `AgentSubscriber` members are excluded:
  *
@@ -302,15 +302,23 @@ const OBSERVED_AGENTS = new WeakSet<AbstractAgent>();
  * path, `safeCall` discards those return values (see its inline
  * documentation).
  *
- * Use `agent.subscribe()` directly when event mutation or per-item
- * notification semantics are needed.
+ * `onThreadIdChanged` is delivered immediately and is not throttled. Use
+ * `agent.subscribe()` directly when event mutation or per-item notification
+ * semantics are needed.
  */
+/** Payload delivered after an observed agent's thread id changes. */
 export interface SubscribeToAgentThreadIdChangedEvent {
   agent: AbstractAgent;
   previousThreadId: string | undefined;
   threadId: string | undefined;
 }
 
+/**
+ * The subset of `AgentSubscriber` callbacks accepted by
+ * {@link CopilotKitCore.subscribeToAgentWithOptions}. Thread changes are
+ * delivered immediately and are not throttled; use `agent.subscribe()` for
+ * event mutation or per-item notification semantics.
+ */
 export type SubscribeToAgentSubscriber = Pick<
   AgentSubscriber,
   Exclude<(typeof SUBSCRIBE_TO_AGENT_KEYS)[number], "onThreadIdChanged">
@@ -1180,16 +1188,81 @@ export class CopilotKitCore {
       }
     };
 
-    if (!OBSERVED_AGENTS.has(agent)) {
-      const descriptor = Object.getOwnPropertyDescriptor(agent, "threadId");
+    if (
+      subscriber.onThreadIdChanged &&
+      !(agent as AbstractAgent & { [THREAD_ID_OBSERVER]?: true })[
+        THREAD_ID_OBSERVER
+      ]
+    ) {
+      const ownDescriptor = Object.getOwnPropertyDescriptor(agent, "threadId");
+      const prototypeDescriptor = ownDescriptor
+        ? undefined
+        : Object.getOwnPropertyDescriptor(
+            Object.getPrototypeOf(agent),
+            "threadId",
+          );
+      const descriptor = ownDescriptor ?? prototypeDescriptor;
+      const observer = (event: SubscribeToAgentThreadIdChangedEvent) => {
+        for (const currentSubscriber of [
+          ...agent.subscribers,
+        ] as SubscribeToAgentSubscriber[]) {
+          const callback = currentSubscriber.onThreadIdChanged;
+          if (!callback) continue;
+          try {
+            const result = callback(event);
+            if (result instanceof Promise) void result.catch(() => undefined);
+          } catch {
+            // Core-wrapped callbacks report through their own safeCall closure.
+          }
+        }
+      };
+
       if (
-        !descriptor ||
-        !("value" in descriptor) ||
-        descriptor.writable !== true ||
-        descriptor.configurable !== true
+        descriptor &&
+        "value" in descriptor &&
+        descriptor.writable === true &&
+        descriptor.configurable === true
       ) {
+        let currentThreadId = descriptor.value as string | undefined;
+        Object.defineProperty(agent, "threadId", {
+          configurable: true,
+          enumerable: descriptor.enumerable,
+          get: () => currentThreadId,
+          set: (threadId: string | undefined) => {
+            const previousThreadId = currentThreadId;
+            currentThreadId = threadId;
+            if (!Object.is(previousThreadId, threadId)) {
+              observer({ agent, previousThreadId, threadId });
+            }
+          },
+        });
+      } else if (
+        descriptor?.get &&
+        descriptor.set &&
+        (!ownDescriptor || descriptor.configurable === true)
+      ) {
+        const getThreadId = () =>
+          descriptor.get!.call(agent) as string | undefined;
+        Object.defineProperty(agent, "threadId", {
+          configurable: true,
+          enumerable: descriptor.enumerable,
+          get: getThreadId,
+          set: (threadId: string | undefined) => {
+            const previousThreadId = getThreadId();
+            descriptor.set!.call(agent, threadId);
+            const nextThreadId = getThreadId();
+            if (!Object.is(previousThreadId, nextThreadId)) {
+              observer({
+                agent,
+                previousThreadId,
+                threadId: nextThreadId,
+              });
+            }
+          },
+        });
+      } else {
         const error = new Error(
-          `Cannot observe agent ${agentLabel}: threadId must be a configurable writable property`,
+          `Cannot observe agent ${agentLabel}: threadId must be configurable and writable`,
         );
         this.logAndEmitError(error.message, {
           error,
@@ -1199,28 +1272,11 @@ export class CopilotKitCore {
         throw error;
       }
 
-      let currentThreadId = descriptor.value as string | undefined;
-      Object.defineProperty(agent, "threadId", {
-        configurable: descriptor.configurable,
-        enumerable: descriptor.enumerable,
-        get: () => currentThreadId,
-        set: (threadId: string | undefined) => {
-          const previousThreadId = currentThreadId;
-          currentThreadId = threadId;
-          if (Object.is(previousThreadId, threadId)) return;
-
-          const event = { agent, previousThreadId, threadId };
-          for (const currentSubscriber of [
-            ...agent.subscribers,
-          ] as SubscribeToAgentSubscriber[]) {
-            const callback = currentSubscriber.onThreadIdChanged;
-            if (callback) {
-              safeCall("onThreadIdChanged", callback, event);
-            }
-          }
-        },
+      Object.defineProperty(agent, THREAD_ID_OBSERVER, {
+        configurable: true,
+        enumerable: false,
+        value: true,
       });
-      OBSERVED_AGENTS.add(agent);
     }
 
     const guardAll = (

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -269,6 +269,10 @@ const ALLOWED_KEYS: ReadonlySet<(typeof SUBSCRIBE_TO_AGENT_KEYS)[number]> =
 
 const THREAD_ID_OBSERVER = Symbol.for("copilotkit.agent.threadIdObserver");
 
+type ThreadIdObserverState = {
+  notify: (event: SubscribeToAgentThreadIdChangedEvent) => void;
+};
+
 /**
  * The subset of `AgentSubscriber` callbacks accepted by
  * {@link CopilotKitCore.subscribeToAgentWithOptions}. Only the callbacks
@@ -1190,9 +1194,11 @@ export class CopilotKitCore {
 
     if (
       subscriber.onThreadIdChanged &&
-      !(agent as AbstractAgent & { [THREAD_ID_OBSERVER]?: true })[
-        THREAD_ID_OBSERVER
-      ]
+      !(
+        agent as AbstractAgent & {
+          [THREAD_ID_OBSERVER]?: ThreadIdObserverState;
+        }
+      )[THREAD_ID_OBSERVER]
     ) {
       const ownDescriptor = Object.getOwnPropertyDescriptor(agent, "threadId");
       const prototypeDescriptor = ownDescriptor
@@ -1202,19 +1208,35 @@ export class CopilotKitCore {
             "threadId",
           );
       const descriptor = ownDescriptor ?? prototypeDescriptor;
-      const observer = (event: SubscribeToAgentThreadIdChangedEvent) => {
-        for (const currentSubscriber of [
-          ...agent.subscribers,
-        ] as SubscribeToAgentSubscriber[]) {
-          const callback = currentSubscriber.onThreadIdChanged;
-          if (!callback) continue;
+      let dispatching = false;
+      const pendingEvents: SubscribeToAgentThreadIdChangedEvent[] = [];
+      const observer: ThreadIdObserverState = {
+        notify: (event) => {
+          pendingEvents.push(event);
+          if (dispatching) return;
+
+          dispatching = true;
           try {
-            const result = callback(event);
-            if (result instanceof Promise) void result.catch(() => undefined);
-          } catch {
-            // Core-wrapped callbacks report through their own safeCall closure.
+            while (pendingEvents.length > 0) {
+              const currentEvent = pendingEvents.shift()!;
+              for (const currentSubscriber of [
+                ...agent.subscribers,
+              ] as SubscribeToAgentSubscriber[]) {
+                const callback = currentSubscriber.onThreadIdChanged;
+                if (!callback) continue;
+                try {
+                  const result = callback(currentEvent);
+                  if (result instanceof Promise)
+                    void result.catch(() => undefined);
+                } catch {
+                  // Core-wrapped callbacks report through their safeCall closure.
+                }
+              }
+            }
+          } finally {
+            dispatching = false;
           }
-        }
+        },
       };
 
       if (
@@ -1232,7 +1254,7 @@ export class CopilotKitCore {
             const previousThreadId = currentThreadId;
             currentThreadId = threadId;
             if (!Object.is(previousThreadId, threadId)) {
-              observer({ agent, previousThreadId, threadId });
+              observer.notify({ agent, previousThreadId, threadId });
             }
           },
         });
@@ -1252,7 +1274,7 @@ export class CopilotKitCore {
             descriptor.set!.call(agent, threadId);
             const nextThreadId = getThreadId();
             if (!Object.is(previousThreadId, nextThreadId)) {
-              observer({
+              observer.notify({
                 agent,
                 previousThreadId,
                 threadId: nextThreadId,
@@ -1275,7 +1297,7 @@ export class CopilotKitCore {
       Object.defineProperty(agent, THREAD_ID_OBSERVER, {
         configurable: true,
         enumerable: false,
-        value: true,
+        value: observer,
       });
     }
 

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -257,7 +257,8 @@ const SUBSCRIBE_TO_AGENT_KEYS = [
   "onRunFinalized",
   "onRunFailed",
   "onRunErrorEvent",
-] as const satisfies readonly (keyof AgentSubscriber)[];
+  "onThreadIdChanged",
+] as const satisfies readonly (keyof AgentSubscriber | "onThreadIdChanged")[];
 
 /**
  * Runtime allowlist derived from {@link SUBSCRIBE_TO_AGENT_KEYS}. Hoisted
@@ -265,6 +266,8 @@ const SUBSCRIBE_TO_AGENT_KEYS = [
  */
 const ALLOWED_KEYS: ReadonlySet<(typeof SUBSCRIBE_TO_AGENT_KEYS)[number]> =
   new Set(SUBSCRIBE_TO_AGENT_KEYS);
+
+const OBSERVED_AGENTS = new WeakSet<AbstractAgent>();
 
 /**
  * The subset of `AgentSubscriber` callbacks accepted by
@@ -302,10 +305,20 @@ const ALLOWED_KEYS: ReadonlySet<(typeof SUBSCRIBE_TO_AGENT_KEYS)[number]> =
  * Use `agent.subscribe()` directly when event mutation or per-item
  * notification semantics are needed.
  */
+export interface SubscribeToAgentThreadIdChangedEvent {
+  agent: AbstractAgent;
+  previousThreadId: string | undefined;
+  threadId: string | undefined;
+}
+
 export type SubscribeToAgentSubscriber = Pick<
   AgentSubscriber,
-  (typeof SUBSCRIBE_TO_AGENT_KEYS)[number]
->;
+  Exclude<(typeof SUBSCRIBE_TO_AGENT_KEYS)[number], "onThreadIdChanged">
+> & {
+  onThreadIdChanged?: (
+    event: SubscribeToAgentThreadIdChangedEvent,
+  ) => void | Promise<void>;
+};
 
 /** Options for {@link CopilotKitCore.subscribeToAgentWithOptions}. */
 export interface SubscribeToAgentOptions {
@@ -1167,6 +1180,49 @@ export class CopilotKitCore {
       }
     };
 
+    if (!OBSERVED_AGENTS.has(agent)) {
+      const descriptor = Object.getOwnPropertyDescriptor(agent, "threadId");
+      if (
+        !descriptor ||
+        !("value" in descriptor) ||
+        descriptor.writable !== true ||
+        descriptor.configurable !== true
+      ) {
+        const error = new Error(
+          `Cannot observe agent ${agentLabel}: threadId must be a configurable writable property`,
+        );
+        this.logAndEmitError(error.message, {
+          error,
+          code: CopilotKitCoreErrorCode.SUBSCRIBER_CALLBACK_FAILED,
+          context: { agentId: agent.agentId, property: "threadId" },
+        });
+        throw error;
+      }
+
+      let currentThreadId = descriptor.value as string | undefined;
+      Object.defineProperty(agent, "threadId", {
+        configurable: descriptor.configurable,
+        enumerable: descriptor.enumerable,
+        get: () => currentThreadId,
+        set: (threadId: string | undefined) => {
+          const previousThreadId = currentThreadId;
+          currentThreadId = threadId;
+          if (Object.is(previousThreadId, threadId)) return;
+
+          const event = { agent, previousThreadId, threadId };
+          for (const currentSubscriber of [
+            ...agent.subscribers,
+          ] as SubscribeToAgentSubscriber[]) {
+            const callback = currentSubscriber.onThreadIdChanged;
+            if (callback) {
+              safeCall("onThreadIdChanged", callback, event);
+            }
+          }
+        },
+      });
+      OBSERVED_AGENTS.add(agent);
+    }
+
     const guardAll = (
       sub: SubscribeToAgentSubscriber,
     ): SubscribeToAgentSubscriber => {
@@ -1199,6 +1255,11 @@ export class CopilotKitCore {
         const fn = sub.onRunErrorEvent;
         guarded.onRunErrorEvent = (params) =>
           safeCall("onRunErrorEvent", fn, params);
+      }
+      if (sub.onThreadIdChanged) {
+        const fn = sub.onThreadIdChanged;
+        guarded.onThreadIdChanged = (params) =>
+          safeCall("onThreadIdChanged", fn, params);
       }
       return guarded;
     };
@@ -1273,6 +1334,8 @@ export class CopilotKitCore {
       lifecycleOnly.onRunFailed = subscriber.onRunFailed;
     if (subscriber.onRunErrorEvent)
       lifecycleOnly.onRunErrorEvent = subscriber.onRunErrorEvent;
+    if (subscriber.onThreadIdChanged)
+      lifecycleOnly.onThreadIdChanged = subscriber.onThreadIdChanged;
 
     const wrappedSubscriber: SubscribeToAgentSubscriber =
       guardAll(lifecycleOnly);


### PR DESCRIPTION
## Summary

Changing an agent's `threadId` updated the property but gave framework consumers no lifecycle notification. Angular stores could therefore keep pending interrupts from the previous thread and present stale actions after a thread switch.

## Root cause

`CopilotKitCore.subscribeToAgentWithOptions` projected message, state, and run lifecycle changes, while thread identity remained an unobserved writable property. The connection path compared thread ids only when `connectAgent` ran, which was too late for immediate consumers and did not cover fresh switches that skip connection.

## Changes

- Extend the guarded core agent subscription lifecycle with an immediate, ordered thread-change callback while preserving direct assignment and same-value no-op behavior. Existing compatible accessors are wrapped without replacing their backing storage; unsupported descriptors fail through the core subscriber error path.
- Route Angular `AgentStore` thread transitions to its existing `InterruptController.setThreadId` clear path.
- Enable the issue-linked stale-interrupt regression and add core callback, connector-route, unsubscribe, failure-isolation, and connection-preservation coverage.
- Add patch changesets for `@copilotkit/core` and `@copilotkit/angular`.

## Out of scope

https://github.com/CopilotKit/CopilotKit/pull/6578 changes Angular effect dependency declaration for https://github.com/CopilotKit/CopilotKit/issues/6561. This change leaves that effect refactor separate and does not alter MCP Apps policy ownership or connection restore semantics.

## Related PRs and Issues

Closes #6574.

Implements the backward-compatible lifecycle direction proposed by @rainerhahnekamp in #6574.

Related: #6578 for the separate Angular `explicitEffect` refactor tracked by #6561.

## Test plan

- [x] `@copilotkit/core` focused subscriber and connect-thread tests, 46 tests passed across 2 files. Covers changed and repeated ids, accessor compatibility, callback isolation, unsubscribe, re-entrant ordering, throttle timing, and restore preservation.
- [x] `@copilotkit/angular` focused store and active-thread connector tests, 29 tests passed across 2 files. Covers direct assignment, same-thread preservation, undefined-thread clearing, and the configuration-driven production route.
- [x] Affected `@copilotkit/core` and `@copilotkit/angular` type checks, builds, oxfmt, and oxlint passed; package suites remained focused to the two required files per target scope.
- [ ] CI green (`static / quality`, `test / unit` on Node 20/22/24, `static / compat`).
