### PR TITLE
docs(showcase): state the frontend-tool requirement per framework (refs OSS-1036)

### DIFF
--- a/showcase/integrations/crewai-crews/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/crewai-crews/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,61 @@
+<Steps>
+  <Step>
+    ### Take the forwarded tools off the Flow's state
+
+    A Flow owns its own model call, so unlike a chat agent it has to hand the
+    forwarded tools to the model itself. Type the Flow on `CopilotKitState` and
+    read `state.copilotkit.actions` — that is where a component registered with
+    `useComponent` arrives.
+
+    ```python title="src/agents/chart_flow.py"
+    from crewai.flow.flow import Flow, start
+    from litellm import acompletion
+
+    from ag_ui_crewai import CopilotKitState, copilotkit_stream
+
+
+    class ChartFlow(Flow[CopilotKitState]):
+        @start()
+        async def chat(self) -> None:
+            actions = self.state.copilotkit.actions or None
+            response = await copilotkit_stream(
+                await acompletion(
+                    model="openai/gpt-4.1-mini",
+                    messages=[
+                        {"role": "system", "content": SYSTEM_PROMPT},
+                        *self.state.messages,
+                    ],
+                    tools=actions,
+                    parallel_tool_calls=False,
+                    stream=True,
+                )
+            )
+            self.state.messages.append(response.choices[0].message)
+    ```
+
+    Wrap the call in `copilotkit_stream` so the tool call reaches the browser as
+    it streams. A Flow that returns only when the model is finished renders
+    nothing until the turn ends.
+
+  </Step>
+  <Step>
+    ### Decide when the component is required
+
+    The Flow controls `tool_choice`, which is the lever a chat agent does not
+    have. Forcing the call on the user's turn and leaving it on `auto`
+    afterwards is what renders the component immediately and still lets the run
+    end: the follow-up turn is plain narration once the browser has returned the
+    result.
+
+    ```python title="src/agents/chart_flow.py"
+    on_user_turn = bool(
+        self.state.messages and self.state.messages[-1].get("role") == "user"
+    )
+    tool_choice = "required" if actions and on_user_turn else "auto"
+    ```
+
+    Leaving `tool_choice` on `auto` for every turn is the usual reason a Flow
+    answers in prose and the component never appears.
+
+  </Step>
+</Steps>

