### PR TITLE
fix(deps): bump @ag-ui/core family 0.0.57 -> 0.0.58 (OSS-924)

### DIFF
--- a/examples/integrations/crewai-crews/package-lock.json
+++ b/examples/integrations/crewai-crews/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
+        "@ag-ui/client": "0.0.58",
         "@ag-ui/crewai": "0.0.3",
         "@copilotkit/react-core": "1.62.3",
         "@copilotkit/runtime": "1.62.3",
@@ -80,13 +80,14 @@
       "license": "MIT"
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.57.tgz",
-      "integrity": "sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==",
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.58.tgz",
+      "integrity": "sha512-9tAUJ6Ot0y2f5Va7xGFhUSO5OPAjilMsPdmKNmAUR774LKWcvNpriJ6mqH3p/ewUue1zfoUo4vpX+9Xo/zsuzA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.57",
-        "@ag-ui/encoder": "0.0.57",
-        "@ag-ui/proto": "0.0.57",
+        "@ag-ui/core": "0.0.58",
+        "@ag-ui/encoder": "0.0.58",
+        "@ag-ui/proto": "0.0.58",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -97,9 +98,10 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.57.tgz",
-      "integrity": "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==",
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.58.tgz",
+      "integrity": "sha512-XgGb7YmhV+yMBaEmlrpsd5S+nUxq0JgSegss2t4gIFR1j7w3w0ibtKfRgcQHWeMvwZxcT5S28VEEarqtgxYYHw==",
+      "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
       }
@@ -115,12 +117,13 @@
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.57.tgz",
-      "integrity": "sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==",
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.58.tgz",
+      "integrity": "sha512-eMfjJbfAGTQECgNX3QO0Mt0V5OrIViowSPmGLzdO92q2x506K2hRs2VBlfEuAzpDFp6Eq23Q/vjNHFzv37StZw==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.57",
-        "@ag-ui/proto": "0.0.57"
+        "@ag-ui/core": "0.0.58",
+        "@ag-ui/proto": "0.0.58"
       }
     },
     "node_modules/@ag-ui/langgraph": {
@@ -154,11 +157,12 @@
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.57.tgz",
-      "integrity": "sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==",
+      "version": "0.0.58",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.58.tgz",
+      "integrity": "sha512-fErOnFPfpZlNSreeOEdUVuCzTQI463JoUo1DNx4grAvSZPOg4tVgqvG2s82qJE9pZoh48VSUqk6hyV82GT/wIA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.57",
+        "@ag-ui/core": "0.0.58",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }
@@ -433,9 +437,9 @@
       "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cfworker/json-schema": {

--- a/examples/integrations/crewai-crews/package.json
+++ b/examples/integrations/crewai-crews/package.json
@@ -13,7 +13,7 @@
     "postinstall": "npm run install:agent"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@ag-ui/crewai": "0.0.3",
     "@copilotkit/react-core": "1.62.3",
     "@copilotkit/runtime": "1.62.3",
@@ -37,9 +37,9 @@
     "typescript": "^5"
   },
   "overrides": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
-    "@ag-ui/encoder": "0.0.57",
-    "@ag-ui/proto": "0.0.57"
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
+    "@ag-ui/encoder": "0.0.58",
+    "@ag-ui/proto": "0.0.58"
   }
 }

--- a/examples/v2/angular/demo/package.json
+++ b/examples/v2/angular/demo/package.json
@@ -11,10 +11,10 @@
     "clean": "rimraf dist .angular"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
-    "@ag-ui/encoder": "0.0.57",
-    "@ag-ui/proto": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
+    "@ag-ui/encoder": "0.0.58",
+    "@ag-ui/proto": "0.0.58",
     "@a2ui/web_core": "0.10.4",
     "@angular/animations": "^22.1.2",
     "@angular/cdk": "^22.1.2",

--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -31,7 +31,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -55,8 +55,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",

--- a/packages/channels-core/package.json
+++ b/packages/channels-core/package.json
@@ -56,8 +56,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/channels-ui": "workspace:~",
     "@copilotkit/core": "workspace:^",
     "@copilotkit/shared": "workspace:^",

