### PR TITLE
test(examples): gate the starters' Intelligence wiring block on one shape (closes OSS-982)

### DIFF
--- a/.github/workflows/static_intelligence-env-names.yml
+++ b/.github/workflows/static_intelligence-env-names.yml
@@ -1,4 +1,4 @@
-name: static / intelligence env names
+name: static / intelligence contracts
 
 # Deliberately unfiltered. A non-canonical Intelligence key name can appear in
 # any README, example, skill, or doc page, and the two workflows that would
@@ -6,6 +6,10 @@ name: static / intelligence env names
 # static/quality by `paths-ignore: examples/**`, which is precisely where the
 # deprecated alias still lives. Scoping this job would re-open the hole it
 # exists to close.
+#
+# The wiring-block check needs the same reach for the same reason. The starters'
+# Intelligence block lives under `examples/**`, which static/quality ignores,
+# and the parity drift check exempts the route it sits in (OSS-982).
 on:
   push:
     branches: [main]
@@ -45,3 +49,12 @@ jobs:
 
       - name: Check Intelligence env var names are canonical
         run: pnpm check:intelligence-env-names
+
+      # Same reasoning as above: the rules are unit-tested here because nothing
+      # else executes scripts/__tests__, and a discovery grep that stopped
+      # matching would leave the check below passing on an empty file list.
+      - name: Test the wiring-block validator's rules
+        run: pnpm exec vitest run scripts/__tests__/validate-intelligence-wiring-block.test.ts
+
+      - name: Check the starters' Intelligence wiring block is one shape
+        run: pnpm check:intelligence-wiring-block

--- a/.github/workflows/static_intelligence-env-names.yml
+++ b/.github/workflows/static_intelligence-env-names.yml
@@ -37,5 +37,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # The rules are unit-tested here rather than by a general runner: nothing
+      # else executes scripts/__tests__, so a rule that silently stopped
+      # matching would leave the check below passing on an empty result.
+      - name: Test the validator's rules
+        run: pnpm exec vitest run scripts/__tests__/validate-intelligence-env-names.test.ts
+
       - name: Check Intelligence env var names are canonical
         run: pnpm check:intelligence-env-names

--- a/examples/integrations/_parity/README.md
+++ b/examples/integrations/_parity/README.md
@@ -34,7 +34,10 @@ Per-instance `allowedDivergence` list in `manifest.json`:
 - `agent/**` — agents are written in different languages/runtimes (Python
   create_agent, TS StateGraph, Python StateGraph+FastAPI). Human-authored.
 - `src/app/api/copilotkit/**` — north-star uses `LangGraphAgent`, Docker
-  instances use `HttpAgent`. Different routes.
+  instances use `HttpAgent`. Different routes. The Intelligence wiring block
+  inside those routes is held to one shape by
+  `scripts/validate-intelligence-wiring-block.ts`, which covers all 22 starters
+  rather than the 7 tracked here (OSS-982).
 - `Dockerfile`, `docker/Dockerfile.agent`, `serve.py`, `scripts/**` —
   language-specific build/run tooling.
 

--- a/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
+++ b/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
@@ -90,9 +90,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
+++ b/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
@@ -97,8 +97,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub - replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,8 +23,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub - replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/adk-angular/server.ts
+++ b/examples/integrations/adk-angular/server.ts
@@ -19,9 +19,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history. The id

--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -24,7 +24,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/agent-spec/.env.example
+++ b/examples/integrations/agent-spec/.env.example
@@ -4,5 +4,9 @@ AGENT_URL=http://localhost:8000/
 # Optional: enable CopilotKit Intelligence Threads locally
 COPILOTKIT_LICENSE_TOKEN=
 INTELLIGENCE_API_KEY=
-INTELLIGENCE_API_URL=http://localhost:4201
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# INTELLIGENCE_API_URL and INTELLIGENCE_GATEWAY_WS_URL point at a self-hosted
+# or local Intelligence deployment only — leave them unset when using managed
+# Intelligence, or the channel host and runtime will try to reach a local
+# stack that usually is not running.
+# INTELLIGENCE_API_URL=http://localhost:4201
+# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -32,8 +32,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -25,9 +25,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -133,9 +133,12 @@ export function buildApp() {
       ? {
           intelligence: new CopilotKitIntelligence({
             apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-            apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-            wsUrl:
-              process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+            ...(process.env.INTELLIGENCE_API_URL
+              ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+              : {}),
+            ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+              ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+              : {}),
           }),
           // Demo stub — replace with your real auth-derived user identity before any
           // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -141,7 +141,9 @@ export function buildApp() {
               : {}),
           }),
           // Demo stub — replace with your real auth-derived user identity before any
-          // multi-user deployment, or all users share one thread history.
+          // multi-user deployment, or all users share one thread history. The id
+          // must correspond to a user that exists in CopilotKit Intelligence;
+          // an unknown id (like this literal) can make thread operations fail.
           identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
           licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
         }

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -24,7 +24,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -29,7 +29,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -29,7 +29,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -30,8 +30,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,9 +23,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -18,9 +18,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -25,8 +25,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -32,7 +32,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -24,9 +24,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -24,7 +24,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -24,7 +24,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/llamaindex/.env.example
+++ b/examples/integrations/llamaindex/.env.example
@@ -8,5 +8,5 @@ INTELLIGENCE_API_KEY=
 # self-hosted or local Intelligence deployment only — leave them unset (or
 # blank) when using managed Intelligence, or the channel host and runtime
 # will try to reach a local stack that usually is not running.
