### PR TITLE
feat(web-inspector): preview launcher HUD on load

### DIFF
--- a/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
@@ -127,6 +127,7 @@ let cleanup: (() => void) | null = null;
 afterEach(() => {
   cleanup?.();
   cleanup = null;
+  vi.useRealTimers();
 });
 
 async function settle(inspector: WebInspectorElement): Promise<void> {
@@ -211,9 +212,54 @@ async function setup(options: Options = {}): Promise<{
   return { inspector, openHud, clickHud, pressLauncher };
 }
 
-test("the HUD is closed until the launcher is hovered", async () => {
+test("the HUD stays closed during the initial page-settle delay", async () => {
   const { inspector } = await setup();
   expect(hud(inspector)).toBeNull();
+});
+
+test("the HUD previews every feature in sequence on page load, then leaves", async () => {
+  vi.useFakeTimers();
+  const { inspector } = await setup({
+    intelligence: true,
+    endpoints: ENABLED_ENDPOINTS,
+  });
+
+  expect(hud(inspector)).toBeNull();
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(inspector);
+
+  const introHud = requireElement(hud(inspector));
+  expect(introHud.getAttribute("data-cpk-hud-intro")).toBe("true");
+  expect(hudRowLabels(inspector)).toEqual([
+    "Open Inspector",
+    "Threads on",
+    "Intelligence connected",
+    "Learning on",
+  ]);
+  expect(
+    Array.from(
+      root(inspector).querySelectorAll<HTMLElement>("[data-cpk-hud-row]"),
+    ).map((row) => row.style.getPropertyValue("--cpk-hud-row-delay")),
+  ).toEqual(["180ms", "350ms", "520ms", "690ms"]);
+
+  await vi.advanceTimersByTimeAsync(3400);
+  await settle(inspector);
+  expect(hud(inspector)).toBeNull();
+});
+
+test("hovering during the page-load preview keeps the HUD open", async () => {
+  vi.useFakeTimers();
+  const { inspector, openHud } = await setup();
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(inspector);
+  expect(hudOpen(inspector)).toBe(true);
+
+  await openHud();
+  await vi.advanceTimersByTimeAsync(3400);
+  await settle(inspector);
+
+  expect(hudOpen(inspector)).toBe(true);
+  expect(hud(inspector)?.hasAttribute("data-cpk-hud-intro")).toBe(false);
 });
 
 test("hovering the launcher shows Open Inspector, Threads, Intelligence, and Learning", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
@@ -742,11 +742,13 @@ test("the launcher animates opacity, transform and a clip — nothing that force
   const context = await setup();
   const css = stylesheetText(context.inspector);
 
-  const keyframes = Array.from(
+  const keyframeMatches = Array.from(
     css.matchAll(/@keyframes\s+cpk-launcher-[\w-]+\s*\{([\s\S]*?\}\s*)\}/g),
-  ).map((match) => match[1] ?? "");
-  // Two for the halo, and one per direction for the pill's reveal.
-  expect(keyframes).toHaveLength(4);
+  );
+  const keyframes = keyframeMatches.map((match) => match[1] ?? "");
+  // Two for the halo, one per direction for both launcher reveals, and one
+  // each for the HUD row and connected check stagger.
+  expect(keyframes).toHaveLength(8);
 
   const animated = new Set(
     keyframes

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -571,6 +571,21 @@ type InspectorColorScheme = "light" | "dark";
 const EDGE_MARGIN = 16;
 /** HUD card plus the hover bridge. Used to pick left vs right. */
 const LAUNCHER_HUD_WIDTH = 248;
+/**
+ * One page-load preview of the launcher's feature HUD.
+ *
+ * The card arrives after the host page has had a beat to settle. Its four rows
+ * then come online in order, stay readable, and leave together. Nothing is
+ * persisted: a new Inspector element means a new preview.
+ */
+const LAUNCHER_HUD_INTRO_MS = {
+  delay: 500,
+  duration: 3400,
+  rowStart: 180,
+  rowStagger: 170,
+  rowDuration: 300,
+  blockedRetry: 250,
+} as const;
 const DRAG_THRESHOLD = 6;
 const MIN_WINDOW_WIDTH = 880;
 const MIN_WINDOW_WIDTH_DOCKED_LEFT = 640;
@@ -5949,6 +5964,10 @@ export class WebInspectorElement extends LitElement {
   private launcherHudSide: "left" | "right" = "left";
   private launcherHudHelp: LauncherHudRowId | null = null;
   private launcherHudCloseTimer: ReturnType<typeof setTimeout> | null = null;
+  private launcherHudIntro = false;
+  private launcherHudIntroStartTimer: ReturnType<typeof setTimeout> | null =
+    null;
+  private launcherHudIntroEndTimer: ReturnType<typeof setTimeout> | null = null;
   /**
    * Leaf a HUD row asked for. Consumed by `openInspector` so a red dot on
    * the circle cannot steal "Turn on Threads". Not a public open option.
@@ -8967,6 +8986,103 @@ ${argsString}</pre
       }
 
       /*
+       * On mount, borrow the hover HUD for one short introduction. The card
+       * establishes the destination first; its rows then resolve in order so
+       * the eye can count the available features instead of receiving one
+       * undifferentiated block. Only opacity and transform move.
+       */
+      @keyframes cpk-launcher-hud-intro {
+        0% {
+          opacity: 0;
+          transform: translateX(8px);
+        }
+        8%,
+        88% {
+          opacity: 1;
+          transform: none;
+        }
+        100% {
+          opacity: 0;
+          transform: translateX(4px);
+        }
+      }
+
+      @keyframes cpk-launcher-hud-intro-right {
+        0% {
+          opacity: 0;
+          transform: translateX(-8px);
+        }
+        8%,
+        88% {
+          opacity: 1;
+          transform: none;
+        }
+        100% {
+          opacity: 0;
+          transform: translateX(-4px);
+        }
+      }
+
+      @keyframes cpk-launcher-hud-row-online {
+        from {
+          opacity: 0;
+          transform: translateY(4px);
+        }
+        to {
+          opacity: 1;
+          transform: none;
+        }
+      }
+
+      @keyframes cpk-launcher-hud-check-online {
+        from {
+          opacity: 0;
+          transform: scale(0.65);
+        }
+        to {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+      .cpk-launcher-hud[data-cpk-hud-intro="true"] {
+        animation: cpk-launcher-hud-intro
+          var(--cpk-launcher-hud-intro-duration)
+          cubic-bezier(0.16, 1, 0.3, 1) both;
+      }
+
+      .cpk-launcher-hud[data-cpk-hud-intro="true"][data-cpk-hud-side="right"] {
+        animation-name: cpk-launcher-hud-intro-right;
+      }
+
+      .cpk-launcher-hud[data-cpk-hud-intro="true"]
+        .cpk-launcher-hud__row {
+        animation: cpk-launcher-hud-row-online
+          var(--cpk-launcher-hud-row-duration)
+          cubic-bezier(0.16, 1, 0.3, 1) both;
+        animation-delay: var(--cpk-hud-row-delay);
+      }
+
+      .cpk-launcher-hud[data-cpk-hud-intro="true"]
+        .cpk-launcher-hud__check {
+        animation: cpk-launcher-hud-check-online 220ms
+          cubic-bezier(0.16, 1, 0.3, 1) both;
+        animation-delay: calc(var(--cpk-hud-row-delay) + 90ms);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .cpk-launcher-hud[data-cpk-hud-intro="true"],
+        .cpk-launcher-hud[data-cpk-hud-intro="true"]
+          .cpk-launcher-hud__row,
+        .cpk-launcher-hud[data-cpk-hud-intro="true"]
+          .cpk-launcher-hud__check {
+          animation: none !important;
+          opacity: 1;
+          transform: none;
+        }
+      }
+
+      /*
        * Marker on the navigation entry, which is what keeps a signal alive
        * once the panel is open and the launcher is hidden. Static by design:
        * the beat belongs to the launcher, and movement here would compete with
@@ -9391,6 +9507,7 @@ ${argsString}</pre
     this.threadsSetupPromptCopyState = "idle";
     this.stopSignalPulse();
     this.cancelGestureTail();
+    this.cancelLauncherHudIntro();
     this.cancelThreadRefreshDebounce();
     this.clearInspectorUsageRefresh();
     this.cleanupThreadsExampleOverviewVideo();
@@ -9451,6 +9568,7 @@ ${argsString}</pre
     this.ensureAnnouncementLoading();
 
     this.updateHostTransform(this.isOpen ? "window" : "button");
+    this.scheduleLauncherHudIntro();
   }
 
   render() {
@@ -9753,6 +9871,50 @@ ${argsString}</pre
     return this.gestureSignal !== null;
   }
 
+  private scheduleLauncherHudIntro(
+    delay: number = LAUNCHER_HUD_INTRO_MS.delay,
+  ): void {
+    if (this.launcherHudIntroStartTimer !== null) {
+      clearTimeout(this.launcherHudIntroStartTimer);
+    }
+    this.launcherHudIntroStartTimer = setTimeout(() => {
+      this.launcherHudIntroStartTimer = null;
+      if (!this.isConnected || this.isOpen) return;
+      if (this.isLauncherHudBlocked()) {
+        this.scheduleLauncherHudIntro(LAUNCHER_HUD_INTRO_MS.blockedRetry);
+        return;
+      }
+
+      this.resolveLauncherHudSide();
+      this.launcherHudIntro = true;
+      this.launcherHudOpen = true;
+      this.requestUpdate();
+      this.launcherHudIntroEndTimer = setTimeout(() => {
+        this.launcherHudIntroEndTimer = null;
+        this.launcherHudIntro = false;
+        this.launcherHudOpen = false;
+        this.launcherHudHelp = null;
+        this.requestUpdate();
+      }, LAUNCHER_HUD_INTRO_MS.duration);
+    }, delay);
+  }
+
+  private cancelLauncherHudIntro(): void {
+    if (this.launcherHudIntroStartTimer !== null) {
+      clearTimeout(this.launcherHudIntroStartTimer);
+      this.launcherHudIntroStartTimer = null;
+    }
+    if (this.launcherHudIntroEndTimer !== null) {
+      clearTimeout(this.launcherHudIntroEndTimer);
+      this.launcherHudIntroEndTimer = null;
+    }
+    if (!this.launcherHudIntro) return;
+    this.launcherHudIntro = false;
+    if (this.isConnected) {
+      this.requestUpdate();
+    }
+  }
+
   private resolveLauncherHudSide(): void {
     if (typeof window === "undefined") {
       this.launcherHudSide = "left";
@@ -9785,6 +9947,7 @@ ${argsString}</pre
   }
 
   private closeLauncherHud(): void {
+    this.cancelLauncherHudIntro();
     if (this.launcherHudCloseTimer !== null) {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
@@ -9796,6 +9959,7 @@ ${argsString}</pre
   }
 
   private handleLauncherHudEnter = (): void => {
+    this.cancelLauncherHudIntro();
     this.openLauncherHud();
   };
 
@@ -9810,6 +9974,7 @@ ${argsString}</pre
   };
 
   private handleLauncherHudFocusIn = (): void => {
+    this.cancelLauncherHudIntro();
     this.openLauncherHud();
   };
 
@@ -9899,6 +10064,7 @@ ${argsString}</pre
     label: string;
     detail: string;
     connected?: boolean;
+    introIndex: number;
   }): TemplateResult {
     const helpOpen = this.launcherHudHelp === args.id;
     const detailId = `cpk-hud-detail-${args.id}`;
@@ -9907,6 +10073,13 @@ ${argsString}</pre
         class="cpk-launcher-hud__row"
         data-cpk-hud-row=${args.id}
         data-cpk-hud-help=${helpOpen ? "open" : nothing}
+        style=${styleMap({
+          "--cpk-hud-row-index": `${args.introIndex}`,
+          "--cpk-hud-row-delay": `${
+            LAUNCHER_HUD_INTRO_MS.rowStart +
+            args.introIndex * LAUNCHER_HUD_INTRO_MS.rowStagger
+          }ms`,
+        })}
         @click=${(event: Event) => this.handleHudRowClick(event, args.id)}
       >
         <button
@@ -9954,7 +10127,12 @@ ${argsString}</pre
         id="cpk-launcher-hud"
         data-cpk-launcher-hud
         data-cpk-hud-side=${this.launcherHudSide}
+        data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
         data-color-scheme=${this.colorScheme}
+        style=${styleMap({
+          "--cpk-launcher-hud-intro-duration": `${LAUNCHER_HUD_INTRO_MS.duration}ms`,
+          "--cpk-launcher-hud-row-duration": `${LAUNCHER_HUD_INTRO_MS.rowDuration}ms`,
+        })}
       >
         <span class="cpk-launcher-hud__arrow" aria-hidden="true"></span>
         <div class="cpk-launcher-hud__card">
@@ -9963,6 +10141,7 @@ ${argsString}</pre
               id: "inspector",
               label: HUD_OPEN_INSPECTOR_LABEL,
               detail: HUD_OPEN_INSPECTOR_DETAIL,
+              introIndex: 0,
             })}
           </ul>
           <ul class="cpk-launcher-hud__list" role="list">
@@ -9973,6 +10152,7 @@ ${argsString}</pre
                 ? HUD_THREADS_ON_DETAIL
                 : HUD_THREADS_OFF_DETAIL,
               connected: threadsOn,
+              introIndex: 1,
             })}
             ${this.renderHudRow({
               id: "intelligence",
@@ -9983,6 +10163,7 @@ ${argsString}</pre
                 ? HUD_INTELLIGENCE_ON_DETAIL
                 : HUD_INTELLIGENCE_OFF_DETAIL,
               connected: intelligenceOn,
+              introIndex: 2,
             })}
             ${this.renderHudRow({
               id: "learning",
@@ -9993,6 +10174,7 @@ ${argsString}</pre
                 ? HUD_LEARNING_ON_DETAIL
                 : HUD_LEARNING_OFF_DETAIL,
               connected: learningOn,
+              introIndex: 3,
             })}
           </ul>
         </div>


### PR DESCRIPTION
## Summary

Automatically preview the existing launcher HUD on every Inspector mount, then fade it away after the feature statuses resolve.

## Why

The closed Inspector launcher did not draw attention to the feature availability and enablement links already exposed on hover.

## How

- open the HUD after a short page-settle delay
- stagger the four rows and connected checks with compositor-only motion
- let hover or focus take control without an automatic close
- respect reduced motion and clean up mount timers
- cover the lifecycle with focused tests