### PR TITLE
docs(react-core): state the blast radius of key-remount and the provisional agent (refs OSS-979)

### DIFF
--- a/packages/react-core/skills/react-core/SKILL.md
+++ b/packages/react-core/skills/react-core/SKILL.md
@@ -97,6 +97,8 @@ your task — do not try to absorb the whole package from this file.
 - Tool-call `status` values are camelCase: `'inProgress' | 'executing' | 'complete'`. In-progress args are `Partial<T>`.
 - `useHumanInTheLoop` synthesized handler **MUST** call `respond(result)` (including reject paths), otherwise the agent run hangs. `respond` is `undefined` outside `Executing` status. Unmounting mid-Executing abandons the run.
 - `useThreads` errors with `'Runtime URL is not configured'` outside Intelligence mode.
+- `useAgent` returns `{ agent, isReady }`. While `isReady` is `false`, `agent` is a provisional stand-in that is **swapped** for the real instance when `/info` resolves — `agent` changes reference and every effect depending on it re-runs. Never initialize app state (correlation maps, in-flight request records) inside an effect keyed on `agent`.
+- A React `key` discards **all** state below it. `key={activeAgent}` / `key={threadId}` belongs on the smallest subtree that genuinely owns that state — on a layout-level provider it silently wipes unrelated app state, and with Intelligence wired the thread id changes asynchronously after mount, so it fires mid-interaction.
 - `v1 → v2` migration renames: `useCopilotAction` → `useFrontendTool` + `useHumanInTheLoop`; `imageUploadsEnabled` → `attachments`. See the `v1-to-v2-migration` lifecycle skill.
 
 ## Reading order for a first-time reader

