### PR TITLE
docs(vue): teach useComponent in the generative-UI guide (closes OSS-1037)

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx
@@ -24,7 +24,8 @@ not depend on the React packages.
 
 | Path | Best fit | Vue setup |
 | --- | --- | --- |
-| Your components | You know the tool and its result shape | `useRenderTool`, or `useFrontendTool` with a `render` |
+| A component the agent shows | You want the agent to display a component and nothing else runs | `useComponent` |
+| Your components | The agent already owns the tool and you draw its call | `useRenderTool`, or `useFrontendTool` with a `render` |
 | Default card | You want *something* better than raw JSON, with no per-tool work | `useDefaultRenderTool()` |
 | A2UI | The agent emits declarative A2UI operations | `:a2ui` on `CopilotKitProvider` |
 | Open Generative UI | The agent generates HTML/CSS to be sandboxed | `:open-generative-ui` on `CopilotKitProvider` |
@@ -33,6 +34,69 @@ not depend on the React packages.
 All of these require the composable or component to sit inside
 [`CopilotKitProvider`](/reference/vue/components/CopilotKitProvider). Import
 everything from the `/v2` subpath.
+
+## Let the agent display a component
+
+The shortest path, and the one that needs nothing on your agent.
+[`useComponent`](/reference/vue/hooks/useComponent) registers a Vue component as a tool the
+agent can call to show it. There is no handler and no user interaction: the agent decides
+when, and fills the props from the schema you declare.
+
+```vue title="src/IncidentCard.vue"
+<script setup lang="ts">
+defineProps<{ id: string; severity: string; summary: string }>();
+</script>
+
+<template>
+  <article class="incident-card">
+    <header>
+      <strong>{{ id }}</strong>
+      <span :data-severity="severity">{{ severity }}</span>
+    </header>
+    <p>{{ summary }}</p>
+  </article>
+</template>
+```
+
+```vue title="src/App.vue"
+<script setup lang="ts">
+import { z } from "zod";
+import { CopilotChat, CopilotKitProvider, useComponent } from "@copilotkit/vue/v2";
+import IncidentCard from "./IncidentCard.vue";
+
+useComponent({
+  name: "show_incident",
+  description: "Show one incident from the incident table.",
+  parameters: z.object({
+    id: z.string().describe("The incident id, such as INC-4711"),
+    severity: z.string().describe("One of sev1, sev2, sev3"),
+    summary: z.string().describe("One sentence on what happened"),
+  }),
+  render: IncidentCard,
+});
+</script>
+```
+
+The schema arrives at the component as its props, so the component stays an ordinary Vue
+component that knows nothing about CopilotKit. Nothing is added to the agent: the tool is
+declared here and forwarded over AG-UI, which is why this works the same behind a Python
+agent as a TypeScript one.
+
+<Callout type="info" title="`useComponent` or `useRenderTool`?">
+  Use `useComponent` when the component *is* the feature and the frontend declares the
+  tool. Use [`useRenderTool`](/reference/vue/hooks/useRenderTool) when your agent already
+  owns the tool and the browser only draws its call, which is the next section. The give-away
+  is where the tool lives: if removing the component would remove the tool from the agent's
+  list, it is a `useComponent`.
+</Callout>
+
+<Callout type="warn" title="A well-formed component is not a correct one">
+  The model fills these props from what it knows. A card rendered over records your
+  application does not hold looks the same in the browser, in a screenshot, and in a video as
+  a correct one. Share the page's data with the agent using
+  [`useAgentContext`](/reference/vue/hooks/useAgentContext), then read the rendered fields
+  against the records you actually hold.
+</Callout>
 
 ## Render a server-side tool call
 
@@ -288,6 +352,7 @@ A surface that silently falls back to text is the common failure. Two checks:
 
 ## Next steps
 
+- [`useComponent`](/reference/vue/hooks/useComponent) — a component the agent calls to display
 - [`useRenderTool`](/reference/vue/hooks/useRenderTool) — full render props and overloads
 - [`useDefaultRenderTool`](/reference/vue/hooks/useDefaultRenderTool) — the wildcard renderer
 - [`useFrontendTool`](/reference/vue/hooks/useFrontendTool) — browser-side tools

