### PR TITLE
docs(adk): publish the frontend context guide

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx
@@ -1,0 +1,58 @@
+---
+title: Readables
+icon: "lucide/BookA"
+description: Share read-only frontend context with a Google ADK agent.
+hideTOC: true
+---
+
+The `useAgentContext` hook lets your frontend share read-only application state
+with a Google ADK agent. CopilotKit forwards the entries into ADK session state
+under `state["copilotkit"]["context"]`.
+
+## Implementation
+
+<Callout>
+  This guide shows the Google ADK setup. The frontend state is read-only
+  context; it is not a replacement for frontend tools or shared state writes.
+</Callout>
+
+<Steps>
+  <Step>
+    ### Install the ADK + AG-UI bridge
+
+    ```bash
+    pip install ag-ui-adk
+    ```
+  </Step>
+
+  <Step>
+    ### Read CopilotKit context before each model call
+
+    `useAgentContext` entries arrive in ADK session state under
+    `state["copilotkit"]["context"]`. Add `AGUIToolset()` to the agent and use
+    a `before_model_callback` to inject those read-only values into the system
+    instruction.
+
+    <DemoCode file="src/agents/readonly_state_agent_context_agent.py" region="agent-context-setup" />
+  </Step>
+</Steps>
+
+## Frontend example
+
+```tsx title="YourComponent.tsx"
+"use client";
+
+import { useAgentContext } from "@copilotkit/react-core/v2";
+
+export function YourComponent({ currentUser }) {
+  useAgentContext({
+    description: "The current user",
+    value: currentUser,
+  });
+
+  return null;
+}
+```
+
+The value is included in the ADK session context on each turn. Keep the value
+small, serializable, and safe to expose to the agent.

--- a/showcase/shell-docs/src/content/docs/integrations/adk/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/meta.json
@@ -8,6 +8,7 @@
     "---App Control---",
     "frontend-tools",
     "shared-state",
+    "agent-app-context",
     "---Deploy---",
     "deploy-langsmith",
     "---Intelligence---",


### PR DESCRIPTION
## What does this PR do?

Publishes the existing Google ADK frontend-context recipe as a first-class CopilotKit docs page at `/google-adk/agent-app-context` and adds it to the ADK navigation.

## Why it's needed

Problem: the documented Google ADK integration page is missing, so users following the framework-specific route receive a 404 or fall back to framework-neutral guidance that incorrectly says no backend setup is needed.

Root Cause: the working showcase recipe already exists under `showcase/integrations/google-adk/docs/setup/agent-context-setup.mdx`, but no authored shell-docs page or ADK `meta.json` entry assembled it into the public docs route.

## Solution

Add a concise authored page that explains `useAgentContext`, the `AGUIToolset()` + `before_model_callback` ADK pattern, a linked demo source region, and a small frontend example. Register the page in the ADK navigation metadata.

## Changes

- Add `showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx`.
- Add `agent-app-context` to the ADK `meta.json` navigation.
- No runtime, package, dependency, or generated registry changes.

## Related PRs and Issues

- Fixes #6668

## Reviewer Test Plan

### How to verify

1. Open the new `/google-adk/agent-app-context` route in shell-docs.
2. Confirm the page is listed under the ADK App Control navigation section.
3. Verify the guide's `DemoCode` path and region resolve to `showcase/integrations/google-adk/src/agents/readonly_state_agent_context_agent.py#agent-context-setup`.
4. Confirm the page distinguishes read-only `useAgentContext` from frontend tools and shared-state writes.

### Evidence (Before & After)

Before: `/google-adk/agent-app-context.md` was missing even though the ADK showcase source recipe existed.

After: a navigable authored page and metadata entry expose the ADK-specific setup, without touching runtime behavior.

### Tested on

| OS | Status |
|---|---|
| Windows 11 | ✅ JSON validation and diff checks; shell-docs dependency gates unverified |

## Testing

- `node` JSON parse of the changed `meta.json`: passed.
- `git diff --check`: passed.
- `pnpm` is available, but shell-docs dependencies are not installed in this filtered clone; `pnpm install`/build/test/typecheck were not run.
- No runtime or API code changed.

## Compatibility/Risk

Documentation-only change. The new page uses the existing showcase source and changes only shell-docs content/navigation; no published package or runtime behavior changes.

## Notes for Reviewer

This contribution was AI-assisted. The source recipe was read from the existing Google ADK showcase integration and adapted into the missing authored page. No Issue claim, assignment, comment, review reply, rerun, resolve, or merge occurred.

## Checklist

- [x] I have read the Contribution Guide
- [x] The relevant documentation was updated
- [x] No runtime functionality changed
- [x] I searched existing open PRs and found no matching PR for #6668
- [x] The diff is limited to the missing page and its navigation entry
- [ ] Allow edits by maintainers is not set by CLI; maintainer can enable it in GitHub