--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -73,7 +73,7 @@ const { agent } = useAgent({
 const isRunning = agent.isRunning;
 ```
 
-`useAgent` returns `{ agent }` only; `isRunning` lives on the agent
+`useAgent` returns `{ agent, isReady }`; `isRunning` lives on the agent
 itself. Subscribing to `OnRunStatusChanged` forces a re-render when the
 value flips, so reading `agent.isRunning` stays live.
 
@@ -93,6 +93,23 @@ useAgentContext({ description: "user cart + route", value });
 const { agent } = useAgent({ agentId: "default" });
 <button onClick={() => agent.abortRun()}>Stop</button>;
 ```
+
+### Wait for the real agent before attaching to it
+
+```tsx
+const { agent, isReady } = useAgent({ agentId: "default" });
+
+useEffect(() => {
+  if (!isReady) return; // provisional stand-in — don't attach yet
+  const sub = agent.subscribe({ onRunStartedEvent: handleRunStarted });
+  return () => sub.unsubscribe();
+}, [agent, isReady]);
+```
+
+Until the runtime `/info` sync resolves, `agent` is a provisional
+stand-in. It is a fully-constructed `AbstractAgent`, so every call on it
+is safe — but it is then **replaced**, and `agent` changes reference.
+Anything keyed to the old instance goes with it.
 
 ## Common Mistakes
 
@@ -125,6 +142,56 @@ class MyAgent extends AbstractAgent {
 instance. This guards per-thread isolation.
 
 Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+
+### HIGH — Deriving app state from `agent` without guarding on `isReady`
+
+Wrong:
+
+```tsx
+const { agent } = useAgent({ agentId: "default" });
+
+// Correlation map for matching responses back to the row that asked.
+const pending = useRef(new Map<string, string>());
+
+useEffect(() => {
+  pending.current = new Map(); // re-runs when `agent` is swapped
+  const sub = agent.subscribe({ onRunFinishedEvent: resolvePending });
+  return () => sub.unsubscribe();
+}, [agent]);
+```
+
+Correct:
+
+```tsx
+const { agent, isReady } = useAgent({ agentId: "default" });
+
+// Owned by the component, not by the agent — survives the swap.
+const pending = useRef(new Map<string, string>());
+
+useEffect(() => {
+  if (!isReady) return;
+  const sub = agent.subscribe({ onRunFinishedEvent: resolvePending });
+  return () => sub.unsubscribe();
+}, [agent, isReady]);
+```
+
+`agent` changes reference exactly once per mount, when `/info` resolves and
+the provisional stand-in is swapped for the real instance. Any effect with
+`agent` in its dependency array re-runs at that moment — so app state
+initialized inside such an effect is silently reset partway through the
+first interaction.
+
+This bites hardest with Intelligence configured, because license
+verification and thread-endpoint discovery lengthen the provisional window
+past the first user action. In plain SSE mode the window usually closes
+before anyone can interact, which is why the bug does not reproduce in
+OSS-only development.
+
+Never put per-component bookkeeping (correlation maps, in-flight request
+records, refs) behind an `agent` dependency. Initialize it in the ref
+itself and let the effect only manage the subscription.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:226-290,465-481`
 
 ### HIGH — Mutating `agent.messages` directly
 

--- a/packages/react-core/skills/react-core/references/switching-agents-recipes.md
+++ b/packages/react-core/skills/react-core/references/switching-agents-recipes.md
@@ -157,4 +157,5 @@ export function KeyboardAgentSwitcher() {
 
 - Use `copilotkit.subscribe({ onAgentsChanged })` — there is no `useAgents()` hook.
 - Always `key={activeAgent}` on `<CopilotChat>` so thread state doesn't leak when swapping agents in the same slot.
+- Keep that `key` on `<CopilotChat>` and nowhere higher. A `key` discards every bit of state beneath it, so on a wrapper or a layout provider it silently wipes app state too.
 - Clean up the subscription with `sub.unsubscribe()` in the effect cleanup.

--- a/packages/react-core/skills/react-core/references/switching-agents.md
+++ b/packages/react-core/skills/react-core/references/switching-agents.md
@@ -123,6 +123,15 @@ Correct:
 Without remount via `key`, prior thread state and in-flight runs leak into
 the new agent's view. The remount pattern gives each agent a clean slate.
 
+Keep the `key` on `<CopilotChat>` itself. It discards all state below it, so
+hoisting it onto a wrapper or a layout-level provider also destroys app
+state that has nothing to do with the agent — correlation maps, in-flight
+request records, refs — with no error and no warning. If a component
+dispatches requests and matches the responses back, it must sit outside the
+keyed subtree. See "Keying a subtree on the active thread id above app
+state" in `references/threads.md` for the thread-switching version of the
+same trap.
+
 Source: `examples/v2/react-router/app/routes/_index.tsx:38-39`
 
 ### MEDIUM — Omitting `agentId` when multiple agents share a tool name

--- a/packages/react-core/skills/react-core/references/threads.md
+++ b/packages/react-core/skills/react-core/references/threads.md
@@ -94,6 +94,11 @@ export function ThreadSwitcher() {
           </li>
         ))}
       </ul>
+      {/*
+        `key` here remounts ONLY <CopilotChat>. Keep it that way: a `key` on
+        an ancestor would remount the app tree below it too. See
+        "Keying a subtree on the active thread id" below.
+      */}
       {activeId && (
         <CopilotChat key={activeId} agentId="default" threadId={activeId} />
       )}
@@ -102,7 +107,67 @@ export function ThreadSwitcher() {
 }
 ```
 
+`activeId` starts as `null` and becomes a real thread id only after the
+`useThreads` fetch resolves — so this is an **asynchronous, post-mount**
+change, not something settled during the first render.
+
 ## Common Mistakes
+
+### HIGH — Keying a subtree on the active thread id above app state
+
+Wrong:
+
+```tsx
+// app/layout.tsx
+const { threadId } = useThreadSelection();
+
+return (
+  <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    {/* Remounts EVERYTHING below on every thread change. */}
+    <MyAppProvider key={threadId}>{children}</MyAppProvider>
+  </CopilotKitProvider>
+);
+```
+
+Correct:
+
+```tsx
+// app/layout.tsx — app state stays mounted across thread changes.
+return (
+  <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <MyAppProvider>{children}</MyAppProvider>
+  </CopilotKitProvider>
+);
+```
+
+```tsx
+// Reset only what is genuinely per-thread, as deep as possible.
+<ThreadScopedTranscript key={threadId} />
+```
+
+`key={threadId}` is a legitimate way to reset per-thread state, but it
+discards **all** state below it — refs, correlation maps, in-flight request
+bookkeeping, scroll positions. Placed on a layout-level provider it wipes
+the whole page, with no error and no warning; the symptom surfaces
+somewhere unrelated, as "our response routing is flaky".
+
+Two properties make this hard to catch:
+
+- The reset is asynchronous. Durable threads only exist in Intelligence
+  mode, so with a plain SSE runtime `useThreads` returns nothing, the
+  selected thread never changes, and the remount never fires. It appears
+  the moment Intelligence is wired.
+- It is timing-dependent. Whether state survives depends on whether the
+  user acted before the thread list resolved.
+
+Put the `key` on the smallest subtree that genuinely owns per-thread
+state, and never above state the application expects to keep. If a
+component both dispatches requests and correlates the responses, it must
+sit **outside** the keyed subtree.
+
+Source: `packages/react-core/src/v2/hooks/use-threads.tsx:282-289` (thread
+endpoints exist only in Intelligence mode), `364-368` (the list fetch is
+deferred until `/info` resolves)
 
 ### HIGH — Using `useThreads` with an SSE-only runtime
 

--- a/skills/react-core/SKILL.md
+++ b/skills/react-core/SKILL.md
@@ -97,6 +97,8 @@ your task — do not try to absorb the whole package from this file.
 - Tool-call `status` values are camelCase: `'inProgress' | 'executing' | 'complete'`. In-progress args are `Partial<T>`.
 - `useHumanInTheLoop` synthesized handler **MUST** call `respond(result)` (including reject paths), otherwise the agent run hangs. `respond` is `undefined` outside `Executing` status. Unmounting mid-Executing abandons the run.
 - `useThreads` errors with `'Runtime URL is not configured'` outside Intelligence mode.
+- `useAgent` returns `{ agent, isReady }`. While `isReady` is `false`, `agent` is a provisional stand-in that is **swapped** for the real instance when `/info` resolves — `agent` changes reference and every effect depending on it re-runs. Never initialize app state (correlation maps, in-flight request records) inside an effect keyed on `agent`.
+- A React `key` discards **all** state below it. `key={activeAgent}` / `key={threadId}` belongs on the smallest subtree that genuinely owns that state — on a layout-level provider it silently wipes unrelated app state, and with Intelligence wired the thread id changes asynchronously after mount, so it fires mid-interaction.
 - `v1 → v2` migration renames: `useCopilotAction` → `useFrontendTool` + `useHumanInTheLoop`; `imageUploadsEnabled` → `attachments`. See the `v1-to-v2-migration` lifecycle skill.
 
 ## Reading order for a first-time reader

--- a/skills/react-core/references/agent-access.md
+++ b/skills/react-core/references/agent-access.md
@@ -73,7 +73,7 @@ const { agent } = useAgent({
 const isRunning = agent.isRunning;
 ```
 
-`useAgent` returns `{ agent }` only; `isRunning` lives on the agent
+`useAgent` returns `{ agent, isReady }`; `isRunning` lives on the agent
 itself. Subscribing to `OnRunStatusChanged` forces a re-render when the
 value flips, so reading `agent.isRunning` stays live.
 
@@ -93,6 +93,23 @@ useAgentContext({ description: "user cart + route", value });
 const { agent } = useAgent({ agentId: "default" });
 <button onClick={() => agent.abortRun()}>Stop</button>;
 ```
+
+### Wait for the real agent before attaching to it
+
+```tsx
+const { agent, isReady } = useAgent({ agentId: "default" });
+
+useEffect(() => {
+  if (!isReady) return; // provisional stand-in — don't attach yet
+  const sub = agent.subscribe({ onRunStartedEvent: handleRunStarted });
+  return () => sub.unsubscribe();
+}, [agent, isReady]);
+```
+
+Until the runtime `/info` sync resolves, `agent` is a provisional
+stand-in. It is a fully-constructed `AbstractAgent`, so every call on it
+is safe — but it is then **replaced**, and `agent` changes reference.
+Anything keyed to the old instance goes with it.
 
 ## Common Mistakes
 
@@ -125,6 +142,56 @@ class MyAgent extends AbstractAgent {
 instance. This guards per-thread isolation.
 
 Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+
+### HIGH — Deriving app state from `agent` without guarding on `isReady`
+
+Wrong:
+
+```tsx
+const { agent } = useAgent({ agentId: "default" });
+
+// Correlation map for matching responses back to the row that asked.
+const pending = useRef(new Map<string, string>());
+
+useEffect(() => {
+  pending.current = new Map(); // re-runs when `agent` is swapped
+  const sub = agent.subscribe({ onRunFinishedEvent: resolvePending });
+  return () => sub.unsubscribe();
+}, [agent]);
+```
+
+Correct:
+
+```tsx
+const { agent, isReady } = useAgent({ agentId: "default" });
+
+// Owned by the component, not by the agent — survives the swap.
+const pending = useRef(new Map<string, string>());
+
+useEffect(() => {
+  if (!isReady) return;
+  const sub = agent.subscribe({ onRunFinishedEvent: resolvePending });
+  return () => sub.unsubscribe();
+}, [agent, isReady]);
+```
+
+`agent` changes reference exactly once per mount, when `/info` resolves and
+the provisional stand-in is swapped for the real instance. Any effect with
+`agent` in its dependency array re-runs at that moment — so app state
+initialized inside such an effect is silently reset partway through the
+first interaction.
+
+This bites hardest with Intelligence configured, because license
+verification and thread-endpoint discovery lengthen the provisional window
+past the first user action. In plain SSE mode the window usually closes
+before anyone can interact, which is why the bug does not reproduce in
+OSS-only development.
+
+Never put per-component bookkeeping (correlation maps, in-flight request
+records, refs) behind an `agent` dependency. Initialize it in the ref
+itself and let the effect only manage the subscription.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:226-290,465-481`
 
 ### HIGH — Mutating `agent.messages` directly
 

--- a/skills/react-core/references/switching-agents-recipes.md
+++ b/skills/react-core/references/switching-agents-recipes.md
@@ -157,4 +157,5 @@ export function KeyboardAgentSwitcher() {
 
 - Use `copilotkit.subscribe({ onAgentsChanged })` — there is no `useAgents()` hook.
 - Always `key={activeAgent}` on `<CopilotChat>` so thread state doesn't leak when swapping agents in the same slot.
+- Keep that `key` on `<CopilotChat>` and nowhere higher. A `key` discards every bit of state beneath it, so on a wrapper or a layout provider it silently wipes app state too.
 - Clean up the subscription with `sub.unsubscribe()` in the effect cleanup.

--- a/skills/react-core/references/switching-agents.md
+++ b/skills/react-core/references/switching-agents.md
@@ -123,6 +123,15 @@ Correct:
 Without remount via `key`, prior thread state and in-flight runs leak into
 the new agent's view. The remount pattern gives each agent a clean slate.
 
+Keep the `key` on `<CopilotChat>` itself. It discards all state below it, so
+hoisting it onto a wrapper or a layout-level provider also destroys app
+state that has nothing to do with the agent — correlation maps, in-flight
+request records, refs — with no error and no warning. If a component
+dispatches requests and matches the responses back, it must sit outside the
+keyed subtree. See "Keying a subtree on the active thread id above app
+state" in `references/threads.md` for the thread-switching version of the
+same trap.
+
 Source: `examples/v2/react-router/app/routes/_index.tsx:38-39`
 
 ### MEDIUM — Omitting `agentId` when multiple agents share a tool name

--- a/skills/react-core/references/threads.md
+++ b/skills/react-core/references/threads.md
@@ -94,6 +94,11 @@ export function ThreadSwitcher() {
           </li>
         ))}
       </ul>
+      {/*
+        `key` here remounts ONLY <CopilotChat>. Keep it that way: a `key` on
+        an ancestor would remount the app tree below it too. See
+        "Keying a subtree on the active thread id" below.
+      */}
       {activeId && (
         <CopilotChat key={activeId} agentId="default" threadId={activeId} />
       )}
@@ -102,7 +107,67 @@ export function ThreadSwitcher() {
 }
 ```
 
+`activeId` starts as `null` and becomes a real thread id only after the
+`useThreads` fetch resolves — so this is an **asynchronous, post-mount**
+change, not something settled during the first render.
+
 ## Common Mistakes
+
+### HIGH — Keying a subtree on the active thread id above app state
+
+Wrong:
+
+```tsx
+// app/layout.tsx
+const { threadId } = useThreadSelection();
+
+return (
+  <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    {/* Remounts EVERYTHING below on every thread change. */}
+    <MyAppProvider key={threadId}>{children}</MyAppProvider>
+  </CopilotKitProvider>
+);
+```
+
+Correct:
+
+```tsx
+// app/layout.tsx — app state stays mounted across thread changes.
+return (
+  <CopilotKitProvider runtimeUrl="/api/copilotkit">
+    <MyAppProvider>{children}</MyAppProvider>
+  </CopilotKitProvider>
+);
+```
+
+```tsx
+// Reset only what is genuinely per-thread, as deep as possible.
+<ThreadScopedTranscript key={threadId} />
+```
+
+`key={threadId}` is a legitimate way to reset per-thread state, but it
+discards **all** state below it — refs, correlation maps, in-flight request
+bookkeeping, scroll positions. Placed on a layout-level provider it wipes
+the whole page, with no error and no warning; the symptom surfaces
+somewhere unrelated, as "our response routing is flaky".
+
+Two properties make this hard to catch:
+
+- The reset is asynchronous. Durable threads only exist in Intelligence
+  mode, so with a plain SSE runtime `useThreads` returns nothing, the
+  selected thread never changes, and the remount never fires. It appears
+  the moment Intelligence is wired.
+- It is timing-dependent. Whether state survives depends on whether the
+  user acted before the thread list resolved.
+
+Put the `key` on the smallest subtree that genuinely owns per-thread
+state, and never above state the application expects to keep. If a
+component both dispatches requests and correlates the responses, it must
+sit **outside** the keyed subtree.
+
+Source: `packages/react-core/src/v2/hooks/use-threads.tsx:282-289` (thread
+endpoints exist only in Intelligence mode), `364-368` (the list fetch is
+deferred until `/info` resolves)
 
 ### HIGH — Using `useThreads` with an SSE-only runtime
 


### PR DESCRIPTION
## Why

An Intelligence integration lost a request-to-row correlation map partway through a user interaction — no error, no warning. It surfaced as "our response routing is flaky". OSS-979 filed it as `CopilotKitProvider` remounting its children.

The provider does nothing of the kind. It renders `{children}` unconditionally at `CopilotKitProvider.tsx:952` — unkeyed, no early return, and there is no `Suspense` boundary anywhere in `v2`. Nothing in the SDK silently re-points the active thread either; every mutation path (`setActiveThreadId`, `startNewThread`, the drawer row click, the inspector override) is caller-driven.

The remount was app-side, and it was app-side because this skill told it to be:

- `references/threads.md:98` teaches `useThreads()` → select → `<CopilotChat key={activeId}>`, and that recipe is only reachable once Intelligence is wired.
- `references/switching-agents.md:123` teaches "`key={activeAgent}` forces remount so thread state doesn't leak" without saying what else that discards.
- `examples/showcases/reskinnable-demo/src/app/[skin]/layout.tsx:223` models `<SubagentActivityProvider key={threadId}>` above `{children}`, commented "Remounting is deliberate".

Follow all three and you key a layout-level provider on a thread id that changes asynchronously after mount. Everything below it dies mid-interaction.

Two properties made it invisible:

- Durable threads exist only in Intelligence mode, so with a plain SSE runtime `useThreads` returns nothing, the selected thread never changes, and the remount never fires. It appears the moment Intelligence is wired.
- Whether state survives depends on whether the user acted before the thread list resolved.

## What changed

Docs only — no library change. Both traps now carry their blast radius, in the four places an agent actually reads:

| File | Change |
|---|---|
| `SKILL.md` | Two invariants in the load-once section, so they land before any reference is opened |
| `references/threads.md` | New HIGH entry on keying above app state; note that `activeId` in the switcher recipe settles asynchronously |
| `references/switching-agents.md` | Existing HIGH entry now states the blast radius and cross-links the threads trap |
| `references/switching-agents-recipes.md` | Key rule amended — keep it on `<CopilotChat>`, nowhere higher |
| `references/agent-access.md` | The second route to the same symptom: `useAgent` swaps a provisional stand-in for the real agent when `/info` resolves, so an effect keyed on `agent` re-runs once, mid-interaction. Adds an `isReady` pattern and a HIGH entry |

`isReady` appeared in **zero** shipped skills before this — it was documented only in `showcase/shell-docs/.../useAgent.mdx` and in JSDoc. Same shape as OSS-888, where the root cause was the shipped skill rather than the library.

Also corrects a factual error: the skill claimed `useAgent` returns `{ agent }` only. It returns `{ agent, isReady }`.

The 10-file diff is 5 source files under `packages/react-core/skills/` plus their 5 mirrors under `skills/`, regenerated with `pnpm sync:plugin-skills`.

## Verification

- `pnpm check:plugin-skills` — mirror in sync
- `pnpm exec vitest run scripts/__tests__/sync-plugin-skills.test.ts` — 12 passed
- `oxfmt --check` — clean over both skill trees
- Full pre-commit suite green, including `test-and-check-packages` (`test`, `publint`, `attw` across 2 projects and 20 dependent tasks)

## Not in scope

Whether the run's app keyed on `threadId` or on `agent` is not settleable from the repo — its source is not in any checkout, and there is no `2026-08-25` strands run report under `tools/one-prompt-development/evaluation/runs` on any branch. Both variants produce the reported symptom and this covers both, so a first-hand repro is a separate task. The `reskinnable-demo` layout is left as-is deliberately: it is a legitimate use of the pattern, and it is now the worked example the guidance warns about.

Scoping detail in the OSS-979 comment.

refs OSS-979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
