### PR TITLE
fix(examples): add missing zod for the OpenRouter demo-server

### DIFF
--- a/examples/v2/angular/demo-server/package.json
+++ b/examples/v2/angular/demo-server/package.json
@@ -14,7 +14,8 @@
     "@copilotkit/demo-agents": "workspace:^",
     "@copilotkit/runtime": "workspace:^",
     "@hono/node-server": "^1.13.6",
-    "hono": "^4.11.4"
+    "hono": "^4.11.4",
+    "zod": "^3.25.75"
   },
   "devDependencies": {
     "nodemon": "^3.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1325,6 +1325,9 @@ importers:
       hono:
         specifier: '>=4.11.7'
         version: 4.12.15
+      zod:
+        specifier: '>=3.22.3'
+        version: 3.25.76
     devDependencies:
       nodemon:
         specifier: ^3.1.7


### PR DESCRIPTION
The Angular OpenRouter demo-server crashed on chat because `@ai-sdk/openai` imports `zod/v4` and the server did not declare `zod`. This PR adds that dependency so pnpm can put `zod` next to the server on Windows.

## What does this PR do?

Adds `zod` to `examples/v2/angular/demo-server`. That is the OpenRouter `createOpenAI` path. The React demo already had this dependency.

## Related PRs and Issues

- Inspector test path: local `main` plus the React Router example also has `zod` linked so chat can run while this PR is open.

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

## Testing

1. **Commands run.** I did not run the monorepo test suite. This change is one private example `package.json` plus the lockfile importer line. I did confirm Node can resolve `zod/v4` from `@ai-sdk/openai` after `zod` is linked into the example `node_modules`.
2. **Manual test.**
   1. On current `main` (before this change), run `examples/v2/angular/demo-server` with `OPENROUTER_API_KEY` set. Send a chat message. The process fails with `Cannot find module 'zod/v4'`.
   2. Check out this branch and run `pnpm install`.
   3. Start the demo-server again and send a chat message. The OpenRouter call starts. No `zod/v4` error.
3. **How this PR makes testing easy.** The OpenRouter example now declares the same `zod` peer the React demo already had.

## Risk / rollback

Low. The change is a private example dependency. Revert the PR to undo it.