### PR TITLE
feat(angular): add registerComponent so a component can be a tool the agent calls (refs OSS-1034)

### DIFF
--- a/packages/angular/API.md
+++ b/packages/angular/API.md
@@ -179,6 +179,7 @@ Import these symbols from `@copilotkit/angular`.
 - `RENDER_A2UI_TOOL_NAME`
 - `ReadAloudButtonContext`
 - `RegenerateButtonContext`
+- `RegisterComponentConfig`
 - `RenderA2UIArgs`
 - `RenderA2UIArgsSchema`
 - `RenderActivityMessageConfig`
@@ -241,6 +242,7 @@ Import these symbols from `@copilotkit/angular`.
 - `provideCopilotKit`
 - `provideSlots`
 - `readA2UILifecycleContent`
+- `registerComponent`
 - `registerFrontendTool`
 - `registerHumanInTheLoop`
 - `registerRenderActivityMessage`

--- a/packages/angular/src/lib/copilotkit.spec.ts
+++ b/packages/angular/src/lib/copilotkit.spec.ts
@@ -219,6 +219,34 @@ describe("CopilotKit", () => {
     expect(handlerSpy).toHaveBeenCalledWith({ value: "ok" }, mockContext);
   });
 
+  it("adds a display-only client tool with no handler at all", () => {
+    TestBed.configureTestingModule({
+      providers: [provideCopilotKit({ licenseKey })],
+    });
+
+    const copilotKit = TestBed.inject(CopilotKit);
+    const injector = TestBed.inject(Injector);
+
+    copilotKit.addFrontendTool({
+      name: "display-only",
+      description: "Renders a card",
+      args: z.object({ value: z.string() }),
+      component: class {
+        toolCall = signal({} as any);
+      },
+      injector,
+    } as never);
+
+    // Core inserts an empty tool result for a tool that declares no handler, so a
+    // display-only registration must reach it with `handler` still absent. Binding
+    // a wrapper around `undefined` here would throw on the first tool call, and
+    // supplying a stub would write a fabricated result into the thread.
+    const tool = mockAddTool.mock.calls.at(-1)![0];
+    expect(tool.name).toBe("display-only");
+    expect(tool.handler).toBeUndefined();
+    expect(copilotKit.clientToolCallRenderConfigs()).toHaveLength(1);
+  });
+
   it("registers human-in-the-loop tools and delegates responses", async () => {
     const onResultSpy = vi
       .spyOn(HumanInTheLoop.prototype, "onResult")

--- a/packages/angular/src/lib/copilotkit.ts
+++ b/packages/angular/src/lib/copilotkit.ts
@@ -300,6 +300,14 @@ export class CopilotKit {
   ): FrontendTool {
     const { injector, handler, ...frontendCandidate } = clientToolWithInjector;
 
+    // A display-only registration declares no handler, and core has its own path
+    // for that: it inserts an empty tool result and completes the turn. Binding a
+    // wrapper here regardless would call `undefined` on the first tool call, and
+    // substituting a stub would put an invented result into the thread instead.
+    if (!handler) {
+      return frontendCandidate;
+    }
+
     return {
       ...frontendCandidate,
       handler: (args, context) =>

--- a/packages/angular/src/lib/directives/__tests__/copilotkit-frontend-tool.directive.spec.ts
+++ b/packages/angular/src/lib/directives/__tests__/copilotkit-frontend-tool.directive.spec.ts
@@ -2,6 +2,7 @@ import { Component, signal, Type } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  registerComponent,
   registerRenderToolCall,
   registerFrontendTool,
   registerHumanInTheLoop,
@@ -110,5 +111,96 @@ describe("tool registration helpers", () => {
       "approval",
       undefined,
     );
+  });
+  describe("registerComponent", () => {
+    it("registers a frontend tool that renders the component and runs nothing", () => {
+      @Component({ standalone: true, template: "" })
+      class HostComponent {
+        constructor() {
+          registerComponent({
+            name: "show_incident",
+            parameters: z.object({ id: z.string() }),
+            component: DummyToolComponent as Type<any>,
+          });
+        }
+      }
+
+      TestBed.createComponent(HostComponent);
+
+      const added = copilotKitStub.addFrontendTool.mock.calls.at(-1)![0];
+      expect(added.name).toBe("show_incident");
+      expect(added.component).toBe(DummyToolComponent);
+      // Display-only: the agent gets a tool it can call, and calling it runs no
+      // application code. A stub handler would put a fabricated result in the
+      // thread; core already inserts an empty tool result for a handler-less tool.
+      expect("handler" in added).toBe(false);
+    });
+
+    it("describes the tool to the model as a component to display", () => {
+      @Component({ standalone: true, template: "" })
+      class HostComponent {
+        constructor() {
+          registerComponent({
+            name: "show_incident",
+            description: "Shows one incident from the incident table.",
+            parameters: z.object({ id: z.string() }),
+            component: DummyToolComponent as Type<any>,
+          });
+        }
+      }
+
+      TestBed.createComponent(HostComponent);
+
+      const added = copilotKitStub.addFrontendTool.mock.calls.at(-1)![0];
+      // Same prefix react-core and vue build, so one agent prompt reads the same
+      // whichever frontend registered the component.
+      expect(added.description).toBe(
+        'Use this tool to display the "show_incident" component in the chat. This tool renders a visual UI component for the user.\n\nShows one incident from the incident table.',
+      );
+    });
+
+    it("carries the model-facing description with no caller description", () => {
+      @Component({ standalone: true, template: "" })
+      class HostComponent {
+        constructor() {
+          registerComponent({
+            name: "show_incident",
+            parameters: z.object({ id: z.string() }),
+            component: DummyToolComponent as Type<any>,
+          });
+        }
+      }
+
+      TestBed.createComponent(HostComponent);
+
+      const added = copilotKitStub.addFrontendTool.mock.calls.at(-1)![0];
+      expect(added.description).toBe(
+        'Use this tool to display the "show_incident" component in the chat. This tool renders a visual UI component for the user.',
+      );
+    });
+
+    it("scopes to an agent and removes that scoped tool on destroy", () => {
+      @Component({ standalone: true, template: "" })
+      class HostComponent {
+        constructor() {
+          registerComponent({
+            name: "show_incident",
+            parameters: z.object({ id: z.string() }),
+            component: DummyToolComponent as Type<any>,
+            agentId: "support-agent",
+          });
+        }
+      }
+
+      const fixture = TestBed.createComponent(HostComponent);
+      const added = copilotKitStub.addFrontendTool.mock.calls.at(-1)![0];
+      expect(added.agentId).toBe("support-agent");
+
+      fixture.destroy();
+      expect(copilotKitStub.removeTool).toHaveBeenCalledWith(
+        "show_incident",
+        "support-agent",
+      );
+    });
   });
 });

--- a/packages/angular/src/lib/tools.ts
+++ b/packages/angular/src/lib/tools.ts
@@ -87,12 +87,41 @@ export interface FrontendToolConfig<
   description: string;
   parameters: StandardSchemaV1<unknown, Args>;
   component?: Type<ToolRenderer<Args>>;
-  handler: (
+  /**
+   * Application code the agent runs by calling this tool.
+   *
+   * Optional, because a display-only registration has none: the agent calls the
+   * tool to show `component` and nothing else happens. Core inserts an empty tool
+   * result for a tool that declares no handler, so leaving this out completes the
+   * turn without writing an invented result into the thread. Prefer
+   * `registerComponent` for that case -- it is this shape with the model-facing
+   * description built for you.
+   */
+  handler?: (
     args: Args,
     context: FrontendToolHandlerContext,
   ) => Promise<unknown>;
   followUp?: boolean;
   agentId?: string;
+}
+
+/**
+ * A component the agent can render in chat, with no application code behind it.
+ *
+ * The Angular counterpart of react-core's and vue's `useComponent`. It carries no
+ * `handler` field at all rather than an optional one: a display-only component
+ * that quietly ran application code would be a different feature, and a caller
+ * who wants both wants `registerFrontendTool`.
+ */
+export interface RegisterComponentConfig<
+  Args extends Record<string, unknown> = Record<string, unknown>,
+> {
+  name: string;
+  description?: string;
+  parameters: StandardSchemaV1<unknown, Args>;
+  component: Type<ToolRenderer<Args>>;
+  agentId?: string;
+  followUp?: boolean;
 }
 
 export interface HumanInTheLoopConfig<
@@ -132,6 +161,52 @@ export function registerFrontendTool<
 
   destroyRef.onDestroy(() => {
     copilotKit.removeTool(frontendTool.name, frontendTool.agentId);
+  });
+}
+
+/**
+ * Registers an Angular component as a tool the agent can call to display it.
+ *
+ * The simplest generative-UI registration there is, and the only one that needs
+ * nothing on the agent side: the tool is declared by the frontend and forwarded to
+ * the agent over AG-UI, so it works the same behind a Python agent as a TypeScript
+ * one. Contrast `registerRenderToolCall`, which draws a tool the agent already
+ * has and therefore requires that tool to exist in the agent.
+ *
+ * The component is an ordinary `ToolRenderer`: it takes the required `toolCall`
+ * signal input and reads `toolCall().args`, exactly as it would under
+ * `registerFrontendTool` or `registerRenderToolCall`.
+ *
+ * Registration is removed when the calling injector is destroyed.
+ *
+ * @param config - Name, parameter schema, and component to render.
+ *
+ * @example
+ * ```ts
+ * registerComponent({
+ *   name: "show_incident",
+ *   description: "Show one incident from the incident table.",
+ *   parameters: z.object({ id: z.string(), severity: z.string() }),
+ *   component: IncidentCardComponent,
+ * });
+ * ```
+ */
+export function registerComponent<
+  Args extends Record<string, unknown> = Record<string, unknown>,
+>(config: RegisterComponentConfig<Args>): void {
+  // The same prefix react-core and vue build, so the tool reads identically to the
+  // model whichever frontend registered the component.
+  const prefix = `Use this tool to display the "${config.name}" component in the chat. This tool renders a visual UI component for the user.`;
+
+  registerFrontendTool<Args>({
+    name: config.name,
+    description: config.description
+      ? `${prefix}\n\n${config.description}`
+      : prefix,
+    parameters: config.parameters,
+    component: config.component,
+    agentId: config.agentId,
+    followUp: config.followUp,
   });
 }
 

