### PR TITLE
feat(runtime): truncate oversized application-context values

### DIFF
--- a/.changeset/context-truncation.md
+++ b/.changeset/context-truncation.md
@@ -1,0 +1,5 @@
+---
+"@copilotkit/runtime": patch
+---
+
+Truncate oversized application-context values (to 20k chars) when assembling the system prompt, preventing context bloat when large data is shared with the agent.

--- a/.changeset/context-truncation.md
+++ b/.changeset/context-truncation.md
@@ -1,5 +1,0 @@
----
-"@copilotkit/runtime": patch
----
-
-Truncate oversized application-context values (to 20k chars) when assembling the system prompt, preventing context bloat when large data is shared with the agent.

--- a/packages/runtime/src/agent/__tests__/context-truncation.test.ts
+++ b/packages/runtime/src/agent/__tests__/context-truncation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { BasicAgent } from "../index";
+import {
+  MAX_CONTEXT_VALUE_LENGTH,
+  truncateContextValue,
+} from "../context-truncation";
 import { streamText } from "ai";
 import { mockStreamTextResponse, finish, collectEvents } from "./test-helpers";
 import type { RunAgentInput } from "@ag-ui/client";
@@ -77,5 +81,34 @@ describe("BuiltInAgent Application Context Truncation", () => {
     const content = callArgs.messages[0].content as string;
     expect(content).toContain("hello");
     expect(content).not.toContain("truncated");
+  });
+});
+
+describe("truncateContextValue", () => {
+  it("keeps the return value (including marker) within MAX_CONTEXT_VALUE_LENGTH", () => {
+    const result = truncateContextValue("x".repeat(50_000));
+    expect(result.length).toBe(MAX_CONTEXT_VALUE_LENGTH);
+    expect(result).toContain("… [truncated by CopilotKit]");
+  });
+
+  it("leaves a value at exactly the limit untouched (no marker)", () => {
+    const value = "x".repeat(MAX_CONTEXT_VALUE_LENGTH);
+    expect(truncateContextValue(value)).toBe(value);
+  });
+
+  it("truncates a value just over the limit to exactly the limit", () => {
+    const value = "x".repeat(MAX_CONTEXT_VALUE_LENGTH + 1);
+    const result = truncateContextValue(value);
+    expect(result.length).toBe(MAX_CONTEXT_VALUE_LENGTH);
+    expect(result).toContain("… [truncated by CopilotKit]");
+  });
+
+  it("does not end on a lone high surrogate when the slice lands mid-pair", () => {
+    // 0xd83d is a high surrogate; "a" + emoji repeated lands a lone high
+    // surrogate at the cut point. The result must not end with an unpaired one.
+    const value = "a" + "😀".repeat(20_000);
+    const result = truncateContextValue(value);
+    const last = result.charCodeAt(result.length - 1);
+    expect(last < 0xd800 || last > 0xdbff).toBe(true);
   });
 });

--- a/packages/runtime/src/agent/__tests__/context-truncation.test.ts
+++ b/packages/runtime/src/agent/__tests__/context-truncation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { BasicAgent } from "../index";
+import { streamText } from "ai";
+import { mockStreamTextResponse, finish, collectEvents } from "./test-helpers";
+import type { RunAgentInput } from "@ag-ui/client";
+
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((config) => config),
+  stepCountIs: vi.fn((count: number) => ({ type: "stepCount", count })),
+}));
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: vi.fn(() => (modelId: string) => ({
+    modelId,
+    provider: "openai",
+  })),
+}));
+
+describe("BuiltInAgent Application Context Truncation", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.OPENAI_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("truncates oversized context values in the assembled system prompt", async () => {
+    const agent = new BasicAgent({ model: "openai/gpt-4o" });
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([finish()]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread1",
+      runId: "run1",
+      messages: [],
+      tools: [],
+      context: [{ description: "big", value: "x".repeat(50_000) }],
+      state: {},
+    };
+
+    await collectEvents(agent["run"](input));
+
+    const callArgs = vi.mocked(streamText).mock.calls[0][0];
+    const content = callArgs.messages[0].content as string;
+
+    expect(content).toContain("## Context from the application");
+    expect(content).toContain("… [truncated by CopilotKit]");
+    expect(content.length).toBeGreaterThan(20_000);
+    expect(content.length).toBeLessThan(50_000);
+  });
+
+  it("leaves within-limit context values unchanged", async () => {
+    const agent = new BasicAgent({ model: "openai/gpt-4o" });
+    vi.mocked(streamText).mockReturnValue(
+      mockStreamTextResponse([finish()]) as any,
+    );
+
+    const input: RunAgentInput = {
+      threadId: "thread2",
+      runId: "run2",
+      messages: [],
+      tools: [],
+      context: [{ description: "small", value: "hello" }],
+      state: {},
+    };
+
+    await collectEvents(agent["run"](input));
+
+    const callArgs = vi.mocked(streamText).mock.calls[0][0];
+    const content = callArgs.messages[0].content as string;
+    expect(content).toContain("hello");
+    expect(content).not.toContain("truncated");
+  });
+});