--- a/packages/channels-core/src/sanitize-agent-events.test.ts
+++ b/packages/channels-core/src/sanitize-agent-events.test.ts
@@ -30,8 +30,12 @@ function streamResponse(
 
 /**
  * A run whose `TOOL_CALL_START` carries `parentMessageId: null` — the shape
- * `@ag-ui/langgraph` emits for the tool call that triggers an interrupt, and
- * the one `EventSchemas.parse` rejects with "Expected string, received null".
+ * `@ag-ui/langgraph` emits for the tool call that triggers an interrupt.
+ *
+ * `EventSchemas.parse` used to reject this with "Expected string, received
+ * null", which is why the sanitizer exists. `@ag-ui/core@0.0.58` widened
+ * `parentMessageId` to accept null and coerce it to `undefined`, so the raw
+ * stream now survives on its own; the sanitizer still normalizes it to `""`.
  */
 const nullParentRun = (): string[] => [
   frame({ type: "RUN_STARTED", threadId: "t1", runId: "r1" }),
@@ -77,12 +81,19 @@ describe("sanitizeAgentEventStream", () => {
     expect(started).toEqual(["ask_human"]);
   });
 
-  it("aborts that same run when the sanitizer is not applied", async () => {
+  it("lets that same run through even without the sanitizer, since @ag-ui/core@0.0.58 accepts the null", async () => {
     const agent = agentServing(nullParentRun());
 
-    await expect(agent.runAgent({})).rejects.toThrow(
-      /parentMessageId|received null/,
+    const started: string[] = [];
+    await agent.runAgent(
+      {},
+      {
+        onToolCallStartEvent: ({ event }) =>
+          void started.push(event.toolCallName),
+      },
     );
+
+    expect(started).toEqual(["ask_human"]);
   });
 
   it("coerces the null to an empty string and leaves every other byte alone", async () => {
@@ -249,11 +260,11 @@ describe("createChannel({ sanitizeAgentEvents })", () => {
     expect(failure).toBeUndefined();
   });
 
-  it("lets the run abort when sanitizing is disabled", async () => {
+  it("still completes the turn when sanitizing is disabled, because core tolerates the null", async () => {
     const failure = await runTurn(agentServing(nullParentRun()), {
       sanitizeAgentEvents: false,
     });
 
-    expect(String(failure)).toMatch(/parentMessageId|received null/);
+    expect(failure).toBeUndefined();
   });
 });

--- a/packages/channels-discord/package.json
+++ b/packages/channels-discord/package.json
@@ -41,7 +41,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "discord.js": "^14.16.0",

--- a/packages/channels-intelligence/package.json
+++ b/packages/channels-intelligence/package.json
@@ -41,7 +41,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-slack": "workspace:^",
     "@copilotkit/channels-teams": "workspace:^",
@@ -49,7 +49,7 @@
     "phoenix": "^1.8.4"
   },
   "devDependencies": {
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/typescript-config": "workspace:^",
     "@types/node": "^22.10.0",
     "@types/phoenix": "^1.6.6",

--- a/packages/channels-slack/package.json
+++ b/packages/channels-slack/package.json
@@ -51,8 +51,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "@copilotkit/core": "workspace:^",

--- a/packages/channels-teams/package.json
+++ b/packages/channels-teams/package.json
@@ -48,8 +48,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "@copilotkit/core": "workspace:^",

--- a/packages/channels-telegram/package.json
+++ b/packages/channels-telegram/package.json
@@ -42,7 +42,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "grammy": "^1.30.0",

--- a/packages/channels-whatsapp/package.json
+++ b/packages/channels-whatsapp/package.json
@@ -42,7 +42,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/shared": "workspace:*",
     "@tanstack/pacer": "^0.20.1",
     "phoenix": "^1.8.4",

--- a/packages/demo-agents/package.json
+++ b/packages/demo-agents/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "openai": "^4.85.1",
     "rxjs": "^7.8.1"
   },

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -75,8 +75,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/runtime-client-gql": "workspace:*",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -81,7 +81,7 @@
     "size:headless": "node scripts/measure-headless.mjs"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/react-core": "workspace:*",
     "@copilotkit/shared": "workspace:*",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -79,9 +79,9 @@
   },
   "dependencies": {
     "@ag-ui/a2ui-middleware": "0.0.10",
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
-    "@ag-ui/encoder": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
+    "@ag-ui/encoder": "0.0.58",
     "@ag-ui/langgraph": "0.0.42",
     "@ag-ui/mcp-apps-middleware": "0.0.3",
     "@ag-ui/mcp-middleware": "0.0.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,7 +50,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/license-verifier": "~0.5.0",
     "@segment/analytics-node": "^2.1.2",
     "@standard-schema/spec": "^1.0.0",
@@ -62,6 +62,7 @@
     "zod-to-json-schema": "^3.23.5"
   },
   "devDependencies": {
+    "@ag-ui/core": "0.0.58",
     "@types/uuid": "^10.0.0",
     "@valibot/to-json-schema": "^1.5.0",
     "arktype": "^2.1.29",

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -31,7 +31,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -78,8 +78,8 @@
   },
   "dependencies": {
     "@a2ui/web_core": "0.10.4",
-    "@ag-ui/client": "0.0.57",
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/client": "0.0.58",
+    "@ag-ui/core": "0.0.58",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "@copilotkit/web-components": "workspace:*",

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -37,7 +37,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
+    "@ag-ui/client": "0.0.58",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "lit": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -351,7 +351,7 @@ importers:
         version: 0.8.3(signal-polyfill@0.2.2)
       '@ag-ui/a2a':
         specifier: ^0.0.6
-        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.57)
+        version: 0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.58)
       '@ag-ui/a2a-middleware':
         specifier: ^0.0.2
         version: 0.0.2(rxjs@7.8.1)
@@ -1172,17 +1172,17 @@ importers:
         specifier: 0.10.4
         version: 0.10.4
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/encoder':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/proto':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@angular/animations':
         specifier: ^22.1.2
         version: 22.1.3(@angular/core@22.1.2(@angular/compiler@22.1.2)(rxjs@7.8.1)(zone.js@0.15.1))
@@ -2023,7 +2023,7 @@ importers:
         version: 0.0.52
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.2
-        version: 0.0.2(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
+        version: 0.0.2(@ag-ui/client@0.0.58)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../../../../packages/core
@@ -2184,8 +2184,8 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -2212,11 +2212,11 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2397,11 +2397,11 @@ importers:
   packages/channels-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-ui':
         specifier: workspace:~
         version: link:../channels-ui
@@ -2434,8 +2434,8 @@ importers:
   packages/channels-discord:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-core':
         specifier: workspace:^
         version: link:../channels-core
@@ -2465,8 +2465,8 @@ importers:
   packages/channels-intelligence:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-core':
         specifier: workspace:^
         version: link:../channels-core
@@ -2484,8 +2484,8 @@ importers:
         version: 1.8.4
     devDependencies:
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/typescript-config':
         specifier: workspace:^
         version: link:../typescript-config
@@ -2508,11 +2508,11 @@ importers:
   packages/channels-slack:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-core':
         specifier: workspace:^
         version: link:../channels-core
@@ -2560,11 +2560,11 @@ importers:
   packages/channels-teams:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-core':
         specifier: workspace:^
         version: link:../channels-core
@@ -2615,8 +2615,8 @@ importers:
   packages/channels-telegram:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-core':
         specifier: workspace:^
         version: link:../channels-core
@@ -2665,8 +2665,8 @@ importers:
   packages/channels-whatsapp:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/channels-core':
         specifier: workspace:^
         version: link:../channels-core
@@ -2690,8 +2690,8 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2748,8 +2748,8 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       openai:
         specifier: ^4.85.1
         version: 4.104.0(encoding@0.1.13)(ws@8.21.3)(zod@3.25.76)
@@ -2776,11 +2776,11 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
         version: link:../a2ui-renderer
@@ -2948,8 +2948,8 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3207,22 +3207,22 @@ importers:
     dependencies:
       '@ag-ui/a2ui-middleware':
         specifier: 0.0.10
-        version: 0.0.10(@ag-ui/client@0.0.57)(rxjs@7.8.1)
+        version: 0.0.10(@ag-ui/client@0.0.58)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/encoder':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/langgraph':
         specifier: 0.0.42
-        version: 0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
+        version: 0.0.42(@ag-ui/client@0.0.58)(@ag-ui/core@0.0.58)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
       '@ag-ui/mcp-apps-middleware':
         specifier: 0.0.3
-        version: 0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+        version: 0.0.3(@ag-ui/client@0.0.58)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware':
         specifier: 0.0.1
         version: 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
@@ -3503,7 +3503,7 @@ importers:
     dependencies:
       '@ag-ui/langgraph':
         specifier: 0.0.42
-        version: 0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.21.3)(zod-to-json-schema@3.25.2(zod@3.25.76))
+        version: 0.0.42(@ag-ui/client@0.0.58)(@ag-ui/core@0.0.58)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.21.3)(zod-to-json-schema@3.25.2(zod@3.25.76))
       '@copilotkit/shared':
         specifier: workspace:*
         version: link:../shared
@@ -3560,11 +3560,8 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
-      '@ag-ui/core':
-        specifier: '>=0.0.48'
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/license-verifier':
         specifier: ~0.5.0
         version: 0.5.0
@@ -3593,6 +3590,9 @@ importers:
         specifier: ^3.23.5
         version: 3.25.1(zod@3.25.76)
     devDependencies:
+      '@ag-ui/core':
+        specifier: 0.0.58
+        version: 0.0.58
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -3624,8 +3624,8 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -3696,11 +3696,11 @@ importers:
         specifier: 0.10.4
         version: 0.10.4
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -3850,8 +3850,8 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.58
+        version: 0.0.58
       '@copilotkit/core':
         specifier: workspace:*
         version: link:../core
@@ -4174,8 +4174,8 @@ packages:
   '@ag-ui/client@0.0.53':
     resolution: {integrity: sha512-Mkup36KUp0KXy9v89QtAOWDUoh8H1s1Vgl4zvQv9HqXuAK1TkbtpXJHpbgZJXIxTqd54KT6yCurmC2UkOP7FDQ==}
 
-  '@ag-ui/client@0.0.57':
-    resolution: {integrity: sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==}
+  '@ag-ui/client@0.0.58':
+    resolution: {integrity: sha512-9tAUJ6Ot0y2f5Va7xGFhUSO5OPAjilMsPdmKNmAUR774LKWcvNpriJ6mqH3p/ewUue1zfoUo4vpX+9Xo/zsuzA==}
 
   '@ag-ui/core@0.0.36':
     resolution: {integrity: sha512-uYUrzw6uxuw4qVQ61mdSeiG0mFh2n/VAWmWsWzwETDuhqJZT7rFmd07IajcFWcyItMr1wjqxFDdlklucAyEYNA==}
@@ -4195,8 +4195,8 @@ packages:
   '@ag-ui/core@0.0.53':
     resolution: {integrity: sha512-11UocR7fFdMWw503bWCX2IOK15vbWfxT11Mn9xOiPBVO/UVcn57ywGrlLL4UaBlPgmUTvuzr2yYR2ElSqiN2wQ==}
 
-  '@ag-ui/core@0.0.57':
-    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
+  '@ag-ui/core@0.0.58':
+    resolution: {integrity: sha512-XgGb7YmhV+yMBaEmlrpsd5S+nUxq0JgSegss2t4gIFR1j7w3w0ibtKfRgcQHWeMvwZxcT5S28VEEarqtgxYYHw==}
 
   '@ag-ui/encoder@0.0.36':
     resolution: {integrity: sha512-p8UNh6a77G/oe/4EZmwkTeYCN/5SnqSY2Cz8f8psZpk4LKzzrPkRNykrUAIBsi1wMp50/VQiM27oTRaade/Qkw==}
@@ -4210,8 +4210,8 @@ packages:
   '@ag-ui/encoder@0.0.53':
     resolution: {integrity: sha512-bAOcfVdm6U4H6G6tW+DZfwPEQm1w/snVBTwaFn9nJcEMW69M7/HZuwvEc/7Zo0rK1jRL32N/j60PwTAeky19fw==}
 
-  '@ag-ui/encoder@0.0.57':
-    resolution: {integrity: sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==}
+  '@ag-ui/encoder@0.0.58':
+    resolution: {integrity: sha512-eMfjJbfAGTQECgNX3QO0Mt0V5OrIViowSPmGLzdO92q2x506K2hRs2VBlfEuAzpDFp6Eq23Q/vjNHFzv37StZw==}
 
   '@ag-ui/langgraph@0.0.11':
     resolution: {integrity: sha512-3xUkaOelnpQ5tbsbuoOTin71tTgWEN0GDZBjGs/7xAwly2Dn4fahbBAoscXullO/pH9kTGGgbuJ0rWDUgo6fKQ==}
@@ -4256,8 +4256,8 @@ packages:
   '@ag-ui/proto@0.0.53':
     resolution: {integrity: sha512-swjz22xWT8YUZt5OhmUwkARDQdwt8XM1hmGZbQrhRnNPXKwrKJX9ELlbnQ4iFUQIKkMWpphzE3vA3yNKs2bbKw==}
 
-  '@ag-ui/proto@0.0.57':
-    resolution: {integrity: sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==}
+  '@ag-ui/proto@0.0.58':
+    resolution: {integrity: sha512-fErOnFPfpZlNSreeOEdUVuCzTQI463JoUo1DNx4grAvSZPOg4tVgqvG2s82qJE9pZoh48VSUqk6hyV82GT/wIA==}
 
   '@ai-sdk/anthropic@2.0.71':
     resolution: {integrity: sha512-JXTtAwlyxGzzRtpiAXk/O93aOTgdfoVX28EoUuRNVqZRgtkoniLQTtqeb8uZ4oXljNJlXzaJLNasS/U90w/wjw==}
@@ -27487,19 +27487,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.57)':
+  '@ag-ui/a2a@0.0.6(@ag-ui/client@0.0.42)(@ag-ui/core@0.0.58)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ag-ui/client': 0.0.42
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/core': 0.0.58
       rxjs: 7.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.57)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.58)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.58
       clarinet: 0.12.6
       rxjs: 7.8.1
 
