### PR TITLE
fix(docs): send Intelligence CTAs through onboarding

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/brand-nav.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/brand-nav.test.tsx
@@ -86,24 +86,21 @@ test("BrandNav renders Clerk's user button in the desktop auth slot", () => {
   expect(markup).not.toContain("Get CopilotKit Intelligence free");
 });
 
-test("BrandNav preserves the current docs URL in the public auth entry URL", () => {
-  const href = buildDocsAuthEntryHref(
-    "https://docs.copilotkit.ai/channels?utm_source=website#install",
-  );
+test("BrandNav sends public auth entry to Intelligence onboarding", () => {
+  const href = buildDocsAuthEntryHref();
 
   expect(href).toBe(
-    "https://dashboard.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar&redirect_url=https%3A%2F%2Fdocs.copilotkit.ai%2Fchannels%3Futm_source%3Dwebsite%23install",
+    "https://dashboard.operations.copilotkit.ai/sign-in?post_auth_redirect=ready&utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar",
   );
 });
 
 test("BrandNav uses the environment-specific Ops origin for auth entry", () => {
   const href = buildDocsAuthEntryHref(
-    "https://docs.staging.copilotkit.ai/react?ref=nav#install",
     "https://dashboard.staging.operations.copilotkit.ai",
   );
 
   expect(href).toBe(
-    "https://dashboard.staging.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar&redirect_url=https%3A%2F%2Fdocs.staging.copilotkit.ai%2Freact%3Fref%3Dnav%23install",
+    "https://dashboard.staging.operations.copilotkit.ai/sign-in?post_auth_redirect=ready&utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar",
   );
 });
 
@@ -124,10 +121,6 @@ test("BrandNav keeps the public auth CTA when Clerk state cannot resolve", () =>
   expect(markup).not.toContain("Account menu");
 });
 
-test("BrandNav refreshes the auth href when its route context changes", () => {
-  expect(docsPublicAuthControlSource).toContain("usePathname()");
-  expect(docsPublicAuthControlSource).toContain("useSearchParams()");
-  expect(docsPublicAuthControlSource).toContain(
-    "[opsPublicUrl, pathname, searchParams]",
-  );
+test("BrandNav does not send public auth back to Docs", () => {
+  expect(docsPublicAuthControlSource).not.toContain("redirect_url");
 });

--- a/showcase/shell-docs/src/components/__tests__/public-clerk-provider.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/public-clerk-provider.test.tsx
@@ -125,7 +125,7 @@ describe("PublicClerkProvider", () => {
       expect(
         screen.getByRole("link", { name: "Auth entry" }).getAttribute("href"),
       ).toBe(
-        "https://dashboard.staging.operations.copilotkit.ai/?utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar&redirect_url=http%3A%2F%2Flocalhost%3A3000%2Freact%3Futm_source%3Ddocs%23intro",
+        "https://dashboard.staging.operations.copilotkit.ai/sign-in?post_auth_redirect=ready&utm_source=docs&utm_medium=cta&utm_campaign=intelligence&utm_content=navbar",
       ),
     );
   });

--- a/showcase/shell-docs/src/components/docs-public-auth-control.tsx
+++ b/showcase/shell-docs/src/components/docs-public-auth-control.tsx
@@ -1,47 +1,23 @@
 "use client";
 
 import { UserButton, useUser } from "@clerk/nextjs";
-import { usePathname, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { Component } from "react";
-import { useEffect, useState } from "react";
+import { buildIntelligenceAuthEntryHref } from "@/lib/docs-cta-href";
 import {
   usePublicClerkAvailable,
   usePublicOpsUrl,
 } from "./public-clerk-provider";
 
-function getCurrentDocsUrl(): string {
-  return typeof window === "undefined"
-    ? "https://docs.copilotkit.ai/"
-    : window.location.href;
-}
-
 export function buildDocsAuthEntryHref(
-  currentUrl = getCurrentDocsUrl(),
   opsPublicUrl = "https://dashboard.operations.copilotkit.ai",
 ): string {
-  const url = new URL(opsPublicUrl);
-  url.searchParams.set("utm_source", "docs");
-  url.searchParams.set("utm_medium", "cta");
-  url.searchParams.set("utm_campaign", "intelligence");
-  url.searchParams.set("utm_content", "navbar");
-  url.searchParams.set("redirect_url", currentUrl);
-  return url.toString();
+  return buildIntelligenceAuthEntryHref(opsPublicUrl, { surface: "navbar" });
 }
 
 export function useDocsAuthEntryHref(): string {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const opsPublicUrl = usePublicOpsUrl();
-  const [href, setHref] = useState(() =>
-    buildDocsAuthEntryHref(getCurrentDocsUrl(), opsPublicUrl),
-  );
-
-  useEffect(() => {
-    setHref(buildDocsAuthEntryHref(getCurrentDocsUrl(), opsPublicUrl));
-  }, [opsPublicUrl, pathname, searchParams]);
-
-  return href;
+  return buildDocsAuthEntryHref(opsPublicUrl);
 }
 
 export function DocsPublicAuthControl({ fallback }: { fallback: ReactNode }) {

--- a/showcase/shell-docs/src/components/react/__tests__/signup-link.ssr.test.tsx
+++ b/showcase/shell-docs/src/components/react/__tests__/signup-link.ssr.test.tsx
@@ -47,6 +47,8 @@ describe("client component SSR safety (shell-docs)", () => {
       </SignupLink>,
     );
     const url = new URL(hrefFromStaticMarkup(html));
+    expect(url.pathname).toBe("/sign-in");
+    expect(url.searchParams.get("post_auth_redirect")).toBe("ready");
     expect(url.searchParams.get("utm_frontend")).toBe("angular");
     expect(url.searchParams.get("utm_backend")).toBe("langgraph-python");
   });
@@ -73,6 +75,8 @@ describe("client component SSR safety (shell-docs)", () => {
       }),
     );
     const url = new URL(hrefFromStaticMarkup(html));
+    expect(url.pathname).toBe("/sign-in");
+    expect(url.searchParams.get("post_auth_redirect")).toBe("ready");
     expect(url.searchParams.get("utm_frontend")).toBe("angular");
     expect(url.searchParams.get("utm_backend")).toBe("google-adk");
   });
