### PR TITLE
fix(react-native): keep the polyfill imports in the built barrel (closes OSS-1002)

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -18,6 +18,10 @@
   },
   "type": "module",
   "sideEffects": [
+    "./src/index.*",
+    "./src/headless.*",
+    "./src/polyfills.*",
+    "./src/polyfills/**/*",
     "./dist/index.*",
     "./dist/headless.*",
     "./dist/polyfills.*",
@@ -69,10 +73,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && node scripts/verify-polyfill-barrel.mjs",
     "dev": "tsdown --watch",
     "test": "vitest run && pnpm run test:scripts",
-    "test:scripts": "node --test scripts/__tests__/measure-headless.test.mjs",
+    "test:scripts": "node --test scripts/__tests__/measure-headless.test.mjs scripts/__tests__/verify-polyfill-barrel.test.mjs",
     "check-types": "tsc --noEmit",
     "publint": "publint .",
     "attw": "attw --pack . --profile node16 --ignore-rules internal-resolution-error",

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -13,6 +13,9 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
       "outputs": ["{projectRoot}/dist/**"]
+    },
+    "test": {
+      "inputs": ["test", "{projectRoot}/scripts/**"]
     }
   }
 }

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills.cjs
@@ -1,0 +1,5 @@
+require("./polyfills/streams.cjs");
+require("./polyfills/encoding.cjs");
+require("./polyfills/crypto.cjs");
+require("./polyfills/dom.cjs");
+require("./polyfills/location.cjs");

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills.mjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills.mjs
@@ -1,0 +1,5 @@
+import "./polyfills/streams.mjs";
+import "./polyfills/encoding.mjs";
+import "./polyfills/crypto.mjs";
+import "./polyfills/dom.mjs";
+import "./polyfills/location.mjs";

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/crypto.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/crypto.cjs
@@ -1,0 +1,1 @@
+globalThis.crypto = { getRandomValues: (a) => a };

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/dom.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/dom.cjs
@@ -1,0 +1,2 @@
+globalThis.DOMException = function DOMException() {};
+globalThis.Headers = function Headers() {};

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/encoding.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/encoding.cjs
@@ -1,0 +1,2 @@
+globalThis.TextEncoder = function TextEncoder() {};
+globalThis.TextDecoder = function TextDecoder() {};

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/location.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/location.cjs
@@ -1,0 +1,3 @@
+if (typeof window !== "undefined" && !window.location) {
+  window.location = { hostname: "react-native.invalid" };
+}

--- a/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/streams.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-complete-barrel/polyfills/streams.cjs
@@ -1,0 +1,3 @@
+globalThis.ReadableStream = function ReadableStream() {};
+globalThis.WritableStream = function WritableStream() {};
+globalThis.TransformStream = function TransformStream() {};

--- a/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/polyfills.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/polyfills.cjs
@@ -1,0 +1,3 @@
+// Mirrors the 1.69.2 defect: every side-effect import tree-shaken away.
+const require_streaming_fetch = require("./streaming-fetch.cjs");
+require_streaming_fetch.installStreamingFetch();

--- a/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/polyfills.mjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/polyfills.mjs
@@ -1,0 +1,2 @@
+import { t as installStreamingFetch } from "./streaming-fetch.mjs";
+installStreamingFetch();

--- a/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/streaming-fetch.cjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/streaming-fetch.cjs
@@ -1,0 +1,1 @@
+exports.installStreamingFetch = function installStreamingFetch() {};

--- a/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/streaming-fetch.mjs
+++ b/packages/react-native/scripts/__tests__/fixtures/dist-empty-barrel/streaming-fetch.mjs
@@ -1,0 +1,1 @@
+export const t = function installStreamingFetch() {};