@@ -27556,11 +27556,11 @@ snapshots:
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/client@0.0.57':
+  '@ag-ui/client@0.0.58':
     dependencies:
-      '@ag-ui/core': 0.0.57
-      '@ag-ui/encoder': 0.0.57
-      '@ag-ui/proto': 0.0.57
+      '@ag-ui/core': 0.0.58
+      '@ag-ui/encoder': 0.0.58
+      '@ag-ui/proto': 0.0.58
       '@types/uuid': 10.0.0
       compare-versions: 6.1.1
       fast-json-patch: 3.1.1
@@ -27595,7 +27595,7 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.57':
+  '@ag-ui/core@0.0.58':
     dependencies:
       zod: 3.25.76
 
@@ -27619,10 +27619,10 @@ snapshots:
       '@ag-ui/core': 0.0.53
       '@ag-ui/proto': 0.0.53
 
-  '@ag-ui/encoder@0.0.57':
+  '@ag-ui/encoder@0.0.58':
     dependencies:
-      '@ag-ui/core': 0.0.57
-      '@ag-ui/proto': 0.0.57
+      '@ag-ui/core': 0.0.58
+      '@ag-ui/proto': 0.0.58
 
   '@ag-ui/langgraph@0.0.11(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(ws@8.21.3)':
     dependencies:
