### PR TITLE
docs: correct four pages that contradict shipped code, and document copilotkit verify

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/angular.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular.mdx
@@ -5,7 +5,7 @@ icon: "lucide/Triangle"
 hideTOC: true
 ---
 
-import OpenInspectorStepAngular from "@/snippets/shared/inspector/open-inspector-step-angular.mdx";
+import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
 `@copilotkit/angular` provides Angular components, directives, and services for CopilotKit. This guide gets you to a working Angular app with a chat UI backed by [Copilot Runtime](/backend/copilot-runtime). When you select an agent backend in the sidebar, the backend step below changes with it; without a selection, the guide uses CopilotKit's `BuiltInAgent`.
 
@@ -107,6 +107,25 @@ headless APIs, and it supports zoneless applications.
           );
         });
         ```
+
+        <Callout type="info" title="Angular runs the runtime as its own process">
+          Angular has no route handler, so Copilot Runtime is a **separate
+          process** from your app — a second terminal here, and a third once you
+          add an agent backend. Nothing proxies it for you, which is why
+          `runtimeUrl` below is an absolute URL rather than a relative path.
+
+          `8200` is only this guide's default. The server above reads `PORT`, so
+          move it without editing any source:
+
+          ```bash
+          PORT=8250 npx tsx server.ts
+          ```
+
+          Set `runtimeUrl` to the matching port when you do. Worth doing
+          deliberately if you run more than one CopilotKit project on the same
+          machine — the default collides, and a runtime that binds a port
+          another project is already using is a confusing failure to diagnose.
+        </Callout>
       </Step>
     </WhenAngularBackend>
     <WhenAngularBackend selected>
@@ -229,7 +248,7 @@ headless APIs, and it supports zoneless applications.
       </Step>
     </WhenAngularBackend>
     <Step>
-        <OpenInspectorStepAngular components={props.components} />
+        <OpenInspectorStep components={props.components} />
     </Step>
 
 </Steps>

--- a/showcase/shell-docs/src/content/docs/frontends/angular/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/inspector.mdx
@@ -1,117 +1,51 @@
 ---
 title: Inspector
-description: Mount the CopilotKit Inspector in an Angular application and keep it out of production builds.
+description: The Inspector mounts itself in Angular applications. What changed, and what to remove if you mounted it by hand.
 icon: "lucide/SearchCheck"
 doc_type: how-to
 ---
 
-The Inspector is a debugging overlay for the live connection between your Angular
-application and your agents. It opens from a floating launcher and reports what
-the application and the runtime exchange as a run happens.
+`@copilotkit/angular` mounts the Inspector for you. It depends on
+`@copilotkit/web-inspector` directly, so there is nothing to install and no
+version to pin — the `CopilotKit` service creates `cpk-web-inspector`, supplies
+your application's core, and appends it to `document.body` after the first
+browser render.
 
-Its navigation has three groups — **Threads**, **Agents**, and **Learning** — and
-opens on Threads, whose contents depend on the runtime's license state. The
-agent-debugging views sit under Agents:
+**[Inspector](/inspector)** is the page to read for what the panes show and how
+`enableInspector` controls visibility. Angular sets it through
+`provideCopilotKit`:
 
-| View                 | What it shows                                                        |
-| -------------------- | -------------------------------------------------------------------- |
-| **AG-UI Events**     | The raw event stream between your application and the agent.          |
-| **Available Agents** | The agents the runtime advertises to your application.                |
-| **Agent State**      | The selected agent's state as it updates.                             |
-| **Frontend Tools**   | The tools you registered, with their parameter schemas.               |
-| **Context**          | The context you sent to the agent, including readables and documents. |
-
-## Mount the element
-
-The Inspector is `cpk-web-inspector`, a framework-agnostic web component in
-`@copilotkit/web-inspector`. `@copilotkit/angular` does not depend on that
-package and does not mount the element, so an Angular application creates it and
-supplies the core itself.
-
-Install the package as a dev dependency to keep it out of your production
-dependency graph:
-
-```bash
-npm install --save-dev @copilotkit/web-inspector
+```ts title="src/app/app.config.ts"
+provideCopilotKit({
+  runtimeUrl: "http://localhost:8200/api/copilotkit",
+  enableInspector: false, // hide it during development
+});
 ```
 
