### PR TITLE
fix(react-core): preserve caret when measuring single-line height in CopilotChatInput

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -665,6 +665,11 @@ export function CopilotChatInput({
 
     const previousValue = textarea.value;
     const previousHeight = textarea.style.height;
+    // Restoring `.value` below resets the caret to the end of the input.
+    // Capture the selection up front and re-apply it so the measurement
+    // pass never moves the user's cursor (see #6167).
+    const selectionStart = textarea.selectionStart;
+    const selectionEnd = textarea.selectionEnd;
 
     textarea.style.height = "auto";
 
@@ -677,6 +682,14 @@ export function CopilotChatInput({
     textarea.value = "";
     const singleLineHeight = textarea.scrollHeight;
     textarea.value = previousValue;
+
+    if (
+      selectionStart !== null &&
+      selectionEnd !== null &&
+      typeof textarea.setSelectionRange === "function"
+    ) {
+      textarea.setSelectionRange(selectionStart, selectionEnd);
+    }
 
     const contentHeight = singleLineHeight - paddingTop - paddingBottom;
     const maxHeight = contentHeight * 5 + paddingTop + paddingBottom;


### PR DESCRIPTION
In expanded mode, editing the input could jump the cursor to the end of the text.

`ensureMeasurements()` temporarily assigns `textarea.value = ""` and then restores it with `textarea.value = previousValue`. A direct `.value` assignment resets the browser caret to the end of the field, so any measurement pass that runs while the user has the caret mid-text moves it.

The fix captures `selectionStart`/`selectionEnd` before the measurement pass and restores them with `setSelectionRange` afterwards, so measurement never moves the user's cursor.

Fixes #6167