--- a/showcase/shell-docs/src/lib/__tests__/vue-generative-ui-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/vue-generative-ui-docs.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+import { loadDoc } from "../docs-render";
+import { renderPageToLlmText } from "../llm-text";
+
+const ROUTE = "frontends/vue/guides/generative-ui";
+
+function loadVueGenerativeUiDoc() {
+  const doc = loadDoc(ROUTE);
+  expect(doc, ROUTE).not.toBeNull();
+  return doc!;
+}
+
+// `@copilotkit/vue/v2` exports its own `useComponent` — a Vue-native composable, not the
+// React one — and it is the shortest path to the case this guide's "your components" row
+// covers: the agent decides when to show a component and nothing else runs. The guide
+// shipped naming only `useRenderTool` and `useFrontendTool`, both of which ask the reader
+// for more than the case needs, and it is the page a developer lands on after the
+// onboarding graph has already told them to reach for `useComponent` (OSS-1034).
+test("the Vue generative-UI guide teaches the useComponent composable", () => {
+  const doc = loadVueGenerativeUiDoc();
+  const source = readFileSync(doc.filePath, "utf8");
+  const llmText = renderPageToLlmText({
+    url: `vue/guides/generative-ui`,
+    title: doc.fm.title,
+    description: doc.fm.description,
+    filePath: doc.filePath,
+    loadSlug: ROUTE,
+  });
+
+  for (const output of [source, doc.source, llmText]) {
+    expect(output, "names the composable").toContain("useComponent");
+    expect(output, "imports it from the Vue package").toMatch(
+      /useComponent[^\n]*from "@copilotkit\/vue\/v2"|from "@copilotkit\/vue\/v2"[^\n]*useComponent/,
+    );
+    // The distinction is the whole point of having both. `useComponent` declares the tool
+    // from the frontend; `useRenderTool` draws a tool the agent already owns.
+    expect(output, "separates it from useRenderTool").toContain(
+      "already owns the tool",
+    );
+  }
+});
+
+// A reader choosing a path reads the table, not the body. Naming the composable only in
+// prose leaves the table recommending the longer route for the simpler job.
+test("the Vue path table offers useComponent for a display-only component", () => {
+  const source = readFileSync(loadVueGenerativeUiDoc().filePath, "utf8");
+  const tableRows = source
+    .split("\n")
+    .filter((line) => line.startsWith("| ") && line.includes("|"));
+
+  const displayOnlyRow = tableRows.find((row) => row.includes("useComponent"));
+  expect(displayOnlyRow, "a path-table row names useComponent").toBeDefined();
+});


### PR DESCRIPTION
## Correcting the ticket first

OSS-1037 was filed on a wrong diagnosis, mine. It said the Vue generative-UI guide was unreachable because of a routing defect. It is not:

```
docs.staging.copilotkit.ai/vue/guides/generative-ui.md   200
docs.copilotkit.ai/vue/guides/generative-ui.md           404
```

The page is merged, built, and live on staging. `showcase_promote.yml` is `workflow_dispatch` only — *"Humans trigger. No automatic prod promotes."* — so prod is simply behind. The same is true of `pydantic-ai/agent-app-context.md` (added 08-28, also 404 on prod, 200 on staging), while pages from 08-24 are live. Nothing about Vue is broken, and there is nothing here to "publish".

So this PR does the one thing that *was* actually wrong with the guide.

## What was wrong

`@copilotkit/vue/v2` exports its own `useComponent` — a Vue-native composable, not the React one — and the guide never named it. Not in the path table, not in the body, not in the closing reference list.

Its path table sent "your components" to `useRenderTool`, or `useFrontendTool` with a `render`. Both work, and both ask the reader for more than the display-only case needs: the agent shows a component and nothing else runs. It is also the case the onboarding graph now tells a Vue run to reach for, so a developer arriving at this guide afterwards would not find the hook they had just been told to use.

## What changed

- A path-table row for the case: **A component the agent shows** → `useComponent`. The existing row is re-scoped to what it is actually for — the agent already owns the tool and you draw its call.
- A **Let the agent display a component** section, placed before the server-side section because it is the shorter path. Vue SFC component plus registration, with the schema arriving as props.
- A callout answering the question a reader will have — `useComponent` or `useRenderTool`? The give-away is where the tool lives: if removing the component would remove the tool from the agent's list, it is a `useComponent`.
- The grounding warning. The model fills these props from what it knows, so a card rendered over records the application does not hold looks identical in a browser, a screenshot and a video to a correct one. Points at `useAgentContext`.
- `useComponent` added to **Next steps**.

Every URL the new section cites was probed and returns 200: `reference/vue/hooks/useComponent`, `reference/vue/hooks/useAgentContext`, `reference/vue/hooks/useRenderTool`.

## Testing

New `vue-generative-ui-docs.test.ts`, written first and confirmed red (`expected '---\ntitle: Generative UI in Vue…' to contain 'useComponent'`). It asserts against the raw source, the loaded doc, and the rendered llm-text, following `deepagents-interrupt-docs.test.ts`, and separately asserts that a **path-table row** names the composable — naming it only in prose would leave the table still recommending the longer route for the simpler job.

`showcase/shell-docs`: 68/70 files, 487 tests pass. The 2 failures are pre-existing on `main` and read files this branch does not touch — a shared inspector snippet that says "Playground", and mastra tool-rendering content.

Closes OSS-1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)