### PR TITLE
fix(channels-slack): stop answering Slack revisions that changed no text (closes OSS-989)

### DIFF
--- a/.changeset/slack-ignore-metadata-revisions.md
+++ b/.changeset/slack-ignore-metadata-revisions.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/channels-slack": patch
----
-
-fix(channels-slack): stop answering Slack revisions that changed no text

--- a/.changeset/slack-ignore-metadata-revisions.md
+++ b/.changeset/slack-ignore-metadata-revisions.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/channels-slack": patch
+---
+
+fix(channels-slack): stop answering Slack revisions that changed no text

--- a/packages/channels-slack/src/ingress-normalize.test.ts
+++ b/packages/channels-slack/src/ingress-normalize.test.ts
@@ -343,6 +343,86 @@ describe("normalizeSlackEvent", () => {
     });
   });
 
+  it("ignores a revision that leaves the text alone", () => {
+    // What Slack sends when a reply lands in the message's thread: same text,
+    // no `edited` stamp, a fresh `event_ts` the engine's dedup cannot collapse.
+    // Answering it revises the message again, which is the loop.
+    expect(
+      normalizeSlackEvent(
+        {
+          event: {
+            type: "message",
+            subtype: "message_changed",
+            channel: "C1",
+            event_ts: "101.2",
+            message: {
+              user: "U2",
+              text: "<@BOT> say hi",
+              ts: "100.1",
+            },
+            previous_message: {
+              user: "U2",
+              text: "<@BOT> say hi",
+              ts: "100.1",
+            },
+          },
+        },
+        "BOT",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("ignores a revision with no edit stamp and nothing to compare against", () => {
+    expect(
+      normalizeSlackEvent(
+        {
+          event: {
+            type: "message",
+            subtype: "message_changed",
+            channel: "C1",
+            event_ts: "101.2",
+            message: {
+              user: "U2",
+              text: "<@BOT> say hi",
+              ts: "100.1",
+            },
+          },
+        },
+        "BOT",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps a revision whose text a person actually changed", () => {
+    expect(
+      normalizeSlackEvent(
+        {
+          event: {
+            type: "message",
+            subtype: "message_changed",
+            channel: "C1",
+            event_ts: "101.2",
+            message: {
+              user: "U2",
+              text: "<@BOT> say hi in French",
+              ts: "100.1",
+              edited: { ts: "101.2" },
+            },
+            previous_message: {
+              user: "U2",
+              text: "<@BOT> say hi",
+              ts: "100.1",
+            },
+          },
+        },
+        "BOT",
+      ),
+    ).toMatchObject({
+      userText: "say hi in French",
+      operation: { kind: "updated", mentioned: true, revisionId: "101.2" },
+    });
+  });
+
   it("maps a slash command", () => {
     const n = normalizeSlackEvent({
       command: "/triage",

--- a/packages/channels-slack/src/ingress-normalize.ts
+++ b/packages/channels-slack/src/ingress-normalize.ts
@@ -247,6 +247,32 @@ export function normalizeSlackEvent(
     const text = deleted ? "" : String(message.text ?? "").trim();
     const hasFiles = hasFilesOn(message);
     if (!deleted && !text && !hasFiles) return undefined;
+    /**
+     * `message_changed` does not mean somebody edited the text. Slack also
+     * sends it when a reply lands in the message's thread, when a link
+     * unfurls, and when attachments are added — and every one of those carries
+     * a fresh `revisionId`, which is exactly what the engine's dedup keys on
+     * (deliberately: a real edit must not be swallowed as a duplicate).
+     *
+     * Forwarding them turns one @mention into an unbounded loop. The bot
+     * answers, the answer revises the parent message, the revision arrives
+     * still carrying the mention, and it answers again — observed live as
+     * ~50 identical replies to one "@bot say hi" in eight seconds.
+     *
+     * `previous_message` is the direct evidence when Slack sends it. When it
+     * does not, `edited` stands in: Slack stamps that only when a person
+     * actually edited the message, and the metadata-only revisions that cause
+     * the loop have neither.
+     */
+    if (subtype === "message_changed") {
+      const previousText =
+        typeof previous?.text === "string" ? previous.text.trim() : undefined;
+      const textChanged =
+        previousText !== undefined
+          ? previousText !== text
+          : edited !== undefined;
+      if (!textChanged) return undefined;
+    }
     const isDM = event.channel_type === "im";
     const eventId = deriveEventId(body, event, channel);
     const mentioned =


### PR DESCRIPTION
One `@bot say hi` in a Slack channel produced about fifty identical replies in eight seconds. The loop is in shared ingress code, so it reaches any Channels app on Slack, not just the one that found it.

## What happens

`message_changed` does not mean somebody edited the text. Slack also sends it when a reply lands in the message's thread, when a link unfurls, and when attachments are added.

Every one of those carries a fresh `revisionId`, and that is exactly what the engine's inbound dedup keys on — deliberately, so a real edit is never swallowed as a duplicate. So each announcement arrived as a fresh mention and started another turn: the bot answered, the answer revised the parent message, the revision asked the same question again, and the next answer revised it again.

Instrumenting one mention showed eleven turns reaching the app. One was the original message. Ten were revisions of it.

## The fix

A revision is a turn only when its text actually differs.

`previous_message` is the direct evidence where Slack sends it. Where it does not, `edited` stands in: Slack stamps that only when a person edited the message, and the metadata-only revisions that cause the loop have neither. Edited mentions still reach the app, deletes are untouched, and the normalizer stays pure — so this covers the Intelligence-side webhook ingress that shares it as well as the local adapter.

## Verification

- `packages/channels-slack`: 414 tests pass, three of them new.
- Each new test fails without the guard (checked by reverting it).
- Found and confirmed against a live Slack workspace, running an OpenTag Composio integration. After the fix: one mention, one agent run, one reply.

The app that hit this carries a local workaround — it ignores any turn that is not the first revision of a message — which it can drop once this ships.