### PR TITLE
fix(docs): replace retired GitHub Models setup

### DIFF
--- a/.github/workflows/test_integration-docs.yml
+++ b/.github/workflows/test_integration-docs.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - "showcase/shell-docs/src/content/**"
       - "showcase/shell-docs/model-allowlist.json"
+      - "showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts"
+      - "showcase/shell-docs/package.json"
+      - "showcase/shell-docs/package-lock.json"
+      - "examples/integrations/ms-agent-framework-dotnet/**"
       - "scripts/validate-doc-model-names.ts"
       - "scripts/doc-tests/**"
       - ".github/workflows/test_integration-docs.yml"
@@ -13,6 +17,10 @@ on:
     paths:
       - "showcase/shell-docs/src/content/**"
       - "showcase/shell-docs/model-allowlist.json"
+      - "showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts"
+      - "showcase/shell-docs/package.json"
+      - "showcase/shell-docs/package-lock.json"
+      - "examples/integrations/ms-agent-framework-dotnet/**"
       - "scripts/validate-doc-model-names.ts"
       - "scripts/doc-tests/**"
       - ".github/workflows/test_integration-docs.yml"
@@ -40,6 +48,29 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm tsx scripts/validate-doc-model-names.ts
+
+  ms-agent-dotnet-guidance:
+    name: Microsoft Agent Framework .NET guidance
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # zizmor: ignore[undocumented-permissions] Depot runner OIDC.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: showcase/shell-docs/package-lock.json
+      - name: Install shell-docs dependencies
+        working-directory: showcase/shell-docs
+        run: npm ci --ignore-scripts
+      - name: Check Microsoft Agent Framework .NET guidance
+        working-directory: showcase/shell-docs
+        run: npm exec -- vitest run src/lib/__tests__/ms-agent-dotnet-provider.test.ts
 
   doc-tests:
     runs-on: depot-ubuntu-24.04-4

--- a/examples/integrations/ms-agent-framework-dotnet/.env.example
+++ b/examples/integrations/ms-agent-framework-dotnet/.env.example
@@ -1,4 +1,4 @@
-# The C# agent reads GitHubToken from .NET user-secrets; see README.md.
+# The C# agent reads OPENAI_API_KEY from .NET user-secrets; see README.md.
 AGENT_URL=http://localhost:8000
 
 # --- CopilotKit Intelligence (optional; set COPILOTKIT_LICENSE_TOKEN to enable Threads — server + UI) ---

