### PR TITLE
feat(showcase): report docs content merged to main but not promoted (closes OSS-1038)

### DIFF
--- a/.github/workflows/showcase_docs_promote_drift.yml
+++ b/.github/workflows/showcase_docs_promote_drift.yml
@@ -25,6 +25,12 @@ name: "Showcase: Docs Promote Drift"
 # Triggers: PRs that touch the script or this workflow (so the gate is reviewed with its
 # own changes), a daily schedule (the actual point — catch a forgotten promote), and
 # manual dispatch.
+#
+# On a pull request it runs with --report-only. Prod's promote state has nothing to do with
+# an author's change, so failing their PR over it would produce a red check they cannot
+# clear — which gets overridden rather than acted on. The report still prints, and an
+# unreadable or unresolvable commit label still fails, because on a PR touching this script
+# that is the regression worth catching.
 
 on:
   pull_request:
@@ -72,9 +78,14 @@ jobs:
           node-version: 22.x
       - name: Report docs promote drift
         run: |
-          npx --yes tsx@4.21.0 showcase/scripts/check-docs-promote-drift.ts \
-            --host "${HOST}" \
-            --max-age-days "${MAX_AGE_DAYS}"
+          # An array rather than an unquoted expansion: the report-only flag is optional,
+          # and quoting an empty variable would pass an empty argument instead of none.
+          args=(--host "${HOST}" --max-age-days "${MAX_AGE_DAYS}")
+          if [ -n "${REPORT_ONLY}" ]; then
+            args+=("${REPORT_ONLY}")
+          fi
+          npx --yes tsx@4.21.0 showcase/scripts/check-docs-promote-drift.ts "${args[@]}"
         env:
           HOST: ${{ inputs.host || 'docs.copilotkit.ai' }}
           MAX_AGE_DAYS: ${{ inputs['max-age-days'] || '3' }}
+          REPORT_ONLY: ${{ github.event_name == 'pull_request' && '--report-only' || '' }}

--- a/.github/workflows/showcase_docs_promote_drift.yml
+++ b/.github/workflows/showcase_docs_promote_drift.yml
@@ -1,0 +1,80 @@
+name: "Showcase: Docs Promote Drift"
+
+# Reports docs content merged to `main` but not promoted to prod.
+#
+# `docs.copilotkit.ai` only moves when a human dispatches showcase_promote.yml
+# ("Humans trigger. No automatic prod promotes."). That gate is deliberate and this
+# workflow does not argue with it — it makes visible what the gate is holding.
+#
+# The failure it prevents: a merged page returns an honest 404 on prod, which nothing
+# distinguishes from a page that was never written. OSS-948 was filed as "written but
+# unpublished"; OSS-1005 was closed by a commit whose page was still not live four days
+# later; OSS-1037 was filed on the wrong diagnosis, reading a 404 as a routing defect and
+# proposing a fix for a route that was never broken. The onboarding graph hits it too — it
+# fetches docs.copilotkit.ai/*.md at run time and treats a failed fetch as an unsupported
+# path, so an un-promoted page fails a run for a gap that does not exist.
+#
+# Needs no secret. The shell renders its own build SHA into every page
+# (shell-docs-commit-label, see showcase/shell-docs/src/app/layout.tsx), so the deployed
+# commit is public and this works on fork PRs like any other check.
+#
+# Drift is the normal state between promotes, so the check reports it and only fails once
+# the oldest unpromoted page is past the age budget (3 days). A check that is always red
+# is a check nobody reads.
+#
+# Triggers: PRs that touch the script or this workflow (so the gate is reviewed with its
+# own changes), a daily schedule (the actual point — catch a forgotten promote), and
+# manual dispatch.
+
+on:
+  pull_request:
+    paths:
+      - "showcase/scripts/check-docs-promote-drift.ts"
+      - "showcase/scripts/check-docs-promote-drift.test.ts"
+      - ".github/workflows/showcase_docs_promote_drift.yml"
+  schedule:
+    # Daily at 09:37 UTC (offset from the other showcase crons to avoid pile-up).
+    - cron: "37 9 * * *"
+  workflow_dispatch:
+    inputs:
+      host:
+        description: "Docs host to read the deployed commit from."
+        required: false
+        default: "docs.copilotkit.ai"
+        type: string
+      max-age-days:
+        description: "Days of unpromoted content tolerated before failing."
+        required: false
+        default: "3"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check-drift:
+    name: Docs promote drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          # Full history: the deployed commit can be well behind `main`, and a shallow
+          # clone cannot resolve it. The script reports an unresolvable commit as its own
+          # failure rather than as zero drift, so a shallow clone would be loud — but it
+          # would also be useless.
+          fetch-depth: 0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+      - name: Report docs promote drift
+        run: |
+          npx --yes tsx@4.21.0 showcase/scripts/check-docs-promote-drift.ts \
+            --host "${HOST}" \
+            --max-age-days "${MAX_AGE_DAYS}"
+        env:
+          HOST: ${{ inputs.host || 'docs.copilotkit.ai' }}
+          MAX_AGE_DAYS: ${{ inputs['max-age-days'] || '3' }}

