### PR TITLE
feat(runtime): expose Learning Container selector

### DIFF
--- a/packages/react-core/src/v2/hooks/use-learning-containers-in-current-thread.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers-in-current-thread.tsx
@@ -8,9 +8,9 @@ import { useLearningContainers } from "./use-learning-containers";
  * sourced from the surrounding `<CopilotChatConfigurationProvider>` at
  * render time.
  *
- * @deprecated Legacy plural-container annotation compatibility only. New
- * Intelligence runtimes assign one container with `ɵlearning.containerId` on
- * `CopilotRuntime`.
+ * @deprecated This type supports only the legacy plural-container annotation.
+ * Configure `getLearningContainerId` on `CopilotKitIntelligence` for new
+ * Intelligence runtimes.
  */
 export type UseLearningContainersInCurrentThreadArgs = Omit<
   UseLearningContainersArgs,
@@ -44,9 +44,9 @@ export type UseLearningContainersInCurrentThreadArgs = Omit<
  * }
  * ```
  *
- * @deprecated Legacy plural-container annotation compatibility only. New
- * Intelligence runtimes assign one container with `ɵlearning.containerId` on
- * `CopilotRuntime`.
+ * @deprecated This hook supports only the legacy plural-container annotation.
+ * Configure `getLearningContainerId` on `CopilotKitIntelligence` for new
+ * Intelligence runtimes.
  */
 export function useLearningContainersInCurrentThread({
   learningContainers,

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -8,9 +8,9 @@ const DEFAULT_CONTAINERS: string[] = ["project"];
 /**
  * Arguments for {@link useLearningContainers}.
  *
- * @deprecated Legacy plural-container annotation compatibility only. New
- * Intelligence runtimes assign one container with `ɵlearning.containerId` on
- * `CopilotRuntime`.
+ * @deprecated This interface supports only the legacy plural-container
+ * annotation. Configure `getLearningContainerId` on `CopilotKitIntelligence`
+ * for new Intelligence runtimes.
  */
 export interface UseLearningContainersArgs {
   /** Thread to apply the learning-container selection to. */
@@ -55,9 +55,9 @@ export interface UseLearningContainersArgs {
  * }
  * ```
  *
- * @deprecated Legacy plural-container annotation compatibility only. New
- * Intelligence runtimes assign one container with `ɵlearning.containerId` on
- * `CopilotRuntime`.
+ * @deprecated This hook supports only the legacy plural-container annotation.
+ * Configure `getLearningContainerId` on `CopilotKitIntelligence` for new
+ * Intelligence runtimes.
  */
 export function useLearningContainers({
   threadId,


### PR DESCRIPTION
## What

- Add `getLearningContainerId` to `CopilotKitIntelligenceConfig`.
- Route the public callback through web runtimes, Channels runtimes, and package-root runtime construction.
- Keep `ɵlearning` as a deprecated compatibility path and document the public API.

## Why

Learning Container assignment is only available through the internal `ɵlearning` option on `CopilotRuntime`. Customers need a supported API on the Intelligence SDK constructor, and the Intelligence app needs a public snippet that users can copy.

## How

- `CopilotKitIntelligence` validates and stores the public selector.
- `CopilotIntelligenceRuntime` adapts it to the existing `CopilotRuntimeLearningContext` resolver, so assignment still happens before Thread creation or the Channels container lock.
- The runtime accepts either the public selector or deprecated `ɵlearning`, but rejects both at once so precedence cannot be ambiguous.
- Runtime tests cover direct v2 construction, package-root construction, invalid config, and the deprecated path.

## Backwards compatibility

1. No selector: runtime construction and Thread creation remain unchanged.
2. Public selector: the selected Learning Container ID flows through the existing resolver.
3. Deprecated `ɵlearning`: existing callers keep the same behavior.
4. Both selectors: runtime construction fails fast with a clear conflict error.
5. Package-root and Channels entry points: the selector reaches the same runtime boundary as direct v2 construction.

## Validation

- `npx --yes pnpm@10.33.4 exec nx test @copilotkit/runtime` — 2,087 tests passed.
- `npx --yes pnpm@10.33.4 exec nx run-many -t build,check-types,check-dts,publint,attw -p @copilotkit/runtime` — passed.
- `npx --yes pnpm@10.33.4 run lint` — passed with existing warnings and no errors.
- `npm run lint`, `npm run typecheck`, and `npm run build` in `showcase/shell-docs` — passed; the build generated 225 pages.
- `npm test` in `showcase/shell-docs` — 475 tests passed; one unrelated existing Mastra canonical-example assertion failed because its generated output omits `createTool`'s import.

## End-to-end test sequence

1. Configure only `getLearningContainerId`, create a web Thread, and verify the new Thread uses the returned Container ID.
2. Configure only deprecated `ɵlearning`, repeat the web test, and verify the result matches the public path.
3. Configure neither selector, create a Thread, and verify the existing unassigned/default behavior is unchanged.
4. Configure both selectors and verify runtime construction rejects the ambiguous setup before serving traffic.
5. Send the first and second messages for one Channels conversation and verify the selector runs before the first lock, then the locked Container remains stable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated deprecation guidance for legacy learning-container hooks and types.
  - Clarified that new Intelligence runtimes should configure learning container IDs through the recommended configuration option.
  - Documented that the affected hooks support only the legacy plural-container annotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->