### PR TITLE
fix(examples): MCP Apps widgets send ui/notifications/size-changed so the host resizes the iframe

### DIFF
--- a/examples/showcases/generative-ui-playground/mcp-server/apps/calculator-app.html
+++ b/examples/showcases/generative-ui-playground/mcp-server/apps/calculator-app.html
@@ -657,7 +657,7 @@
 
         function reportSize() {
           const app = document.getElementById("app");
-          sendNotification("ui/notifications/size-change", {
+          sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(app.scrollWidth),
             height: Math.ceil(app.scrollHeight),
           });

--- a/examples/showcases/generative-ui-playground/mcp-server/apps/flights-app.html
+++ b/examples/showcases/generative-ui-playground/mcp-server/apps/flights-app.html
@@ -1695,7 +1695,7 @@
       function reportSize() {
         requestAnimationFrame(() => {
           const rect = document.body.getBoundingClientRect();
-          mcpApp.sendNotification("ui/notifications/size-change", {
+          mcpApp.sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(rect.width),
             height: Math.ceil(rect.height),
           });

--- a/examples/showcases/generative-ui-playground/mcp-server/apps/hotels-app.html
+++ b/examples/showcases/generative-ui-playground/mcp-server/apps/hotels-app.html
@@ -1702,7 +1702,7 @@
       function reportSize() {
         requestAnimationFrame(() => {
           const rect = document.body.getBoundingClientRect();
-          mcpApp.sendNotification("ui/notifications/size-change", {
+          mcpApp.sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(rect.width),
             height: Math.ceil(rect.height),
           });

--- a/examples/showcases/generative-ui-playground/mcp-server/apps/kanban-app.html
+++ b/examples/showcases/generative-ui-playground/mcp-server/apps/kanban-app.html
@@ -1243,7 +1243,7 @@
 
       function reportSize() {
         const app = document.getElementById("app");
-        mcpApp.sendNotification("ui/notifications/size-change", {
+        mcpApp.sendNotification("ui/notifications/size-changed", {
           width: Math.ceil(app.scrollWidth),
           height: Math.ceil(app.scrollHeight),
         });

--- a/examples/showcases/generative-ui-playground/mcp-server/apps/todo-app.html
+++ b/examples/showcases/generative-ui-playground/mcp-server/apps/todo-app.html
@@ -662,7 +662,7 @@
 
         function reportSize() {
           const app = document.getElementById("app");
-          sendNotification("ui/notifications/size-change", {
+          sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(app.scrollWidth),
             height: Math.ceil(app.scrollHeight),
           });

--- a/examples/showcases/generative-ui-playground/mcp-server/apps/trading-app.html
+++ b/examples/showcases/generative-ui-playground/mcp-server/apps/trading-app.html
@@ -1127,7 +1127,7 @@
 
         function reportSize() {
           const app = document.getElementById("app");
-          sendNotification("ui/notifications/size-change", {
+          sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(app.scrollWidth),
             height: Math.ceil(app.scrollHeight),
           });

--- a/examples/showcases/mcp-apps/mcp-server/apps/flights-app.html
+++ b/examples/showcases/mcp-apps/mcp-server/apps/flights-app.html
@@ -1695,7 +1695,7 @@
       function reportSize() {
         requestAnimationFrame(() => {
           const rect = document.body.getBoundingClientRect();
-          mcpApp.sendNotification("ui/notifications/size-change", {
+          mcpApp.sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(rect.width),
             height: Math.ceil(rect.height),
           });

--- a/examples/showcases/mcp-apps/mcp-server/apps/hotels-app.html
+++ b/examples/showcases/mcp-apps/mcp-server/apps/hotels-app.html
@@ -1682,7 +1682,7 @@
       function reportSize() {
         requestAnimationFrame(() => {
           const rect = document.body.getBoundingClientRect();
-          mcpApp.sendNotification("ui/notifications/size-change", {
+          mcpApp.sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(rect.width),
             height: Math.ceil(rect.height),
           });

--- a/examples/showcases/mcp-apps/mcp-server/apps/kanban-app.html
+++ b/examples/showcases/mcp-apps/mcp-server/apps/kanban-app.html
@@ -1141,7 +1141,7 @@
 
       function reportSize() {
         const app = document.getElementById("app");
-        mcpApp.sendNotification("ui/notifications/size-change", {
+        mcpApp.sendNotification("ui/notifications/size-changed", {
           width: Math.ceil(app.scrollWidth),
           height: Math.ceil(app.scrollHeight),
         });

--- a/examples/showcases/mcp-apps/mcp-server/apps/trading-app.html
+++ b/examples/showcases/mcp-apps/mcp-server/apps/trading-app.html
@@ -1127,7 +1127,7 @@
 
         function reportSize() {
           const app = document.getElementById("app");
-          sendNotification("ui/notifications/size-change", {
+          sendNotification("ui/notifications/size-changed", {
             width: Math.ceil(app.scrollWidth),
             height: Math.ceil(app.scrollHeight),
           });


### PR DESCRIPTION
## What

The MCP Apps example widgets report their intrinsic size with
`ui/notifications/size-change`, but both the host and the ext-apps spec use
`ui/notifications/size-changed`:

- Host: `MCPAppsActivityRenderer` only handles `case "ui/notifications/size-changed"` and
  reads `{ width, height }` from it to size the iframe.
- Spec: `@modelcontextprotocol/ext-apps` defines `McpUiSizeChangedNotification` with
  `method: "ui/notifications/size-changed"` (`App.sendSizeChanged`).

Because the names differ by one letter, the host never receives the size and the widget
iframe stays at its initial height instead of growing to fit its content.

## Fix

Rename the notification to the spec name in the affected widgets. The payload is unchanged
(`{ width, height }`), which is exactly what the host reads, so this is a one-line change per
widget on the sender side only.

No host change: in JSON-RPC a notification (no `id`) must not be answered, so the host
silently ignoring the old name is correct behavior; the bug is purely that the widgets sent
the wrong method name.

## Affected widgets

- `examples/showcases/mcp-apps/mcp-server/apps`: flights, hotels, kanban, trading
- `examples/showcases/generative-ui-playground/mcp-server/apps`: calculator, flights, hotels,
  kanban, todo, trading

## Testing

Reproduced against a local run of `examples/showcases/mcp-apps` (Next frontend + MCP server):
before, the widget iframe rendered at its initial height; after the rename the host receives
`size-changed` and the iframe resizes to the widget content.

## A note from the contributors

From the team at MCP Apps Builders - part of our ongoing series to round out MCP Apps host
support in CopilotKit. Opening as a draft for review.

