### PR TITLE
feat(channels): carry an application author on a managed inbound turn

### DIFF
--- a/packages/channels-core/src/create-channel.ts
+++ b/packages/channels-core/src/create-channel.ts
@@ -434,6 +434,31 @@ export interface CreateChannelOptions<
    * configure direct Slack with `slack({ replyContinuation })` instead.
    */
   replyContinuation?: ReplyContinuationOptions;
+  /**
+   * Per-replica ceiling on managed deliveries executing at once.
+   *
+   * The managed delivery transport has always accepted this, but a Channel
+   * activated through `CopilotRuntime` had no way to set it, so every such
+   * deployment ran on the transport default of 8 regardless of how the host was
+   * sized. Since a replica's throughput is about
+   * `maxConcurrentDeliveries / meanTurnSeconds`, that default — not the agent
+   * and not the provider — was the binding constraint on managed throughput.
+   *
+   * Unset keeps the transport default, so raising it is an explicit decision by
+   * an operator who knows what the host and the agent can absorb.
+   *
+   * Ignored for direct-adapter Channels, which do not go through the managed
+   * delivery transport.
+   */
+  maxConcurrentDeliveries?: number;
+  /**
+   * Per-replica ceiling on managed deliveries that are claimed but not yet
+   * executing. Invitations beyond
+   * `maxConcurrentDeliveries + maxPendingDeliveries` are declined as overflow
+   * and left for another replica rather than queued locally, so this trades
+   * local tail latency against how often this replica declines work.
+   */
+  maxPendingDeliveries?: number;
   agent?: AbstractAgent | ((threadId: string) => AbstractAgent);
   /**
    * Tolerate the AG-UI event streams real agents emit. On by default.
@@ -483,6 +508,17 @@ export interface Channel<TState = unknown> {
    * Undefined leaves the provider defaults in place.
    */
   readonly replyContinuation?: ReplyContinuationOptions;
+  /**
+   * Managed delivery capacity from `createChannel({ maxConcurrentDeliveries })`.
+   * Undefined leaves the delivery transport's own default in place.
+   */
+  readonly maxConcurrentDeliveries?: number;
+  /**
+   * Managed pending-delivery capacity from
+   * `createChannel({ maxPendingDeliveries })`. Undefined leaves the delivery
+   * transport's own default in place.
+   */
+  readonly maxPendingDeliveries?: number;
   /** Declared slash-command names (normalized). Surfaced for Channel activation metadata. */
   readonly commandNames: string[];
   onMention(h: ChannelHandler<TState>): void;
@@ -559,6 +595,11 @@ function msgFromTurn(turn: IncomingTurn): ChannelMessage {
     eventId: turn.eventId,
     turnId: turn.turnId,
     deliveryId: turn.deliveryId,
+    // Carried, never interpreted. Core deliberately takes no branch on the
+    // authoring surface: routing, dedup and ordering must stay identical for a
+    // web-composed turn and a provider one, or the two surfaces stop being one
+    // conversation. Only the handler's own rendering may read this.
+    authoredBy: turn.authoredBy,
   };
 }
 
@@ -1323,6 +1364,12 @@ export function createChannel<
       : {}),
     ...(opts.replyContinuation !== undefined
       ? { replyContinuation: opts.replyContinuation }
+      : {}),
+    ...(opts.maxConcurrentDeliveries !== undefined
+      ? { maxConcurrentDeliveries: opts.maxConcurrentDeliveries }
+      : {}),
+    ...(opts.maxPendingDeliveries !== undefined
+      ? { maxPendingDeliveries: opts.maxPendingDeliveries }
       : {}),
     get adapters() {
       // Defensive read-only copy: mutating the returned array must not affect

--- a/packages/channels-core/src/platform-adapter.ts
+++ b/packages/channels-core/src/platform-adapter.ts
@@ -2,6 +2,7 @@ import type { AgentSubscriber, AbstractAgent } from "@ag-ui/client";
 import type {
   AgentContentPart,
   ApplicationUser,
+  ChannelAuthoredActor,
   ChannelNode,
   EmojiValue,
   EphemeralResult,
@@ -166,6 +167,12 @@ export interface IncomingTurn extends IngressEventBase, IngressIds {
    */
   contentParts?: AgentContentPart[];
   platform: string;
+  /**
+   * Set when this turn was composed on an application surface rather than the
+   * provider surface. Provider-authored turns omit it, so an adapter that
+   * cannot produce application turns needs no change at all.
+   */
+  authoredBy?: ChannelAuthoredActor;
 }
 
 export interface InteractionEvent extends IngressEventBase, IngressIds {

--- a/packages/channels-intelligence/src/delivery-adapter.ts
+++ b/packages/channels-intelligence/src/delivery-adapter.ts
@@ -407,6 +407,13 @@ export class DeliveryAdapter implements PlatformAdapter {
                 ],
               }
             : {}),
+          // Only a text turn can be application-authored: an interaction, a
+          // reaction or a welcome is by construction something that happened on
+          // the provider surface, so forwarding an author there would describe
+          // an event that did not occur.
+          ...(delivery.turn.authoredBy !== undefined
+            ? { authoredBy: delivery.turn.authoredBy }
+            : {}),
         });
         return;
       }