@@ -27640,11 +27640,11 @@ snapshots:
       - react-dom
       - ws
 
-  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.58)(@ag-ui/core@0.0.58)(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/client': 0.0.58
+      '@ag-ui/core': 0.0.58
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.19.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
@@ -27662,11 +27662,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.21.3)(zod-to-json-schema@3.25.2(zod@3.25.76))':
+  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.58)(@ag-ui/core@0.0.58)(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.21.3)(zod-to-json-schema@3.25.2(zod@3.25.76))':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/client': 0.0.58
+      '@ag-ui/core': 0.0.58
       '@langchain/core': 1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3)
       '@langchain/langgraph-sdk': 1.8.9(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))
       langchain: 1.3.5(@langchain/core@1.1.42(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(ws@8.21.3))(@opentelemetry/api@1.9.0)(openai@6.44.0(ws@8.21.3)(zod@3.25.76))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vue@3.5.34(typescript@5.9.3))(ws@8.21.3)(zod-to-json-schema@3.25.2(zod@3.25.76))
@@ -27704,9 +27704,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.2(@ag-ui/client@0.0.58)(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.58
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -27714,9 +27714,9 @@ snapshots:
       - supports-color
       - zod
 
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.58)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.58
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -27758,9 +27758,9 @@ snapshots:
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 
-  '@ag-ui/proto@0.0.57':
+  '@ag-ui/proto@0.0.58':
     dependencies:
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/core': 0.0.58
       '@bufbuild/protobuf': 2.11.0
       '@protobuf-ts/protoc': 2.11.1
 