@@ -90,6 +94,7 @@ describe("client component SSR safety (shell-docs)", () => {
     expect(`${url.origin}${url.pathname}`).toBe(
       "https://copilotkit.ai/talk-to-an-engineer",
     );
+    expect(url.searchParams.has("post_auth_redirect")).toBe(false);
     expect(url.searchParams.get("utm_content")).toBe("test-surface");
   });
 

--- a/showcase/shell-docs/src/components/react/ops-platform-cta.tsx
+++ b/showcase/shell-docs/src/components/react/ops-platform-cta.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { CopilotKitMark } from "@/components/copilotkit-mark";
+import {
+  buildIntelligenceAuthEntryHref,
+  buildTrackedDocsHref,
+} from "@/lib/docs-cta-href";
 import { getRuntimeConfig } from "@/lib/runtime-config.client";
 import posthog from "posthog-js";
 import { useCallback } from "react";
@@ -96,14 +100,10 @@ function buildHref(
   // CTA treatment for related Enterprise actions, such as talking to an
   // engineer about self-hosting.
   const signupUrl = getRuntimeConfig().intelligenceSignupUrl;
-  const url = new URL(hrefOverride ?? signupUrl);
-  url.searchParams.set("utm_source", "docs");
-  url.searchParams.set("utm_medium", "cta");
-  url.searchParams.set("utm_campaign", "intelligence");
-  url.searchParams.set("utm_content", surface);
-  if (frontend) url.searchParams.set("utm_frontend", frontend);
-  if (backend) url.searchParams.set("utm_backend", backend);
-  return url.toString();
+  const attribution = { surface, frontend, backend };
+  return hrefOverride
+    ? buildTrackedDocsHref(hrefOverride, attribution)
+    : buildIntelligenceAuthEntryHref(signupUrl, attribution);
 }
 
 export function OpsPlatformCTA({

--- a/showcase/shell-docs/src/components/react/signup-link.tsx
+++ b/showcase/shell-docs/src/components/react/signup-link.tsx
@@ -2,6 +2,7 @@
 
 import posthog from "posthog-js";
 import { useCallback } from "react";
+import { buildIntelligenceAuthEntryHref } from "@/lib/docs-cta-href";
 import { getRuntimeConfig } from "@/lib/runtime-config.client";
 
 export interface SignupLinkProps {
@@ -26,14 +27,11 @@ function buildHref(
   // vs prod by changing the Railway env var. The reader already returns
   // a fallback when NEXT_PUBLIC_INTELLIGENCE_SIGNUP_URL is unset.
   const signupUrl = getRuntimeConfig().intelligenceSignupUrl;
-  const url = new URL(signupUrl);
-  url.searchParams.set("utm_source", "docs");
-  url.searchParams.set("utm_medium", "cta");
-  url.searchParams.set("utm_campaign", "intelligence");
-  url.searchParams.set("utm_content", surface);
-  if (frontend) url.searchParams.set("utm_frontend", frontend);
-  if (backend) url.searchParams.set("utm_backend", backend);
-  return url.toString();
+  return buildIntelligenceAuthEntryHref(signupUrl, {
+    surface,
+    frontend,
+    backend,
+  });
 }
 
 export function SignupLink({

--- a/showcase/shell-docs/src/lib/docs-cta-href.ts
+++ b/showcase/shell-docs/src/lib/docs-cta-href.ts
@@ -1,0 +1,34 @@
+export interface DocsCtaAttribution {
+  surface: string;
+  frontend?: string;
+  backend?: string;
+}
+
+function addDocsCtaAttribution(
+  url: URL,
+  { surface, frontend, backend }: DocsCtaAttribution,
+): string {
+  url.searchParams.set("utm_source", "docs");
+  url.searchParams.set("utm_medium", "cta");
+  url.searchParams.set("utm_campaign", "intelligence");
+  url.searchParams.set("utm_content", surface);
+  if (frontend) url.searchParams.set("utm_frontend", frontend);
+  if (backend) url.searchParams.set("utm_backend", backend);
+  return url.toString();
+}
+
+export function buildIntelligenceAuthEntryHref(
+  opsPublicUrl: string,
+  attribution: DocsCtaAttribution,
+): string {
+  const url = new URL("/sign-in", opsPublicUrl);
+  url.searchParams.set("post_auth_redirect", "ready");
+  return addDocsCtaAttribution(url, attribution);
+}
+
+export function buildTrackedDocsHref(
+  destination: string,
+  attribution: DocsCtaAttribution,
+): string {
+  return addDocsCtaAttribution(new URL(destination), attribution);
+}


### PR DESCRIPTION
## Bug

[Sam reported](https://copilotkit.slack.com/archives/C0BR0V2P4QJ/p1787777419496249) two live Docs CTA failures:

- The navbar signup CTA returned users to Docs after authentication.
- Other Intelligence CTAs could send signed-in users to Pricing.

## Fix

- Send every Docs Intelligence signup CTA to the matching environment at `/sign-in?post_auth_redirect=ready`.
- Remove the Docs `redirect_url` that explicitly caused the return to Docs.
- Share the URL builder across the navbar and in-page CTAs so their destinations stay aligned.
- Preserve existing UTM attribution and custom Talk to an Engineer destinations.

## Validation

- 18 focused tests passed.
- Shell Docs TypeScript check passed.
- Focused lint and formatting checks passed.

No visual changes.