--- a/packages/channels-intelligence/src/delivery-authored-actor.test.ts
+++ b/packages/channels-intelligence/src/delivery-authored-actor.test.ts
@@ -1,0 +1,309 @@
+import { createChannel } from "@copilotkit/channels-core";
+import type { ChannelAuthoredActor } from "@copilotkit/channels-ui";
+import { expect, test, vi } from "vitest";
+import {
+  DeliveryTestGateway,
+  preparedDelivery,
+} from "./delivery-test-gateway.js";
+import { ChannelDeliveryTransport } from "./delivery-transport.js";
+import type { PreparedChannelDelivery } from "./delivery-transport.js";
+import type {
+  RealtimeGatewayDeliveryChannel,
+  RealtimeGatewaySession,
+} from "./realtime-gateway.js";
+import { startChannelsWithGatewayControl } from "./realtime-gateway-launcher.js";
+
+/**
+ * Contract tests for CopilotKit/CopilotKit#6751 — a turn composed on an
+ * application surface (a web composer continuing a Slack thread) delivered
+ * through the ordinary managed path.
+ *
+ * The invariant these pin down is that an application turn is an ordinary
+ * delivery in every respect except who is named as its author. Nothing about
+ * routing, identity resolution or the provider actor may change, because the
+ * two surfaces are meant to be one conversation.
+ */
+
+const AUTHORED_BY: ChannelAuthoredActor = {
+  kind: "application",
+  surface: "web",
+  appUserId: "openbot:user-42",
+  displayName: "Jerel via OpenBot",
+};
+
+const SHARED_THREAD_ID = "thread_authored_fifo";
+const PROVIDER_DELIVERY_ID = "dlv_authoredFifoProvider";
+const APPLICATION_DELIVERY_ID = "dlv_authoredFifoApplication";
+
+/** One claimed-and-acknowledged delivery topic, mirroring the transport suite. */
+function deliveryChannel(
+  joinReply: PreparedChannelDelivery,
+): RealtimeGatewayDeliveryChannel {
+  return {
+    joinReply,
+    push: vi.fn().mockImplementation((_event, packet) => {
+      const identity = packet as {
+        deliveryId: string;
+        seq: number;
+        packetId: string;
+      };
+      return Promise.resolve({
+        deliveryId: identity.deliveryId,
+        seq: identity.seq,
+        packetId: identity.packetId,
+        phase: "applied",
+        result: { providerReference: "pref_v1_message_authored" },
+      });
+    }),
+    on: vi.fn(),
+    onClose: vi.fn(),
+    leave: vi.fn(),
+  };
+}
+
+function claimResult(deliveryId: string) {
+  return {
+    result: "claimed" as const,
+    deliveryId,
+    ownerGeneration: 7,
+    joinToken: `chj_token_${deliveryId.slice(4)}`,
+    joinTokenExpiresAt: "2099-07-29T16:01:00.000Z",
+    deliveryExpiresAt: "2099-07-29T17:00:00.000Z",
+  };
+}
+
+function invitation(deliveryId: string) {
+  return {
+    protocol: "channel_delivery_v1" as const,
+    deliveryId,
+    canonicalThreadId: SHARED_THREAD_ID,
+    channelName: "support",
+    adapter: "slack" as const,
+  };
+}
+
+/** Attach an application author to an otherwise ordinary text delivery. */
+function authoredDelivery(
+  suffix: string,
+  authoredBy: unknown = AUTHORED_BY,
+): PreparedChannelDelivery {
+  const base = preparedDelivery(suffix, "slack", {
+    kind: "text",
+    text: "follow-up from the web",
+  });
+  return {
+    ...base,
+    turn: { ...base.turn, authoredBy: authoredBy as ChannelAuthoredActor },
+  };
+}
+
+test("an application-authored turn reaches the handler as attribution, not as a provider actor", async () => {
+  const observed: {
+    authoredBy?: ChannelAuthoredActor;
+    actorId?: string;
+    actorKind?: string;
+    text?: string;
+  } = {};
+  const gateway = new DeliveryTestGateway();
+  const channel = createChannel({
+    identifyUser: () => ({ id: "person-1", name: "Ada App" }),
+    name: "support",
+  });
+  channel.onMessage(({ message }) => {
+    observed.authoredBy = message.authoredBy;
+    observed.actorId = message.actor.id;
+    observed.actorKind = message.actor.kind;
+    observed.text = message.text;
+  });
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 1, channelName: "support" },
+    runtimeInstanceId: "rti_authored_actor",
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+
+  try {
+    await gateway.deliver(authoredDelivery("authoredActor"));
+  } finally {
+    await handle.stop();
+  }
+
+  expect(observed.authoredBy).toEqual(AUTHORED_BY);
+  expect(observed.text).toBe("follow-up from the web");
+  // The provider actor is preserved exactly. A web-composed message must never
+  // be laundered into "the Slack user said this" — the author is additive.
+  expect(observed.actorKind).toBe("human");
+  expect(observed.actorId).toBe("user_authoredActor");
+});
+
+test("a provider-authored turn carries no application author", async () => {
+  let authoredBy: ChannelAuthoredActor | undefined | "unset" = "unset";
+  const gateway = new DeliveryTestGateway();
+  const channel = createChannel({
+    identifyUser: () => ({ id: "person-1", name: "Ada App" }),
+    name: "support",
+  });
+  channel.onMessage(({ message }) => {
+    authoredBy = message.authoredBy;
+  });
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 1, channelName: "support" },
+    runtimeInstanceId: "rti_provider_actor",
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+
+  try {
+    await gateway.deliver(
+      preparedDelivery("providerAuthored", "slack", {
+        kind: "text",
+        text: "hello from Slack",
+      }),
+    );
+  } finally {
+    await handle.stop();
+  }
+
+  // Absence is the signal a handler switches on, so it must be a real
+  // `undefined` rather than a defaulted empty object.
+  expect(authoredBy).toBeUndefined();
+});
+
+test.each([
+  ["an unknown author class", { ...AUTHORED_BY, kind: "provider" }],
+  ["an unexpected extra field", { ...AUTHORED_BY, escalate: true }],
+  ["a missing display name", { ...AUTHORED_BY, displayName: undefined }],
+  ["a blank display name", { ...AUTHORED_BY, displayName: "   " }],
+  [
+    "an unsafe application user id",
+    { ...AUTHORED_BY, appUserId: "../../root" },
+  ],
+  ["a non-string surface", { ...AUTHORED_BY, surface: 7 }],
+])("the join boundary refuses %s", async (_label, authoredBy) => {
+  const observed: ChannelAuthoredActor[] = [];
+  const gateway = new DeliveryTestGateway();
+  const channel = createChannel({
+    identifyUser: () => ({ id: "person-1", name: "Ada App" }),
+    name: "support",
+  });
+  channel.onMessage(({ message }) => {
+    if (message.authoredBy) observed.push(message.authoredBy);
+  });
+  const handle = await startChannelsWithGatewayControl([channel], {
+    session: gateway,
+    scope: { projectId: 1, channelName: "support" },
+    runtimeInstanceId: "rti_authored_reject",
+    runCanonical: async (args) => args.execute({}),
+    loadHistory: async () => [],
+  });
+
+  try {
+    await gateway
+      .deliver(authoredDelivery("authoredReject", authoredBy))
+      .catch(() => undefined);
+  } finally {
+    await handle.stop();
+  }
+
+  // A malformed author must not reach a handler at all. Rendering an
+  // unvalidated name as attribution is precisely the impersonation this
+  // boundary exists to prevent, so a partial accept is worse than a refusal.
+  expect(observed).toEqual([]);
+});
+
+/**
+ * Same-thread ordering has to be exercised at the transport, not through
+ * {@link DeliveryTestGateway}: that helper holds one prepared delivery at a
+ * time and waits for its topic to close, so two turns published through it are
+ * sequential by construction and would prove nothing. Driving the transport
+ * directly lets the second invitation genuinely arrive while the first turn is
+ * still running.
+ *
+ * What this pins is that an application-authored delivery is chained onto the
+ * same `threadTails` predecessor as a provider delivery. Capacity is left with
+ * headroom on purpose so a local concurrency ceiling cannot be what orders the
+ * two turns; if application turns were ever exempted from that chain, the two
+ * handlers would overlap and the interleaving below would change.
+ */
+test("an application turn waits for the provider turn already running on its thread", async () => {
+  const order: string[] = [];
+  let releaseProvider: (() => void) | undefined;
+  const providerDone = new Promise<void>((resolve) => {
+    releaseProvider = resolve;
+  });
+  const control: RealtimeGatewaySession = {
+    push: vi
+      .fn()
+      .mockImplementation((_event, payload) =>
+        Promise.resolve(
+          claimResult((payload as { deliveryId: string }).deliveryId),
+        ),
+      ),
+    on: vi.fn(),
+    join: vi.fn().mockImplementation((topic: string) => {
+      const deliveryId = topic.replace("delivery:", "");
+      const base = preparedDelivery(deliveryId.slice("dlv_".length), "slack", {
+        kind: "text",
+        text: "hello",
+      });
+      return Promise.resolve(
+        deliveryChannel({
+          ...base,
+          deliveryId,
+          canonicalThreadId: SHARED_THREAD_ID,
+          ...(deliveryId === APPLICATION_DELIVERY_ID
+            ? { turn: { ...base.turn, authoredBy: AUTHORED_BY } }
+            : {}),
+        }),
+      );
+    }),
+  };
+  const transport = new ChannelDeliveryTransport({
+    session: control,
+    runtimeInstanceId: "rti_authored_fifo",
+    // Headroom on purpose: with a ceiling of 1 this test would pass because the
+    // replica ran out of slots, not because the two turns share a thread.
+    maxConcurrentDeliveries: 4,
+  });
+  transport.start(async (_claimed, delivery) => {
+    const label = delivery.turn.authoredBy ? "application" : "provider";
+    order.push(`start:${label}`);
+    if (delivery.deliveryId === PROVIDER_DELIVERY_ID) await providerDone;
+    order.push(`end:${label}`);
+  });
+  const invite = vi.mocked(control.on).mock.calls[0]![1];
+
+  invite(invitation(PROVIDER_DELIVERY_ID));
+  await vi.waitFor(() => expect(order).toEqual(["start:provider"]));
+
+  // Arrives while the provider turn is still inside its handler.
+  invite(invitation(APPLICATION_DELIVERY_ID));
+  await vi.waitFor(() =>
+    expect(control.push).toHaveBeenCalledWith(
+      "claim",
+      expect.objectContaining({ deliveryId: APPLICATION_DELIVERY_ID }),
+    ),
+  );
+  // Claiming is only the first hop; joining the topic and entering the handler
+  // are further awaits. Drain the queues so the application turn has a real
+  // opportunity to start — asserting straight after the claim would pass even
+  // if nothing were serialising these two turns.
+  for (let tick = 0; tick < 20; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  // Given that opportunity, it still must not have run behind the live turn.
+  expect(order).toEqual(["start:provider"]);
+
+  releaseProvider?.();
+  await vi.waitFor(() =>
+    expect(order).toEqual([
+      "start:provider",
+      "end:provider",
+      "start:application",
+      "end:application",
+    ]),
+  );
+  await transport.stop();
+});

--- a/packages/channels-intelligence/src/delivery-transport.ts
+++ b/packages/channels-intelligence/src/delivery-transport.ts
@@ -4,6 +4,7 @@ import {
   isChannelDeliveryTerminatedError,
 } from "@copilotkit/channels-core";
 import type { AgentContentPart } from "@copilotkit/channels-ui";
+import type { ChannelAuthoredActor } from "@copilotkit/channels-ui";
 import type { MessageOperation } from "@copilotkit/channels-ui";
 import type {
   RealtimeGatewayDeliveryChannel,
@@ -114,6 +115,13 @@ export interface PreparedChannelDelivery {
       handle?: string;
       email?: string;
     };
+    /**
+     * Application author, set by the Gateway when this delivery came from an
+     * authenticated application caller instead of a provider event. The SDK
+     * only forwards it; it is minted from the caller's verified session inside
+     * Intelligence, so a runtime cannot manufacture one.
+     */
+    authoredBy?: ChannelAuthoredActor;
     raw?: unknown;
   };
 }