--- a/showcase/integrations/llamaindex/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/llamaindex/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,31 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    The AG-UI protocol forwards frontend tool definitions to the agent at
+    request time, so the backend agent declares no bespoke tools. The LLM sees
+    a component registered with `useComponent` through the AG-UI request payload
+    and picks it when the user asks for what it draws.
+
+    ```python title="src/agents/chart_agent.py"
+    from llama_index.llms.openai import OpenAI
+
+    llm = OpenAI(model="gpt-4.1-mini")
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    The tool arrives on every run, but a model with no instruction about it will
+    answer in prose instead of calling it. Name the tool in the system prompt.
+
+    ```python title="src/agents/chart_agent.py"
+    SYSTEM_PROMPT = """You are a data visualization assistant.
+
+    When the user asks for a chart, call `render_bar_chart` with a concise
+    title and a `data` array of `{label, value}` items."""
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/ms-agent-python/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/ms-agent-python/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,36 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    CopilotKit's runtime forwards frontend tool definitions to the agent at
+    request time, so the agent can call a component registered with
+    `useComponent` by name. There are no backend tools to declare.
+
+    ```python title="src/agents/chart_agent.py"
+    from agent_framework import Agent
+
+    agent = Agent(
+        chat_client=chat_client,
+        instructions=SYSTEM_PROMPT,
+    )
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    The agent's job here is to recognize the intent in the user's message and
+    emit a tool call with structured data. Say so in the instructions, or the
+    model will answer in prose and the component will never render.
+
+    ```python title="src/agents/chart_agent.py"
+    SYSTEM_PROMPT = """
+    You are a data visualization assistant.
+
+    When the user asks for a chart, call `render_bar_chart` with a concise
+    title and a `data` array of `{label, value}` items.
+    """
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/pydantic-ai/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/pydantic-ai/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,40 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    PydanticAI's AG-UI bridge surfaces frontend-registered tools to the model on
+    every run, so the agent declares no tools of its own. A component registered
+    with `useComponent` reaches the model through the AG-UI request payload and
+    the model calls it by name.
+
+    ```python title="src/agents/chart_agent.py"
+    from pydantic_ai import Agent
+    from pydantic_ai.models.openai import OpenAIResponsesModel
+
+    agent = Agent(
+        model=OpenAIResponsesModel("gpt-4.1-mini"),
+        system_prompt=SYSTEM_PROMPT,
+    )
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in the system prompt and say what it is for.
+
+    ```python title="src/agents/chart_agent.py"
+    SYSTEM_PROMPT = """
+    You are a data visualization assistant.
+
+    When the user asks for a chart, call `render_bar_chart` with a concise
+    title and a `data` array of `{label, value}` items.
+
+    Keep chat responses brief — let the chart do the talking.
+    """
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "vitest";
+
+import setupContentData from "@/data/setup-content.json";
+import { getIntegrations } from "../registry";
+import { resolveBundledSetupConcept } from "../setup-content";
+import type { SetupContentBundle } from "../setup-content";
+
+const setupContent = setupContentData as SetupContentBundle;
+const CONCEPT = "frontend-tools-setup";
+
+/**
+ * Frameworks whose `frontend-tools-setup` requirement has not been established yet.
+ *
+ * `generative-ui/tool-based` is the terminal page every onboarding run fetches
+ * (OSS-1034), and its `## How it works in code` section is this concept. Where the
+ * concept is unbundled the section renders nothing, and nothing distinguishes "this
+ * framework needs no agent-side wiring" from "it needs some and nobody wrote it down"
+ * (OSS-1036).
+ *
+ * Every name here is unfinished work, not an exemption on the merits. Establishing the
+ * answer means reading the framework's AG-UI adapter and its own `gen-ui-tool-based`
+ * demo agent, then writing the snippet — including when the snippet's content is
+ * "nothing is required", which is a real and common answer worth stating.
+ *
+ * Removing a name is the whole job. Adding one needs a reason in the pull request.
+ */
+const REQUIREMENT_NOT_ESTABLISHED = [
+  "ag2",
+  "agno",
+  "built-in-agent",
+  "deepagents",
+  "mastra",
+  "ms-agent-dotnet",
+  "ms-agent-harness-dotnet",
+  "strands",
+  "strands-typescript",
+] as const;
+
+function frameworksServingToolBased(): string[] {
+  return getIntegrations()
+    .filter((integration) => integration.docs_mode !== "hidden")
+    .map((integration) => integration.slug)
+    .sort();
+}
+
+test("every framework either documents its frontend-tool requirement or is a named gap", () => {
+  const missing = frameworksServingToolBased().filter(
+    (slug) =>
+      resolveBundledSetupConcept(slug, CONCEPT, setupContent) === null &&
+      !REQUIREMENT_NOT_ESTABLISHED.includes(
+        slug as (typeof REQUIREMENT_NOT_ESTABLISHED)[number],
+      ),
+  );
+
+  expect(
+    missing,
+    `these frameworks serve generative-ui/tool-based with no frontend-tools-setup snippet and are not on the known-gap list. Either write the snippet or add the slug to REQUIREMENT_NOT_ESTABLISHED with a reason`,
+  ).toEqual([]);
+});
+
+test("the known-gap list holds no framework that has since been documented", () => {
+  const documented = REQUIREMENT_NOT_ESTABLISHED.filter(
+    (slug) => resolveBundledSetupConcept(slug, CONCEPT, setupContent) !== null,
+  );
+
+  expect(
+    documented,
+    "these frameworks now bundle frontend-tools-setup, so remove them from REQUIREMENT_NOT_ESTABLISHED",
+  ).toEqual([]);
+});
+
+// The two shapes the bundled snippets have to keep apart. A framework whose adapter
+// forwards the tools on its own still needs the model told to call the component --
+// omitting that is why an agent answers in prose and the component never renders -- and a
+// framework that owns its model call has to hand the tools over itself.
+test("a snippet says what the framework's own demo agent proves about it", () => {
+  const forwardsAutomatically = [
+    "pydantic-ai",
+    "llamaindex",
+    "ms-agent-python",
+  ];
+  for (const slug of forwardsAutomatically) {
+    const source = resolveBundledSetupConcept(slug, CONCEPT, setupContent);
+    expect(source, slug).not.toBeNull();
+    expect(source, `${slug}: says there is nothing to wire`).toMatch(
+      /Nothing to wire on the agent/,
+    );
+    expect(source, `${slug}: still requires instructing the model`).toMatch(
+      /Tell the model when to call it/,
+    );
+  }
+
+  // A CrewAI Flow owns its own model call, so the tools do not reach the model unless the
+  // Flow passes them. `tool_choice` is the lever it has and a chat agent does not. Only
+  // `crewai-crews` is checked: `crewai-conversational-flows` is `docs_mode: hidden`, so a
+  // snippet written for it would never be served.
+  for (const slug of ["crewai-crews"]) {
+    const source = resolveBundledSetupConcept(slug, CONCEPT, setupContent);
+    expect(source, slug).not.toBeNull();
+    expect(source, `${slug}: reads the forwarded tools off state`).toContain(
+      "state.copilotkit.actions",
+    );
+    expect(source, `${slug}: hands them to the model`).toContain(
+      "tools=actions",
+    );
+    expect(
+      source,
+      `${slug}: streams so the call reaches the browser`,
+    ).toContain("copilotkit_stream");
+    expect(source, `${slug}: names the tool_choice lever`).toContain(
+      "tool_choice",
+    );
+  }
+});

