### PR TITLE
fix(examples): stop overriding the managed Intelligence URL defaults (closes OSS-981)

### DIFF
--- a/.github/workflows/static_intelligence-env-names.yml
+++ b/.github/workflows/static_intelligence-env-names.yml
@@ -37,5 +37,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # The rules are unit-tested here rather than by a general runner: nothing
+      # else executes scripts/__tests__, so a rule that silently stopped
+      # matching would leave the check below passing on an empty result.
+      - name: Test the validator's rules
+        run: pnpm exec vitest run scripts/__tests__/validate-intelligence-env-names.test.ts
+
       - name: Check Intelligence env var names are canonical
         run: pnpm check:intelligence-env-names

--- a/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
+++ b/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
@@ -90,9 +90,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub - replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/adk-angular/server.ts
+++ b/examples/integrations/adk-angular/server.ts
@@ -19,9 +19,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history. The id

--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/agent-spec/.env.example
+++ b/examples/integrations/agent-spec/.env.example
@@ -4,5 +4,9 @@ AGENT_URL=http://localhost:8000/
 # Optional: enable CopilotKit Intelligence Threads locally
 COPILOTKIT_LICENSE_TOKEN=
 INTELLIGENCE_API_KEY=
-INTELLIGENCE_API_URL=http://localhost:4201
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# INTELLIGENCE_API_URL and INTELLIGENCE_GATEWAY_WS_URL point at a self-hosted
+# or local Intelligence deployment only — leave them unset when using managed
+# Intelligence, or the channel host and runtime will try to reach a local
+# stack that usually is not running.
+# INTELLIGENCE_API_URL=http://localhost:4201
+# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -25,9 +25,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -133,9 +133,12 @@ export function buildApp() {
       ? {
           intelligence: new CopilotKitIntelligence({
             apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-            apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-            wsUrl:
-              process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+            ...(process.env.INTELLIGENCE_API_URL
+              ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+              : {}),
+            ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+              ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+              : {}),
           }),
           // Demo stub — replace with your real auth-derived user identity before any
           // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,9 +23,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -18,9 +18,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -24,9 +24,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/llamaindex/.env.example
+++ b/examples/integrations/llamaindex/.env.example
@@ -8,5 +8,5 @@ INTELLIGENCE_API_KEY=
 # self-hosted or local Intelligence deployment only — leave them unset (or
 # blank) when using managed Intelligence, or the channel host and runtime
 # will try to reach a local stack that usually is not running.
-INTELLIGENCE_API_URL=http://localhost:4203
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4403
+# INTELLIGENCE_API_URL=http://localhost:4203
+# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4403

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -14,9 +14,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/mcp-apps/.env.example
+++ b/examples/integrations/mcp-apps/.env.example
@@ -7,5 +7,5 @@ INTELLIGENCE_API_KEY=
 # self-hosted or local Intelligence deployment only — leave them unset (or
 # blank) when using managed Intelligence, or the channel host and runtime
 # will try to reach a local stack that usually is not running.
