### PR TITLE
docs(react-native): state the version /headless needs, and what to do below it (closes OSS-956)

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 
 `@copilotkit/react-native` gives you CopilotKit's provider and hooks for React Native, plus optional pre-built chat components. This guide builds a fully custom chat UI with the hooks, backed by a [Copilot Runtime](/backend/copilot-runtime) endpoint on your server.
 
-The package has three import surfaces — `/headless` (provider + hooks, no native peer dependencies), the root barrel, and `/components` (the rendered chat UI). See [Import surfaces](#import-surfaces) for what each one pulls in; this guide uses `/headless` throughout.
+The package has three import surfaces — `/headless` (provider + hooks, no native peer dependencies, **1.64.0+**), the root barrel, and `/components` (the rendered chat UI). See [Import surfaces](#import-surfaces) for what each one pulls in; this guide uses `/headless` throughout.
 
 ## Prerequisites
 
@@ -54,6 +54,18 @@ The package has three import surfaces — `/headless` (provider + hooks, no nati
                 ```
             </Tab>
         </Tabs>
+
+        <Callout type="warn" title="`/headless` needs `@copilotkit/react-native` 1.64.0 or later">
+            This guide imports from `@copilotkit/react-native/headless` throughout. That subpath first ships in **1.64.0** — the commands above install the latest version, so a fresh install has it, but a project already pinned to 1.63.x or earlier does not. There, every `/headless` import fails at bundle time with `Unable to resolve module @copilotkit/react-native/headless`, which on Metro reads like a broken install rather than a version skew.
+
+            Check what you actually resolved before going further:
+
+            ```bash
+            npm ls @copilotkit/react-native
+            ```
+
+            On 1.63.x or earlier, prefer upgrading to 1.64.0+. If you cannot — because you are matching a pinned `@copilotkit/runtime` — the same `CopilotKitProvider`, `useAgent` and `useCopilotKit` are exported from the package root, so dropping `/headless` from the import path is the whole code change. It is not a free swap, though: on those versions the root barrel statically imports `expo-document-picker` and `expo-file-system`, so you must also install (or stub) both, or your release bundle fails with `Unable to resolve module expo-document-picker`. See [Import surfaces](#import-surfaces).
+        </Callout>
     </Step>
     <Step>
         ### Add polyfills
@@ -301,11 +313,11 @@ The package has three import surfaces — `/headless` (provider + hooks, no nati
 
 `@copilotkit/react-native` has three JavaScript entry points. They differ in what UI they give you and — crucially for release bundles — which native peer dependencies Metro has to resolve.
 
-| Import | What you get | Native peers Metro must resolve |
-|--------|--------------|---------------------------------|
-| `@copilotkit/react-native/headless` | `CopilotKitProvider` and every platform-agnostic hook. No components. | **None** |
-| `@copilotkit/react-native` (root) | Everything in `/headless`, plus `useAttachments`, the two *headless* chat wrappers (`CopilotChat`, `CopilotModal`) and the `CopilotSidebar` / `CopilotPopup` chrome | `expo-document-picker`, `expo-file-system` (via `useAttachments`) |
-| `@copilotkit/react-native/components` | The **rendered** chat UI: a `CopilotChat` with a message list, a bottom-sheet `CopilotModal`, `CopilotMarkdown`, `AssistantMessage`, `UserMessage` | `@gorhom/bottom-sheet` (which itself needs `react-native-reanimated` + `react-native-gesture-handler`), `react-native-streamdown` |
+| Import | Available since | What you get | Native peers Metro must resolve |
+|--------|-----------------|--------------|---------------------------------|
+| `@copilotkit/react-native/headless` | **1.64.0** | `CopilotKitProvider` and every platform-agnostic hook. No components. | **None** |
+| `@copilotkit/react-native` (root) | all versions | Everything in `/headless`, plus `useAttachments`, the two *headless* chat wrappers (`CopilotChat`, `CopilotModal`) and the `CopilotSidebar` / `CopilotPopup` chrome | `expo-document-picker`, `expo-file-system` (via `useAttachments`) |
+| `@copilotkit/react-native/components` | all versions | The **rendered** chat UI: a `CopilotChat` with a message list, a bottom-sheet `CopilotModal`, `CopilotMarkdown`, `AssistantMessage`, `UserMessage` | `@gorhom/bottom-sheet` (which itself needs `react-native-reanimated` + `react-native-gesture-handler`), `react-native-streamdown` |
 
 Supporting entry points:
 
@@ -328,6 +340,8 @@ import {
   useFrontendTool,
 } from "@copilotkit/react-native/headless"; // [!code highlight]
 ```
+
+On `@copilotkit/react-native` 1.63.x and earlier there is no `/headless` — the subpath was added in 1.64.0 ([#6142](https://github.com/CopilotKit/CopilotKit/pull/6142)) precisely to make this custom-UI case possible without the chat and attachment peers. The root barrel is still the package's default, full surface, and it exports the same provider and hooks on every version; `/headless` is the lean alternative, not a replacement. On a pinned older version, import from the root and install or stub `expo-document-picker` and `expo-file-system`.
 
 Importing the provider auto-installs the polyfills: `/headless` runs the polyfill barrel as its first statement, and the root barrel gets it through its `/headless` re-export. `/components` does **not** install them itself — it relies on the provider you import alongside it (from `/headless` or the root). And because the root barrel re-exports everything from `/headless`, existing `@copilotkit/react-native` imports keep working unchanged.
 


### PR DESCRIPTION
## What does this PR do?

The React Native guide imports `CopilotKitProvider`, `useAgent` and `useCopilotKit` from `@copilotkit/react-native/headless` and names no version. That subpath first ships in **1.64.0** (#6142), so a project pinned to 1.63.x or earlier fails every one of those imports with:

```
Unable to resolve module @copilotkit/react-native/headless
```

On Metro that reads like a broken install rather than a version skew, and it sends the reader into the package-exports and polyfill debugging the same guide warns about a few sections later. The actual fix is one word in an import path.

This states the boundary in the three places a reader meets the subpath. Prose only — no snippet in this page changed.

### The version boundary, verified against the registry

Not inferred from a changelog — `npm view @copilotkit/react-native@<v> exports` on each:

| version | `./headless` |
| -- | -- |
| 1.62.0, 1.62.2, 1.62.3 | absent |
| 1.63.0, 1.63.1, 1.63.2 | absent |
| **1.64.0** | **present** |
| 1.64.1+, 1.65.0, 1.69.2 | present |

`./components` and the polyfill subpaths exist across all of the above, so `/headless` is the only path in the guide that carries a version boundary. Introduced by 0a582df4dd / #6142.

### What changed

- **Intro line** — `/headless` is marked `1.64.0+` where the three import surfaces are first introduced.
- **Install step** — a `type="warn"` callout, placed where the resolved version is actually decided. States the boundary, quotes the exact Metro error, gives `npm ls @copilotkit/react-native` to check what you resolved, and covers the fallback.
- **Import surfaces table** — a new "Available since" column.
- **Import surfaces prose** — records what `/headless` *is*, which the guide never said: a lean alternative entry added so custom-UI consumers skip the chat and attachment native deps — **not** a replacement for the root barrel, which remains the package's default full surface and re-exports everything in `/headless`.

### The fallback advice is deliberately not just "import from the root"

On 1.62.2 and 1.63.2 the root barrel does export all three names (checked in the shipped tarballs, not assumed). But `package/dist/index.mjs` on those versions statically imports `expo-document-picker` and `expo-file-system`. A reader who switches to the root therefore inherits exactly the peer-dependency resolution failure that this guide's `/headless` choice exists to avoid:

```
Unable to resolve module expo-document-picker
```

So the callout says to prefer upgrading to 1.64.0+, and if you cannot (because you are matching a pinned `@copilotkit/runtime`), names the install-or-stub requirement that comes with the root import rather than presenting it as a free swap.

### Why not backport `./headless` to 1.62.x

That was the alternative the issue floated, and it looks unnecessary. `/headless` was never intended as the canonical entry that supersedes the root — #6142's message, `src/index.ts` (`export * from "./headless"`, with a root quick-start that uses the root), and `src/headless.ts` ("existing imports from `@copilotkit/react-native` are unchanged") all agree it is a lean *alternative*. Adding an entry point in a patch of an older line would also change what "the pinned set" means for anyone matching client to runtime.

## Related PRs and Issues

- Closes OSS-956
- #6142 — added the `/headless` subpath in 1.64.0
- #5883 — the `@copilotkit/react-core/v2/headless` entry that #6142 mirrors

## Verification

- MDX compiles via `@mdx-js/mdx` + `remark-gfm`, edited and baseline both
- 4-column Import surfaces table parses; 19/19 `<Callout>` tags balanced
- `commitlint` exit 0
- `pnpm check:intelligence-env-names` passes
- `.mdx` is not in lefthook's `lint-fix` glob, so oxfmt/oxlint never applied to this file
- This page carries no `doctest=` fences, and no fence in it changed, so the guide's snippets stay runnable as they were

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
