### PR TITLE
fix(showcase): make harness worker recycling durable

### DIFF
--- a/showcase/RAILWAY.md
+++ b/showcase/RAILWAY.md
@@ -280,8 +280,8 @@ Planned max-job recycling is an ordinary, clean worker replacement path: the
 worker drains, deregisters from the roster, shuts down its browser pool, then
 exits `0`. Railway's `ALWAYS` restart policy replaces both clean exits and
 failed exits. Staging reasserts the policy before creating desired state; prod
-reasserts and verifies it while promoting. Ordinary Ruby pin/restore operations
-preserve it. We do not manage a retry-max field or claim infinite restarts for
+reasserts and verifies it while promoting. The direct named `harness-workers`
+pin path preserves it. We do not manage a retry-max field or claim infinite restarts for
 pathological crash loops.
 
 Prod rollout waits for staging evidence. Direct named `harness-workers` rollback

--- a/showcase/RAILWAY.md
+++ b/showcase/RAILWAY.md
@@ -274,6 +274,19 @@ replica count** strictly 1:1. `HARNESS_POOL_COUNT` is an **informational-only**
 control-plane hint — it does NOT fork additional workers. The authoritative
 per-worker concurrency knob is `BROWSER_POOL_MAX_CONTEXTS`.
 
+### Harness-worker recycling
+
+Planned max-job recycling is an ordinary, clean worker replacement path: the
+worker drains, deregisters from the roster, shuts down its browser pool, then
+exits `0`. Railway's `ALWAYS` restart policy replaces both clean exits and
+failed exits. Staging reasserts the policy before creating desired state; prod
+reasserts and verifies it while promoting. Ordinary Ruby pin/restore operations
+preserve it. We do not manage a retry-max field or claim infinite restarts for
+pathological crash loops.
+
+Prod rollout waits for staging evidence. Direct named `harness-workers` rollback
+is disabled, so operators pin the prior image by its `@sha256` digest instead.
+
 ### Effective replica count — `multiRegionConfig`, not top-level `numReplicas`
 
 `harness-workers` is a single-region service (`us-west2`). Railway derives the

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1399,7 +1399,7 @@ module Railway
                     last_restart_policy = active_restart_policy
                     policy_ok = restart_policy_type.nil? ||
                         active_restart_policy == restart_policy_type
-                    if serving == expected_digest && policy_ok
+                    if deploy && deploy["id"] == new_deployment_id && serving == expected_digest && policy_ok
                         return inst
                     end
                     if serving == expected_digest &&

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -2610,8 +2610,25 @@ module Railway
                 return 0
             end
 
-            RestoreCommand.pin_and_redeploy(gql,
-                service_id: service_id, env_id: env_id, image: image)
+            if options[:service] == "harness-workers"
+                ssot_env = env_id == PRODUCTION_ENV_ID ? "prod" : "staging"
+                promote_helper = PromoteCommand.new([])
+                ssot_entry = promote_helper.ssot_service(options[:service]) || {}
+                ssot_healthcheck = ssot_entry.dig("healthcheckPath", ssot_env)
+                ssot_replicas = promote_helper.ssot_replica_config(options[:service], ssot_env)
+                ssot_restart_policy = ssot_entry.dig("workerProvisioning", ssot_env, "restartPolicyType")
+
+                PromoteCommand.pin_and_verify(gql,
+                    service_id: service_id,
+                    env_id: env_id,
+                    image: image,
+                    healthcheck_path: ssot_healthcheck,
+                    replica_config: ssot_replicas,
+                    restart_policy_type: ssot_restart_policy)
+            else
+                RestoreCommand.pin_and_redeploy(gql,
+                    service_id: service_id, env_id: env_id, image: image)
+            end
             puts "pinned #{options[:service]} -> #{image}"
             0
         end

--- a/showcase/bin/railway
+++ b/showcase/bin/railway
@@ -1007,7 +1007,14 @@ module Railway
             parser.parse!(argv)
             Railway.die!("--env required") unless options[:env]
             Railway.die!("--service required") unless options[:service]
-
+            if options[:service] == "harness-workers"
+                Railway.die!(
+                    "Direct rollback is disabled for harness-workers; use " \
+                    "`bin/railway pin --env <env> --service harness-workers " \
+                    "--image <prior-ref@sha256:digest>` to pin the prior image " \
+                    "while preserving the current restart policy.",
+                )
+            end
             env_id = Railway.env_id_for(options[:env])
             Railway.confirm_destructive!(
                 env_label: options[:env],
@@ -1194,6 +1201,23 @@ module Railway
             digest
         end
 
+        def self.restart_policy_type_from_deployment(deployment)
+            return nil unless deployment.is_a?(Hash)
+
+            meta = deployment["meta"]
+            meta = (JSON.parse(meta) rescue nil) if meta.is_a?(String)
+            return nil unless meta.is_a?(Hash)
+
+            service_manifest = meta["serviceManifest"]
+            return nil unless service_manifest.is_a?(Hash)
+
+            deploy = service_manifest["deploy"]
+            return nil unless deploy.is_a?(Hash)
+
+            restart_policy_type = deploy["restartPolicyType"]
+            restart_policy_type if restart_policy_type.is_a?(String)
+        end
+
         # Pin + verify: confirms the boolean mutation result AND re-queries
         # serviceInstance to confirm BOTH source.image advanced to the new
         # digest AND updatedAt strictly advanced past the pre-mutation value.
@@ -1222,7 +1246,9 @@ module Railway
         # replica on redeploy — the confirmed harness-workers -> 1 de-scale
         # incident. When nil/empty, the key is OMITTED (never sent as null), so a
         # service without an override keeps its live config untouched.
-        def self.pin_and_verify(gql, service_id:, env_id:, image:, healthcheck_path: nil, replica_config: nil, sleeper: ->(n) { sleep(n) })
+        def self.pin_and_verify(gql, service_id:, env_id:, image:,
+                healthcheck_path: nil, replica_config: nil,
+                restart_policy_type: nil, sleeper: ->(n) { sleep(n) })
             # Upfront guard: this method's contract is to pin a DIGEST-form
             # image. Pre-fix, a stray tag ref would fall through to retries
             # (since expected_digest stayed nil and image_ok was always false)
@@ -1249,8 +1275,8 @@ module Railway
             # an explicit null, which Railway would treat as "clear this field"),
             # so a service tracking neither keeps its live config untouched.
             mutation, vars = RestoreCommand.build_update_image_mutation(
-                image: image, healthcheck_path: healthcheck_path,
-                replica_config: replica_config)
+                image: image, healthcheck_path: healthcheck_path, replica_config: replica_config)
+            vars[:input][:restartPolicyType] = restart_policy_type if restart_policy_type
             updated = gql.query(mutation,
                 { serviceId: service_id, envId: env_id }.merge(vars))
             unless updated && updated["serviceInstanceUpdate"] == true
@@ -1320,6 +1346,7 @@ module Railway
             verify_serving_digest!(gql,
                 service_id: service_id, env_id: env_id, image: image,
                 expected_digest: expected_digest, new_deployment_id: new_deployment_id,
+                restart_policy_type: restart_policy_type,
                 sleeper: sleeper)
 
             config_inst
@@ -1331,9 +1358,11 @@ module Railway
         # the new deployment never converges within the retry budget.
         def self.verify_serving_digest!(gql, service_id:, env_id:, image:,
                                         expected_digest:, new_deployment_id:,
+                                        restart_policy_type: nil,
                                         sleeper: ->(n) { sleep(n) })
             last_status = nil
             last_serving = nil
+            last_restart_policy = nil
 
             SERVING_RETRY_COUNT.times do |i|
                 data = gql.query(SERVICE_INSTANCE_RECHECK_QUERY,
@@ -1364,9 +1393,22 @@ module Railway
 
                 if status == "SUCCESS"
                     serving = serving_digest_from_deployment(deploy)
+                    active_restart_policy =
+                        restart_policy_type_from_deployment(deploy)
                     last_serving = serving
-                    if serving == expected_digest
+                    last_restart_policy = active_restart_policy
+                    policy_ok = restart_policy_type.nil? ||
+                        active_restart_policy == restart_policy_type
+                    if serving == expected_digest && policy_ok
                         return inst
+                    end
+                    if serving == expected_digest &&
+                            deploy && deploy["id"] == new_deployment_id
+                        raise MutationError,
+                            "P5: new deployment #{new_deployment_id} for #{service_id} succeeded with " \
+                            "digest #{serving.inspect} but active restartPolicyType " \
+                            "#{active_restart_policy.inspect}, expected #{restart_policy_type.inspect}. " \
+                            "Refusing to declare promote successful — prod is not serving with the required policy."
                     end
                     # SUCCESS but serving a different digest: only acceptable if
                     # this is still the OLD deployment (Railway eventual
@@ -1387,7 +1429,8 @@ module Railway
             raise MutationError,
                 "P5: prod did not converge to SERVING the pinned digest #{expected_digest.inspect} for " \
                 "#{service_id} -> #{image} after #{SERVING_RETRY_COUNT} retries " \
-                "(last deploy status=#{last_status.inspect}, last serving digest=#{last_serving.inspect}). " \
+                "(last deploy status=#{last_status.inspect}, last serving digest=#{last_serving.inspect}, " \
+                "last restartPolicyType=#{last_restart_policy.inspect}). " \
                 "Refusing to declare promote successful — prod may be serving a stale image."
         end
 
@@ -2488,12 +2531,15 @@ module Railway
                     # pin_and_verify then OMITS multiRegionConfig rather than
                     # touching it.
                     ssot_replicas = ssot_replica_config(svc["name"], "prod")
+                    ssot_restart_policy = (ssot_service(svc["name"]) || {})
+                        .dig("workerProvisioning", "prod", "restartPolicyType")
                     PromoteCommand.pin_and_verify(gql,
                         service_id: pmatch["service_id"],
                         env_id: PRODUCTION_ENV_ID,
                         image: image,
                         healthcheck_path: ssot_healthcheck,
-                        replica_config: ssot_replicas)
+                        replica_config: ssot_replicas,
+                        restart_policy_type: ssot_restart_policy)
                     puts "promoted #{svc['name']} -> #{image}"
                     already_pinned << svc["name"]
                 # Broadened rescue: a transient GraphQL or network error

