### PR TITLE
fix(react-core): honor chatInputToolbarAddButtonLabel in the add menu tooltip

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatInput.tsx
@@ -1327,7 +1327,7 @@ export namespace CopilotChatInput {
           </TooltipTrigger>
           <TooltipContent side="bottom">
             <p className="cpk:flex cpk:items-center cpk:gap-1 cpk:text-xs cpk:font-medium">
-              <span>Add attachments</span>
+              <span>{labels.chatInputToolbarAddButtonLabel}</span>
               <code className="cpk:rounded cpk:bg-[#4a4a4a] cpk:px-1 cpk:py-[1px] cpk:font-mono cpk:text-[11px] cpk:text-white cpk:dark:bg-[#e0e0e0] cpk:dark:text-black">
                 /
               </code>

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatInput.test.tsx
@@ -786,6 +786,37 @@ describe("CopilotChatInput", () => {
     expect(handleCustom).toHaveBeenCalledTimes(1);
   });
 
+  it("uses the configured add button label for the add menu tooltip", async () => {
+    const { container } = render(
+      <CopilotChatConfigurationProvider
+        threadId={TEST_THREAD_ID}
+        labels={{ chatInputToolbarAddButtonLabel: "Upload attachment" }}
+      >
+        <CopilotChatInput
+          onAddFile={vi.fn()}
+          onSubmitMessage={mockOnSubmitMessage}
+        />
+      </CopilotChatConfigurationProvider>,
+    );
+
+    const addButton = getAddMenuButton(container);
+    expect(addButton).not.toBeNull();
+
+    // Radix tooltips are mocked to a passthrough in this suite (see
+    // src/v2/__tests__/setup.ts), so the content renders without hovering.
+    const tooltipContent = addButton
+      ?.closest('[data-slot="tooltip"]')
+      ?.querySelector('[data-slot="tooltip-content"]');
+    expect(tooltipContent).not.toBeNull();
+
+    expect(tooltipContent?.textContent).toContain("Upload attachment");
+    expect(tooltipContent?.textContent).not.toContain("Add attachments");
+    // The "/" shortcut hint is a key glyph, not prose, so it stays as-is.
+    expect(tooltipContent?.querySelector("code")?.textContent?.trim()).toBe(
+      "/",
+    );
+  });
+
   // Controlled component tests
   describe("Controlled component behavior", () => {
     it("displays the provided value prop", () => {


### PR DESCRIPTION
## Problem

The add-menu ("+") button in `CopilotChat` renders its tooltip from a hardcoded string, so `labels.chatInputToolbarAddButtonLabel` retitles the **menu item** but leaves the **tooltip** in English:

```tsx
<CopilotChat labels={{ chatInputToolbarAddButtonLabel: "上传附件" }} />
// menu item → "上传附件"   ✅
// tooltip   → "Add attachments /"  ❌
```

That blocks full localization of the chat UI unless you replace the entire add-button slot just to change one string.

`packages/react-core/src/v2/components/chat/CopilotChatInput.tsx:1330` (before):

```tsx
<span>Add attachments</span>
```

## Why this is a bug, not a design choice

Two independent signals say the hardcoded string was an oversight:

1. **Every other tooltip in the v2 chat surface is already label-driven** — `CopilotChatInput.tsx:1186` renders `<p>{labels[labelKey]}</p>`, and `CopilotChatUserMessage.tsx:303` / `CopilotChatAssistantMessage.tsx:255` both render `<p>{title}</p>`. The add-menu button was the only hardcoded tooltip in the package.
2. **Angular already does it the right way** — `packages/angular/src/lib/components/chat/copilot-chat-tools-menu.ts:183` derives the same tooltip from `chatInputToolbarAddButtonLabel`. React was the outlier.

## Change

One-line fix: the tooltip now reads the existing label.

```tsx
<span>{labels.chatInputToolbarAddButtonLabel}</span>
```

I deliberately **reused `chatInputToolbarAddButtonLabel`** rather than adding the `chatInputToolbarAddButtonTooltip` key the issue also floated:

- It matches what Angular already ships, so this closes a parity gap instead of opening a new one.
- A second key adds public API surface for a case nobody has actually hit (menu item and tooltip needing to differ). It can be added later as a non-breaking addition if a real need shows up.
- The default label is already `"Add attachments"` (`CopilotChatConfigurationProvider.tsx:22`), so **the rendered default text is unchanged** — no visual or snapshot regression.

The `/` shortcut glyph stays hardcoded: it is a key name, not prose.

## Out of scope (flagging, not fixing)

The React default for this label (`"Add attachments"`) differs from Vue's and Angular's (`"Add photos or files"` — `packages/vue/src/v2/providers/types.ts:6`, `packages/angular/src/lib/chat-config.ts:30`). That is a pre-existing cross-framework inconsistency; changing it here would silently alter someone's default string, so I left it alone. Vue's add button has no tooltip at all, so it needs no counterpart change.

## Testing

**1. New test fails without the fix (mutation-checked, not a self-fulfilling probe).**

Run against the unfixed source, the assertion catches the hardcoded string:

```
FAIL  src/v2/components/chat/__tests__/CopilotChatInput.test.tsx > CopilotChatInput
      > uses the configured add button label for the add menu tooltip
AssertionError: expected 'Add attachments/' to contain 'Upload attachment'

Expected: "Upload attachment"
Received: "Add attachments/"
```

Worth noting: my first draft of this test used `user.hover()` + `findByRole("tooltip")` and failed for the *wrong* reason (no tooltip ever rendered). This suite mocks `@radix-ui/react-tooltip` to a passthrough (`src/v2/__tests__/setup.ts:92`), so tooltip content renders eagerly and there is no real open/close or `role="tooltip"`. The committed test asserts on `[data-slot="tooltip-content"]` scoped to the add button's tooltip root, which is the convention this mock implies — and it demonstrably fails on unfixed code, as shown above.

**2. Target file green with the fix — 56/56.**

```
✓ src/v2/components/chat/__tests__/CopilotChatInput.test.tsx (56 tests) 1050ms

 Test Files  1 passed (1)
      Tests  56 passed (56)
```

**3. Full `@copilotkit/react-core` suite: no regressions.** Baseline at clean `HEAD` vs. this branch, same worktree, same command:

| | Tests | Passed | Failed |
|---|---|---|---|
| `HEAD` (unfixed) | 1514 | 1505 | 7 |
| This branch | 1515 | **1506** | 7 |

Exactly +1 test and +1 pass — my added test — with the identical 7 failures on both sides. Those 7 pre-existing failures are in `CopilotChatView.pinToSend.test.tsx`, `use-pin-to-send.test.tsx`, and three `src/v1-deprecated/hooks/__tests__/` files; none touch the add button or labels.

**4. Typecheck — zero errors in the touched files.**

`tsc --noEmit` reports 21 pre-existing errors in this worktree, all in the inspector/threads family (`use-inspector-thread-override.ts`, `inspector-thread-override.test.tsx`, `CopilotKitInspector.tsx`, `CopilotKitProvider.tsx`, `use-threads.tsx`, `CopilotChatMessageView.tsx`, `CopilotChat.tsx`). None in `CopilotChatInput.tsx` or its test:

```
$ tsc --noEmit 2>&1 | grep -c 'CopilotChatInput'
0
```

**5. Pre-commit hooks passed in full** (not bypassed — no `--no-verify`):

```
✔️ check-binaries (0.04 seconds)
✔️ lint-fix (2.16 seconds)
✔️ check-intelligence-env-names (7.97 seconds)
✔️ test-and-check-packages (52.53 seconds)
✔️ commitlint (0.61 seconds)
```

`test-and-check-packages` runs `nx run-many -t test,publint,attw` for the affected package, so react-core's `test`, `publint`, and `attw` all passed. Formatting applied with `oxfmt`.

Fixes #6750