-INTELLIGENCE_API_URL=http://localhost:4201
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# INTELLIGENCE_API_URL=http://localhost:4201
+# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -19,9 +19,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -19,9 +19,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/scripts/__tests__/validate-intelligence-env-names.test.ts
+++ b/scripts/__tests__/validate-intelligence-env-names.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  findViolations,
+  managedUrlEnvFileAssignment,
+  managedUrlFallback,
+} from "../validate-intelligence-env-names.js";
+
+/**
+ * `CopilotKitIntelligence` resolves `apiUrl`/`wsUrl` to the managed hosts when
+ * they are omitted, so supplying any fallback for the two env vars that feed
+ * them overrides that default. A starter that does it points a managed user at
+ * whatever the fallback names — in practice a local stack that is not running
+ * (OSS-981).
+ *
+ * The rule is the pattern, not the literal: a staging host substituted for
+ * localhost would be just as wrong, so the check flags the fallback itself.
+ */
+describe("managedUrlFallback", () => {
+  it("flags a nullish fallback on the API URL", () => {
+    expect(
+      managedUrlFallback(
+        '          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",',
+      ),
+    ).toBe("INTELLIGENCE_API_URL");
+  });
+
+  it("flags a nullish fallback on the gateway websocket URL", () => {
+    expect(
+      managedUrlFallback(
+        '            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",',
+      ),
+    ).toBe("INTELLIGENCE_GATEWAY_WS_URL");
+  });
+
+  it("flags a logical-or fallback, which fails the same way", () => {
+    expect(
+      managedUrlFallback(
+        '  const apiUrl = process.env.INTELLIGENCE_API_URL || "https://staging.example.com";',
+      ),
+    ).toBe("INTELLIGENCE_API_URL");
+  });
+
+  it("allows the conditional spread, which leaves the managed default in place", () => {
+    expect(
+      managedUrlFallback("    ...(process.env.INTELLIGENCE_API_URL"),
+    ).toBeNull();
+    expect(
+      managedUrlFallback(
+        "      ? { apiUrl: process.env.INTELLIGENCE_API_URL }",
+      ),
+    ).toBeNull();
+  });
+
+  it("allows a bare read with no default", () => {
+    expect(
+      managedUrlFallback("  apiUrl: process.env.INTELLIGENCE_API_URL,"),
+    ).toBeNull();
+  });
+
+  it("allows an env file assignment, which is a value and not a code default", () => {
+    expect(
+      managedUrlFallback("# INTELLIGENCE_API_URL=http://localhost:4201"),
+    ).toBeNull();
+    expect(
+      managedUrlFallback("INTELLIGENCE_API_URL=http://localhost:4203"),
+    ).toBeNull();
+  });
+
+  it("ignores an unrelated variable that merely takes a fallback", () => {
+    expect(
+      managedUrlFallback(
+        '  url: process.env.AGENT_URL ?? "http://localhost:8000/",',
+      ),
+    ).toBeNull();
+  });
+});
+
+/**
+ * The same failure by a second route. An `.env.example` is copied to `.env`, so
+ * an uncommented managed URL there hands the reader the local value the code no
+ * longer defaults to. Three starters did it, two of them directly under a
+ * comment telling the reader to leave the variable unset (OSS-981).
+ */
+describe("managedUrlEnvFileAssignment", () => {
+  it("flags an uncommented assignment with a value", () => {
+    expect(
+      managedUrlEnvFileAssignment("INTELLIGENCE_API_URL=http://localhost:4203"),
+    ).toBe("INTELLIGENCE_API_URL");
+    expect(
+      managedUrlEnvFileAssignment(
+        "INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4403",
+      ),
+    ).toBe("INTELLIGENCE_GATEWAY_WS_URL");
+  });
+
+  it("allows a commented assignment, which sets nothing", () => {
+    expect(
+      managedUrlEnvFileAssignment(
+        "# INTELLIGENCE_API_URL=http://localhost:4201",
+      ),
+    ).toBeNull();
+  });
+
+  it("allows an empty assignment, which is the documented managed setting", () => {
+    expect(managedUrlEnvFileAssignment("INTELLIGENCE_API_URL=")).toBeNull();
+  });
+
+  it("ignores a different Intelligence variable", () => {
+    expect(
+      managedUrlEnvFileAssignment("INTELLIGENCE_API_KEY=cpk_example"),
+    ).toBeNull();
+  });
+});
+
+describe("the repository", () => {
+  // A repo-wide scan: several `git grep` passes over the whole tree.
+  it("never overrides the managed Intelligence URL defaults", () => {
+    const offenders = findViolations().filter(
+      (violation) => violation.reason === MANAGED_URL_FALLBACK_REASON,
+    );
+
+    expect(
+      offenders.map((violation) => `${violation.file}:${violation.line}`),
+    ).toEqual([]);
+  }, 60_000);
+
+  it("never ships an env example that sets a managed Intelligence URL", () => {
+    const offenders = findViolations().filter(
+      (violation) => violation.reason === MANAGED_URL_ENV_FILE_REASON,
+    );
+
+    expect(
+      offenders.map((violation) => `${violation.file}:${violation.line}`),
+    ).toEqual([]);
+  }, 60_000);
+});
+
+/** Kept in step with the reason string the validator reports. */
+const MANAGED_URL_FALLBACK_REASON =
+  "overrides the managed Intelligence default; omit the fallback";
+
+/** Kept in step with the reason string the validator reports. */
+const MANAGED_URL_ENV_FILE_REASON =
+  "env example sets a managed Intelligence URL; comment it out";

