### PR TITLE
docs: add inspector-workbench skill for agent Inspector UI work

### DIFF
--- a/.claude/docs/documentation.md
+++ b/.claude/docs/documentation.md
@@ -62,6 +62,9 @@ Before editing framework docs, check the framework's `docs_mode`.
   shared/root pages and framework-specific pages.
 - When adding, renaming, or removing an Inspector pane, follow
   `skills/inspector-docs/SKILL.md` so the matching docs Callout stays in sync.
+- Inspector UI, chrome, and overlay work uses
+  `skills/inspector-workbench/SKILL.md`. Start the standalone lab and take
+  screenshots. Do not use a showcase app as the default host.
 - To **flip a framework to showcase-driven docs**, complete showcase coverage first, then
   change `docs_mode`, regenerate shell-docs data, and verify routes, sidebar entries, search
   results, snippets, and framework switching.

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ lefthook-local.yml
 # Private agent instructions (not shared with the team)
 private-agents.md
 
+# Agent screenshots from the Inspector workbench skill. Session-only. Never commit.
+.inspector-workbench/
+
 # Release artifacts
 release-notes.md
 release-notes-notion.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ AI agent framework with three layers: **Frontend** (React/Angular/Vanilla) → *
 - **Always start from fresh remote main** — at the start of every new task, before creating any branch or worktree, and before running `nx affected` or any base-sensitive comparison, run `git fetch origin main`. Create new work from `origin/main`, never from the local `main` ref. Local `main` may be arbitrarily stale and must not be used as an affected base. For an existing branch, compare against the fetched merge base explicitly (for example, `BASE=$(git merge-base HEAD origin/main)` followed by `nx affected --base="$BASE" --head=HEAD`).
 - **Commit as you go** — every meaningful unit of work gets its own commit, pushed immediately. Don't let untracked files accumulate across a session. Tests belong in the commit that introduces the code being tested. Full rules in [Git & PRs](.claude/docs/git.md#commit-early-and-often-in-logical-chunks).
 - **Documentation lives in shell-docs** — author CopilotKit docs in `showcase/shell-docs/src/content/`. The top-level `docs/` path is only a symlink to `showcase/shell-docs/`; never recreate the old `docs/content/docs/` tree for live documentation. AG-UI protocol docs are authored upstream in `ag-ui-protocol/ag-ui`, not directly in this repo. See [Documentation](.claude/docs/documentation.md).
+- **Inspector UI work** — follow `skills/inspector-workbench/SKILL.md`. Start the standalone workbench and take screenshots after each visual change. Pane add/rename/remove also uses `skills/inspector-docs/SKILL.md`.
 
 ## Private Agent Instructions
 