--- a/showcase/bin/spec/test_harness_worker_restart_policy.rb
+++ b/showcase/bin/spec/test_harness_worker_restart_policy.rb
@@ -149,6 +149,25 @@ class HarnessWorkerRestartPolicyTest < Minitest::Test
         cmd
     end
 
+    def pin_command_with(argv, gql:)
+        cmd = Railway::PinCommand.new(argv)
+        cmd.instance_variable_set(:@gql, gql)
+        cmd
+    end
+
+    def with_resolved_service_id(expected_env_id:, expected_name:, service_id:)
+        original = Railway::RollbackCommand.instance_method(:resolve_service_id)
+        Railway::RollbackCommand.define_method(:resolve_service_id) do |env_id, name|
+            raise "unexpected env_id #{env_id.inspect}" unless env_id == expected_env_id
+            raise "unexpected service name #{name.inspect}" unless name == expected_name
+
+            service_id
+        end
+        yield
+    ensure
+        Railway::RollbackCommand.define_method(:resolve_service_id, original)
+    end
+
     def worker_rollback_guidance
         "Direct rollback is disabled for harness-workers; use " \
             "`bin/railway pin --env <env> --service harness-workers " \
@@ -259,6 +278,45 @@ class HarnessWorkerRestartPolicyTest < Minitest::Test
         assert_includes err, worker_rollback_guidance
         refute_includes err, "without --yes"
         refute_includes err, "Type 'production'"
+    end
+
+    def test_worker_pin_reasserts_ssot_restart_policy_and_replicas_then_deploys_and_verifies
+        image = "ghcr.io/copilotkit/showcase-harness@sha256:expected"
+        gql = RecordingGQL.new(deployment_meta_by_service: {
+            "svc-worker" => worker_policy_meta,
+        })
+        cmd = pin_command_with(
+            [
+                "--env", "production",
+                "--service", "harness-workers",
+                "--image", image,
+                "--yes",
+                "--non-interactive",
+            ],
+            gql: gql,
+        )
+
+        out, err = capture_io do
+            @rc = with_resolved_service_id(
+                expected_env_id: Railway::PRODUCTION_ENV_ID,
+                expected_name: "harness-workers",
+                service_id: "svc-worker",
+            ) do
+                cmd.run
+            end
+        end
+
+        assert_equal 0, @rc, "pin should succeed with recording fake; out=#{out.inspect} err=#{err.inspect}"
+        assert_includes err, "[non-interactive] proceeding with pin on production (--yes given)."
+        assert_includes out, "pinned harness-workers -> #{image}"
+
+        worker_vars = gql.update_vars_for("svc-worker")
+        assert_equal image, worker_vars.dig(:input, :source, :image)
+        assert_equal "ALWAYS", worker_vars.dig(:input, :restartPolicyType)
+        assert_equal 6, worker_vars.dig(:input, :multiRegionConfig, "us-west2", :numReplicas)
+        assert_equal [:recheck, :update, :deploy, :recheck, :recheck],
+            gql.call_order_for("svc-worker"),
+            "worker pin should deploy and verify the newly spawned deployment"
     end
 
     def test_non_worker_named_rollback_still_reaches_existing_rollback_path

