### PR TITLE
docs(vue): document the generative-UI path and publish it in the Vue sidebar (closes OSS-1005)

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/vue.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/vue.mdx
@@ -165,6 +165,7 @@ The runtime runs on your server, keeps model credentials out of the browser, and
 
 ## Where to go next
 
+- [Generative UI in Vue](/vue/guides/generative-ui): render a tool result as a card, an A2UI surface, or sandboxed UI instead of plain text. This is the same regardless of which agent framework you put behind the runtime.
 - [Copilot Runtime](/backend/copilot-runtime): runtime setup, auth, middleware, and routing.
 - [Built-in Agent quickstart](/quickstart): configure the in-process agent used in this quickstart.
 - [Integrations](/integrations/langgraph): connect LangGraph, CrewAI, Mastra, and other agents through the runtime.

--- a/showcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx
@@ -1,0 +1,295 @@
+---
+title: Generative UI in Vue
+description: Render an agent's tool calls, A2UI surfaces, and sandboxed UI as real Vue components instead of plain text.
+icon: "lucide/Paintbrush"
+doc_type: how-to
+---
+
+Generative UI is how a tool result becomes a rendered surface — a card, a
+badge, a form — instead of a paragraph of text in the chat log. Everything on
+this page is Vue-native: `@copilotkit/vue` ships its own renderers and does
+not depend on the React packages.
+
+<Callout type="info" title="This does not depend on your agent framework">
+  Generative UI is a **frontend** concern. It reads AG-UI tool calls, and every
+  agent framework the runtime supports — LangGraph, CrewAI, Mastra, AWS
+  Strands, Agno, a `BuiltInAgent`, or a custom `AbstractAgent` — emits the same
+  tool calls. Nothing on this page changes when you swap the agent behind the
+  runtime. If a framework's page does not mention Vue rendering, that is
+  because rendering is not a framework-specific topic, not because the path is
+  missing.
+</Callout>
+
+## Choose a path
+
+| Path | Best fit | Vue setup |
+| --- | --- | --- |
+| Your components | You know the tool and its result shape | `useRenderTool`, or `useFrontendTool` with a `render` |
+| Default card | You want *something* better than raw JSON, with no per-tool work | `useDefaultRenderTool()` |
+| A2UI | The agent emits declarative A2UI operations | `:a2ui` on `CopilotKitProvider` |
+| Open Generative UI | The agent generates HTML/CSS to be sandboxed | `:open-generative-ui` on `CopilotKitProvider` |
+| MCP Apps | An MCP server returns an interactive app resource | Nothing — the renderer is always registered |
+
+All of these require the composable or component to sit inside
+[`CopilotKitProvider`](/reference/vue/components/CopilotKitProvider). Import
+everything from the `/v2` subpath.
+
+## Render a server-side tool call
+
+When the tool runs on your server and the browser only draws the result, use
+[`useRenderTool`](/reference/vue/hooks/useRenderTool). Give it the tool name, a
+schema for the arguments, and a renderer.
+
+This is not JSX. The renderer is either a function returning a `VNodeChild`
+(build it with Vue's `h()`) or a plain Vue component.
+
+```vue title="src/TriageCard.vue"
+<script setup lang="ts">
+defineProps<{
+  name: string;
+  toolCallId: string;
+  status: "inProgress" | "executing" | "complete";
+  parameters: { incidentId?: string; severity?: string };
+  result?: string;
+}>();
+</script>
+
+<template>
+  <p v-if="status !== 'complete'">Triaging {{ parameters.incidentId }}…</p>
+  <article v-else class="triage-card">
+    <header>
+      <strong>{{ parameters.incidentId }}</strong>
+      <span :data-severity="parameters.severity">{{ parameters.severity }}</span>
+    </header>
+    <p>{{ result }}</p>
+  </article>
+</template>
+```
+
+Register it once, anywhere under the provider:
+
+```vue title="src/App.vue"
+<script setup lang="ts">
+import { z } from "zod";
+import { CopilotChat, CopilotKitProvider, useRenderTool } from "@copilotkit/vue/v2";
+import TriageCard from "./TriageCard.vue";
+
+useRenderTool({
+  name: "display_triage",
+  parameters: z.object({
+    incidentId: z.string(),
+    severity: z.enum(["sev1", "sev2", "sev3"]),
+  }),
+  render: TriageCard,
+});
+</script>
+
+<template>
+  <CopilotKitProvider runtime-url="http://localhost:8200/api/copilotkit">
+    <div style="height: 100vh"><CopilotChat /></div>
+  </CopilotKitProvider>
+</template>
+```
+
+The renderer runs three times as the call progresses. `status` moves
+`"inProgress"` → `"executing"` → `"complete"`, and `parameters` is a
+`Partial<T>` while arguments are still streaming, so guard on `status` before
+reading a field you require.
+
+<Callout type="warn" title="Pass reactive values through `deps`">
+  `useRenderTool` takes a second argument of Vue `WatchSource`s — refs or
+  getters, *not* a React-style dependency array. If your renderer closes over
+  reactive state, list it there or the registered renderer keeps the stale
+  value:
+
+  ```ts
+  useRenderTool({ name: "display_triage", parameters, render }, [locale]);
+  ```
+</Callout>
+
+## Give every other tool a card
+
+`useDefaultRenderTool()` registers a wildcard renderer for any tool without a
+named one. Called with no arguments it installs CopilotKit's built-in
+expandable card showing the tool name, status, arguments, and result — a
+one-line upgrade from raw output.
+
+```vue
+<script setup lang="ts">
+import { useDefaultRenderTool } from "@copilotkit/vue/v2";
+
+useDefaultRenderTool();
+</script>
+```
+
+Pass `{ render }` to substitute your own component. It is a thin wrapper around
+`useRenderTool({ name: "*" })`, so the props are the same.
+
+## Render a tool that runs in the browser
+
+When the agent should call code in the page, use
+[`useFrontendTool`](/reference/vue/hooks/useFrontendTool) and give the same
+registration a `render`.
+
+```vue
+<script setup lang="ts">
+import { h } from "vue";
+import { z } from "zod";
+import { useFrontendTool } from "@copilotkit/vue/v2";
+
+useFrontendTool({
+  name: "applyDashboardFilter",
+  description: "Filter the incident dashboard",
+  parameters: z.object({ severity: z.string() }),
+  handler: async ({ severity }, { signal }) => {
+    const response = await fetch(`/api/incidents?severity=${severity}`, { signal });
+    return response.text();
+  },
+  render: ({ args, status }) =>
+    h("div", `Filtering by ${args.severity ?? "…"} (${status})`),
+});
+</script>
+```
+
+<Callout type="warn" title="The two renderers do not receive the same props">
+  This is the easiest thing to get wrong. `useRenderTool` normalizes its
+  props; `useFrontendTool` passes yours straight through to the core renderer.
+
+  | | `useRenderTool` / `useDefaultRenderTool` | `useFrontendTool`'s `render` |
+  | --- | --- | --- |
+  | Arguments | `parameters` | `args` |
+  | Status | `"inProgress" \| "executing" \| "complete"` | the `ToolCallStatus` enum |
+
+  A renderer written for one will silently draw nothing in the other. If you
+  want to share a component between them, wrap it rather than reusing it
+  directly.
+</Callout>
+
+## A2UI surfaces
+
+[A2UI](/generative-ui/a2ui) lets the agent describe a surface declaratively and
+the frontend build it from a catalog of allowed components. The Vue renderer is
+built on `@a2ui/web_core` and deliberately duplicates the small amount of
+shared logic it needs, so enabling A2UI in a Vue app pulls in no React
+dependencies.
+
+Enable A2UI on the runtime:
+
+```ts title="server.ts"
+const runtime = new CopilotRuntime({
+  agents: { default: myAgent },
+  a2ui: {},
+});
+```
+
+A bare `a2ui: {}` is enough to turn it on — the option is treated as enabled
+whenever it is present, and only an explicit `a2ui: { enabled: false }` turns
+it off.
+
+The frontend needs nothing else — the built-in renderer activates on its own
+once the runtime reports A2UI is configured. Pass `:a2ui` only to override
+something:
+
+```vue
+<template>
+  <CopilotKitProvider runtime-url="/api/copilotkit" :a2ui="{}">
+    <div style="height: 100vh"><CopilotChat /></div>
+  </CopilotKitProvider>
+</template>
+```
+
+`a2ui` accepts `theme`, `catalog`, `loadingComponent`, and `includeSchema`.
+
+### Supplying your own catalog
+
+Passing a `catalog` does double duty: it selects the components the agent may
+use, *and* it tells the runtime a catalog exists by forwarding
+`a2uiCatalogAvailable`. That means A2UI switches on from the client side even
+when the runtime has no `a2ui` configuration of its own.
+
+```vue
+<script setup lang="ts">
+import { CopilotChat, CopilotKitProvider, vueBasicCatalog } from "@copilotkit/vue/v2";
+</script>
+
+<template>
+  <CopilotKitProvider
+    runtime-url="/api/copilotkit"
+    :a2ui="{ catalog: vueBasicCatalog }"
+  >
+    <div style="height: 100vh"><CopilotChat /></div>
+  </CopilotKitProvider>
+</template>
+```
+
+`vueBasicCatalog` is the built-in component set, exported directly from
+`@copilotkit/vue/v2`. To have the agent compose your own design system instead,
+build a catalog of your components and pass that — see
+[A2UI](/generative-ui/a2ui) for the catalog format and the fixed- versus
+dynamic-schema tradeoff.
+
+## Open Generative UI
+
+Open Generative UI lets the agent generate markup that renders inside a
+sandboxed iframe with no same-origin access. It can only reach back into your
+app through host functions you list explicitly.
+
+```vue
+<script setup lang="ts">
+import { z } from "zod";
+import { CopilotChat, CopilotKitProvider } from "@copilotkit/vue/v2";
+
+const openGenerativeUI = {
+  sandboxFunctions: [
+    {
+      name: "setDashboardFilter",
+      description: "Set the active dashboard filter",
+      parameters: z.object({ filter: z.string() }),
+      handler: async ({ filter }: { filter: string }) => {
+        sessionStorage.setItem("dashboard-filter", filter);
+        return { applied: filter };
+      },
+    },
+  ],
+};
+</script>
+
+<template>
+  <CopilotKitProvider
+    runtime-url="/api/copilotkit"
+    :open-generative-ui="openGenerativeUI"
+  >
+    <div style="height: 100vh"><CopilotChat /></div>
+  </CopilotKitProvider>
+</template>
+```
+
+`sandboxFunctions` must be a stable array — define it outside the template, as
+above, rather than inline. `designSkill` overrides the design guidance handed
+to the generation tool.
+
+## MCP Apps
+
+Nothing to configure. The built-in MCP Apps renderer is always merged into the
+provider's activity renderers, so an interactive app resource returned by an
+MCP server renders in chat as soon as the agent surfaces it. See
+[MCP Apps](/generative-ui/mcp-apps).
+
+## Verify it rendered
+
+A surface that silently falls back to text is the common failure. Two checks:
+
+- Open the [Inspector](/inspector) and confirm the tool call appears
+  with the status transitions above. A call that never reaches `"complete"`
+  means the tool failed server-side, not that the renderer is wrong.
+- Confirm the registered name matches the tool name exactly. A renderer
+  registered under the wrong name is not an error — the call just falls through
+  to the default renderer, or to text if you have not registered one.
+
+## Next steps
+
+- [`useRenderTool`](/reference/vue/hooks/useRenderTool) — full render props and overloads
+- [`useDefaultRenderTool`](/reference/vue/hooks/useDefaultRenderTool) — the wildcard renderer
+- [`useFrontendTool`](/reference/vue/hooks/useFrontendTool) — browser-side tools
+- [`CopilotKitProvider`](/reference/vue/components/CopilotKitProvider) — `a2ui`, `openGenerativeUI`, and renderer props
+- [A2UI](/generative-ui/a2ui) — the protocol, fixed and dynamic schemas

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -31,6 +31,7 @@ import {
 import { buildBreadcrumbs, loadDoc } from "../docs-render";
 import type { NavNode } from "../docs-render";
 import { resolveFrontendDocPage } from "../frontend-doc-policy";
+import { resolveDocsHref } from "../docs-link-rewrite";
 import {
   getAngularDocsNavTree,
   resolveAngularDoc,
@@ -703,4 +704,48 @@ test("renders docs-catch-up copy only for frontends that still use it", () => {
     " guides are ready with more guides on the way.",
   );
   expect(slackUpcoming).toBeUndefined();
+});
+
+test("publishes the Vue generative UI guide as a reachable sidebar page", () => {
+  const pageUrls = collectPageUrls(
+    navTreeToPageTree(getFrontendQuickstartNavTree("vue"), "/vue"),
+  );
+
+  expect(pageUrls).toContain("/vue/guides/generative-ui");
+  expect(resolveFrontendDocPage("vue", "guides/generative-ui")).toEqual(
+    expect.objectContaining({
+      status: "found",
+      slugPath: "guides/generative-ui",
+      contentSlugPath: "frontends/vue/guides/generative-ui",
+      canonicalPath: "/vue/guides/generative-ui",
+    }),
+  );
+});
+
+test("links the Vue quickstart to its guide with an href that survives rewriting", () => {
+  const quickstart = loadDoc(getFrontendContentSlug("vue"));
+  const href = quickstart?.source.match(
+    /\]\((\S*guides\/generative-ui)\)/,
+  )?.[1];
+
+  // A relative or root-relative href is passed through untouched by
+  // resolveDocsHref, so the browser would resolve it against `/vue` and land
+  // on `/guides/generative-ui`, which does not exist.
+  expect(href).toBe("/vue/guides/generative-ui");
+
+  const rendered = resolveDocsHref(href, { slugHrefPrefix: "/vue" });
+  expect(rendered).toBe("/vue/guides/generative-ui");
+  expect(resolveFrontendDocPage("vue", "guides/generative-ui").status).toBe(
+    "found",
+  );
+});
+
+test("keeps frontends without guides free of an empty Guides section", () => {
+  const navTree = getFrontendQuickstartNavTree("react-native");
+
+  expect(navTree).not.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ type: "section", title: "Guides" }),
+    ]),
+  );
 });

