### PR TITLE
docs(vue): document threads and the threads drawer for Vue

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/vue/guides/threads-and-drawer.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/vue/guides/threads-and-drawer.mdx
@@ -11,8 +11,8 @@ want a thread switcher beside the chat without wiring active-thread state
 yourself.
 
 Threads are persisted by [CopilotKit Intelligence](/premium/managed-intelligence-platform).
-Until a runtime is connected to Intelligence, the drawer renders its locked
-state rather than a thread list.
+The drawer reads the platform's `threads` license feature and renders its
+locked state instead of a thread list when that feature is unavailable.
 
 ## Resume a specific thread
 

--- a/showcase/shell-docs/src/content/docs/frontends/vue/guides/threads-and-drawer.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/vue/guides/threads-and-drawer.mdx
@@ -1,0 +1,96 @@
+---
+title: Threads and the threads drawer
+description: Persist Vue agent conversations and add a ready-made thread switcher with CopilotThreadsDrawer.
+icon: "lucide/Layers3"
+doc_type: how-to
+---
+
+`CopilotChat` covers the common conversation path. Use the thread APIs when you
+want conversations that survive a reload, and `CopilotThreadsDrawer` when you
+want a thread switcher beside the chat without wiring active-thread state
+yourself.
+
+Threads are persisted by [CopilotKit Intelligence](/premium/managed-intelligence-platform).
+Until a runtime is connected to Intelligence, the drawer renders its locked
+state rather than a thread list.
+
+## Resume a specific thread
+
+Pass `threadId` to connect the chat to an existing conversation:
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import { CopilotChat } from "@copilotkit/vue";
+
+const selectedThreadId = ref<string | undefined>(undefined);
+</script>
+
+<template>
+  <CopilotChat agentId="support" :threadId="selectedThreadId" />
+</template>
+```
+
+## Add the threads drawer
+
+`CopilotThreadsDrawer` lists, switches, starts, archives and deletes threads.
+Put the drawer and chat under the same `CopilotChatConfigurationProvider` so
+selection and new-thread actions update the chat:
+
+```vue
+<script setup lang="ts">
+import {
+  CopilotChat,
+  CopilotChatConfigurationProvider,
+  CopilotThreadsDrawer,
+} from "@copilotkit/vue";
+</script>
+
+<template>
+  <CopilotChatConfigurationProvider agentId="support">
+    <div class="flex">
+      <CopilotThreadsDrawer :limit="20" />
+      <CopilotChat />
+    </div>
+  </CopilotChatConfigurationProvider>
+</template>
+```
+
+### Options
+
+| Prop | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `agentId` | `string` | the default agent | Which agent's threads the drawer lists. |
+| `limit` | `number` | the element's own default | How many threads to list. |
+| `label` | `string` | the element's own default | Accessible label for the drawer. |
+| `recentLabel` | `string` | `"Recent Conversations"` | Heading above the thread list. |
+| `collapsible` | `boolean` | `true` | Whether the drawer offers a collapse toggle. |
+| `onThreadSelect` | `(threadId: string) => void` | — | Called when a thread is selected. |
+| `onNewThread` | `() => void` | — | Called when a new thread is started. |
+| `licenseUrl` | `string` | — | Where the locked state sends a developer without Intelligence. |
+| `onLicensed` | `() => void` | — | Called when the locked state's action is taken. |
+
+### Server-side rendering
+
+The drawer wraps a custom element, which needs a DOM. `@copilotkit/vue` imports
+that element lazily on mount, so importing the component is safe under Nuxt and
+other SSR setups; the drawer renders on the client.
+
+## Build your own thread UI
+
+`useThreads` exposes the same data and actions headlessly when you want your own
+interface:
+
+```vue
+<script setup lang="ts">
+import { useThreads } from "@copilotkit/vue";
+
+const { threads, isLoading } = useThreads({ agentId: "support" });
+</script>
+
+<template>
+  <ul v-if="!isLoading">
+    <li v-for="thread in threads" :key="thread.id">{{ thread.name ?? "Untitled conversation" }}</li>
+  </ul>
+</template>
+```


### PR DESCRIPTION
Vue ships CopilotThreadsDrawer and useThreads but no page documents them, so an integration guide that needs to name a Vue threads page has nothing to cite. Adds the guide, modelled on the Angular one.

Needed by CopilotKit/Intelligence OSS-1033, whose conversion leg cites this URL.

## Notes

Corrected against the source while writing this (`packages/vue/src/v2/components/chat/CopilotThreadsDrawer.vue`, `packages/vue/src/v2/hooks/use-threads.ts`):
- The "drawer + chat as bare siblings" example in the draft would not actually sync selection to the chat — `CopilotThreadsDrawer` only calls `config.value?.setActiveThreadId(...)` when a `CopilotChatConfigurationProvider` ancestor exists; a sibling `CopilotChat` provides its own config internally, which a sibling drawer can't see. Wrapped both in a shared `CopilotChatConfigurationProvider`, matching how the Angular guide documents the same pattern.
- `Thread.name` is `string | null`, not `title`; fixed the headless example to use `name` with a fallback for `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)