--- a/scripts/validate-intelligence-env-names.ts
+++ b/scripts/validate-intelligence-env-names.ts
@@ -30,9 +30,19 @@ import * as path from "node:path";
  * The managed pair is `api.intelligence.copilotkit.ai` /
  * `realtime.intelligence.copilotkit.ai`.
  *
+ * Finally it guards the two env vars that feed `CopilotKitIntelligence`'s
+ * `apiUrl` and `wsUrl`. Those options resolve to the managed hosts when they are
+ * omitted, so supplying a code fallback for either variable silently overrides
+ * the one setting that is always correct against the managed service. Every
+ * starter route did exactly that, defaulting a managed reader onto a local
+ * stack that is not running (OSS-981) — the failure its own `.env.example`
+ * warns about. The rule is the pattern rather than the literal: a staging host
+ * substituted for localhost would be just as wrong.
+ *
  * This is a documentation-drift guard, not a runtime check. It fails on a
  * retired name reappearing anywhere, on the alias appearing outside its
- * allowlist, and on a dead host appearing outside its allowlist.
+ * allowlist, on a dead host appearing outside its allowlist, and on a managed
+ * URL fallback appearing outside its allowlist.
  */
 
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -101,6 +111,99 @@ const DEAD_HOST_ALLOWLIST = [
   "packages/channels-intelligence/src/realtime-gateway.test.ts",
   "scripts/validate-intelligence-env-names.ts",
 ];
