### PR TITLE
fix(runtime): reject `runner` passed alongside `intelligence` (closes OSS-933)

### DIFF
--- a/packages/runtime/skills/runtime/references/agent-runners.md
+++ b/packages/runtime/skills/runtime/references/agent-runners.md
@@ -189,10 +189,13 @@ new CopilotRuntime({
 
 `CopilotIntelligenceRuntimeOptions` does not declare a `runner` field — Intelligence mode
 auto-wires `IntelligenceAgentRunner` pointed at the Intelligence service socket. Excess-property checks will
-flag a `runner:` key on an Intelligence-shaped options object as a type error, and at runtime
-the auto-wired Intelligence runner wins regardless of what you pass.
+flag a `runner:` key on an Intelligence-shaped options object as a type error, and a caller who
+evades that check (JS, `as any`, or a non-literal options object) gets a `throw` at construction
+rather than a silently ignored runner.
 
-Source: `packages/runtime/src/v2/runtime/core/runtime.ts:149-173,285-294`.
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts` — `runner?` is declared only on
+`CopilotSseRuntimeOptions` (:239); the Intelligence constructor guard is at :512 and the
+auto-wired runner at :582.
 
 ### HIGH Forgetting the better-sqlite3 peer
 

--- a/packages/runtime/src/v2/runtime/__tests__/channels-option.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/channels-option.test.ts
@@ -3,6 +3,7 @@ import { CopilotRuntime } from "../core/runtime";
 import { createCopilotRuntimeHandler } from "../core/fetch-handler";
 import { CopilotKitIntelligence } from "../intelligence-platform";
 import { createChannel } from "@copilotkit/channels";
+import { InMemoryAgentRunner } from "../runner/in-memory";
 
 const intelligence = () =>
   new CopilotKitIntelligence({
@@ -142,6 +143,29 @@ describe("CopilotRuntime — channels option", () => {
         realtimeMetadata: false,
       },
     });
+  });
+
+  it("intelligence runtime rejects a caller-supplied runner", () => {
+    expect(
+      () =>
+        new CopilotRuntime({
+          agents: {},
+          intelligence: intelligence(),
+          identifyUser,
+          runner: new InMemoryAgentRunner(),
+        } as unknown as ConstructorParameters<typeof CopilotRuntime>[0]),
+    ).toThrow(/runner/);
+  });
+
+  it("intelligence runtime tolerates an explicitly undefined runner", () => {
+    const rt = new CopilotRuntime({
+      agents: {},
+      intelligence: intelligence(),
+      identifyUser,
+      runner: undefined,
+    } as unknown as ConstructorParameters<typeof CopilotRuntime>[0]);
+
+    expect(rt.runner).toBeDefined();
   });
 
   it("sse runtime rejects channels", () => {

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -499,8 +499,25 @@ export class CopilotIntelligenceRuntime
       identifyUser?: unknown;
       channels?: unknown;
       memory?: unknown;
+      runner?: unknown;
       ɵlearning?: unknown;
     };
+    // Runtime guard mirroring the `channels` guard in `CopilotSseRuntime`: this
+    // constructor hardcodes `IntelligenceAgentRunner` into its `super()` call,
+    // so a caller-supplied `runner` can never be honored. The type forbids it
+    // (`runner` is declared only on `CopilotSseRuntimeOptions`), but that is an
+    // excess-property check — a JS / `as any` / non-literal caller passing
+    // `{ intelligence, runner }` would otherwise land here and have `runner`
+    // silently dropped in favor of the auto-wired one. Fail loud instead.
+    if (rawOptions.runner !== undefined) {
+      throw new Error(
+        "Intelligence Runtime auto-wires its own `runner`; passing `runner` " +
+          "alongside `intelligence` is not supported. Durability is managed by " +
+          "the Intelligence service, so `InMemoryAgentRunner` / a SQLite runner " +
+          "is unnecessary here — drop `runner`, or drop `intelligence` to run " +
+          "in SSE mode with a runner you control.",
+      );
+    }
     if (
       rawOptions.identifyUser !== undefined &&
       typeof rawOptions.identifyUser !== "function"

--- a/skills/runtime/references/agent-runners.md
+++ b/skills/runtime/references/agent-runners.md
@@ -189,10 +189,13 @@ new CopilotRuntime({
 
 `CopilotIntelligenceRuntimeOptions` does not declare a `runner` field — Intelligence mode
 auto-wires `IntelligenceAgentRunner` pointed at the Intelligence service socket. Excess-property checks will
-flag a `runner:` key on an Intelligence-shaped options object as a type error, and at runtime
-the auto-wired Intelligence runner wins regardless of what you pass.
+flag a `runner:` key on an Intelligence-shaped options object as a type error, and a caller who
+evades that check (JS, `as any`, or a non-literal options object) gets a `throw` at construction
+rather than a silently ignored runner.
 
-Source: `packages/runtime/src/v2/runtime/core/runtime.ts:149-173,285-294`.
+Source: `packages/runtime/src/v2/runtime/core/runtime.ts` — `runner?` is declared only on
+`CopilotSseRuntimeOptions` (:239); the Intelligence constructor guard is at :512 and the
+auto-wired runner at :582.
 
 ### HIGH Forgetting the better-sqlite3 peer
 


### PR DESCRIPTION
## Problem

`runner` and `intelligence` are mutually exclusive by construction, but the exclusivity was enforced in only one direction and only for object literals.

`CopilotIntelligenceRuntime` hardcodes `new IntelligenceAgentRunner(...)` into its `super()` call (`runtime.ts:582`), and `runner?` is declared only on `CopilotSseRuntimeOptions` (`runtime.ts:239`). The type system catches a `runner:` key on an Intelligence-shaped **object literal** via excess-property checking — but that is the only barrier. A JS caller, an `as any`, or a non-literal options object routes through `CopilotRuntimeShim`'s `hasIntelligenceOptions()` dispatch into the Intelligence constructor and has `runner` **silently dropped**, with no diagnostic.

The mirror case is already guarded: `CopilotSseRuntime` throws on `channels`, and the comment there states the exact reasoning that applies here — "the type forbids it, but a JS / `as any` caller ... would otherwise land here and have `channels` silently dropped — fail loud instead." The Intelligence constructor validates `identifyUser`, `channels`, `memory`, and `ɵlearning`. Same file, same pattern, one case missing.

### It also made a shipped skill lie

`packages/runtime/skills/runtime/SKILL.md:87` asserted:

> Passing both `runner` and `intelligence` to `CopilotRuntime` is rejected at construction.

It was not. And that contradicted the skill's own reference page, `references/agent-runners.md`, which correctly described the silent drop. Two files in the same shipped skill said opposite things about the same behaviour.

## Change

- **Guard** (`runtime.ts:512`) — `CopilotIntelligenceRuntime` now throws when `runner` is present, mirroring the `channels` guard in `CopilotSseRuntime`. The message names the exclusivity and points out that an in-memory/SQLite runner is unnecessary in Intelligence mode, where durability is managed by the service.
- **`SKILL.md:87` unchanged** — the guard makes it accurate.
- **`references/agent-runners.md` updated** — this is *not* optional. That page was the accurate one before this change; adding the guard makes its "the auto-wired Intelligence runner wins regardless of what you pass" false. Leaving it would fix SKILL.md's lie by creating the same lie in the reference — rotating the contradiction rather than resolving it. Its stale `:149-173,285-294` source citation is corrected to the real line numbers too. Root `skills/` mirror regenerated via `pnpm sync:plugin-skills`.

## Behavior notes

- Explicit `runner: undefined` still constructs. This matches how the sibling `identifyUser` / `channels` / `memory` guards treat `undefined`, and avoids breaking callers that spread an options object.
- The v1 deprecated compat path is unaffected: `copilot-runtime.ts:492-509` already omits `runner` from its Intelligence branch, so nothing routes a `runner` into this constructor from v1.

## Tests

Two tests in `channels-option.test.ts`, alongside the existing `sse runtime rejects channels` mirror:

- `intelligence runtime rejects a caller-supplied runner` — written first and confirmed **red** against the unpatched constructor (`AssertionError: expected [Function] to throw an error`), green after.
- `intelligence runtime tolerates an explicitly undefined runner` — pins the undefined-tolerance above so the guard cannot over-throw.

## Verification

| Gate | Result |
|---|---|
| `nx test @copilotkit/runtime` | 144 files, **2080 passed, 0 failed** |
| `nx check-types @copilotkit/runtime` | Successfully ran (+22 deps) |
| `oxlint` (changed files) | 0 warnings, 0 errors |
| `oxfmt --check` | no issues in changed files |
| lefthook pre-commit + commit-msg | all green |

Closes OSS-933.