--- a/showcase/shell-docs/src/content/docs/frontends/angular/guides/frontend-tools-generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/angular/guides/frontend-tools-generative-ui.mdx
@@ -9,6 +9,62 @@ Frontend tools let an agent call code inside the user's browser. Add a renderer
 to the same registration when the tool should show progress or a result in
 chat.
 
+## Let the agent display one of your components
+
+The simplest generative UI there is, and the only kind that needs nothing on the
+agent side. `registerComponent` registers a standalone component as a tool the
+agent can call to show it. The agent decides when, and fills the props.
+
+```ts title="src/app/incident-card.component.ts"
+import { Component, input } from "@angular/core";
+import { AngularToolCall, ToolRenderer } from "@copilotkit/angular";
+
+type IncidentArgs = { id: string; severity: string };
+
+@Component({
+  selector: "app-incident-card",
+  standalone: true,
+  template: `
+    @let call = toolCall();
+    @if (call.status === "in-progress") {
+      <p>Loading incident…</p>
+    } @else {
+      <article>
+        <strong>{{ call.args.id }}</strong>
+        <span>{{ call.args.severity }}</span>
+      </article>
+    }
+  `,
+})
+export class IncidentCardComponent implements ToolRenderer<IncidentArgs> {
+  readonly toolCall = input.required<AngularToolCall<IncidentArgs>>();
+}
+```
+
+```ts
+registerComponent({
+  name: "show_incident",
+  description: "Show one incident from the incident table.",
+  parameters: z.object({
+    id: z.string().describe("The incident id, such as INC-4711"),
+    severity: z.string().describe("One of sev1, sev2, sev3"),
+  }),
+  component: IncidentCardComponent,
+});
+```
+
+There is no `handler`, and nothing changes in your agent. The tool is declared by
+the frontend and forwarded over AG-UI, so this works the same behind a Python
+agent as a TypeScript one.
+
+<Callout type="warn" title="A well-formed component is not a correct one">
+  The model fills these props from what it knows. A card rendered over records
+  your application does not hold looks the same in the browser, in a screenshot,
+  and in a video as a correct one. Share the page's data with the agent using
+  [`CopilotKitAgentContext`](/reference/angular/directives/CopilotKitAgentContext),
+  then read the rendered fields against the records you hold.
+</Callout>
+
 ## Register a browser tool
 
 Call `registerFrontendTool` from an Angular injection context. The live
