### PR TITLE
fix(examples): derive identifyUser from request headers (closes OSS-987)

### DIFF
--- a/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
+++ b/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
@@ -97,11 +97,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
+++ b/examples/integrations/a2a-a2ui/app/api/copilotkit/[[...slug]]/route.tsx
@@ -97,7 +97,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/a2a-middleware/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/adk-angular/README.md
+++ b/examples/integrations/adk-angular/README.md
@@ -92,7 +92,7 @@ Run `copilotkit license` to provision a license. When `COPILOTKIT_LICENSE_TOKEN`
 > **Notes for the Intelligence path:**
 >
 > - The managed-Intelligence path requires **Node.js ≥ 22** (the base UI + runtime run on Node 20+).
-> - `server.ts` ships a demo `identifyUser` stub returning `demo-user`. CopilotKit Intelligence requires the identified user to actually exist, so thread persistence needs a **real, provisioned user id** — replace the stub with your auth-derived identity (the `copilotkit` CLI provisions one when it scaffolds a project). Leaving `demo-user` in place can cause thread operations to fail.
+> - `server.ts` derives the user from the `x-user-id` and `x-user-name` request headers, falling back to `anonymous`. Threads are per-user, so until your app sets those headers every visitor shares one history — wire them to your auth-derived identity before any multi-user deployment. The id is an opaque string scoped to your project; nothing needs to pre-register it.
 > - Set `INTELLIGENCE_API_KEY` whenever you set `COPILOTKIT_LICENSE_TOKEN`. The runtime builds `CopilotKitIntelligence` off the license token alone; if the API key is missing, threads/memory fail with an opaque auth error at request time rather than a clear startup error.
 
 ## 📚 Documentation

--- a/examples/integrations/adk-angular/server.ts
+++ b/examples/integrations/adk-angular/server.ts
@@ -26,11 +26,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/adk-angular/server.ts
+++ b/examples/integrations/adk-angular/server.ts
@@ -26,7 +26,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/adk/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -32,7 +32,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agent-spec/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -32,11 +32,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -140,11 +140,11 @@ export function buildApp() {
               ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
               : {}),
           }),
-          // Demo stub — replace with your real auth-derived user identity before any
-          // multi-user deployment, or all users share one thread history. The id
-          // must correspond to a user that exists in CopilotKit Intelligence;
-          // an unknown id (like this literal) can make thread operations fail.
-          identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+          // Threads are per-user. Without this every visitor shares one history.
+          identifyUser: (request) => ({
+            id: request.headers.get("x-user-id") ?? "anonymous",
+            name: request.headers.get("x-user-name") ?? "Anonymous",
+          }),
           licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
         }
       : { runner: new AgentCoreRunner() }),

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/src/runtime.ts
@@ -140,7 +140,9 @@ export function buildApp() {
               ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
               : {}),
           }),