--- a/showcase/bin/spec/test_harness_worker_restart_policy.rb
+++ b/showcase/bin/spec/test_harness_worker_restart_policy.rb
@@ -1,0 +1,284 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+# Production promote must re-assert the worker restart policy from the generated
+# SSOT in the same serviceInstanceUpdate that pins source.image. Non-workers
+# must omit the key entirely so their live restart policy is untouched.
+class HarnessWorkerRestartPolicyTest < Minitest::Test
+    class RecordingGQL
+        attr_reader :calls
+
+        def initialize(deployment_meta_by_service: {})
+            @calls = []
+            @pinned_images = {}
+            @deploy_ids = {}
+            @deployment_meta_by_service = deployment_meta_by_service
+        end
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            service_id = vars[:serviceId]
+
+            if q.include?("serviceInstanceUpdate")
+                @pinned_images[service_id] = vars.dig(:input, :source, :image)
+                { "serviceInstanceUpdate" => true }
+            elsif q.include?("serviceInstanceDeployV2")
+                @deploy_ids[service_id] = "dep-#{service_id}"
+                { "serviceInstanceDeployV2" => @deploy_ids.fetch(service_id) }
+            elsif q.include?("ServiceInstanceRecheck")
+                image = @pinned_images[service_id]
+                if image
+                    digest = image.split("@", 2).last
+                    deployment = {
+                        "id" => @deploy_ids.fetch(service_id),
+                        "status" => "SUCCESS",
+                        "meta" => deployment_meta_for(service_id, digest),
+                    }
+                    {
+                        "serviceInstance" => {
+                            "id" => "inst-#{service_id}",
+                            "source" => { "image" => image },
+                            "updatedAt" => "2026-05-29T00:00:01Z",
+                            "latestDeployment" => deployment,
+                        },
+                    }
+                else
+                    {
+                        "serviceInstance" => {
+                            "id" => "inst-#{service_id}",
+                            "source" => { "image" => "ghcr.io/copilotkit/x@sha256:OLD" },
+                            "updatedAt" => "2026-05-28T00:00:00Z",
+                        },
+                    }
+                end
+            else
+                {}
+            end
+        end
+
+        def update_vars_for(service_id)
+            update = @calls.find do |q, vars|
+                q.include?("serviceInstanceUpdate") && vars[:serviceId] == service_id
+            end
+            update && update[1]
+        end
+
+        def call_order_for(service_id)
+            @calls.filter_map do |q, vars|
+                next unless vars[:serviceId] == service_id
+
+                if q.include?("serviceInstanceUpdate")
+                    :update
+                elsif q.include?("serviceInstanceDeployV2")
+                    :deploy
+                elsif q.include?("ServiceInstanceRecheck")
+                    :recheck
+                end
+            end
+        end
+
+        def deployment_meta_for(service_id, digest)
+            configured = @deployment_meta_by_service[service_id]
+            return configured.call(digest) if configured.respond_to?(:call)
+            return configured unless configured.nil?
+
+            { "imageDigest" => digest }
+        end
+    end
+
+    class RollbackRecordingGQL
+        attr_reader :calls
+
+        def initialize
+            @calls = []
+        end
+
+        def query(q, vars = {})
+            @calls << [q, vars]
+            if q.include?("ProjectServices")
+                {
+                    "project" => {
+                        "services" => {
+                            "edges" => [
+                                { "node" => { "name" => "docs", "id" => "svc-docs" } },
+                            ],
+                        },
+                    },
+                }
+            else
+                raise "unexpected GraphQL query: #{q}"
+            end
+        end
+    end
+
+    def command_with(gql:, promote_refs:)
+        cmd = Railway::PromoteCommand.new(["--non-interactive", "--yes"])
+        cmd.parser.parse!(cmd.argv)
+        cmd.instance_variable_set(:@gql, gql)
+        cmd.instance_variable_set(:@promote_refs, promote_refs)
+        cmd
+    end
+
+    def worker_policy_meta(digest = "sha256:expected")
+        {
+            "imageDigest" => digest,
+            "serviceManifest" => {
+                "deploy" => { "restartPolicyType" => "ALWAYS" },
+            },
+        }
+    end
+
+    def promote_single(service_name:, service_id:, image:, meta:)
+        gql = RecordingGQL.new(deployment_meta_by_service: { service_id => meta })
+        cmd = command_with(gql: gql, promote_refs: { service_name => image })
+
+        out, err = capture_io do
+            @rc = cmd.execute_promotion(
+                { "services" => [{ "name" => service_name }] },
+                { "services" => [{ "name" => service_name, "service_id" => service_id }] },
+            )
+        end
+
+        [@rc, out, err, gql]
+    end
+
+    def rollback_command_with(argv, gql:)
+        cmd = Railway::RollbackCommand.new(argv)
+        cmd.instance_variable_set(:@gql, gql)
+        cmd
+    end
+
+    def worker_rollback_guidance
+        "Direct rollback is disabled for harness-workers; use " \
+            "`bin/railway pin --env <env> --service harness-workers " \
+            "--image <prior-ref@sha256:digest>` to pin the prior image while " \
+            "preserving the current restart policy."
+    end
+
+    def test_worker_promotion_reasserts_ssot_restart_policy_and_non_worker_omits_it
+        worker_image = "ghcr.io/copilotkit/showcase-harness@sha256:expected"
+        normal_image = "ghcr.io/copilotkit/docs@sha256:normal"
+        gql = RecordingGQL.new(deployment_meta_by_service: {
+            "svc-worker" => worker_policy_meta.to_json,
+        })
+        cmd = command_with(gql: gql, promote_refs: {
+            "harness-workers" => worker_image,
+            "docs" => normal_image,
+        })
+
+        out, err = capture_io do
+            @rc = cmd.execute_promotion(
+                {
+                    "services" => [
+                        { "name" => "harness-workers" },
+                        { "name" => "docs" },
+                    ],
+                },
+                {
+                    "services" => [
+                        { "name" => "harness-workers", "service_id" => "svc-worker" },
+                        { "name" => "docs", "service_id" => "svc-docs" },
+                    ],
+                },
+            )
+        end
+
+        assert_equal 0, @rc, "promotion should succeed with recording fake; out=#{out.inspect} err=#{err.inspect}"
+
+        assert_equal [:recheck, :update, :deploy, :recheck, :recheck],
+            gql.call_order_for("svc-worker"),
+            "worker promote should preserve pin_and_verify GraphQL call order"
+        assert_equal [:recheck, :update, :deploy, :recheck, :recheck],
+            gql.call_order_for("svc-docs"),
+            "non-worker promote should preserve pin_and_verify GraphQL call order"
+
+        worker_vars = gql.update_vars_for("svc-worker")
+        assert_equal "ALWAYS", worker_vars.dig(:input, :restartPolicyType)
+        assert_equal({ image: worker_image }, worker_vars.dig(:input, :source))
+
+        normal_vars = gql.update_vars_for("svc-docs")
+        refute normal_vars.fetch(:input).key?(:restartPolicyType)
+        assert_equal({ image: normal_image }, normal_vars.dig(:input, :source))
+    end
+
+    def test_worker_promotion_rejects_wrong_active_restart_policy_even_with_matching_digest
+        image = "ghcr.io/copilotkit/showcase-harness@sha256:expected"
+        rc, out, err, = promote_single(
+            service_name: "harness-workers",
+            service_id: "svc-worker",
+            image: image,
+            meta: {
+                "imageDigest" => "sha256:expected",
+                "serviceManifest" => {
+                    "deploy" => { "restartPolicyType" => "ON_FAILURE" },
+                },
+            },
+        )
+
+        assert_equal 1, rc
+        refute_includes out, "promoted harness-workers"
+        assert_includes err, "dep-svc-worker"
+        assert_includes err, "sha256:expected"
+        assert_includes err, "ON_FAILURE"
+        refute_includes err, "serviceManifest"
+    end
+
+    def test_worker_rollback_without_to_exits_before_env_resolution_or_graphql_with_pin_guidance
+        gql = RollbackRecordingGQL.new
+        cmd = rollback_command_with(
+            ["--env", "definitely-not-an-env", "--service", "harness-workers"],
+            gql: gql,
+        )
+
+        out, err = capture_io do
+            ex = assert_raises(SystemExit) { cmd.run }
+            assert_equal 2, ex.status
+        end
+
+        assert_empty out
+        assert_empty gql.calls
+        assert_includes err, worker_rollback_guidance
+        refute_includes err, "Unknown env"
+    end
+
+    def test_worker_rollback_with_to_exits_before_confirmation_or_graphql_with_pin_guidance
+        gql = RollbackRecordingGQL.new
+        cmd = rollback_command_with(
+            ["--env", "production", "--service", "harness-workers", "--to", "dep-worker"],
+            gql: gql,
+        )
+
+        out, err = capture_io do
+            ex = assert_raises(SystemExit) { cmd.run }
+            assert_equal 2, ex.status
+        end
+
+        assert_empty out
+        assert_empty gql.calls
+        assert_includes err, worker_rollback_guidance
+        refute_includes err, "without --yes"
+        refute_includes err, "Type 'production'"
+    end
+
+    def test_non_worker_named_rollback_still_reaches_existing_rollback_path
+        gql = RollbackRecordingGQL.new
+        cmd = rollback_command_with(
+            ["--env", "staging", "--service", "docs", "--to", "dep-docs", "--dry-run"],
+            gql: gql,
+        )
+
+        out, err = capture_io do
+            @rc = cmd.run
+        end
+
+        assert_equal 0, @rc
+        assert_empty err
+        assert_includes out, "[dry-run] would rollback docs -> deployment dep-docs"
+        assert_equal 1, gql.calls.size
+        query, vars = gql.calls.fetch(0)
+        assert_includes query, "ProjectServices"
+        assert_equal({ projectId: Railway::PROJECT_ID }, vars)
+    end
+
+end

--- a/showcase/bin/spec/test_promote_p5.rb
+++ b/showcase/bin/spec/test_promote_p5.rb
@@ -30,7 +30,15 @@ class PromoteP5Test < Minitest::Test
     # Helper: a serving-digest recheck response. The NEW deployment has reached
     # the given status and serves the given digest. Defaults to the SUCCESS +
     # pinned-digest happy path.