@@ -1508,7 +1516,7 @@ function assertPreparedDelivery(
     !hasExactFields(
       prepared.turn,
       ["eventId", "receivedAt", "input"],
-      ["typingDelayMs", "actor", "raw"],
+      ["typingDelayMs", "actor", "authoredBy", "raw"],
     ) ||
     !isEventId(prepared.turn.eventId) ||
     !isIsoDateTime(prepared.turn.receivedAt) ||
@@ -1517,6 +1525,8 @@ function assertPreparedDelivery(
       prepared.turn.typingDelayMs !== 300) ||
     (prepared.turn.actor !== undefined &&
       !isPreparedActor(prepared.turn.actor)) ||
+    (prepared.turn.authoredBy !== undefined &&
+      !isPreparedAuthoredActor(prepared.turn.authoredBy)) ||
     !isRecord(prepared.turn.input) ||
     typeof prepared.turn.input.kind !== "string" ||
     !PREPARED_TURN_KINDS.has(prepared.turn.input.kind) ||
@@ -1699,6 +1709,32 @@ function isPreparedActor(value: unknown): boolean {
         value.displayName.trim().length <= 120)) &&
     (value.handle === undefined || isBoundedString(value.handle, 1, 512)) &&
     (value.email === undefined || isBoundedString(value.email, 1, 512))