-INTELLIGENCE_API_URL=http://localhost:4203
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4403
+# INTELLIGENCE_API_URL=http://localhost:4203
+# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4403

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,8 +23,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,8 +21,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -14,9 +14,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/mcp-apps/.env.example
+++ b/examples/integrations/mcp-apps/.env.example
@@ -7,5 +7,5 @@ INTELLIGENCE_API_KEY=
 # self-hosted or local Intelligence deployment only — leave them unset (or
 # blank) when using managed Intelligence, or the channel host and runtime
 # will try to reach a local stack that usually is not running.
-INTELLIGENCE_API_URL=http://localhost:4201
-INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401
+# INTELLIGENCE_API_URL=http://localhost:4201
+# INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4401

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,8 +23,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -16,9 +16,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,6 +23,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -19,9 +19,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -26,6 +26,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -19,9 +19,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
         // before any multi-user deployment, or all users share one thread history.

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -26,8 +26,10 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your own auth-derived user identity (e.g. OIDC)
-        // before any multi-user deployment, or all users share one thread history.
+        // Demo stub — replace with your real auth-derived user identity before any
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -29,7 +29,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,9 +21,12 @@ const runtime = new CopilotRuntime({
     ? {
         intelligence: new CopilotKitIntelligence({
           apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
-          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",
-          wsUrl:
-            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",
+          ...(process.env.INTELLIGENCE_API_URL
+            ? { apiUrl: process.env.INTELLIGENCE_API_URL }
+            : {}),
+          ...(process.env.INTELLIGENCE_GATEWAY_WS_URL
+            ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
+            : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
         // multi-user deployment, or all users share one thread history.

--- a/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -29,7 +29,9 @@ const runtime = new CopilotRuntime({
             : {}),
         }),
         // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history.
+        // multi-user deployment, or all users share one thread history. The id
+        // must correspond to a user that exists in CopilotKit Intelligence;
+        // an unknown id (like this literal) can make thread operations fail.
         identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "validate:model-names": "tsx scripts/validate-doc-model-names.ts",
     "validate:retired-anthropic-models": "nx run repo-scripts:validate-retired-anthropic-models",
     "check:intelligence-env-names": "tsx scripts/validate-intelligence-env-names.ts",
+    "check:intelligence-wiring-block": "tsx scripts/validate-intelligence-wiring-block.ts",
     "check:plugin-skills": "tsx scripts/sync-plugin-skills.ts --check",
     "generate:channel-native-catalogs": "node scripts/channel-native-catalogs.mjs generate",
     "check:channel-native-catalogs": "node scripts/channel-native-catalogs.mjs check",

--- a/scripts/__tests__/validate-intelligence-env-names.test.ts
+++ b/scripts/__tests__/validate-intelligence-env-names.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  findViolations,
+  managedUrlEnvFileAssignment,
+  managedUrlFallback,
+} from "../validate-intelligence-env-names.js";
+
+/**
+ * `CopilotKitIntelligence` resolves `apiUrl`/`wsUrl` to the managed hosts when
+ * they are omitted, so supplying any fallback for the two env vars that feed
+ * them overrides that default. A starter that does it points a managed user at
+ * whatever the fallback names — in practice a local stack that is not running
+ * (OSS-981).
+ *
+ * The rule is the pattern, not the literal: a staging host substituted for
+ * localhost would be just as wrong, so the check flags the fallback itself.
+ */
+describe("managedUrlFallback", () => {
+  it("flags a nullish fallback on the API URL", () => {
+    expect(
+      managedUrlFallback(
+        '          apiUrl: process.env.INTELLIGENCE_API_URL ?? "http://localhost:4201",',
+      ),
+    ).toBe("INTELLIGENCE_API_URL");
+  });
+
+  it("flags a nullish fallback on the gateway websocket URL", () => {
+    expect(
+      managedUrlFallback(
+        '            process.env.INTELLIGENCE_GATEWAY_WS_URL ?? "ws://localhost:4401",',
+      ),
+    ).toBe("INTELLIGENCE_GATEWAY_WS_URL");
+  });
+
+  it("flags a logical-or fallback, which fails the same way", () => {
+    expect(
+      managedUrlFallback(
+        '  const apiUrl = process.env.INTELLIGENCE_API_URL || "https://staging.example.com";',
+      ),
+    ).toBe("INTELLIGENCE_API_URL");
+  });
+
+  it("allows the conditional spread, which leaves the managed default in place", () => {
+    expect(
+      managedUrlFallback("    ...(process.env.INTELLIGENCE_API_URL"),
+    ).toBeNull();
+    expect(
+      managedUrlFallback(
+        "      ? { apiUrl: process.env.INTELLIGENCE_API_URL }",
+      ),
+    ).toBeNull();
+  });
+
+  it("allows a bare read with no default", () => {
+    expect(
+      managedUrlFallback("  apiUrl: process.env.INTELLIGENCE_API_URL,"),
+    ).toBeNull();
+  });
+
+  it("allows an env file assignment, which is a value and not a code default", () => {
+    expect(
+      managedUrlFallback("# INTELLIGENCE_API_URL=http://localhost:4201"),
+    ).toBeNull();
+    expect(
+      managedUrlFallback("INTELLIGENCE_API_URL=http://localhost:4203"),
+    ).toBeNull();
+  });
+
+  it("ignores an unrelated variable that merely takes a fallback", () => {
+    expect(
+      managedUrlFallback(
+        '  url: process.env.AGENT_URL ?? "http://localhost:8000/",',
+      ),
+    ).toBeNull();
+  });
+});
+
+/**
+ * The same failure by a second route. An `.env.example` is copied to `.env`, so
+ * an uncommented managed URL there hands the reader the local value the code no
+ * longer defaults to. Three starters did it, two of them directly under a
+ * comment telling the reader to leave the variable unset (OSS-981).
+ */
+describe("managedUrlEnvFileAssignment", () => {
+  it("flags an uncommented assignment with a value", () => {
+    expect(
+      managedUrlEnvFileAssignment("INTELLIGENCE_API_URL=http://localhost:4203"),
+    ).toBe("INTELLIGENCE_API_URL");
+    expect(
+      managedUrlEnvFileAssignment(
+        "INTELLIGENCE_GATEWAY_WS_URL=ws://localhost:4403",
+      ),
+    ).toBe("INTELLIGENCE_GATEWAY_WS_URL");
+  });
+
+  it("allows a commented assignment, which sets nothing", () => {
+    expect(
+      managedUrlEnvFileAssignment(
+        "# INTELLIGENCE_API_URL=http://localhost:4201",
+      ),
+    ).toBeNull();
+  });
+
+  it("allows an empty assignment, which is the documented managed setting", () => {
+    expect(managedUrlEnvFileAssignment("INTELLIGENCE_API_URL=")).toBeNull();
+  });
+
+  it("ignores a different Intelligence variable", () => {
+    expect(
+      managedUrlEnvFileAssignment("INTELLIGENCE_API_KEY=cpk_example"),
+    ).toBeNull();
+  });
+});
+
+describe("the repository", () => {
+  // A repo-wide scan: several `git grep` passes over the whole tree.
+  it("never overrides the managed Intelligence URL defaults", () => {
+    const offenders = findViolations().filter(
+      (violation) => violation.reason === MANAGED_URL_FALLBACK_REASON,
+    );
+
+    expect(
+      offenders.map((violation) => `${violation.file}:${violation.line}`),
+    ).toEqual([]);
+  }, 60_000);
+
+  it("never ships an env example that sets a managed Intelligence URL", () => {
+    const offenders = findViolations().filter(
+      (violation) => violation.reason === MANAGED_URL_ENV_FILE_REASON,
+    );
+
+    expect(
+      offenders.map((violation) => `${violation.file}:${violation.line}`),
+    ).toEqual([]);
+  }, 60_000);
+});
+
+/** Kept in step with the reason string the validator reports. */
+const MANAGED_URL_FALLBACK_REASON =
+  "overrides the managed Intelligence default; omit the fallback";
+
+/** Kept in step with the reason string the validator reports. */
+const MANAGED_URL_ENV_FILE_REASON =
+  "env example sets a managed Intelligence URL; comment it out";

--- a/scripts/__tests__/validate-intelligence-wiring-block.test.ts
+++ b/scripts/__tests__/validate-intelligence-wiring-block.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPEN_MARKER,
+  blockDiff,
+  extractBlock,
+  findViolations,
+  markerFiles,
+  maskRunner,
+  normalizeBlock,
+  runnerName,
+} from "../validate-intelligence-wiring-block.js";
+
+/**
+ * A starter's Intelligence wiring is the one region a hosted reader copies
+ * verbatim, and until this check landed nothing held it still. The parity
+ * manifest lists `src/app/api/copilotkit/**` under `allowedDivergence` for
+ * every instance it tracks, and no smoke test sets `COPILOTKIT_LICENSE_TOKEN`,
+ * so the `intelligence:` arm has never executed in CI (OSS-982).
+ *
+ * The block was already byte-identical in 21 of 22 starters when the check was
+ * written, so this is a ratchet rather than a migration. What had drifted was
+ * the warning comment — into five variants, two of them missing outright — and
+ * that drift is how the localhost default of OSS-981 survived in all 22 copies.
+ */
+
+const CANONICAL = `  // --- copilotkit:intelligence (remove this block to opt out) ---
+  ...(process.env.COPILOTKIT_LICENSE_TOKEN
+    ? {
+        intelligence: new CopilotKitIntelligence({
+          apiKey: process.env.INTELLIGENCE_API_KEY ?? "",
+        }),
+        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
+      }
+    : { runner: new InMemoryAgentRunner() }),
+  // --- /copilotkit:intelligence ---`;
+
+describe("extractBlock", () => {
+  it("returns the marker-delimited region, both markers included", () => {
+    const source = `export const runtime = new CopilotRuntime({\n${CANONICAL}\n});\n`;
+
+    expect(extractBlock(source)).toBe(CANONICAL);
+  });
+
+  it("returns null when the file carries no opening marker", () => {
+    expect(
+      extractBlock("export const runtime = new CopilotRuntime({});\n"),
+    ).toBe(null);
+  });
+
+  it("returns null for an unterminated block, so the caller can report it", () => {
+    const source = `${OPEN_MARKER}\n  ...(process.env.COPILOTKIT_LICENSE_TOKEN ? {} : {}),\n`;
+
+    expect(extractBlock(source)).toBe(null);
+  });
+});
+
+/**
+ * The block sits at a different nesting depth in `agentcore`, whose runtime is
+ * a Lambda handler rather than a Next.js route, so a raw string comparison
+ * would report every line of it. Depth is not drift; the code is what matters.
+ */
+describe("normalizeBlock", () => {
+  it("dedents to the shallowest line", () => {
+    expect(normalizeBlock("    a\n      b\n    c")).toBe("a\n  b\nc");
+  });
+
+  it("makes the same block at two nesting depths compare equal", () => {
+    const deeper = CANONICAL.split("\n")
+      .map((line) => `  ${line}`)
+      .join("\n");
+
+    expect(normalizeBlock(deeper)).toBe(normalizeBlock(CANONICAL));
+  });
+
+  it("strips carriage returns and trailing spaces", () => {
+    expect(normalizeBlock("  a  \r\n  b\r\n")).toBe("a\nb");
+  });
+});
+
+/**
+ * The else arm is the one line that legitimately differs: `agentcore` runs
+ * `AgentCoreRunner` because its agent is a Bedrock AgentCore session, not an
+ * in-process runner. Masking the name lets the rest of the block be compared
+ * exactly while the name itself is checked against a per-starter expectation.
+ */
+describe("runnerName", () => {
+  it("reads the runner out of the else arm", () => {
+    expect(runnerName(CANONICAL)).toBe("InMemoryAgentRunner");
+  });
+
+  it("reads a different runner", () => {
+    const agentcore = CANONICAL.replace(
+      "InMemoryAgentRunner",
+      "AgentCoreRunner",
+    );
+
+    expect(runnerName(agentcore)).toBe("AgentCoreRunner");
+  });
+
+  it("returns null when the else arm constructs nothing", () => {
+    const noRunner = CANONICAL.replace(
+      ": { runner: new InMemoryAgentRunner() }),",
+      ": {}),",
+    );
+
+    expect(runnerName(noRunner)).toBe(null);
+  });
+});
+
+describe("maskRunner", () => {
+  it("makes two blocks that differ only in the runner compare equal", () => {
+    const agentcore = CANONICAL.replace(
+      "InMemoryAgentRunner",
+      "AgentCoreRunner",
+    );
+
+    expect(maskRunner(agentcore)).toBe(maskRunner(CANONICAL));
+  });
+
+  it("leaves every other difference visible", () => {
+    const drifted = CANONICAL.replace("demo-user", "someone-else");
+
+    expect(maskRunner(drifted)).not.toBe(maskRunner(CANONICAL));
+  });
+});
+
+describe("blockDiff", () => {
+  it("returns null for identical blocks", () => {
+    expect(blockDiff(CANONICAL, CANONICAL)).toBe(null);
+  });
+
+  it("reports the first differing line, numbered from one", () => {
+    const drifted = CANONICAL.replace(
+      '        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),',
+      '        identifyUser: () => ({ id: "someone-else", name: "Demo User" }),',
+    );
+
+    expect(blockDiff(CANONICAL, drifted)).toEqual({
+      line: 7,
+      expected:
+        '        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),',
+      actual:
+        '        identifyUser: () => ({ id: "someone-else", name: "Demo User" }),',
+    });
+  });
+
+  it("reports a missing line as an absent actual", () => {
+    const truncated = CANONICAL.split("\n").slice(0, 3).join("\n");
+
+    expect(blockDiff(CANONICAL, truncated)?.line).toBe(4);
+  });
+
+  it("reports an extra line as an absent expectation", () => {
+    const extended = `${CANONICAL}\n  // trailing`;
+
+    expect(blockDiff(CANONICAL, extended)).toEqual({
+      line: 12,
+      expected: null,
+      actual: "  // trailing",
+    });
+  });
+});
+
+/**
+ * Two assertions, because either alone can pass while the check does nothing.
+ * A count that dropped to zero would make the violation list vacuously empty —
+ * the failure mode of every `passWithNoTests` gate — so the file count is
+ * asserted against the starter inventory as well.
+ */
+describe("the repository's wiring sites", () => {
+  it("finds one marked site in every starter that wires Intelligence", () => {
+    expect(markerFiles().length).toBeGreaterThanOrEqual(22);
+  });
+
+  it("holds every site to one shape", () => {
+    expect(findViolations()).toEqual([]);
+  });
+});

--- a/scripts/validate-intelligence-env-names.ts
+++ b/scripts/validate-intelligence-env-names.ts
@@ -30,9 +30,19 @@ import * as path from "node:path";
  * The managed pair is `api.intelligence.copilotkit.ai` /
  * `realtime.intelligence.copilotkit.ai`.
  *
+ * Finally it guards the two env vars that feed `CopilotKitIntelligence`'s
+ * `apiUrl` and `wsUrl`. Those options resolve to the managed hosts when they are
+ * omitted, so supplying a code fallback for either variable silently overrides
+ * the one setting that is always correct against the managed service. Every
+ * starter route did exactly that, defaulting a managed reader onto a local
+ * stack that is not running (OSS-981) — the failure its own `.env.example`
+ * warns about. The rule is the pattern rather than the literal: a staging host
+ * substituted for localhost would be just as wrong.
+ *
  * This is a documentation-drift guard, not a runtime check. It fails on a
  * retired name reappearing anywhere, on the alias appearing outside its
- * allowlist, and on a dead host appearing outside its allowlist.
+ * allowlist, on a dead host appearing outside its allowlist, and on a managed
+ * URL fallback appearing outside its allowlist.
  */
 
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -101,6 +111,99 @@ const DEAD_HOST_ALLOWLIST = [
   "packages/channels-intelligence/src/realtime-gateway.test.ts",
   "scripts/validate-intelligence-env-names.ts",
 ];
+
+/**
+ * Env vars that feed `CopilotKitIntelligence`'s `apiUrl` and `wsUrl`. Both
+ * options default to the managed hosts when omitted, so a fallback here is
+ * never load-bearing — it can only replace a correct default with a worse one.
+ */
+const MANAGED_URL_ENV_VARS = [
+  "INTELLIGENCE_API_URL",
+  "INTELLIGENCE_GATEWAY_WS_URL",
+] as const;
+
+/** Reported for a code fallback on a {@link MANAGED_URL_ENV_VARS} entry. */
+const MANAGED_URL_FALLBACK_REASON =
+  "overrides the managed Intelligence default; omit the fallback";
+
+/**
+ * Paths allowed to write a managed URL fallback.
+ *
+ * Both carry the pattern as text — the rule's own definition and its fixtures —
+ * so matching them would make the check fail on itself.
+ */
+const MANAGED_URL_FALLBACK_ALLOWLIST = [
+  "scripts/validate-intelligence-env-names.ts",
+  "scripts/__tests__/validate-intelligence-env-names.test.ts",
+  // Playwright harnesses that stand up a local Intelligence on dedicated ports
+  // and drive it with a seed key. Here the fallback is the point: resolving to
+  // the managed hosts would aim an offline test suite at production.
+  "examples/showcases/banking/playwright.config.ts",
+  "examples/showcases/reskinnable-demo/playwright.config.ts",
+];
+
+/**
+ * Returns the managed URL env var this line supplies a default for, or `null`.
+ *
+ * Only a `process.env` read can carry a code default. A bare `NAME=value` line
+ * in an `.env.example` is a value a reader opts into, not a default that
+ * overrides one, so it is left alone; and the conditional-spread form
+ * (`...(process.env.X ? { apiUrl: process.env.X } : {})`) is the correct
+ * pattern, which passes because it never names a fallback.
+ *
+ * @param text - One line of source.
+ * @returns The offending variable name, or `null` when the line is fine.
+ */
+export function managedUrlFallback(text: string): string | null {
+  for (const name of MANAGED_URL_ENV_VARS) {
+    if (
+      new RegExp(String.raw`process\.env\.${name}\s*(\?\?|\|\|)`).test(text)
+    ) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/** Reported for an env example that assigns a {@link MANAGED_URL_ENV_VARS} entry. */
+const MANAGED_URL_ENV_FILE_REASON =
+  "env example sets a managed Intelligence URL; comment it out";
+
+/**
+ * Paths allowed to assign a managed URL in an env example.
+ *
+ * `agentcore/docker` is the local development stack documented in
+ * `agentcore/docs/LOCAL_DEVELOPMENT.md`; its whole purpose is a local
+ * deployment, so naming one is correct there.
+ */
+const MANAGED_URL_ENV_FILE_ALLOWLIST = [
+  "examples/integrations/agentcore/docker/.env.example",
+  // Local demo stacks, each pinned to its own vendored docker-compose ports and
+  // seeded org key so the two can run side by side. Both name a local
+  // deployment on purpose; neither is a managed-service starting point.
+  "examples/showcases/banking/.env.example",
+  "examples/showcases/reskinnable-demo/.env.example",
+];
+
+/**
+ * Returns the managed URL env var this env-file line assigns, or `null`.
+ *
+ * An `.env.example` is copied to `.env`, so an uncommented assignment hands the
+ * reader a value rather than leaving the managed default in place. A commented
+ * line documents the self-hosted override without setting it, and an empty
+ * assignment is the documented managed setting; both pass.
+ *
+ * @param text - One line of an env file.
+ * @returns The offending variable name, or `null` when the line is fine.
+ */
+export function managedUrlEnvFileAssignment(text: string): string | null {
+  for (const name of MANAGED_URL_ENV_VARS) {
+    if (new RegExp(String.raw`^\s*${name}=\S`).test(text)) {
+      return name;
+    }
+  }
+  return null;
+}
 
 interface Violation {
   file: string;
@@ -175,6 +278,33 @@ export function findViolations(): Violation[] {
     }
   }
 
+  for (const envVar of MANAGED_URL_ENV_VARS) {
+    for (const hit of grepRepo(envVar)) {
+      if (MANAGED_URL_FALLBACK_ALLOWLIST.includes(hit.file)) continue;
+      if (!managedUrlFallback(hit.text)) continue;
+      violations.push({
+        file: hit.file,
+        line: hit.line,
+        name: envVar,
+        reason: MANAGED_URL_FALLBACK_REASON,
+      });
+    }
+  }
+
+  for (const envVar of MANAGED_URL_ENV_VARS) {
+    for (const hit of grepRepo(envVar)) {
+      if (!path.basename(hit.file).startsWith(".env")) continue;
+      if (MANAGED_URL_ENV_FILE_ALLOWLIST.includes(hit.file)) continue;
+      if (!managedUrlEnvFileAssignment(hit.text)) continue;
+      violations.push({
+        file: hit.file,
+        line: hit.line,
+        name: envVar,
+        reason: MANAGED_URL_ENV_FILE_REASON,
+      });
+    }
+  }
+
   return violations;
 }
 
@@ -199,7 +329,11 @@ function main(): void {
       "provisions. The canonical hosts are api.intelligence.copilotkit.ai and\n" +
       "realtime.intelligence.copilotkit.ai. If a site legitimately implements the deprecated\n" +
       "alias fallback, or genuinely needs a non-resolving host, add it to ALIAS_ALLOWLIST or\n" +
-      "DEAD_HOST_ALLOWLIST in scripts/validate-intelligence-env-names.ts.",
+      "DEAD_HOST_ALLOWLIST in scripts/validate-intelligence-env-names.ts.\n\n" +
+      "For a managed URL fallback, delete the fallback rather than changing it: apiUrl and\n" +
+      "wsUrl already default to the managed hosts when omitted. To keep a self-hosted override\n" +
+      "working, spread it conditionally:\n" +
+      "  ...(process.env.INTELLIGENCE_API_URL ? { apiUrl: process.env.INTELLIGENCE_API_URL } : {}),",
   );
   process.exit(1);
 }

--- a/scripts/validate-intelligence-wiring-block.ts
+++ b/scripts/validate-intelligence-wiring-block.ts
@@ -1,0 +1,308 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Holds the starters' Intelligence wiring block to one shape.
+ *
+ * Every starter ends its runtime construction with the same marked region: a
+ * spread that reads `COPILOTKIT_LICENSE_TOKEN` and either wires the managed
+ * platform or falls back to a local runner. It is the region a hosted reader
+ * copies verbatim, and nothing gated it (OSS-982). Both gaps that could have
+ * caught drift are deliberate:
+ *
+ * - The parity manifest lists `src/app/api/copilotkit/**` under
+ *   `allowedDivergence` for every instance it tracks, so the drift check skips
+ *   the route on purpose. What it does hold byte-identical is the demo
+ *   frontend.
+ * - No `docker-compose.test.yml` sets `COPILOTKIT_LICENSE_TOKEN`, so every
+ *   smoke-tested starter takes the else arm. The `intelligence:` arm has never
+ *   run in CI.
+ *
+ * The cost was already visible. The block's code was byte-identical in 21 of 22
+ * starters, but its warning comment had drifted into five variants and two
+ * starters shipped the `demo-user` stub with no warning at all. Comment drift
+ * is harmless by itself; it is the tracer showing nothing held the region
+ * still, and it is how the localhost default of OSS-981 survived in all 22
+ * copies at once.
+ *
+ * The check compares each site against the north-star starter rather than
+ * against a literal kept here, so improving the block means editing the north
+ * star and running the other 21 to match. Two normalisations keep it honest
+ * without weakening it: the block is dedented, because `agentcore` nests it
+ * deeper, and the else arm's runner name is masked, because that name is the
+ * one thing a starter may legitimately choose. Everything else, comment text
+ * included, must match to the byte.
+ *
+ * This is a shape gate, not a content gate. It cannot tell a good block from a
+ * bad one — 22 identically wrong copies still pass. What it guarantees is that
+ * a fix reaches all of them or none.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+/** Opens every wiring site. Selects the code sites and nothing else. */
+export const OPEN_MARKER =
+  "// --- copilotkit:intelligence (remove this block to opt out) ---";
+
+/** Closes every wiring site. */
+export const CLOSE_MARKER = "// --- /copilotkit:intelligence ---";
+
+/**
+ * The starter every other site is compared against, matching `northStar` in
+ * `examples/integrations/_parity/manifest.json`.
+ */
+const NORTH_STAR =
+  "examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts";
+
+/** Stands in for the else arm's runner while the rest is compared exactly. */
+const RUNNER_PLACEHOLDER = "«runner»";
+
+/**
+ * The runner each starter is expected to name in its else arm.
+ *
+ * Anything absent from this map must use `InMemoryAgentRunner`. `agentcore` is
+ * the one exception in the tree: its runtime is a Lambda handler in front of a
+ * Bedrock AgentCore session, so an in-process runner has nothing to run.
+ * Adding an entry is a deliberate act, which is the point — a runner swapped in
+ * by accident fails instead.
+ */
+const EXPECTED_RUNNER: Record<string, string> = {
+  agentcore: "AgentCoreRunner",
+};
+
+/** Used for every starter with no {@link EXPECTED_RUNNER} entry. */
+const DEFAULT_RUNNER = "InMemoryAgentRunner";
+
+/**
+ * Returns the marked wiring region of one source file, markers included.
+ *
+ * @param source - The file's full text.
+ * @returns The region, or `null` when the file has no opening marker or the
+ *   block is never closed. The caller reports the unterminated case; discovery
+ *   already guarantees the opening marker is present.
+ */
+export function extractBlock(source: string): string | null {
+  const start = source.indexOf(OPEN_MARKER);
+  if (start === -1) return null;
+
+  const end = source.indexOf(CLOSE_MARKER, start + OPEN_MARKER.length);
+  if (end === -1) return null;
+
+  const lineStart = source.lastIndexOf("\n", start) + 1;
+  return source.slice(lineStart, end + CLOSE_MARKER.length);
+}
+
+/**
+ * Removes the block's own indentation and any trailing whitespace.
+ *
+ * The block sits two levels deeper in `agentcore` than in a Next.js route.
+ * Nesting depth is a property of the file around the block, not of the block,
+ * so it is normalised away; relative indentation inside the block is kept.
+ *
+ * @param block - A wiring region, as returned by {@link extractBlock}.
+ * @returns The block, dedented to its shallowest line and newline-normalised.
+ */
+export function normalizeBlock(block: string): string {
+  const lines = block.replace(/\r\n?/g, "\n").split("\n");
+  const indents = lines
+    .filter((line) => line.trim() !== "")
+    .map((line) => line.length - line.trimStart().length);
+  const base = indents.length > 0 ? Math.min(...indents) : 0;
+
+  return lines
+    .map((line) => line.slice(base).trimEnd())
+    .join("\n")
+    .trim();
+}
+
+/**
+ * Returns the runner the else arm constructs, or `null`.
+ *
+ * @param block - A wiring region.
+ * @returns The constructor name, or `null` when the arm constructs nothing —
+ *   which is itself a violation, since the fallback is what makes the starter
+ *   run without a license.
+ */
+export function runnerName(block: string): string | null {
+  return /:\s*\{\s*runner:\s*new\s+(\w+)\s*\(/.exec(block)?.[1] ?? null;
+}
+
+/**
+ * Replaces the else arm's runner name with {@link RUNNER_PLACEHOLDER}.
+ *
+ * @param block - A wiring region.
+ * @returns The block with the runner masked, leaving every other difference
+ *   visible to {@link blockDiff}.
+ */
+export function maskRunner(block: string): string {
+  return block.replace(
+    /(:\s*\{\s*runner:\s*new\s+)\w+(\s*\()/,
+    `$1${RUNNER_PLACEHOLDER}$2`,
+  );
+}
+
+/** One line where two blocks disagree. `null` means the line is absent. */
+export interface BlockDiff {
+  line: number;
+  expected: string | null;
+  actual: string | null;
+}
+
+/**
+ * Returns the first line where two blocks disagree, or `null`.
+ *
+ * @param expected - The north star's normalised block.
+ * @param actual - The site's normalised block.
+ * @returns The first disagreement, numbered from one, or `null` when the two
+ *   are identical.
+ */
+export function blockDiff(expected: string, actual: string): BlockDiff | null {
+  const want = expected.split("\n");
+  const got = actual.split("\n");
+
+  for (let i = 0; i < Math.max(want.length, got.length); i++) {
+    if (want[i] === got[i]) continue;
+    return {
+      line: i + 1,
+      expected: want[i] ?? null,
+      actual: got[i] ?? null,
+    };
+  }
+  return null;
+}
+
+/**
+ * Returns every file carrying a wiring marker, repository-relative.
+ *
+ * Discovery is a grep rather than a list, so a starter added later is covered
+ * the day it lands. Two things are excluded by construction rather than by an
+ * allowlist: the `.env.example` files, which use a different marker text, and
+ * this file and its test, which quote the marker and sit outside `examples`.
+ */
+export function markerFiles(): string[] {
+  let out: string;
+  try {
+    out = execFileSync(
+      "git",
+      ["grep", "-l", "--fixed-strings", OPEN_MARKER, "--", "examples"],
+      { cwd: REPO_ROOT, encoding: "utf-8" },
+    );
+  } catch {
+    // git grep exits 1 when there are no matches.
+    return [];
+  }
+  return out.split("\n").filter(Boolean).sort();
+}
+
+/** The starter directory a wiring site belongs to. */
+function starterOf(file: string): string {
+  return file.split("/")[2] ?? file;
+}
+
+function readBlock(file: string): string | null {
+  const source = fs.readFileSync(path.join(REPO_ROOT, file), "utf-8");
+  const block = extractBlock(source);
+  return block === null ? null : normalizeBlock(block);
+}
+
+interface Violation {
+  file: string;
+  reason: string;
+}
+
+/** Collects every wiring site that disagrees with the north star. */
+export function findViolations(): Violation[] {
+  const violations: Violation[] = [];
+
+  const canonical = readBlock(NORTH_STAR);
+  if (canonical === null) {
+    return [
+      {
+        file: NORTH_STAR,
+        reason: "north-star wiring block is missing or unterminated",
+      },
+    ];
+  }
+
+  for (const file of markerFiles()) {
+    const block = readBlock(file);
+    if (block === null) {
+      violations.push({
+        file,
+        reason: `block is never closed; add ${CLOSE_MARKER}`,
+      });
+      continue;
+    }
+
+    const runner = runnerName(block);
+    const wanted = EXPECTED_RUNNER[starterOf(file)] ?? DEFAULT_RUNNER;
+    if (runner === null) {
+      violations.push({
+        file,
+        reason: `else arm constructs no runner; expected new ${wanted}()`,
+      });
+    } else if (runner !== wanted) {
+      violations.push({
+        file,
+        reason: `else arm uses ${runner}; expected ${wanted}`,
+      });
+    }
+
+    const diff = blockDiff(maskRunner(canonical), maskRunner(block));
+    if (diff !== null) {
+      violations.push({
+        file,
+        reason:
+          `line ${diff.line} differs from the north star\n` +
+          `      expected: ${diff.expected ?? "(no line)"}\n` +
+          `      actual:   ${diff.actual ?? "(no line)"}`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function main(): void {
+  const files = markerFiles();
+  const violations = findViolations();
+
+  if (files.length === 0) {
+    console.log(
+      "Found no Intelligence wiring markers. Either every starter lost its\n" +
+        `wiring or OPEN_MARKER no longer matches the tree:\n  ${OPEN_MARKER}`,
+    );
+    process.exit(1);
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `All ${files.length} Intelligence wiring sites match ${starterOf(NORTH_STAR)}.`,
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `Found ${violations.length} Intelligence wiring site${
+      violations.length === 1 ? "" : "s"
+    } out of shape:\n`,
+  );
+  for (const v of violations) {
+    console.log(`  ${v.file}\n      ${v.reason}`);
+  }
+  console.log(
+    `\nEvery starter's wiring block must match ${NORTH_STAR}, ignoring nesting\n` +
+      "depth and the else arm's runner name. To change the block, edit the north star and\n" +
+      "run the other sites to match; a fix that reaches one starter must reach all of them.\n" +
+      "To let a starter name a different runner, add it to EXPECTED_RUNNER in\n" +
+      "scripts/validate-intelligence-wiring-block.ts with the reason.",
+  );
+  process.exit(1);
+}
+
+const isDirectRun = typeof require !== "undefined" && require.main === module;
+
+if (isDirectRun) {
+  main();
+}


### PR DESCRIPTION
**Merge order: #6711 → #6718 → this PR.**

#6718 rewrites `identifyUser` in the same 22 blocks and is a sibling of this branch, not stacked on it, so the two overlap on the same lines. Landing the gate last means it ratchets on the finished shape and avoids a conflict. If this PR goes first instead, #6718 goes red until it moves all 22 sites together — which is the gate working, but noisier.

Stacked on #6711 — merge that first. This branch descends from it, so the diff below carries its commit too; GitHub drops those once #6711 lands.

Basing this PR on `main` rather than on #6711's branch is deliberate: 17 of 35 workflows filter `pull_request: branches: [main]`, including the one this PR extends, so a PR based on the 981 branch would not run the check it adds.

## Problem

The marked block that wires managed Intelligence is the region a hosted reader copies verbatim, and nothing checked it. Both gaps are deliberate, not accidental:

- `examples/integrations/_parity/manifest.json` lists `src/app/api/copilotkit/**` under `allowedDivergence` for every instance it tracks. What parity does hold byte-identical is the demo frontend: 54 verbatim paths of example canvas, todo columns and charts.
- No `examples/integrations/*/docker-compose.test.yml` sets `COPILOTKIT_LICENSE_TOKEN`. The wiring is a ternary on that variable, so all 13 smoke-tested starters take the else arm. The `intelligence:` arm has never executed in CI, in any starter.

The cost was already visible. The block's code was byte-identical in 21 of 22 starters, but its warning comment had drifted into five variants and the two `ms-agent-framework-*` starters shipped the `demo-user` stub with no warning at all. Comment drift is harmless by itself; it is the tracer showing nothing held the region still, and it is how the localhost default of #6711 survived in all 22 copies at once.

## Change

`scripts/validate-intelligence-wiring-block.ts` greps the opening marker, compares every site against the north-star starter, and fails on the first line that differs. Two normalisations keep it usable:

- The block is dedented, because `agentcore` nests it two levels deeper — its runtime is a Lambda handler, not a Next.js route.
- The else arm's runner name is masked, because `agentcore` runs `AgentCoreRunner` in front of a Bedrock AgentCore session where an in-process runner has nothing to run. `EXPECTED_RUNNER` holds that one exception, so a runner swapped in by accident still fails.

Everything else, comment text included, must match to the byte. Then the warning is unified at all 22 sites on the fullest existing wording, which also says the id must exist in Intelligence or thread operations can fail.

It compares against the north star rather than a literal kept in the script, so improving the block means editing `langgraph-python` and running the other 21 to match.

## What it does and does not guarantee

It is a shape gate, not a content gate: 22 identically wrong copies still pass. What it guarantees is that a fix reaches all of them or none. The check passes on day one — 21 of 22 already matched on code — so it is a ratchet, not a migration.

## Verification

Mutating a real starter three ways, each caught:

| Mutation | Reported as |
| --- | --- |
| Dropped one comment line | `line 15 differs from the north star`, exit 1 |
| \`InMemoryAgentRunner\` → \`SomeOtherRunner\` | `else arm uses SomeOtherRunner; expected InMemoryAgentRunner` |
| Reintroduced \`?? \"http://localhost:4201\"\` | `line 6 differs`, both sides shown |

The third matters: the #6711 regression is now caught at a second site, independent of the env-name validator.

Commands run, all exit 0:

- `pnpm exec vitest run scripts/__tests__/validate-intelligence-wiring-block.test.ts scripts/__tests__/validate-intelligence-env-names.test.ts` — 30 passed
- `pnpm check:intelligence-wiring-block` — `All 22 Intelligence wiring sites match langgraph-python.`
- `pnpm check:intelligence-env-names` — unaffected, still canonical
- `pnpm parity:verify`
- `oxfmt --check`, `oxlint`, and `tsc --noEmit --strict` on the new pair

Two tests guard the gate against going vacuous: one asserts at least 22 marker files are discovered, so an empty violation list cannot pass on an empty file list.

Not run locally: the lefthook pre-commit suite, which fails environmentally in a worktree without per-package installs (`sh: vite: command not found`). This diff touches no package source.

## Not covered

Enrolling the `intelligence:` arm in the smoke path. It needs a license token in CI secrets and an endpoint reachable from the compose network — a different size of job, tracked separately.