-    def serving(digest:, status: "SUCCESS", deploy_id: NEW_DEPLOY_ID)
+    def serving(digest:, status: "SUCCESS", deploy_id: NEW_DEPLOY_ID,
+                restart_policy_type: nil)
+        meta = { "imageDigest" => digest }
+        if restart_policy_type
+            meta["serviceManifest"] = {
+                "deploy" => { "restartPolicyType" => restart_policy_type },
+            }
+        end
+
         {
             data: {
                 "serviceInstance" => {
@@ -39,7 +47,7 @@ class PromoteP5Test < Minitest::Test
                     "updatedAt" => "2026-05-28T03:00:00Z",
                     "latestDeployment" => {
                         "id" => deploy_id, "status" => status,
-                        "meta" => { "imageDigest" => digest },
+                        "meta" => meta,
                     },
                 },
             },
@@ -141,6 +149,29 @@ class PromoteP5Test < Minitest::Test
         Railway::PromoteCommand.pin_and_verify(gql,
             service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
             sleeper: ->(_n) {})
+    end
+
+    def test_keeps_polling_when_old_success_matches_digest_and_restart_policy_before_new_deployment_is_latest
+        # Bug (false-success): right after DeployV2 spawns new_deployment_id,
+        # latestDeployment may still briefly point to the OLD deployment. Even
+        # if that stale deployment reports SUCCESS, the expected pinned digest,
+        # and the requested restartPolicyType, promote must not return until the
+        # NEW deployment id is latest and satisfies those same checks.
+        gql = FakeGQL.new([
+            pre("2026-05-27T00:00:00Z"),
+            { data: { "serviceInstanceUpdate" => true } },
+            deploy_ok,
+            post(image: "ghcr.io/copilotkit/x@sha256:NEW", ts: "2026-05-28T01:00:00Z"),
+            serving(digest: "sha256:NEW", deploy_id: "dep-old",
+                restart_policy_type: "ON_FAILURE"),
+            serving(digest: "sha256:NEW", deploy_id: NEW_DEPLOY_ID,
+                restart_policy_type: "ON_FAILURE"),
+        ])
+        Railway::PromoteCommand.pin_and_verify(gql,
+            service_id: "s", env_id: "e", image: "ghcr.io/copilotkit/x@sha256:NEW",
+            restart_policy_type: "ON_FAILURE",
+            sleeper: ->(_n) {})
+        assert_equal 6, gql.calls.size
     end
 
     def test_refuses_when_image_advanced_but_updatedAt_did_NOT_advance

--- a/showcase/bin/spec/test_snapshot_ivar_lint.rb
+++ b/showcase/bin/spec/test_snapshot_ivar_lint.rb
@@ -54,33 +54,33 @@ class SnapshotIvarLintTest < Minitest::Test
     #                       prose (do not perform a read)
     ALLOWED_LINES = [
         # `run` — capture full-fleet view before optional narrowing.
-        '1504:@full_staging_snapshot = @staging_snapshot',
-        '1505:@full_prod_snapshot    = @prod_snapshot',
+        '1547:@full_staging_snapshot = @staging_snapshot',
+        '1548:@full_prod_snapshot    = @prod_snapshot',
 
         # Doc comment above narrow_snapshots_to_single_service!.
-        '1513:# Narrow @staging_snapshot and @prod_snapshot to only the named',
+        '1556:# Narrow @staging_snapshot and @prod_snapshot to only the named',
 
         # narrow_snapshots_to_single_service! — the WRITE site.
-        '1521:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1526:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
-        '1527:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
-        '1528:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
+        '1564:staging_match = (@staging_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1569:@staging_snapshot = @staging_snapshot.merge("services" => staging_match)',
+        '1570:prod_match = (@prod_snapshot["services"] || []).select { |s| s["name"] == name }',
+        '1571:@prod_snapshot = @prod_snapshot.merge("services" => prod_match)',
 
         # Doc comment above capture_snapshots.
-        '1532:# @staging_snapshot / @prod_snapshot directly.',
+        '1575:# @staging_snapshot / @prod_snapshot directly.',
 
         # capture_snapshots — single test-seam assignment site.
-        '1534:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
-        '1535:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
+        '1577:@staging_snapshot ||= SnapshotCommand.new(["--env", "staging", "--dry-run"]).build_snapshot(STAGING_ENV_ID)',
+        '1578:@prod_snapshot    ||= SnapshotCommand.new(["--env", "production", "--dry-run"]).build_snapshot(PRODUCTION_ENV_ID)',
 
         # Doc comment above the accessor block (explains test seam).
-        '1559:# promote tests stub @staging_snapshot/@prod_snapshot directly',
+        '1602:# promote tests stub @staging_snapshot/@prod_snapshot directly',
 
         # The four accessor bodies — the ONLY sanctioned reads.
-        '1571:@full_staging_snapshot || @staging_snapshot',
-        '1575:@full_prod_snapshot || @prod_snapshot',
-        '1579:@staging_snapshot',
-        '1583:@prod_snapshot',
+        '1614:@full_staging_snapshot || @staging_snapshot',
+        '1618:@full_prod_snapshot || @prod_snapshot',
+        '1622:@staging_snapshot',
+        '1626:@prod_snapshot',
     ].freeze
 
     def setup

--- a/showcase/harness/src/fleet/orchestrator.test.ts
+++ b/showcase/harness/src/fleet/orchestrator.test.ts
@@ -13,7 +13,6 @@ import type {
 } from "./contracts.js";
 import type { Logger } from "../types/index.js";
 import { drainFleetWorker, makeRecycleExit } from "../orchestrator.js";
-import { WORKER_RECYCLE_EXIT_CODE } from "./worker/worker-loop.js";
 import { BrowserPool } from "../probes/helpers/browser-pool.js";
 import type {
   LaunchBrowser,
@@ -197,7 +196,7 @@ describe("runWorker default (self-contained) boot", () => {
 
 describe("runWorker recycle exit — deregister-first before process.exit", () => {
   it(
-    "forwards the injected recycle exit to the loop so a WORKER_MAX_JOBS recycle runs drainFleetWorker (deregister) BEFORE exiting non-zero",
+    "forwards the injected recycle exit to the loop so a WORKER_MAX_JOBS recycle runs drainFleetWorker (deregister) BEFORE exiting cleanly",
     { timeout: 20000 },
     async () => {
       // The GAP this guards: a WORKER_MAX_JOBS recycle must deregister the roster
@@ -220,11 +219,9 @@ describe("runWorker recycle exit — deregister-first before process.exit", () =
       const shutdownPool = async (): Promise<void> => {
         order.push("shutdownPool");
       };
-      const exitCodes: number[] = [];
-      const processExit = (code: number): void => {
-        order.push("processExit");
-        exitCodes.push(code);
-      };
+      const processExit = vi.fn((code: number): void => {
+        order.push(`processExit:${code}`);
+      });
 
       // Late-bound worker handle (assigned by runWorker below) — mirrors the
       // production wiring: the exit only dereferences it at recycle time.
@@ -245,11 +242,12 @@ describe("runWorker recycle exit — deregister-first before process.exit", () =
           shutdownPool,
         });
       };
-      const exit = makeRecycleExit({
+      const recycleExit = makeRecycleExit({
         gracefulTeardown,
         logger: silentLogger,
         processExit,
       });
+      const forwardedExit = vi.fn<() => void>(() => recycleExit());
 
       // Safety net: if a regression drops the forwarding, the loop's DEFAULT exit
       // is the real `process.exit` — stub it so a broken test can't kill the
@@ -279,7 +277,7 @@ describe("runWorker recycle exit — deregister-first before process.exit", () =
           pollIntervalMs: 1,
           launchBrowser: makeNoopLauncher(),
           cgroupPidsReader: headroomPidsReader,
-          exit,
+          exit: forwardedExit,
         });
         // The threshold was read at construction; unstub NOW so a lazy-threshold-
         // read regression (reading the knob at recycle time instead) sees the
@@ -288,14 +286,16 @@ describe("runWorker recycle exit — deregister-first before process.exit", () =
         vi.unstubAllEnvs();
 
         // One job settles → recycle fires → the forwarded exit runs to completion.
-        await vi.waitFor(
-          () => expect(exitCodes).toContain(WORKER_RECYCLE_EXIT_CODE),
-          { timeout: 5000 },
-        );
+        await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(0), {
+          timeout: 5000,
+        });
+        expect(forwardedExit).toHaveBeenCalledTimes(1);
+        expect(forwardedExit).toHaveBeenCalledWith();
+        expect(processExit).toHaveBeenCalledTimes(1);
 
         // Deregister-first: the roster delete ran BEFORE the process exit.
         const deregisterAt = order.indexOf("deregister");
-        const exitAt = order.indexOf("processExit");
+        const exitAt = order.indexOf("processExit:0");
         expect(deregisterAt).toBeGreaterThanOrEqual(0);
         expect(exitAt).toBeGreaterThanOrEqual(0);
         expect(deregisterAt).toBeLessThan(exitAt);

--- a/showcase/harness/src/fleet/orchestrator.ts
+++ b/showcase/harness/src/fleet/orchestrator.ts
@@ -147,11 +147,11 @@ export interface RunWorkerOptions {
    * verbatim to `startWorkerLoop`. Production (orchestrator.ts `runWorker`)
    * injects a RICHER exit that runs the same deregister-first graceful teardown
    * as SIGTERM (`drainFleetWorker` — roster delete + pool shutdown) BEFORE
-   * exiting non-zero, so a recycled worker never leaves a stale roster row for
+   * exiting cleanly, so a recycled worker never leaves a stale roster row for
    * fleet-health to reclaim (~180s → transient false-red). When omitted the
-   * loop defaults to a bare `process.exit` (which does NOT deregister).
+   * loop defaults to a bare clean `process.exit` (which does NOT deregister).
    */
-  exit?: (code: number) => void;
+  exit?: () => void;
   /**
    * Override the per-service driver (tests inject a fake). Defaults to the real
    * pooled d6 driver wired onto the constructed `BrowserPool`.
@@ -293,8 +293,8 @@ export async function runWorker(
       pollIntervalMs: opts.pollIntervalMs,
       onCurrentJobChange: opts.onCurrentJobChange,
       // Forward the injectable recycle exit. Production injects a richer exit
-      // that deregisters (drainFleetWorker) before exiting non-zero; when
-      // omitted the loop falls back to a bare process.exit.
+      // that deregisters (drainFleetWorker) before exiting cleanly; when
+      // omitted the loop falls back to a bare clean process.exit.
       exit: opts.exit,
     });
   } catch (err) {

--- a/showcase/harness/src/fleet/worker/worker-loop.test.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.test.ts
@@ -3086,7 +3086,7 @@ describe("startWorkerLoop PID headroom gate", () => {
 //
 // After ~WORKER_MAX_JOBS settled jobs (staggered per-replica by a deterministic
 // jitter) the worker stops claiming, runs the existing graceful drain, and exits
-// NON-ZERO so Railway (restartPolicyType ON_FAILURE) replaces the container —
+// cleanly so Railway's ALWAYS restart policy replaces the container —
 // pre-empting slow Chromium/heap growth on long-lived workers. Mirrors Gunicorn
 // --max-requests / Celery max-tasks-per-child.
 
@@ -3110,10 +3110,10 @@ function recordingLogger(): { logger: Logger; messages: string[] } {
 }
 
 describe("startWorkerLoop — worker recycle (WORKER_MAX_JOBS)", () => {
-  it("recycles after WORKER_MAX_JOBS settled jobs: drains and exits non-zero", async () => {
+  it("recycles after WORKER_MAX_JOBS settled jobs: drains and exits cleanly", async () => {
     // Two claimable jobs, threshold 2 (jitter 0 → deterministic). After the 2nd
     // job SETTLES the worker must stop claiming, fire the drain, and call the
-    // (injected) exit with a NON-ZERO code.
+    // zero-argument injected exit exactly once.
     const queue = makeQueue([
       { claimed: true, lease: makeLease({ job: { id: "job-1" } }) },
       { claimed: true, lease: makeLease({ job: { id: "job-2" } }) },
@@ -3123,7 +3123,9 @@ describe("startWorkerLoop — worker recycle (WORKER_MAX_JOBS)", () => {
       cells: [{ featureId: "shared-state", state: "green" }],
       aggregateState: "green",
     });
-    const exit = vi.fn<(code: number) => void>();
+    const exit = vi.fn<() => void>(() => {
+      expect(queue.reports).toHaveLength(2);
+    });
     const { logger, messages } = recordingLogger();
     const handle = startWorkerLoop({
       workerId: "worker-test",
@@ -3144,14 +3146,12 @@ describe("startWorkerLoop — worker recycle (WORKER_MAX_JOBS)", () => {
       exit,
     });
 
-    // The (injected) exit is called with a NON-ZERO code once the 2nd job settles.
+    // The injected exit is called once, with no arguments, after the 2nd job settles.
     await vi.waitFor(() => expect(exit).toHaveBeenCalledTimes(1));
+    expect(exit).toHaveBeenCalledWith();
     // The loop stopped on its own (drain → break), so `done` resolves.
     await handle.done;
 
-    const code = exit.mock.calls[0]![0];
-    expect(code).not.toBe(0);
-    expect(code).toBeGreaterThan(0);
     // Both jobs ran and were reported before the recycle fired.
     expect(queue.reports).toHaveLength(2);
     // The EXISTING drain path was invoked (requestDrain logs drain-requested),
@@ -3184,7 +3184,7 @@ describe("startWorkerLoop — worker recycle (WORKER_MAX_JOBS)", () => {
       cells: [{ featureId: "shared-state", state: "green" }],
       aggregateState: "green",
     });
-    const exit = vi.fn<(code: number) => void>();
+    const exit = vi.fn<() => void>();
     const handle = startWorkerLoop({
       workerId: "worker-test",
       queue,
@@ -3228,7 +3228,7 @@ describe("startWorkerLoop — worker recycle (WORKER_MAX_JOBS)", () => {
         cells: [{ featureId: "shared-state", state: "green" }],
         aggregateState: "green",
       });
-      const exit = vi.fn<(code: number) => void>();
+      const exit = vi.fn<() => void>();
       const handle = startWorkerLoop({
         workerId,
         queue,

--- a/showcase/harness/src/fleet/worker/worker-loop.ts
+++ b/showcase/harness/src/fleet/worker/worker-loop.ts
@@ -211,9 +211,9 @@ export interface WorkerLoopDeps {
   onCurrentJobChange?: (currentJobId: string | null) => void;
   /**
    * Max SETTLED jobs this worker processes before it recycles: stops claiming,
-   * runs the existing graceful drain, and exits non-zero so the platform
-   * restarts a fresh container (pre-empting slow Chromium/heap growth on a
-   * long-lived worker — Gunicorn `--max-requests` / Celery
+   * runs the existing graceful drain, and exits cleanly so Railway's ALWAYS
+   * restart policy starts a fresh container (pre-empting slow Chromium/heap
+   * growth on a long-lived worker — Gunicorn `--max-requests` / Celery
    * `max-tasks-per-child`). Injectable override; when omitted the loop resolves
    * `WORKER_MAX_JOBS` (default `DEFAULT_WORKER_MAX_JOBS`). `0` DISABLES the
    * feature (the worker runs forever, pre-recycle behavior).
@@ -232,11 +232,11 @@ export interface WorkerLoopDeps {
    * Injectable process-exit, ABSTRACTED so the recycle path is unit-testable
    * without killing the test process. Defaults to `process.exit`. The
    * entrypoint MAY inject a richer exit that runs the full graceful teardown
-   * (`drainFleetWorker` — deregister + pool shutdown) BEFORE exiting non-zero;
+   * (`drainFleetWorker` — deregister + pool shutdown) BEFORE exiting cleanly;
    * the bare default only fires the loop-local `requestDrain()` (which, at the
    * settle point, has no in-flight run to drain) then exits.
    */
-  exit?: (code: number) => void;
+  exit?: () => void;
 }
 
 /** Handle returned by `startWorkerLoop` — `stop()` requests a bounded drain. */
@@ -452,7 +452,7 @@ export function safeLog(
 
 /**
  * Default recycle threshold: after this many SETTLED jobs a worker drains and
- * exits non-zero for a fresh restart. 100 mirrors a conservative Gunicorn
+ * exits cleanly for a fresh restart. 100 mirrors a conservative Gunicorn
  * `--max-requests`; the exact value trades restart churn against how much
  * Chromium/heap growth accumulates on a long-lived worker. Env-overridable via
  * `WORKER_MAX_JOBS`; `0` disables the feature.
@@ -466,16 +466,6 @@ export const DEFAULT_WORKER_MAX_JOBS = 100;
  * `WORKER_MAX_JOBS_JITTER`.
  */
 export const DEFAULT_WORKER_MAX_JOBS_JITTER = 15;
-/**
- * Exit code the worker uses when RECYCLING (max-jobs reached). NON-ZERO is
- * REQUIRED: Railway's `restartPolicyType: ON_FAILURE` only replaces the
- * container on a non-zero exit — a zero exit reads as an intentional stop and
- * may NOT restart, which would silently drain the fleet. 42 is an arbitrary
- * distinctive non-zero sentinel (distinct from the boot-failure `1`) so a
- * recycle is greppable in platform logs.
- */
-export const WORKER_RECYCLE_EXIT_CODE = 42;
-
 /**
  * Resolve a NON-NEGATIVE integer env knob (the recycle max-jobs / jitter share
  * this shape: `0` is a MEANINGFUL value — disabled / no-stagger — so unlike the
@@ -1287,11 +1277,7 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
           ),
       )
     : 0;
-  const exit =
-    deps.exit ??
-    ((code: number): void => {
-      process.exit(code);
-    });
+  const exit = deps.exit ?? ((): void => process.exit(0));
   // Count of SETTLED jobs (claimed → ran → reported). Never incremented on
   // empty poll cycles or abandoned (grace-expiry) runs. Closure-scoped so each
   // loop instance counts independently (one worker per process in production;
@@ -1684,7 +1670,7 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
       // runs never reach here. Once the per-process threshold is crossed, stop
       // claiming (the EXISTING loop-local drain, `requestDrain()` — no in-flight
       // run remains at the settle point, so nothing to wait on), break the loop,
-      // and exit NON-ZERO below so the platform restart policy replaces the
+      // and exit cleanly below so Railway's ALWAYS restart policy replaces the
       // container — pre-empting slow Chromium/heap growth on a long-lived worker
       // (Gunicorn `--max-requests` / Celery `max-tasks-per-child`).
       completedJobs++;
@@ -1695,7 +1681,6 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
           recycleThreshold,
           maxJobs,
           maxJobsJitter,
-          exitCode: WORKER_RECYCLE_EXIT_CODE,
         });
         recycleTriggered = true;
         requestDrain();
@@ -1704,13 +1689,12 @@ export function startWorkerLoop(deps: WorkerLoopDeps): WorkerLoopHandle {
     }
     safeLog(logger, "info", "fleet.worker.loop-stopped", { workerId });
     if (recycleTriggered) {
-      // Exit NON-ZERO so the platform (Railway `restartPolicyType: ON_FAILURE`)
-      // replaces this container with a fresh one. A zero exit would read as an
-      // intentional stop and might NOT restart — silently shrinking the fleet.
-      // `exit` is injectable (default `process.exit`) so the recycle path is
-      // testable without killing the test process; a richer injected exit MAY
-      // run the full graceful teardown (deregister + pool shutdown) first.
-      exit(WORKER_RECYCLE_EXIT_CODE);
+      // Exit cleanly so Railway's ALWAYS restart policy replaces this
+      // container with a fresh one. `exit` is injectable (default
+      // `process.exit(0)`) so the recycle path is testable without killing the
+      // test process; a richer injected exit MAY run the full graceful teardown
+      // (deregister + pool shutdown) first.
+      exit();
     }
   })();
 

--- a/showcase/harness/src/orchestrator.test.ts
+++ b/showcase/harness/src/orchestrator.test.ts
@@ -3607,10 +3607,9 @@ describe("drainFleetWorker — deregister-FIRST drain ordering", () => {
 /**
  * `makeRecycleExit` — the WORKER_MAX_JOBS recycle `exit` dep injected into the
  * worker loop. It must run the deregister-first graceful teardown
- * (`gracefulTeardown` → `drainFleetWorker`) BEFORE exiting, and it must ALWAYS
- * exit (with the non-zero recycle code) even if the teardown rejects — otherwise
- * a failed drain would strand a recycled worker that never surrenders to the
- * platform restart policy.
+ * (`gracefulTeardown` → `drainFleetWorker`) BEFORE exiting with success, and it
+ * must ALWAYS exit 1 if teardown rejects — otherwise a failed drain would strand
+ * a recycled worker that never surrenders to the platform restart policy.
  */
 describe("makeRecycleExit — deregister BEFORE process.exit", () => {
   const silentLogger: Logger = {
@@ -3620,7 +3619,7 @@ describe("makeRecycleExit — deregister BEFORE process.exit", () => {
     debug: () => {},
   };
 
-  it("runs gracefulTeardown (deregister) BEFORE process-exit and forwards the recycle code", async () => {
+  it("runs gracefulTeardown (deregister) BEFORE process-exit and exits 0 when teardown fulfills", async () => {
     const order: string[] = [];
     const gracefulTeardown = vi.fn(async (): Promise<void> => {
       order.push("teardown");
@@ -3634,15 +3633,15 @@ describe("makeRecycleExit — deregister BEFORE process.exit", () => {
       processExit,
     });
 
-    exit(42);
+    exit();
 
-    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(42));
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(0));
     // Teardown ran FIRST, then the exit — the ordering the roster-row fix needs.
-    expect(order).toEqual(["teardown", "exit:42"]);
+    expect(order).toEqual(["teardown", "exit:0"]);
     expect(gracefulTeardown).toHaveBeenCalledTimes(1);
   });
 
-  it("STILL exits with the non-zero code even if gracefulTeardown REJECTS (finally-guaranteed restart)", async () => {
+  it("exits 1 when gracefulTeardown REJECTS (finally-guaranteed restart)", async () => {
     const processExit = vi.fn<(code: number) => void>();
     const gracefulTeardown = vi.fn(async (): Promise<void> => {
       throw new Error("deregister blew up");
@@ -3653,10 +3652,34 @@ describe("makeRecycleExit — deregister BEFORE process.exit", () => {
       processExit,
     });
 
-    exit(42);
+    exit();
 
     // The rejected teardown does not swallow the exit — Railway still restarts.
-    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(42));
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(1));
+  });
+
+  it("still exits 1 if the logger throws while reporting a rejected teardown", async () => {
+    const processExit = vi.fn<(code: number) => void>();
+    const gracefulTeardown = vi.fn(async (): Promise<void> => {
+      throw new Error("deregister blew up");
+    });
+    const throwingLogger: Logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {
+        throw new Error("logger blew up");
+      },
+      debug: () => {},
+    };
+    const exit = makeRecycleExit({
+      gracefulTeardown,
+      logger: throwingLogger,
+      processExit,
+    });
+
+    exit();
+
+    await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(1));
   });
 });
 
@@ -3701,9 +3724,9 @@ describe("teardown once-latch (recycle + SIGTERM do not double-teardown)", () =>
       processExit,
     });
 
-    // Fire the recycle exit (path 1) and the handle's stop() (path 2 — SIGTERM)
-    // concurrently, then await both settling.
-    exit(0); // makeRecycleExit calls gracefulTeardown() then processExit
+    // Fire the zero-arg recycle exit (path 1) and the handle's stop() (path 2
+    // — SIGTERM) concurrently, then await both settling.
+    exit(); // makeRecycleExit calls gracefulTeardown() then processExit(0)
     await gracefulTeardown(); // the handle's stop() awaits the same teardown
     await vi.waitFor(() => expect(processExit).toHaveBeenCalledTimes(1));
 
@@ -3728,7 +3751,7 @@ describe("teardown once-latch (recycle + SIGTERM do not double-teardown)", () =>
       processExit,
     });
 
-    exit(0);
+    exit();
     await rawTeardown();
     await vi.waitFor(() => expect(processExit).toHaveBeenCalledTimes(1));
 

--- a/showcase/harness/src/orchestrator.ts
+++ b/showcase/harness/src/orchestrator.ts
@@ -4029,29 +4029,38 @@ export function latchOnce<T>(fn: () => Promise<T>): () => Promise<T> {
  * deregister-first graceful teardown as SIGTERM (`gracefulTeardown`, which wraps
  * `drainFleetWorker` — roster delete + pool shutdown) BEFORE exiting.
  *
- * The `finally` GUARANTEES the (non-zero) exit even if the teardown rejects, so a
- * failed drain still surrenders the container to Railway's restart policy — the
- * recycle's whole purpose. Teardown is best-effort; the exit is load-bearing.
- * `processExit` is injectable so the recycle path is unit-testable without
- * killing the test process (defaults to `process.exit`).
+ * A fulfilled teardown exits 0. A rejected teardown exits 1, even if the
+ * best-effort error log itself throws, so a failed drain still surrenders the
+ * container to Railway's restart policy — the recycle's whole purpose. Teardown
+ * is best-effort; the exit is load-bearing. `processExit` is injectable so the
+ * recycle path is unit-testable without killing the test process (defaults to
+ * `process.exit`).
  */
 export function makeRecycleExit(deps: {
   gracefulTeardown: () => Promise<void>;
   logger: Logger;
   processExit?: (code: number) => void;
-}): (code: number) => void {
+}): () => void {
   const doExit = deps.processExit ?? ((code: number) => process.exit(code));
-  return (code: number): void => {
-    void deps
-      .gracefulTeardown()
-      .catch((err) =>
-        logErrorWithStack(
-          deps.logger,
-          "showcase-harness.fleet.worker.recycle-drain-failed",
-          err,
-        ),
-      )
-      .finally(() => doExit(code));
+  return (): void => {
+    void (async () => {
+      try {
+        await deps.gracefulTeardown();
+        doExit(0);
+      } catch (err) {
+        try {
+          logErrorWithStack(
+            deps.logger,
+            "showcase-harness.fleet.worker.recycle-drain-failed",
+            err,
+          );
+        } catch {
+          // Best-effort logging must never block the load-bearing exit.
+        } finally {
+          doExit(1);
+        }
+      }
+    })();
   };
 }
 

--- a/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
+++ b/showcase/scripts/__tests__/harness-workers-provisioning.test.ts
@@ -111,6 +111,13 @@ describe("harness-workers provisioning SSOT", () => {
     expect(stagingProv?.drainingSeconds).toBe(180);
   });
 
+  it('restartPolicyType = "ALWAYS" for both envs', () => {
+    const prodProv = workerProvisioningFor("harness-workers", "prod");
+    const stagingProv = workerProvisioningFor("harness-workers", "staging");
+    expect(prodProv?.restartPolicyType).toBe("ALWAYS");
+    expect(stagingProv?.restartPolicyType).toBe("ALWAYS");
+  });
+
   it("HARNESS_POOL_COUNT is recorded as informational only — NOT used as a fork factor", () => {
     // The worker boots 1 process per replica (keyed on HOSTNAME). HARNESS_POOL_COUNT
     // is forwarded to each worker as a control-plane hint but NEVER forks additional
@@ -129,7 +136,10 @@ describe("harness-workers provisioning SSOT", () => {
   it("workerProvisioningFor returns undefined for non-worker services", () => {
     // Only harness-workers carries this field; every other service returns undefined.
     expect(workerProvisioningFor("harness", "prod")).toBeUndefined();
+    expect(workerProvisioningFor("harness", "staging")).toBeUndefined();
     expect(workerProvisioningFor("aimock", "prod")).toBeUndefined();
+    expect(workerProvisioningFor("aimock", "staging")).toBeUndefined();
+    expect(workerProvisioningFor("pocketbase", "prod")).toBeUndefined();
     expect(workerProvisioningFor("pocketbase", "staging")).toBeUndefined();
   });
 });
@@ -281,6 +291,28 @@ describe("harness-workers provisioning drift gate (SSOT vs generated JSON snapsh
       snapshotEntry?.workerProvisioning?.staging?.drainingSeconds,
     );
   });
+
+  it("SSOT restartPolicyType matches committed generated JSON snapshot and omits retry max", () => {
+    const snapshot = loadGeneratedSnapshot();
+    const snapshotEntry = snapshot.services.find(
+      (s) => s.name === "harness-workers",
+    );
+
+    const ssotProd = workerProvisioningFor("harness-workers", "prod");
+    const ssotStaging = workerProvisioningFor("harness-workers", "staging");
+
+    expect(ssotProd?.restartPolicyType).toBe("ALWAYS");
+    expect(ssotStaging?.restartPolicyType).toBe("ALWAYS");
+    expect(snapshotEntry?.workerProvisioning?.prod.restartPolicyType).toBe(
+      "ALWAYS",
+    );
+    expect(snapshotEntry?.workerProvisioning?.staging.restartPolicyType).toBe(
+      "ALWAYS",
+    );
+    expect(JSON.stringify(snapshotEntry?.workerProvisioning)).not.toContain(
+      "restartPolicyMaxRetries",
+    );
+  });
 });
 
 describe("harness-workers provisioning with injected test data", () => {
@@ -299,11 +331,13 @@ describe("harness-workers provisioning with injected test data", () => {
         effectiveReplicas: 5,
         numReplicas: 5,
         BROWSER_POOL_MAX_CONTEXTS: 20,
+        restartPolicyType: "ALWAYS",
       },
       staging: {
         effectiveReplicas: 10,
         numReplicas: 10,
         BROWSER_POOL_MAX_CONTEXTS: 20,
+        restartPolicyType: "ALWAYS",
       },
     };
     (

--- a/showcase/scripts/railway-envs.generated.json
+++ b/showcase/scripts/railway-envs.generated.json
@@ -186,7 +186,8 @@
           "BROWSER_POOL_MAX_CONTEXTS": 40,
           "HARNESS_POOL_COUNT": 3,
           "overlapSeconds": 45,
-          "drainingSeconds": 180
+          "drainingSeconds": 180,
+          "restartPolicyType": "ALWAYS"
         },
         "staging": {
           "effectiveReplicas": 6,
@@ -194,7 +195,8 @@
           "BROWSER_POOL_MAX_CONTEXTS": 40,
           "HARNESS_POOL_COUNT": 2,
           "overlapSeconds": 45,
-          "drainingSeconds": 180
+          "drainingSeconds": 180,
+          "restartPolicyType": "ALWAYS"
         }
       },
       "autoUpdates": {

--- a/showcase/scripts/railway-envs.ts
+++ b/showcase/scripts/railway-envs.ts
@@ -240,6 +240,14 @@ export interface WorkerProvisioning {
    * layer-(b) grace is retuned, raise this in lockstep.
    */
   drainingSeconds?: number;
+  /**
+   * Railway deployment restart policy for routine worker recycling. The
+   * harness-workers fleet exits cleanly after planned max-job teardown and
+   * relies on Railway, not an internal supervisor, to start the replacement.
+   * This SSOT intentionally records ONLY the policy type; do not add
+   * restartPolicyMaxRetries for the worker.
+   */
+  restartPolicyType: "ALWAYS";
 }
 
 /**
@@ -821,6 +829,7 @@ export const SERVICES: Record<
         // showcase/RAILWAY.md "Deploy rollover".
         overlapSeconds: 45,
         drainingSeconds: 180,
+        restartPolicyType: "ALWAYS",
       },
       staging: {
         // EFFECTIVE = multiRegionConfig.us-west2.numReplicas (Railway honors this).
@@ -838,6 +847,7 @@ export const SERVICES: Record<
         // showcase/RAILWAY.md "Deploy rollover".
         overlapSeconds: 45,
         drainingSeconds: 180,
+        restartPolicyType: "ALWAYS",
       },
     },
   },

--- a/showcase/scripts/redeploy-env.test.ts
+++ b/showcase/scripts/redeploy-env.test.ts
@@ -11,6 +11,7 @@ import {
   ENV_ID_BY_NAME,
   PRODUCTION_ENV_ID,
   SERVICES,
+  STAGING_ENV_ID,
 } from "./railway-envs";
 
 describe("runRedeploy", () => {
@@ -225,6 +226,57 @@ describe("runRedeploy", () => {
     for (const c of calls) {
       expect(c.environmentId).toBe("8edfef02-ea09-4a20-8689-261f21cc2849");
     }
+  });
+
+  it("makes a staging worker failure release-blocking without stopping independent services", async () => {
+    const redeploy = vi.fn(async (serviceId: string) =>
+      serviceId === SERVICES["harness-workers"].serviceId
+        ? { ok: false as const, error: "worker policy update failed" }
+        : { ok: true as const },
+    );
+
+    const result = await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+      services: ["harness-workers", "showcase-mastra"],
+    });
+
+    expect(redeploy).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(1);
+    expect(result.records).toEqual([
+      {
+        service: "harness-workers",
+        status: "error",
+        error: "worker policy update failed",
+      },
+      { service: "showcase-mastra", status: "ok" },
+    ]);
+  });
+
+  it("makes a thrown staging worker failure release-blocking without stopping independent services", async () => {
+    const redeploy = vi.fn(async (serviceId: string) => {
+      if (serviceId === SERVICES["harness-workers"].serviceId) {
+        throw new Error("worker request failed");
+      }
+      return { ok: true as const };
+    });
+
+    const result = await runRedeploy({
+      env: "staging",
+      redeploy,
+      appendSummary,
+      services: ["harness-workers", "showcase-mastra"],
+    });
+
+    expect(redeploy).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(1);
+    expect(
+      result.records.map(({ service, status }) => ({ service, status })),
+    ).toEqual([
+      { service: "harness-workers", status: "error" },
+      { service: "showcase-mastra", status: "ok" },
+    ]);
   });
 
   it("targets the prod env id when env=prod", async () => {
@@ -636,6 +688,75 @@ describe("makeLiveRedeploy", () => {
     const outcome = await redeploy("svc-id", "env-id");
     expect(outcome).toEqual({ ok: true });
     expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("updates the staging worker policy and replica count before deploying desired state", async () => {
+    const fetchMock = stubFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+      };
+      if (body.query.includes("serviceInstanceUpdate")) {
+        return {
+          ok: true,
+          json: async () => ({ data: { serviceInstanceUpdate: true } }),
+        };
+      }
+      if (body.query.includes("serviceInstanceDeployV2")) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: { serviceInstanceDeployV2: "deployment-id" },
+          }),
+        };
+      }
+      throw new Error("unexpected Railway mutation");
+    });
+
+    const outcome = await makeLiveRedeploy("test-token")(
+      SERVICES["harness-workers"].serviceId,
+      STAGING_ENV_ID,
+    );
+
+    expect(outcome).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const requests = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(String(init?.body)),
+    );
+    expect(requests[0]).toMatchObject({
+      variables: {
+        serviceId: SERVICES["harness-workers"].serviceId,
+        environmentId: STAGING_ENV_ID,
+        input: {
+          source: {
+            image: "ghcr.io/copilotkit/showcase-harness:latest",
+          },
+          restartPolicyType: "ALWAYS",
+          multiRegionConfig: {
+            "us-west2": { numReplicas: 6 },
+          },
+        },
+      },
+    });
+    expect(requests[0].query).toContain("serviceInstanceUpdate");
+    expect(requests[1].query).toContain("serviceInstanceDeployV2");
+  });
+
+  it("does not deploy the staging worker when its policy update fails", async () => {
+    const fetchMock = stubFetch(async () => ({
+      ok: true,
+      json: async () => ({ data: { serviceInstanceUpdate: false } }),
+    }));
+
+    const outcome = await makeLiveRedeploy("test-token")(
+      SERVICES["harness-workers"].serviceId,
+      STAGING_ENV_ID,
+    );
+
+    expect(outcome).toEqual({
+      ok: false,
+      error: "serviceInstanceUpdate returned false",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("sanitizes GraphQL errors[].message through sanitizeErrorBody", async () => {

--- a/showcase/scripts/redeploy-env.ts
+++ b/showcase/scripts/redeploy-env.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env npx tsx
 /**
- * redeploy-env.ts — Trigger Railway `serviceInstanceRedeploy` for the
- * CI-built showcase services in the named environment.
+ * redeploy-env.ts — Trigger Railway deployments for the CI-built showcase
+ * services in the named environment.
  *
  * Usage:
  *   npx tsx showcase/scripts/redeploy-env.ts <env> [--services <csv>]
@@ -40,19 +40,16 @@
  *     print FAIL lines to stdout and land in the markdown summary written
  *     to $GITHUB_STEP_SUMMARY (mirrored to stderr). Exit-code policy is
  *     FAIL-LOUD BY DEFAULT: any per-service failure yields a non-zero
- *     exitCode for EVERY env except staging. Staging is the single
- *     documented carve-out (failures stay non-fatal) because staging is
- *     not a release gate — the verify-deploy workflow is what fails on
- *     bad images. A future env (preview, canary, …) inherits the fatal
- *     default; do NOT add it to a carve-out list unless it also gets its
- *     own downstream gate.
+ *     exitCode for EVERY env except ordinary staging services. A staging
+ *     harness-workers failure is release-blocking because that path must
+ *     apply `ALWAYS` before deploying clean-recycling workers. Other
+ *     staging failures remain non-fatal because verify-deploy is their gate.
  *   - Operator/config errors (bad env name, unknown service, missing or
  *     malformed token) ALWAYS fail loud with a non-zero exit.
  *
  * Auth: RAILWAY_TOKEN env var or ~/.railway/config.json.
- * Exit code: 0 on staging even when per-service redeploys fail; non-zero
- * for per-service failures in any other env and for any operator/config
- * error.
+ * Exit code: non-zero for staging harness-workers failures, per-service
+ * failures in any other env, and operator/config errors.
  */
 
 import fs from "fs";
@@ -62,8 +59,11 @@ import {
   ENV_IDS,
   ENV_ID_BY_NAME,
   SERVICES,
+  STAGING_ENV_ID,
+  repoNameFor,
   resolveEnv,
   serviceForDispatchName,
+  workerProvisioningFor,
 } from "./railway-envs";
 import type { EnvName } from "./railway-envs";
 import {
@@ -107,6 +107,42 @@ export type RedeployFn = (
   environmentId: string,
 ) => Promise<RedeployOutcome>;
 
+type RailwayMutationResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: string };
+
+async function railwayMutation(
+  token: string,
+  query: string,
+  variables: Record<string, unknown>,
+  resultField: string,
+): Promise<RailwayMutationResult> {
+  const res = await fetch(RAILWAY_API, {
+    method: "POST",
+    signal: AbortSignal.timeout(30_000),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) {
+    const body = sanitizeErrorBody(await res.text());
+    return { ok: false, error: `HTTP ${res.status}: ${body}` };
+  }
+  const json = (await res.json()) as {
+    data?: Record<string, unknown>;
+    errors?: Array<{ message: string }>;
+  };
+  if (json.errors?.length) {
+    return {
+      ok: false,
+      error: json.errors.map((e) => sanitizeErrorBody(e.message)).join("; "),
+    };
+  }
+  return { ok: true, value: json.data?.[resultField] };
+}
+
 /**
  * Build a `liveRedeploy` RedeployFn bound to a single resolved token, so
  * token resolution happens once per process rather than once per service.
@@ -117,44 +153,84 @@ export function makeLiveRedeploy(token: string): RedeployFn {
     serviceId: string,
     environmentId: string,
   ): Promise<RedeployOutcome> {
-    const res = await fetch(RAILWAY_API, {
-      method: "POST",
-      // A hung Railway API must surface as a per-service FAIL (the timeout
-      // rejection is caught by runRedeploy's per-service try/catch), not
-      // stall the CI job until the runner's global timeout.
-      signal: AbortSignal.timeout(30_000),
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        query: `mutation serviceInstanceRedeploy($serviceId: String!, $environmentId: String!) {
+    const isStagingWorker =
+      serviceId === SERVICES["harness-workers"].serviceId &&
+      environmentId === STAGING_ENV_ID;
+    if (isStagingWorker) {
+      const provisioning = workerProvisioningFor("harness-workers", "staging");
+      if (provisioning === undefined) {
+        return {
+          ok: false,
+          error: "harness-workers staging provisioning is missing from SSOT",
+        };
+      }
+
+      // A clean recycle needs the replacement policy in the deployment
+      // Railway creates from desired state.
+      const update = await railwayMutation(
+        token,
+        `mutation serviceInstanceUpdate($serviceId: String!, $environmentId: String!, $input: ServiceInstanceUpdateInput!) {
+        serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: $input)
+      }`,
+        {
+          serviceId,
+          environmentId,
+          input: {
+            source: {
+              image: `ghcr.io/copilotkit/${repoNameFor(
+                "harness-workers",
+                "staging",
+              )}:latest`,
+            },
+            restartPolicyType: provisioning.restartPolicyType,
+            multiRegionConfig: {
+              "us-west2": {
+                numReplicas: provisioning.effectiveReplicas,
+              },
+            },
+          },
+        },
+        "serviceInstanceUpdate",
+      );
+      if (!update.ok) return update;
+      if (update.value !== true) {
+        return {
+          ok: false,
+          error: `serviceInstanceUpdate returned ${JSON.stringify(update.value)}`,
+        };
+      }
+
+      const deploy = await railwayMutation(
+        token,
+        `mutation serviceInstanceDeployV2($serviceId: String!, $environmentId: String!) {
+        serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId)
+      }`,
+        { serviceId, environmentId },
+        "serviceInstanceDeployV2",
+      );
+      if (!deploy.ok) return deploy;
+      if (typeof deploy.value !== "string" || deploy.value.trim() === "") {
+        return {
+          ok: false,
+          error: `serviceInstanceDeployV2 returned ${JSON.stringify(deploy.value)}`,
+        };
+      }
+      return { ok: true };
+    }
+
+    const redeploy = await railwayMutation(
+      token,
+      `mutation serviceInstanceRedeploy($serviceId: String!, $environmentId: String!) {
         serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId)
       }`,
-        variables: { serviceId, environmentId },
-      }),
-    });
-    if (!res.ok) {
-      const body = sanitizeErrorBody(await res.text());
-      return { ok: false, error: `HTTP ${res.status}: ${body}` };
-    }
-    const json = (await res.json()) as {
-      data?: { serviceInstanceRedeploy?: boolean };
-      errors?: Array<{ message: string }>;
-    };
-    if (json.errors?.length) {
-      // Sanitize each GraphQL error message exactly like the HTTP-error
-      // path above — Railway/Cloudflare error strings can be multi-KB and
-      // markdown-breaking too.
+      { serviceId, environmentId },
+      "serviceInstanceRedeploy",
+    );
+    if (!redeploy.ok) return redeploy;
+    if (redeploy.value !== true) {
       return {
         ok: false,
-        error: json.errors.map((e) => sanitizeErrorBody(e.message)).join("; "),
-      };
-    }
-    if (json.data?.serviceInstanceRedeploy !== true) {
-      return {
-        ok: false,
-        error: `serviceInstanceRedeploy returned ${JSON.stringify(json.data?.serviceInstanceRedeploy)}`,
+        error: `serviceInstanceRedeploy returned ${JSON.stringify(redeploy.value)}`,
       };
     }
     return { ok: true };
@@ -181,7 +257,7 @@ export interface RunRedeployOpts {
 
 /**
  * A single per-service redeploy outcome. `status:"ok"` means Railway accepted
- * the `serviceInstanceRedeploy` for that service; `status:"error"` carries the
+ * the deployment request for that service; `status:"error"` carries the
  * sanitized failure. Callers that must confirm a SPECIFIC service was actually
  * redeployed (e.g. reconcile-staging's per-service remediation check) match on
  * these records rather than the post-expansion `attempted` COUNT — imageOf
@@ -433,10 +509,10 @@ export async function runRedeploy(
   // by showcase_deploy.yml's `enforce-redeploy-gate` (A.7) via the
   // REDEPLOY_SUMMARY_JSON artifact. Shape:
   //   Array<{ service: string; status: "ok" | "error"; error?: string }>
-  // Built in parallel with the existing `failures`/`succeeded` tallies so
-  // PR #5093's exit-code computation below is untouched.
+  // Built in parallel with the existing `failures`/`succeeded` tallies.
   const records: RedeployServiceRecord[] = [];
   let succeeded = 0;
+  let hasReleaseBlockingFailure = false;
 
   appendSummary(`## Railway redeploy — env=${env}`);
   appendSummary("");
@@ -455,6 +531,8 @@ export async function runRedeploy(
         `Unknown service "${name}" — not an SSOT key in railway-envs.ts. Add it to SERVICES or fix the caller.`,
       );
     }
+    const isReleaseBlockingWorker =
+      env === "staging" && name === "harness-workers";
     process.stdout.write(`  ${name.padEnd(36)} `);
     try {
       const outcome = await redeploy(entry.serviceId, envId);
@@ -463,11 +541,13 @@ export async function runRedeploy(
         records.push({ service: name, status: "ok" });
         process.stdout.write("OK\n");
       } else {
+        if (isReleaseBlockingWorker) hasReleaseBlockingFailure = true;
         failures.push({ service: name, error: outcome.error });
         records.push({ service: name, status: "error", error: outcome.error });
         process.stdout.write(`FAIL: ${outcome.error}\n`);
       }
     } catch (e: unknown) {
+      if (isReleaseBlockingWorker) hasReleaseBlockingFailure = true;
       // Sanitize like the non-throw FAIL path: makeLiveRedeploy pre-sanitizes
       // the errors it RETURNS, but a rejection thrown by the redeploy fn
       // (e.g. an AbortSignal timeout, or a fetch error wrapping a multi-KB
@@ -502,7 +582,11 @@ export async function runRedeploy(
       appendSummary(`| \`${f.service}\` | FAIL | ${safeErr} |`);
     }
     appendSummary("");
-    if (env === "staging") {
+    if (env === "staging" && hasReleaseBlockingFailure) {
+      appendSummary(
+        "The harness-workers failure is release-blocking; independent staging services were still attempted.",
+      );
+    } else if (env === "staging") {
       appendSummary(
         "Staging redeploys are non-fatal — the verify-deploy workflow is the gate.",
       );
@@ -542,13 +626,10 @@ export async function runRedeploy(
     }
   }
 
-  // Fail-loud DEFAULT: per-service failures yield a non-zero exit in
-  // every env. Staging is the single documented carve-out (non-fatal —
-  // the verify-deploy workflow is its real release gate). Inverted from
-  // the historic `env === "prod"` allowlist so a future env (preview,
-  // canary, …) inherits fatal semantics instead of silently swallowing
-  // failures the way only staging is meant to.
-  const exitCode = env !== "staging" && failed > 0 ? 1 : 0;
+  // Fail-loud by default. Ordinary staging services keep their historical
+  // non-fatal behavior; the clean-recycling worker is release-blocking.
+  const exitCode =
+    failed > 0 && (env !== "staging" || hasReleaseBlockingFailure) ? 1 : 0;
   return { exitCode, attempted, succeeded, failed, records };
 }
 


### PR DESCRIPTION
## Summary

- make planned max-job harness-worker recycling exit cleanly after ordered teardown, while escaped teardown failures still exit non-zero
- declare Railway `ALWAYS` as the staging and production `harness-workers` restart policy in the existing service source of truth
- apply and verify the worker policy in the existing staging redeploy and production promotion paths
- preserve the policy for direct named `harness-workers` pins and block direct worker rollback with safer pin guidance

## Operational contract

- Railway remains the only worker supervisor; this does not add an in-process restart manager
- staging worker update/readback failures are release-blocking for that target, while independent staging services continue
- production promotion verifies the exact newly-created deployment ID, serving digest, and active restart policy before reporting success
- no retry-max field is managed, and this does not claim unlimited restarts for pathological crash loops
- generic restore, generic non-worker pin, and generic production redeploy behavior are intentionally unchanged

## Review fixes

- require production promotion readback to match the deployment ID just created
- preserve SSOT restart policy and replica settings on direct named worker pin
- narrow the runbook language to the direct named worker pin path actually covered by the implementation

## Verification

- `@copilotkit/showcase-scripts`: 78 test files / 2,539 tests passed
- `@copilotkit/showcase-harness`: 177 test files passed / 2 skipped; 3,723 tests passed / 18 skipped
- Ruby 3.3 Railway suite: 195 runs / 782 assertions / 0 failures
- formatter, explicit Nx typecheck, affected Nx build, and `git diff --check` passed
- Tier-3 CR loop converged with zero mandatory findings after two confirmation rounds

## Post-merge validation

Observe one unchanged staging worker identity through more than ten ordinary recycle/restart cycles, confirm it continues claiming work, and confirm the active deployment remains `SUCCESS` with `restartPolicyType: ALWAYS`. This is bounded staging evidence, not an infinite-restart guarantee.