--- a/showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts
@@ -83,3 +83,28 @@ test.each([
     );
   },
 );
+
+// A snippet that is not bundled and a bundled snippet that fails to compile both left
+// `FrameworkSetup` returning `null`, so a rendering defect shipped looking exactly like a
+// deliberate omission — the only trace a `console.error` nobody reads in production
+// (OSS-1036). Absence is a real state and stays quiet; a broken snippet is not.
+test("a concept nobody bundled for this framework renders nothing, quietly", async () => {
+  const result = await FrameworkSetup({
+    concept: "frontend-tools-setup",
+    currentFramework: "ag2",
+  });
+
+  expect(result).toBeNull();
+  expect(mocks.mdxRemote).not.toHaveBeenCalled();
+});
+
+test("a bundled snippet that fails to compile is loud, not null", async () => {
+  mocks.mdxRemote.mockRejectedValueOnce(new Error("Unexpected token"));
+
+  await expect(
+    FrameworkSetup({
+      concept: "frontend-tools-setup",
+      currentFramework: "google-adk",
+    }),
+  ).rejects.toThrow(/frontend-tools-setup.*google-adk/);
+});

--- a/showcase/shell-docs/src/lib/setup-concept.tsx
+++ b/showcase/shell-docs/src/lib/setup-concept.tsx
@@ -75,10 +75,15 @@ export async function FrameworkSetup({
       },
     });
   } catch (err) {
-    console.error(
-      `[framework-setup] failed to compile bundled concept "${concept}" for ${currentFramework}`,
-      err,
+    // A concept nobody bundled for this framework returns `null` above, which is a
+    // deliberate state. A concept that IS bundled and does not compile is a defect, and
+    // returning `null` here made the two indistinguishable: the page rendered as though
+    // the framework had no requirement, and the only trace was a `console.error` nobody
+    // reads in production (OSS-1036). Same shape `llm-text` already refuses for
+    // `channels-agent-setup`.
+    throw new Error(
+      `[framework-setup] bundled concept "${concept}" for ${currentFramework} failed to compile`,
+      { cause: err },
     );
-    return null;
   }
 }


### PR DESCRIPTION
## Why

OSS-1034 makes `/<framework>/generative-ui/tool-based.md` the terminal page every onboarding run fetches, on all 19 framework routes. That page's `## How it works in code` section is a bundled `frontend-tools-setup` concept, and only **5 of 19** frameworks shipped one.