--- a/scripts/release/lib/angular-package.test.ts
+++ b/scripts/release/lib/angular-package.test.ts
@@ -151,7 +151,7 @@ test("creates an exact packed Angular consumer without framework overrides", () 
       "serve:ssr": "node dist/smoke/server/server.mjs",
     },
     dependencies: {
-      "@ag-ui/client": "0.0.57",
+      "@ag-ui/client": "0.0.58",
       "@angular/cdk": "22.0.0",
       "@angular/common": "22.0.0",
       "@angular/core": "22.0.0",

--- a/scripts/release/lib/angular-package.ts
+++ b/scripts/release/lib/angular-package.ts
@@ -230,7 +230,7 @@ export function createAngularConsumerManifest({
       "serve:ssr": "node dist/smoke/server/server.mjs",
     },
     dependencies: {
-      "@ag-ui/client": "0.0.57",
+      "@ag-ui/client": "0.0.58",
       "@angular/cdk": support.cdk,
       "@angular/common": support.angular,
       "@angular/core": support.angular,


### PR DESCRIPTION
Closes OSS-924.

## Problem

Our packages pin `@ag-ui/{core,client,encoder,proto}` **exactly** at `0.0.57`. `@ag-ui/mastra@1.1.2` imports `tokenUsageFromAiSdkUsage`, which only exists from `@ag-ui/core@0.0.58`, while declaring a loose `>=0.0.44` peer. An app that pins core to whatever our runtime pins installs cleanly, typechecks, and then dies at bundle time on a missing export — no signal pointing at dependency resolution.

Verified directly against the published tarballs:

```
@ag-ui/mastra@1.1.2  dist/*.mjs:  import{tokenUsageFromAiSdkUsage as i}from"@ag-ui/core"
@ag-ui/mastra@1.1.1  dist/*:      no import from @ag-ui/core at all
@ag-ui/core@0.0.57:  absent    @ag-ui/core@0.0.58: present
```

Note the trigger is narrower than "a loose peer against an exact pin". A clean `npm i @copilotkit/runtime @ag-ui/mastra` hoists 0.0.58 at the root and works. The break needs something pinning core to `0.0.57` **at the app root** — which the `overrides` block in our own integration examples does.

## What this changes

`0.0.57 -> 0.0.58` for `@ag-ui/{core,client,encoder,proto}` across the **18 `packages/*`** manifests. That is the durable fix: it stops the *published* runtime pinning 0.0.57, so integrations tracking core independently stop colliding with us.

Also bumped: `scripts/release/lib/angular-package.ts` — the Angular release smoke-test consumer manifest still installed `@ag-ui/client@0.0.57` with no override, which would have given the smoke app two copies of the client (0.0.57 at the root, 0.0.58 nested under the packed tarball) — exactly the shape that consumer test exists to rule out. Also `examples/integrations/crewai-crews` (direct dep **and** its override, moved together) and `examples/v2/angular/demo` (workspace-linked). `packages/shared` gains `@ag-ui/core` as a devDependency so its loose `>=0.0.48` peer resolves to 0.0.58 in-workspace instead of leaving a stale second copy — the published peer range is unchanged.

### What is deliberately NOT bumped

`showcase/integrations/*` and the examples that pin published `@copilotkit` versions. None of them has an `@ag-ui` override, and every published runtime through 1.68.1 pins core at 0.0.57, so raising only their direct pin **creates** a split:

| | `@ag-ui/core` copies |
|---|---|
| showcase today (0.0.57) | **1** — coherent |
| after a naive bump | **5** — 0.0.58 at root + four nested 0.0.57 under `@copilotkit/*` |

They pick up 0.0.58 when they bump their `@copilotkit` pins. Same reasoning left `a2a-a2ui`, `agent-spec`, `claude-managed-agents/server`, and `strands-typescript/agent` alone.

## Behavior change worth reading

`0.0.58` is additive over `0.0.57` (`TokenUsage` schema + helpers, optional `usage` field) **plus one input-widening**:

```
core@0.0.57  accepts null parentMessageId: false -> rejects: Expected string, received null
core@0.0.58  accepts null parentMessageId: true  -> coerced to undefined
```

This matters because `channels-core`'s `sanitizeAgentEventStream` exists *purely* to work around that bug (`@ag-ui/langgraph` emits `parentMessageId: null` on interrupt-triggering tool calls). **0.0.58 fixes it upstream**, which made two negative-control tests stale — they asserted the run still aborts without the sanitizer. Updated to assert the new behavior.

The sanitizer is **kept**: it normalizes null to `""` whereas core coerces to `undefined`, and it is public API. Whether it is now redundant is a separate call, not this PR.

## Testing

- **Fix proven against the original failure.** Runtime family at 0.0.58 + `@ag-ui/mastra@1.1.2`:
  ```
  === core copies ===
    0.0.58  <- @ag-ui/core/package.json          (single copy)
  === symbol mastra needs ===
    mastra resolves core -> 0.0.58
    tokenUsageFromAiSdkUsage: function
  ```
  Against the pre-fix shape (root pinned 0.0.57) the same probe gives `tokenUsageFromAiSdkUsage: undefined` and `has symbol: false` for the ESM named export.

- **Regression shape checked before committing.** Built the showcase configuration both ways and counted copies; that is where the "do not bump showcase" decision above came from.

- **`pnpm install --frozen-lockfile`** — exit 0 (the CI gate). Lefthook `sync-lockfile` also green on commit.

- **Lockfile is ag-ui-only.** A first pass dragged 3,049 lines of unrelated drift (`esbuild 0.27.3->0.28.2`, `sass`, `rollup`, Angular/Babel) from a stray `pnpm update -r`; reset and redone. Final diff is 206 lines, entirely `@ag-ui` version bumps + 4 integrity hashes + 1 specifier. Zero `0.0.57` references remain.

- **Builds and tests over all 18 changed packages** — `nx run-many -t build` and `-t test` across every `packages/*` manifest this PR touches (`agentcore-runner`, `angular`, `channels-{core,discord,intelligence,slack,teams,telegram,whatsapp}`, `core`, `demo-agents`, `react-core`, `react-native`, `runtime`, `shared`, `sqlite-runner`, `vue`, `web-inspector`): both exit 0.

- **Release tooling** — `vitest run scripts/release/__tests__ scripts/release/lib`: 154 passed (13 files), exit 0.

- **Tests**, per-project exit codes (a `| tail` in an earlier run masked nx's exit code behind `tail`'s, so these were re-run and captured individually):

  | project | result |
  |---|---|
  | shared | 300 passed (13 files) |
  | core | 718 passed (65 files) |
  | runtime | 2078 passed (144 files) |
  | react-core | 1074 passed (100 files) |
  | channels-core | 267 passed (41 files) |
  | angular | 310 passed, 1 skipped (48 files) |
  | vue | 1086 passed (101 files) |
  | sqlite-runner | 15 passed (2 files) |

  All exit 0. Full pre-commit hook (`test-and-check-packages`, `lint-fix`, `sync-lockfile`, `commitlint`) green.

  Flake note: the first commit attempt failed the hook on `runtime:test` + `sqlite-runner:test` (nx labelled runtime flaky under parallel load). Both pass standalone and on retry.

## Follow-up, not in this PR

`@ag-ui/mastra`'s peer floor should be `>=0.0.58`, not `>=0.0.44`, so this class of conflict fails at **install** with a readable peer error instead of at bundle time. That lives in `ag-ui-protocol/ag-ui` and is the more durable of the two fixes — it covers the next package that references a newer core symbol.