--- a/examples/integrations/ms-agent-framework-dotnet/README.md
+++ b/examples/integrations/ms-agent-framework-dotnet/README.md
@@ -4,9 +4,7 @@ This is a starter template for building AI agents using [Microsoft Agent Framewo
 
 ## Prerequisites
 
-- **GitHub Personal Access Token** (for GitHub Models API)
-  - Retrieve from GitHub using [these instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
-  - or generate via `gh auth token` in your CLI (requires [GitHub CLI](https://github.com/cli/cli?tab=readme-ov-file#installation))
+- **OpenAI API key** from the [API key page](https://platform.openai.com/api-keys)
 - **.NET 9.0 SDK**
   - [Download directly](https://dotnet.microsoft.com/download/dotnet/9.0)
   - macOS/Linux
@@ -77,26 +75,12 @@ This is a starter template for building AI agents using [Microsoft Agent Framewo
    > npm run install:agent
    > ```
 
-2. Set up your GitHub token for GitHub Models:
-
-   First, get your GitHub token:
-
-   ```bash
-   gh auth token
-   ```
-
-   Then, navigate to the agent directory and set it as a user secret:
+2. Save your OpenAI API key as a .NET user secret:
 
    ```bash
    cd agent
-   dotnet user-secrets set GitHubToken "<your-token>"
+   dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
    cd ..
-   ```
-
-   Or set it in one command:
-
-   ```bash
-   cd agent; dotnet user-secrets set GitHubToken "$(gh auth token)"; cd ..
    ```
 
 3. Start the development server:
@@ -197,10 +181,10 @@ This starter showcases key AG-UI protocol features:
 ## 📚 Documentation
 
 - [Microsoft Agent Framework](https://github.com/microsoft/agents) - Learn about Microsoft's agent framework
+- [Microsoft Agent Framework model providers](https://learn.microsoft.com/en-us/agent-framework/integrations/by-component/model-providers/) - Choose another model provider
 - [AG-UI Protocol](https://github.com/copilotkit/ag-ui) - AG-UI protocol specification
 - [CopilotKit Documentation](https://docs.copilotkit.ai) - CopilotKit features and API
 - [Next.js Documentation](https://nextjs.org/docs) - Next.js features and API
-- [GitHub Models](https://github.com/marketplace/models) - Free AI models via GitHub
 
 ## Contributing
 
@@ -217,7 +201,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 If you see "I'm having trouble connecting to my tools", make sure:
 
 1. The C# agent is running on port 8000
-2. Your GitHub token is set correctly via user secrets
+2. Your OpenAI API key is set via .NET user secrets
 3. Both servers started successfully (check terminal output)
 
 ### .NET SDK Not Installed
@@ -263,24 +247,13 @@ dotnet restore
 dotnet run
 ```
 
-### GitHub Token Issues
+### OpenAI API Key Issues
 
-If the agent fails to start with "GitHubToken not found":
+If the agent fails to start with "OPENAI_API_KEY not found":
 
 ```bash
 cd agent
-dotnet user-secrets set GitHubToken "$(gh auth token)"
-```
-
-Or manually:
-
-```bash
-# Get your token
-gh auth token
-
-# Set it as a user secret
-cd agent
-dotnet user-secrets set GitHubToken "YOUR_TOKEN_HERE"
+dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
 ```
 
 ### Port Conflicts

--- a/examples/integrations/ms-agent-framework-dotnet/agent/Program.cs
+++ b/examples/integrations/ms-agent-framework-dotnet/agent/Program.cs
@@ -4,13 +4,14 @@ using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Options;
 using OpenAI;
+using OpenAI.Chat;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Services.ConfigureHttpJsonOptions(options => options.SerializerOptions.TypeInfoResolverChain.Add(ProverbsAgentSerializerContext.Default));
-builder.Services.AddAGUI();
+builder.Services.AddAGUIServer();
 
 WebApplication app = builder.Build();
 
@@ -20,7 +21,7 @@ var jsonOptions = app.Services.GetRequiredService<IOptions<JsonOptions>>();
 var agentFactory = new ProverbsAgentFactory(builder.Configuration, loggerFactory, jsonOptions.Value.SerializerOptions);
 
 app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
-app.MapAGUI("/", agentFactory.CreateProverbsAgent());
+app.MapAGUIServer("/", agentFactory.CreateProverbsAgent());
 
 await app.RunAsync();
 
@@ -50,37 +51,38 @@ public class ProverbsAgentFactory
         _logger = loggerFactory.CreateLogger<ProverbsAgentFactory>();
         _jsonSerializerOptions = jsonSerializerOptions;
 
-        // Get the GitHub token from configuration
-        var githubToken = _configuration["GitHubToken"]
+        var openAiApiKey = _configuration["OPENAI_API_KEY"]
             ?? throw new InvalidOperationException(
-                "GitHubToken not found in configuration. " +
-                "Please set it using: dotnet user-secrets set GitHubToken \"<your-token>\" " +
-                "or get it using: gh auth token");
+                "OPENAI_API_KEY not found in configuration. " +
+                "Set it with: dotnet user-secrets set OPENAI_API_KEY \"<your-openai-api-key>\"");
 
-        _openAiClient = new(
-            new System.ClientModel.ApiKeyCredential(githubToken),
-            new OpenAIClientOptions
-            {
-                Endpoint = new Uri(Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? "https://models.inference.ai.azure.com")
-            });
+        var openAiBaseUrl = _configuration["OPENAI_BASE_URL"];
+        _openAiClient = string.IsNullOrWhiteSpace(openAiBaseUrl)
+            ? new OpenAIClient(openAiApiKey)
+            : new OpenAIClient(
+                new System.ClientModel.ApiKeyCredential(openAiApiKey),
+                new OpenAIClientOptions { Endpoint = new Uri(openAiBaseUrl) });
     }
 
     public AIAgent CreateProverbsAgent()
     {
-        var chatClient = _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient();
-
-        var chatClientAgent = new ChatClientAgent(
-            chatClient,
-            name: "ProverbsAgent",
-            description: @"A helpful assistant that helps manage and discuss proverbs.
-            You have tools available to add, set, or retrieve proverbs from the list.
-            When discussing proverbs, ALWAYS use the get_proverbs tool to see the current list before mentioning, updating, or discussing proverbs with the user.",
-            tools: [
-                AIFunctionFactory.Create(GetProverbs, options: new() { Name = "get_proverbs", SerializerOptions = _jsonSerializerOptions }),
-                AIFunctionFactory.Create(AddProverbs, options: new() { Name = "add_proverbs", SerializerOptions = _jsonSerializerOptions }),
-                AIFunctionFactory.Create(SetProverbs, options: new() { Name = "set_proverbs", SerializerOptions = _jsonSerializerOptions }),
-                AIFunctionFactory.Create(GetWeather, options: new() { Name = "get_weather", SerializerOptions = _jsonSerializerOptions })
-            ]);
+        var chatClientAgent = _openAiClient.GetChatClient("gpt-4o-mini").AsAIAgent(
+            new ChatClientAgentOptions
+            {
+                Name = "ProverbsAgent",
+                Description = "A helpful assistant that helps manage and discuss proverbs.",
+                ChatOptions = new ChatOptions
+                {
+                    Instructions = @"You have tools available to add, set, or retrieve proverbs from the list.
+                    When discussing proverbs, ALWAYS use the get_proverbs tool to see the current list before mentioning, updating, or discussing proverbs with the user.",
+                    Tools = [
+                        AIFunctionFactory.Create(GetProverbs, options: new() { Name = "get_proverbs", SerializerOptions = _jsonSerializerOptions }),
+                        AIFunctionFactory.Create(AddProverbs, options: new() { Name = "add_proverbs", SerializerOptions = _jsonSerializerOptions }),
+                        AIFunctionFactory.Create(SetProverbs, options: new() { Name = "set_proverbs", SerializerOptions = _jsonSerializerOptions }),
+                        AIFunctionFactory.Create(GetWeather, options: new() { Name = "get_weather", SerializerOptions = _jsonSerializerOptions })
+                    ]
+                }
+            });
 
         return new SharedStateAgent(chatClientAgent, _jsonSerializerOptions);
     }

--- a/examples/integrations/ms-agent-framework-dotnet/agent/ProverbsAgent.csproj
+++ b/examples/integrations/ms-agent-framework-dotnet/agent/ProverbsAgent.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.AI.Hosting.AGUI.AspNetCore" Version="1.0.0-preview.251110.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.2-preview.1.25552.1" />
-    <PackageReference Include="OpenAI" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Agents.AI.Hosting.AGUI.AspNetCore" Version="1.19.0-preview.260822.1" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.19.0" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/integrations/ms-agent-framework-dotnet/agent/SharedStateAgent.cs
+++ b/examples/integrations/ms-agent-framework-dotnet/agent/SharedStateAgent.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using AGUI.Abstractions;
+using AGUI.Server;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 
@@ -15,37 +17,36 @@ internal sealed class SharedStateAgent : DelegatingAIAgent
         _jsonSerializerOptions = jsonSerializerOptions;
     }
 
-    public override Task<AgentRunResponse> RunAsync(IEnumerable<ChatMessage> messages, AgentThread? thread = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
+    protected override Task<AgentResponse> RunCoreAsync(IEnumerable<ChatMessage> messages, AgentSession? session = null, AgentRunOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return RunStreamingAsync(messages, thread, options, cancellationToken).ToAgentRunResponseAsync(cancellationToken);
+        return RunCoreStreamingAsync(messages, session, options, cancellationToken).ToAgentResponseAsync(cancellationToken);
     }
 
-    public override async IAsyncEnumerable<AgentRunResponseUpdate> RunStreamingAsync(
+    protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
         IEnumerable<ChatMessage> messages,
-        AgentThread? thread = null,
+        AgentSession? session = null,
         AgentRunOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        if (options is not ChatClientAgentRunOptions { ChatOptions.AdditionalProperties: { } properties } chatRunOptions ||
-            !properties.TryGetValue("ag_ui_state", out JsonElement state))
+        if (options is not ChatClientAgentRunOptions { ChatOptions: { } chatOptions } chatRunOptions ||
+            !chatOptions.TryGetRunAgentInput(out RunAgentInput? input) ||
+            input.State is not { ValueKind: JsonValueKind.Object } state)
         {
-            await foreach (var update in InnerAgent.RunStreamingAsync(messages, thread, options, cancellationToken).ConfigureAwait(false))
+            await foreach (var update in InnerAgent.RunStreamingAsync(messages, session, options, cancellationToken).ConfigureAwait(false))
             {
                 yield return update;
             }
             yield break;
         }
 
-        var firstRunOptions = new ChatClientAgentRunOptions
+        var firstRunChatOptions = chatRunOptions.ChatOptions.Clone();
+        var firstRunOptions = new ChatClientAgentRunOptions(firstRunChatOptions)
         {
-            ChatOptions = chatRunOptions.ChatOptions.Clone(),
-            AllowBackgroundResponses = chatRunOptions.AllowBackgroundResponses,
-            ContinuationToken = chatRunOptions.ContinuationToken,
             ChatClientFactory = chatRunOptions.ChatClientFactory,
         };
 
         // Configure JSON schema response format for structured state output
-        firstRunOptions.ChatOptions.ResponseFormat = ChatResponseFormat.ForJsonSchema<ProverbsStateSnapshot>(
+        firstRunChatOptions.ResponseFormat = ChatResponseFormat.ForJsonSchema<ProverbsStateSnapshot>(
             schemaName: "ProverbsStateSnapshot",
             schemaDescription: "A response containing the current list of proverbs");
 
@@ -59,8 +60,8 @@ internal sealed class SharedStateAgent : DelegatingAIAgent
 
         var firstRunMessages = messages.Append(stateUpdateMessage);
 
-        var allUpdates = new List<AgentRunResponseUpdate>();
-        await foreach (var update in InnerAgent.RunStreamingAsync(firstRunMessages, thread, firstRunOptions, cancellationToken).ConfigureAwait(false))
+        var allUpdates = new List<AgentResponseUpdate>();
+        await foreach (var update in InnerAgent.RunStreamingAsync(firstRunMessages, session, firstRunOptions, cancellationToken).ConfigureAwait(false))
         {
             allUpdates.Add(update);
 
@@ -72,29 +73,37 @@ internal sealed class SharedStateAgent : DelegatingAIAgent
             }
         }
 
-        var response = allUpdates.ToAgentRunResponse();
+        var response = allUpdates.ToAgentResponse();
 
-        if (response.TryDeserialize(_jsonSerializerOptions, out JsonElement stateSnapshot))
+        JsonElement? stateSnapshot = null;
+        try
         {
-            byte[] stateBytes = JsonSerializer.SerializeToUtf8Bytes(
-                stateSnapshot,
-                _jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)));
-            yield return new AgentRunResponseUpdate
-            {
-                Contents = [new DataContent(stateBytes, "application/json")]
-            };
+            stateSnapshot = JsonSerializer.Deserialize<JsonElement>(response.Text, _jsonSerializerOptions);
         }
-        else
+        catch (JsonException)
+        {
+            // The model did not return the requested state snapshot.
+        }
+
+        if (stateSnapshot is not { } parsedStateSnapshot)
         {
             yield break;
         }
+
+        byte[] stateBytes = JsonSerializer.SerializeToUtf8Bytes(
+            parsedStateSnapshot,
+            _jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)));
+        yield return new AgentResponseUpdate
+        {
+            Contents = [new DataContent(stateBytes, "application/json")]
+        };
 
         var secondRunMessages = messages.Concat(response.Messages).Append(
             new ChatMessage(
                 ChatRole.System,
                 [new TextContent("Please provide a concise summary of the state changes in at most two sentences.")]));
 
-        await foreach (var update in InnerAgent.RunStreamingAsync(secondRunMessages, thread, options, cancellationToken).ConfigureAwait(false))
+        await foreach (var update in InnerAgent.RunStreamingAsync(secondRunMessages, session, options, cancellationToken).ConfigureAwait(false))
         {
             yield return update;
         }

--- a/examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml
+++ b/examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml
@@ -1,7 +1,7 @@
 # Docker Compose stack for e2e smoke testing with aimock.
 # Mirrors the user experience: Next.js frontend + .NET agent + aimock as LLM.
-# The .NET agent uses GitHubToken + models.inference.ai.azure.com endpoint,
-# but for testing we redirect to aimock via OPENAI_BASE_URL override.
+# The .NET agent uses OpenAI by default. Tests redirect it to aimock with
+# OPENAI_BASE_URL while keeping the same OPENAI_API_KEY contract.
 # Usage: docker compose -f docker-compose.test.yml up -d
 services:
   aimock:
@@ -16,7 +16,7 @@ services:
       context: ./agent
       dockerfile: ../docker/Dockerfile.agent
     environment:
-      - GitHubToken=test-key-for-aimock
+      - OPENAI_API_KEY=test-key-for-aimock
       - OPENAI_BASE_URL=http://aimock:4010/v1
     depends_on:
       aimock:

--- a/examples/integrations/ms-agent-framework-dotnet/docker/Dockerfile.agent
+++ b/examples/integrations/ms-agent-framework-dotnet/docker/Dockerfile.agent
@@ -6,8 +6,6 @@ WORKDIR /src
 COPY *.csproj ./
 RUN dotnet restore
 COPY . .
-# Patch hardcoded endpoint to read from OPENAI_BASE_URL env var
-RUN sed -i 's|Endpoint = new Uri("https://models.inference.ai.azure.com")|Endpoint = new Uri(Environment.GetEnvironmentVariable("OPENAI_BASE_URL") ?? "https://models.inference.ai.azure.com")|' Program.cs
 RUN dotnet publish -c Release -o /app
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0

--- a/examples/integrations/ms-agent-framework-dotnet/fixtures/default.json
+++ b/examples/integrations/ms-agent-framework-dotnet/fixtures/default.json
@@ -63,7 +63,7 @@
     {
       "match": {},
       "response": {
-        "content": "You're currently running against aimock (a mock LLM server). This response is a catch-all for requests that don't match any test fixture. To use a real LLM: (1) Set your GitHubToken, (2) Remove or unset OPENAI_BASE_URL from your environment, (3) Restart the agent."
+        "content": "You're currently running against aimock (a mock LLM server). This response is a catch-all for requests that don't match any test fixture. To use a real LLM: (1) Set OPENAI_API_KEY, (2) Remove or unset OPENAI_BASE_URL from your environment, (3) Restart the agent."
       }
     }
   ]

--- a/showcase/shell-docs/src/content/docs/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/auth.mdx
@@ -342,6 +342,7 @@ using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using OpenAI;
+using OpenAI.Chat;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -360,21 +361,20 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     });
 
 builder.Services.AddAuthorization();