-          // Threads are per-user. Without this every visitor shares one history.
+          // Threads are per-user, so until your app sends x-user-id every
+          // visitor shares the "anonymous" history. Wire these headers to
+          // your auth-derived identity before any multi-user deployment.
           identifyUser: (request) => ({
             id: request.headers.get("x-user-id") ?? "anonymous",
             name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/agno/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,7 +28,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,11 +28,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,7 +28,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/claude-sdk-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,11 +28,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -30,7 +30,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-crews/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -30,11 +30,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -25,7 +25,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/crewai-flows/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -25,11 +25,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -31,11 +31,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-fastapi/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -31,7 +31,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-js/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/langgraph-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/llamaindex/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,7 +21,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mastra/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -21,11 +21,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/mcp-apps/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,11 +23,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-dotnet/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -23,7 +23,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -26,11 +26,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/ms-agent-framework-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -26,7 +26,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -26,11 +26,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/pydantic-ai/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -26,7 +26,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,7 +28,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-python/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,11 +28,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,7 +28,9 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Threads are per-user. Without this every visitor shares one history.
+        // Threads are per-user, so until your app sends x-user-id every
+        // visitor shares the "anonymous" history. Wire these headers to
+        // your auth-derived identity before any multi-user deployment.
         identifyUser: (request) => ({
           id: request.headers.get("x-user-id") ?? "anonymous",
           name: request.headers.get("x-user-name") ?? "Anonymous",

--- a/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/strands-typescript/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -28,11 +28,11 @@ const runtime = new CopilotRuntime({
             ? { wsUrl: process.env.INTELLIGENCE_GATEWAY_WS_URL }
             : {}),
         }),
-        // Demo stub — replace with your real auth-derived user identity before any
-        // multi-user deployment, or all users share one thread history. The id
-        // must correspond to a user that exists in CopilotKit Intelligence;
-        // an unknown id (like this literal) can make thread operations fail.
-        identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
+        // Threads are per-user. Without this every visitor shares one history.
+        identifyUser: (request) => ({
+          id: request.headers.get("x-user-id") ?? "anonymous",
+          name: request.headers.get("x-user-name") ?? "Anonymous",
+        }),
         licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN,
       }
     : { runner: new InMemoryAgentRunner() }),

--- a/scripts/__tests__/integration-intelligence-migration.test.ts
+++ b/scripts/__tests__/integration-intelligence-migration.test.ts
@@ -299,7 +299,7 @@ describe("batch-2 Intelligence integration migration", () => {
       expect(route).toContain(
         "licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN",
       );
-      expect(route).toContain('id: "demo-user"');
+      expect(route).toContain('request.headers.get("x-user-id")');
       expect(route).toContain("new InMemoryAgentRunner()");
       expect(route).toContain("export const GET = handle(app)");
       expect(route).toContain("export const POST = handle(app)");
@@ -394,7 +394,7 @@ test("a2a-middleware runtime route is gated for Intelligence threads", () => {
   expect(route).toContain("process.env.INTELLIGENCE_API_KEY");
   expect(route).toContain("process.env.INTELLIGENCE_API_URL");
   expect(route).toContain("process.env.INTELLIGENCE_GATEWAY_WS_URL");
-  expect(route).toContain('id: "demo-user"');
+  expect(route).toContain('request.headers.get("x-user-id")');
   expect(route).toContain("licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN");
   expect(route).toContain(": { runner: new InMemoryAgentRunner() }");
   expect(route).toContain("export const GET = handle(app);");
@@ -489,7 +489,7 @@ test("a2a-a2ui runtime route is gated for Intelligence threads", () => {
   expect(route).toContain("process.env.INTELLIGENCE_API_KEY");
   expect(route).toContain("process.env.INTELLIGENCE_API_URL");
   expect(route).toContain("process.env.INTELLIGENCE_GATEWAY_WS_URL");
-  expect(route).toContain('id: "demo-user"');
+  expect(route).toContain('request.headers.get("x-user-id")');
   expect(route).toContain("licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN");
   expect(route).toContain(": { runner: new InMemoryAgentRunner() }");
   expect(route).toContain("a2ui: {}");
@@ -575,7 +575,7 @@ describe("agentcore Intelligence integration migration", () => {
     expect(runtime).toContain(
       "licenseToken: process.env.COPILOTKIT_LICENSE_TOKEN",
     );
-    expect(runtime).toContain('id: "demo-user"');
+    expect(runtime).toContain('request.headers.get("x-user-id")');
     expect(runtime).toContain(": { runner: new AgentCoreRunner() }");
     expect(runtime).toContain('basePath: "/copilotkit"');
   });


### PR DESCRIPTION
Was stacked on #6711 (OSS-981); that has merged, so this is now rebased directly onto `main` and carries only the identity change.

**Supersedes the wording #6716 (OSS-982) standardised.** #6716 landed after this PR was opened and unified the warning at all 22 sites on the *fullest* variant — the one that says the id "must correspond to a user that exists in CopilotKit Intelligence". That sentence is the claim this PR deletes as false (see below). #6716's own gate is a *relative* shape check against the north star and explicitly permits a change that reaches all 22 sites at once, so replacing the wording everywhere keeps it green.

## Problem

All 22 starters carrying the `copilotkit:intelligence` marker shipped:

```ts
identifyUser: () => ({ id: "demo-user", name: "Demo User" }),
```

`premium/connect-your-runtime` — the page the onboarding graph teaches the runtime constructor from (`subagent/create-plan.md`, `credentials/finalize-plan.md`) — shows the opposite, on the one option that decides whether thread history is per-user or shared:

```ts
// Threads are per-user. Without this every visitor shares one history.
identifyUser: (request) => ({
  id: request.headers.get("x-user-id") ?? "anonymous",
  name: request.headers.get("x-user-name") ?? "Anonymous",
}),
```

So the artifact `copilotkit init` clones contradicted the page the graph teaches from. `ms-agent-framework-python` and `ms-agent-framework-dotnet` shipped the stub with **no warning comment at all**.

## What changed

- The documented header-derived form in all 22 sites. It degrades correctly for a demo — with no headers set it returns `anonymous` / `Anonymous`, one anonymous user and one history — and becomes correct the moment a real deployment sets the headers. The stub bought nothing that `?? "anonymous"` does not.
- The warning comment collapses to the docs page's own one-liner at all 22 sites. (When this PR was written the comments had drifted into five variants and two starters had none; #6716 has since unified them on the longest variant, so this is now a replacement of one uniform comment with another.)
- **`adk-angular`'s comment was factually wrong** and is deleted rather than normalised. It claimed the id "must correspond to a user that exists in CopilotKit Intelligence; an unknown id (like this literal) can make thread operations fail", and its README went further ("requires the identified user to actually exist", "the `copilotkit` CLI provisions one"). Neither holds: `resolve-intelligence-user.ts` validates **shape only** (`isValidIdentifier(user.id)` plus a non-empty name, 400 otherwise), and app-api takes `userId: z.string().trim().min(1)` and runs it through `scopedEndUserId(projectId, endUserId)` with no existence check and no unknown-user error anywhere. Had the claim been true, the documented page would be broken too, since `?? "anonymous"` is exactly as "unknown" as `demo-user`. The README bullet is rewritten accordingly.
- `scripts/__tests__/integration-intelligence-migration.test.ts` asserted the literal in 4 places; those now assert `request.headers.get("x-user-id")`, i.e. that identity is request-derived, which is the contract worth pinning.

## Verification

- **Contextual typing checked before touching 22 files.** `identifyUser` sits inside a conditional spread, so the unannotated `(request)` param could have been an implicit `any`. Isolated `tsc --strict` repro against the real `IdentifyUserCallback` signature: exit 0 for both the direct-property and conditional-spread shapes, with a control (`const f = (request) => request.headers`) confirming the check does catch TS7006. No annotation needed; matches the docs verbatim.
- **Non-Next hosts verified.** `adk-angular` (`createCopilotNodeListener`) and `agentcore` (Hono on Lambda) are not fetch-native, so the header read had to be confirmed reachable: `endpoints/express-fetch-bridge.ts:110` copies inbound headers into a real WHATWG `Request`.
- `oxfmt --check`: clean on all 23 changed TS files.
- `parity:check`: output **byte-identical** to the base commit.
- `check:intelligence-env-names`: green.
- `integration-intelligence-migration.test.ts`: 23 failed / 52 passed both before and after, with the failing test **names** diffed — `newly failing: NONE`, `newly passing: NONE`. Those 23 are pre-existing (stale version pins, files that no longer exist) and out of scope here; see below.

**Re-verified after rebasing onto current `main`** (now post-#6711, #6683, #6716, #6672, #6710).

The first rebase was conflict-free once the stale duplicate of the OSS-981 commit was dropped — the copy this branch carried was byte-identical in tree and patch to the `314f1ca55d` main merged, so nothing was lost. The second rebase hit real conflicts in all 21 comment-bearing sites, because #6716 rewrote the same lines; `git show` confirms #6716 touched **only** those comment lines in these files, so keeping this PR's side loses none of its work. One conflict block per file, asserted programmatically.

Gates on the new base:

- **`check:intelligence-wiring-block` (#6716's new gate): exit 0 — "All 22 Intelligence wiring sites match langgraph-python."** Its own unit test: 17/17 passing.
- `oxfmt --check`: clean on all 23 changed TS files.
- `parity:check`: exit 0, output **byte-identical** to `origin/main`.
- `check:intelligence-env-names`: exit 0.
- `integration-intelligence-migration.test.ts`: 23 failed / 52 passed on both base and head, failing test **names** diffed — newly failing NONE, newly passing NONE.

**The false-claim finding re-checked against current `main`,** since this PR now deletes wording #6716 deliberately standardised. `resolve-intelligence-user.ts` still validates shape only: `isValidIdentifier(user?.id)` (a `/^[\w.@:=-]+$/` charset plus a 128-char cap) and a non-empty `name`, 400 otherwise — no lookup, no existence check. A structural search for an existence path (`user not found`, `unknown user`, `verifyUser`, `ensureUser`, …) across `packages/runtime/src` and `packages/core/src` returns nothing.

**The `anonymous` fallback verified against the real validator,** since a rejected id would 400 the demo rather than degrade: `"anonymous"` → `true`, `"Anonymous"` → `true` under the actual `isValidIdentifier` predicate.


## Note on the untested test file

`integration-intelligence-migration.test.ts` is not run by CI — `static_quality.yml` runs exactly one `scripts/__tests__` file (`validate-dts-ambient.test.ts`). That is how 23 of its assertions rotted unnoticed. OSS-982 has since been closed by #6716, which added `check:intelligence-wiring-block` as a real gate; this stale file is still ungated and still out of scope here.


