### PR TITLE
fix(web-inspector): play the launcher HUD intro once per tab

### DIFF
--- a/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
@@ -16,6 +16,7 @@ import type {
 import { afterEach, expect, test, vi } from "vitest";
 
 import { WebInspectorElement } from "../index.js";
+import { markLauncherHudIntroPlayed } from "../lib/persistence.js";
 
 const RUNTIME_URL = "https://runtime.launcher-hud.test";
 const ANNOUNCEMENT_URL = "https://cdn.copilotkit.ai/announcements.json";
@@ -31,6 +32,12 @@ type Options = Readonly<{
   endpoints?: ThreadEndpointRuntimeInfo;
   intelligence?: boolean;
   licenseStatus?: RuntimeLicenseStatus;
+  /**
+   * Start from a tab that has already played the page-load preview, i.e. a
+   * reload rather than a first visit. Set through the exported persistence
+   * helper so the spec never has to name the storage key.
+   */
+  introAlreadyPlayed?: boolean;
 }>;
 
 class HudTestCore extends CopilotKitCore {
@@ -137,6 +144,31 @@ async function settle(inspector: WebInspectorElement): Promise<void> {
   }
 }
 
+/**
+ * Mounts one inspector element into the current document, leaving storage
+ * alone. Calling it a second time models a fresh page load in the SAME browser
+ * tab, which is what the once-per-tab preview rule is about.
+ */
+async function mount(options: Options = {}): Promise<WebInspectorElement> {
+  const inspector = new WebInspectorElement();
+  const core = new HudTestCore(options);
+  document.body.append(inspector);
+  inspector.core = core;
+  await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Connected);
+  await settle(inspector);
+  return inspector;
+}
+
+async function hoverLauncher(inspector: WebInspectorElement): Promise<void> {
+  const wrapper = requireElement(
+    root(inspector).querySelector<HTMLElement>(".console-button-wrapper"),
+  );
+  wrapper.dispatchEvent(
+    new PointerEvent("pointerenter", { bubbles: true, composed: true }),
+  );
+  await settle(inspector);
+}
+
 async function setup(options: Options = {}): Promise<{
   inspector: WebInspectorElement;
   openHud: () => Promise<void>;
@@ -146,6 +178,9 @@ async function setup(options: Options = {}): Promise<{
   document.body.replaceChildren();
   window.localStorage.clear();
   window.sessionStorage.clear();
+  if (options.introAlreadyPlayed === true) {
+    markLauncherHudIntroPlayed();
+  }
   vi.stubGlobal(
     "fetch",
     Object.assign(
@@ -163,12 +198,7 @@ async function setup(options: Options = {}): Promise<{
     ),
   );
 
-  const inspector = new WebInspectorElement();
-  const core = new HudTestCore(options);
-  document.body.append(inspector);
-  inspector.core = core;
-  await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Connected);
-  await settle(inspector);
+  const inspector = await mount(options);
 
   const teardown = (): void => {
     inspector.remove();
@@ -180,15 +210,7 @@ async function setup(options: Options = {}): Promise<{
   };
   cleanup = teardown;
 
-  const openHud = async (): Promise<void> => {
-    const wrapper = requireElement(
-      root(inspector).querySelector<HTMLElement>(".console-button-wrapper"),
-    );
-    wrapper.dispatchEvent(
-      new PointerEvent("pointerenter", { bubbles: true, composed: true }),
-    );
-    await settle(inspector);
-  };
+  const openHud = (): Promise<void> => hoverLauncher(inspector);
 
   const clickHud = async (row: string): Promise<void> => {
     const control = requireElement(
@@ -260,6 +282,117 @@ test("hovering during the page-load preview keeps the HUD open", async () => {
 
   expect(hudOpen(inspector)).toBe(true);
   expect(hud(inspector)?.hasAttribute("data-cpk-hud-intro")).toBe(false);
+});
+
+test("the preview stays away in a tab that has already seen it", async () => {
+  vi.useFakeTimers();
+  const { inspector } = await setup({ introAlreadyPlayed: true });
+
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(inspector);
+  expect(hud(inspector)).toBeNull();
+
+  // Dropped, not deferred: it must not surface later in the page's life.
+  await vi.advanceTimersByTimeAsync(3400);
+  await settle(inspector);
+  expect(hud(inspector)).toBeNull();
+});
+
+test("hover still opens the HUD in a tab that has already seen the preview", async () => {
+  const { inspector, openHud } = await setup({ introAlreadyPlayed: true });
+
+  await openHud();
+
+  expect(hudOpen(inspector)).toBe(true);
+  expect(hud(inspector)?.hasAttribute("data-cpk-hud-intro")).toBe(false);
+  expect(hudRowLabels(inspector)).toEqual([
+    "Open Inspector",
+    "Turn on Threads",
+    "Turn on Intelligence",
+    "Turn on Learning",
+  ]);
+});
+
+test("a fresh element in the same tab does not replay the preview", async () => {
+  vi.useFakeTimers();
+  const { inspector } = await setup();
+
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(inspector);
+  expect(hud(inspector)?.getAttribute("data-cpk-hud-intro")).toBe("true");
+  await vi.advanceTimersByTimeAsync(3400);
+  await settle(inspector);
+
+  // A reload, a client-side route change and a StrictMode double-mount all
+  // look like this: same tab, new element.
+  inspector.remove();
+  const reloaded = await mount();
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(reloaded);
+
+  expect(hud(reloaded)).toBeNull();
+  await hoverLauncher(reloaded);
+  expect(hudOpen(reloaded)).toBe(true);
+});
+
+test("a preview that never started leaves the tab its turn", async () => {
+  vi.useFakeTimers();
+  const { inspector } = await setup();
+
+  // Gone before the settle delay elapses, so nobody ever saw the card. The
+  // budget is spent when the preview starts, not when it is scheduled.
+  await vi.advanceTimersByTimeAsync(200);
+  inspector.remove();
+
+  const reloaded = await mount();
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(reloaded);
+
+  expect(hud(reloaded)?.getAttribute("data-cpk-hud-intro")).toBe("true");
+});
+
+test("hovering before the preview starts leaves the tab its turn", async () => {
+  vi.useFakeTimers();
+  const { inspector } = await setup();
+
+  // Hover inside the settle delay cancels the pending preview and opens the
+  // HUD as an ordinary hover. The reader was shown the HUD but never the
+  // introduction, so the tab has not spent its one preview.
+  await vi.advanceTimersByTimeAsync(200);
+  await hoverLauncher(inspector);
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(inspector);
+  expect(hud(inspector)?.hasAttribute("data-cpk-hud-intro")).toBe(false);
+
+  inspector.remove();
+  const reloaded = await mount();
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(reloaded);
+
+  expect(hud(reloaded)?.getAttribute("data-cpk-hud-intro")).toBe("true");
+});
+
+test("a sessionStorage that throws still previews, and the throw never escapes", async () => {
+  vi.useFakeTimers();
+  const { inspector } = await setup();
+  // Private mode, a sandboxed iframe or an exhausted quota. Stubbed after
+  // setup so its own storage reset still runs against the real store.
+  vi.stubGlobal("sessionStorage", {
+    getItem: () => {
+      throw new DOMException("SecurityError");
+    },
+    setItem: () => {
+      throw new DOMException("QuotaExceededError");
+    },
+  });
+
+  await vi.advanceTimersByTimeAsync(500);
+  await settle(inspector);
+  expect(hud(inspector)?.getAttribute("data-cpk-hud-intro")).toBe("true");
+
+  await vi.advanceTimersByTimeAsync(3400);
+  await settle(inspector);
+  expect(hud(inspector)).toBeNull();
 });
 
 test("hovering the launcher shows Open Inspector, Threads, Intelligence, and Learning", async () => {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -55,9 +55,11 @@ import {
 } from "./lib/context-helpers.js";
 import {
   clearLegacyAnnouncementReadState,
+  hasLauncherHudIntroPlayed,
   loadAnnouncementPulsedTimestamp,
   loadAnnouncementReadTimestamp,
   loadInspectorState,
+  markLauncherHudIntroPlayed,
   saveAnnouncementPulsedTimestamp,
   saveAnnouncementReadTimestamp,
   saveInspectorState,
@@ -582,8 +584,15 @@ const LAUNCHER_HUD_WIDTH = 248;
  * One page-load preview of the launcher's feature HUD.
  *
  * The card arrives after the host page has had a beat to settle. Its four rows
- * then come online in order, stay readable, and leave together. Nothing is
- * persisted: a new Inspector element means a new preview.
+ * then come online in order, stay readable, and leave together.
+ *
+ * It plays once per browser tab, not once per element: a reload shows nothing,
+ * a new tab introduces itself again. `hasLauncherHudIntroPlayed` carries that
+ * rule, and explains why sessionStorage is the store with the right lifetime.
+ *
+ * "Seen once", not "scheduled once": a mount that never showed the card —
+ * panel already open, element removed inside the delay, reader hovering first
+ * — leaves the next load its turn, and an error pill only delays a preview.
  */
 const LAUNCHER_HUD_INTRO_MS = {
   delay: 500,
@@ -10900,12 +10909,18 @@ export class WebInspectorElement extends LitElement {
     this.launcherHudIntroStartTimer = setTimeout(() => {
       this.launcherHudIntroStartTimer = null;
       if (!this.isConnected || this.isOpen) return;
+      // Inside the timeout so the blocked-retry path below re-checks it, and
+      // ahead of that retry so a tab that has played stops rescheduling.
+      if (hasLauncherHudIntroPlayed()) return;
       if (this.isLauncherHudBlocked()) {
         this.scheduleLauncherHudIntro(LAUNCHER_HUD_INTRO_MS.blockedRetry);
         return;
       }
 
       this.resolveLauncherHudSide();
+      // Where the preview starts, not where it is scheduled — see
+      // `LAUNCHER_HUD_INTRO_MS`.
+      markLauncherHudIntroPlayed();
       this.launcherHudIntro = true;
       this.launcherHudOpen = true;
       this.requestUpdate();

--- a/packages/web-inspector/src/lib/__tests__/telemetry.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/telemetry.test.ts
@@ -29,10 +29,12 @@ import {
   _resetTelemetryPersistenceForTesting,
   clearLegacyAnnouncementReadState,
   getOrCreateTelemetryDistinctId,
+  hasLauncherHudIntroPlayed,
   hasTelemetryDisclosureBeenShown,
   isTelemetryOptedOut,
   loadAnnouncementPulsedTimestamp,
   loadAnnouncementReadTimestamp,
+  markLauncherHudIntroPlayed,
   markTelemetryDisclosureShown,
   saveAnnouncementPulsedTimestamp,
   saveAnnouncementReadTimestamp,
@@ -689,6 +691,68 @@ describe("announcement pulse suppression", () => {
     expect(() => saveAnnouncementPulsedTimestamp("ts")).not.toThrow();
     // Losing the suppression costs one extra pulse, never correctness.
     expect(loadAnnouncementPulsedTimestamp()).toBeNull();
+  });
+});
+
+// ─── Launcher HUD intro suppression (per browser tab) ───────────────────────
+
+describe("launcher HUD intro suppression", () => {
+  const SESSION_KEY = "cpk:inspector:hud-intro-played";
+
+  beforeEach(() => {
+    // The outer hook only clears localStorage; this state is session-scoped.
+    window.sessionStorage.clear();
+  });
+
+  it("reports nothing played in a fresh tab", () => {
+    expect(hasLauncherHudIntroPlayed()).toBe(false);
+  });
+
+  it("remembers the preview for the rest of the tab", () => {
+    markLauncherHudIntroPlayed();
+
+    expect(hasLauncherHudIntroPlayed()).toBe(true);
+    // sessionStorage, not localStorage: the preview must not replay on a
+    // reload (which rules out an in-memory flag) but must still greet a new
+    // tab (which rules out localStorage).
+    expect(window.sessionStorage.getItem(SESSION_KEY)).toBe("true");
+    expect(window.localStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it("is idempotent, so a second mark is not an error", () => {
+    markLauncherHudIntroPlayed();
+    markLauncherHudIntroPlayed();
+
+    expect(hasLauncherHudIntroPlayed()).toBe(true);
+  });
+
+  it("is not shared with the announcement pulse suppression", () => {
+    markLauncherHudIntroPlayed();
+
+    expect(loadAnnouncementPulsedTimestamp()).toBeNull();
+  });
+
+  it("degrades to replaying when sessionStorage throws", () => {
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => {
+        throw new DOMException("SecurityError");
+      },
+      setItem: () => {
+        throw new DOMException("QuotaExceededError");
+      },
+    });
+
+    expect(() => markLauncherHudIntroPlayed()).not.toThrow();
+    // A lost mark costs one extra preview — the behaviour before this rule
+    // existed — never a broken host app.
+    expect(hasLauncherHudIntroPlayed()).toBe(false);
+  });
+
+  it("does not throw in SSR (window undefined)", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(() => markLauncherHudIntroPlayed()).not.toThrow();
+    expect(hasLauncherHudIntroPlayed()).toBe(false);
   });
 });
 

--- a/packages/web-inspector/src/lib/persistence.ts
+++ b/packages/web-inspector/src/lib/persistence.ts
@@ -236,6 +236,43 @@ export function saveAnnouncementPulsedTimestamp(timestamp: string): void {
   }
 }
 
+// Launcher HUD intro — the launcher plays a one-shot preview of its own hover
+// HUD on page load. It is an introduction, so it must not replay on every
+// reload; but it must still greet a genuinely new tab, and a remount of the
+// element within one page load (StrictMode, a client-side route change, the
+// host toggling the component) is not a new visit either.
+//
+// sessionStorage is the only store with exactly that lifetime: it is scoped to
+// the tab AND survives a reload. An in-memory flag dies with the page, and
+// localStorage would silence the preview forever on the first load.
+const LAUNCHER_HUD_INTRO_SESSION_KEY = "cpk:inspector:hud-intro-played";
+
+/** Whether this browser tab has already played the launcher HUD preview. */
+export function hasLauncherHudIntroPlayed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      window.sessionStorage.getItem(LAUNCHER_HUD_INTRO_SESSION_KEY) === "true"
+    );
+  } catch {
+    // Read as "not played yet": storage we cannot reach costs one extra
+    // preview per load — the behaviour before this rule existed — which is
+    // strictly better than letting a private-mode or sandboxed-iframe host
+    // see a thrown error.
+    return false;
+  }
+}
+
+/** Suppresses the launcher HUD preview for the rest of this browser tab. */
+export function markLauncherHudIntroPlayed(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(LAUNCHER_HUD_INTRO_SESSION_KEY, "true");
+  } catch {
+    // No-op — see hasLauncherHudIntroPlayed.
+  }
+}
+
 function parseTimestampPayload(raw: string | null): string | null {
   if (!raw) return null;
   try {


### PR DESCRIPTION
## Summary

The launcher HUD preview added in #6715 replays on every mount, so every page reload introduces the Inspector again. It now plays once per browser tab.

## Why

An introduction is only an introduction the first time. A reload — the most common thing a developer does while working — is not a new visit, and neither is a remount inside one page load (StrictMode, a client-side route change, the host toggling the component). Repeating it turns a helpful reveal into a recurring interruption that also covers the corner it is pointing at.

## How

- `sessionStorage` carries the rule, because it is the only store with the required lifetime: scoped to the tab **and** surviving a reload. An in-memory flag dies with the page; `localStorage` would silence the preview forever after the first load.
- new key `cpk:inspector:hud-intro-played` with `hasLauncherHudIntroPlayed` / `markLauncherHudIntroPlayed` in `lib/persistence.ts`, next to the existing session-scoped `cpk:inspector:pulsed` precedent rather than as a new persistence convention
- the guard sits inside the intro's start timeout, so the blocked-retry path (error pill on screen) still re-checks it and a tab that has not played keeps retrying, while a tab that has played stops rescheduling instead of polling
- the tab is marked where the preview actually starts, not where it is scheduled: a mount that never showed the card — panel already open, element removed inside the settle delay, reader hovering first — leaves the next load its turn
- unreachable storage (private mode, sandboxed iframe) reads as "not played" and never throws, degrading to the previous behaviour

No change to timings, layout, copy, animation, or the hover path.

## Verification

- `pnpm --filter @copilotkit/web-inspector test` → 640 tests across 31 files, green; `check-types` clean; `oxfmt --check` clean; `oxlint` adds no findings
- 12 new tests cover suppression, the mark, a second element mounted in the same tab, the hover-first case, and throwing storage
- Checked in a browser against the v2 React demo: first load in a fresh tab plays the preview and sets the key; a reload shows nothing across 8s of observation with the element mounted; a genuinely new tab plays it again; and in a tab that has spent its preview, hover still opens the card, correctly unmarked

## Related PRs and Issues

- follows #6715, which added the on-load preview
- the HUD itself: #6684