--- a/packages/react-native/scripts/__tests__/verify-polyfill-barrel.test.mjs
+++ b/packages/react-native/scripts/__tests__/verify-polyfill-barrel.test.mjs
@@ -1,0 +1,187 @@
+// Standalone Node test (not vitest) — the check under test deliberately runs in
+// a realm stripped of ReadableStream, TextEncoder, crypto and DOMException, and
+// the package-wide vitest setup is jsdom, which supplies exactly those. Running
+// with `node --test` keeps the probe honest. This mirrors the sibling
+// measure-headless.test.mjs.
+//
+// Invoked from package.json `test:scripts` and the chained `test` command.
+//
+// What this locks down: verify-polyfill-barrel.mjs is the gate that stands
+// between a tree-shaken barrel and npm (OSS-1002), so its FAILURE modes are the
+// thing worth testing — an empty barrel must be rejected in both formats, a
+// healthy one must pass, and an unbuilt package must say "run the build".
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  assertBuilt,
+  BUILD_COMMAND,
+  GROUPS,
+  isEntrypoint,
+  missingEsmImports,
+  verifyBarrel,
+} from "../verify-polyfill-barrel.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDir = path.join(here, "fixtures");
+const emptyBarrel = path.join(fixtureDir, "dist-empty-barrel");
+const completeBarrel = path.join(fixtureDir, "dist-complete-barrel");
+const scriptPath = path.join(here, "..", "verify-polyfill-barrel.mjs");
+
+describe("verifyBarrel", () => {
+  it("rejects the tree-shaken barrel that shipped in 1.69.2", () => {
+    const report = verifyBarrel(emptyBarrel);
+    assert.equal(report.ok, false);
+    // Every group is gone, in both formats — not just the one that happened to
+    // be noticed first.
+    assert.deepEqual(
+      report.esmMissing,
+      GROUPS.map((g) => g.name),
+    );
+    for (const entry of report.cjs) {
+      assert.equal(
+        entry.installed.length,
+        0,
+        `${entry.group} should install nothing`,
+      );
+    }
+  });
+
+  it("accepts a barrel that reaches all five polyfill groups", () => {
+    const report = verifyBarrel(completeBarrel);
+    assert.equal(report.ok, true, JSON.stringify(report));
+    assert.deepEqual(report.esmMissing, []);
+    for (const entry of report.cjs) {
+      assert.deepEqual(
+        entry.missing,
+        [],
+        `${entry.group} should install every global`,
+      );
+    }
+  });
+
+  it("fails when a single group regresses, not only when all five do", () => {
+    // The realistic regression is one import going missing, which is exactly
+    // what a whole-barrel assertion would wave through.
+    const partial = fs.mkdtempSync(path.join(os.tmpdir(), "rn-barrel-"));
+    fs.cpSync(completeBarrel, partial, { recursive: true });
+    fs.writeFileSync(
+      path.join(partial, "polyfills.cjs"),
+      fs
+        .readFileSync(path.join(partial, "polyfills.cjs"), "utf8")
+        .replace('require("./polyfills/crypto.cjs");\n', ""),
+    );
+    fs.writeFileSync(
+      path.join(partial, "polyfills.mjs"),
+      fs
+        .readFileSync(path.join(partial, "polyfills.mjs"), "utf8")
+        .replace('import "./polyfills/crypto.mjs";\n', ""),
+    );
+
+    const report = verifyBarrel(partial);
+    assert.equal(report.ok, false);
+    assert.deepEqual(report.esmMissing, ["crypto"]);
+    assert.deepEqual(report.cjs.find((e) => e.group === "crypto").missing, [
+      "crypto.getRandomValues",
+    ]);
+    // The other four must still read as healthy.
+    for (const entry of report.cjs.filter((e) => e.group !== "crypto")) {
+      assert.deepEqual(entry.missing, []);
+    }
+    fs.rmSync(partial, { recursive: true, force: true });
+  });
+});
+
+describe("missingEsmImports", () => {
+  it("names every group the ESM barrel no longer imports", () => {
+    assert.deepEqual(
+      missingEsmImports(""),
+      GROUPS.map((g) => g.name),
+    );
+    assert.deepEqual(
+      missingEsmImports(
+        GROUPS.map((g) => `import "./polyfills/${g.name}.mjs";`).join("\n"),
+      ),
+      [],
+    );
+  });
+});
+
+describe("assertBuilt", () => {
+  it("tells an unbuilt package to run the build", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "rn-unbuilt-"));
+    assert.throws(
+      () => assertBuilt(empty),
+      (error) => {
+        assert.match(error.message, /Built barrel not found/);
+        assert.ok(
+          error.message.includes(BUILD_COMMAND),
+          "should name the build command",
+        );
+        return true;
+      },
+    );
+    fs.rmSync(empty, { recursive: true, force: true });
+  });
+});
+
+describe("isEntrypoint", () => {
+  it("is false when the module is imported rather than run", () => {
+    // argv[1] here is this test file, not the verifier, so the verifier's CLI
+    // block must stay inert — otherwise importing it would run a real check.
+    assert.equal(
+      isEntrypoint(pathToFileURL(scriptPath).href, process.argv[1]),
+      false,
+    );
+  });
+
+  it("matches through symlinked paths", () => {
+    // os.tmpdir() is /var/... on macOS but resolves to /private/var/..., so a
+    // raw string compare would leave the CLI silently inert there.
+    assert.equal(
+      isEntrypoint(pathToFileURL(scriptPath).href, scriptPath),
+      true,
+    );
+  });
+});
+
+describe("cli", () => {
+  it("exits non-zero and explains the tree-shake when the barrel is empty", () => {
+    // Point the CLI at the empty fixture by running it from a package root
+    // whose dist/ is that fixture.
+    const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rn-cli-"));
+    fs.mkdirSync(path.join(fakeRoot, "scripts"));
+    fs.cpSync(scriptPath, path.join(fakeRoot, "scripts", "verify.mjs"));
+    fs.cpSync(emptyBarrel, path.join(fakeRoot, "dist"), { recursive: true });
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(fakeRoot, "scripts", "verify.mjs")],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /sideEffects/);
+    assert.match(result.stdout, /FAIL {2}cjs {2}streams/);
+    fs.rmSync(fakeRoot, { recursive: true, force: true });
+  });
+
+  it("emits a machine-readable report under --json", () => {
+    const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rn-cli-json-"));
+    fs.mkdirSync(path.join(fakeRoot, "scripts"));
+    fs.cpSync(scriptPath, path.join(fakeRoot, "scripts", "verify.mjs"));
+    fs.cpSync(completeBarrel, path.join(fakeRoot, "dist"), { recursive: true });
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(fakeRoot, "scripts", "verify.mjs"), "--json"],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0);
+    assert.equal(JSON.parse(result.stdout).ok, true);
+    fs.rmSync(fakeRoot, { recursive: true, force: true });
+  });
+});

