### PR TITLE
fix(telemetry): stamp sampling metadata and emitter markers on every event

### DIFF
--- a/packages/runtime/src/v2/runtime/telemetry/__tests__/global-properties.test.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/__tests__/global-properties.test.ts
@@ -135,9 +135,18 @@ describe("telemetry global properties", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
-  it("adds nothing when none are set", async () => {
+  it("adds nothing of the caller's when none are set", async () => {
     await client().capture("oss.runtime.agent_execution_stream_started", {});
 
-    expect(sent().globalProperties).toEqual({});
+    // Sampling metadata and the emitter markers always ride in this slot
+    // (OSS-1017); what this pins is that nothing else joins them.
+    expect(Object.keys(sent().globalProperties).sort()).toEqual([
+      "sampleRate",
+      "sampleRateAdjustmentFactor",
+      "sampleWeight",
+      "telemetry_emitter",
+      "telemetry_identified",
+      "telemetry_transport",
+    ]);
   });
 });

--- a/packages/runtime/src/v2/runtime/telemetry/__tests__/telemetry-client.test.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/__tests__/telemetry-client.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { lambdaClient } from "@copilotkit/shared";
+import { TelemetryClient } from "../telemetry-client";
+
+// Guards the half of the sampling contract that lives in the v2 client:
+// it gates anonymous events at sampleRate and lets identified ones
+// through, so every event it emits has to record which branch it took.
+// It didn't, and ~24% of runtime volume became unweightable from the data
+// alone (OSS-1017 / OSS-1018).
+describe("v2 TelemetryClient sampling metadata", () => {
+  let lambdaSpy: MockInstance<typeof lambdaClient.send>;
+
+  beforeEach(() => {
+    lambdaSpy = vi.spyOn(lambdaClient, "send").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function jwtWith(payload: Record<string, unknown>): string {
+    const b64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    return `header.${b64}.sig`;
+  }
+
+  const baseInstanceEvent = {
+    actionsAmount: 0,
+    endpointsAmount: 0,
+    endpointTypes: [],
+    "cloud.api_key_provided": false,
+  } as never;
+
+  function globalsOf(callIndex = 0): Record<string, unknown> {
+    return lambdaSpy.mock.calls[callIndex][0].globalProperties as Record<
+      string,
+      unknown
+    >;
+  }
+
+  test("anonymous events carry the 5% gate's weight of 20", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const client = new TelemetryClient({ sampleRate: 0.05 });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    expect(globalsOf()).toMatchObject({
+      sampleRate: 0.05,
+      sampleRateAdjustmentFactor: 0.95,
+      sampleWeight: 20,
+      telemetry_identified: false,
+    });
+  });
+
+  test("identified events bypass the gate and carry weight 1", async () => {
+    // Math.random would fail a 5% gate; the identified branch must send
+    // anyway, and must not inherit the anonymous population's weight.
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    const client = new TelemetryClient({ sampleRate: 0.05 });
+    client.setLicenseToken(jwtWith({ telemetry_id: "abc-123" }));
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    expect(lambdaSpy).toHaveBeenCalledTimes(1);
+    expect(globalsOf()).toMatchObject({
+      sampleRate: 1,
+      sampleWeight: 1,
+      telemetry_identified: true,
+    });
+  });
+
+  test("events are stamped with the v2 emitter and its transport", async () => {
+    // What lets a consumer attribute an event to this code path directly
+    // instead of inferring it from $lib and which fields are absent.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const client = new TelemetryClient({ sampleRate: 0.05 });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    expect(globalsOf()).toMatchObject({
+      telemetry_emitter: "v2-runtime",
+      telemetry_transport: "lambda",
+    });
+  });
+
+  test("sampling metadata does not displace caller globalProperties", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const client = new TelemetryClient({ sampleRate: 0.05 });
+    client.setGlobalProperties({ "copilotkit.package.name": "runtime" });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    expect(globalsOf()).toMatchObject({
+      "copilotkit.package.name": "runtime",
+      sampleWeight: 20,
+    });
+  });
+
+  test("the license token itself never reaches the event properties", async () => {
+    // Only the decoded id travels, and only as a header. A regression here
+    // would ship a signed JWT to the analytics sink on every event.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const token = jwtWith({ telemetry_id: "abc-123" });
+    const client = new TelemetryClient({ sampleRate: 0.05 });
+    client.setLicenseToken(token);
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    const sent = JSON.stringify([
+      lambdaSpy.mock.calls[0][0].globalProperties,
+      lambdaSpy.mock.calls[0][0].properties,
+    ]);
+    expect(sent).not.toContain(token);
+    expect(sent).not.toContain("abc-123");
+  });
+
+  test("gated-out anonymous events send nothing at all", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    const client = new TelemetryClient({ sampleRate: 0.05 });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    expect(lambdaSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
+++ b/packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts
@@ -1,5 +1,10 @@
 import type { AnalyticsEvents } from "./events";
-import { lambdaClient, parseAndWarnTelemetryId } from "@copilotkit/shared";
+import {
+  lambdaClient,
+  parseAndWarnTelemetryId,
+  computeSamplingMeta,
+  TELEMETRY_EMITTER_V2,
+} from "@copilotkit/shared";
 import * as packageJson from "../../../../package.json";
 
 export function isTelemetryDisabled(): boolean {
@@ -97,7 +102,21 @@ export class TelemetryClient {
       // the analytics event, and v1's client sends package name and version the
       // same way. Folding it in would work and would put a process-level fact
       // in the per-event slot, where nothing downstream expects to find one.
-      globalProperties: this.globalProperties,
+      // Sampling metadata rides in the same slot, as it does in v1: an event
+      // that records no sampling decision can't be weighted, and anyone
+      // counting raw events understates anonymous volume ~20× (OSS-1017).
+      globalProperties: {
+        ...this.globalProperties,
+        ...computeSamplingMeta({
+          telemetryId: this.telemetryId,
+          sampleRate: this.sampleRate,
+        }),
+        telemetry_emitter: TELEMETRY_EMITTER_V2,
+        // This client has one transport, so the marker is constant here. It
+        // is stamped anyway so the property means the same thing on every
+        // event whichever client produced it (OSS-1019).
+        telemetry_transport: "lambda",
+      },
       packageName: packageJson.name,
       packageVersion: packageJson.version,
       licenseToken: this.licenseToken ?? undefined,

--- a/packages/shared/src/telemetry/index.ts
+++ b/packages/shared/src/telemetry/index.ts
@@ -1,4 +1,5 @@
 export * from "./telemetry-client";
+export * from "./sampling";
 export {
   lambdaClient,
   parseTelemetryIdFromLicense,

--- a/packages/shared/src/telemetry/sampling.test.ts
+++ b/packages/shared/src/telemetry/sampling.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import {
+  computeSamplingMeta,
+  TELEMETRY_EMITTER_V1,
+  TELEMETRY_EMITTER_V2,
+} from "./sampling";
+
+describe("computeSamplingMeta", () => {
+  test("anonymous callers get the population weight 1/sampleRate", () => {
+    // The gate let 5% through, so each surviving event stands for 20.
+    expect(
+      computeSamplingMeta({ telemetryId: null, sampleRate: 0.05 }),
+    ).toEqual({
+      sampleRate: 0.05,
+      sampleRateAdjustmentFactor: 0.95,
+      sampleWeight: 20,
+      telemetry_identified: false,
+    });
+  });
+
+  test("identified callers get weight 1 — they bypassed the gate", () => {
+    // The branch that matters: an identified event represents only itself,
+    // so weighting it by the anonymous population's 20 would inflate every
+    // paying customer's volume 20×.
+    expect(
+      computeSamplingMeta({ telemetryId: "abc-123", sampleRate: 0.05 }),
+    ).toEqual({
+      sampleRate: 1,
+      sampleRateAdjustmentFactor: 0,
+      sampleWeight: 1,
+      telemetry_identified: true,
+    });
+  });
+
+  test("telemetry_identified stays true when sampleRate=1 makes the weights identical", () => {
+    // COPILOTKIT_TELEMETRY_SAMPLE_RATE=1 gives anonymous events weight 1
+    // too, so weight alone stops separating the populations. This is the
+    // case that makes the flag worth carrying rather than inferring
+    // (OSS-1018).
+    const anon = computeSamplingMeta({ telemetryId: null, sampleRate: 1 });
+    const identified = computeSamplingMeta({
+      telemetryId: "abc-123",
+      sampleRate: 1,
+    });
+
+    expect(anon.sampleWeight).toBe(identified.sampleWeight);
+    expect(anon.telemetry_identified).toBe(false);
+    expect(identified.telemetry_identified).toBe(true);
+  });
+
+  test("an empty telemetry_id is anonymous, not identified", () => {
+    // parseTelemetryIdFromLicense only returns strings or null, but a
+    // token carrying `telemetry_id: ""` would otherwise read as identified
+    // and silently bypass the sample gate.
+    expect(
+      computeSamplingMeta({ telemetryId: "", sampleRate: 0.05 }),
+    ).toMatchObject({ sampleWeight: 20, telemetry_identified: false });
+  });
+
+  test("the two emitter markers are distinct", () => {
+    // Downstream separates the populations by this value; if they ever
+    // collide the dedupe rule silently keeps or drops both.
+    expect(TELEMETRY_EMITTER_V1).not.toBe(TELEMETRY_EMITTER_V2);
+  });
+});

--- a/packages/shared/src/telemetry/sampling.ts
+++ b/packages/shared/src/telemetry/sampling.ts
@@ -1,0 +1,70 @@
+// Per-event telemetry metadata shared by both TelemetryClients.
+//
+// Two clients emit `oss.runtime.*`: the v1 client in this package and the
+// v2 client in @copilotkit/runtime. Both gate anonymous events at
+// `sampleRate` and let identified callers (a license token that yielded a
+// telemetry_id) through at 100%, so real volume can only be recovered
+// downstream as sum(sampleWeight) — a flat multiplier is wrong whenever
+// the identified share moves, which it does as Intelligence keys roll out.
+//
+// The two clients computed this independently and drifted: v2 sampled but
+// stamped nothing, leaving ~24% of runtime volume unweightable from the
+// data alone (OSS-1017). Computing it here is what stops them drifting
+// again.
+
+/** Identifies which client emitted an event. */
+export const TELEMETRY_EMITTER_V1 = "v1-shared";
+export const TELEMETRY_EMITTER_V2 = "v2-runtime";
+
+export type TelemetryEmitter =
+  | typeof TELEMETRY_EMITTER_V1
+  | typeof TELEMETRY_EMITTER_V2;
+
+/**
+ * Which wire an event copy travelled on. The v1 client sends each capture
+ * to both, so this is what tells the two copies apart downstream
+ * (OSS-1019); the v2 client only ever sends to the lambda sink.
+ */
+export type TelemetryTransport = "segment" | "lambda";
+
+export interface SamplingMeta {
+  /** The rate this event was actually gated at: 1 when identified. */
+  sampleRate: number;
+  sampleRateAdjustmentFactor: number;
+  /** Multiply by this to extrapolate the population the event stands for. */
+  sampleWeight: number;
+  /** Whether the event bypassed the sample gate. */
+  telemetry_identified: boolean;
+}
+
+/**
+ * Compute the sampling block for one captured event.
+ *
+ * `telemetryId` is the caller's parsed license telemetry_id, or null when
+ * anonymous — it decides the branch, and is deliberately not returned:
+ * only the non-PII shape below travels on the event.
+ */
+export function computeSamplingMeta({
+  telemetryId,
+  sampleRate,
+}: {
+  telemetryId: string | null;
+  sampleRate: number;
+}): SamplingMeta {
+  const identified = Boolean(telemetryId);
+  // Identified events ship at a 100% effective rate, anonymous ones at
+  // sampleRate. Computed per event because a single global weight would
+  // overweight identified-customer counts by 1/sampleRate.
+  const effectiveSampleRate = identified ? 1 : sampleRate;
+
+  return {
+    sampleRate: effectiveSampleRate,
+    sampleRateAdjustmentFactor: 1 - effectiveSampleRate,
+    sampleWeight: 1 / effectiveSampleRate,
+    // Stated outright rather than inferred from sampleWeight === 1:
+    // under COPILOTKIT_TELEMETRY_SAMPLE_RATE=1 anonymous events also
+    // weigh 1, and the two populations stop being distinguishable
+    // (OSS-1018).
+    telemetry_identified: identified,
+  };
+}

--- a/packages/shared/src/telemetry/telemetry-client.test.ts
+++ b/packages/shared/src/telemetry/telemetry-client.test.ts
@@ -262,6 +262,90 @@ describe("v1 TelemetryClient", () => {
       }
     }
   });
+
+  test("both copies of one capture share a telemetry_event_id and differ only by transport", async () => {
+    // The dual-write is the whole of OSS-1019: one request, two rows, and
+    // before this nothing on either row said they were the same event.
+    // Consumers had to infer it from $lib, which is incidental.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const client = makeClient({ sampleRate: 0.05 });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    const lambdaGlobals = lambdaSpy.mock.calls[0][0].globalProperties as Record<
+      string,
+      unknown
+    >;
+    const segmentProps = segmentTrackMock.mock.calls[0][0].properties as Record<
+      string,
+      unknown
+    >;
+
+    expect(lambdaGlobals.telemetry_event_id).toEqual(expect.any(String));
+    expect(segmentProps.telemetry_event_id).toBe(
+      lambdaGlobals.telemetry_event_id,
+    );
+    expect(lambdaGlobals.telemetry_transport).toBe("lambda");
+    expect(segmentProps.telemetry_transport).toBe("segment");
+  });
+
+  test("each capture gets its own telemetry_event_id", async () => {
+    // A per-client id would collapse every event from one process into a
+    // single row under a dedupe-by-id rule.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const client = makeClient({ sampleRate: 0.05 });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    const first = (
+      lambdaSpy.mock.calls[0][0].globalProperties as Record<string, unknown>
+    ).telemetry_event_id;
+    const second = (
+      lambdaSpy.mock.calls[1][0].globalProperties as Record<string, unknown>
+    ).telemetry_event_id;
+
+    expect(first).not.toBe(second);
+  });
+
+  test("both copies are stamped as emitted by the v1 client", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const client = makeClient({ sampleRate: 0.05 });
+
+    await client.capture("oss.runtime.instance_created", baseInstanceEvent);
+
+    expect(lambdaSpy.mock.calls[0][0].globalProperties).toMatchObject({
+      telemetry_emitter: "v1-shared",
+    });
+    expect(segmentTrackMock.mock.calls[0][0]).toMatchObject({
+      properties: expect.objectContaining({ telemetry_emitter: "v1-shared" }),
+    });
+  });
+
+  test("telemetry_identified rides on both copies and tracks the gate branch", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const anonClient = makeClient({ sampleRate: 0.05 });
+    await anonClient.capture("oss.runtime.instance_created", baseInstanceEvent);
+    expect(lambdaSpy.mock.calls[0][0].globalProperties).toMatchObject({
+      telemetry_identified: false,
+    });
+    expect(segmentTrackMock.mock.calls[0][0]).toMatchObject({
+      properties: expect.objectContaining({ telemetry_identified: false }),
+    });
+
+    lambdaSpy.mockClear();
+    segmentTrackMock.mockReset();
+
+    const idClient = makeClient({ sampleRate: 0.05 });
+    idClient.setLicenseToken(jwtWith({ telemetry_id: "abc-123" }));
+    await idClient.capture("oss.runtime.instance_created", baseInstanceEvent);
+    expect(lambdaSpy.mock.calls[0][0].globalProperties).toMatchObject({
+      telemetry_identified: true,
+    });
+    expect(segmentTrackMock.mock.calls[0][0]).toMatchObject({
+      properties: expect.objectContaining({ telemetry_identified: true }),
+    });
+  });
 });
 
 describe("isTelemetryDisabled", () => {

--- a/packages/shared/src/telemetry/telemetry-client.ts
+++ b/packages/shared/src/telemetry/telemetry-client.ts
@@ -3,6 +3,7 @@ import type { AnalyticsEvents } from "./events";
 import { flattenObject } from "./utils";
 import { v4 as uuidv4 } from "uuid";
 import { lambdaClient, parseAndWarnTelemetryId } from "./lambda-client";
+import { computeSamplingMeta, TELEMETRY_EMITTER_V1 } from "./sampling";
 
 /**
  * Checks if telemetry is disabled via environment variables.
@@ -104,22 +105,30 @@ export class TelemetryClient {
       return;
     }
 
-    // Identified events ship at 100% effective rate, anonymous events at
-    // sampleRate. Compute per-event so downstream weight-based extrapolation
-    // (sampleWeight = 1 / effectiveRate) is correct for both populations;
-    // a single global sampleWeight would overweight identified-customer
-    // counts by 1/sampleRate.
-    const effectiveSampleRate = this.telemetryId ? 1 : this.sampleRate;
-    const samplingMeta = {
-      sampleRate: effectiveSampleRate,
-      sampleRateAdjustmentFactor: 1 - effectiveSampleRate,
-      sampleWeight: 1 / effectiveSampleRate,
+    // Sampling metadata is computed in ./sampling so this client and the
+    // v2 runtime client can't drift apart again — see the note there.
+    const samplingMeta = computeSamplingMeta({
+      telemetryId: this.telemetryId,
+      sampleRate: this.sampleRate,
+    });
+
+    // Everything below travels identically on both copies of this event.
+    // The event id is what makes the dual-write dedupable downstream:
+    // one capture() produces one id, stamped on the lambda copy and the
+    // Segment copy alike, so consumers no longer have to infer the
+    // duplication from $lib or from which fields happen to be present
+    // (OSS-1019).
+    const eventMeta = {
+      ...samplingMeta,
+      telemetry_emitter: TELEMETRY_EMITTER_V1,
+      telemetry_event_id: uuidv4(),
     };
 
     const flattenedProperties = flattenObject(properties);
     const propertiesWithGlobal: Record<string, any> = {
       ...this.globalProperties,
-      ...samplingMeta,
+      ...eventMeta,
+      telemetry_transport: "segment",
       ...flattenedProperties,
     };
     const orderedPropertiesWithGlobal = Object.keys(propertiesWithGlobal)
@@ -135,7 +144,11 @@ export class TelemetryClient {
     await lambdaClient.send({
       event,
       properties: flattenedProperties,
-      globalProperties: { ...this.globalProperties, ...samplingMeta },
+      globalProperties: {
+        ...this.globalProperties,
+        ...eventMeta,
+        telemetry_transport: "lambda",
+      },
       packageName: this.packageName,
       packageVersion: this.packageVersion,
       licenseToken: this.licenseToken ?? undefined,
@@ -198,8 +211,8 @@ export class TelemetryClient {
 
     this.sampleRate = _sampleRate;
     // Per-event sampling metadata (sampleRate/sampleRateAdjustmentFactor/
-    // sampleWeight) is computed in capture() so identified events get
-    // their own effectiveSampleRate=1 weight instead of the anonymous
-    // population's 1/sampleRate.
+    // sampleWeight) is computed per capture() in ./sampling, so identified
+    // events get their own effectiveSampleRate=1 weight instead of the
+    // anonymous population's 1/sampleRate.
   }
 }


### PR DESCRIPTION
Closes OSS-1017, OSS-1018, OSS-1019.

Runtime volume can't currently be counted from the telemetry data alone. Three separate reasons, all in the two `TelemetryClient`s, all fixed here.

## What was wrong

**OSS-1017 — v2 samples but doesn't say so.** `packages/runtime/src/v2/runtime/telemetry/telemetry-client.ts` gates anonymous events at 5% and lets identified callers through at 100%, then sends without stamping `sampleRate` / `sampleWeight`. The v1 client has computed that block for a while; v2 never did. Measured in PostHog (project 26816, `oss.runtime.copilot_request_created`), the share of runtime volume arriving unweightable was 1.1% in May, 12.2% in June, 20.2% in July, 24.4% in August — roughly doubling each month. It has already produced wrong GTM numbers: raw counts understate real volume 10–18× *and* overstate growth (+211% vs a true +128% Jan→Jul), because the sampled/unsampled mix drifts as v2 adoption rises.

**OSS-1018 — identified v2 events aren't detectable downstream.** The telemetry id travels as the `X-CopilotKit-Telemetry-Id` header, not an event property, so whether an event was sampled at 5% or captured at 100% wasn't recoverable from the event. Consumers had to probe for whatever identity fields happened to be present, which only ~2.7% of v2 events carry.

**OSS-1019 — v1 writes every event twice.** `capture()` sends to both `lambdaClient.send()` and `segment.track()`, so one request becomes two PostHog rows with nothing marking them as copies. Both prior dedupe attempts produced wrong numbers: a "≥ 1.60 dual-emits" version cutoff is wrong (1.59.5 dual-emits too — it added ~13M phantom requests to June), and Segment-only drops the entire v2 runtime (19.5M in August).

## What changed

A new `packages/shared/src/telemetry/sampling.ts` holds `computeSamplingMeta`, and both clients call it. The v1 client's inline block is replaced by that call with identical output, so the pre-existing v1 tests act as the regression check that the extraction is behavior-preserving. v2 passes the result in `globalProperties`, the slot the sink already spreads into the event and the same one v1 uses — so both emitters are now identical on the wire.

`telemetry_identified` is carried explicitly rather than inferred from `sampleWeight === 1`. Under `COPILOTKIT_TELEMETRY_SAMPLE_RATE=1` anonymous events also weigh 1, and weight alone stops separating the populations.

For the dual-write, per the issue's option 3 plus a dedupe key — additive only, both transports keep flowing:

| property | value |
| -- | -- |
| `telemetry_emitter` | `v1-shared` \| `v2-runtime` |
| `telemetry_transport` | `segment` \| `lambda` |
| `telemetry_event_id` | one uuid per v1 `capture()`, identical on both copies |

v2 doesn't carry an event id — it has a single transport, so there's nothing to dedupe.

## The counting rule this enables

Drop v1's lambda copy, keep everything else, and sum the stamped weight:

```sql
sumIf(sampleWeight, NOT (telemetry_transport = 'lambda' AND telemetry_emitter = 'v1-shared'))
```

Note for whoever runs the next month-close: **this release breaks the existing runbook query.** It isolates v2 with `NOT JSONHas(properties,'sampleRate')`, which matches nothing once v2 starts stamping `sampleRate` — `v2_runtime` would silently read zero and total volume would lose ~24%. The runbook has been updated with an era-agnostic query that gives the same answer either side of the release; historical events don't get backfilled, so the old inference path stays as the fallback for pre-fix data.

## Testing

Run from the worktree with `@copilotkit/shared` built so the runtime resolves the real helper rather than a mock.

**`packages/shared` — 35 passed (35)**, including all 20 pre-existing v1 tests, unchanged. New `sampling.test.ts` (5) covers both branches, the `sampleRate=1` collision that motivates the explicit flag, and an empty-string telemetry id. New cases in `telemetry-client.test.ts` (4) cover both copies sharing one `telemetry_event_id`, a fresh id per capture, the emitter marker on both copies, and `telemetry_identified` tracking the gate branch.

```
 ✓ src/telemetry/sampling.test.ts (5 tests)
 ✓ src/telemetry/lambda-client.test.ts (6 tests)
 ✓ src/telemetry/telemetry-client.test.ts (24 tests)
 Test Files  3 passed (3)
      Tests  35 passed (35)
```

**`packages/runtime` v2 telemetry — 37 passed (37)**, covering the new client suite plus the four pre-existing license/telemetry integration files:

```
 ✓ src/v2/runtime/telemetry/__tests__/telemetry-client.test.ts (6 tests)
 ✓ src/v2/runtime/telemetry/__tests__/global-properties.test.ts (6 tests)
 ✓ src/v2/runtime/telemetry/__tests__/instance-created.test.ts (5 tests)
 ✓ src/v2/runtime/__tests__/telemetry.test.ts (15 tests)
 ✓ src/v2/runtime/__tests__/sse-license-telemetry.integration.test.ts (1 test)
 ✓ src/v2/runtime/__tests__/sse-license-env-fallback.integration.test.ts (1 test)
 ✓ src/v2/runtime/__tests__/license-telemetry-endpoints.integration.test.ts (3 tests)
      Tests  37 passed (37)
```

One pre-existing assertion changed: `global-properties.test.ts` asserted `globalProperties` equals `{}` when the caller sets none, which is wrong by design now that sampling metadata always rides there. Rewritten to pin the exact key set, which preserves the original intent (nothing of the caller's is added) and is strictly stronger.

**Mutation-checked** — each new test was verified to fail when its mechanism is broken, then the mutation reverted and green confirmed:

| mutation | result |
| -- | -- |
| `effectiveSampleRate` always `= sampleRate` (drop identified branch) | shared 2 failed, runtime 1 failed |
| `telemetry_identified` hardcoded `false` | shared 3 failed, runtime 1 failed |
| v1 event id hoisted per-client instead of per-capture | shared 1 failed |
| both v1 copies stamped `transport: "lambda"` | shared 1 failed |
| v2 drops the sampling block from `globalProperties` | runtime 4 failed |
| *(reverted)* | shared 35/35, runtime 17/17 |

**Build/lint** — `tsdown` clean for both `@copilotkit/shared` (115 files) and `@copilotkit/runtime` (414 files); `oxfmt` applied; `oxlint` reports 0 errors. The one warning on new code (`consistent-function-scoping` on a test-local `jwtWith`) is the same pattern the existing v1 test file already uses at `telemetry-client.test.ts:42`.

Not run locally: the pre-commit `test-and-check-packages` hook, which builds the whole monorepo and fails in this worktree on packages that were never installed there (`core`, `sdk-js`, `channels-ui`) — environmental, unrelated to these files. Leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)