-Add a component that owns the element's lifecycle. It reuses an existing element
-or creates one after the first browser render, supplies the core, appends the
-element to `document.body`, and removes it when the component is destroyed:
+<Callout type="warn" title="Remove a hand-written mount before upgrading">
+  `@copilotkit/angular` did not mount the Inspector before **0.4.0**, and this
+  page previously described a `WebInspector` component that created the element
+  by hand. If your application still has that component, delete it — along with
+  its `<app-web-inspector />` usage and any direct `@copilotkit/web-inspector`
+  dependency in `package.json`.
 
-```ts title="src/app/web-inspector.ts"
-import { afterNextRender, Component, DestroyRef, inject } from "@angular/core";
-import { CopilotKit } from "@copilotkit/angular";
-import { WEB_INSPECTOR_TAG } from "@copilotkit/web-inspector";
-import type { WebInspectorElement } from "@copilotkit/web-inspector";
+  Leaving it in place is worse than redundant. The framework reuses an existing
+  `cpk-web-inspector` rather than creating a second one, but the hand-written
+  component's `DestroyRef.onDestroy` removes that element unconditionally — so
+  a route change that destroys the component tears out the Inspector the
+  framework is now driving, and it does not come back without a full reload.
+</Callout>
 
-@Component({
-  selector: "app-web-inspector",
-  template: "",
-})
-export class WebInspector {
-  readonly #copilotKit = inject(CopilotKit);
-  readonly #destroyRef = inject(DestroyRef);
+## Production and server rendering
 
-  constructor() {
-    afterNextRender(() => {
-      const existing =
-        document.querySelector<WebInspectorElement>(WEB_INSPECTOR_TAG);
-      const inspector =
-        existing ??
-        (document.createElement(WEB_INSPECTOR_TAG) as WebInspectorElement);
+Nothing to do for either.
 
-      // Supply the application's core instead of letting the element find one.
-      inspector.core = this.#copilotKit.core;
-      inspector.setAttribute("auto-attach-core", "false");
-
-      if (!existing) {
-        document.body.appendChild(inspector);
-      }
-
-      this.#destroyRef.onDestroy(() => {
-        if (inspector.isConnected) {
-          inspector.remove();
-        }
-      });
-    });
-  }
-}
-```
-
-Render the component once, from the root component, behind a development-only
-`@defer`:
-
-```ts title="src/app/app.ts"
-import { Component, isDevMode } from "@angular/core";
-import { WebInspector } from "./web-inspector";
-
-@Component({
-  selector: "app-root",
-  imports: [WebInspector],
-  template: `
-    <!-- your application -->
-
-    @defer (when isDev) {
-      <app-web-inspector />
-    }
-  `,
-})
-export class App {
-  protected readonly isDev = isDevMode();
-}
-```
-
-## Supply the application's core
-
-`inspector.core = copilotKit.core` is what makes the Inspector report your
-application rather than show an empty panel. Without an assigned core, the
-element searches development globals such as `window.__COPILOTKIT_CORE__` for
-one. Setting `auto-attach-core="false"` disables that search, so the element
-observes the core you assigned and nothing else.
-
-Assign `core` directly. It is a property, not an attribute, and
-`auto-attach-core` is the only attribute the element observes.
+The `@copilotkit/web-inspector` import is a dynamic `import()` inside the
+service, so the bundler splits it into its own chunk and a production build
+never requests it. Mounting runs in `afterNextRender` behind an
+`isPlatformBrowser` check, so the element is never created during a server
+render. Both matter, because the web component registers itself against
+`customElements`, which does not exist on the server.
 
 ## Position the launcher
 
@@ -132,30 +66,9 @@ cpk-web-inspector {
 }
 ```
 
-## Keep it out of production builds
-
-The element has no production guard of its own, so exclude it in the same place
-you mount it. `@defer (when isDev)` compiles the component and its
-`@copilotkit/web-inspector` import into a lazy chunk, and `isDevMode()` returns
-`false` in a production build, so that chunk is never requested. Removing the
-component and its `<app-web-inspector />` usage removes the Inspector entirely.
-
-## Server rendering
-
-`afterNextRender` runs only in the browser, so the element is never created
-during a server render. The deferred import also keeps the package out of the
-server bundle. Both matter: the web component registers itself against
-`customElements`, which does not exist on the server.
-
-## Clean up on destroy
-
-The element lives in `document.body`, outside the component's own view, so
-Angular does not remove it. `DestroyRef.onDestroy` removes it explicitly.
-Without that cleanup, a route change that destroys the component leaves an
-orphaned panel bound to a core the application no longer uses.
-
 ## Next steps
 
+- [Inspector](/inspector)
 - [Troubleshooting Angular apps](/angular/guides/troubleshooting)
 - [AG-UI Event Inspector](/troubleshooting/event-inspector)
 - [Angular API: CopilotKit](/reference/angular/services/CopilotKit)

--- a/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-native.mdx
@@ -666,10 +666,10 @@ On the web you prove an integration by opening a browser and watching the tool U
 npx copilotkit verify --round-trip
 ```
 