+builder.Services.AddAGUIServer();
 
 var app = builder.Build();
 
 app.UseAuthentication();
 app.UseAuthorization();
 
-string githubToken = builder.Configuration["GitHubToken"]!;
-var openAI = new OpenAIClient(
-    new System.ClientModel.ApiKeyCredential(githubToken),
-    new OpenAIClientOptions { Endpoint = new Uri("https://models.inference.ai.azure.com") }
-);
+string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+    ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
+var openAI = new OpenAIClient(openAiApiKey);
 var agent = openAI.GetChatClient("gpt-5.4-mini")
-    .CreateAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
+    .AsAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
 
-app.MapAGUI("/", agent).RequireAuthorization();
+app.MapAGUIServer("/", agent).RequireAuthorization();
 
 await app.RunAsync();
 ```
@@ -384,9 +384,15 @@ Settings live in `appsettings.json`:
 ```json title="appsettings.json"
 {
   "JwtAuthority": "https://login.microsoftonline.com/{your-tenant-id}/v2.0",
-  "JwtAudience": "api://{your-client-id}",
-  "GitHubToken": "your-github-token-here"
+  "JwtAudience": "api://{your-client-id}"
 }
+```
+
+Save the model key outside `appsettings.json`:
+
+```bash
+dotnet user-secrets init
+dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
 ```
 
 </Tab>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/agent-app-context.mdx
@@ -54,31 +54,34 @@ This context can then be shared with your AG-UI server and agent logic.
 
     <Step>
         ### Consume the data in your AG-UI server
-        The `context` you register on the frontend is forwarded to your AG-UI server in `ChatOptions.AdditionalProperties["ag_ui_context"]`. Use middleware to access this context and inject it into the agent's conversation.
+        The `context` you register on the frontend is forwarded in the AG-UI `RunAgentInput`. Use middleware to read it and inject it into the agent's conversation.
 
         <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
           <Tab value=".NET">
             ```csharp title="Program.cs"
             using System.Runtime.CompilerServices;
             using System.Text;
-            using Azure.AI.OpenAI;
-            using Azure.Identity;
+            using AGUI.Abstractions;
+            using AGUI.Server;
             using Microsoft.Agents.AI;
             using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
             using Microsoft.AspNetCore.Builder;
             using Microsoft.Extensions.AI;
+            using OpenAI;
+            using OpenAI.Chat;
+            using AIChatMessage = Microsoft.Extensions.AI.ChatMessage;
 
             var builder = WebApplication.CreateBuilder(args);
-            builder.Services.AddAGUI();
+            builder.Services.AddAGUIServer();
             var app = builder.Build();
 
-            string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]!;
-            string deployment = builder.Configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]!;
+            string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+                ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
 
             // Create the base agent