@@ -90,6 +146,7 @@ registerRenderToolCall({
 
 | Path | Best fit | Angular setup |
 | --- | --- | --- |
+| Your components, display only | The agent should show a component and nothing else runs | `registerComponent` |
 | Your components | Known data shapes and application actions | `registerFrontendTool` or `registerRenderToolCall` with a component |
 | A2UI | A server emits A2UI operations or snapshots | Runtime capability turns on the built-in renderer; an optional `a2ui` config supplies a catalog or theme |
 | Open Generative UI | The agent produces streamed HTML, CSS, and script expressions | Set `openGenerativeUI` in `provideCopilotKit` |
@@ -154,6 +211,7 @@ browser provider does not take a server URL.
 
 ## Next steps
 
+- [registerComponent API](/reference/angular/functions/registerComponent)
 - [registerFrontendTool API](/reference/angular/functions/registerFrontendTool)
 - [registerRenderToolCall API](/reference/angular/functions/registerRenderToolCall)
 - [Activity renderers](/reference/angular/functions/registerRenderActivityMessage)

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerComponent.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerComponent.mdx
@@ -1,0 +1,198 @@
+---
+title: "registerComponent"
+description: "Angular function for registering a standalone component the agent can call as a tool to display it in the chat, with no handler and nothing to add on the agent side"
+---
+
+## Overview
+
+`registerComponent` registers a standalone Angular component as a tool the agent can call to display it. When the agent calls the tool, CopilotKit renders your component in the chat with the tool call's arguments. There is no handler, no user interaction, and no server-side execution: the agent decides when to show the component and populates its data.
+
+This is the simplest form of generative UI, and the only one that needs nothing on the agent side. The tool is declared by the frontend and forwarded to the agent over AG-UI, so it behaves the same behind a Python agent as a TypeScript one. Contrast [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall), which draws a tool the agent already has and therefore requires that tool to exist in the agent.
+
+You call `registerComponent` inside an Angular injection context (a component or service constructor, or a field initializer). The registration happens immediately and is removed when the owning injector is destroyed.
+
+`registerComponent` is the Angular counterpart of `useComponent` in `@copilotkit/react-core/v2` and `@copilotkit/vue/v2`. It builds the same model-facing tool description, so the tool reads identically to the model whichever frontend registered the component.
+
+<Callout type="info">
+  Import from the package root, `@copilotkit/angular`. There is no `/v2`
+  subpath. `registerComponent` must run in an injection context that has
+  [`provideCopilotKit`](/reference/angular/functions/provideCopilotKit) in
+  scope.
+</Callout>
+
+## Signature
+
+```ts
+import { registerComponent } from "@copilotkit/angular";
+
+function registerComponent<Args extends Record<string, unknown>>(
+  config: RegisterComponentConfig<Args>,
+): void;
+```
+
+## Parameters
+
+<PropertyReference name="config" type="RegisterComponentConfig<Args>" required>
+  The component registration object.
+
+  <PropertyReference name="name" type="string" required>
+    The tool name the agent sees. Make it a verb the model will reach for when
+    the user asks for that visualization, such as `show_incident` or
+    `render_bar_chart`.
+  </PropertyReference>
+
+  <PropertyReference name="parameters" type="StandardSchemaV1<unknown, Args>" required>
+    A [Standard Schema](https://standardschema.dev) (for example a Zod object)
+    describing the arguments. It is advertised to the model as the tool's
+    parameters and types the `args` your component reads. Describe each field —
+    the model reads those descriptions when it fills the payload.
+  </PropertyReference>
+
+  <PropertyReference name="component" type="Type<ToolRenderer<Args>>" required>
+    The standalone Angular component class to render. CopilotKit instantiates it
+    and binds a `toolCall` signal input, exactly as it does for
+    [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall).
+  </PropertyReference>
+
+  <PropertyReference name="description" type="string">
+    What the component shows, for the model. CopilotKit prepends its own
+    sentence explaining that the tool renders a visual component, then appends
+    yours.
+  </PropertyReference>
+
+  <PropertyReference name="agentId" type="string">
+    Optional agent scope. When set, only the agent with this id is offered the
+    tool. When omitted, it applies across agents.
+  </PropertyReference>
+
+  <PropertyReference name="followUp" type="boolean">
+    Whether the agent takes another turn after the component renders. Leave it
+    unset for a component that ends the turn.
+  </PropertyReference>
+</PropertyReference>
+
+There is no `handler` field. A display-only component runs no application code, and CopilotKit completes the agent's turn with an empty tool result rather than an invented one. If you want to run browser code as well as render, use [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with both `handler` and `component`.
+
+## Return Value
+
+`registerComponent` returns `void`. It registers the tool and its renderer as a side effect, and removes both when the owning injector is destroyed.
+
+## The component
+
+Your `component` implements the `ToolRenderer<Args>` interface — the same contract every other Angular renderer uses. Declare the `toolCall` input with Angular's `input.required()` and read `toolCall().args`:
+
+```ts
+import { Signal } from "@angular/core";
+
+interface ToolRenderer<Args extends Record<string, unknown>> {
+  toolCall: Signal<AngularToolCall<Args>>;
+}
+```
+
+`toolCall()` is a discriminated union keyed on `status`. While the model is still streaming the payload the status is `in-progress` and `args` is `Partial<Args>`, so narrow on `status` before reading a field you require. See [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall#angulartoolcall) for the full union.
+
+## Usage
+
+### Display a card the agent fills in
+
+```ts title="src/app/incident-card.component.ts"
+import { Component, input } from "@angular/core";
+import { AngularToolCall, ToolRenderer } from "@copilotkit/angular";
+
+type IncidentArgs = { id: string; severity: string; summary: string };
+
+@Component({
+  selector: "app-incident-card",
+  standalone: true,
+  template: `
+    @let call = toolCall();
+    @if (call.status === "in-progress") {
+      <div class="text-sm opacity-70">Loading incident…</div>
+    } @else {
+      <article class="rounded-lg border p-4">
+        <header class="flex items-baseline justify-between">
+          <strong>{{ call.args.id }}</strong>
+          <span class="text-xs uppercase">{{ call.args.severity }}</span>
+        </header>
+        <p class="text-sm">{{ call.args.summary }}</p>
+      </article>
+    }
+  `,
+})
+export class IncidentCardComponent implements ToolRenderer<IncidentArgs> {
+  readonly toolCall = input.required<AngularToolCall<IncidentArgs>>();
+}
+```
+
+Register it once, anywhere under `provideCopilotKit`:
+
+```ts title="src/app/chat.component.ts"
+import { Component } from "@angular/core";
+import { z } from "zod";
+import { registerComponent } from "@copilotkit/angular";
+import { IncidentCardComponent } from "./incident-card.component";
+
+@Component({
+  selector: "app-chat",
+  standalone: true,
+  template: ``,
+})
+export class ChatComponent {
+  constructor() {
+    registerComponent({
+      name: "show_incident",
+      description: "Show one incident from the incident table.",
+      parameters: z.object({
+        id: z.string().describe("The incident id, such as INC-4711"),
+        severity: z.string().describe("One of sev1, sev2, sev3"),
+        summary: z.string().describe("One sentence on what happened"),
+      }),
+      component: IncidentCardComponent,
+    });
+  }
+}
+```
+
+Nothing is added to the agent. The tool reaches it in the run's tool list, and the agent calls it by name.
+
+### Scoping to one agent
+
+```ts
+registerComponent({
+  name: "show_incident",
+  parameters: incidentSchema,
+  component: IncidentCardComponent,
+  agentId: "support-agent",
+});
+```
+
+## Grounding the component in your own data
+
+A component that renders correctly over records your application does not hold looks identical to a correct one, in the browser and in a screenshot alike. The model fills these props from what it knows, so a component whose data never reached the agent is drawn from what the agent invented.
+
+Registering the component is the rendering half. Give the agent the data it should describe with [`CopilotKitAgentContext`](/reference/angular/directives/CopilotKitAgentContext) or [`connectAgentContext`](/reference/angular/functions/connectAgentContext), then check the rendered fields against the records your application holds.
+
+## Related
+
+<Cards>
+  <Card
+    title="registerFrontendTool"
+    description="Register a client-side tool with an async handler and an optional renderer component."
+    href="/reference/angular/functions/registerFrontendTool"
+  />
+  <Card
+    title="registerRenderToolCall"
+    description="Draw a tool the agent already has, with access to streaming arguments, status, and result."
+    href="/reference/angular/functions/registerRenderToolCall"
+  />
+  <Card
+    title="registerHumanInTheLoop"
+    description="Register a tool that pauses the agent and waits for the user to respond from a rendered component."
+    href="/reference/angular/functions/registerHumanInTheLoop"
+  />
+  <Card
+    title="CopilotKitAgentContext"
+    description="Share the data on the page with the agent, so a rendered component describes records you hold."
+    href="/reference/angular/directives/CopilotKitAgentContext"
+  />
+</Cards>

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
@@ -11,6 +11,8 @@ You call `registerFrontendTool` inside an Angular injection context (a component
 
 The handler runs inside the same injector that registered the tool, so it can call `inject()` to reach your other Angular services.
 
+If there is nothing to run in the browser and you only want the agent to display a component with the arguments it supplies, use [`registerComponent`](/reference/angular/functions/registerComponent) instead of a stub handler.
+
 <Callout type="info">
   Import from the package root, `@copilotkit/angular`. There is no `/v2`
   subpath. `registerFrontendTool` must run in an injection context that has
@@ -257,6 +259,11 @@ export class WeatherComponent {
 ## Related
 
 <Cards>
+  <Card
+    title="registerComponent"
+    description="Let the agent display one of your components, with no handler and nothing to add on the agent side."
+    href="/reference/angular/functions/registerComponent"
+  />
   <Card
     title="registerRenderToolCall"
     description="Register a renderer for a tool call (including server-side and agentic tools) with full access to status and results."

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerRenderToolCall.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerRenderToolCall.mdx
@@ -9,7 +9,7 @@ description: "Angular function for registering a renderer component for a tool c
 
 You call `registerRenderToolCall` inside an Angular injection context (a component or service constructor, or a field initializer). The renderer registers immediately. When the owning injector is destroyed, CopilotKit removes tool and renderer registrations with the same name and optional agent id.
 
-If you want to run a browser handler and render UI, use [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with its `component` field instead.
+If you want to run a browser handler and render UI, use [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool) with its `component` field instead. If the agent does not already have the tool and you only want it to display one of your components, use [`registerComponent`](/reference/angular/functions/registerComponent), which declares the tool from the frontend so nothing has to be added on the agent side.
 
 <Callout type="info">
   Import from the package root, `@copilotkit/angular`. There is no `/v2`
@@ -206,6 +206,11 @@ registerRenderToolCall({
 ## Related
 
 <Cards>
+  <Card
+    title="registerComponent"
+    description="Let the agent display one of your components, with no handler and nothing to add on the agent side."
+    href="/reference/angular/functions/registerComponent"
+  />
   <Card
     title="registerFrontendTool"
     description="Register a client-side tool with an async handler and an optional renderer component."

--- a/showcase/shell-docs/src/content/reference/angular/index.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/index.mdx
@@ -113,6 +113,8 @@ for the full setup, cleanup, error, SSR, hydration, and zoneless contract.
 
 <Callout type="info">
   Looking for tool rendering? Start with
+  [`registerComponent`](/reference/angular/functions/registerComponent) to let
+  the agent display one of your components,
   [`registerFrontendTool`](/reference/angular/functions/registerFrontendTool),
   [`registerRenderToolCall`](/reference/angular/functions/registerRenderToolCall),
   and

--- a/showcase/shell-docs/src/content/reference/angular/public-api.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/public-api.mdx
@@ -22,7 +22,7 @@ requires every export to appear exactly once in that inventory.
   `AgentStore`, `connectAgentContext`, `CopilotKitAgentContext`,
   `injectChatState`, `injectThreads`, `injectMemories`, and their stores,
   controllers, and types.
-- **Tools and activities:** `registerFrontendTool`, `registerRenderToolCall`,
+- **Tools and activities:** `registerComponent`, `registerFrontendTool`, `registerRenderToolCall`,
   `registerHumanInTheLoop`, `registerRenderActivityMessage`, `RenderToolCalls`,
   `CopilotDefaultToolRenderer`, schemas, configurations, renderer interfaces,
   and safe parsing/serialization utilities.


### PR DESCRIPTION
## Why

Angular had no counterpart to `useComponent` in `@copilotkit/react-core/v2` and `@copilotkit/vue/v2`. Letting an agent display one of your components meant either `registerFrontendTool` with a handler the component does not need, or `registerRenderToolCall`, which draws a tool the agent already has and therefore requires that tool to exist in the agent.

That gap is load-bearing for OSS-1034, which ends the default onboarding proof at a component rendered through the frontend's own registration. Every other supported frontend ships `useComponent`; Angular was the only one that could not express the shape.

## What changed

**`FrontendToolConfig.handler` is now optional**, and `CopilotKit.#bindClientTool` returns the config unwrapped when it is absent. This is the actual missing capability. Core already has the render-only path — a tool that declares no handler gets an empty tool result and the turn completes (`packages/core/src/core/run-handler.ts`, the `if (tool.handler)` guards around lines 854 and 1112). Angular bound a wrapper unconditionally:

\`\`\`ts
handler: (args, context) =>
  runInInjectionContext(injector, () => handler(args, context)),
\`\`\`

so a display-only tool called \`undefined\` on its first tool call. A stub handler is the wrong fix in the other direction: whatever it returns becomes the tool's result in the thread, which is a fabricated result rather than an absent one.

**`registerComponent`** is that shape with the model-facing description built for it — the same prefix react-core and vue build, so the tool reads identically to the model whichever frontend registered the component. It carries no `handler` field at all: a display-only component that quietly ran application code would be a different feature, and a caller who wants both wants `registerFrontendTool`.

The component stays an ordinary `ToolRenderer` with a required `toolCall` signal input reading `toolCall().args`. No new component contract, and it renders through the existing `pickToolCallHandler` → `NgComponentOutlet` path unchanged.

Because the tool is declared by the frontend and forwarded over AG-UI, a display-only component needs nothing added to the agent — on any framework, Python included.

\`\`\`ts
registerComponent({
  name: "show_incident",
  description: "Show one incident from the incident table.",
  parameters: z.object({ id: z.string(), severity: z.string() }),
  component: IncidentCardComponent,
});
\`\`\`

## Docs

- New `reference/angular/functions/registerComponent.mdx`, wired into the reference index callout and the `public-api.mdx` summary.
- A display-only section and a new path-table row in the Angular generative-UI guide.
- `packages/angular/API.md` — the `public-api-documentation.spec.ts` gate fails on any undocumented export, which is how the omission surfaced immediately.

The reference page also carries the grounding warning: the model fills these props from what it knows, so a component rendered over records the application does not hold looks identical to a correct one in a browser and in a screenshot.

## Testing

Five tests written before the implementation, confirmed red (`(0 , registerComponent) is not a function` ×4, plus the handler-less binding test) with the 14 pre-existing registration tests still passing, then green.

- `pnpm nx run @copilotkit/angular:test` — 49 files, 321 passed, 1 skipped.
- `pnpm nx build @copilotkit/angular` — passes, so widening `handler` to optional broke no caller.
- `showcase/shell-docs` — 66/68 files, 480 tests pass. The 2 failures are pre-existing on `main` and read files this branch does not touch (a shared inspector snippet, and mastra tool-rendering content).
- `pnpm run check-format` — the 22 reported files are all pre-existing; none is in this diff.

Refs OSS-1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)