Where the concept is unbundled, `FrameworkSetup` returns `null` and the section renders nothing. Absence encoded two different facts and nothing separated them:

- this framework needs no agent-side wiring, or
- it needs some and nobody wrote it down.

For the 5 that had a snippet, the requirement is substantial and load-bearing — ADK's `AGUIToolset()` in the `tools=` list, LangGraph's `CopilotKitMiddleware` / `CopilotKitStateAnnotation`, Claude SDK's Messages-API tool conversion. So "nobody wrote it down" was a live possibility for the other 14, not a theoretical one.

## Coverage: 6 → 10 of 19

Four frameworks whose own `gen-ui-tool-based` demo agent settles the question. I used the demo agents as the evidence rather than the docs, because the demos are the thing that actually runs.

**Nothing to wire** — `pydantic-ai`, `llamaindex`, `ms-agent-python`. Their demo agents declare no tools at all and say why in as many words:

> *"CopilotKit's runtime injects those tool definitions into the agent request at runtime, so the agent does not need to declare them locally — PydanticAI's AG-UI bridge surfaces frontend-registered tools to the model on each run."*
> — `showcase/integrations/pydantic-ai/src/agents/gen_ui_tool_based.py`

Their snippets say that, and then say the half that is easy to miss: **the tool arriving is not the same as the model calling it.** Every one of those demo agents carries a `SYSTEM_PROMPT` naming the tool. Omit it and the agent answers in prose while the component never renders — which looks like a broken integration and is not one.

**Real wiring** — `crewai-crews`. The opposite case, and the one the silence was hiding. A Flow owns its own model call, so the forwarded tools do not reach the model unless the Flow passes them: read `state.copilotkit.actions`, hand them over as `tools=`, wrap in `copilotkit_stream` so the call reaches the browser as it streams, and drive `tool_choice`. Its own demo comments on why:

> *"Force the chart on the user's turn. Once the browser has returned the render result the follow-up is plain narration, so leaving this on 'auto' is what ends the run."*

I did **not** write snippets for the nine I could not establish from source. Guessing "nothing is required" into the docs is worse than the silence it replaces.

## A compile failure is no longer silent

```ts
// before — both states returned null
if (source === null) return null;          // nobody bundled it: deliberate
} catch (err) { console.error(...); return null; }  // bundled and broken: a defect
```

A snippet that fails to compile shipped looking exactly like a framework with no requirement, and the only trace was a `console.error` nobody reads in production. Absence stays quiet; a broken snippet now throws. This is the shape `llm-text.ts` already refuses for `channels-agent-setup`.

## The remaining nine are named, not silent

`frontend-tools-setup-coverage.test.ts` holds `REQUIREMENT_NOT_ESTABLISHED` — `ag2`, `agno`, `built-in-agent`, `deepagents`, `mastra`, `ms-agent-dotnet`, `ms-agent-harness-dotnet`, `strands`, `strands-typescript`. Two tests bind it in both directions: a framework serving the page with no snippet and no listing fails, and a listed framework that has since been documented fails until its name is removed. So a new framework cannot join the gap quietly, and closing one is a deletion.

That test earned its keep immediately — it caught that I had written `aws-strands` (the docs folder) where the registry slug is `strands`.

A third test asserts the two snippet shapes stay distinguishable, so a future edit cannot quietly turn the CrewAI wiring into a "nothing required" note.

## Testing

- `setup-concept.test.ts` — 2 new tests, the compile-failure one confirmed red before the fix.
- `frontend-tools-setup-coverage.test.ts` — 3 new tests.
- `showcase/shell-docs`: 487 tests pass. The 2 failures are pre-existing on `main` and read files this branch does not touch.
- Formatting: my files pass `oxfmt`. The two `claude-sdk-*` snippets it also flags are pre-existing and untouched here.

## Not done

The nine frameworks above. Each needs its AG-UI adapter and demo agent read, then a snippet — including where the honest content is "nothing is required". Left on OSS-1036.

Refs OSS-1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)