--- a/showcase/scripts/check-docs-promote-drift.test.ts
+++ b/showcase/scripts/check-docs-promote-drift.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyContentDrift,
+  parseDeployedCommit,
+  summarizeDocsDrift,
+} from "./check-docs-promote-drift";
+
+describe("parseDeployedCommit", () => {
+  it("reads the short SHA the shell already renders", () => {
+    const html = `<body><div aria-hidden="true" class="shell-docs-commit-label">54567d1</div></body>`;
+    expect(parseDeployedCommit(html)).toBe("54567d1");
+  });
+
+  it("reads it regardless of attribute order", () => {
+    const html = `<div class="shell-docs-commit-label" aria-hidden="true">d692f25</div>`;
+    expect(parseDeployedCommit(html)).toBe("d692f25");
+  });
+
+  // The shell distinguishes these three deliberately: `dev` means the build ARG was
+  // unset, `unknown` means it was an empty string (a Docker ARG scope bug). Neither is
+  // a commit, and treating either as one would resolve to nothing and report the whole
+  // content tree as drifted.
+  it.each(["dev", "unknown"])("refuses the %s placeholder", (label) => {
+    const html = `<div class="shell-docs-commit-label">${label}</div>`;
+    expect(parseDeployedCommit(html)).toBeNull();
+  });
+
+  it("returns null when the label is absent rather than guessing", () => {
+    expect(parseDeployedCommit("<body>no label here</body>")).toBeNull();
+  });
+});
+
+describe("classifyContentDrift", () => {
+  // An added page and a modified page are different findings. A reader hitting an added
+  // page gets a 404; a reader hitting a modified page gets stale content and no signal
+  // that anything is missing. Only the first is what OSS-1037 was misfiled about.
+  it("separates pages a reader cannot reach from pages that are merely stale", () => {
+    const nameStatus = [
+      "A\tshowcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx",
+      "M\tshowcase/shell-docs/src/content/docs/quickstart.mdx",
+      "A\tshowcase/shell-docs/src/content/docs/integrations/pydantic-ai/agent-app-context.mdx",
+      "D\tshowcase/shell-docs/src/content/docs/retired.mdx",
+    ].join("\n");
+
+    const drift = classifyContentDrift(nameStatus);
+
+    expect(drift.added).toEqual([
+      "showcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx",
+      "showcase/shell-docs/src/content/docs/integrations/pydantic-ai/agent-app-context.mdx",
+    ]);
+    expect(drift.modified).toEqual([
+      "showcase/shell-docs/src/content/docs/quickstart.mdx",
+    ]);
+    expect(drift.deleted).toEqual([
+      "showcase/shell-docs/src/content/docs/retired.mdx",
+    ]);
+  });
+
+  it("counts a rename as an added page, because its URL is new", () => {
+    const drift = classifyContentDrift(
+      "R096\tshowcase/shell-docs/src/content/docs/old.mdx\tshowcase/shell-docs/src/content/docs/new.mdx",
+    );
+
+    expect(drift.added).toEqual([
+      "showcase/shell-docs/src/content/docs/new.mdx",
+    ]);
+    expect(drift.deleted).toEqual([
+      "showcase/shell-docs/src/content/docs/old.mdx",
+    ]);
+  });
+
+  it("is empty for an empty diff", () => {
+    expect(classifyContentDrift("")).toEqual({
+      added: [],
+      modified: [],
+      deleted: [],
+    });
+  });
+});
+
+describe("summarizeDocsDrift", () => {
+  const base = {
+    host: "docs.copilotkit.ai",
+    deployedSha: "54567d1d12",
+    headSha: "80091aa96f",
+    maxAgeDays: 3,
+  };
+
+  it("passes when prod is serving the current content tree", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      drift: { added: [], modified: [], deleted: [] },
+      oldestUnpromotedAgeDays: null,
+    });
+
+    expect(summary.shouldFail).toBe(false);
+    const text = summary.lines.join("\n");
+    expect(text).toContain("no docs content is waiting");
+    // The check runs against staging too, so the report names the host it read rather
+    // than calling every host "prod".
+    expect(text).toContain("docs.copilotkit.ai");
+  });
+
+  it("names the host it actually read, not the production one", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      host: "docs.staging.copilotkit.ai",
+      drift: { added: [], modified: [], deleted: [] },
+      oldestUnpromotedAgeDays: null,
+    });
+
+    expect(summary.lines.join("\n")).toContain("docs.staging.copilotkit.ai");
+  });
+
+  // Drift is the normal state between promotes — the gate is manual on purpose. Reporting
+  // it is the point; failing on it the moment a PR merges would make the check noise, and
+  // a check that is always red is a check nobody reads.
+  it("reports fresh drift without failing", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      drift: {
+        added: ["showcase/shell-docs/src/content/docs/a.mdx"],
+        modified: [],
+        deleted: [],
+      },
+      oldestUnpromotedAgeDays: 1,
+    });
+
+    expect(summary.shouldFail).toBe(false);
+    const text = summary.lines.join("\n");
+    expect(text).toContain("1 page");
+    expect(text).toContain("showcase/shell-docs/src/content/docs/a.mdx");
+  });
+
+  it("fails once the oldest unpromoted page is older than the budget", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      drift: {
+        added: ["showcase/shell-docs/src/content/docs/a.mdx"],
+        modified: ["showcase/shell-docs/src/content/docs/b.mdx"],
+        deleted: [],
+      },
+      oldestUnpromotedAgeDays: 4,
+    });
+
+    expect(summary.shouldFail).toBe(true);
+    const text = summary.lines.join("\n");
+    // Both halves in one sentence: an age alone is ambiguous against its own budget.
+    expect(text).toContain("4+ days");
+    expect(text).toContain("3-day budget");
+    expect(text).toContain("shell-docs");
+  });
+
+  // Staleness alone is not reader-visible: a modified page still resolves. An added page
+  // past the budget is someone getting a 404 on documentation that exists, so the two are
+  // reported with different words even at the same age.
+  it("names the reader-visible consequence when an added page is overdue", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      drift: {
+        added: ["showcase/shell-docs/src/content/docs/a.mdx"],
+        modified: [],
+        deleted: [],
+      },
+      oldestUnpromotedAgeDays: 9,
+    });
+
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toContain("404");
+  });
+
+  it("reports an unreadable label as its own failure, not as zero drift", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      deployedSha: null,
+      drift: { added: [], modified: [], deleted: [] },
+      oldestUnpromotedAgeDays: null,
+    });
+
+    expect(summary.shouldFail).toBe(true);
+    const text = summary.lines.join("\n");
+    expect(text).toContain("could not read");
+    // An absent label must never read as "prod is current".
+    expect(text).not.toContain("no docs content is waiting");
+  });
+
+  it("reports a label that does not resolve in this checkout", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      deployedSha: "54567d1",
+      resolved: false,
+      drift: { added: [], modified: [], deleted: [] },
+      oldestUnpromotedAgeDays: null,
+    });
+
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toContain("does not resolve");
+  });
+});

