### PR TITLE
fix(showcase): forward A2UI recovery headers in LangGraph Python

### DIFF
--- a/showcase/integrations/langgraph-python/src/agents/_header_forwarding_middleware.py
+++ b/showcase/integrations/langgraph-python/src/agents/_header_forwarding_middleware.py
@@ -47,7 +47,10 @@ from langchain.agents.middleware import (
     AgentState,
     ModelRequest,
     ModelResponse,
+    ToolCallRequest,
 )
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
 
 # Reuse the installed copilotkit's existing header-forwarding helpers so
 # the behaviour stays bit-identical to the full CopilotKitMiddleware's
@@ -257,6 +260,40 @@ class HeaderForwardingMiddleware(AgentMiddleware[AgentState, Any]):
         run.agent_exit(terminal_outcome="ok")
         run.response_complete(http_status=200)
         return response
+
+
+class AuxiliaryModelHeaderForwardingMiddleware(AgentMiddleware[AgentState, Any]):
+    """Forward current request headers for tool-owned auxiliary model calls."""
+
+    def __init__(self, *models: Any) -> None:
+        if not models:
+            raise ValueError("at least one auxiliary model is required")
+        self._models = tuple(models)
+
+    @property
+    def name(self) -> str:
+        return "AuxiliaryModelHeaderForwardingMiddleware"
+
+    def _prepare_tool_call(self) -> None:
+        _extract_forwarded_headers_from_config()
+        for model in self._models:
+            _ensure_httpx_hook(model)
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        self._prepare_tool_call()
+        return handler(request)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        self._prepare_tool_call()
+        return await handler(request)
 
 
 def _model_name(request: ModelRequest) -> str:

--- a/showcase/integrations/langgraph-python/src/agents/recovery_agent.py
+++ b/showcase/integrations/langgraph-python/src/agents/recovery_agent.py
@@ -4,10 +4,10 @@ Same dynamic-schema A2UI setup as `a2ui_dynamic.py` (declarative-gen-ui), but
 with the toolkit's validate->retry recovery loop made *visible*. The two
 aimock pills drive the inner `render_a2ui` sub-agent two ways:
 
-  - HEAL pill: the model emits FREE-FORM / sloppy A2UI args (components and data
-    as JSON strings rather than structured arrays) — the toolkit heals them via
-    `parse_and_fix` into a valid surface in a single pass, which paints. (A
-    single deterministic response: no per-attempt fixture switching needed.)
+  - HEAL pill: attempt 1 is structurally invalid because the root references a
+    missing child; attempt 2 is valid and paints. Aimock stages those attempts
+    with per-test `sequenceIndex` 0 and 1, so the inner model request must keep
+    its active request headers instead of falling into the global default test.
   - EXHAUST pill: every attempt is structurally invalid (the root references a
     missing child), so the validate->retry loop hits the cap and the tool
     returns the `a2ui_recovery_exhausted` hard-fail envelope, which the renderer
@@ -21,6 +21,11 @@ the toolkit recovery loop IN-GRAPH. The dedicated route sets
 `injectA2UITool: false` so the runtime does not inject a second copy. Only this
 backend-owned path surfaces the recovery loop + `a2ui_recovery_exhausted`
 hard-fail explicitly (the runtime auto-injection path has no equivalent loop).
+
+The A2UI tool invokes a separate inner model from inside a LangGraph tool node,
+and that inner call is not handed the usual RunnableConfig. The compatibility
+middleware below rebinds the active `x-*` headers at the tool boundary and hooks
+that inner model's HTTP clients before `generate_a2ui` runs.
 
 Mirrors `showcase/integrations/google-adk/src/agents/recovery_agent.py` (the
 ADK sibling, which uses the singular `get_a2ui_tool`). Catalog is reused from
@@ -38,6 +43,10 @@ from copilotkit import CopilotKitMiddleware
 from langchain.agents import create_agent
 from langchain_openai import ChatOpenAI
 from ag_ui_langgraph import get_a2ui_tools