-            AIAgent baseAgent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-                .GetChatClient(deployment)
-                .CreateAIAgent(
+            AIAgent baseAgent = new OpenAIClient(openAiApiKey)
+                .GetChatClient("gpt-5.4-mini")
+                .AsAIAgent(
                     name: "AGUIAssistant",
                     instructions: "You are a helpful assistant. Use the provided context about colleagues to answer questions.");
 
@@ -89,37 +92,37 @@ This context can then be shared with your AG-UI server and agent logic.
                 .Build();
 
             // Map the AG-UI endpoint
-            app.MapAGUI("/", agent);
+            app.MapAGUIServer("/", agent);
             await app.RunAsync();
 
             // Middleware to inject useAgentContext context as a system message
-            async IAsyncEnumerable<AgentRunResponseUpdate> InjectContextMiddleware(
-                IEnumerable<ChatMessage> messages,
-                AgentThread? thread,
+            async IAsyncEnumerable<AgentResponseUpdate> InjectContextMiddleware(
+                IEnumerable<AIChatMessage> messages,
+                AgentSession? session,
                 AgentRunOptions? options,
                 AIAgent innerAgent,
-                CancellationToken cancellationToken)
+                [EnumeratorCancellation] CancellationToken cancellationToken)
             {
-                // Extract context from AG-UI additional properties and inject if present
-                if (options is ChatClientAgentRunOptions { ChatOptions.AdditionalProperties: { } properties } &&
-                    properties.TryGetValue("ag_ui_context", out KeyValuePair<string, string>[]? context) &&
-                    context?.Length > 0)
+                // Recover the AG-UI request and inject its context if present
+                if (options is ChatClientAgentRunOptions { ChatOptions: { } chatOptions } &&
+                    chatOptions.TryGetRunAgentInput(out RunAgentInput? input) &&
+                    input?.Context is { Count: > 0 } context)
                 {
                     var contextBuilder = new StringBuilder();
                     contextBuilder.AppendLine("The following context from the user's application is available:");
-                    foreach (var item in context)
+                    foreach (AGUIContext item in context)
                     {
-                        contextBuilder.AppendLine($"- {item.Key}: {item.Value}");
+                        contextBuilder.AppendLine($"- {item.Description}: {item.Value}");
                     }
 
-                    var contextMessage = new ChatMessage(
+                    var contextMessage = new AIChatMessage(
                         ChatRole.System,
                         [new TextContent(contextBuilder.ToString())]);
 
                     messages = messages.Append(contextMessage);
                 }
 
-                await foreach (var update in innerAgent.RunStreamingAsync(messages, thread, options, cancellationToken))
+                await foreach (var update in innerAgent.RunStreamingAsync(messages, session, options, cancellationToken))
                 {
                     yield return update;
                 }
@@ -154,11 +157,11 @@ This context can then be shared with your AG-UI server and agent logic.
         </Tabs>
 
         <Callout type="info">
-          Context registered with `useAgentContext` is automatically forwarded by the AG-UI protocol in `ChatOptions.AdditionalProperties["ag_ui_context"]` as an array of key-value pairs (`description` to `value`). The middleware extracts and injects this context into the conversation.
+          Context registered with `useAgentContext` is forwarded in `RunAgentInput.Context` as `AGUIContext` entries. `TryGetRunAgentInput` recovers the request without depending on hosting-layer keys.
         </Callout>
 
         <Callout type="tip">
-          **Configuration & Error Handling**: This example uses environment variables for configuration. Set `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_CHAT_DEPLOYMENT_NAME` via `appsettings.json`, user-secrets, or environment variables. For production deployments, add appropriate error handling and consider using the [Quickstart](/microsoft-agent-framework/quickstart) or [Authentication](/microsoft-agent-framework/auth) guides for complete setup patterns.
+          **Configuration & Error Handling**: This example uses `OPENAI_API_KEY` for configuration. Set it with user secrets or an environment variable. For production deployments, add appropriate error handling and consider using the [Quickstart](/microsoft-agent-framework/quickstart) or [Authentication](/microsoft-agent-framework/auth) guides for complete setup patterns.
         </Callout>
     </Step>
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/auth.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/auth.mdx
@@ -36,6 +36,7 @@ Configure authentication in your AG-UI server:
     using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using OpenAI;
+    using OpenAI.Chat;
 
     var builder = WebApplication.CreateBuilder(args);
 
@@ -55,6 +56,7 @@ Configure authentication in your AG-UI server:
         });
 
     builder.Services.AddAuthorization();
+    builder.Services.AddAGUIServer();
 
     var app = builder.Build();
 
@@ -62,15 +64,13 @@ Configure authentication in your AG-UI server:
     app.UseAuthorization();
 
     // Create and map your agent
-    string githubToken = builder.Configuration["GitHubToken"]!;
-    var openAI = new OpenAIClient(
-        new System.ClientModel.ApiKeyCredential(githubToken),
-        new OpenAIClientOptions { Endpoint = new Uri("https://models.inference.ai.azure.com") }
-    );
+    string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+        ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
+    var openAI = new OpenAIClient(openAiApiKey);
     var agent = openAI.GetChatClient("gpt-5.4-mini")
-        .CreateAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
+        .AsAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
 
-    app.MapAGUI("/", agent).RequireAuthorization();
+    app.MapAGUIServer("/", agent).RequireAuthorization();
 
     await app.RunAsync();
     ```
@@ -144,9 +144,15 @@ Add settings to your server configuration:
     ```json title="appsettings.json"
     {
       "JwtAuthority": "https://login.microsoftonline.com/{your-tenant-id}/v2.0",
-      "JwtAudience": "api://{your-client-id}",
-      "GitHubToken": "your-github-token-here"
+      "JwtAudience": "api://{your-client-id}"
     }
+    ```
+
+    Save the model key outside `appsettings.json`:
+
+    ```bash
+    dotnet user-secrets init
+    dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
     ```
   </Tab>
   <Tab value="Python">

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/frontend-tools.mdx
@@ -80,25 +80,25 @@ Use frontend tools when you need your agent to interact with client-side primiti
         <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
           <Tab value=".NET">
             ```csharp title="Program.cs"
-            using Azure.AI.OpenAI;
-            using Azure.Identity;
             using Microsoft.Agents.AI;
             using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+            using OpenAI;
+            using OpenAI.Chat;
 
             var builder = WebApplication.CreateBuilder(args);
-            builder.Services.AddAGUI();
+            builder.Services.AddAGUIServer();
             var app = builder.Build();
 
-            string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]!;
-            string deployment = builder.Configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]!;
+            string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+                ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
 
             // Create the agent
-            var agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-                .GetChatClient(deployment)
-                .CreateAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
+            var agent = new OpenAIClient(openAiApiKey)
+                .GetChatClient("gpt-5.4-mini")
+                .AsAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
 
             // Map the AG-UI endpoint
-            app.MapAGUI("/", agent);
+            app.MapAGUIServer("/", agent);
             await app.RunAsync();
             ```
           </Tab>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/generative-ui/state-rendering.mdx
@@ -106,8 +106,8 @@ is a situation where a user and an agent are working together to solve a problem
         ```csharp title="Program.cs"
         using System.Runtime.CompilerServices;
         using System.Text.Json;
-        using Azure.AI.OpenAI;
-        using Azure.Identity;
+        using AGUI.Abstractions;
+        using AGUI.Server;
         using Microsoft.Agents.AI;
         using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
         using Microsoft.AspNetCore.Builder;
@@ -115,21 +115,25 @@ is a situation where a user and an agent are working together to solve a problem
         using Microsoft.Extensions.AI;
         using Microsoft.Extensions.DependencyInjection;
         using Microsoft.Extensions.Options;
+        using OpenAI;
+        using OpenAI.Chat;
+        using AIChatMessage = Microsoft.Extensions.AI.ChatMessage;
+        using AIChatResponseFormat = Microsoft.Extensions.AI.ChatResponseFormat;
 
         var builder = WebApplication.CreateBuilder(args);
-        builder.Services.AddAGUI();
+        builder.Services.AddAGUIServer();
         var app = builder.Build();
 
-        string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]!;
-        string deployment = builder.Configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]!;
+        string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+            ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
 
         // Get JSON serializer options
         var jsonOptions = app.Services.GetRequiredService<IOptions<JsonOptions>>();
 
         // Create the base agent
