### PR TITLE
docs: fix typo in Mastra shared state guide

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/index.mdx
@@ -12,7 +12,7 @@ The foundation of this system is built on Mastra's stateful architecture via AG-
 internal state throughout execution, which you can access via the `useAgent` hook.
 
 ## When should I use this?
-State streaming is perfect when you want to faciliate collaboration between your agent and the user. Any state that your Mastra agent
+State streaming is perfect when you want to facilitate collaboration between your agent and the user. Any state that your Mastra agent
 persists will be automatically shared by the UI. Similarly, any state that the user updates in the UI will be automatically reflected.
 
 This allows for a consistent experience where both the agent and the user are on the same page.


### PR DESCRIPTION
## What does this PR do?

Corrects `faciliate` to `facilitate` in the Mastra shared state documentation.

## Related PRs and Issues

- None.

## Validation

- `codespell showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/index.mdx`
- `git diff --check`

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
- [x] The relevant documentation is updated by this PR.
- [x] "Allow edits by maintainers" is enabled.