--- a/packages/react-native/scripts/verify-polyfill-barrel.mjs
+++ b/packages/react-native/scripts/verify-polyfill-barrel.mjs
@@ -1,0 +1,220 @@
+// Verifies that the BUILT polyfill barrel actually installs every polyfill.
+//
+// src/polyfills.ts is five side-effect-only imports plus installStreamingFetch().
+// Side-effect-only imports are exactly what a bundler drops when it believes a
+// module is pure, so the barrel can build down to a no-op while every source
+// file and every source-level test stays green. That is not hypothetical:
+// 1.69.2 shipped a 195-byte barrel that installed nothing but streaming fetch,
+// and src/__tests__/polyfills.test.ts stayed green throughout because it
+// imports "../polyfills" — the source, which is never bundled and so is never
+// tree-shaken (OSS-1002).
+//
+// This therefore runs against dist/, not src/. Two checks, one per published
+// format:
+//
+//   - CJS is executed for real, in a child realm stripped of the globals Hermes
+//     lacks. Node ships ReadableStream, TextEncoder, crypto and DOMException
+//     natively, so asserting they are merely "defined" afterwards would pass on
+//     an empty barrel; clearing them first is what makes the check honest. It
+//     runs in a child process so the probe cannot poison this one.
+//   - ESM is checked structurally. It cannot be executed here: the encoding
+//     polyfill takes a named import from `text-encoding`, which is CommonJS.
+//     Metro rewrites that to a require() and it works in React Native; bare
+//     Node ESM refuses it. Asserting the five imports survive the bundler is
+//     the part this file exists to protect.
+//
+// Invoked from package.json `build`, so a barrel that installs nothing fails
+// the build rather than reaching npm.
+//
+// Usage:
+//   node scripts/verify-polyfill-barrel.mjs          # human readable, exits 1 on failure
+//   node scripts/verify-polyfill-barrel.mjs --json   # machine readable report
+
+import fs, { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import process from "node:process";
+
+/**
+ * Each group is one `import "./polyfills/<name>"` line in src/polyfills.ts,
+ * paired with the globals that line exists to install.
+ */
+export const GROUPS = [
+  {
+    name: "streams",
+    globals: ["ReadableStream", "WritableStream", "TransformStream"],
+  },
+  { name: "encoding", globals: ["TextEncoder", "TextDecoder"] },
+  { name: "crypto", globals: ["crypto.getRandomValues"] },
+  { name: "dom", globals: ["DOMException", "Headers"] },
+  { name: "location", globals: ["window.location"] },
+];
+
+export const BUILD_COMMAND = "pnpm --filter @copilotkit/react-native build";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+export function assertBuilt(distDir) {
+  for (const file of ["polyfills.cjs", "polyfills.mjs"]) {
+    const artifact = path.join(distDir, file);
+    if (!existsSync(artifact)) {
+      throw new Error(
+        `Built barrel not found at ${artifact}.\n` +
+          `Run \`${BUILD_COMMAND}\` first — this check verifies build output, ` +
+          `so an unbuilt package cannot be checked.`,
+      );
+    }
+  }
+}
+
+/**
+ * Which polyfill modules the ESM barrel no longer imports. Pure; the ESM barrel
+ * is read as text rather than executed (see the header note on text-encoding).
+ */
+export function missingEsmImports(esmSource) {
+  return GROUPS.filter(
+    (group) => !esmSource.includes(`./polyfills/${group.name}.mjs`),
+  ).map((group) => group.name);
+}
+
+/** The probe body run inside the stripped child realm. */
+function probeSource(cjsBarrel) {
+  return `
+    const GROUPS = ${JSON.stringify(GROUPS)};
+    // Emulate Hermes: none of these exist there.
+    for (const group of GROUPS) {
+      for (const dotted of group.globals) delete globalThis[dotted.split(".")[0]];
+    }
+    // React Native defines \`window\`; the location polyfill no-ops without it.
+    globalThis.window = {};
+    // Metro defines \`__DEV__\` in every React Native bundle. The streaming-fetch
+    // feature detection reads it on its error path, so a bare realm without it
+    // turns an ordinary fallback into a ReferenceError.
+    globalThis.__DEV__ = false;
+    // The crypto polyfill warns loudly by design. Keep the report readable.
+    const realWarn = console.warn;
+    console.warn = () => {};
+    require(${JSON.stringify(cjsBarrel)});
+    console.warn = realWarn;
+    const read = (dotted) =>
+      dotted.split(".").reduce((acc, k) => (acc == null ? undefined : acc[k]), globalThis);
+    process.stdout.write(JSON.stringify(GROUPS.map((group) => ({
+      group: group.name,
+      installed: group.globals.filter((g) => read(g) !== undefined),
+      missing: group.globals.filter((g) => read(g) === undefined),
+    }))));
+  `;
+}
+
+/**
+ * Executes the CJS barrel in a child realm stripped of the globals Hermes
+ * lacks, and reports which groups installed.
+ */
+export function checkCjsBarrel(cjsBarrel) {
+  const result = spawnSync(process.execPath, ["-e", probeSource(cjsBarrel)], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Could not execute the built CJS barrel ${cjsBarrel}:\n${result.stderr.trim()}`,
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+/** Runs both checks against a built dist directory. */
+export function verifyBarrel(distDir) {
+  assertBuilt(distDir);
+  const cjs = checkCjsBarrel(path.join(distDir, "polyfills.cjs"));
+  const esmMissing = missingEsmImports(
+    readFileSync(path.join(distDir, "polyfills.mjs"), "utf8"),
+  );
+  const ok =
+    cjs.every((entry) => entry.missing.length === 0) && esmMissing.length === 0;
+  return { ok, cjs, esmMissing };
+}
+
+export function formatReport({ cjs, esmMissing }) {
+  const lines = cjs.map(
+    (entry) =>
+      `${entry.missing.length === 0 ? "PASS" : "FAIL"}  cjs  ${entry.group.padEnd(9)} ` +
+      `${entry.installed.join(", ") || "(nothing installed)"}`,
+  );
+  for (const group of GROUPS) {
+    lines.push(
+      `${esmMissing.includes(group.name) ? "FAIL" : "PASS"}  esm  ${group.name.padEnd(9)} ` +
+        `import "./polyfills/${group.name}.mjs"`,
+    );
+  }
+  return lines.join("\n");
+}
+
+export function failureMessage({ cjs, esmMissing }) {
+  const dropped = [
+    ...cjs.flatMap((entry) => entry.missing),
+    ...esmMissing.map((name) => `import "./polyfills/${name}.mjs"`),
+  ];
+  return (
+    `The built polyfill barrel does not install everything it should.\n` +
+    `Missing: ${dropped.join(", ")}\n\n` +
+    `The side-effect imports in src/polyfills.ts were tree-shaken away. Check that\n` +
+    `the "sideEffects" globs in package.json match this package's SOURCE paths —\n` +
+    `globs that only match ./dist/** tell the bundler the src files are pure.`
+  );
+}
+
+function realPath(p) {
+  const absolute = path.resolve(p);
+  try {
+    return fs.realpathSync(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+export function isEntrypoint(moduleUrl, argv1) {
+  if (!argv1) return false;
+  let modulePath;
+  try {
+    modulePath = fileURLToPath(moduleUrl);
+  } catch {
+    // Not a `file:` URL (e.g. `data:`), so it cannot be the CLI entry.
+    return false;
+  }
+  // realpath both sides: on macOS os.tmpdir() is /var/... while import.meta.url
+  // resolves through to /private/var/..., and a raw compare would never match.
+  return realPath(modulePath) === realPath(argv1);
+}
+
+// CLI entry — only runs when invoked directly, so importing this module from
+// tests doesn't run a check at module-load time (mirrors measure-headless.mjs).
+if (isEntrypoint(import.meta.url, process.argv[1])) {
+  const jsonMode = process.argv.includes("--json");
+  let report;
+  try {
+    report = verifyBarrel(path.join(packageRoot, "dist"));
+  } catch (error) {
+    if (jsonMode) {
+      process.stdout.write(
+        JSON.stringify({ ok: false, error: error.message }) + "\n",
+      );
+    } else {
+      process.stderr.write(`\n${error.message}\n`);
+    }
+    process.exit(1);
+  }
+
+  if (jsonMode) {
+    process.stdout.write(JSON.stringify(report) + "\n");
+  } else {
+    process.stdout.write(formatReport(report) + "\n");
+    if (!report.ok) process.stderr.write(`\n${failureMessage(report)}\n`);
+    else
+      process.stdout.write(`\nAll ${GROUPS.length} polyfill groups install.\n`);
+  }
+  process.exit(report.ok ? 0 : 1);
+}

--- a/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
@@ -303,6 +303,7 @@ The package has three import surfaces — `/headless` (provider + hooks, no nati
                 - **Streaming not working**: Make sure polyfills are imported before any CopilotKit code in your entry point.
                 - **No response from the runtime**: Confirm the runtime server is running, `http://localhost:8200/api/copilotkit/info` returns the `default` agent, and the device can reach `runtimeUrl`. For physical devices, use your machine's LAN IP instead of `localhost`.
                 - **Model auth errors**: Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx server.ts`.
+                - **`Property 'ReadableStream' doesn't exist`** (or the same for `TextEncoder`, `DOMException` or `Headers`): the polyfills did not install. In **1.69.2 and every earlier version** the `polyfills` barrel was published empty — the build dropped all five polyfill imports out of it — so following the setup above installed nothing and the first runtime call failed. Upgrade to the latest version, or, if you are pinned, use the [granular imports](#polyfills), which were never affected. This is the *opposite* of the conflict case below: here you have no polyfill at all, not a competing one.
                 - **Existing polyfill conflicts**: Use the granular imports instead of the barrel `polyfills` import.
             </Accordion>
         </Accordions>


### PR DESCRIPTION
## The bug

`src/polyfills.ts` is five side-effect-only imports plus `installStreamingFetch()`. The published barrel was 195 bytes:

```js
// node_modules/@copilotkit/react-native/dist/polyfills.mjs — 1.69.2
import { t as installStreamingFetch } from "./streaming-fetch-BnQh3vBz.mjs";
installStreamingFetch();
export {  };
```

Every React Native app following the documented setup died on its first runtime call:

```
E ReactNativeJS: '[CopilotKit] Error (runtime_info_fetch_failed):',
  [ReferenceError: Property 'ReadableStream' doesn't exist]
```

## Root cause

The `sideEffects` field, but not in the way it first looks. It is correct for *consumers* and wrong for *this package's own build*:

```json
"sideEffects": ["./dist/index.*", "./dist/headless.*", "./dist/polyfills.*", "./dist/polyfills/**/*"]
```

tsdown/rolldown reads the package's own `sideEffects` while bundling and matches it against **source** paths. `src/polyfills/streams.ts` matches none of those `dist` globs, so it is declared side-effect-free — a hard assertion that lets rolldown drop the import without analysing the `globalThis` assignments inside.

Reproduced in isolation at the pinned tsdown (0.20.3):

| `sideEffects` | built barrel |
|---|---|
| `["./dist/polyfills.*", "./dist/polyfills/**/*"]` | `export { };` — empty |
| same + `["./src/polyfills.*", "./src/polyfills/**/*"]` | `import "./polyfills/streams.mjs";` |
| field absent | `import "./polyfills/streams.mjs";` |

**Wider than the ticket recorded:** `dist/index.mjs` and `dist/headless.mjs` also had zero polyfill code, so the package's advertised auto-install on first import did not happen either. Not RN-specific in principle — but I surveyed every package at `origin/main` and this is the only one exposed. The other `sideEffects` arrays (`react-core`, `react-ui`, `react-textarea`) are `["**/*.css"]`, which matches source and works.

## The fix

Add matching `./src/**` globs. Barrel goes 195B → 362B with all five imports; `headless.mjs` now leads with `import "./polyfills.mjs"`.

## The test, and why the existing one didn't catch this

`src/__tests__/polyfills.test.ts` has ~20 assertions covering all five groups and was green the whole time — it imports `"../polyfills"`, the TypeScript **source**, which vitest transpiles without bundling and therefore without tree-shaking. It exercises a graph the published package does not contain.

So the new check runs against `dist/`. Two things it has to get right to be honest:

- **Node ships these globals natively.** Asserting `ReadableStream` is "defined" after import passes on an empty barrel. The probe clears all nine first, emulating Hermes.
- **The two formats need different treatment.** CJS is executed for real in a child realm. ESM is checked structurally — it cannot be executed here because `encoding.mjs` takes a named import from CommonJS `text-encoding`, which Metro rewrites to a `require()` but bare Node ESM rejects.

It is wired into `build`, so a dead barrel fails the build rather than reaching npm — which matters, because this shipped through a fully green suite.

## Docs

Added the `Property 'ReadableStream' doesn't exist` symptom to troubleshooting, which previously covered only the inverse case (a polyfill *conflict*).

I deliberately left the reference docs' "auto-installs on first import" claims and the crypto import-order callout alone: both become **true** once the build is fixed, and I verified the auto-install behaviourally.

## Verification

- **Red/green proven, not assumed:** reverted the `sideEffects` change, rebuilt → 5/5 groups FAIL in both formats. Restored → 5/5 PASS. There is also a test for a *single* group regressing, which a whole-barrel assertion would wave through.
- **Packed tarball** (`pnpm pack`) verified behaviourally: all nine globals install.
- 289 vitest + 26 script tests pass; `check-types` clean; `attw` green; `publint` clean apart from a pre-existing `repository.url` suggestion; oxfmt/oxlint clean.
- Added `{projectRoot}/scripts/**` to the package's `test` inputs and confirmed cache invalidation (19/19 cached → 18/19 after touching the verifier); without it, editing the verifier alone would restore a cached pass.

**Not verified:** the on-device round trip — no emulator in this environment. The bare-realm equivalent passes on the packed tarball.

## Follow-up worth its own ticket

`dist/polyfills/encoding.mjs` uses a named import from CommonJS `text-encoding`. Metro handles it; a true-ESM consumer would not. Pre-existing and not RN-facing, so left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
