### PR TITLE
docs(shell-docs): fix broken Fixed Schema (Streaming) link

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/generative-ui/a2ui/index.mdx
@@ -42,7 +42,7 @@ Without `a2ui` configured in your CopilotRuntime, A2UI surfaces will not render 
 CopilotKit supports three approaches to A2UI, each with different tradeoffs:
 
 - **[Fixed Schema](./fixed-schema)** — Pre-defined schema loaded from JSON. Agent provides data only. Fastest — no LLM schema generation.
-- **[Fixed Schema (Streaming)](./fixed-schema-streaming)** — Same pre-defined schema, but cards appear one-by-one as the LLM streams data. Great for lists.
+- **[Fixed Schema (Streaming)](./fixed-schema)** — Same pre-defined schema, but cards appear one-by-one as the LLM streams data. Great for lists.
 - **[Dynamic Schema](./dynamic-schema)** — A secondary LLM generates both the schema and data. Fully flexible — any UI from any prompt.
 
 ## When to use which?

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/generative-ui/a2ui/index.mdx
@@ -42,7 +42,7 @@ Without `a2ui` configured in your CopilotRuntime, A2UI surfaces will not render 
 CopilotKit supports three approaches to A2UI, each with different tradeoffs:
 
 - **[Fixed Schema](./fixed-schema)** — Pre-defined schema loaded from JSON. Agent provides data only. Fastest — no LLM schema generation.
-- **[Fixed Schema (Streaming)](./fixed-schema-streaming)** — Same pre-defined schema, but cards appear one-by-one as the LLM streams data. Great for lists.
+- **[Fixed Schema (Streaming)](./fixed-schema)** — Same pre-defined schema, but cards appear one-by-one as the LLM streams data. Great for lists.
 - **[Dynamic Schema](./dynamic-schema)** — A secondary LLM generates both the schema and data. Fully flexible — any UI from any prompt.
 
 ## When to use which?


### PR DESCRIPTION
The A2UI overview pages for both the DeepAgents and LangGraph integrations link to ./fixed-schema-streaming, but that file does not exist (only dvanced, dynamic-schema, ixed-schema, index, styling exist). Point both links to the existing ./fixed-schema page.