### PR TITLE
test(angular): stub inspector thread-bridge helpers in @copilotkit/core mock

### DIFF
--- a/packages/angular/src/lib/copilotkit.spec.ts
+++ b/packages/angular/src/lib/copilotkit.spec.ts
@@ -91,6 +91,13 @@ vi.mock("@copilotkit/core", () => {
   return {
     CopilotKitCore: MockCopilotKitCore,
     CopilotKitCoreRuntimeConnectionStatus,
+    // Inspector-by-default (#6577) makes the Angular component dynamically import
+    // @copilotkit/web-inspector, which calls these thread-bridge helpers (added
+    // in #6562) on @copilotkit/core. Without stubs the calls throw on an async
+    // path after the spec finishes, surfacing as flaky "unhandled errors".
+    isInspectorThreadBridgeEnabled: () => false,
+    subscribeToInspectorThreadBridge: () => () => {},
+    unsubscribeFromInspectorThreadBridge: () => {},
   } as any;
 });
 


### PR DESCRIPTION
## Problem

`@copilotkit/angular:test` is flaky on `main`. It passes on most CI matrix cells and fails on others (for example `Node 22.x, React 18`). Every Angular spec reports as passing, but Vitest then fails the run with unhandled errors:

```
⎯⎯ Unhandled Errors ⎯⎯
Vitest caught 4 unhandled errors during the test run.
Error: [vitest] No "isInspectorThreadBridgeEnabled" export is defined on the "@copilotkit/core" mock.
```

## Root cause

`packages/angular/src/lib/copilotkit.spec.ts` fully replaces `@copilotkit/core` via `vi.mock(...)`, returning only `CopilotKitCore` and `CopilotKitCoreRuntimeConnectionStatus`.

Since #6577 (enable Inspector by default in browser frameworks), the Angular `CopilotKit` component sets up the Inspector by default, which triggers a dynamic `import("@copilotkit/web-inspector")` in `packages/angular/src/lib/inspector.ts`. `packages/web-inspector/src/index.ts` then calls, on `@copilotkit/core`, the thread-bridge helpers added in #6562 (add view thread in your app):

- `isInspectorThreadBridgeEnabled`
- `subscribeToInspectorThreadBridge`
- `unsubscribeFromInspectorThreadBridge`

The mock does not stub these, so the calls throw. Because they run on an async path (dynamic import plus bridge subscription) that can settle after the spec has finished, they surface as unhandled errors rather than a failed assertion. That timing is why the failure is intermittent and only appears on some matrix cells.

## Fix

Add no-op stubs for the three thread-bridge helpers to the `@copilotkit/core` mock.

## Validation

`nx run @copilotkit/angular:test` locally: 49 test files pass (315 tests, 1 skipped) with no unhandled errors.