### PR TITLE
fix(runtime): stop reporting every connect failure as a 404 (closes OSS-971)

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/handle-connect.test.ts
@@ -323,11 +323,85 @@ describe("handleConnectAgent", () => {
       });
     });
 
-    it("returns 404 when connect planning is not available", async () => {
+    it("reports an unreachable platform as 502, not 404", async () => {
+      // A thrown error with no status never reached the platform: a socket
+      // timeout, DNS failure, or connection reset. 404 would assert the thread
+      // does not exist and send the caller to investigate the wrong thing.
       const platform = {
         ɵconnectThread: vi
           .fn()
-          .mockRejectedValue(new Error("No active connect plan")),
+          .mockRejectedValue(new Error("connect ECONNREFUSED 10.0.0.1:4201")),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+
+      const response = await handleConnectAgent({
+        runtime,
+        request: createConnectRequest(),
+        agentId: "my-agent",
+      });
+
+      expect(response.status).toBe(502);
+      const body = await response.json();
+      expect(body.error).toBe("Connect request failed");
+      // The real cause reaches the caller instead of only server-side stderr.
+      expect(body.message).toBe("connect ECONNREFUSED 10.0.0.1:4201");
+    });
+
+    it("passes a platform 500 through instead of relabelling it 404", async () => {
+      // Regression from a production incident. Redis filled, app-api returned
+      // 500 on the join-code write, and the browser was told the connect plan
+      // was not available with a 404. The platform was up and the request was
+      // retryable; the reported status said neither.
+      const platform = {
+        ɵconnectThread: vi.fn().mockRejectedValue(
+          Object.assign(new Error("Intelligence platform error 500"), {
+            status: 500,
+          }),
+        ),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+
+      const response = await handleConnectAgent({
+        runtime,
+        request: createConnectRequest(),
+        agentId: "my-agent",
+      });
+
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body.error).toBe("Connect request failed");
+      expect(body.message).toBe("Intelligence platform error 500");
+    });
+
+    it("passes a platform 503 through so the caller knows to retry", async () => {
+      const platform = {
+        ɵconnectThread: vi.fn().mockRejectedValue(
+          Object.assign(new Error("Service Unavailable"), {
+            status: 503,
+          }),
+        ),
+      };
+      const runtime = createIntelligenceRuntime(platform);
+
+      const response = await handleConnectAgent({
+        runtime,
+        request: createConnectRequest(),
+        agentId: "my-agent",
+      });
+
+      expect(response.status).toBe(503);
+    });
+
+    it("still reports a genuine platform 404 as 404", async () => {
+      // The rejection branch must keep working: a real not-found is not the same
+      // as an unreachable platform, and widening the pass-through must not blur
+      // the two.
+      const platform = {
+        ɵconnectThread: vi.fn().mockRejectedValue(
+          Object.assign(new Error("thread not found"), {
+            status: 404,
+          }),
+        ),
       };
       const runtime = createIntelligenceRuntime(platform);
 
@@ -339,7 +413,8 @@ describe("handleConnectAgent", () => {
 
       expect(response.status).toBe(404);
       const body = await response.json();
-      expect(body.error).toBe("Connect plan not available");
+      expect(body.error).toBe("Connect request rejected");
+      expect(body.message).toBe("thread not found");
     });
 
     it("preserves platform not found errors when connect fails with 404", async () => {

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/connect.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/connect.ts
@@ -1,4 +1,4 @@
-import { CopilotIntelligenceRuntimeLike } from "../../core/runtime";
+import type { CopilotIntelligenceRuntimeLike } from "../../core/runtime";
 import { getPlatformErrorStatus } from "../shared/intelligence-utils";
 import { resolveIntelligenceUser } from "../shared/resolve-intelligence-user";
 import { isHandlerResponse } from "../shared/json-response";
@@ -72,6 +72,9 @@ export async function handleIntelligenceConnect({
     );
   } catch (error) {
     const status = getPlatformErrorStatus(error);
+    const message =
+      error instanceof Error ? error.message : "Connect request failed";
+
     if (
       status === 400 ||
       status === 401 ||
@@ -91,12 +94,32 @@ export async function handleIntelligenceConnect({
       );
     }
 
-    console.error("Connect plan not available:", error);
+    // The platform answered, but with a status we do not special-case above.
+    // Pass it through rather than relabelling it: reporting a 503 as a 404 tells
+    // the browser the thread does not exist, when the truth is that the platform
+    // is temporarily unwell and the request is worth retrying.
+    if (typeof status === "number") {
+      console.error(`Connect request failed with status ${status}:`, error);
+      return Response.json(
+        { error: "Connect request failed", message },
+        {
+          status,
+        },
+      );
+    }
+
+    // No status at all, so this never reached the platform: a socket timeout, a
+    // DNS failure, a connection reset, or a bug on our side. 502 says "the thing
+    // behind me is unreachable", which is both true and actionable. It must not
+    // be a 404, which asserts the thread does not exist and sends the caller off
+    // to investigate the wrong thing entirely.
+    console.error("Connect request could not reach Intelligence:", error);
     return Response.json(
       {
-        error: "Connect plan not available",
+        error: "Connect request failed",
+        message,
       },
-      { status: 404 },
+      { status: 502 },
     );
   }
 }


### PR DESCRIPTION
## Summary

The Intelligence connect handler classified a handful of platform rejections and flattened everything else into `404 "Connect plan not available"`, writing the real cause only to server-side stderr.

So a 500 from app-api, a socket timeout, a connection reset and a bug in our own code all produced the same misleading answer, and the only way to learn what actually happened was to read the runtime container's logs.

## Why it matters

This came out of a production incident on a self-hosted deployment. Redis filled, app-api returned 500 on a join-code write, and the operator saw a 404 naming a "connect plan" that had nothing to do with the failure. The platform was up and the request was retryable; the reported status communicated neither, and pointed the investigation at a missing thread instead. Diagnosing it took about a day, almost all of it spent on the wrong hypothesis.

## What changes

| Case | Before | After |
| --- | --- | --- |
| Platform 400/401/403/404/409 | rejection + message | unchanged |
| Platform 500, 503, any other status | `404` "Connect plan not available" | that status, with the message |
| No status: timeout, ECONNRESET, DNS, our own bug | `404` "Connect plan not available" | `502`, with the message |

`502` for the no-status case says "the thing behind me is unreachable", which is true and actionable. `404` asserts the thread does not exist, which sends the caller to investigate the wrong thing entirely.

Every branch now returns the underlying message rather than burying it in a log line the caller cannot see.

## Verification

- `handle-connect.test.ts` 20 passed, including three new cases: platform 500 passes through, platform 503 passes through, and an unreachable platform reports 502. The existing genuine-404 case is asserted unchanged, so widening the pass-through does not blur a real not-found with an unreachable platform.
- Red/green checked: reverting the handler while keeping the tests fails 3 of 20.
- `packages/runtime` v2 suite goes 1270 to 1273 passing, the three additions. The 13 test files that fail to collect and the 26 `tsc` errors are identical with and without this change; they are unbuilt workspace deps in a fresh worktree, not related to it.
- Full lefthook pre-commit suite passes.

## Not addressed here

`handlers/shared/sse-response.ts` has the same shape: it returns `200` and `text/event-stream` before the run starts, so a later throw closes the stream with zero events and no error frame. From the client that is indistinguishable from a silent no-op send. Fixing it means changing the streaming contract, so it wants its own PR.

Related, same family of bug, different file: #6697.