+
+from src.agents._header_forwarding_middleware import (
+    AuxiliaryModelHeaderForwardingMiddleware,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +75,7 @@ SYSTEM_PROMPT = (
 )
 
 _MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+_A2UI_MODEL = ChatOpenAI(model=_MODEL)
 
 # Backend-owned A2UI with the recovery loop made explicit. `maxAttempts` is set
 # so the renderer's "Retrying… (N/M)" label matches the adapter's cap. Recovery
@@ -76,13 +86,16 @@ graph = create_agent(
     tools=[
         get_a2ui_tools(
             {
-                "model": ChatOpenAI(model=_MODEL),
+                "model": _A2UI_MODEL,
                 "default_catalog_id": "declarative-gen-ui-catalog",
                 "recovery": {"maxAttempts": 3},
                 "on_a2ui_attempt": _log_attempt,
             }
         )
     ],
-    middleware=[CopilotKitMiddleware()],
+    middleware=[
+        AuxiliaryModelHeaderForwardingMiddleware(_A2UI_MODEL),
+        CopilotKitMiddleware(),
+    ],
     system_prompt=SYSTEM_PROMPT,
 )

--- a/showcase/integrations/langgraph-python/tests/test_a2ui_header_forwarding.py
+++ b/showcase/integrations/langgraph-python/tests/test_a2ui_header_forwarding.py
@@ -1,0 +1,108 @@
+"""Regression tests for auxiliary A2UI model header forwarding."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from copilotkit import copilotkit_lg_middleware
+from langchain_core.runnables.config import var_child_runnable_config
+
+from src.agents._header_forwarding_middleware import (
+    AuxiliaryModelHeaderForwardingMiddleware,
+)
+
+
+_HEADER_CASES = (
+    ("run-a", {"x-test-id": "run-a", "x-aimock-context": "run-a"}),
+    ("run-b", {"x-test-id": "run-b", "x-aimock-context": "run-b"}),
+    ("empty", {}),
+    ("run-a", {"x-test-id": "run-a", "x-aimock-context": "run-a"}),
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_copilotkit_hooked_clients():
+    copilotkit_lg_middleware._hooked_clients.clear()
+    yield
+    copilotkit_lg_middleware._hooked_clients.clear()
+
+
+@contextmanager
+def active_child_runnable_config(headers):
+    token = var_child_runnable_config.set(
+        {"configurable": headers, "context": {}, "metadata": {}}
+    )
+    try:
+        yield
+    finally:
+        var_child_runnable_config.reset(token)
+
+
+def observed_pair(request):
+    return (
+        request.headers.get("x-test-id"),
+        request.headers.get("x-aimock-context"),
+    )
+
+
+def expected_pair(headers):
+    return (
+        headers.get("x-test-id"),
+        headers.get("x-aimock-context"),
+    )
+
+
+def test_auxiliary_model_tool_calls_forward_current_request_headers():
+    sync_observed = []
+    async_observed = []
+
+    def sync_transport(request):
+        sync_observed.append(observed_pair(request))
+        return httpx.Response(200)
+
+    async def async_transport(request):
+        async_observed.append(observed_pair(request))
+        return httpx.Response(200)
+
+    async def drive_tool_calls():
+        with httpx.Client(
+            transport=httpx.MockTransport(sync_transport),
+            base_url="https://inner-model.test",
+        ) as client:
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(async_transport),
+                base_url="https://inner-model.test",
+            ) as async_client:
+                model = SimpleNamespace(client=client, async_client=async_client)
+                middleware = AuxiliaryModelHeaderForwardingMiddleware(model)
+
+                def sync_handler(request):
+                    response = model.client.get("/v1/responses")
+                    response.raise_for_status()
+                    return request
+
+                async def async_handler(request):
+                    response = await model.async_client.get("/v1/chat/completions")
+                    response.raise_for_status()
+                    return request
+
+                for case_name, headers in _HEADER_CASES:
+                    request = SimpleNamespace(tool_call={"name": case_name})
+                    with active_child_runnable_config(headers):
+                        assert (
+                            middleware.wrap_tool_call(request, sync_handler) is request
+                        )
+                        assert (
+                            await middleware.awrap_tool_call(request, async_handler)
+                            is request
+                        )
+
+    asyncio.run(drive_tool_calls())
+
+    expected = [expected_pair(headers) for _, headers in _HEADER_CASES]
+    assert sync_observed == expected
+    assert async_observed == expected


### PR DESCRIPTION
## Summary

- forward request-scoped `x-*` headers into the backend-owned A2UI auxiliary model at the LangGraph tool boundary, for both sync and async execution
- share the exact auxiliary `ChatOpenAI` instance between `get_a2ui_tools(...)` and the forwarding middleware
- add a focused regression test for changing, repeated, and cleared request headers
- keep the branch diff limited to the three LangGraph-Python implementation/test files; there are no net Claude SDK or examples changes

## Why

The A2UI recovery tool performs inner model calls from a tool node, outside the normal model-call middleware boundary. Those calls could therefore miss Aimock correlation headers even though the outer agent request was correctly scoped.

## Validation

- full-root lint, typecheck, test, and build gates passed before removing the formatter-only branch noise; that cleanup did not change production or test behavior
- current-head `pnpm check-format` reports 25 files already byte-identical to `origin/main` because the root formatter scans the entire checkout
- production LangGraph-Python image regression test: 1/1 passed
- Aimock recovery proof: exactly 9 HTTP 200 calls with uniform LangGraph-Python correlation headers, heal sequence `0 -> 1`, three exhaustion attempts, and no fixture misses
- live OpenAI transport checks: sync, async, and one A2UI recovery-envelope request returned HTTP 200 with forwarded probe headers

## Test-environment note

The Codex host exports `DO_NOT_TRACK=1`, which correctly disables telemetry and initially made default-path telemetry tests fail. With only that host variable removed—the GitHub unit-test environment does not set it—the no-cache shared/runtime controls passed 300/300 and 2,078/2,078, followed by green lint, typecheck, test, and build gates. No telemetry source or test was changed.