+  );
+}
+
+/**
+ * Validate the application author on a prepared delivery.
+ *
+ * Exact-field, like every other join-boundary check here: an unexpected key is
+ * rejected rather than ignored, so a future Gateway field cannot arrive as a
+ * silently-trusted extra. `kind` is pinned to the single literal the SDK knows;
+ * a newer Gateway sending an unknown author class must fail the join loudly
+ * instead of being flattened into "application" by a permissive check.
+ *
+ * `appUserId` is bounded by the same id shape as every other external id here
+ * so it cannot carry a provider reference, a path, or a control character into
+ * a handler that renders it.
+ */
+function isPreparedAuthoredActor(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    hasExactFields(value, ["kind", "surface", "appUserId", "displayName"]) &&
+    value.kind === "application" &&
+    isSafeExternalId(value.surface) &&
+    isSafeAppUserId(value.appUserId) &&
+    typeof value.displayName === "string" &&
+    value.displayName.trim().length >= 1 &&
+    value.displayName.trim().length <= 120
   );
 }
 

--- a/packages/channels-ui/src/types.ts
+++ b/packages/channels-ui/src/types.ts
@@ -30,6 +30,48 @@ export interface ProviderActor {
   readonly email?: string;
 }
 
+/**
+ * Who authored an inbound turn when the provider surface did not.
+ *
+ * Present only on turns the managed path accepted from an authenticated
+ * application caller — a web composer continuing a Slack thread, for example.
+ * It is server-minted from that caller's verified session during authenticated
+ * ingress; no adapter, agent, tool result, or delivery payload may choose it.
+ * An application therefore cannot name itself as somebody else, so a handler
+ * may render it as attribution without re-verifying anything.
+ *
+ * Absent on every provider-authored turn, which is what keeps existing handlers
+ * unaffected: reading it is opt-in, and its absence means "the provider actor
+ * really did write this".
+ *
+ * Distinct from {@link ApplicationUser}, which is the identity a Channel
+ * developer selects for their own purposes and which the platform never
+ * verifies. This one is chosen by the platform and cannot be set by the
+ * developer, which is exactly why it is safe to render as attribution.
+ */
+export interface ChannelAuthoredActor {
+  /**
+   * Authoring surface class. A union rather than a boolean so a later class of
+   * author can be added without breaking handlers that switch on it.
+   */
+  readonly kind: "application";
+  /** Free-form surface label the application declared, e.g. `"web"`. */
+  readonly surface: string;
+  /**
+   * Opaque, tenant-scoped id of the authoring application user. This is NOT a
+   * provider user id: it never resolves to a Slack member, and passing it to a
+   * provider lookup is a bug rather than a fallback.
+   */
+  readonly appUserId: string;
+  /**
+   * Display name the managed path already rendered into the provider surface
+   * when it echoed this turn. Carried so a handler's own rendering agrees with
+   * what the provider thread already shows, instead of inventing a second name
+   * for the same person.
+   */
+  readonly displayName: string;
+}
+
 /** Provider-neutral identity and dispatch semantics for one message revision. */
 export interface MessageOperation {
   kind: "created" | "updated" | "deleted";
@@ -86,6 +128,12 @@ export interface IncomingMessage {
   turnId?: string;
   /** Lease/delivery id (managed/Intelligence path). */
   deliveryId?: string;
+  /**
+   * Application author, when this turn was composed off-provider (managed path
+   * only). Provider-authored turns omit it, so `authoredBy === undefined` is
+   * the check for "the provider actor wrote this".
+   */
+  authoredBy?: ChannelAuthoredActor;
 }
 
 /** Incoming message delivered specifically to `onMention` or `onMessage`. */

--- a/packages/runtime/src/v2/runtime/core/__tests__/channel-activation-config.test.ts
+++ b/packages/runtime/src/v2/runtime/core/__tests__/channel-activation-config.test.ts
@@ -143,6 +143,49 @@ describe("deriveChannelActivationConfig", () => {
     expect(config).not.toHaveProperty("provider");
   });
 
+  it("forwards managed delivery capacity so a runtime-hosted Channel is not pinned to the transport defaults", () => {
+    // Without this passthrough the transport falls back to 8 concurrent / 32
+    // pending regardless of how the host is sized, which caps a replica at
+    // roughly `8 / meanTurnSeconds` turns per second. The options existed on
+    // the launcher all along; only this derivation was missing.
+    const intelligence = fakeIntelligence("cpk-42_short_long");
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+      maxConcurrentDeliveries: 64,
+      maxPendingDeliveries: 256,
+    });
+
+    const config = deriveChannelActivationConfig({
+      intelligence,
+      channel,
+      runtimeInstanceId: "rti_capacity",
+    });
+
+    expect(config.maxConcurrentDeliveries).toBe(64);
+    expect(config.maxPendingDeliveries).toBe(256);
+  });
+
+  it("omits delivery capacity entirely when the Channel declares none, leaving the transport default in place", () => {
+    // Omission has to stay omission rather than an explicit undefined: the
+    // launcher spreads these conditionally, and a present-but-undefined key
+    // would override the transport default with `undefined`.
+    const intelligence = fakeIntelligence("cpk-42_short_long");
+    const channel = createChannel({
+      identifyUser: "platform",
+      name: "support",
+    });
+
+    const config = deriveChannelActivationConfig({
+      intelligence,
+      channel,
+      runtimeInstanceId: "rti_capacity_default",
+    });
+
+    expect(config).not.toHaveProperty("maxConcurrentDeliveries");
+    expect(config).not.toHaveProperty("maxPendingDeliveries");
+  });
+
   it("throws ChannelConfigError when the channel has no name", () => {
     const intelligence = fakeIntelligence("cpk-42_short_long");
     const channel = createChannel({ identifyUser: "platform" });

--- a/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-activation-config.ts
@@ -47,6 +47,26 @@ export interface ChannelActivationConfig {
    * messages. Unset leaves the provider renderer's defaults in place.
    */
   replyContinuation?: ReplyContinuationOptions;
+  /**
+   * Per-replica ceiling on deliveries executing at once.
+   *
+   * The delivery transport already accepts this, but the runtime never passed
+   * it, so a Channel activated by `CopilotRuntime` was pinned to the transport
+   * default of 8 no matter how the host was sized. That ceiling — not the
+   * agent, the provider, or the gateway — is what caps a replica at roughly
+   * `maxConcurrentDeliveries / meanTurnSeconds` turns per second.
+   *
+   * Left unset, the transport default still applies, so existing deployments
+   * keep their current behaviour exactly.
+   */
+  maxConcurrentDeliveries?: number;
+  /**
+   * Per-replica ceiling on claimed-but-not-yet-executing deliveries.
+   * Invitations past `maxConcurrentDeliveries + maxPendingDeliveries` are
+   * declined as overflow and left for another replica rather than queued here,
+   * so raising this trades tail latency for a lower decline rate.
+   */
+  maxPendingDeliveries?: number;
   /** Identifier for the runtime instance activating this Channel. */
   runtimeInstanceId: string;
 }
@@ -160,6 +180,12 @@ export function deriveChannelActivationConfig(args: {
       : {}),
     ...(channel.replyContinuation !== undefined
       ? { replyContinuation: channel.replyContinuation }
+      : {}),
+    ...(channel.maxConcurrentDeliveries !== undefined
+      ? { maxConcurrentDeliveries: channel.maxConcurrentDeliveries }
+      : {}),
+    ...(channel.maxPendingDeliveries !== undefined
+      ? { maxPendingDeliveries: channel.maxPendingDeliveries }
       : {}),
     runtimeInstanceId,
   };

--- a/packages/runtime/src/v2/runtime/core/channel-manager.ts
+++ b/packages/runtime/src/v2/runtime/core/channel-manager.ts
@@ -401,6 +401,10 @@ export interface ChannelsIntelligenceModule {
       showToolStatus?: boolean;
       /** Optional per-Channel tuning for continuation messages on long replies. */
       replyContinuation?: ReplyContinuationOptions;
+      /** Optional per-replica ceiling on deliveries executing at once. */
+      maxConcurrentDeliveries?: number;
+      /** Optional per-replica ceiling on claimed-but-not-executing deliveries. */
+      maxPendingDeliveries?: number;
       /** Intelligence app-api HTTP base URL, forwarded to the transport so the
        * managed realtime path enables file/history parity (HTTP-only) — OSS-476. */
       appApiBaseUrl?: string;
@@ -512,6 +516,16 @@ export async function defaultActivateChannel(
       : {}),
     ...(config.replyContinuation !== undefined
       ? { replyContinuation: config.replyContinuation }
+      : {}),
+    // Forward the delivery capacity so a runtime-hosted managed Channel is not
+    // silently pinned to the transport defaults (8 concurrent / 32 pending).
+    // The launcher has always accepted these; only this call site was missing,
+    // which capped every runtime-activated Channel regardless of host size.
+    ...(config.maxConcurrentDeliveries !== undefined
+      ? { maxConcurrentDeliveries: config.maxConcurrentDeliveries }
+      : {}),
+    ...(config.maxPendingDeliveries !== undefined
+      ? { maxPendingDeliveries: config.maxPendingDeliveries }
       : {}),
     // Forward the app-api HTTP base URL so the transport wires file/history
     // (HTTP-only) on the NORMAL managed path — without this, Channels started by


### PR DESCRIPTION
> **Half of a paired change.** This PR is the SDK half of #6751 and is
> deliberately inert on its own: nothing in the OSS repo can *produce* an
> application-authored turn. The Gateway half that mints one is
> CopilotKit/Intelligence#1064. **This PR must merge first** — an older SDK
> rejects `authoredBy` as an unexpected key at its exact-field join boundary.
> The pair is now proven end to end against a real Slack workspace; the
> recording is below.

## Problem

A managed Channel can only answer a provider event. There is no supported way
for an authenticated application surface — a web composer continuing a Slack
thread — to submit a turn into an existing managed conversation, and no way to
say who wrote it if one arrives.

The concrete workflow this blocks: start a thread with `@openbot` in Slack, open
that same conversation on the application's own domain, continue it from the
web, and see both the web-authored message and the agent's reply land back in
the original Slack thread — one ordered conversation on both surfaces.

`IncomingTurn` carries `userText`, `operation`, `messageRef`, `contentParts`,
`platform` and the ingress ids, and nothing else. There is no field for an
author, so a web-composed message could only be attributed by naming the Slack
actor — which would be a lie, and exactly the impersonation #6751 rules out.

## Proven end to end

![Full journey](https://raw.githubusercontent.com/jerelvelarde/openbot/evidence/bidirectional-turn/evidence/openbot-journey-hd.gif)

Recorded against the real CopilotKit Slack workspace (`#openbot-channels`, team
`T05QFA4BW9X`) with app-api, the Realtime Gateway and OpenBot running locally,
and the `@openbot` app's Event Request URL pointed at that stack for the run.
Every Slack message in the recording is a real message in that workspace.

1. **Slack** — a person types `@openbot in one sentence, what does the CopilotKit
   Channels SDK do?`. It carries no `app_id`, so ingress classifies the actor
   `kind: "human"` and OpenBot answers in the thread, posting its
   "Open in OpenBot" transcript card.
2. **OpenBot** — the same conversation, opened from that card. OpenBot created
   the thread binding itself from the inbound delivery; nothing was seeded. The
   composer is live because Intelligence issued a conversation reference for it.
3. **The person composes their follow-up there.**
4. **OpenBot** — the agent answers.
5. **Slack** — the follow-up is in the same thread as
   `dev@openbot.local via openbot`, with the agent's answer beneath it.

One conversation, two surfaces, correct order, attribution intact.

Delivery rows for that run: the inbound turn is
`origin=provider, actor.kind=human, provider_delivery_complete`; the web turn is
`origin=application` carrying
`authoredBy={kind: application, surface: openbot, appUserId: dev-local-user}`,
with an allocated `next_turn_seq` slot and
`authored_echo_provider_message_id=1788187934.740279` — the Slack ts of the echo.

Higher-resolution renders, and the 3840×2072 source frames, are on the
[`evidence/bidirectional-turn`](https://github.com/jerelvelarde/openbot/tree/evidence/bidirectional-turn/evidence)
branch: [1080p MP4](https://raw.githubusercontent.com/jerelvelarde/openbot/evidence/bidirectional-turn/evidence/openbot-journey-1080p.mp4) ·
[4K MP4](https://raw.githubusercontent.com/jerelvelarde/openbot/evidence/bidirectional-turn/evidence/openbot-journey-4k.mp4).

## What this changes

Four optional fields and one options passthrough. Purely additive.

| | |
|---|---|
| `ChannelAuthoredActor` | New public type in `channels-ui`: `kind`, `surface`, `appUserId`, `displayName`. |
| `IncomingMessage.authoredBy?` | So a handler can render attribution. `ChannelMessage` extends it. |
| `IncomingTurn.authoredBy?` | The ingress-side field an adapter may set. |
| `PreparedChannelDelivery.turn.authoredBy?` | The managed wire field, validated at join. |
| `maxConcurrentDeliveries` / `maxPendingDeliveries` | Now reach the transport from `CopilotRuntime`. |

**No new method on `Channel`, no new lifecycle seam, no `channel.trigger()`.**

That is the main design decision and it is worth stating plainly. The obvious
shape for #6751 is a programmatic trigger API. I did not add one, because a web
turn does not need a second ingress path — it needs to *be* an ordinary inbound
delivery. Modelled that way it reuses the entire existing dedupe → prepare →
claim → admit → fence pipeline unchanged, and inherits per-conversation ordering
and idempotency for free. Anything the SDK invented here would be a second,
weaker copy of machinery Intelligence already has.

It also keeps the in-process `conversationTurnQueues` out of the picture. That
map is per-replica and could never satisfy "one ordered conversation" across a
fleet; the durable gate is `ConversationStore.admit` in the Gateway, keyed on
the canonical thread id, and a web turn contends on exactly that key.

### Attribution is unrepresentable-by-forgery, not merely validated

`authoredBy` is minted by Intelligence from the caller's verified session during
authenticated ingress. The SDK only forwards it. There is no field on any
ingress type by which an adapter, an agent, a tool result, or a delivery payload
can name an author — so an application cannot claim to be somebody else, and the
provider actor is left untouched on the turn. Attribution is additive; it never
launders a web message into "the Slack user said this".

At the join boundary the field is validated the same way as everything else that
crosses that wire (`hasExactFields` + regex-bounded ids, per
`delivery-transport.ts`): unknown keys are rejected rather than ignored, `kind`
is pinned to the single literal the SDK knows so a newer Gateway fails loudly
instead of being flattened, and `appUserId` is bounded by `isSafeAppUserId` so it
cannot carry a path or control characters into a handler that renders it.

### The capacity fix is not incidental

`defaultActivateChannel` never forwarded `maxConcurrentDeliveries` /
`maxPendingDeliveries`, though the launcher and transport have always accepted
them. Every Channel activated through `CopilotRuntime` therefore ran pinned at
the transport defaults of **8 concurrent / 32 pending**, regardless of host size.

Throughput per replica is about `maxConcurrentDeliveries / meanTurnSeconds`, so
at a 4 s mean turn one replica was capped near **2 turns/sec**. Reaching the
1000 concurrent-turns/sec the managed path is meant to serve would have needed
~500 replicas to work around a default. Unset still means the transport default,
so no existing deployment changes behaviour.

## Tests

New: `packages/channels-intelligence/src/delivery-authored-actor.test.ts` (9).

- an application-authored turn reaches the handler as attribution, with the
  provider actor preserved exactly;
- a provider-authored turn carries no author (absence is the signal, so it must
  be a real `undefined`);
- **6 join-boundary refusals** — unknown author class, unexpected extra field,
  missing display name, blank display name, unsafe `appUserId`, non-string
  surface;
- an application turn waits for the provider turn already running on its thread.

Plus 2 in `channel-activation-config.test.ts` for the capacity passthrough and
for omission staying omission.

**Every test was mutation-checked**, because a test that cannot fail is worse
than no test:

- Neutering `isPreparedAuthoredActor` → all 6 refusal cases fail (a `surface: 7`
  author reaches the handler).
- The ordering test needed two corrections before it was honest. It first passed
  with `maxConcurrentDeliveries: 1`, where the replica's own capacity ceiling did
  the ordering rather than the shared thread — so capacity now has headroom. It
  then still passed because the assertion ran before the async join resolved — so
  it now drains the queues to give the second turn a genuine opportunity to run
  before asserting it did not. With both fixed, removing the `threadTails`
  chaining in `delivery-transport.ts` fails it.

## Verification

Run in a clean worktree off `origin/main` (`4ccae6fe2`):

```
pnpm check-format                                  # clean
pnpm lint                                          # 0 errors
pnpm nx run-many -t check-types -p channels*,runtime   # clean
pnpm nx run-many -t test -p channels*,runtime      # 3123 passed
pnpm nx run-many -t build -p channels*,runtime     # clean
pnpm nx run-many -t publint,attw -p channels*      # clean
pnpm check:public-api-manifest                     # current
```

Commits: `c2edad3b276da9029fcd64f09681864709e00a4f`, `90dd8bdd5428763569c2cd8d05db993394b02e88`.

No changeset: Channels versioning is the `channels` scope in
`release.config.json` (`sharedVersion`, `versionSource @copilotkit/channels`).

## Known limitations

- **Inert alone.** Nothing here produces an `authoredBy`; the Gateway does.
- **Text turns only.** An interaction, reaction or welcome is by construction
  something that happened on the provider surface, so an author there would
  describe an event that did not occur.
- **No revocable conversation reference.** #6751 also asks for an opaque,
  persistable, revocable managed-conversation reference. That is entirely a
  Gateway concern — the SDK never sees it — so it lives in the paired PR.
- **Whether Slack renders the author as a distinct message author** (`username` /
  `icon_url` overrides) or as in-body text depends on the installed app's
  scopes. Open question on #6751; the SDK contract is unaffected either way.
- **Attribution is not authorization.** `appUserId` is an opaque tenant-scoped
  id, deliberately not resolvable via `Thread.lookupUser`.

## Links

- Contract issue: #6751
- Paired Gateway PR: CopilotKit/Intelligence#1064
- Consumer: https://github.com/jerelvelarde/openbot

## Update — rebased onto `main`, and the Intelligence half is live

Rebased onto `main` (`9909ca4`); the branch was merge-dirty against an import
list in `platform-adapter.ts` that `main` had also touched. Resolved by keeping
both imports. **The PR is now MERGEABLE.**

`main` has since added `ApplicationUser` to `channels-ui`, which is a different
thing and worth not confusing: `ApplicationUser` is the identity a Channel
developer selects for their own purposes and the platform never verifies.
`ChannelAuthoredActor` is chosen by the platform and cannot be set by the
developer, which is exactly why a handler may render it as attribution without
re-verifying anything. The doc comment now says so.

The paired Gateway half is CopilotKit/Intelligence#1064, which now mints these
authors server-side and delivers them. Verified against a live app-api, Realtime
Gateway and an OpenBot runtime built from **this** branch: a web-composed turn
was accepted, prepared with `authoredBy` in `prepared_input`, published as a
wake, claimed by the runtime, and reached the handler with the author intact.

That last part is why the ordering matters: an SDK on the published `0.9.0`
rejects `authoredBy` as an unexpected key in `assertPreparedDelivery`'s
exact-field check, so an application turn delivered to it fails the join rather
than reaching a handler. **This PR ships first.**

## Live run — what it does and does not prove

![Application-authored turn traversing a local Intelligence stack](https://raw.githubusercontent.com/jerelvelarde/openbot/pr-media/evidence/application-turn-live-run.png)

**This is not a bidirectional turn.** No Slack workspace was involved at any
point: the adapter is attached to a fabricated workspace (`T0LOCALDEV1`), the
conversation is a seeded row, and `cpki.channel_provider_messages` is empty
afterwards. Neither the attributed echo nor the agent's reply left the machine,
and the deliveries end `uncertain` rather than `complete`. Nothing was typed
into a composer either — the turn was posted to the same route the composer
calls.

What it does prove, against running services rather than tests — Intelligence
app-api, the Elixir Realtime Gateway, PostgreSQL, Redis, and an OpenBot runtime
on the control socket — is the part of this change that was pure design before:

- a conversation reports `readOnly: false` because Intelligence issued a
  reference for it, which no thread could reach before this branch;
- a web-authored turn is accepted and becomes an **ordinary inbound delivery** —
  `origin=application`, ordering slot 0, wake settled, echo claimed — in the same
  table and pipeline a Slack webhook uses;
- the server-minted `authoredBy` reaches `prepared_input`, which is where the
  SDK reads it;
- the Gateway invites the runtime, the runtime claims, and the agent runs;
- the Redis conversation owner carries `activeOrigin: application`, the gate that
  stops the two surfaces superseding each other.

The script is
[`evidence/live-run.sh`](https://github.com/jerelvelarde/openbot/blob/pr-media/evidence/live-run.sh).
An uncut Slack → web → Slack recording needs a real workspace bot token and is
still outstanding.