-        AIAgent baseAgent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-            .GetChatClient(deployment)
-            .CreateAIAgent(
+        AIAgent baseAgent = new OpenAIClient(openAiApiKey)
+            .GetChatClient("gpt-5.4-mini")
+            .AsAIAgent(
                 name: "ResearchAssistant",
                 instructions: "You are a research assistant that tracks your progress.");
 
@@ -137,7 +141,7 @@ is a situation where a user and an agent are working together to solve a problem
         AIAgent agent = new StateStreamingAgent(baseAgent, jsonOptions.Value.SerializerOptions);
 
         // Map the AG-UI endpoint
-        app.MapAGUI("/", agent);
+        app.MapAGUIServer("/", agent);
         await app.RunAsync();
 
         // Agent wrapper that streams state updates
@@ -151,39 +155,49 @@ is a situation where a user and an agent are working together to solve a problem
                 this._jsonSerializerOptions = jsonSerializerOptions;
             }
 
-            public override async IAsyncEnumerable<AgentRunResponseUpdate> RunStreamingAsync(
-                IEnumerable<ChatMessage> messages,
-                AgentThread? thread = null,
+            protected override Task<AgentResponse> RunCoreAsync(
+                IEnumerable<AIChatMessage> messages,
+                AgentSession? session = null,
+                AgentRunOptions? options = null,
+                CancellationToken cancellationToken = default) =>
+                RunCoreStreamingAsync(messages, session, options, cancellationToken)
+                    .ToAgentResponseAsync(cancellationToken);
+
+            protected override async IAsyncEnumerable<AgentResponseUpdate> RunCoreStreamingAsync(
+                IEnumerable<AIChatMessage> messages,
+                AgentSession? session = null,
                 AgentRunOptions? options = null,
                 [EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
-                // Get current state from options if provided
-                JsonElement currentState = default;
-                if (options is ChatClientAgentRunOptions { ChatOptions.AdditionalProperties: { } properties } &&
-                    properties.TryGetValue("ag_ui_state", out object? stateObj) && stateObj is JsonElement state)
+                // Recover the state sent in the AG-UI request
+                JsonElement? currentState = null;
+                if (options is ChatClientAgentRunOptions { ChatOptions: { } chatOptions } &&
+                    chatOptions.TryGetRunAgentInput(out RunAgentInput? input) &&
+                    input?.State is { ValueKind: JsonValueKind.Object } state)
                 {
                     currentState = state;
                 }
 
-                // Create options with JSON schema for structured state output
-                ChatClientAgentRunOptions stateOptions = new ChatClientAgentRunOptions
+                // Clone the run options, then request structured state output
+                var chatRunOptions = options as ChatClientAgentRunOptions;
+                var stateChatOptions = chatRunOptions?.ChatOptions?.Clone() ?? new ChatOptions();
+                stateChatOptions.ResponseFormat = AIChatResponseFormat.ForJsonSchema<AgentStateSnapshot>(
+                    schemaName: "AgentStateSnapshot",
+                    schemaDescription: "Research progress state");
+
+                ChatClientAgentRunOptions stateOptions = new(stateChatOptions)
                 {
-                    ChatOptions = new ChatOptions
-                    {
-                        ResponseFormat = ChatResponseFormat.ForJsonSchema<AgentStateSnapshot>(
-                            schemaName: "AgentStateSnapshot",
-                            schemaDescription: "Research progress state")
-                    }
+                    ChatClientFactory = chatRunOptions?.ChatClientFactory,
                 };
 
                 // Add system message with current state
-                var stateMessage = new ChatMessage(ChatRole.System,
-                    $"Current state: {(currentState.ValueKind != JsonValueKind.Undefined ? currentState.GetRawText() : "{}")}");
+                var stateMessage = new AIChatMessage(ChatRole.System,
+                    $"Current state: {currentState?.GetRawText() ?? "{}"}");
                 var messagesWithState = messages.Append(stateMessage);
 
                 // Collect all updates
-                var allUpdates = new List<AgentRunResponseUpdate>();
-                await foreach (var update in this.InnerAgent.RunStreamingAsync(messagesWithState, thread, stateOptions, cancellationToken))
+                var allUpdates = new List<AgentResponseUpdate>();
+                await foreach (var update in InnerAgent.RunStreamingAsync(messagesWithState, session, stateOptions, cancellationToken))
                 {
                     allUpdates.Add(update);
                     // Stream non-text updates immediately
@@ -194,24 +208,36 @@ is a situation where a user and an agent are working together to solve a problem
                 }
 
                 // Deserialize state snapshot from response
-                var response = allUpdates.ToAgentRunResponse();
-                if (response.TryDeserialize(this._jsonSerializerOptions, out JsonElement stateSnapshot))
+                var response = allUpdates.ToAgentResponse();
+                JsonElement? stateSnapshot = null;
+                try
+                {
+                    stateSnapshot = JsonSerializer.Deserialize<JsonElement>(
+                        response.Text,
+                        this._jsonSerializerOptions);
+                }
+                catch (JsonException)
+                {
+                    // The model did not return the requested state snapshot.
+                }
+
+                if (stateSnapshot is { } parsedStateSnapshot)
                 {
                     byte[] stateBytes = JsonSerializer.SerializeToUtf8Bytes(
-                        stateSnapshot,
+                        parsedStateSnapshot,
                         this._jsonSerializerOptions.GetTypeInfo(typeof(JsonElement)));
 
                     // Emit state snapshot as DataContent
-                    yield return new AgentRunResponseUpdate
+                    yield return new AgentResponseUpdate
                     {
                         Contents = [new DataContent(stateBytes, "application/json")]
                     };
                 }
 
                 // Stream text summary
-                var summaryMessage = new ChatMessage(ChatRole.System, "Provide a brief summary of your progress.");
-                await foreach (var update in this.InnerAgent.RunStreamingAsync(
-                    messages.Concat(response.Messages).Append(summaryMessage), thread, options, cancellationToken))
+                var summaryMessage = new AIChatMessage(ChatRole.System, "Provide a brief summary of your progress.");
+                await foreach (var update in InnerAgent.RunStreamingAsync(
+                    messages.Concat(response.Messages).Append(summaryMessage), session, options, cancellationToken))
                 {
                     yield return update;
                 }

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/generative-ui/tool-rendering.mdx
@@ -49,17 +49,18 @@ Define a tool function that your agent can call. Microsoft Agent Framework will 
   <Tab value=".NET">
     ```csharp title="Program.cs"
     using System.ComponentModel;
-    using Azure.AI.OpenAI;
-    using Azure.Identity;
     using Microsoft.Agents.AI;
     using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+    using Microsoft.Extensions.AI;
+    using OpenAI;
+    using OpenAI.Chat;
 
     var builder = WebApplication.CreateBuilder(args);
-    builder.Services.AddAGUI();
+    builder.Services.AddAGUIServer();
     var app = builder.Build();
 
-    string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]!;
-    string deployment = builder.Configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]!;
+    string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+        ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
 
     // [!code highlight:4]
     // Define the weather tool function
@@ -67,15 +68,17 @@ Define a tool function that your agent can call. Microsoft Agent Framework will 
     static string GetWeather([Description("The location to get weather for")] string location)
         => $"The weather for {location} is 70 degrees.";
 
+    AITool getWeather = AIFunctionFactory.Create(GetWeather, name: "get_weather");
+
     // Create the agent with tools
-    var agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-        .GetChatClient(deployment)
-        .CreateAIAgent(
+    var agent = new OpenAIClient(openAiApiKey)
+        .GetChatClient("gpt-5.4-mini")
+        .AsAIAgent(
             name: "AGUIAssistant",
-            tools: [AIFunctionFactory.Create(GetWeather, options: new() { Name = "get_weather" })]);
+            tools: [getWeather]);
 
     // Map the AG-UI endpoint
-    app.MapAGUI("/", agent);
+    app.MapAGUIServer("/", agent);
 
     await app.RunAsync();
     ```

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop.mdx
@@ -84,25 +84,25 @@ Use frontend tools when you need your agent to interact with client-side primiti
         <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
           <Tab value=".NET">
             ```csharp title="Program.cs"
-            using Azure.AI.OpenAI;
-            using Azure.Identity;
             using Microsoft.Agents.AI;
             using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
+            using OpenAI;
+            using OpenAI.Chat;
 
             var builder = WebApplication.CreateBuilder(args);
-            builder.Services.AddAGUI();
+            builder.Services.AddAGUIServer();
             var app = builder.Build();
 
-            string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]!;
-            string deployment = builder.Configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]!;
+            string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+                ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
 
             // Create the agent - frontend tools are automatically available
-            var agent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-                .GetChatClient(deployment)
-                .CreateAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
+            var agent = new OpenAIClient(openAiApiKey)
+                .GetChatClient("gpt-5.4-mini")
+                .AsAIAgent(name: "AGUIAssistant", instructions: "You are a helpful assistant.");
 
             // Map the AG-UI endpoint
-            app.MapAGUI("/", agent);
+            app.MapAGUIServer("/", agent);
             await app.RunAsync();
             ```
           </Tab>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -19,7 +19,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
 
 Before you begin, you'll need the following:
 
-- A GitHub Personal Access Token (for GitHub Models API - free AI access)
+- An [OpenAI API key](https://platform.openai.com/api-keys) for the .NET starter
 - .NET 9.0 SDK or later
 - Node.js 20+
 - Your favorite package manager (npm, pnpm, yarn, or bun)
@@ -94,27 +94,17 @@ Before you begin, you'll need the following:
 
                 <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
                     <Tab value=".NET">
-                        The starter template uses GitHub Models API for free access to AI models. Set up your GitHub token:
+                        The .NET starter uses OpenAI. Save your API key as a .NET user secret:
 
-                        First, get your GitHub token (requires [GitHub CLI](https://github.com/cli/cli)):
-                        ```bash
-                        gh auth token
-                        ```
-
-                        Then navigate to the agent directory and set it as a user secret:
                         ```bash
                         cd agent
-                        dotnet user-secrets set GitHubToken "$(gh auth token)"
+                        dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
                         cd ..
                         ```
 
                         <Callout type="info" title="Want to use a different model provider?">
-                          The starter template is configured to use GitHub Models (free), but you can modify it to use:
-                          - OpenAI directly
-                          - Azure OpenAI
-                          - Any other model supported by Microsoft Agent Framework
-
-                          Check the `agent/Program.cs` file to customize the model configuration.
+                          Edit `agent/Program.cs` to use Azure OpenAI or another
+                          [Microsoft Agent Framework model provider](https://learn.microsoft.com/en-us/agent-framework/integrations/by-component/model-providers/).
                         </Callout>
                     </Tab>
                     <Tab value="Python">
@@ -179,9 +169,8 @@ Before you begin, you'll need the following:
                         ```bash
                         dotnet new web -n AGUIServer
                         cd AGUIServer
-                        dotnet add package Microsoft.Agents.AI.Hosting.AGUI.AspNetCore --version 1.0.0-preview.251110.1
-                        dotnet add package Microsoft.Extensions.AI.OpenAI --version 9.10.2-preview.1.25552.1
-                        dotnet add package OpenAI --version 2.6.0
+                        dotnet add package Microsoft.Agents.AI.Hosting.AGUI.AspNetCore --prerelease
+                        dotnet add package Microsoft.Agents.AI.OpenAI
                         dotnet user-secrets init
                         ```
 
@@ -191,38 +180,31 @@ Before you begin, you'll need the following:
                         using Microsoft.Agents.AI;
                         // [!code highlight:1]
                         using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
-                        using Microsoft.Extensions.AI;
                         using OpenAI;
+                        using OpenAI.Chat;
 
                         var builder = WebApplication.CreateBuilder(args);
                         // [!code highlight:1]
-                        builder.Services.AddAGUI();
+                        builder.Services.AddAGUIServer();
                         var app = builder.Build();
 
-                        // Get your GitHub token for GitHub Models (free)
-                        var githubToken = builder.Configuration["GitHubToken"]!;
-                        var openAI = new OpenAIClient(
-                            new System.ClientModel.ApiKeyCredential(githubToken),
-                            new OpenAIClientOptions {
-                                Endpoint = new Uri("https://models.inference.ai.azure.com")
-                            });
+                        var openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+                            ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
+                        var openAI = new OpenAIClient(openAiApiKey);
 
-                        var chatClient = openAI.GetChatClient("gpt-5.4-mini").AsIChatClient();
-                        var agent = new ChatClientAgent(
-                            chatClient,
+                        var agent = openAI.GetChatClient("gpt-5.4-mini").AsAIAgent(
                             name: "MyAgent",
-                            description: "You are a helpful assistant.");
+                            instructions: "You are a helpful assistant.");
 
                         // [!code highlight:1]
-                        app.MapAGUI("/", agent);
+                        app.MapAGUIServer("/", agent);
                         app.Run("http://localhost:8000");
                         ```
 
-                        Then just setup the environment and run your agent:
+                        Set the key, then run the agent:
 
                         ```bash
-                        # Set your GitHub token and run
-                        dotnet user-secrets set GitHubToken "$(gh auth token)"
+                        dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
                         dotnet run
                         ```
                     </Tab>
@@ -495,14 +477,14 @@ Before you begin, you'll need the following:
                 **Agent Connection Issues**
                 - If you see "I'm having trouble connecting to my tools", make sure:
                   - The C# agent is running on port 8000
-                  - Your GitHub token is set correctly via user secrets
+                  - Your OpenAI API key is set via .NET user secrets
                   - Both servers started successfully (check terminal output)
 
-                **GitHub Token Issues**
-                - If the agent fails with "GitHubToken not found":
+                **OpenAI API Key Issues**
+                - If the agent fails with "OPENAI_API_KEY not found":
                   ```bash
                   cd agent
-                  dotnet user-secrets set GitHubToken "$(gh auth token)"
+                  dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"
                   ```
 
                 **.NET SDK Issues**

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -169,8 +169,8 @@ Before you begin, you'll need the following:
                         ```bash
                         dotnet new web -n AGUIServer
                         cd AGUIServer
-                        dotnet add package Microsoft.Agents.AI.Hosting.AGUI.AspNetCore --prerelease
-                        dotnet add package Microsoft.Agents.AI.OpenAI
+                        dotnet add package Microsoft.Agents.AI.Hosting.AGUI.AspNetCore --version 1.19.0-preview.260822.1
+                        dotnet add package Microsoft.Agents.AI.OpenAI --version 1.19.0
                         dotnet user-secrets init
                         ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/shared-state/predictive-state-updates.mdx
@@ -71,122 +71,58 @@ Use predictive state updates when you want to:
   </Step>
 
   <Step>
-    ### Emit the intermediate state (tool-based predictive updates)
-    Configure AG-UI state management to treat tool arguments as predictive updates to `observed_steps`. As the LLM streams arguments for the tool call, AG-UI emits state delta events immediately.
+    ### Map tool calls to state
+    Configure AG-UI state management to map the `step_progress` tool arguments to `observed_steps`. The .NET adapter emits a state snapshot when it receives the completed tool call. The Python adapter can also stream partial tool arguments as state deltas.
 
     <Tabs groupId="language" items={[".NET", "Python"]}>
       <Tab value=".NET">
         ```csharp title="agent/Program.cs (excerpt)"
         using System.ComponentModel;
         using System.Text.Json;
-        using System.Text.Json.Serialization;
-        using Azure.AI.OpenAI;
-        using Azure.Identity;
+        using AGUI.Abstractions;
+        using AGUI.Server;
         using Microsoft.Agents.AI;
         using Microsoft.Agents.AI.Hosting.AGUI.AspNetCore;
-        using Microsoft.AspNetCore.Http.Json;
         using Microsoft.Extensions.AI;
-        using Microsoft.Extensions.DependencyInjection;
-        using Microsoft.Extensions.Options;
+        using OpenAI;
+        using OpenAI.Chat;
 
         var builder = WebApplication.CreateBuilder(args);
-        builder.Services.AddAGUI();
-        // Register a source-generated serializer context for fast, typed JSON
-        builder.Services.ConfigureHttpJsonOptions(options =>
-            options.SerializerOptions.TypeInfoResolverChain.Add(AGUIDojoServerSerializerContext.Default));
-
+        builder.Services.AddAGUIServer();
         var app = builder.Build();
 
-        string endpoint = builder.Configuration["AZURE_OPENAI_ENDPOINT"]!;
-        string deployment = builder.Configuration["AZURE_OPENAI_CHAT_DEPLOYMENT_NAME"]!;
+        string openAiApiKey = builder.Configuration["OPENAI_API_KEY"]
+            ?? throw new InvalidOperationException("Set OPENAI_API_KEY");
 
-        // Define a tool the LLM may call as it progresses to report partial steps
+        // Define a tool the LLM may call to report its progress
         [Description("Report current step progress.")]
         static string StepProgress([Description("Steps completed so far")] string[] steps)
             => "Progress received.";
 
-        // Create the base agent with the reporting tool
-        var baseAgent = new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
-            .GetChatClient(deployment)
-            .CreateAIAgent(
+        AITool stepProgress = AIFunctionFactory.Create(StepProgress, name: "step_progress");
+        var agent = new OpenAIClient(openAiApiKey)
+            .GetChatClient("gpt-5.4-mini")
+            .AsAIAgent(
                 name: "AGUIAssistant",
                 instructions: "You are a helpful assistant that may call the 'step_progress' tool to report intermediate steps.",
-                tools: [AIFunctionFactory.Create(StepProgress, options: new() { Name = "step_progress" })]);
+                tools: [stepProgress]);
 
-        // Wrap with a streaming middleware that emits interim state snapshots (typed, source-generated).
-        // See the "Stream state from your agent" section in the Agent State guide for a full example of a DelegatingAIAgent
-        // that reads streaming updates and emits DataContent with an AgentStateSnapshot.
-        var jsonOptions = app.Services.GetRequiredService<IOptions<JsonOptions>>();
-        AIAgent agent = new StateStreamingAgent(baseAgent, jsonOptions.Value.SerializerOptions);
-
-        app.MapAGUI("/", agent);
-        await app.RunAsync();
-
-        // Example: streaming agent wrapper emitting state snapshots (simplified)
-        internal sealed class StateStreamingAgent : DelegatingAIAgent
-        {
-            private readonly JsonSerializerOptions _jsonOptions;
-            public StateStreamingAgent(AIAgent inner, JsonSerializerOptions jsonOptions) : base(inner)
+        // Map the completed tool arguments to a shared-state snapshot
+        AGUIStreamOptions streamOptions = new AGUIStreamOptions()
+            .MapCall("step_progress", call =>
             {
-                _jsonOptions = jsonOptions;
-            }
-
-            public override async IAsyncEnumerable<AgentRunResponseUpdate> RunStreamingAsync(
-                IEnumerable<ChatMessage> messages,
-                AgentThread? thread = null,
-                AgentRunOptions? options = null,
-                [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
-            {
-                var observedSteps = new List<string>();
-                await foreach (var update in this.InnerAgent.RunStreamingAsync(messages, thread, options, cancellationToken))
+                if (call.Arguments?.TryGetValue("steps", out object? steps) is not true)
                 {
-                    // Inspect streaming contents for function calls and collect step arguments as they arrive
-                    foreach (var content in update.Contents)
-                    {
-                        if (content is FunctionCallContent f
-                            && string.Equals(f.Name, "step_progress", StringComparison.OrdinalIgnoreCase)
-                            && f.Arguments is JsonElement args)
-                        {
-                            if (args.TryGetProperty("steps", out var stepsElement))
-                            {
-                                if (stepsElement.Deserialize(_jsonOptions.GetTypeInfo(typeof(string[]))) is string[] steps)
-                                {
-                                    observedSteps.Clear();
-                                    foreach (var s in steps)
-                                    {
-                                        observedSteps.Add(s);
-                                    }
-                                    // Emit a typed state snapshot into the AG‑UI stream
-                                    var snapshot = new AgentStateSnapshot { Steps = observedSteps };
-                                    byte[] stateBytes = JsonSerializer.SerializeToUtf8Bytes(
-                                        snapshot,
-                                        _jsonOptions.GetTypeInfo(typeof(AgentStateSnapshot)));
-                                    yield return new AgentRunResponseUpdate
-                                    {
-                                        Contents = [ new DataContent(stateBytes, "application/json") ]
-                                    };
-                                }
-                            }
-                        }
-                    }
-
-                    // Always forward the original update (text deltas / final tool results, etc.)
-                    yield return update;
+                    return [];
                 }
-            }
-        }
 
-        // Typed state snapshot for source-generated JSON
-        internal sealed class AgentStateSnapshot
-        {
-            [JsonPropertyName("observed_steps")]
-            public List<string> Steps { get; set; } = new();
-        }
+                JsonElement snapshot = JsonSerializer.SerializeToElement(
+                    new { observed_steps = steps });
+                return [new StateSnapshotEvent { Snapshot = snapshot }];
+            });
 
-        // Source-generated serializer context (register above via ConfigureHttpJsonOptions)
-        [JsonSerializable(typeof(AgentStateSnapshot))]
-        [JsonSerializable(typeof(string[]))]
-        internal sealed partial class AGUIDojoServerSerializerContext : JsonSerializerContext;
+        app.MapAGUIServer("/", agent).WithMetadata(streamOptions);
+        await app.RunAsync();
         ```
       </Tab>
       <Tab value="Python">
@@ -240,14 +176,16 @@ Use predictive state updates when you want to:
       </Tab>
     </Tabs>
     <Callout>
-      With this configuration, AG-UI emits predictive state updates as soon as the model streams the tool arguments, without waiting for tool completion.
+      On .NET, `MapCall` maps the completed `FunctionCallContent` to a state
+      snapshot. Progressive .NET tool-argument updates require a provider-specific
+      extractor registered with `MapStreamingToolCallArguments`.
     </Callout>
 
   </Step>
 
   <Step>
-    ### Observe predictions on the client
-    Add a state renderer to observe the predicted `observed_steps` updates as they stream in.
+    ### Observe state on the client
+    Add a state renderer to observe the `observed_steps` updates as they arrive.
 
     ```tsx title="ui/app/page.tsx"
     "use client";
@@ -259,10 +197,10 @@ Use predictive state updates when you want to:
     };
 
     export default function Page() {
-      // Access both predicted and final states
+      // Access the latest shared state
       const { agent } = useAgent({ agentId: "sample_agent" });
 
-      // Observe predictions by reading the agent's streamed state
+      // Read the agent's shared state
       const progress =
         agent.state?.observed_steps?.length ? (
           <div>

--- a/showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, test } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../../../..");
+const MAF_DOCS_ROOT =
+  "showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework";
+
+function listMarkdownFiles(relativeDirectory: string): string[] {
+  const absoluteDirectory = path.join(REPO_ROOT, relativeDirectory);
+
+  return fs
+    .readdirSync(absoluteDirectory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const relativePath = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) {
+        return listMarkdownFiles(relativePath);
+      }
+      return entry.isFile() && entry.name.endsWith(".mdx")
+        ? [relativePath]
+        : [];
+    })
+    .sort();
+}
+
+const guardedFiles = [
+  "showcase/shell-docs/src/content/docs/auth.mdx",
+  ...listMarkdownFiles(MAF_DOCS_ROOT),
+  "examples/integrations/ms-agent-framework-dotnet/README.md",
+  "examples/integrations/ms-agent-framework-dotnet/agent/Program.cs",
+  "examples/integrations/ms-agent-framework-dotnet/agent/ProverbsAgent.csproj",
+  "examples/integrations/ms-agent-framework-dotnet/agent/SharedStateAgent.cs",
+  "examples/integrations/ms-agent-framework-dotnet/docker-compose.test.yml",
+  "examples/integrations/ms-agent-framework-dotnet/docker/Dockerfile.agent",
+  "examples/integrations/ms-agent-framework-dotnet/fixtures/default.json",
+];
+
+const staleGuidance = [
+  /GitHub Models/i,
+  /GitHubToken/,
+  /models\.inference\.ai\.azure\.com/,
+  /models\.github\.ai/,
+  /github\.com\/marketplace\/models/,
+  /AddAGUI\(/,
+  /MapAGUI\(/,
+  /Microsoft\.Extensions\.AI\.OpenAI/,
+  /AgentThread/,
+  /AgentRunResponse/,
+  /ag_ui_state/,
+] as const;
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
+}
+
+test("does not publish retired provider or obsolete .NET API guidance", () => {
+  const offenders = guardedFiles.flatMap((relativePath) => {
+    const source = read(relativePath);
+    return staleGuidance
+      .filter((pattern) => pattern.test(source))
+      .map((pattern) => `${relativePath}: ${pattern.source}`);
+  });
+
+  expect(offenders).toEqual([]);
+});
+
+test("uses the current Agent Framework server and OpenAI APIs", () => {
+  const quickstart = read(
+    "showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx",
+  );
+  const authGuides = [
+    read("showcase/shell-docs/src/content/docs/auth.mdx"),
+    read(
+      "showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/auth.mdx",
+    ),
+  ];
+  const starter = read(
+    "examples/integrations/ms-agent-framework-dotnet/agent/Program.cs",
+  );
+  const project = read(
+    "examples/integrations/ms-agent-framework-dotnet/agent/ProverbsAgent.csproj",
+  );
+
+  for (const authGuide of authGuides) {
+    expect(authGuide).toMatch(
+      /dotnet user-secrets init\s+dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"/,
+    );
+  }
+  expect(quickstart).toContain(
+    'dotnet user-secrets set OPENAI_API_KEY "<your-openai-api-key>"',
+  );
+  expect(starter).toContain('_configuration["OPENAI_API_KEY"]');
+  expect(starter).toContain('_configuration["OPENAI_BASE_URL"]');
+  expect(starter).toContain("builder.Services.AddAGUIServer()");
+  expect(starter).toContain('app.MapAGUIServer("/"');
+  expect(starter).toContain(".AsAIAgent(");
+  expect(project).toContain(
+    'PackageReference Include="Microsoft.Agents.AI.OpenAI"',
+  );
+});

--- a/showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts
@@ -27,6 +27,7 @@ function listMarkdownFiles(relativeDirectory: string): string[] {
 const guardedFiles = [
   "showcase/shell-docs/src/content/docs/auth.mdx",
   ...listMarkdownFiles(MAF_DOCS_ROOT),
+  "examples/integrations/ms-agent-framework-dotnet/.env.example",
   "examples/integrations/ms-agent-framework-dotnet/README.md",
   "examples/integrations/ms-agent-framework-dotnet/agent/Program.cs",
   "examples/integrations/ms-agent-framework-dotnet/agent/ProverbsAgent.csproj",
@@ -97,5 +98,72 @@ test("uses the current Agent Framework server and OpenAI APIs", () => {
   expect(starter).toContain(".AsAIAgent(");
   expect(project).toContain(
     'PackageReference Include="Microsoft.Agents.AI.OpenAI"',
+  );
+});
+
+test("pins quickstart packages to the starter's tested versions", () => {
+  const quickstart = read(
+    "showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx",
+  );
+  const project = read(
+    "examples/integrations/ms-agent-framework-dotnet/agent/ProverbsAgent.csproj",
+  );
+  const packages = [
+    "Microsoft.Agents.AI.Hosting.AGUI.AspNetCore",
+    "Microsoft.Agents.AI.OpenAI",
+  ] as const;
+
+  for (const packageName of packages) {
+    const packageReference = project
+      .split("\n")
+      .find((line) =>
+        line.includes(`<PackageReference Include="${packageName}"`),
+      );
+    const version = packageReference?.match(/Version="([^"]+)"/)?.[1];
+
+    expect(
+      version,
+      `${packageName} must be pinned in the starter`,
+    ).toBeDefined();
+    expect(quickstart).toContain(
+      `dotnet add package ${packageName} --version ${version}`,
+    );
+  }
+
+  expect(quickstart).not.toContain("--prerelease");
+});
+
+test("registers predictive state mappings as AG-UI endpoint metadata", () => {
+  const guide = read(
+    "showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/shared-state/predictive-state-updates.mdx",
+  );
+
+  expect(guide).toMatch(
+    /AGUIStreamOptions streamOptions = new AGUIStreamOptions\(\)[\s\S]*?\.MapCall\("step_progress",[\s\S]*?app\.MapAGUIServer\("\/", agent\)\.WithMetadata\(streamOptions\);/,
+  );
+});
+
+test("runs the provider guard in docs CI for docs and starter changes", () => {
+  const workflow = read(".github/workflows/test_integration-docs.yml");
+  const pathTriggers = [
+    "showcase/shell-docs/src/content/**",
+    "showcase/shell-docs/model-allowlist.json",
+    "showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts",
+    "showcase/shell-docs/package.json",
+    "showcase/shell-docs/package-lock.json",
+    "examples/integrations/ms-agent-framework-dotnet/**",
+  ] as const;
+
+  for (const pathTrigger of pathTriggers) {
+    const matchingLines = workflow
+      .split("\n")
+      .filter((line) => line === `      - "${pathTrigger}"`);
+    expect(
+      matchingLines,
+      `${pathTrigger} must trigger on PRs and pushes`,
+    ).toHaveLength(2);
+  }
+  expect(workflow).toContain(
+    "npm exec -- vitest run src/lib/__tests__/ms-agent-dotnet-provider.test.ts",
   );
 });


### PR DESCRIPTION
## What does this PR do?

- Replaces the retired GitHub Models setup in the Microsoft Agent Framework .NET starter with direct OpenAI.
- Updates the live .NET guides to the current Agent Framework AG-UI hosting, session, state, and response APIs.
- Pins quickstart packages to the versions tested by the starter.
- Adds a recursive retired-guidance guard and runs it in docs CI for docs or starter-only changes.

GitHub Models was fully retired on July 30, 2026, so the published setup can no longer work.

## Related PRs and Issues

- Companion CLI cleanup: https://github.com/CopilotKit/Intelligence/pull/1029

## Validation

- `npm exec -- vitest run src/lib/__tests__/ms-agent-dotnet-provider.test.ts` (5 tests passed)
- `npm run typecheck`
- `npm run lint` (existing warnings only)
- `npm run build`
- `pnpm run validate:model-names`
- Workflow syntax and formatting checks passed.
- `docker build -f docker/Dockerfile.agent agent`
- `docker compose -f docker-compose.test.yml config`
- Compiled all nine full .NET guide examples against the pinned Agent Framework and AG-UI packages.
- TestServer proof returned `200 text/event-stream` and emitted the expected `STATE_SNAPSHOT` through `WithMetadata(streamOptions)`.
- Full shell-docs test run: 469 tests passed; one unrelated existing Mastra fixture test failed in `llm-text.test.ts`.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)