-This sends one request through the runtime and reads the answer back off the thread, so it separates an agent that is *configured* from an agent that *works* — with no browser and no device involved. Run it from the machine hosting the runtime, not from the device. Add `--runtime-url` if the runtime is not at `http://localhost:8200/api/copilotkit`, and `--agent <id>` if the runtime declares more than one.
+This sends one request through the runtime and reads the answer back off the thread, so it separates an agent that is *configured* from an agent that *works* — with no browser and no device involved. Run it from the machine hosting the runtime, not from the device. The CLI probes `http://localhost:3000/api/copilotkit` by default, so pass `--runtime-url http://localhost:8200/api/copilotkit` for the runtime this guide sets up, and `--agent <id>` if the runtime declares more than one.
 
 <Callout type="warn" title="What --round-trip does not prove">
-  It sends a **fixed** prompt and records the answer's length and any tool-call names — never the answer's text. It proves an answer came back; it can never tell you what the answer said. It also proves an agent answered under the declared id, not *which* deployment answered: a runtime pointed at another project's agent responds identically. So this is step one of three, not a green light.
+  It proves an answer came back — never what the answer said, and never *which* deployment answered. See [what `--round-trip` does not prove](/cli#verify-your-setup) for the full boundary. So this is step one of three, not a green light.
 </Callout>
 
 ### 2. The tool UI actually renders on the device

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -30,6 +30,18 @@ varies between integrations:
 
 Ask about a flight and the agent renders a fully structured card from a pre-defined schema:
 
+<Callout type="info" title="The flight card is an illustrative domain">
+  Everything below uses flight booking so the wiring has something concrete to
+  render — `display_flight`, `flight-fixed-catalog`, and the airport/airline
+  components are this page's example, not part of the API.
+
+  What transfers is the **shape**: a fixed catalog, a tool that returns data
+  against it, and `a2ui.render(...)` with `createSurface` + `updateComponents` +
+  `updateDataModel`. Keep your own application's domain and substitute your own
+  components and tool — a page teaching the pattern is not a brief to build a
+  flight booker.
+</Callout>
+
 ## How it works
 
 1. The schema is made available to the agent, either loaded from a

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/background-tasks.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/background-tasks.mdx
@@ -250,6 +250,7 @@ Two switches, both required:
    ```typescript title="app/api/copilotkit/route.ts"
    const localAgents = getLocalAgents({
      mastra,
+     resourceId: "user-1",
      observationalMemory: true, // [!code highlight]
    });
    ```

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/copilot-runtime.mdx
@@ -126,6 +126,7 @@ extra wiring.
   const runtime = new CopilotRuntime({
     agents: MastraAgent.getLocalAgents({
       mastra,
+      resourceId: "user-1",
       tracingOptions: {
         traceId: myTraceId,
         metadata: { feature: "support-chat", tenant: tenantId },

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-read.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-read.mdx
@@ -29,7 +29,7 @@ You can easily use the realtime agent state not only in the chat UI, but also in
 
   ```ts
   const runtime = new CopilotRuntime({
-    agents: MastraAgent.getLocalAgents({ mastra }),
+    agents: MastraAgent.getLocalAgents({ mastra, resourceId: "user-1" }),
   });
   ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-write.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/in-app-agent-write.mdx
@@ -29,7 +29,7 @@ You can easily write to your agent's state from your native application, allowin
 
   ```ts
   const runtime = new CopilotRuntime({
-    agents: MastraAgent.getLocalAgents({ mastra }),
+    agents: MastraAgent.getLocalAgents({ mastra, resourceId: "user-1" }),
   });
   ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/predictive-state-updates.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/shared-state/predictive-state-updates.mdx
@@ -42,7 +42,7 @@ Mastra injects a built-in `updateWorkingMemory` tool whenever working memory is 
 
   ```ts
   const runtime = new CopilotRuntime({
-    agents: MastraAgent.getLocalAgents({ mastra }),
+    agents: MastraAgent.getLocalAgents({ mastra, resourceId: "user-1" }),
   });
   ```
 </Callout>

--- a/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/cli/cli.mdx
@@ -147,6 +147,61 @@ Project selection updates the app configuration; the importer still receives its
 
 For the full adoption flow, see [Import & Synchronize Thread History](/threads-import). Source-specific setup lives in [Synchronize ADK threads](/google-adk/threads-import) and [Synchronize LangGraph threads](/langgraph-python/threads-import).
 
+## Verify your setup
+
+`verify` answers the question every integration reaches: *is this actually
+working?* It checks the wiring from outside the browser, so it is the proof to
+reach for on a surface that has no browser at all — React Native, or a runtime
+on a remote host.
+
+```bash
+npx copilotkit@latest verify
+```
+
+It checks that a hosted project is selected, that a project API key
+authenticates, that the runtime responds, and that the runtime declares at least
+one agent — then reports the runtime version, the agent framework, gateway
+wiring, and license state.
+
+<Callout type="warn" title="Read the individual checks, not the summary">
+  Every check reports **PASS**, **FAIL**, or **UNKNOWN**. `UNKNOWN` means the
+  check could not run. It never means the check passed.
+</Callout>
+
+To prove the agent actually *runs* rather than that it is *configured*, add
+`--round-trip`. It sends one real request through the runtime and reads the
+answer back off the thread:
+
+```bash
+npx copilotkit@latest verify --round-trip
+```
+
+<Callout type="warn" title="What --round-trip does not prove">
+  It sends a **fixed** prompt and records the answer's character count and any
+  tool-call names — **never the answer's text**. It proves an answer came back;
+  it can never tell you what the answer said, so it is no substitute for
+  checking a response against the data your project actually holds.
+
+  It also proves an agent answered under the *declared id*, not **which
+  deployment** answered — a runtime pointed at another project's agent responds
+  identically.
+
+  Because it runs the agent, it costs a model call and records a thread. That is
+  why it is opt-in rather than the default.
+</Callout>
+
+| Option | What it does |
+|---|---|
+| `--runtime-url <url>` | The runtime endpoint to probe. Default `http://localhost:3000/api/copilotkit` — pass this whenever your runtime is elsewhere. |
+| `--round-trip` | Also run the agent and read its answer back. |
+| `--agent <id>` | Which declared agent to run, when the runtime declares several. |
+| `--expect-runtime <mode>` | `intelligence` (default) or `oss`. With `oss`, hosted-project and credential checks do not apply. |
+| `--timeout <seconds>` | How long to wait for the answer. Default `90`. |
+| `--header "<name>: <value>"` | Extra request header, repeatable. Use it when your `identifyUser` reads a session the CLI does not carry. |
+| `--json` | Emit a machine-readable payload alone on stdout. |
+
+`verify` exits non-zero unless every check passed, so it works as a CI gate.
+
 ## Auth commands
 
 | Command | What it does |

--- a/showcase/shell-docs/src/content/snippets/shared/inspector/open-inspector-step-angular.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/inspector/open-inspector-step-angular.mdx
@@ -1,9 +1,0 @@
-### Open Inspector and confirm setup
-
-Angular does not mount Inspector by default. First follow [Inspector for Angular](/angular/inspector). Then, on localhost, click the Inspector button.
-
-1. Open **Agents**, then **Agent**. Your agent is listed.
-2. Send a chat message. Open **Agents**, then **AG-UI Events**. Events are moving.
-3. Open **Threads**. The list is unlocked (Intelligence is on), or locked with Enable Intelligence (Intelligence is off).
-
-More detail: [Inspector](/inspector).

--- a/showcase/shell-docs/src/lib/__tests__/angular-quickstart.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/angular-quickstart.test.ts
@@ -28,11 +28,15 @@ describe("backend-scoped Angular quickstart", () => {
     expect(quickstartSource).toContain("CopilotKit Intelligence");
   });
 
-  it("imports the Angular Open Inspector step after the first chat", () => {
-    expect(quickstartSource).toContain("open-inspector-step-angular.mdx");
-    expect(quickstartSource).toContain("<OpenInspectorStepAngular");
-    expect(
-      quickstartSource.indexOf("<OpenInspectorStepAngular"),
-    ).toBeGreaterThan(quickstartSource.indexOf("send a"));
+  it("imports the shared Open Inspector step after the first chat", () => {
+    // Angular auto-mounts the Inspector from @copilotkit/angular >= 0.4.0, so it
+    // uses the same step as every other web frontend rather than an Angular
+    // variant that sends the reader off to install the element by hand.
+    expect(quickstartSource).toContain("open-inspector-step.mdx");
+    expect(quickstartSource).toContain("<OpenInspectorStep");
+    expect(quickstartSource).not.toContain("open-inspector-step-angular");
+    expect(quickstartSource.indexOf("<OpenInspectorStep")).toBeGreaterThan(
+      quickstartSource.indexOf("send a"),
+    );
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
@@ -42,16 +42,29 @@ test("shared Open Inspector step names the three sanity checks", () => {
   expect(step).toContain("[Inspector](/inspector)");
 });
 
-test("Angular Open Inspector step links the Angular install page first", () => {
-  const step = read(
-    "snippets/shared/inspector/open-inspector-step-angular.mdx",
-  );
+test("Angular uses the shared Open Inspector step, not a manual-mount variant", () => {
+  // @copilotkit/angular >= 0.4.0 depends on @copilotkit/web-inspector and mounts
+  // cpk-web-inspector itself, so Angular is no longer a special case here.
+  expect(
+    existsSync(join(SNIPPETS_DIR, "open-inspector-step-angular.mdx")),
+    "the Angular Open Inspector variant should stay deleted: Angular auto-mounts",
+  ).toBe(false);
+});
 
-  expect(step).toContain("[Inspector for Angular](/angular/inspector)");
-  expect(step).toContain("Open **Agents**, then **Agent**");
-  expect(step).toContain("AG-UI Events");
-  expect(step).toContain("Enable Intelligence");
-  expect(step).not.toContain("/frontends/angular");
+test("the Angular Inspector page does not teach a manual mount", () => {
+  const page = read("docs/frontends/angular/inspector.mdx");
+
+  // The claims that made this page a trap once Angular started auto-mounting.
+  expect(page).not.toContain("does not depend on that package");
+  expect(page).not.toContain(
+    "npm install --save-dev @copilotkit/web-inspector",
+  );
+  expect(page).not.toContain("auto-attach-core");
+  expect(page).not.toContain("document.createElement(WEB_INSPECTOR_TAG)");
+
+  // What it must say instead.
+  expect(page).toContain("mounts the Inspector for you");
+  expect(page).toContain("[Inspector](/inspector)");
 });
 
 test("every web integration quickstart imports the Open Inspector step", () => {
@@ -93,8 +106,9 @@ test("Vue and Angular getting-started pages include the Open Inspector step", ()
   expect(vue).toContain("open-inspector-step.mdx");
   expect(vue).toContain("<OpenInspectorStep");
   expect(vue).toContain('show-dev-console="auto"');
-  expect(angular).toContain("open-inspector-step-angular.mdx");
-  expect(angular).toContain("<OpenInspectorStepAngular");
+  expect(angular).toContain("open-inspector-step.mdx");
+  expect(angular).toContain("<OpenInspectorStep");
+  expect(angular).not.toContain("open-inspector-step-angular");
 });
 
 test("mapped feature pages import the matching Inspector Callout", () => {

--- a/skills/copilotkit-debug/references/agent-debugging.md
+++ b/skills/copilotkit-debug/references/agent-debugging.md
@@ -287,13 +287,27 @@ The CopilotKit Web Inspector (`@copilotkit/web-inspector`) provides real-time vi
 - Agent state snapshots
 - Tool call lifecycle
 
-Enable it during development:
+It mounts itself. React, Vue, and Angular all depend on
+`@copilotkit/web-inspector` and mount `cpk-web-inspector` from their provider,
+so there is nothing to import and nothing to render:
 
 ```tsx
-import { CopilotKitWebInspector } from "@copilotkit/web-inspector";
-
-<CopilotKit runtimeUrl="/api/copilotkit">
-  <CopilotKitWebInspector />
+<CopilotKitProvider runtimeUrl="/api/copilotkit">
   <YourApp />
-</CopilotKit>;
+</CopilotKitProvider>
 ```
+
+Visibility is decided by `shouldEnableInspector` in `@copilotkit/shared`:
+`isBrowser && isDevelopment && enableInspector !== false`. All three must hold,
+so `enableInspector` is an **opt-out** — setting it to `true` cannot add the
+Inspector to a production build.
+
+```tsx
+<CopilotKitProvider runtimeUrl="/api/copilotkit" enableInspector={false}>
+```
+
+Vue uses the kebab-case prop `:enable-inspector="false"`; Angular configures it
+through `provideCopilotKit({ enableInspector: false })`.
+
+There is no `CopilotKitWebInspector` React component — `@copilotkit/web-inspector`
+exports the custom-element tag (`WEB_INSPECTOR_TAG`), not a wrapper.


### PR DESCRIPTION
## What

Five defects from the onboarding sweeps that share one shape: **a page states something the library stopped doing, or never said something the library requires.** Grouped because they are the same failure class and the files do not overlap; each is independently revertable.

| Issue | Defect | Fix |
|---|---|---|
| OSS-936 | `getLocalAgents({ mastra })` does not compile | `resourceId` added at 6 doc sites |
| OSS-948 | Angular Inspector page teaches a mount that now destroys the framework's own element | page rewritten; lying snippet deleted |
| OSS-950 | Nothing says the Angular runtime is its own process, or how to move it off 8200 | `PORT` documented |
| OSS-953 | `copilotkit verify` documented nowhere | added to the shared CLI snippet |
| OSS-944 | the a2ui flight example is copied as an application | domain marked illustrative |

## Corrections to the issues as filed

Three tickets were wrong on a load-bearing detail. Recording these because each changed the fix:

- **OSS-936 — "the docs may be right and the type over-strict".** They are not. `resourceId` is Mastra's memory-scoping key, required identically on `GetLocalAgentsOptions`, `GetLocalAgentOptions` **and** `GetRemoteAgentsOptions`. `@ag-ui/mastra`'s own `registerCopilotKit` resolves it per request as `requestContext.get(MASTRA_RESOURCE_ID_KEY) ?? fallback`. Defaulting it silently would put every user in one memory scope. So the snippets were wrong, not the type.
- **OSS-948 — "Vue has no Inspector documentation at all".** It does. `docs/inspector.mdx` already documents the auto-mount for React, Vue and Angular, `enableInspector`, and the fact that an explicit `true` cannot override the production gate. The *only* wrong page was the Angular override, which shadowed that correct shared content. No Vue page was needed.
- **OSS-950 — "`agent-only` used `COPILOT_RUNTIME_PORT`, so a mechanism exists".** That variable appears **zero times in CopilotKit and zero times in Intelligence**. The real knob is `PORT`, which `angular.mdx` already passed to `server.ts` without ever telling the reader.

## Found while fixing, not filed separately

- **#6663 left a sixth broken fence** in a file it edited — the tracing example at `copilot-runtime.mdx:127` also omits `resourceId`.
- **`react-native.mdx` named the wrong default.** It implied `verify` defaults to `:8200`; the CLI defaults to `http://localhost:3000/api/copilotkit`.
- **A shipped skill taught a non-existent export.** `skills/copilotkit-debug/references/agent-debugging.md` showed `import { CopilotKitWebInspector } from "@copilotkit/web-inspector"`. That symbol is not exported — `index.ts` exports the tag, not a wrapper. This is exactly OSS-891's failure mode, so it is fixed here.
- **The Angular Inspector page had drifted three separate ways**, not one: the manual mount, the `does not depend on that package` claim, *and* a navigation table (`Threads / Agents / Learning`) contradicting the shared page's `Home / Workbench / Inspect`. That is why the page is now thin and points at `/inspector` instead of restating it.

## Deliberately not in this PR

- **The a2ui domain swap (OSS-944's other half).** The docs side is one file, but the example lives in **21 showcase cells / 264 files / 20 e2e specs**, 106 of which contain `flight`. It also wants the post-OSS-942 re-run to say whether it is still needed. Only the illustrative-domain callout is here.
- **The three Mastra example files** (`examples/canvas/mastra`, `examples/canvas/mastra-pm`, `examples/integrations/mastra`). `examples/integrations/mastra/src/agent.ts:13` carries `// @ts-expect-error` over exactly this call, so fixing it requires removing the suppression — but that example's typecheck is **already red on main** for unrelated `@mastra/core` `Memory` type errors, so the change cannot be verified. Left for a PR that fixes the example build.
- **OSS-935 / OSS-891.** 935 needs a canonical-route decision plus redirect infra; 891 is a CI gate, not docs.

## Testing

Worktree at `origin/main` `4b3b1cd88e`.

**1. The Mastra type claim — proved by compiling, both directions.** `@ag-ui/mastra@1.1.2`, `@mastra/core`, NodeNext + strict:

```
OLD  getLocalAgents({ mastra })                    -> exit 1
     old.ts(4,45): error TS2741: Property 'resourceId' is missing in type
     '{ mastra: Mastra<...> }' but required in type 'GetLocalAgentsOptions'.
NEW  getLocalAgents({ mastra, resourceId: "user-1" }) -> exit 0
```

**2. Every changed MDX compiles**, and the gate is mutation-checked:

```
OK  frontends/angular/inspector.mdx        OK  integrations/mastra/copilot-runtime.mdx
OK  frontends/angular.mdx                  OK  integrations/mastra/background-tasks.mdx
OK  frontends/react-native.mdx             OK  .../shared-state/in-app-agent-read.mdx
OK  snippets/shared/cli/cli.mdx            OK  .../shared-state/in-app-agent-write.mdx
OK  generative-ui/a2ui/fixed-schema.mdx    OK  .../shared-state/predictive-state-updates.mdx
all compiled

mutation: append an unclosed <Callout>
  -> FAIL  Expected a closing tag for `<Callout>` (76:1-76:37)   # the gate is live
```

**3. shell-docs suite — 456/458.**

```
Test Files  3 failed | 59 passed (62)
Tests       2 failed | 456 passed (458)
```

Both failures are **pre-existing on `origin/main`**, proved by reverting every file in this PR to `origin/main` in place and re-running:

```
baseline (origin/main content + origin/main tests):
  x inspector-docs > Inspector Callout snippets name the shipped pane   <- "Playground"
  x llm-text > canonical tool-rendering example for mastra
  Tests  2 failed | 66 passed (68)
```

`open-inspector-pane-threads.mdx` says "copy it into a Playground scratch session" while the test forbids `/\bPlayground\b/` across that directory. **`main` is red on this today** — worth a look independently of this PR. The three remaining failed *files* cannot start in this worktree (`@clerk/nextjs`, jsdom); they are environment, not content.

**4. The two new Angular guards are mutation-checked** — neither is self-fulfilling:

```
mutation A: re-add "does not depend on that package" to inspector.mdx
  -> x the Angular Inspector page does not teach a manual mount
mutation B: recreate open-inspector-step-angular.mdx
  -> x Angular uses the shared Open Inspector step, not a manual-mount variant
restored -> both pass
```

**5. One test caught a real repo rule I had broken.** `angular-docs-content > keeps published Angular docs standalone and canonical` forbids naming another frontend in Angular docs; my first draft said "behaves exactly like React and Vue". Reworded, now green (7/7).

**6. Doctest gating unchanged.** Extraction reports **22** fences on this branch — exactly the count #6663 established. No fence added or lost. (The Mastra fences edited here are not gated: they reference `@/mastra`, which cannot resolve in the extraction directory.)

**7. Pre-commit gates, run manually:**

```
check:intelligence-env-names   Intelligence env var names and hosts are canonical.   exit 0
check:plugin-skills            plugin skill mirror in sync
oxfmt --check                  All matched files use the correct format.
oxlint                         Found 0 warnings and 0 errors.
commitlint                     found 0 problems, 1 warnings
```

**8. Interaction with the one overlapping open PR.** #6712 (`refs OSS-977`) touches `react-native.mdx` and `inspector-docs.test.ts` too. `git merge-tree` reports no conflict, and I merged it locally and ran the tests — **both PRs' tests pass together** (21/22, the 22nd being the pre-existing Playground failure):

```
✓ Inspector states that it needs a browser and React Native has none      (#6712)
✓ the React Native page lists the missing Inspector among its limitations (#6712)
✓ the Angular Inspector page does not teach a manual mount                (this PR)
✓ Angular uses the shared Open Inspector step, not a manual-mount variant (this PR)
```

Merge order does not matter.

Refs OSS-936, OSS-948, OSS-950, OSS-953, OSS-944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