--- a/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
@@ -234,6 +234,19 @@ describe("convertInputToTanStackAI", () => {
 
       expect(systemPrompts).toHaveLength(0);
     });
+
+    it("truncates oversized context values", () => {
+      const input = createDefaultInput({
+        context: [{ description: "Big document", value: "x".repeat(50_000) }],
+      });
+
+      const { systemPrompts } = convertInputToTanStackAI(input);
+
+      const prompt = systemPrompts.find((p) => p.startsWith("Big document:"));
+      expect(prompt).toBeDefined();
+      expect(prompt).toContain("… [truncated by CopilotKit]");
+      expect(prompt!.length).toBeLessThan(50_000);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/packages/runtime/src/agent/context-truncation.ts
+++ b/packages/runtime/src/agent/context-truncation.ts
@@ -1,0 +1,33 @@
+/**
+ * Maximum length (in characters) of a single application-context value before it
+ * is truncated in the assembled system prompt.
+ *
+ * Application context (`useAgentContext`) is injected verbatim into the prompt.
+ * Oversized values (a full document, a large JSON blob) can blow the context
+ * window and inflate cost, so we clamp each value to this limit.
+ */
+export const MAX_CONTEXT_VALUE_LENGTH = 20_000;
+
+const TRUNCATION_MARKER = "\n… [truncated by CopilotKit]";
+
+/**
+ * The returned value (including the truncation marker) stays within
+ * `MAX_CONTEXT_VALUE_LENGTH`, so the output limit is a hard contract rather
+ * than a payload-only one. A trailing UTF-16 surrogate is also trimmed so the
+ * value never ends on a lone high surrogate (which stricter providers reject).
+ */
+export function truncateContextValue(value: string): string {
+  if (value.length <= MAX_CONTEXT_VALUE_LENGTH) return value;
+  let head = value.slice(0, MAX_CONTEXT_VALUE_LENGTH - TRUNCATION_MARKER.length);
+
+  // `slice` can land between a surrogate pair, leaving a lone high surrogate at
+  // the end. Drop it so the value doesn't end on an unpaired codepoint.
+  if (head.length > 0) {
+    const last = head.charCodeAt(head.length - 1);
+    if (last >= 0xd800 && last <= 0xdbff) {
+      head = head.slice(0, -1);
+    }
+  }
+
+  return `${head}${TRUNCATION_MARKER}`;
+}

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -18,6 +18,7 @@ import type {
 } from "@ag-ui/client";
 import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
+import { truncateContextValue } from "../context-truncation";
 import { createStateEventNormalizer } from "../state-delta";
 import {
   aggregateRunUsage,
@@ -298,7 +299,9 @@ export function convertInputToTanStackAI(
 
   if (input.context?.length) {
     for (const ctx of input.context) {
-      systemPrompts.push(`${ctx.description}:\n${ctx.value}`);
+      systemPrompts.push(
+        `${ctx.description}:\n${truncateContextValue(ctx.value)}`,
+      );
     }
   }
 

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -955,6 +955,20 @@ function isFactoryConfig(
   return "factory" in config;
 }
 
+/**
+ * Maximum length (in characters) of a single application-context value before it
+ * is truncated in the assembled system prompt.
+ *
+ * Application context (`useAgentContext`) is injected verbatim into the prompt.
+ * Oversized values (a full document, a large JSON blob) can blow the context
+ * window and inflate cost, so we clamp each value to this limit.
+ */
+const MAX_CONTEXT_VALUE_LENGTH = 20_000;
+
+function truncateContextValue(value: string): string {
+  if (value.length <= MAX_CONTEXT_VALUE_LENGTH) return value;
+  return `${value.slice(0, MAX_CONTEXT_VALUE_LENGTH)}\n… [truncated by CopilotKit]`;
+}
 export class BuiltInAgent extends AbstractAgent {
   private abortController?: AbortController;
 
@@ -1061,7 +1075,9 @@ export class BuiltInAgent extends AbstractAgent {
         if (hasContext) {
           parts.push("\n## Context from the application\n");
           for (const ctx of input.context) {
-            parts.push(`${ctx.description}:\n${ctx.value}\n`);
+            parts.push(
+              `${ctx.description}:\n${truncateContextValue(ctx.value)}\n`,
+            );
           }
         }
 

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -53,6 +53,7 @@ import {
   convertAISDKStream,
   getAISDKRunFinishedDetails,
 } from "./converters/aisdk";
+import { truncateContextValue } from "./context-truncation";
 import { convertTanStackStream } from "./converters/tanstack";
 import {
   collectStandardRunFinishedDetails,
@@ -955,20 +956,6 @@ function isFactoryConfig(
   return "factory" in config;
 }
 
-/**
- * Maximum length (in characters) of a single application-context value before it
- * is truncated in the assembled system prompt.
- *
- * Application context (`useAgentContext`) is injected verbatim into the prompt.
- * Oversized values (a full document, a large JSON blob) can blow the context
- * window and inflate cost, so we clamp each value to this limit.
- */
-const MAX_CONTEXT_VALUE_LENGTH = 20_000;
-
-function truncateContextValue(value: string): string {
-  if (value.length <= MAX_CONTEXT_VALUE_LENGTH) return value;
-  return `${value.slice(0, MAX_CONTEXT_VALUE_LENGTH)}\n… [truncated by CopilotKit]`;
-}
 export class BuiltInAgent extends AbstractAgent {
   private abortController?: AbortController;
 


### PR DESCRIPTION
### What does this PR do?

When an app shares context with an agent via `useAgentContext`, each context
value is currently injected verbatim into the assembled system prompt. Large
values (a full document, a big JSON blob) can blow the context window and
inflate token cost.

This change clamps each context value to `MAX_CONTEXT_VALUE_LENGTH` (20,000
chars) before it is added to the system prompt, appending a marker
(`… [truncated by CopilotKit]`) so the model knows the content was cut off
rather than simply absent. Within-limit values are left unchanged.

### Changes

- `packages/runtime/src/agent/index.ts` — added `MAX_CONTEXT_VALUE_LENGTH` +
  `truncateContextValue()`, applied when building the system prompt.
- `packages/runtime/src/agent/__tests__/context-truncation.test.ts` — new tests
  for truncation and pass-through.
- `.changeset/context-truncation.md` — patch entry.

### Verification

- `nx run @copilotkit/runtime:test` — 145 test files / 2086 tests passed.
- oxfmt + oxlint — 0 errors (pre-existing `no-shadow` warnings only).

### Checklist

- [x] Change is non-breaking and limited in scope
- [x] Tests added/updated for the new behavior
- [x] "Allow edits by maintainers" is checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited oversized application context values to 20,000 characters before inclusion in agent system prompts.
  * Added a clear truncation marker when context values exceed the limit.
  * Applied consistent context truncation across classic agent runs and TanStack prompt generation.
  * Preserved context values that remain within the allowed size.
  * Ensured truncation does not split surrogate pairs or create malformed characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->