### PR TITLE
docs(example): remove dead links to non-existent docs files in agentcore README

### DIFF
--- a/examples/integrations/agentcore/README.md
+++ b/examples/integrations/agentcore/README.md
@@ -52,8 +52,6 @@ cp .env.example .env
 
 The full chain runs locally: `browser:3000 → bridge:3001 → agent:8080`. AWS is only used for Memory and Gateway (SSM/OAuth2).
 
-See `docs/LOCAL_DEVELOPMENT.md` for full details.
-
 ## Agent dependencies
 
 Each single-agent directory under `agents/` — `langgraph-single-agent/` and
@@ -83,7 +81,6 @@ hashes both, so a dependency change retriggers the image build on the next apply
 | `infra-cdk/`                     | CDK: Cognito, AgentCore, CopilotKit Lambda bridge, Amplify |
 | `infra-terraform/`               | Terraform equivalent — see `infra-terraform/README.md`     |
 | `docker/`                        | Local dev via Docker Compose                               |
-| `docs/`                          | LOCAL_DEVELOPMENT.md, LOCAL_DOCKER_TESTING.md              |
 
 ## Architecture
 
@@ -110,5 +107,3 @@ cd infra-cdk && npx cdk@latest destroy --all --output ../cdk.out-st   # Strands 
 
 - [CopilotKit](https://docs.copilotkit.ai)
 - [AWS Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/)
-- [Local Development](docs/LOCAL_DEVELOPMENT.md)
-- [Local Docker Testing](docs/LOCAL_DOCKER_TESTING.md)

--- a/examples/integrations/agentcore/docker/docker-compose.yml
+++ b/examples/integrations/agentcore/docker/docker-compose.yml
@@ -4,7 +4,7 @@
 # Use ./up.sh instead of docker compose directly —
 # it resolves STACK_NAME + MEMORY_ID and generates a local aws-exports.json.
 #
-# Requires a deployed AWS stack. See ../docs/LOCAL_DEVELOPMENT.md.
+# Requires a deployed AWS stack — see the README's "Local Development" section.
 #
 # Frontend hot reloads on save (volume mount + Vite).
 # Agent changes require: docker compose up --build agent

--- a/scripts/validate-intelligence-env-names.ts
+++ b/scripts/validate-intelligence-env-names.ts
@@ -172,9 +172,9 @@ const MANAGED_URL_ENV_FILE_REASON =
 /**
  * Paths allowed to assign a managed URL in an env example.
  *
- * `agentcore/docker` is the local development stack documented in
- * `agentcore/docs/LOCAL_DEVELOPMENT.md`; its whole purpose is a local
- * deployment, so naming one is correct there.
+ * `agentcore/docker` is the local development stack (documented in the
+ * agentcore example README); its whole purpose is a local deployment,
+ * so naming one is correct there.
  */
 const MANAGED_URL_ENV_FILE_ALLOWLIST = [
   "examples/integrations/agentcore/docker/.env.example",


### PR DESCRIPTION
The `examples/integrations/agentcore` README references `docs/LOCAL_DEVELOPMENT.md` and `docs/LOCAL_DOCKER_TESTING.md`, but the example has no `docs/` directory and neither file exists anywhere in the example. The local-development workflow is already fully documented inline in the "Local Development" section, so these references are dead links.

Verified: `docs/` is absent from `examples/integrations/agentcore/`, and a repo-wide search finds no `LOCAL_DEVELOPMENT.md` / `LOCAL_DOCKER_TESTING.md`.