### PR TITLE
docs(react-core): state that an agent receives useAgentContext value as a JSON string (closes OSS-1003)

### DIFF
--- a/examples/v2/docs/reference/use-agent-context.mdx
+++ b/examples/v2/docs/reference/use-agent-context.mdx
@@ -57,7 +57,7 @@ useAgentContext({
 
 `any` **(required)**
 
-The actual data to provide as context. Can be any serializable value including objects, arrays, strings, or numbers.
+The actual data to provide as context. Can be any serializable value including objects, arrays, strings, or numbers. Anything that is not already a string is stringified with `JSON.stringify` before it is sent, so the agent receives a JSON string rather than the value you passed — see [What the agent receives](#what-the-agent-receives).
 
 ```tsx
 useAgentContext({
@@ -339,6 +339,61 @@ function OptimizedContext({ items }) {
   return null;
 }
 ```
+
+## What the agent receives
+
+Every registered entry reaches the agent as `{ description, value }`, and `value` is a **JSON string** — not the object or array you passed. The AG-UI protocol types it as a string, so this is not an implementation detail you can ignore when writing the agent.
+
+Registering this:
+
+```tsx
+useAgentContext({
+  description: "Incident dashboard records",
+  value: [{ id: "INC-1041", severity: "sev1" }],
+});
+```
+
+delivers this to the agent:
+
+```json
+{
+  "description": "Incident dashboard records",
+  "value": "[{\"id\":\"INC-1041\",\"severity\":\"sev1\"}]"
+}
+```
+
+Parse it before reading any field. In a Python agent:
+
+```python
+import json
+
+def dashboard_records(context):
+    entry = next(
+        (item for item in context if item["description"] == "Incident dashboard records"),
+        None,
+    )
+    return None if entry is None else json.loads(entry["value"])
+```
+
+In a TypeScript agent:
+
+```ts
+const entry = context.find(
+  (item) => item.description === "Incident dashboard records",
+);
+const records = entry ? JSON.parse(entry.value) : undefined;
+```
+
+Where that context list surfaces in your agent depends on your framework's AG-UI adapter — see your integration's guide for the field it populates.
+
+<Warning>
+  Do not type-check `value` against the shape you registered.
+  `isinstance(entry["value"], list)` in Python, or `Array.isArray(entry.value)`
+  in TypeScript, can never be true, because `value` is always a string on the
+  wire. An agent that reads such a failed check as "no context was sent" will
+  refuse every request while the browser is registering context correctly, and
+  the two cases are indistinguishable from the UI.
+</Warning>
 
 ## Integration with Agents
 

--- a/showcase/shell-docs/src/content/reference/hooks/useAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgentContext.mdx
@@ -28,7 +28,7 @@ function useAgentContext(context: AgentContextInput): void;
 </PropertyReference>
 
   <PropertyReference name="value" type="JsonSerializable" required>
-    The context value to provide. Must be JSON-serializable: `string`, `number`, `boolean`, `null`, arrays, or plain objects with string keys and serializable values. Object values are serialized automatically.
+    The context value to provide. Must be JSON-serializable: `string`, `number`, `boolean`, `null`, arrays, or plain objects with string keys and serializable values. Anything that is not already a string is stringified with `JSON.stringify` before it is sent, so the agent receives a JSON string rather than the value you passed -- see [What the agent receives](#what-the-agent-receives).
   </PropertyReference>
 </PropertyReference>
 
@@ -113,11 +113,66 @@ function Sidebar() {
 }
 ```
 
+## What the agent receives
+
+Every registered entry reaches the agent as `{ description, value }`, and `value` is a **JSON string** -- not the object or array you passed. The AG-UI protocol types it as a string, so this is not an implementation detail you can ignore when writing the agent.
+
+Registering this:
+
+```tsx
+useAgentContext({
+  description: "Incident dashboard records",
+  value: [{ id: "INC-1041", severity: "sev1" }],
+});
+```
+
+delivers this to the agent:
+
+```json
+{
+  "description": "Incident dashboard records",
+  "value": "[{\"id\":\"INC-1041\",\"severity\":\"sev1\"}]"
+}
+```
+
+Parse it before reading any field. In a Python agent:
+
+```python
+import json
+
+def dashboard_records(context):
+    entry = next(
+        (item for item in context if item["description"] == "Incident dashboard records"),
+        None,
+    )
+    return None if entry is None else json.loads(entry["value"])
+```
+
+In a TypeScript agent:
+
+```ts
+const entry = context.find(
+  (item) => item.description === "Incident dashboard records",
+);
+const records = entry ? JSON.parse(entry.value) : undefined;
+```
+
+Where that context list surfaces in your agent depends on your framework's AG-UI adapter -- see your integration's guide for the field it populates.
+
+<Callout type="warn">
+  Do not type-check `value` against the shape you registered.
+  `isinstance(entry["value"], list)` in Python, or `Array.isArray(entry.value)`
+  in TypeScript, can never be true, because `value` is always a string on the
+  wire. An agent that reads such a failed check as "no context was sent" will
+  refuse every request while the browser is registering context correctly, and
+  the two cases are indistinguishable from the UI.
+</Callout>
+
 ## Behavior
 
 - **Mount/Unmount lifecycle**: The context is registered when the component mounts and automatically removed when it unmounts. There is no manual cleanup required.
 - **Reactive updates**: When the `context` object changes between renders, the agent immediately sees the updated value.
-- **Serialization**: The `value` must conform to `JsonSerializable` (`string | number | boolean | null | JsonSerializable[] | { [key: string]: JsonSerializable }`). Non-serializable values such as functions, class instances, or symbols will cause errors.
+- **Serialization**: The `value` must conform to `JsonSerializable` (`string | number | boolean | null | JsonSerializable[] | { [key: string]: JsonSerializable }`). Non-serializable values such as functions, class instances, or symbols will cause errors. Strings are sent through unchanged; every other value is stringified, so the agent always reads a string -- see [What the agent receives](#what-the-agent-receives).
 - **Multiple contexts**: Multiple `useAgentContext` calls across your component tree are all visible to the agent concurrently. Each is identified by its description and value.
 - **No return value**: The hook returns `void`. Unlike `useCopilotReadable`, it does not return an ID for parent-child hierarchies.
 

--- a/showcase/shell-docs/src/content/reference/react-native/hooks/useAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/hooks/useAgentContext.mdx
@@ -32,7 +32,7 @@ function useAgentContext(context: AgentContextInput): void;
 </PropertyReference>
 
   <PropertyReference name="value" type="JsonSerializable" required>
-    The context value to provide. Must be JSON-serializable: `string`, `number`, `boolean`, `null`, arrays, or plain objects with string keys and serializable values. Object values are serialized automatically.
+    The context value to provide. Must be JSON-serializable: `string`, `number`, `boolean`, `null`, arrays, or plain objects with string keys and serializable values. Anything that is not already a string is stringified with `JSON.stringify` before it is sent, so the agent receives a JSON string rather than the value you passed: see [What the agent receives](#what-the-agent-receives).
   </PropertyReference>
 </PropertyReference>
 
@@ -132,11 +132,66 @@ function Sidebar() {
 }
 ```
 
+## What the agent receives
+
+Every registered entry reaches the agent as `{ description, value }`, and `value` is a **JSON string**: not the object or array you passed. The AG-UI protocol types it as a string, so this is not an implementation detail you can ignore when writing the agent.
+
+Registering this:
+
+```tsx
+useAgentContext({
+  description: "Incident dashboard records",
+  value: [{ id: "INC-1041", severity: "sev1" }],
+});
+```
+
+delivers this to the agent:
+
+```json
+{
+  "description": "Incident dashboard records",
+  "value": "[{\"id\":\"INC-1041\",\"severity\":\"sev1\"}]"
+}
+```
+
+Parse it before reading any field. In a Python agent:
+
+```python
+import json
+
+def dashboard_records(context):
+    entry = next(
+        (item for item in context if item["description"] == "Incident dashboard records"),
+        None,
+    )
+    return None if entry is None else json.loads(entry["value"])
+```
+
+In a TypeScript agent:
+
+```ts
+const entry = context.find(
+  (item) => item.description === "Incident dashboard records",
+);
+const records = entry ? JSON.parse(entry.value) : undefined;
+```
+
+Where that context list surfaces in your agent depends on your framework's AG-UI adapter: see your integration's guide for the field it populates.
+
+<Callout type="warn">
+  Do not type-check `value` against the shape you registered.
+  `isinstance(entry["value"], list)` in Python, or `Array.isArray(entry.value)`
+  in TypeScript, can never be true, because `value` is always a string on the
+  wire. An agent that reads such a failed check as "no context was sent" will
+  refuse every request while the app is registering context correctly, and the
+  two cases are indistinguishable from the UI.
+</Callout>
+
 ## Behavior
 
 - **Mount/Unmount lifecycle**: The context is registered when the component mounts and automatically removed when it unmounts. There is no manual cleanup required.
 - **Reactive updates**: When the `context` object changes between renders, the agent immediately sees the updated value.
-- **Serialization**: The `value` must conform to `JsonSerializable` (`string | number | boolean | null | JsonSerializable[] | { [key: string]: JsonSerializable }`). Non-serializable values such as functions, class instances, or symbols will cause errors.
+- **Serialization**: The `value` must conform to `JsonSerializable` (`string | number | boolean | null | JsonSerializable[] | { [key: string]: JsonSerializable }`). Non-serializable values such as functions, class instances, or symbols will cause errors. Strings are sent through unchanged; every other value is stringified, so the agent always reads a string: see [What the agent receives](#what-the-agent-receives).
 - **Multiple contexts**: Multiple `useAgentContext` calls across your component tree are all visible to the agent concurrently. Each is identified by its description and value.
 - **No return value**: The hook returns `void`. Unlike `useCopilotReadable`, it does not return an ID for parent-child hierarchies.
 

--- a/showcase/shell-docs/src/content/reference/vue/hooks/useAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/vue/hooks/useAgentContext.mdx
@@ -39,8 +39,10 @@ function useAgentContext(context: AgentContextInput): void;
     The context value to provide. Must resolve to a JSON-serializable value:
     `string`, `number`, `boolean`, `null`, arrays, or plain objects with string
     keys and serializable values. Non-string values are serialized with
-    `JSON.stringify` automatically. Accepts a plain value, a ref, a computed, or
-    a getter function.
+    `JSON.stringify` before they are sent, so the agent receives a JSON string
+    rather than the value you passed.
+    See [What the agent receives](#what-the-agent-receives).
+    Accepts a plain value, a ref, a computed, or a getter function.
   </PropertyReference>
 </PropertyReference>
 
@@ -154,11 +156,70 @@ useAgentContext({
 </template>
 ```
 
+## What the agent receives
+
+Every registered entry reaches the agent as `{ description, value }`, and `value` is a **JSON string** - not the object or array you passed. The AG-UI protocol types it as a string, so this is not an implementation detail you can ignore when writing the agent.
+
+Registering this:
+
+```vue
+<script setup lang="ts">
+import { useAgentContext } from "@copilotkit/vue/v2";
+
+useAgentContext({
+  description: "Incident dashboard records",
+  value: [{ id: "INC-1041", severity: "sev1" }],
+});
+</script>
+```
+
+delivers this to the agent:
+
+```json
+{
+  "description": "Incident dashboard records",
+  "value": "[{\"id\":\"INC-1041\",\"severity\":\"sev1\"}]"
+}
+```
+
+Parse it before reading any field. In a Python agent:
+
+```python
+import json
+
+def dashboard_records(context):
+    entry = next(
+        (item for item in context if item["description"] == "Incident dashboard records"),
+        None,
+    )
+    return None if entry is None else json.loads(entry["value"])
+```
+
+In a TypeScript agent:
+
+```ts
+const entry = context.find(
+  (item) => item.description === "Incident dashboard records",
+);
+const records = entry ? JSON.parse(entry.value) : undefined;
+```
+
+Where that context list surfaces in your agent depends on your framework's AG-UI adapter - see your integration's guide for the field it populates.
+
+<Callout type="warn">
+  Do not type-check `value` against the shape you registered.
+  `isinstance(entry["value"], list)` in Python, or `Array.isArray(entry.value)`
+  in TypeScript, can never be true, because `value` is always a string on the
+  wire. An agent that reads such a failed check as "no context was sent" will
+  refuse every request while the app is registering context correctly, and the
+  two cases are indistinguishable from the UI.
+</Callout>
+
 ## Behavior
 
 - **Scope lifecycle**: The context is registered while the composable's reactive scope is active and is removed automatically on scope cleanup (component unmount). No manual cleanup is required.
 - **Reactive updates**: `description` and `value` are resolved with `toValue`, so refs, computeds, and getters are tracked. When a resolved value changes, the previous context entry is removed and the new value is re-registered, keeping the agent in sync.
-- **Serialization**: String values are passed through as-is. Any other value is serialized with `JSON.stringify`, so it must conform to `JsonSerializable` (`string | number | boolean | null | JsonSerializable[] | { [key: string]: JsonSerializable }`). Non-serializable values such as functions, class instances, or symbols will not serialize correctly.
+- **Serialization**: String values are passed through as-is. Any other value is serialized with `JSON.stringify`, so it must conform to `JsonSerializable` (`string | number | boolean | null | JsonSerializable[] | { [key: string]: JsonSerializable }`). Non-serializable values such as functions, class instances, or symbols will not serialize correctly. The agent therefore always reads a string - see [What the agent receives](#what-the-agent-receives).
 - **Multiple contexts**: Multiple `useAgentContext` calls across your component tree are all visible to the agent concurrently. Each is identified internally by an ID returned from `addContext` and removed on cleanup.
 - **No return value**: The composable returns `void`.
 


### PR DESCRIPTION
## Problem

`useAgentContext` stringifies any non-string value before it leaves the browser, and the AG-UI protocol types `Context.value` as a string on both ends. An agent therefore always reads a **JSON string** — never the object or array that was registered.

None of the four reference pages said so. They stopped at the browser half:

- `/reference/v2/hooks/useAgentContext` — "Object values are serialized automatically."
- `/reference/react-native/hooks/useAgentContext` — the same sentence.
- `/reference/vue/hooks/useAgentContext` — "Non-string values are serialized with `JSON.stringify` automatically."
- `examples/v2/docs/reference/use-agent-context.mdx` — "Can be any serializable value."

"Serialized automatically" reads as *the framework handles it*, not *your agent gets a string and must parse it*. No page mentioned `json.loads`, `JSON.parse`, or what the agent side receives.

## Why it matters

An author who believes that writes an agent that reads the object. When the shape check fails, the agent cannot distinguish "context arrived JSON-encoded" from "no context was sent" — the two are byte-identical — so it refuses every request while the browser is registering context perfectly.

That is what happened on the `both-oss::langgraph-python::nextjs` conversion journey (OSS-1003). The agent guarded on `isinstance(entry["value"], list)`, which the protocol can never satisfy, so its success path was unreachable on every real run and the journey was dead on arrival. Reproduced directly against that graph:

```
A  wire shape (value = JSON string) -> "...context is missing."
B  object shape (value = list)      -> resolved correctly
C  no context at all               -> identical to A
```

## Change

Each of the four pages gains a `## What the agent receives` section:

- the wire shape shown as literal JSON
- `json.loads` (Python) and `JSON.parse` (TypeScript) agent-side examples
- a callout naming the shape check as the trap, and why a failed check is indistinguishable from absent context

The `value` parameter description and the `Serialization` behavior bullet on each page now name the consequence for the agent author and link to that section, instead of stopping at the browser half.

Docs only — no source or runtime behavior changes.

## Verification

- All four files parse-check clean: balanced code fences, balanced JSX, anchor targets present and linked.
- `Callout` is globally registered (`showcase/shell-docs/src/lib/mdx-registry.tsx:263`), so no per-file import is needed.
- `shell-docs` `llm-text.test.ts`: **10 failed | 32 passed** both with and without these edits — identical, so this change introduces nothing. Those 10 are pre-existing `claude-sdk`/`google-adk` content assertions that fail on stale generated data in a fresh worktree.
- `.mdx` is outside lefthook's `lint-fix` glob, so oxfmt/oxlint do not reformat these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