--- a/showcase/scripts/check-docs-promote-drift.test.ts
+++ b/showcase/scripts/check-docs-promote-drift.test.ts
@@ -170,6 +170,56 @@ describe("summarizeDocsDrift", () => {
     expect(summary.lines.join("\n")).toContain("404");
   });
 
+  // On a pull request the budget is not the author's to satisfy: prod's promote state has
+  // nothing to do with their change, and a red check they cannot clear is a check that
+  // gets ignored or overridden. Report-only keeps the report and drops the enforcement.
+  it("reports overdue drift without failing when enforcement is off", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      reportOnly: true,
+      drift: {
+        added: ["showcase/shell-docs/src/content/docs/a.mdx"],
+        modified: [],
+        deleted: [],
+      },
+      oldestUnpromotedAgeDays: 9,
+    });
+
+    expect(summary.shouldFail).toBe(false);
+    const text = summary.lines.join("\n");
+    expect(text).toContain("9+ days");
+    expect(text).toContain("not enforced here");
+  });
+
+  // Report-only drops the budget, not the sanity checks. An unreadable label on a PR that
+  // touches the parser is exactly the regression this check exists to catch.
+  it("still fails on an unreadable label even when enforcement is off", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      reportOnly: true,
+      deployedSha: null,
+      drift: { added: [], modified: [], deleted: [] },
+      oldestUnpromotedAgeDays: null,
+    });
+
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toContain("could not read");
+  });
+
+  it("still fails on an unresolvable commit even when enforcement is off", () => {
+    const summary = summarizeDocsDrift({
+      ...base,
+      reportOnly: true,
+      deployedSha: "54567d1",
+      resolved: false,
+      drift: { added: [], modified: [], deleted: [] },
+      oldestUnpromotedAgeDays: null,
+    });
+
+    expect(summary.shouldFail).toBe(true);
+    expect(summary.lines.join("\n")).toContain("does not resolve");
+  });
+
   it("reports an unreadable label as its own failure, not as zero drift", () => {
     const summary = summarizeDocsDrift({
       ...base,

--- a/showcase/scripts/check-docs-promote-drift.ts
+++ b/showcase/scripts/check-docs-promote-drift.ts
@@ -1,0 +1,369 @@
+#!/usr/bin/env npx tsx
+/**
+ * check-docs-promote-drift.ts — reports docs content merged to main but not promoted.
+ *
+ * `docs.copilotkit.ai` only changes when a human dispatches `showcase_promote.yml`
+ * ("Humans trigger. No automatic prod promotes."). That is a deliberate release gate,
+ * and this gate does not argue with it. What was missing is any way to see what the
+ * gate is currently holding.
+ *
+ * The consequence is not cosmetic. A merged page returns an honest 404 on prod, which
+ * is indistinguishable from a page that was never written:
+ *
+ *   - OSS-948  — "Angular's Inspector fix is written but unpublished".
+ *   - OSS-1005 — closed by a commit whose page was still not live four days later.
+ *   - OSS-1037 — filed on the wrong diagnosis. A 404 was read as a routing defect and
+ *                a fix was proposed for a route that was never broken.
+ *
+ * It reaches the onboarding graph too: the graph fetches `docs.copilotkit.ai/*.md` at
+ * run time and reads a failed fetch as "documentation does not support the selection",
+ * routing to `unsupported/no-validated-path`. An un-promoted page therefore fails a run
+ * for a documentation gap that does not exist.
+ *
+ * No secret is needed. The shell already renders its own build SHA into every page
+ * (`shell-docs-commit-label`, see showcase/shell-docs/src/app/layout.tsx), so the
+ * deployed commit is public. This reads it, resolves it in the checkout, and diffs the
+ * docs content tree against HEAD.
+ *
+ * Usage:
+ *   npx tsx showcase/scripts/check-docs-promote-drift.ts
+ *   npx tsx showcase/scripts/check-docs-promote-drift.ts --host docs.staging.copilotkit.ai
+ *   npx tsx showcase/scripts/check-docs-promote-drift.ts --max-age-days 5
+ *   npx tsx showcase/scripts/check-docs-promote-drift.ts --json
+ *
+ * Exit: 0 when prod is current, or when the drift is younger than the age budget.
+ *       1 when the oldest unpromoted page is past the budget, or when the deployed
+ *       commit cannot be read or resolved — an unreadable label must never be
+ *       reported as "prod is current".
+ */
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/** Content the docs site serves. A change under here is reader-visible once promoted. */
+export const DOCS_CONTENT_PATH = "showcase/shell-docs/src/content";
+
+const DEFAULT_HOST = "docs.copilotkit.ai";
+
+/**
+ * Days of unpromoted content treated as normal pipeline latency.
+ *
+ * Drift is the expected state between promotes, so failing the moment a PR merges would
+ * make this check noise, and a check that is always red is a check nobody reads. Past
+ * this, the promote was forgotten rather than pending.
+ */
+const DEFAULT_MAX_AGE_DAYS = 3;
+
+/** Labels the shell renders when it has no commit to report. Neither is a SHA. */
+const NON_COMMIT_LABELS = new Set(["dev", "unknown"]);
+
+export interface ContentDrift {
+  /** Pages that do not exist on prod at all. A reader gets a 404. */
+  readonly added: string[];
+  /** Pages that exist on prod with older content, and give no sign of it. */
+  readonly modified: string[];
+  /** Pages prod still serves that main has removed. */
+  readonly deleted: string[];
+}
+
+export interface DocsDriftSummary {
+  readonly shouldFail: boolean;
+  readonly lines: string[];
+}
+
+export interface SummarizeDocsDriftInput {
+  /** The host the label was read from. Named in the report: this also runs on staging. */
+  readonly host: string;
+  /** Short or full SHA read from the deployed page, or null when unreadable. */
+  readonly deployedSha: string | null;
+  readonly headSha: string;
+  readonly drift: ContentDrift;
+  /** Age of the oldest commit carrying unpromoted content, or null when there is none. */
+  readonly oldestUnpromotedAgeDays: number | null;
+  readonly maxAgeDays: number;
+  /** False when the deployed SHA does not resolve in this checkout. Defaults to true. */
+  readonly resolved?: boolean;
+}
+
+/**
+ * Reads the deployed commit out of a rendered page.
+ *
+ * @param html - The page body.
+ * @returns The short SHA, or null when the page carries no commit.
+ */
+export function parseDeployedCommit(html: string): string | null {
+  const match =
+    /<div[^>]*class="[^"]*\bshell-docs-commit-label\b[^"]*"[^>]*>\s*([^<\s]+)\s*</.exec(
+      html,
+    );
+  const label = match?.[1];
+  if (!label) return null;
+  // `dev` (ARG unset) and `unknown` (ARG empty) are the shell's own words for "no
+  // commit". Resolving either would find nothing and report the whole tree as drifted.
+  if (NON_COMMIT_LABELS.has(label)) return null;
+  return /^[0-9a-f]{7,40}$/.test(label) ? label : null;
+}
+
+/**
+ * Splits a `git diff --name-status` block into the three reader-visible outcomes.
+ *
+ * @param nameStatus - Raw `--name-status` output, one record per line.
+ * @returns Paths grouped by what a reader would experience before the promote.
+ */
+export function classifyContentDrift(nameStatus: string): ContentDrift {
+  const added: string[] = [];
+  const modified: string[] = [];
+  const deleted: string[] = [];
+
+  for (const line of nameStatus.split("\n")) {
+    if (!line.trim()) continue;
+    const [status, ...paths] = line.split("\t");
+    if (!status || paths.length === 0) continue;
+
+    if (status.startsWith("R") && paths.length >= 2) {
+      // A rename is two findings at once: the new URL 404s and the old one still
+      // resolves. Counting it as a modification would hide both.
+      deleted.push(paths[0]!);
+      added.push(paths[1]!);
+      continue;
+    }
+
+    const path = paths[paths.length - 1]!;
+    if (status.startsWith("A")) added.push(path);
+    else if (status.startsWith("D")) deleted.push(path);
+    else modified.push(path);
+  }
+
+  return { added, modified, deleted };
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** Renders at most `limit` paths, then says how many were withheld. */
+function listPaths(paths: string[], limit = 20): string[] {
+  const shown = paths.slice(0, limit).map((path) => `    ${path}`);
+  if (paths.length > limit) {
+    shown.push(`    … and ${paths.length - limit} more`);
+  }
+  return shown;
+}
+
+/**
+ * Turns a measured drift into a verdict and the lines a human reads.
+ *
+ * @param input - The deployed commit, the diff against HEAD, and the age budget.
+ * @returns Whether to fail, and the report.
+ */
+export function summarizeDocsDrift(
+  input: SummarizeDocsDriftInput,
+): DocsDriftSummary {
+  const {
+    host,
+    deployedSha,
+    headSha,
+    drift,
+    oldestUnpromotedAgeDays,
+    maxAgeDays,
+  } = input;
+  const resolved = input.resolved ?? true;
+  const lines: string[] = [];
+
+  if (deployedSha === null) {
+    return {
+      shouldFail: true,
+      lines: [
+        `✗ could not read the deployed commit from ${host}.`,
+        "  Every page renders it in `.shell-docs-commit-label` (see shell-docs/src/app/layout.tsx).",
+        "  A `dev` or `unknown` label means the build ARG was unset or empty — fix the",
+        "  Dockerfile ARG scope rather than treating prod as current.",
+      ],
+    };
+  }
+
+  if (!resolved) {
+    return {
+      shouldFail: true,
+      lines: [
+        `✗ the deployed commit ${deployedSha} on ${host} does not resolve in this checkout.`,
+        "  Fetch full history (`fetch-depth: 0`) — a shallow clone cannot reach an older",
+        "  build. If it resolves nowhere, prod is serving a commit that left main.",
+      ],
+    };
+  }
+
+  const total =
+    drift.added.length + drift.modified.length + drift.deleted.length;
+  if (total === 0) {
+    return {
+      shouldFail: false,
+      lines: [
+        `✓ ${host} is serving ${deployedSha.slice(0, 7)} and no docs content is waiting to be promoted.`,
+      ],
+    };
+  }
+
+  const age = oldestUnpromotedAgeDays;
+  const overdue = age !== null && age > maxAgeDays;
+
+  lines.push(
+    overdue
+      ? `✗ docs content has been waiting ${Math.floor(age)}+ days to be promoted, past the ${maxAgeDays}-day budget.`
+      : `• docs content is waiting to be promoted, within the ${maxAgeDays}-day budget.`,
+  );
+  lines.push(
+    `  ${host} ${deployedSha.slice(0, 7)} → main ${headSha.slice(0, 7)}: ${plural(total, "page")} differ under ${DOCS_CONTENT_PATH}.`,
+  );
+
+  if (drift.added.length > 0) {
+    lines.push(
+      overdue
+        ? `  ${plural(drift.added.length, "page")} merged and still returning 404:`
+        : `  ${plural(drift.added.length, "page")} not live yet:`,
+    );
+    lines.push(...listPaths(drift.added));
+  }
+  if (drift.modified.length > 0) {
+    lines.push(
+      `  ${plural(drift.modified.length, "page")} serving older content:`,
+    );
+    lines.push(...listPaths(drift.modified));
+  }
+  if (drift.deleted.length > 0) {
+    lines.push(
+      `  ${plural(drift.deleted.length, "page")} removed from main but still served:`,
+    );
+    lines.push(...listPaths(drift.deleted));
+  }
+
+  if (overdue) {
+    lines.push(
+      "  Promote shell-docs: run the `Showcase: Promote (staging → prod)` workflow",
+      "  with service `shell-docs`. Prod does not move on its own.",
+    );
+  }
+
+  return { shouldFail: overdue, lines };
+}
+
+/** Runs git in the repository and returns trimmed stdout. */
+function git(args: string[]): string {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function readArg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+async function main(): Promise<void> {
+  const host = readArg("host") ?? DEFAULT_HOST;
+  const maxAgeDays = Number(readArg("max-age-days") ?? DEFAULT_MAX_AGE_DAYS);
+  const asJson = process.argv.includes("--json");
+
+  const response = await fetch(`https://${host}/`, {
+    headers: { "user-agent": "check-docs-promote-drift" },
+  });
+  if (!response.ok) {
+    console.error(`✗ ${host} answered ${response.status}`);
+    process.exit(1);
+  }
+
+  const deployedSha = parseDeployedCommit(await response.text());
+  const headSha = git(["rev-parse", "HEAD"]);
+
+  let resolved = false;
+  let drift: ContentDrift = { added: [], modified: [], deleted: [] };
+  let oldestUnpromotedAgeDays: number | null = null;
+
+  if (deployedSha !== null) {
+    try {
+      git(["cat-file", "-e", `${deployedSha}^{commit}`]);
+      resolved = true;
+    } catch {
+      resolved = false;
+    }
+  }
+
+  if (deployedSha !== null && resolved) {
+    drift = classifyContentDrift(
+      git([
+        "diff",
+        "--name-status",
+        "-M",
+        `${deployedSha}..HEAD`,
+        "--",
+        DOCS_CONTENT_PATH,
+      ]),
+    );
+
+    // Age comes from the oldest unpromoted commit that touched content, not from the
+    // deployed commit's own date: a promote can be old while the content it is missing
+    // is new, and the second is what a reader is waiting on.
+    const oldest = git([
+      "log",
+      "--reverse",
+      "--format=%cI",
+      `${deployedSha}..HEAD`,
+      "--",
+      DOCS_CONTENT_PATH,
+    ])
+      .split("\n")
+      .find((line) => line.trim().length > 0);
+    if (oldest) {
+      oldestUnpromotedAgeDays =
+        (Date.now() - new Date(oldest).getTime()) / 86_400_000;
+    }
+  }
+
+  const summary = summarizeDocsDrift({
+    host,
+    deployedSha,
+    headSha,
+    drift,
+    oldestUnpromotedAgeDays,
+    maxAgeDays,
+    resolved,
+  });
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          host,
+          deployedSha,
+          headSha,
+          resolved,
+          drift,
+          oldestUnpromotedAgeDays,
+          maxAgeDays,
+          shouldFail: summary.shouldFail,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    for (const line of summary.lines) {
+      (summary.shouldFail ? console.error : console.log)(line);
+    }
+  }
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `### Docs promote drift (${host})\n\n\`\`\`\n${summary.lines.join("\n")}\n\`\`\`\n`,
+    );
+  }
+
+  process.exit(summary.shouldFail ? 1 : 0);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/showcase/scripts/check-docs-promote-drift.ts
+++ b/showcase/scripts/check-docs-promote-drift.ts
@@ -30,6 +30,7 @@
  *   npx tsx showcase/scripts/check-docs-promote-drift.ts --host docs.staging.copilotkit.ai
  *   npx tsx showcase/scripts/check-docs-promote-drift.ts --max-age-days 5
  *   npx tsx showcase/scripts/check-docs-promote-drift.ts --json
+ *   npx tsx showcase/scripts/check-docs-promote-drift.ts --report-only
  *
  * Exit: 0 when prod is current, or when the drift is younger than the age budget.
  *       1 when the oldest unpromoted page is past the budget, or when the deployed
@@ -83,6 +84,15 @@ export interface SummarizeDocsDriftInput {
   readonly maxAgeDays: number;
   /** False when the deployed SHA does not resolve in this checkout. Defaults to true. */
   readonly resolved?: boolean;
+  /**
+   * Report the drift without enforcing the age budget.
+   *
+   * Set on pull requests. Prod's promote state has nothing to do with an author's change,
+   * so a red check they cannot clear would be ignored or overridden rather than acted on.
+   * It drops the budget only: an unreadable or unresolvable commit still fails, because on
+   * a PR touching this script that is the regression the check exists to catch.
+   */
+  readonly reportOnly?: boolean;
 }
 
 /**
@@ -206,10 +216,13 @@ export function summarizeDocsDrift(
 
   const age = oldestUnpromotedAgeDays;
   const overdue = age !== null && age > maxAgeDays;
+  const reportOnly = input.reportOnly ?? false;
 
   lines.push(
     overdue
-      ? `✗ docs content has been waiting ${Math.floor(age)}+ days to be promoted, past the ${maxAgeDays}-day budget.`
+      ? reportOnly
+        ? `• docs content has been waiting ${Math.floor(age)}+ days to be promoted, past the ${maxAgeDays}-day budget (not enforced here).`
+        : `✗ docs content has been waiting ${Math.floor(age)}+ days to be promoted, past the ${maxAgeDays}-day budget.`
       : `• docs content is waiting to be promoted, within the ${maxAgeDays}-day budget.`,
   );
   lines.push(
@@ -244,7 +257,7 @@ export function summarizeDocsDrift(
     );
   }
 
-  return { shouldFail: overdue, lines };
+  return { shouldFail: overdue && !reportOnly, lines };
 }
 
 /** Runs git in the repository and returns trimmed stdout. */
@@ -261,6 +274,7 @@ async function main(): Promise<void> {
   const host = readArg("host") ?? DEFAULT_HOST;
   const maxAgeDays = Number(readArg("max-age-days") ?? DEFAULT_MAX_AGE_DAYS);
   const asJson = process.argv.includes("--json");
+  const reportOnly = process.argv.includes("--report-only");
 
   const response = await fetch(`https://${host}/`, {
     headers: { "user-agent": "check-docs-promote-drift" },
@@ -325,6 +339,7 @@ async function main(): Promise<void> {
     oldestUnpromotedAgeDays,
     maxAgeDays,
     resolved,
+    reportOnly,
   });
 
   if (asJson) {


### PR DESCRIPTION
## Why

`docs.copilotkit.ai` moves only when a human dispatches `showcase_promote.yml` — *"Humans trigger. No automatic prod promotes."* That gate is deliberate and this PR does not argue with it. What was missing is any way to see **what the gate is currently holding.**

A merged page returns an honest 404 on prod, and nothing distinguishes that from a page nobody wrote. Three tickets are that same confusion:

- **OSS-948** — filed as "Angular's Inspector fix is written but unpublished".
- **OSS-1005** — closed by a commit whose page was still not live four days later.
- **OSS-1037** — I filed it, on the wrong diagnosis: I read a 404 as a routing defect and proposed fixing a route that was never broken. That cost an investigation and a retraction.

It reaches the onboarding graph too. The graph fetches `docs.copilotkit.ai/*.md` at run time and reads a failed fetch as "documentation does not support the selection", routing to `unsupported/no-validated-path`. An un-promoted page therefore fails a run for a documentation gap that does not exist — which is why OSS-1034's Angular node had to cite an older live guide instead of the new reference page.

## The signal was already public

I filed OSS-1038 claiming "nothing today can answer *is prod current?*". That was wrong too. The shell already renders its own build SHA into every page:

```tsx
// showcase/shell-docs/src/app/layout.tsx
<div aria-hidden="true" className="shell-docs-commit-label">{commitLabel}</div>
```

So the deployed commit is readable with a GET and **no secret** — this check works on fork PRs like any other. Nothing was consuming it.

## What it reports

Run against prod the day this was written:

```
✗ docs content has been waiting 3+ days to be promoted, past the 3-day budget.
  docs.copilotkit.ai 54567d1 → main addd3f8: 48 pages differ under showcase/shell-docs/src/content.
  3 pages merged and still returning 404:
    showcase/shell-docs/src/content/docs/frontends/vue/guides/generative-ui.mdx
    showcase/shell-docs/src/content/docs/integrations/pydantic-ai/agent-app-context.mdx
    showcase/shell-docs/src/content/snippets/integrations/agno/frontend-tool-persistence.mdx
  44 pages serving older content:
    …
  1 page removed from main but still served:
    showcase/shell-docs/src/content/snippets/shared/inspector/open-inspector-step-angular.mdx
  Promote shell-docs: run the `Showcase: Promote (staging → prod)` workflow
  with service `shell-docs`. Prod does not move on its own.
```

And against staging, which is current:

```
✓ docs.staging.copilotkit.ai is serving d692f25 and no docs content is waiting to be promoted.
```

## Design decisions worth reviewing

**Added, modified and deleted are separate findings**, because a reader experiences them differently: an added page 404s, a modified page serves older content and gives no sign of it, a deleted page is still being served. A rename counts as **both** an add and a delete — the new URL 404s while the old one still resolves, and calling it a modification would hide both.

**Age comes from the oldest unpromoted *content* commit, not the deployed commit's date.** A promote can be old while the content it is missing is new, and the second is what a reader is waiting on.

**It reports, and fails only past a budget** (3 days, configurable). Drift is the normal state between promotes, so failing the moment a PR merges would make this noise — and a check that is always red is a check nobody reads.

**An unreadable or unresolvable label is its own failure**, never "prod is current". `dev` and `unknown` are the shell's own words for "no commit" (unset vs. empty build ARG); resolving either would find nothing and report the entire tree as drifted. An unresolvable SHA tells you to fetch full history, which is why the workflow uses `fetch-depth: 0`.

**No Slack.** Matches the sibling `showcase_autoupdate_drift.yml`, which also just fails. Easy to add later if the daily failure proves too quiet.

## Testing

15 tests, written before the implementation. Two rounds of red:

1. The initial suite failed to collect (module absent), then passed once implemented.
2. Live verification then exposed two real defects the unit tests had not covered — the report called every host "prod" even with `--host` pointing at staging, and "waiting 3 days" against a 3-day budget read as *within* budget. I added tests for both, confirmed them red, and fixed the wording to name the host and the budget it breached.

Verified end-to-end against both live hosts, all three output modes (human, `--json`, `GITHUB_STEP_SUMMARY`), and both exit codes — 1 against prod, 0 against prod with `--max-age-days 30`, 0 against staging.

`actionlint` clean on the new workflow.

## What this does NOT do: the graph

To be exact, because the ticket implies otherwise and my first draft of this section overclaimed: **the onboarding graph cannot use any of this code.** It is a CI script. It needs a git checkout to diff against and runs on a GitHub runner; the graph runs on a developer machine with no CopilotKit checkout (deliberately — OSS-921) and no ability to run repo tooling.

So "this PR gives the graph the signal it needs" was wrong. The signal the graph needs is a different one, and it does not depend on this PR at all: **probe both hosts for the same path.** If `docs.copilotkit.ai/x.md` 404s and `docs.staging.copilotkit.ai/x.md` returns 200, the page exists and is merely un-promoted — which is a documentation-delivery problem, not the "no validated path" the graph currently concludes. That is one extra GET, no secret, no checkout.

The two pieces share a diagnosis and nothing else. The graph rule is independently implementable today and belongs in a separate Intelligence issue rather than as a follow-on to this one.

## Not in scope

The graph rule above. Also: making prod promotes automatic — the manual gate is deliberate and this PR does not argue with it.

Closes OSS-1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)