### PR TITLE
docs(inspector): say that Inspector needs a browser and React Native has none (refs OSS-977)

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
@@ -681,7 +681,7 @@ So read the records your app actually holds, and confirm the answer names those 
 ## Known limitations
 
 - **Markdown in a custom UI** — the rendered chat on `@copilotkit/react-native/components` renders markdown for you (via `CopilotMarkdown`, backed by `react-native-streamdown`). If you build your own UI, a plain `Text` shows markdown as-is — reuse `CopilotMarkdown` or bring your own renderer.
-- **Inspector** — the [Inspector](/inspector#where-inspector-runs) is a browser overlay that mounts a custom element into the DOM, so it has no React Native surface and `@copilotkit/react-native` does not ship it. Nothing is broken when you cannot find it. The three checks under [Proving it works](#proving-it-works) replace what it would have shown you, and the [AG-UI Event Inspector](/troubleshooting/event-inspector) in the VS Code extension covers the event stream — it reads the runtime's `/cpk-debug-events` route, not the page, so it works with no browser in the picture.
+- **Inspector** — the [Inspector](/inspector#where-inspector-runs) is a browser overlay that mounts a custom element into the DOM, so it has no React Native surface and `@copilotkit/react-native` does not ship it. The three checks under [Proving it works](#proving-it-works) cover what it would have shown you.
 - **Voice** — `@copilotkit/voice` has not been adapted for React Native; wire your own STT as above.
 - **`threadId` on `useAgent`** — not supported yet ([#6141](https://github.com/CopilotKit/CopilotKit/pull/6141)). Thread scoping comes from a chat-configuration provider; a `threadId` passed to `useAgent` does not typecheck and is ignored.
 - **Cloud provider props** — `publicApiKey` / `licenseToken` are not supported on the React Native provider; connect via `runtimeUrl`.

--- a/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
@@ -681,6 +681,7 @@ So read the records your app actually holds, and confirm the answer names those 
 ## Known limitations
 
 - **Markdown in a custom UI** — the rendered chat on `@copilotkit/react-native/components` renders markdown for you (via `CopilotMarkdown`, backed by `react-native-streamdown`). If you build your own UI, a plain `Text` shows markdown as-is — reuse `CopilotMarkdown` or bring your own renderer.
+- **Inspector** — the [Inspector](/inspector#where-inspector-runs) is a browser overlay that mounts a custom element into the DOM, so it has no React Native surface and `@copilotkit/react-native` does not ship it. Nothing is broken when you cannot find it. The three checks under [Proving it works](#proving-it-works) replace what it would have shown you, and the [AG-UI Event Inspector](/troubleshooting/event-inspector) in the VS Code extension covers the event stream — it reads the runtime's `/cpk-debug-events` route, not the page, so it works with no browser in the picture.
 - **Voice** — `@copilotkit/voice` has not been adapted for React Native; wire your own STT as above.
 - **`threadId` on `useAgent`** — not supported yet ([#6141](https://github.com/CopilotKit/CopilotKit/pull/6141)). Thread scoping comes from a chat-configuration provider; a `threadId` passed to `useAgent` does not typecheck and is ignored.
 - **Cloud provider props** — `publicApiKey` / `licenseToken` are not supported on the React Native provider; connect via `runtimeUrl`.

--- a/showcase/shell-docs/src/content/docs/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/inspector.mdx
@@ -20,24 +20,20 @@ return to the last pane you used.
 
 ## Where Inspector runs
 
-Inspector is a browser overlay. It mounts a custom element into the page's DOM,
-so it needs a browser: React, Next.js, React SPA, Vue, and Angular all have one.
+Inspector is a browser overlay: it mounts a custom element into the page's DOM.
+It runs on React, Next.js, React SPA, Vue, and Angular.
 
-There is no React Native build of Inspector, and a browser cannot stand in for a
-device — a native app has no DOM to mount into. If you are building with
-`@copilotkit/react-native`, none of the panes below are reachable from your app,
-and their absence is the frontend rather than a fault in your wiring. Debug a
-mobile integration with these instead:
+There is no React Native build of Inspector, and `@copilotkit/react-native` does
+not ship it. Channels — Slack and Teams — have no browser surface either. On
+those surfaces none of the panes below are reachable.
+
+Debug a React Native integration with these instead:
 
 | Instead of this pane | Use |
 | --- | --- |
 | Agent, and whether the runtime answers | `npx copilotkit verify --round-trip`, which sends one request through the runtime and reads the answer back off the thread. See [Proving it works](/react-native#proving-it-works). |
-| AG-UI Events | The [AG-UI Event Inspector](/troubleshooting/event-inspector) in the [VS Code Extension](/vs-code-extension). It reads the runtime's `/cpk-debug-events` route rather than the page, so the event stream stays reachable with no browser involved. |
 | Errors and tool calls | Runtime [Debug Mode](/troubleshooting/debug-mode) beside the device log — `adb logcat` on Android, where a redbox appears that a screen capture never shows. |
 | Threads | The thread view in [CopilotKit Intelligence](/premium/overview). |
-
-Channels — Slack and Teams — have no browser surface either, for the same
-reason.
 
 ## Navigation and Threads
 

--- a/showcase/shell-docs/src/content/docs/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/inspector.mdx
@@ -18,6 +18,27 @@ return to the last pane you used.
   muted
 />
 
+## Where Inspector runs
+
+Inspector is a browser overlay. It mounts a custom element into the page's DOM,
+so it needs a browser: React, Next.js, React SPA, Vue, and Angular all have one.
+
+There is no React Native build of Inspector, and a browser cannot stand in for a
+device — a native app has no DOM to mount into. If you are building with
+`@copilotkit/react-native`, none of the panes below are reachable from your app,
+and their absence is the frontend rather than a fault in your wiring. Debug a
+mobile integration with these instead:
+
+| Instead of this pane | Use |
+| --- | --- |
+| Agent, and whether the runtime answers | `npx copilotkit verify --round-trip`, which sends one request through the runtime and reads the answer back off the thread. See [Proving it works](/react-native#proving-it-works). |
+| AG-UI Events | The [AG-UI Event Inspector](/troubleshooting/event-inspector) in the [VS Code Extension](/vs-code-extension). It reads the runtime's `/cpk-debug-events` route rather than the page, so the event stream stays reachable with no browser involved. |
+| Errors and tool calls | Runtime [Debug Mode](/troubleshooting/debug-mode) beside the device log — `adb logcat` on Android, where a redbox appears that a screen capture never shows. |
+| Threads | The thread view in [CopilotKit Intelligence](/premium/overview). |
+
+Channels — Slack and Teams — have no browser surface either, for the same
+reason.
+
 ## Navigation and Threads
 
 The sidebar has three groups:

--- a/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
@@ -177,11 +177,8 @@ test("React Native and Channels do not tell the reader to click the Inspector bu
   expect(channels).not.toContain("OpenInspectorStep");
 });
 
-// Skipping the Open Inspector step keeps the docs from pointing React Native at a surface
-// it has no way to open, but silence was its own defect: a mobile developer reads the
-// Inspector as the debugging story everywhere else, finds nothing, and concludes the wiring
-// is broken. A run that reached a fully working native app on 2026-08-25 hit exactly this
-// (OSS-977). Both pages now state the absence rather than leaving the reader to infer it.
+// Skipping the Open Inspector step kept the docs from pointing React Native at a surface it
+// cannot open, but it never stated the absence. Both pages now say it (OSS-977).
 test("Inspector states that it needs a browser and React Native has none", () => {
   const inspector = read("docs/inspector.mdx");
 
@@ -191,15 +188,14 @@ test("Inspector states that it needs a browser and React Native has none", () =>
 
   // Naming the gap without naming the substitutes moves the cost rather than removing it.
   expect(inspector).toContain("copilotkit verify --round-trip");
-  expect(inspector).toContain("/troubleshooting/event-inspector");
+  expect(inspector).toContain("/troubleshooting/debug-mode");
   expect(inspector).toContain("/react-native#proving-it-works");
 });
 
 test("the React Native page lists the missing Inspector among its limitations", () => {
   const reactNative = read("docs/frontends/react-native.mdx");
 
-  // The limitations list is where a mobile developer checks what does not carry over, and
-  // it named voice and the web-only hooks while staying silent on the Inspector.
+  // The limitations list is where a mobile developer checks what does not carry over.
   const limitationsAt = reactNative.indexOf("## Known limitations");
   const inspectorAt = reactNative.indexOf("**Inspector**");
   expect(limitationsAt).toBeGreaterThanOrEqual(0);
@@ -207,11 +203,5 @@ test("the React Native page lists the missing Inspector among its limitations", 
 
   expect(reactNative).toContain("no React Native surface");
   expect(reactNative).toContain("[Inspector](/inspector#where-inspector-runs)");
-
-  // `/cpk-debug-events` is a runtime HTTP route, so the AG-UI event stream is the one
-  // Inspector pane a mobile developer can still reach. Saying so is the difference between
-  // a limitation and a dead end.
-  expect(reactNative).toContain(
-    "[AG-UI Event Inspector](/troubleshooting/event-inspector)",
-  );
+  expect(reactNative).toContain("[Proving it works](#proving-it-works)");
 });

--- a/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
@@ -176,3 +176,42 @@ test("React Native and Channels do not tell the reader to click the Inspector bu
   expect(channels).not.toContain("click the Inspector button");
   expect(channels).not.toContain("OpenInspectorStep");
 });
+
+// Skipping the Open Inspector step keeps the docs from pointing React Native at a surface
+// it has no way to open, but silence was its own defect: a mobile developer reads the
+// Inspector as the debugging story everywhere else, finds nothing, and concludes the wiring
+// is broken. A run that reached a fully working native app on 2026-08-25 hit exactly this
+// (OSS-977). Both pages now state the absence rather than leaving the reader to infer it.
+test("Inspector states that it needs a browser and React Native has none", () => {
+  const inspector = read("docs/inspector.mdx");
+
+  expect(inspector).toContain("## Where Inspector runs");
+  expect(inspector).toContain("Inspector is a browser overlay");
+  expect(inspector).toContain("There is no React Native build of Inspector");
+
+  // Naming the gap without naming the substitutes moves the cost rather than removing it.
+  expect(inspector).toContain("copilotkit verify --round-trip");
+  expect(inspector).toContain("/troubleshooting/event-inspector");
+  expect(inspector).toContain("/react-native#proving-it-works");
+});
+
+test("the React Native page lists the missing Inspector among its limitations", () => {
+  const reactNative = read("docs/frontends/react-native.mdx");
+
+  // The limitations list is where a mobile developer checks what does not carry over, and
+  // it named voice and the web-only hooks while staying silent on the Inspector.
+  const limitationsAt = reactNative.indexOf("## Known limitations");
+  const inspectorAt = reactNative.indexOf("**Inspector**");
+  expect(limitationsAt).toBeGreaterThanOrEqual(0);
+  expect(inspectorAt).toBeGreaterThan(limitationsAt);
+
+  expect(reactNative).toContain("no React Native surface");
+  expect(reactNative).toContain("[Inspector](/inspector#where-inspector-runs)");
+
+  // `/cpk-debug-events` is a runtime HTTP route, so the AG-UI event stream is the one
+  // Inspector pane a mobile developer can still reach. Saying so is the difference between
+  // a limitation and a dead end.
+  expect(reactNative).toContain(
+    "[AG-UI Event Inspector](/troubleshooting/event-inspector)",
+  );
+});

--- a/skills/inspector-docs/references/pane-map.md
+++ b/skills/inspector-docs/references/pane-map.md
@@ -25,5 +25,12 @@ Update this file in the same change that adds or removes a pane.
 
 ## Surfaces that do not get the Open Inspector step
 
-- React Native
-- Channels
+Neither has a browser, so neither can mount the overlay. Skipping the step is not
+enough on its own: a reader who meets Inspector as the debugging story everywhere
+else and then finds nothing reads that as broken wiring. Each surface states the
+absence and names what to use instead.
+
+| Surface      | Where the absence is stated                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| React Native | `docs/inspector.mdx` "Where Inspector runs", and the Known limitations list on `docs/frontends/react-native.mdx` |
+| Channels     | `docs/inspector.mdx` "Where Inspector runs"                                                                      |

--- a/skills/inspector-docs/references/pane-map.md
+++ b/skills/inspector-docs/references/pane-map.md
@@ -25,9 +25,7 @@ Update this file in the same change that adds or removes a pane.
 
 ## Surfaces that do not get the Open Inspector step
 
-Neither has a browser, so neither can mount the overlay. Skipping the step is not
-enough on its own: a reader who meets Inspector as the debugging story everywhere
-else and then finds nothing reads that as broken wiring. Each surface states the
+Neither has a browser, so neither can mount the overlay. Each surface states the
 absence and names what to use instead.
 
 | Surface      | Where the absence is stated                                                                                      |


### PR DESCRIPTION
## Problem

Inspector is a browser overlay, so a React Native developer cannot open it. Nothing in the docs said so.

The docs already skipped the Open Inspector step on React Native, so they never told a mobile developer to click a button that isn't there. But they also never stated the absence, and Inspector is presented as the debugging story on every other frontend.

An onboarding run on 2026-08-25 reached a fully working native app on an Android emulator — round trip proven, three grounded turns typed into the device — and fell back to `adb exec-out screencap` for visual proof, with no way to tell whether the missing Inspector meant something was wrong.

## Why the absence is permanent

- `packages/react-core/src/v2/components/CopilotKitInspector.tsx` mounts `@copilotkit/web-inspector` through `@lit-labs/react` — a Lit custom element needing `document` and `customElements`.
- `packages/react-native` does not depend on `@copilotkit/web-inspector`, and `packages/react-native/src/__tests__/headless-entry-surface.test.ts` lists it in `FORBIDDEN_HEAVY`, so that test fails if the mobile bundle ever reaches it.

This documents an existing, tested architectural decision. No Inspector or package change.

## Change

- **`docs/inspector.mdx`** — new `## Where Inspector runs` section, placed before the pane tour so a reader learns whether the page applies to them before learning its navigation. It states the browser requirement and maps the panes a mobile developer loses onto what replaces them: `npx copilotkit verify --round-trip`, runtime Debug Mode beside `adb logcat`, and the Intelligence thread view.
- **`docs/frontends/react-native.mdx`** — Inspector added to **Known limitations**, the list a mobile developer actually checks. It already named voice, the web-only rendering hooks, `threadId`, and the cloud provider props.
- **`skills/inspector-docs/references/pane-map.md`** — the "Surfaces that do not get the Open Inspector step" section now records where each browserless surface states its absence.

Channels — Slack and Teams — are named in the same section for the same reason.

## Tests

`inspector-docs.test.ts` already had a negative guard (`React Native and Channels do not tell the reader to click the Inspector button`), which forbade the wrong statement without requiring the right one. Two positive tests now require it:

- `Inspector states that it needs a browser and React Native has none`
- `the React Native page lists the missing Inspector among its limitations`

Both were written first and observed failing.

## Verification

- `showcase/shell-docs` `inspector-docs.test.ts`: **11/11 pass** (9 before, +2 new).
- Mutation check: replacing `There is no React Native build of Inspector` and `no React Native surface` in the two pages fails both new tests (2 failed | 9 passed), so they are not self-fulfilling.
- `oxfmt --check` and `oxlint` clean on the changed test.
- `scripts/sync-plugin-skills.ts --check`: `plugin skill mirror in sync` (`inspector-docs` is a `RESERVED_LIFECYCLE_SLUGS` standalone skill, so root `skills/` is its source, not a mirror).
- The full shell-docs suite shows 18 unrelated failures in `channels-guide-search`, `registry`, `setup-content`, `setup-concept`, and `llm-text`. **Confirmed pre-existing**: the same 18 fail identically in a pristine `origin/main` worktree sharing the same `node_modules` and the same generated `src/data`. None of them read either page touched here.

## Companion

The CLI half is CopilotKit/Intelligence#1001 — the onboarding graph's completion prompt carried the same unconditional "How to use the CopilotKit Inspector" instruction. Both carry `refs OSS-977` rather than `closes`, so the ticket stays open until both land.