+
+/**
+ * Env vars that feed `CopilotKitIntelligence`'s `apiUrl` and `wsUrl`. Both
+ * options default to the managed hosts when omitted, so a fallback here is
+ * never load-bearing — it can only replace a correct default with a worse one.
+ */
+const MANAGED_URL_ENV_VARS = [
+  "INTELLIGENCE_API_URL",
+  "INTELLIGENCE_GATEWAY_WS_URL",
+] as const;
+
+/** Reported for a code fallback on a {@link MANAGED_URL_ENV_VARS} entry. */
+const MANAGED_URL_FALLBACK_REASON =
+  "overrides the managed Intelligence default; omit the fallback";
+
+/**
+ * Paths allowed to write a managed URL fallback.
+ *
+ * Both carry the pattern as text — the rule's own definition and its fixtures —
+ * so matching them would make the check fail on itself.
+ */
+const MANAGED_URL_FALLBACK_ALLOWLIST = [
+  "scripts/validate-intelligence-env-names.ts",
+  "scripts/__tests__/validate-intelligence-env-names.test.ts",
+  // Playwright harnesses that stand up a local Intelligence on dedicated ports
+  // and drive it with a seed key. Here the fallback is the point: resolving to
+  // the managed hosts would aim an offline test suite at production.
+  "examples/showcases/banking/playwright.config.ts",
+  "examples/showcases/reskinnable-demo/playwright.config.ts",
+];
+
+/**
+ * Returns the managed URL env var this line supplies a default for, or `null`.
+ *
+ * Only a `process.env` read can carry a code default. A bare `NAME=value` line
+ * in an `.env.example` is a value a reader opts into, not a default that
+ * overrides one, so it is left alone; and the conditional-spread form
+ * (`...(process.env.X ? { apiUrl: process.env.X } : {})`) is the correct
+ * pattern, which passes because it never names a fallback.
+ *
+ * @param text - One line of source.
+ * @returns The offending variable name, or `null` when the line is fine.
+ */
+export function managedUrlFallback(text: string): string | null {
+  for (const name of MANAGED_URL_ENV_VARS) {
+    if (
+      new RegExp(String.raw`process\.env\.${name}\s*(\?\?|\|\|)`).test(text)
+    ) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/** Reported for an env example that assigns a {@link MANAGED_URL_ENV_VARS} entry. */
+const MANAGED_URL_ENV_FILE_REASON =
+  "env example sets a managed Intelligence URL; comment it out";
+
+/**
+ * Paths allowed to assign a managed URL in an env example.
+ *
+ * `agentcore/docker` is the local development stack documented in
+ * `agentcore/docs/LOCAL_DEVELOPMENT.md`; its whole purpose is a local
+ * deployment, so naming one is correct there.
+ */
+const MANAGED_URL_ENV_FILE_ALLOWLIST = [
+  "examples/integrations/agentcore/docker/.env.example",
+  // Local demo stacks, each pinned to its own vendored docker-compose ports and
+  // seeded org key so the two can run side by side. Both name a local
+  // deployment on purpose; neither is a managed-service starting point.
+  "examples/showcases/banking/.env.example",
+  "examples/showcases/reskinnable-demo/.env.example",
+];
+
+/**
+ * Returns the managed URL env var this env-file line assigns, or `null`.
+ *
+ * An `.env.example` is copied to `.env`, so an uncommented assignment hands the
+ * reader a value rather than leaving the managed default in place. A commented
+ * line documents the self-hosted override without setting it, and an empty
+ * assignment is the documented managed setting; both pass.
+ *
+ * @param text - One line of an env file.
+ * @returns The offending variable name, or `null` when the line is fine.
+ */
+export function managedUrlEnvFileAssignment(text: string): string | null {
+  for (const name of MANAGED_URL_ENV_VARS) {
+    if (new RegExp(String.raw`^\s*${name}=\S`).test(text)) {
+      return name;
+    }
+  }
+  return null;
+}
 
 interface Violation {
   file: string;
@@ -175,6 +278,33 @@ export function findViolations(): Violation[] {
     }
   }
 
+  for (const envVar of MANAGED_URL_ENV_VARS) {
+    for (const hit of grepRepo(envVar)) {
+      if (MANAGED_URL_FALLBACK_ALLOWLIST.includes(hit.file)) continue;
+      if (!managedUrlFallback(hit.text)) continue;
+      violations.push({
+        file: hit.file,
+        line: hit.line,
+        name: envVar,
+        reason: MANAGED_URL_FALLBACK_REASON,
+      });
+    }
+  }
+
+  for (const envVar of MANAGED_URL_ENV_VARS) {
+    for (const hit of grepRepo(envVar)) {
+      if (!path.basename(hit.file).startsWith(".env")) continue;
+      if (MANAGED_URL_ENV_FILE_ALLOWLIST.includes(hit.file)) continue;
+      if (!managedUrlEnvFileAssignment(hit.text)) continue;
+      violations.push({
+        file: hit.file,
+        line: hit.line,
+        name: envVar,
+        reason: MANAGED_URL_ENV_FILE_REASON,
+      });
+    }
+  }
+
   return violations;
 }
 
@@ -199,7 +329,11 @@ function main(): void {
       "provisions. The canonical hosts are api.intelligence.copilotkit.ai and\n" +
       "realtime.intelligence.copilotkit.ai. If a site legitimately implements the deprecated\n" +
       "alias fallback, or genuinely needs a non-resolving host, add it to ALIAS_ALLOWLIST or\n" +
-      "DEAD_HOST_ALLOWLIST in scripts/validate-intelligence-env-names.ts.",
+      "DEAD_HOST_ALLOWLIST in scripts/validate-intelligence-env-names.ts.\n\n" +
+      "For a managed URL fallback, delete the fallback rather than changing it: apiUrl and\n" +
+      "wsUrl already default to the managed hosts when omitted. To keep a self-hosted override\n" +
+      "working, spread it conditionally:\n" +
+      "  ...(process.env.INTELLIGENCE_API_URL ? { apiUrl: process.env.INTELLIGENCE_API_URL } : {}),",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## What does this PR do?

`CopilotKitIntelligence` is built to be correct when the caller says nothing: omitting `apiUrl`/`wsUrl` resolves to `https://api.intelligence.copilotkit.ai` and `wss://realtime.intelligence.copilotkit.ai`, and its docstring says so outright — *"leaving both unset is always correct against it."*

Every starter's runtime route defeated that default:

```ts
apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
wsUrl:
  process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
```

With the variables unset — the correct configuration for a managed user — the `??` supplies localhost and the runtime aims at a local stack that is not running. This is the artifact `copilotkit init` clones, so it is the first thing a new managed user runs.

The starter's own `.env.example` already warns about exactly this failure, two files away:

> `INTELLIGENCE_API_URL` and `INTELLIGENCE_GATEWAY_WS_URL` point at a self-hosted or local Intelligence deployment only — leave them unset when using managed Intelligence, or the channel host and runtime will try to reach a local stack that usually is not running.

So the documentation was right and the code contradicted it. `channel-host.mts`, in the same directories, already had the correct shape.

### The fix

**22 runtime wiring sites** (20 route handlers, `adk-angular/server.ts`, and the AgentCore Lambda) now use the conditional spread these starters already use in `channel-host.mts`, so a self-hosted override still works and the managed default applies when absent:

```ts
...(process.env.INTELLIGENCE_API_URL
  ? { apiUrl: process.env.INTELLIGENCE_API_URL }
  : {}),
```

No hosted URL is written into the examples — the library already owns them, so this is a deletion.

**3 `.env.example` files** (`agent-spec`, `llamaindex`, `mcp-apps`) set the same values *uncommented*. Two do it directly beneath a comment telling the reader to leave them unset, and an `.env.example` is copied to `.env`, so these were the remaining route to a localhost value once the code default was gone. Commented out to match the other nineteen starters; `agent-spec` had no explanation at all and gets the standard one.

**A guard**, added to the existing `scripts/validate-intelligence-env-names.ts` rather than a new script — it already polices the canonical Intelligence key name and the two dead hosts, and its workflow is deliberately unfiltered so it sees every README, example and skill. Two rules: `managedUrlFallback` (a `??`/`||` default on either variable) and `managedUrlEnvFileAssignment` (an uncommented env-example assignment). The rule is the *pattern*, not the literal, so a staging host substituted for localhost fails the same way.

Five files legitimately want a local target and are allowlisted with their reasons: the `playwright.config.ts` and `.env.example` of the banking and reskinnable-demo showcases (own vendored compose ports 7050/7053 and 7250/7253, own seeded org keys) and `agentcore/docker/.env.example` (the documented local development stack). Resolving those to the managed hosts would aim an offline test suite at production.

`scripts/__tests__` has no general runner, so the workflow runs this test file explicitly, following the `plugin-skills-check.yml` precedent — otherwise a rule that silently stopped matching would leave the check passing on an empty result.

## Related PRs and Issues

- Closes OSS-981.
- Supersedes the canceled ENT-922, whose blocker ("do not invent hosted URLs; rewrite once the managed env contract is final") no longer applies: the contract shipped as `MANAGED_INTELLIGENCE_API_URL` / `MANAGED_INTELLIGENCE_WS_URL`, and the fix removes a fallback rather than adding a URL.
- ENT-949 shipped a warning for this class of mistake, but `warnOnPartialHostOverride` only fires on a *partial* override — both values defaulting to localhost together is not partial, so nothing warned.

## Verification

- `pnpm exec vitest run scripts/__tests__/validate-intelligence-env-names.test.ts` — 13 passed. Written first: the rules were red before they existed, then reported **48 violations across 24 files** for the code rule and **10 across 5** for the env-file rule; the fixes took both to green.
- `pnpm check:intelligence-env-names` — exit 0.
- `oxfmt --check` and `oxlint` over all 25 touched files — clean.
- The spread typechecks under `strict` + `exactOptionalPropertyTypes`, the setting that would reject `apiUrl: string | undefined`.
- The marked wiring block stays byte-identical across 21 of 22 starters (`agentcore` differs only in its runner), and no `localhost` remains inside any marked block.
- Not run locally: the 13 starter Next builds. `test_smoke-starter.yml` typechecks the route handlers in CI on this PR.

### Out of scope

`agentcore/docker/docker-compose.yml` keeps its `${INTELLIGENCE_API_URL:-http://localhost:4201}`: it is compose substitution in the documented local-dev stack, not shipped runtime code. Separately that default cannot work anyway — inside the bridge container `localhost` is the container's own loopback — but that is a different bug.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
