### PR TITLE
test(web-inspector): stop the gesture tests racing the beat on real timers

### DIFF
--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -2640,9 +2640,10 @@ test("the beat ends and leaves the resting dot behind", async () => {
   const context = await setup({ realTimers: true });
 
   await context.breakConnection();
-  await context.advance(200);
-  expect(pulsing(context.inspector)).toBe(true);
 
+  // No assertion about *being* mid-beat here: on real timers that is a race
+  // against ERROR_BEAT_MS, and the fake clock already pins it above. This test
+  // only claims the beat ends on its own.
   for (let attempt = 0; attempt < 400; attempt += 1) {
     if (!pulsing(context.inspector)) break;
     await context.advance(20);
@@ -2661,9 +2662,10 @@ test("the whole gesture completes on its own and leaves the resting state behind
   const context = await setup({ realTimers: true });
 
   await context.breakConnection();
-  await context.advance(200);
-  expect(pillPhase(context.inspector)).toBe("closed");
 
+  // No assertion about the phase *before* the beat here: on real timers that is
+  // a race against ERROR_BEAT_MS, and the fake clock already pins it above.
+  // This test only claims the gesture runs to its end on its own.
   let sawOpenPill = false;
   for (let attempt = 0; attempt < 500; attempt += 1) {
     if (pillOpen(context.inspector)) sawOpenPill = true;


### PR DESCRIPTION
## Problem

`packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts` is failing intermittently on `test / unit`, across unrelated branches and on `main`. It is currently red on the **v1.69.1 release PR**.

```
FAIL  src/__tests__/launcher-error-signal.spec.ts >
      the whole gesture completes on its own and leaves the resting state behind
AssertionError: expected 'opening' to be 'closed'
```

| When | Branch | Shard | Run |
|---|---|---|---|
| 19:29Z | `release/publish/monorepo/v1.69.1` | Node 24 / React 18 | [32886136479](https://github.com/CopilotKit/CopilotKit/actions/runs/32886136479) |
| 14:09Z | `ben1/oss-924-agui-core-058` (#6687) | Node 24 / React 19 | [32857130830](https://github.com/CopilotKit/CopilotKit/actions/runs/32857130830) |
| 12:41Z | `lukas/oss-903-presentation-…` | Node 20 / React 18 | [32848616256](https://github.com/CopilotKit/CopilotKit/actions/runs/32848616256) |

Neither #6687 (an `@ag-ui/core` version bump) nor the presentation branch touches gesture timing, and no shard fails consistently — it follows runner load, not code.

## Cause

Both real-timer tests in this suite asserted a *pre-beat* state 200ms after breaking the connection:

```ts
const context = await setup({ realTimers: true });
await context.breakConnection();
await context.advance(200);
expect(pillPhase(context.inspector)).toBe("closed");   // ← races the beat
```

Under `realTimers`, `advance(ms)` is a literal `setTimeout(resolve, ms)` (spec L656–664). The pill's `closed → opening` transition fires at `ERROR_GESTURE_MS.beat = 400` (`index.ts` L330–339, scheduled at L18998). So the assertion had a **200ms margin against a 400ms boundary on a wall clock**. On a loaded runner the 200ms sleep overshoots 400ms, the beat has already fired, and the phase reads `opening`.

The comment directly above the test already says phase boundaries are asserted on the fake clock "because real timers would make this suite slow and flaky" — and then this was a phase-boundary assertion on real timers.

The same 200-vs-400 race sat in the adjacent test (`pulsing` is true only for the beat's 400ms), so both are fixed here.

## Fix

Remove the two racy preconditions. Both claims are already pinned deterministically on the fake clock at spec L411–427, which asserts `pillPhase === "closed"` **and** `pulsing === true` right after arming, then walks every phase boundary. These real-timer tests exist only to show the beat and the gesture run to their end on their own — which the loops and their closing assertions still prove.

This also matches the idiom the sibling `launcher-signal.spec.ts` already uses (L667–676): assert at t≈0, then poll for the end.

## Testing

**1. Reproduced the CI failure locally.** Injected a 250ms stall before the assertion on the unmodified test, simulating a loaded runner (200ms sleep + 250ms ≈ 450ms > the 400ms beat):

```
FAIL  src/__tests__/launcher-error-signal.spec.ts > the whole gesture completes on its own …
AssertionError: expected 'opening' to be 'closed' // Object.is equality
Expected: "closed"
Received: "opening"
 ❯ src/__tests__/launcher-error-signal.spec.ts:2666:40
```

Byte-for-byte the CI assertion.

**2. The fix survives that same simulation.** With a 700ms stall (well past the beat) injected into both tests:

```
 ✓ the beat ends and leaves the resting dot behind  750ms
 ✓ the whole gesture completes on its own and leaves the resting state behind  3435ms
 Tests  2 passed | 88 skipped (90)
```

**3. Mutation-checked that the remaining assertions still have teeth.** Three separate breaks to `src/index.ts`, each caught:

| Mutation | Result |
|---|---|
| Gesture opens but never closes (drop the `closing` phase + `endGesture`) | `FAIL … AssertionError: expected <span …> to be null` |
| Pill never opens at all (`openPill` returns early) | `FAIL … AssertionError: expected false to be true` (`sawOpenPill`) |
| Beat never ends (`beat: 400` → `999_999`) | `FAIL … AssertionError: expected true to be false` (`pulsing`) |

Source restored afterwards; `git status` confirms this PR touches only the spec file.

**4. Full `@copilotkit/web-inspector` suite:**

```
 Test Files  29 passed (29)
      Tests  625 passed (625)
```

**5. Pre-commit gate** (`test-and-check-packages`: test, publint, attw across 5 projects + 22 dependencies, incl. `@copilotkit/react-core`, `@copilotkit/angular`, `@copilotkit/runtime`) passed on the committed tree.

## Note

`main` also has a second, unrelated flake I did not touch here — `CopilotChatToolRerenders.e2e.test.tsx > should not re-render a completed tool call when subsequent text is streamed` (`expected 4 to be 3`), which reddened `main` at `0943c519` ([run 32750372113](https://github.com/CopilotKit/CopilotKit/actions/runs/32750372113)), a runtime `.d.ts` change that touches no react-core chat code. Different mechanism, worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)