### PR TITLE
feat(runtime): expose Learning Container selector

### DIFF
--- a/packages/channels-core/src/channel-memory.test.ts
+++ b/packages/channels-core/src/channel-memory.test.ts
@@ -82,6 +82,7 @@ test("project-only Memory works when Channel identity is null", async () => {
 
   expect(lifecycle).toHaveBeenCalledWith(
     expect.objectContaining({
+      user: null,
       memory: {
         grant: { user: "none", project: "read-write" },
         user: null,
@@ -120,6 +121,7 @@ test("a custom identity callback may map a non-human actor to personal Memory", 
 
   expect(lifecycle).toHaveBeenCalledWith(
     expect.objectContaining({
+      user: { id: "service:sync-bot", name: "Sync Bot" },
       memory: {
         grant: { user: "read", project: "none" },
         user: { id: "service:sync-bot", name: "Sync Bot" },

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -1,6 +1,7 @@
 import type { AgentSubscriber, AbstractAgent } from "@ag-ui/client";
 import type {
   AgentContentPart,
+  ApplicationUser,
   ChannelNode,
   EmojiValue,
   EphemeralResult,
@@ -112,6 +113,8 @@ export interface ChannelAgentLifecycleArgs {
    * agent command and never crosses the managed run-open boundary.
    */
   isResume?: boolean;
+  /** Canonical application user resolved for the current Channel event. */
+  user?: ApplicationUser | null;
   /** Explicit Memory access resolved before agent execution. */
   memory?: ResolvedChannelMemory;
   execute(

--- a/packages/channels-core/src/thread.ts
+++ b/packages/channels-core/src/thread.ts
@@ -796,6 +796,7 @@ export class Thread implements ThreadInterface {
               tools: toolDescriptors,
               context,
               isResume: initialResume !== undefined,
+              user: this.deps.user,
               memory: extra?.memory,
               execute: (subscriber, canonicalRun) =>
                 runAgentLoop({

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -9,6 +9,7 @@ import type {
 } from "@ag-ui/client";
 import type {
   AgentContentPart,
+  ApplicationUser,
   ChannelNode,
   EmojiValue,
   MessageRef,
@@ -103,6 +104,8 @@ export interface CanonicalChannelRunArgs {
   threadId: string;
   runId: string;
   userId: string;
+  /** Canonical application user when the Channel identity strategy resolved one. */
+  user?: ApplicationUser | null;
   memory?: ResolvedChannelMemory;
   agentId: string;
   tools: readonly AgentToolDescriptor[];
@@ -485,6 +488,7 @@ export class DeliveryAdapter implements PlatformAdapter {
       threadId,
       runId,
       userId: target.delivery.appUserId,
+      user: args.user ?? null,
       memory: args.memory,
       agentId: this.options.channelName,
       tools: args.tools,

--- a/packages/channels-intelligence/src/delivery-channel-name.test.ts
+++ b/packages/channels-intelligence/src/delivery-channel-name.test.ts
@@ -85,6 +85,10 @@ test("managed deliveries use the declared Channel name for canonical runs", asyn
 
     expect(runCanonical).toHaveBeenCalledOnce();
     expect(runCanonical.mock.calls[0]![0].agentId).toBe("support");
+    expect(runCanonical.mock.calls[0]![0].user).toEqual({
+      id: "slack:tenant_channel_name:user_channel_name",
+      name: "Ada",
+    });
     expect(runCanonical.mock.calls[0]![0].memory).toEqual({
       grant: { user: "read", project: "read-write" },
       user: {

--- a/packages/runtime/src/v2/runtime/__tests__/learning-container-selector.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/learning-container-selector.test.ts
@@ -1,0 +1,319 @@
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { AbstractAgent } from "@ag-ui/client";
+import { createChannel } from "@copilotkit/channels";
+import type { Observable } from "rxjs";
+import { EMPTY } from "rxjs";
+import { expect, test, vi } from "vitest";
+
+import type { ChannelsIntelligenceModule } from "../core/channel-manager";
+import { defaultActivateChannel } from "../core/channel-manager";
+import { CopilotIntelligenceRuntime } from "../core/runtime";
+import { handleIntelligenceRun } from "../handlers/intelligence/run";
+import { CopilotKitIntelligence } from "../intelligence-platform/client";
+import { AgentRunner } from "../runner/agent-runner";
+import type {
+  AgentRunnerConnectRequest,
+  AgentRunnerIsRunningRequest,
+  AgentRunnerRunRequest,
+  AgentRunnerStopRequest,
+} from "../runner/agent-runner";
+
+class TestAgent extends AbstractAgent {
+  run(): Observable<BaseEvent> {
+    return EMPTY;
+  }
+}
+
+class TestRunner extends AgentRunner {
+  run(_request: AgentRunnerRunRequest): Observable<BaseEvent> {
+    return EMPTY;
+  }
+
+  connect(_request: AgentRunnerConnectRequest): Observable<BaseEvent> {
+    return EMPTY;
+  }
+
+  isRunning(_request: AgentRunnerIsRunningRequest): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  stop(_request: AgentRunnerStopRequest): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+}
+
+type RunCanonical = Parameters<
+  ChannelsIntelligenceModule["startChannelsOverRealtimeGateway"]
+>[1]["runCanonical"];
+
+function setup(
+  getLearningContainerId = vi.fn(async () => "enterprise-support"),
+) {
+  const user = { id: "user-1", name: "Ada Lovelace" };
+  const input: RunAgentInput = {
+    threadId: "thread-1",
+    runId: "run-1",
+    state: { account: { plan: "enterprise" } },
+    messages: [
+      {
+        id: "message-1",
+        role: "user",
+        content: "Help with an enterprise account",
+      },
+    ],
+    tools: [],
+    context: [{ description: "region", value: "eu" }],
+    forwardedProps: { workspaceId: "workspace-1" },
+  };
+  const intelligence = new CopilotKitIntelligence({
+    apiKey: "test-api-key",
+    apiUrl: "https://intelligence.example",
+    wsUrl: "wss://intelligence.example",
+    getLearningContainerId,
+  });
+  const getOrCreateThread = vi
+    .spyOn(intelligence, "getOrCreateThread")
+    .mockResolvedValue({
+      thread: { id: input.threadId, name: "Existing thread" },
+      created: false,
+    });
+  vi.spyOn(intelligence, "ɵacquireThreadLock").mockRejectedValue(
+    new Error("stop after thread assignment"),
+  );
+  const runtime = new CopilotIntelligenceRuntime({
+    agents: {},
+    intelligence,
+    identifyUser: async () => user,
+  });
+  const request = new Request("https://runtime.example/agent/support/run", {
+    method: "POST",
+  });
+
+  return {
+    agent: new TestAgent({ agentId: "support" }),
+    getLearningContainerId,
+    getOrCreateThread,
+    input,
+    request,
+    runtime,
+    teardown: () => vi.restoreAllMocks(),
+    user,
+  };
+}
+
+test("the Intelligence client rejects a non-callback Learning Container selector", () => {
+  expect(() =>
+    Reflect.construct(CopilotKitIntelligence, [
+      {
+        apiKey: "test-api-key",
+        getLearningContainerId: "support-quality",
+      },
+    ]),
+  ).toThrow(
+    "CopilotKitIntelligence `getLearningContainerId` must be a callback",
+  );
+});
+
+test("the runtime rejects public and deprecated Learning Container selectors together", () => {
+  const intelligence = new CopilotKitIntelligence({
+    apiKey: "test-api-key",
+    getLearningContainerId: () => "support-quality",
+  });
+
+  expect(
+    () =>
+      new CopilotIntelligenceRuntime({
+        agents: {},
+        intelligence,
+        identifyUser: async () => ({ id: "user-1", name: "Ada Lovelace" }),
+        ɵlearning: { containerId: "support-quality" },
+      }),
+  ).toThrow(
+    "Configure Learning Containers with `getLearningContainerId` on `CopilotKitIntelligence`",
+  );
+});
+
+test("an invalid selected Learning Container ID stops the web run", async () => {
+  const selector = vi.fn(async () => "Invalid Container");
+  const { agent, getOrCreateThread, input, request, runtime, teardown } =
+    setup(selector);
+
+  try {
+    const response = await handleIntelligenceRun({
+      runtime,
+      request,
+      agentId: "support",
+      agent,
+      input,
+    });
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to resolve Learning Container",
+    });
+    expect(selector).toHaveBeenCalledOnce();
+    expect(getOrCreateThread).not.toHaveBeenCalled();
+  } finally {
+    teardown();
+  }
+});
+
+test("a null Learning Container selection leaves the Thread unassigned", async () => {
+  const selector = vi.fn(async () => null);
+  const { agent, getOrCreateThread, input, request, runtime, teardown, user } =
+    setup(selector);
+
+  try {
+    const response = await handleIntelligenceRun({
+      runtime,
+      request,
+      agentId: "support",
+      agent,
+      input,
+    });
+
+    expect(response.status).toBe(502);
+    expect(getOrCreateThread).toHaveBeenCalledWith({
+      threadId: input.threadId,
+      userId: user.id,
+      agentId: "support",
+    });
+  } finally {
+    teardown();
+  }
+});
+
+test("the Intelligence selector receives the resolved user and AG-UI run input", async () => {
+  const {
+    agent,
+    getLearningContainerId,
+    getOrCreateThread,
+    input,
+    request,
+    runtime,
+    teardown,
+    user,
+  } = setup();
+
+  try {
+    const response = await handleIntelligenceRun({
+      runtime,
+      request,
+      agentId: "support",
+      agent,
+      input,
+    });
+
+    expect(response.status).toBe(502);
+    expect(getLearningContainerId).toHaveBeenCalledOnce();
+    expect(getLearningContainerId).toHaveBeenCalledWith({
+      surface: "web",
+      user,
+      agentId: "support",
+      input,
+    });
+    expect(getOrCreateThread).toHaveBeenCalledWith({
+      threadId: input.threadId,
+      userId: user.id,
+      agentId: "support",
+      learningContainerId: "enterprise-support",
+    });
+  } finally {
+    teardown();
+  }
+});
+
+test("the Intelligence selector receives the Channel user and canonical run input", async () => {
+  const user = { id: "user-2", name: "Grace Hopper" };
+  const getLearningContainerId = vi.fn(async () => "channel-support");
+  const intelligence = new CopilotKitIntelligence({
+    apiKey: "test-api-key",
+    apiUrl: "https://intelligence.example",
+    wsUrl: "wss://intelligence.example",
+    getLearningContainerId,
+  });
+  vi.spyOn(intelligence, "ɵacquireThreadLock").mockRejectedValue(
+    new Error("stop after Channel assignment"),
+  );
+  let runCanonical: RunCanonical | undefined;
+  const importer = async (): Promise<ChannelsIntelligenceModule> => ({
+    startChannelsOverRealtimeGateway: async (_channels, options) => {
+      runCanonical = options.runCanonical;
+      return { metadata: {}, stop: async () => undefined };
+    },
+  });
+  await defaultActivateChannel(
+    {
+      wsUrl: "wss://intelligence.example",
+      apiUrl: "https://intelligence.example",
+      apiKey: "test-api-key",
+      projectId: 42,
+      channelName: "support",
+      runtimeInstanceId: "runtime-1",
+    },
+    createChannel({ identifyUser: "platform", name: "support" }),
+    importer,
+    undefined,
+    { runner: new TestRunner(), intelligence },
+  );
+  if (!runCanonical) throw new Error("runCanonical was not configured");
+  const agent = new TestAgent({
+    agentId: "support",
+    initialMessages: [
+      {
+        id: "message-2",
+        role: "user",
+        content: "A Channel question",
+      },
+    ],
+    initialState: { source: "slack" },
+  });
+  const tools = [
+    {
+      name: "lookup-account",
+      description: "Look up one account",
+      parameters: { type: "object" },
+    },
+  ];
+  const context = [{ description: "channel", value: "support" }];
+  const channelRun = {
+    agent,
+    deliveryId: "delivery-1",
+    threadId: "thread-2",
+    runId: "run-2",
+    user,
+    userId: user.id,
+    agentId: "support",
+    tools,
+    context,
+    persistedInputMessages: agent.messages,
+    execute: async () => ({ iterations: 1, interrupted: false }),
+  };
+
+  try {
+    await expect(runCanonical(channelRun)).rejects.toThrow(
+      "stop after Channel assignment",
+    );
+
+    expect(getLearningContainerId).toHaveBeenCalledOnce();
+    expect(getLearningContainerId).toHaveBeenCalledWith({
+      surface: "channel",
+      user,
+      agentId: "support",
+      input: {
+        threadId: "thread-2",
+        runId: "run-2",
+        messages: agent.messages,
+        state: agent.state,
+        tools,
+        context,
+        forwardedProps: undefined,
+      },
+    });
+    expect(intelligence.ɵacquireThreadLock).toHaveBeenCalledWith(
+      expect.objectContaining({ learningContainerId: "channel-support" }),
+    );
+  } finally {
+    vi.restoreAllMocks();
+  }
+});

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -12,6 +12,7 @@ import type {
   AgentSubscriber,
   BaseEvent,
   Message,
+  RunAgentInput,
   RunAgentParameters,
   RunAgentResult,
 } from "@ag-ui/client";
@@ -35,7 +36,11 @@ import type {
   ResolvedChannelMemory,
 } from "@copilotkit/channels-core";
 import type { CopilotRuntimeLearningConfig } from "./learning";
-import { resolveLearningContainerId } from "./learning";
+import {
+  resolveLearningContainerId,
+  resolveLearningContainerSelector,
+} from "./learning";
+import type { CopilotRuntimeUser } from "./learning";
 
 /**
  * Lifecycle status of a single Channel activation, or of the manager overall.
@@ -410,6 +415,7 @@ export interface ChannelsIntelligenceModule {
         threadId: string;
         runId: string;
         userId: string;
+        user?: CopilotRuntimeUser | null;
         agentId: string;
         tools: readonly {
           name: string;
@@ -547,6 +553,7 @@ interface CanonicalRunArgs {
   threadId: string;
   runId: string;
   userId: string;
+  user?: CopilotRuntimeUser | null;
   memory?: ResolvedChannelMemory;
   agentId: string;
   tools: readonly {
@@ -564,6 +571,19 @@ interface CanonicalRunArgs {
     interrupted: boolean;
     deliveryError?: unknown;
   }>;
+}
+
+/** Builds the AG-UI input used to select and execute one Channel run. */
+function buildCanonicalChannelRunInput(args: CanonicalRunArgs): RunAgentInput {
+  return {
+    threadId: args.threadId,
+    runId: args.runId,
+    messages: args.agent.messages,
+    state: args.agent.state,
+    tools: [...args.tools],
+    context: [...args.context],
+    forwardedProps: undefined,
+  };
 }
 
 /** Attach grant-scoped Intelligence Memory tools to one isolated Channel agent. */
@@ -654,14 +674,23 @@ async function runCanonicalChannelAgent(
   interrupted: boolean;
   deliveryError?: unknown;
 }> {
-  const learningContainerId = await resolveLearningContainerId(learning, {
-    surface: "channel",
-    threadId: args.threadId,
-    runId: args.runId,
-    agentId: args.agentId,
-    userId: args.userId,
-    deliveryId: args.deliveryId,
-  });
+  const input = buildCanonicalChannelRunInput(args);
+  const selector = intelligence.ɵgetLearningContainerId?.();
+  const learningContainerId = selector
+    ? await resolveLearningContainerSelector(selector, {
+        surface: "channel",
+        user: args.user ?? null,
+        agentId: args.agentId,
+        input,
+      })
+    : await resolveLearningContainerId(learning, {
+        surface: "channel",
+        threadId: args.threadId,
+        runId: args.runId,
+        agentId: args.agentId,
+        userId: args.userId,
+        deliveryId: args.deliveryId,
+      });
   const lock = await intelligence.ɵacquireThreadLock({
     threadId: args.threadId,
     runId: args.runId,
@@ -749,13 +778,9 @@ async function runCanonicalChannelAgent(
         threadId: canonicalThreadId,
         agent: outer,
         input: {
+          ...input,
           threadId: canonicalThreadId,
           runId: canonicalRunId,
-          messages: args.agent.messages,
-          state: args.agent.state,
-          tools: [...args.tools],
-          context: [...args.context],
-          forwardedProps: undefined,
         },
         persistedInputMessages: args.persistedInputMessages,
       });

--- a/packages/runtime/src/v2/runtime/core/learning.ts
+++ b/packages/runtime/src/v2/runtime/core/learning.ts
@@ -1,4 +1,31 @@
+import type { RunAgentInput } from "@ag-ui/client";
 import type { MaybePromise } from "@copilotkit/shared";
+
+/** Application user resolved by an Intelligence runtime. */
+export interface CopilotRuntimeUser {
+  readonly id: string;
+  readonly name: string;
+}
+
+/** Context for choosing a Learning Container through the public Intelligence SDK. */
+export type LearningContainerSelectorInput =
+  | {
+      readonly surface: "web";
+      readonly user: CopilotRuntimeUser;
+      readonly agentId: string;
+      readonly input: Readonly<RunAgentInput>;
+    }
+  | {
+      readonly surface: "channel";
+      readonly user: CopilotRuntimeUser | null;
+      readonly agentId: string;
+      readonly input: Readonly<RunAgentInput>;
+    };
+
+/** Chooses one developer-created Learning Container for an Intelligence run. */
+export type GetLearningContainerId = (
+  input: LearningContainerSelectorInput,
+) => MaybePromise<string | null | undefined>;
 
 /** Context for choosing one Learning Container for an Intelligence run. */
 export type CopilotRuntimeLearningContext =
@@ -43,6 +70,16 @@ export function assertStableLearningContainerId(value: unknown): string {
     );
   }
   return value;
+}
+
+/** Resolves and validates a public Intelligence Learning Container selection. */
+export async function resolveLearningContainerSelector(
+  selector: GetLearningContainerId,
+  input: LearningContainerSelectorInput,
+): Promise<string | undefined> {
+  const value = await selector(input);
+  if (value == null) return undefined;
+  return assertStableLearningContainerId(value);
 }
 
 /** Resolves the configured Container once for one web or Channel run. */

--- a/packages/runtime/src/v2/runtime/core/runtime.ts
+++ b/packages/runtime/src/v2/runtime/core/runtime.ts
@@ -43,12 +43,18 @@ import {
   attachRuntimeErrorReporter,
   getRuntimeErrorReporterFromOptions,
 } from "./runtime-error-reporter";
-import type { CopilotRuntimeLearningConfig } from "./learning";
+import type {
+  CopilotRuntimeLearningConfig,
+  CopilotRuntimeUser,
+} from "./learning";
 import { assertStableLearningContainerId } from "./learning";
 
 export type {
+  CopilotRuntimeUser,
   CopilotRuntimeLearningConfig,
   CopilotRuntimeLearningContext,
+  GetLearningContainerId,
+  LearningContainerSelectorInput,
 } from "./learning";
 
 export const VERSION = pkg.version;
@@ -207,11 +213,6 @@ interface BaseCopilotRuntimeOptions extends CopilotRuntimeMiddlewares {
   exposeMemoryRoutes?: boolean;
 }
 
-export interface CopilotRuntimeUser {
-  id: string;
-  name: string;
-}
-
 export type IdentifyUserCallback = (
   request: Request,
 ) => MaybePromise<CopilotRuntimeUser>;
@@ -246,7 +247,10 @@ export interface CopilotSseRuntimeOptions extends BaseCopilotRuntimeOptions {
 interface CopilotIntelligenceRuntimeBaseOptions extends BaseCopilotRuntimeOptions {
   /** Configures Intelligence mode for durable threads and realtime events. */
   intelligence: CopilotKitIntelligence;
-  /** Chooses one stable Learning Container ID for each web or Channel run. */
+  /**
+   * Chooses one stable Learning Container ID for each web or Channel run.
+   * @deprecated Configure `getLearningContainerId` on `CopilotKitIntelligence`.
+   */
   ɵlearning?: CopilotRuntimeLearningConfig;
   /** Auto-generate short names for newly created threads. */
   generateThreadNames?: boolean;
@@ -567,6 +571,14 @@ export class CopilotIntelligenceRuntime
     ) {
       throw new Error(
         "Intelligence Runtime `ɵlearning.containerId` must be a stable ID or callback",
+      );
+    }
+    if (
+      rawOptions.ɵlearning !== undefined &&
+      options.intelligence.ɵgetLearningContainerId?.() !== undefined
+    ) {
+      throw new Error(
+        "Configure Learning Containers with `getLearningContainerId` on `CopilotKitIntelligence`; do not also pass deprecated `ɵlearning` to `CopilotRuntime`",
       );
     }
     if (

--- a/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/intelligence/run.ts
@@ -15,7 +15,10 @@ import type { AgentRunnerRunRequest } from "../../runner/agent-runner";
 import type { Observable } from "rxjs";
 import { getRuntimeErrorReporter } from "../../core/runtime-error-reporter";
 import type { RuntimeErrorPhase } from "../../core/runtime-error-reporter";
-import { resolveLearningContainerId } from "../../core/learning";
+import {
+  resolveLearningContainerId,
+  resolveLearningContainerSelector,
+} from "../../core/learning";
 import { getPlatformErrorStatus } from "../shared/intelligence-utils";
 
 /**
@@ -88,14 +91,22 @@ export async function handleIntelligenceRun({
 
   let learningContainerId: string | undefined;
   try {
-    learningContainerId = await resolveLearningContainerId(runtime.learning, {
-      surface: "web",
-      request,
-      threadId: input.threadId,
-      runId: input.runId,
-      agentId,
-      userId,
-    });
+    const selector = runtime.intelligence.ɵgetLearningContainerId?.();
+    learningContainerId = selector
+      ? await resolveLearningContainerSelector(selector, {
+          surface: "web",
+          user,
+          agentId,
+          input,
+        })
+      : await resolveLearningContainerId(runtime.learning, {
+          surface: "web",
+          request,
+          threadId: input.threadId,
+          runId: input.runId,
+          agentId,
+          userId,
+        });
   } catch (error) {
     logger.error("Failed to resolve Learning Container:", error);
     return Response.json(

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -1,6 +1,7 @@
 import { logger, parseInspectorMetadataV1 } from "@copilotkit/shared";
 import type { InspectorMetadataV1 } from "@copilotkit/shared";
 import { randomUUID } from "crypto";
+import type { GetLearningContainerId } from "../core/learning";
 
 /**
  * Header name carrying the per-call end-user identity that the CopilotKit
@@ -108,6 +109,14 @@ export interface CopilotKitIntelligenceConfig {
   wsUrl?: string;
   /** API key for authenticating with CopilotKit Intelligence */
   apiKey: string;
+  /**
+   * Chooses the stable Learning Container ID for each Intelligence run.
+   * The callback receives the resolved application user and AG-UI run input.
+   * It must return the same ID for every run on one Thread because a Thread
+   * cannot move between Learning Containers after its first assignment.
+   * Return `null` or `undefined` to leave the Thread unassigned.
+   */
+  getLearningContainerId?: GetLearningContainerId;
   /**
    * Enable Enterprise Learning — expose CopilotKit Intelligence's
    * built-in tools (bash + thread/memory tools) to agent runs on an
@@ -494,11 +503,20 @@ export class CopilotKitIntelligence {
   #channelsWsUrl: string;
   #apiKey: string;
   #enterpriseLearningEnabled: boolean;
+  #getLearningContainerId?: GetLearningContainerId;
   #threadCreatedListeners = new Set<(thread: ThreadSummary) => void>();
   #threadUpdatedListeners = new Set<(thread: ThreadSummary) => void>();
   #threadDeletedListeners = new Set<(params: ThreadDeletedPayload) => void>();
 
   constructor(config: CopilotKitIntelligenceConfig) {
+    if (
+      config.getLearningContainerId !== undefined &&
+      typeof config.getLearningContainerId !== "function"
+    ) {
+      throw new Error(
+        "CopilotKitIntelligence `getLearningContainerId` must be a callback",
+      );
+    }
     const configuredApiUrl = configuredUrl(config.apiUrl);
     const configuredWsUrl = configuredUrl(config.wsUrl);
     warnOnPartialHostOverride(configuredApiUrl, configuredWsUrl);
@@ -516,6 +534,7 @@ export class CopilotKitIntelligence {
     this.#channelsWsUrl = deriveChannelsWsUrl(intelligenceWsUrl);
     this.#apiKey = config.apiKey;
     this.#enterpriseLearningEnabled = config.enableEnterpriseLearning ?? false;
+    this.#getLearningContainerId = config.getLearningContainerId;
 
     if (config.onThreadCreated) {
       this.onThreadCreated(config.onThreadCreated);
@@ -611,6 +630,11 @@ export class CopilotKitIntelligence {
   /** @internal Used by `attachIntelligenceEnterpriseLearning` to populate `Authorization`. */
   ɵgetApiKey(): string {
     return this.#apiKey;
+  }
+
+  /** @internal Used by the Intelligence runtime to assign Learning Containers. */
+  ɵgetLearningContainerId(): GetLearningContainerId | undefined {
+    return this.#getLearningContainerId;
   }
 
   /** @internal Used by `attachIntelligenceEnterpriseLearning` to gate MCP attachment. */

--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -131,41 +131,48 @@ The examples below take `intelligence` and `identifyUser` as given. `intelligenc
 
 #### Assign Threads to Learning Containers
 
-Create a Learning Container in your Intelligence Project, then pass its stable
-ID to the Runtime:
+Create a Learning Container in your Intelligence Project, then choose its stable
+ID in the Intelligence SDK:
 
 ```ts title="runtime.ts"
-const runtime = new CopilotRuntime({
-  agents: { default: myAgent },
-  intelligence,
-  identifyUser,
-  ɵlearning: {
-    containerId: "support-quality",
+const intelligence = new CopilotKitIntelligence({
+  apiKey: process.env.INTELLIGENCE_API_KEY!,
+  getLearningContainerId: () => "support-quality",
+});
+```
+
+The selector receives the resolved application user and the AG-UI run input.
+The same API handles web and Channel runs:
+
+```ts title="runtime.ts"
+const intelligence = new CopilotKitIntelligence({
+  apiKey: process.env.INTELLIGENCE_API_KEY!,
+  getLearningContainerId: async ({ surface, user, agentId, input }) => {
+    return chooseLearningContainer({
+      surface,
+      user,
+      agentId,
+      threadId: input.threadId,
+      runId: input.runId,
+      state: input.state,
+      messages: input.messages,
+      forwardedProps: input.forwardedProps,
+    });
   },
 });
 ```
 
-Use a callback when the Container depends on the run. The same callback handles
-web and Channel runs:
+For web runs, `user` is the full result from `identifyUser`. For Channel runs,
+it is the application user resolved by the Channel identity strategy, or `null`
+when no application user was resolved. `input` contains the parsed run fields,
+including `threadId`, `runId`, `messages`, `state`, `tools`, `context`, and
+`forwardedProps`.
 
-```ts title="runtime.ts"
-const runtime = new CopilotRuntime({
-  agents: { default: myAgent },
-  intelligence,
-  identifyUser,
-  channels: [supportChannel],
-  ɵlearning: {
-    containerId: async ({ surface, agentId, userId, threadId }) => {
-      return chooseLearningContainer({ surface, agentId, userId, threadId });
-    },
-  },
-});
-```
-
-The callback runs once per agent run. Return a 1–64 character stable ID made
-from lowercase letters, numbers, and single hyphens. Return `null` to leave the
-Thread unassigned. A Thread can receive its first assignment when it is created
-or locked, but it cannot move to another Learning Container later.
+The callback runs once for each attempted agent run. Return a 1–64 character
+stable ID made from lowercase letters, numbers, and single hyphens. Return
+`null` or `undefined` to leave the Thread unassigned. Always return the same ID
+for the same Thread. A Thread cannot move after its first assignment, and a
+Thread with an earlier agent run cannot receive its first assignment later.
 
 The Runtime sends only the Container ID with the normal Thread create and lock
 calls. It does not upload transcripts. The Intelligence AgentRunner's persisted


### PR DESCRIPTION
## What does this PR do?

Adds `getLearningContainerId` to `CopilotKitIntelligence` so developers can assign Intelligence Threads to Learning Containers without a theta-prefixed Runtime option.

The selector receives:

- The resolved application `user`.
- The parsed AG-UI `input` for the run.
- The `agentId` and the `web` or `channel` surface.

Web runs pass the exact parsed `RunAgentInput`. Channel runs build the same canonical input that the AgentRunner receives. Channels also carry the resolved application user through the core and Intelligence adapter boundaries.

The Runtime validates the selected stable ID and sends only that ID with the existing Thread create or lock call. Intelligence stays responsible for project scope, entitlements, Container lookup, and the one-time Thread binding. Persisted AG-UI events remain the source for Learning snapshots.

The old `ɵlearning` Runtime option remains as a deprecated fallback. The Runtime rejects configurations that set both APIs.

## Why?

Learning Container assignment is an Intelligence SDK concern. Developers also need the resolved user and complete run input to select a Container from application data without reading raw transport details.

## Related PRs and Issues

- Refs [ENT-1149](https://linear.app/copilotkit/issue/ENT-1149/enable-projects-to-learn-from-agent-runs-and-publish-reusable-skills)
- Related design: #6746

## Validation

- GitHub CI: 53 passed, 3 skipped
- `pnpm nx run-many -t test,check-types,build -p @copilotkit/runtime @copilotkit/channels-core @copilotkit/channels-intelligence`
- `pnpm nx run-many -t publint,attw,check-dts -p @copilotkit/runtime @copilotkit/channels-core @copilotkit/channels-intelligence`
- `pnpm lint` (0 errors; existing warnings remain)
- `npm run typecheck` and `npm run build` in `showcase/shell-docs`
- `npm test` in `showcase/shell-docs` has one pre-existing failure at `inspector-docs.test.ts:141`: the tracked Threads callout contains `Playground`.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] Maintainer edits are available because this PR uses a branch in the main repository