@@ -60,6 +61,7 @@ Before editing anything that looks like product docs, read [Documentation](.clau
 - For showcase-driven frameworks (`docs_mode: generated`), update the showcase source of truth: manifests, demos, feature coverage, source regions, registry inputs, shared/root MDX, and sparse framework overrides. Do not hand-edit generated files under `showcase/shell-docs/src/data/frameworks/`.
 - For authored frameworks (`docs_mode: authored`), edit `showcase/shell-docs/src/content/docs/integrations/<docsFolder>/` and its `meta.json`.
 - For snippets, edit `showcase/shell-docs/src/content/snippets/`; snippets can feed root docs, authored framework pages, and showcase-driven framework pages.
+- When the task changes Inspector UI, chrome, panes, or overlay behavior, follow `skills/inspector-workbench/SKILL.md`. Start the standalone workbench and take screenshots after each visual change.
 - When adding, renaming, or removing an Inspector pane, follow `skills/inspector-docs/SKILL.md` so the matching docs Callout stays in sync.
 - **AG-UI protocol docs** are canonical upstream in `ag-ui-protocol/ag-ui`. The `showcase/shell-docs/src/content/ag-ui/` tree is a downstream mirror; change AG-UI upstream first, then sync the mirror back.
 - **Do not recreate `docs/content/docs/`**. Top-level `docs/` is only a symlink to shell-docs. The retired Next app no longer publishes to `docs.copilotkit.ai`. Historical content is available from the archive branch/tag, not from `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ AI agent framework with three layers: **Frontend** (React/Angular/Vanilla) → *
 - **No changesets** — releases are conventional-commit-driven (`scripts/release/` reads commit subjects). This repo migrated off Changesets; never create `.changeset/*` files — nothing consumes them and CI fails on them. Describe the change in the commit subject instead, and leave `package.json` versions and `CHANGELOG.md` files to the release tooling.
 - **Worktrees** — always work in a git worktree for isolation. See [Git & PRs](.claude/docs/git.md) for the full workflow.
 - **Documentation lives in shell-docs** — author all CopilotKit docs in `showcase/shell-docs/src/content/`. The top-level `docs/` path is only a symlink to `showcase/shell-docs/`; never recreate the old `docs/content/docs/` tree. AG-UI protocol docs are authored upstream in `ag-ui-protocol/ag-ui`, not here. See [Documentation](.claude/docs/documentation.md).
+- **Inspector UI work** — follow `skills/inspector-workbench/SKILL.md`. Start the standalone workbench and take screenshots after each visual change. Pane add/rename/remove also uses `skills/inspector-docs/SKILL.md`.
 
 ## Reference (read when relevant to your task)
 

--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -188,7 +188,8 @@ describe("syncPluginSkills", () => {
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("setup-slack-channel");
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("channels-setup");
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("inspector-docs");
-    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(12);
+    expect(RESERVED_LIFECYCLE_SLUGS).toContain("inspector-workbench");
+    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(13);
   });
 
   // Version sync — the plugin version tracks packages/runtime/package.json.

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -20,6 +20,7 @@ export const RESERVED_LIFECYCLE_SLUGS: ReadonlySet<string> = new Set([
   "setup-slack-channel",
   "channels-setup",
   "inspector-docs",
+  "inspector-workbench",
 ]);
 
 // Version sync — plugin version tracks this package's version.

--- a/skills/inspector-docs/SKILL.md
+++ b/skills/inspector-docs/SKILL.md
@@ -7,7 +7,7 @@ description: >
   docs that mention Inspector. Don't use for Inspector UI polish that does
   not add a pane, for CLI or agent-prompt copy, or for unshipped Inspector
   ideas.
-version: 1.0.0
+version: 1.0.1
 ---
 
 # Inspector Docs Callouts
@@ -25,7 +25,10 @@ Load this skill when:
 - A PR touches both Inspector source and product docs
 
 Do not load it for icon, ping, layout, or copy-only Inspector changes that
-do not add a pane.
+do not add a pane. Those UI changes use `inspector-workbench`.
+
+If the same change also edits Inspector UI, load `inspector-workbench` as
+well and start the standalone lab.
 
 ## Procedures
 

--- a/skills/inspector-workbench/SKILL.md
+++ b/skills/inspector-workbench/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: inspector-workbench
+description: >
+  Runs Inspector UI work on the standalone Threads state lab so the agent
+  can see the overlay. Use when a CopilotKit employee asks an agent to
+  fix, polish, add, or debug Inspector UI, chrome, panes, overlay actions,
+  launcher, Home, Threads, Playground, Memory, or any visual behavior in
+  @copilotkit/web-inspector. Don't use for docs-only Callout updates (load
+  inspector-docs), runtime or core changes with no Inspector UI, showcase
+  cell work, or reading Inspector as a consumer inside an app.
+version: 1.0.0
+---
+
+# Inspector Workbench
+
+The Inspector overlay is a visual product. Code that compiles is not proof.
+The agent must run the standalone workbench and look at screenshots after
+each visual change.
+
+This skill does not replace `inspector-docs`. If a pane is added, renamed,
+or removed, load `inspector-docs` as well.
+
+## When To Use
+
+Load this skill at the start of any task that changes
+`packages/web-inspector` UI, chrome, or overlay behavior.
+
+Do not load it for docs-only Callout work. Do not load it for showcase
+cells. If the host app is the bug (z-index against host CSS, CopilotChat
+layout), use that host, then still take screenshots.
+
+## Default host
+
+The default host is the standalone Threads state lab:
+
+- Command, from the repo root: `nx run @copilotkit/web-inspector:dev:standalone`
+- URL: `http://127.0.0.1:5177/?scenario=pro-enabled-existing&reset=1`
+- The lab mounts the real `cpk-web-inspector` and opens the overlay.
+
+Do not start a showcase app, an example app, or Storybook as the default
+host. Those are slower and hide Inspector-only faults.
+
+The Nx target runs Vite and the CSS watch together. Do not run Vite alone.
+Do not run `pnpm --filter @copilotkit/web-inspector run dev`. That watch
+serves consumers, not this lab.
+
+## Procedures
+
+### Procedure 1: Start the workbench
+
+1. If the change adds, renames, or removes a pane, load `inspector-docs` too.
+2. From the repo root, start `nx run @copilotkit/web-inspector:dev:standalone`.
+3. Wait until `http://127.0.0.1:5177` serves.
+4. Open the browser tool this session has (Playwright MCP, Claude browser, or Codex computer use).
+5. Go to `http://127.0.0.1:5177/?scenario=pro-enabled-existing&reset=1`.
+6. If the bug is an empty, locked, error, or unread state, pick that scenario in the lab dropdown, then reload.
+7. Wait until the overlay is open on Home or Threads. The lab clicks the launcher.
+8. Take a baseline screenshot. Look at it before any edit.
+
+### Procedure 2: Edit, screenshot, look
+
+1. Edit Inspector source under `packages/web-inspector/src`.
+2. Wait for Vite to reload the lab.
+3. If the page did not pick up the change, reload the lab URL, then wait for the overlay.
+4. Take a screenshot of the pane that must change.
+5. If the browser tool writes a file, write it under `.inspector-workbench/<task>/`. Never write a PNG at the repo root.
+6. Look at the screenshot. If the change is not visible, the work is not done.
+7. Repeat steps 1–6 after every visual change.
+8. If layout or the collapsed rail is in scope, take a second screenshot at a narrow viewport.
+9. If theme or contrast is in scope, take light and dark screenshots.
+
+Unit tests still belong in the same change. Screenshots do not replace tests.
+
+### Procedure 3: Stop the workbench
+
+1. After the Inspector task is done, stop the `dev:standalone` process tree.
+2. Do not leave Vite or the CSS watch running.
+3. Do not commit files under `.inspector-workbench/`.
+4. Do not commit PNG files at the repo root.
+
+## Decision Tree
+
+- Inspector UI, chrome, overlay, launcher, or pane visuals:
+  - Start: Procedure 1
+  - While editing: Procedure 2
+  - After the task: Procedure 3
+  - If a pane is added, renamed, or removed: also load `inspector-docs`
+- Docs Callout only: stop. Load `inspector-docs` instead.
+- Bug exists only inside a host app: use that host, then still follow Procedure 2 screenshots.
+- Runtime or core change with no Inspector UI: this skill does not apply.
+
+## Red Flags
+
+| Signal                                              | What it means                        | Do instead                                            |
+| --------------------------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| Showcase, example, or Storybook is the first server | The agent skipped the workbench      | Stop that server. Run Procedure 1                     |
+| No screenshot after a visual edit                   | The agent is guessing from CSS       | Take a screenshot. Look at it                         |
+| PNG files at the repo root (`inspector-open.png`)   | The screenshot path is wrong         | Write under `.inspector-workbench/<task>/`            |
+| "The CSS looks correct, so the UI is done"          | Overlay bugs do not show in source   | Screenshot the lab. Fix what the image shows          |
+| Vite started without the Nx target                  | CSS watch is missing                 | Use `nx run @copilotkit/web-inspector:dev:standalone` |
+| Port 5178 or a random port                          | The lab pins 5177                    | Free 5177. Do not pick another port                   |
+| Workbench still running after the task              | Watchers leak memory on this machine | Run Procedure 3                                       |
+| Pane added with no `inspector-docs` pass            | Docs Callout will drift              | Load `inspector-docs` in the same change              |
+
+## Error Handling
+
+- **Port 5177 is in use**: stop the leftover Inspector workbench on that port, then retry Procedure 1. Do not pick another port. The lab uses `strictPort`.
+- **No browser tool in this session**: tell the user the session cannot see Inspector. Do not guess visual results from CSS or unit tests alone.
+- **Lab is blank or the overlay is closed**: wait for boot. Then screenshot the lab console Runtime line. If Runtime is not connected, fix the lab before UI edits.
+- **Screenshot does not show the intended change**: do not claim done. Reload, screenshot again, then fix the source.
+- **HMR did not apply a source edit**: reload `http://127.0.0.1:5177` with the same scenario query. Then screenshot.
+- **Need a closed launcher or unread halo**: open `http://127.0.0.1:5177/?scenario=pro-enabled-existing&replay-notification=1`.
+- **Any unexpected error**: halt and surface the raw error. Do not switch to a showcase app to work around the lab.


### PR DESCRIPTION
When an agent is asked to fix Inspector UI, it must start the standalone lab and take screenshots.

This PR adds `skills/inspector-workbench/SKILL.md` next to `inspector-docs`. `AGENTS.md` and `CLAUDE.md` point at it, so CopilotKit employee sessions load it by default.

## What does this PR do?

- Adds the `inspector-workbench` skill. The default host is `nx run @copilotkit/web-inspector:dev:standalone` at `http://127.0.0.1:5177`.
- Requires a screenshot after each visual change. Screenshot files go in `.inspector-workbench/` (gitignored), not the repo root.
- Cross-links `inspector-docs` when a pane is added, renamed, or removed.
- Registers the slug in `RESERVED_LIFECYCLE_SLUGS` so `pnpm sync:plugin-skills` does not delete the skill.

## Related PRs and Issues

None.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

## Testing

1. Commands run:
   - `pnpm check:plugin-skills` passed (`plugin skill mirror in sync`).
   - `pnpm exec vitest run scripts/__tests__/sync-plugin-skills.test.ts` passed.
   - Full package tests were not run. This change is agent instructions plus the reserved-slug list.
2. Manual test:
   1. Open `skills/inspector-workbench/SKILL.md`.
   2. Confirm the default command is `nx run @copilotkit/web-inspector:dev:standalone`.
   3. Ask an agent to fix Inspector UI. Confirm it starts the lab and takes a screenshot before it claims the UI is done.
3. How this PR makes testing easy: the reserved-slug unit test now includes `inspector-workbench`. CI `plugin-skills-check` will run on this path.

## Risk / rollback

Low. This is agent instruction plus a gitignore folder. Revert the PR to undo.
