### PR TITLE
fix(runtime): keep thread naming task after transcript

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/thread-names.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/thread-names.test.ts
@@ -161,6 +161,17 @@ describe("buildThreadTitlePrompt", () => {
     expect(result).toContain("assistant: It is sunny today.");
   });
 
+  it("places the title task after the transcript", () => {
+    const result = buildThreadTitlePrompt([
+      msg("user", "Explain gravity in one short sentence."),
+    ])!;
+
+    expect(result.indexOf("user: Explain gravity")).toBeLessThan(
+      result.indexOf("Generate a short title"),
+    );
+    expect(result).toContain("Do not answer the conversation");
+  });
+
   it("filters out tool role messages", () => {
     const messages = [
       msg("user", "Search for cats"),

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/thread-names.ts
@@ -166,9 +166,9 @@ function buildThreadTitlePrompt(
   }
 
   return [
-    "Generate a short title for this conversation.",
     "Conversation:",
     transcript.join("\n"),
+    'Generate a short title for the conversation above. Return JSON only in this exact shape: {"title":"..."}. Do not answer the conversation.',
   ].join("\n\n");
 }
 


### PR DESCRIPTION
## Summary

- place the thread-title task after the embedded conversation transcript
- explicitly tell the reused agent not to answer the conversation
- add a regression test that locks the prompt ordering

## Why

LangGraph starter agents can interpret the final embedded `user:` line as the active request when the transcript comes last. They answer the conversation instead of returning title JSON, causing retries and eventual `Untitled` thread names.

## Validation

- reproduced with the latest LangGraph starter and `@copilotkit/runtime@1.69.2`
- original prompt: 0/12 direct calls returned title JSON; 4/4 targeted threads fell back to `Untitled`
- reordered prompt: 12/12 direct calls returned title JSON; 4/4 targeted threads received generated titles
- runtime thread-name unit suite: 28/28 passing
- pre-commit affected package checks passing under the repository Node 22 toolchain