### PR TITLE
docs(shell-docs): fix broken Action Handlers link in a2ui fixed-schema page

### DIFF
--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -365,7 +365,7 @@ When available, a button declares its action like this:
 And the Python tool matches it with a handler keyed by the action
 name (plus a `"*"` catch-all). Until the SDK lands, handle the click on the
 frontend instead — see
-[Advanced — Action Handlers](./advanced#action-handlers) for the
+[Action Handlers](#action-handlers-reference) for the
 `createA2UIMessageRenderer` / `onAction` pattern.
 
 ## When should I use fixed schemas?

--- a/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/a2ui/fixed-schema.mdx
@@ -365,7 +365,7 @@ When available, a button declares its action like this:
 And the Python tool matches it with a handler keyed by the action
 name (plus a `"*"` catch-all). Until the SDK lands, handle the click on the
 frontend instead — see
-[Action Handlers](#action-handlers-reference) for the
+[Advanced — Action Handlers](/integrations/langgraph/generative-ui/a2ui/advanced#action-handlers) for the
 `createA2UIMessageRenderer` / `onAction` pattern.
 
 ## When should I use fixed schemas?


### PR DESCRIPTION
The "Advanced — Action Handlers" link pointed to `./advanced#action-handlers`, but there is no `advanced.mdx` page in `docs/generative-ui/a2ui/`. The "Action handlers (reference)" section lives in this same file, so the link now points to it directly with `#action-handlers-reference`.