--- a/showcase/shell-docs/src/lib/frontend-page-content.ts
+++ b/showcase/shell-docs/src/lib/frontend-page-content.ts
@@ -39,6 +39,27 @@ export const ANGULAR_GUIDE_PAGES = [
   },
 ] as const;
 
+export const VUE_GUIDE_PAGES = [
+  { title: "Generative UI in Vue", slug: "guides/generative-ui" },
+] as const;
+
+interface FrontendGuidePage {
+  title: string;
+  slug: string;
+}
+
+/**
+ * Frontend-owned task guides, keyed by frontend. A frontend absent from this
+ * map has no guides yet and shows only its quickstart, docs status, and
+ * reference in the sidebar.
+ */
+const FRONTEND_GUIDE_PAGES: Partial<
+  Record<FrontendPageId, readonly FrontendGuidePage[]>
+> = {
+  angular: ANGULAR_GUIDE_PAGES,
+  vue: VUE_GUIDE_PAGES,
+};
+
 /**
  * React's root IA names frontend-specific capabilities more granularly than
  * the Angular task guides. Keep selector changes useful without copying the
@@ -226,20 +247,26 @@ export function getFrontendQuickstartNavTree(id: FrontendPageId): NavNode[] {
   const frontendName =
     FRONTEND_OPTIONS.find((option) => option.id === id)?.name ?? id;
 
-  const authoredGuides: NavNode[] =
-    id === "angular"
-      ? [
+  const guidePages: NavNode[] = (FRONTEND_GUIDE_PAGES[id] ?? []).map(
+    (guide): NavNode => ({
+      type: "page",
+      title: guide.title,
+      slug: guide.slug,
+    }),
+  );
+  const authoredGuides: NavNode[] = [
+    ...(id === "angular"
+      ? ([
           { type: "page", title: "Feature examples", slug: "features" },
+        ] satisfies NavNode[])
+      : []),
+    ...(guidePages.length > 0
+      ? ([
           { type: "section", title: "Guides", icon: "lucide/BookOpen" },
-          ...ANGULAR_GUIDE_PAGES.map(
-            (guide): NavNode => ({
-              type: "page",
-              title: guide.title,
-              slug: guide.slug,
-            }),
-          ),
-        ]
-      : [];
+        ] satisfies NavNode[])
+      : []),
+    ...guidePages,
+  ];
   const upcomingGuides: NavNode[] =
     id === "angular"
       ? []


### PR DESCRIPTION
## Problem

Vue 3 is a documented frontend and generative UI is the capability that turns a chat box into the product — every completing showcase cell's proof is a *card*, not a paragraph. But no page described how a tool result becomes a rendered surface in Vue.

A showcase run pairing AWS Strands with Vue reached exactly that point, correctly refused to invent a rendering path, and said so:

> "The official Vue documentation also does not document Strands generative-UI rendering, so none was invented or claimed."

It shipped a text answer. Vue has 2 recorded runs against Next.js's 42 — the least-covered frontend is also the one where the most valuable capability was undocumented, and those reinforce each other.

## The capability was never missing

`packages/vue` already ships the whole surface: `useRenderTool`, `useDefaultRenderTool`, `A2UIMessageRenderer`, `A2UISurfaceActivityRenderer`, `OpenGenerativeUIRenderer`, `MCPAppsActivityRenderer`, a full `src/v2/components/a2ui/` catalog and adapter, e2e coverage, and two working demo pages under `examples/v2/vue/demo/`. Notably it is React-free *by design* — the A2UI code carries comments explaining it duplicates small helpers specifically to avoid pulling `@copilotkit/a2ui-renderer`'s React dependencies.

So this is a docs task, not an SDK one.

## But the gap was structural, not editorial

This is the part worth reviewing carefully, because it's why a guide file alone would not have fixed anything.

**Sidebar.** `getFrontendQuickstartNavTree()` gated its guides branch on `id === "angular"`. Angular gets its 8 guides; every other frontend got an empty array plus a "Guides coming soon" placeholder. The new test's red-check shows Vue's entire sidebar:

```
AssertionError: expected [ '/vue', …(2) ] to include '/vue/guides/generative-ui'
```

Three URLs.

**Routing.** `resolveFrontendDocPage()` serves `/<frontend>/<slug>` only from a `frontends/<frontend>/<slug>` variant file, or from a doc whose nearest `meta.json` declares `frontend: universal`. `generative-ui/meta.json` declares no policy at all, so `/vue/generative-ui/*` resolves **not-found**. Those pages weren't merely React-flavored for a Vue reader — they were unreachable in the Vue namespace.

The irony: `concepts/meta.json` **is** universal, and it holds `generative-ui-overview`. A Vue developer could reach the page explaining *what* generative UI is, and no page showing *how*.

## Changes

| File | Change |
| --- | --- |
| `docs/frontends/vue/guides/generative-ui.mdx` | New. The guide. |
| `lib/frontend-page-content.ts` | `VUE_GUIDE_PAGES` + a `FRONTEND_GUIDE_PAGES` lookup replacing the `id === "angular"` branch, so a frontend's guides are data rather than a conditional. Angular's tree is unchanged. |
| `docs/frontends/vue.mdx` | The missing "Where to go next" pointer. |
| `lib/__tests__/frontend-options.test.ts` | Three tests. |

The guide covers `useRenderTool`, `useDefaultRenderTool`, `useFrontendTool` with a renderer, A2UI (provider-level and catalog-on-provider), Open Generative UI, and MCP Apps — written from `packages/vue` source and the in-repo demos, not translated from the React docs.

Two things it states deliberately:

- **It does not depend on the agent framework.** The reporting run read the absence as Strands-specific. Generative UI reads AG-UI tool calls; nothing changes when you swap the agent. The guide says so up front.
- **`useRenderTool` and `useFrontendTool` do not hand their renderers the same props.** The former normalizes to `parameters` + a string-union status; the latter passes through to core with `args` + the `ToolCallStatus` enum. A renderer written for one silently draws nothing in the other. Verified in source, not inferred.

### One note on the link form

The quickstart links the guide as `/vue/guides/generative-ui`, not the relative `guides/generative-ui` that `angular.mdx` uses. `resolveDocsHref` returns any non-root-relative href untouched, and `next.config.ts` sets no `trailingSlash` — so the relative form would resolve against `/vue` and land on `/guides/generative-ui`, which doesn't exist. A test pins the authored href and asserts it both survives rewriting and resolves. (`angular.mdx:241` uses the relative form and looks like it has the same problem; not touched here.)

## Verification

- `frontend-options.test.ts` — 25/25. **Red-checked twice**: commenting out the single nav wiring line fails the sidebar test; reverting the href to the relative form fails the link test. Both can actually fail.
- Full `shell-docs` suite — 475/476. The one failure (`llm-text.test.ts`, mastra tool-rendering) **reproduces on unmodified `origin/main`** with these changes reverted. Pre-existing, unrelated.
- `tsc --noEmit` clean. `oxfmt --check` and `oxlint` clean.
- Search index regenerated: the page parses and is indexed at `href: "/vue/guides/generative-ui"`, section "Frontends".

## Deliberately out of scope

1. **No Vue redirect map.** Angular's `ANGULAR_DOC_REDIRECTS` maps ~20 `generative-ui/*` slugs onto its guides, so `/angular/generative-ui/tool-rendering` lands somewhere useful. `/vue/generative-ui/tool-rendering` still 404s. That's a policy decision about how much React IA to mirror into Vue.

2. **Backend-scoped variant.** On `/vue/<backend>`, `resolveDocsHref` rewrites cross-section links — `/generative-ui/a2ui`, `/generative-ui/mcp-apps`, `/inspector` — into that prefix, where they resolve not-found. This follows from those sections having no `frontend:` policy, is the same for every non-Angular frontend page today, and is not introduced here. The sidebar link to the guide is correct in both contexts.

3. **`FRONTEND_REFERENCE_SLUGS.vue` left alone — but please look at it.** Vue's sidebar "Reference docs" link points at `"reference"`, the **React** reference, despite a complete 25-page `/reference/vue` tree existing and registered in `reference-items.ts`. It's pinned by an assertion at `frontend-options.test.ts:538`, so it looks deliberate. If it's an oversight it compounds this exact bug — a Vue developer sent to the React reference cannot find `useRenderTool`'s Vue signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)