### PR TITLE
feat(docs): add Intelligence onboarding prompts

### DIFF
--- a/showcase/shell-docs/src/app/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[[...slug]]/page.tsx
@@ -7,7 +7,7 @@
 
 import React from "react";
 import type { Metadata } from "next";
-import { ChannelsActivationStrip } from "@/components/channels-activation-strip";
+import { IntelligenceOnboardingPrompt } from "@/components/intelligence-onboarding-prompt";
 import { DocsLandingNext } from "@/components/docs-landing-next";
 import { HeroQuickstartDropdown } from "@/components/hero-quickstart-dropdown";
 import {
@@ -24,7 +24,6 @@ import {
   loadDoc,
 } from "@/lib/docs-render";
 import { compareByDisplayOrder } from "@/lib/framework-order";
-import { getChannelsActivationBackendOptions } from "@/lib/channels-activation-options";
 import { navTreeToPageTree } from "@/lib/page-tree-bridge";
 import {
   getDocsFolder,
@@ -34,7 +33,6 @@ import {
   ROOT_FRAMEWORK,
 } from "@/lib/registry";
 import { buildDocMetadata } from "@/lib/seo-metadata";
-import { getRuntimeConfig } from "@/lib/runtime-config";
 
 // Force dynamic rendering so unknown slugs reliably return HTTP 404
 // from `notFound()` instead of being cached as a 200 with the not-found
@@ -128,8 +126,6 @@ function DocsOverview() {
           ? "/quickstart"
           : `/${i.slug}/quickstart`,
     }));
-  const channelsBackends = getChannelsActivationBackendOptions();
-  const docsBaseUrl = getRuntimeConfig().baseUrl;
   return (
     <ShellDocsLayout tree={pageTree} banner={<SidebarFrameworkSelector />}>
       <div className="docs-inner-content max-w-[1040px] mx-auto px-4 md:px-6 pt-0 pb-6">
@@ -158,11 +154,13 @@ function DocsOverview() {
           </div>
         </section>
 
-        <div className="space-y-10 pt-8">
-          <ChannelsActivationStrip
-            backends={channelsBackends}
-            docsBaseUrl={docsBaseUrl}
-          />
+        <div className="space-y-10 pt-4">
+          <div className="[&>section]:!my-0">
+            <IntelligenceOnboardingPrompt
+              feature="learning"
+              surface="docs_landing_learning"
+            />
+          </div>
           <LandingSampleTabs />
           <DocsLandingNext />
         </div>

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -43,6 +43,8 @@ import type { OpsPlatformCTAProps } from "@/components/react/ops-platform-cta";
 import { ChannelsStartPrompt } from "@/components/channels-start-prompt";
 import type { ChannelsStartPromptProps } from "@/components/channels-start-prompt";
 import { RichThreadsSetupPrompt } from "@/components/rich-threads-setup-prompt";
+import { IntelligenceOnboardingPrompt } from "@/components/intelligence-onboarding-prompt";
+import type { IntelligenceOnboardingPromptProps } from "@/components/intelligence-onboarding-prompt";
 import { SignupLink } from "@/components/react/signup-link";
 import type { SignupLinkProps } from "@/components/react/signup-link";
 import { FrameworkSetup } from "@/lib/setup-concept";
@@ -108,6 +110,16 @@ export interface DocsPageViewProps {
    * (or suppress them) based on its own state.
    */
   ContentWrapper?: React.ComponentType<{ children: React.ReactNode }>;
+}
+
+function IntelligenceOnboardingPromptMdx(
+  props: IntelligenceOnboardingPromptProps,
+): React.JSX.Element {
+  return (
+    <div className="mb-6">
+      <IntelligenceOnboardingPrompt {...props} />
+    </div>
+  );
 }
 
 /**
@@ -343,6 +355,8 @@ export async function DocsPageView({
                           />
                         ),
                         RichThreadsSetupPrompt,
+                        IntelligenceOnboardingPrompt:
+                          IntelligenceOnboardingPromptMdx,
                         OpsPlatformCTA: (props: OpsPlatformCTAProps) => (
                           <OpsPlatformCTA
                             {...props}

--- a/showcase/shell-docs/src/components/intelligence-onboarding-prompt.tsx
+++ b/showcase/shell-docs/src/components/intelligence-onboarding-prompt.tsx
@@ -133,7 +133,7 @@ export function IntelligenceOnboardingPrompt({
 
       {feature === "learning" ? (
         <div className="mt-4 border-t border-[#DBDBE5] pt-3 text-sm leading-[1.55] text-[var(--text-secondary)] dark:border-[#57575B]">
-          <div className="grid gap-3 md:grid-cols-[1.45fr_0.9fr_1fr] md:gap-0">
+          <div className="grid gap-3 md:grid-cols-[1.4fr_1fr_1.25fr] md:gap-0">
             {content.points.map((point, index) => (
               <p
                 key={point.body}
@@ -144,7 +144,20 @@ export function IntelligenceOnboardingPrompt({
                     {point.label}{" "}
                   </span>
                 ) : null}
-                {point.body}
+                {index === 2 ? (
+                  <>
+                    <span className="font-semibold text-[var(--text)]">
+                      Build
+                    </span>{" "}
+                    a new agent or{" "}
+                    <span className="font-semibold text-[var(--text)]">
+                      bring
+                    </span>{" "}
+                    one you already have. Any frontend, any backend.
+                  </>
+                ) : (
+                  point.body
+                )}
               </p>
             ))}
           </div>

--- a/showcase/shell-docs/src/components/intelligence-onboarding-prompt.tsx
+++ b/showcase/shell-docs/src/components/intelligence-onboarding-prompt.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import React from "react";
+import { Copy, Lightbulb, MessagesSquare } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import {
+  createIntelligenceOnboardingPrompt,
+  createOnboardingRunId,
+  INTELLIGENCE_ONBOARDING_EVENTS,
+} from "@/lib/intelligence-onboarding-prompt";
+
+export type IntelligenceOnboardingFeature = "learning" | "threads";
+
+export interface IntelligenceOnboardingPromptProps {
+  feature: IntelligenceOnboardingFeature;
+  surface: string;
+}
+
+const FEATURE_COPY = {
+  learning: {
+    title: "Build agents that get smarter with every use.",
+    points: [
+      {
+        label: "Rich Threads",
+        body: "keep messages, generative UI, and tool activity available across sessions and devices.",
+      },
+      {
+        label: "Learning",
+        body: "turns real usage into skills that improve your agent.",
+      },
+      {
+        body: "Build a new agent or bring one you already have. Any frontend, any backend.",
+      },
+    ],
+  },
+  threads: {
+    title: "Conversations that never lose context.",
+    points: [
+      {
+        label: "CopilotKit Intelligence Rich Threads",
+        body: "keep messages, generative UI, and tool activity available across sessions and devices. Build a new agent or bring one you already have. Any frontend, any backend.",
+      },
+    ],
+  },
+} as const;
+
+type CopyState = "idle" | "copied" | "error";
+
+/** One onboarding action with feature-specific value copy. */
+export function IntelligenceOnboardingPrompt({
+  feature,
+  surface,
+}: IntelligenceOnboardingPromptProps): React.JSX.Element {
+  const content = FEATURE_COPY[feature];
+  const pathname = usePathname();
+  const posthog = usePostHog();
+  const [copyState, setCopyState] = React.useState<CopyState>("idle");
+  const headingId = React.useId();
+
+  function capture(event: string, properties: Record<string, unknown>) {
+    try {
+      posthog?.capture(event, properties);
+    } catch {
+      // Analytics must never interrupt docs rendering or clipboard actions.
+    }
+  }
+
+  async function copyPrompt() {
+    const runId = createOnboardingRunId();
+
+    try {
+      await navigator.clipboard.writeText(
+        createIntelligenceOnboardingPrompt(runId),
+      );
+    } catch {
+      setCopyState("error");
+      setTimeout(() => setCopyState("idle"), 2600);
+      return;
+    }
+
+    setCopyState("copied");
+    capture(INTELLIGENCE_ONBOARDING_EVENTS.promptCopied, {
+      feature,
+      from_path: pathname,
+      run_id: runId,
+      surface,
+    });
+    setTimeout(() => setCopyState("idle"), 1800);
+  }
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      data-feature={feature}
+      data-surface={surface}
+      className="shell-docs-radius-surface not-prose relative border border-[#DBDBE5] bg-[linear-gradient(135deg,#FFFFFF_0%,#F7F7F9_46%,#EDEDF5_100%)] p-5 shadow-[0_1px_3px_rgba(1,5,7,0.08),inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-[#57575B] dark:bg-[linear-gradient(135deg,#2B2B2B_0%,color-mix(in_oklch,#EDEDF5_8%,var(--bg-surface))_100%)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.32)]"
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <span
+            aria-hidden="true"
+            className="shell-docs-radius-control flex h-10 w-10 shrink-0 items-center justify-center border border-[#DBDBE5] bg-white text-[var(--accent)] shadow-[0_1px_3px_rgba(1,5,7,0.08)] dark:border-[#57575B] dark:bg-[#2B2B2B]"
+          >
+            {feature === "learning" ? (
+              <Lightbulb className="h-[22px] w-[22px]" strokeWidth={2} />
+            ) : (
+              <MessagesSquare className="h-[22px] w-[22px]" strokeWidth={2} />
+            )}
+          </span>
+
+          <h2
+            id={headingId}
+            className="!m-0 text-xl font-semibold tracking-[-0.02em] text-[var(--text)] sm:text-2xl"
+          >
+            {content.title}
+          </h2>
+        </div>
+
+        <button
+          type="button"
+          onClick={copyPrompt}
+          className="shell-docs-radius-control inline-flex min-h-10 w-full shrink-0 cursor-pointer items-center justify-center gap-2 border border-[#010507] bg-[#010507] px-4 text-sm font-semibold text-white shadow-[0_1px_3px_rgba(1,5,7,0.12)] transition-[background-color,transform] hover:bg-[#2B2B2B] active:translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#BEC2FF] focus-visible:ring-offset-2 focus-visible:ring-offset-[#EDEDF5] sm:w-auto"
+        >
+          <Copy aria-hidden="true" className="h-4 w-4" />
+          {copyState === "copied"
+            ? "Copied"
+            : copyState === "error"
+              ? "Copy blocked"
+              : "Copy prompt"}
+        </button>
+      </div>
+
+      {feature === "learning" ? (
+        <div className="mt-4 border-t border-[#DBDBE5] pt-3 text-sm leading-[1.55] text-[var(--text-secondary)] dark:border-[#57575B]">
+          <div className="grid gap-3 md:grid-cols-[1.45fr_0.9fr_1fr] md:gap-0">
+            {content.points.map((point, index) => (
+              <p
+                key={point.body}
+                className={`!m-0 ${index > 0 ? "md:border-l md:border-[#DBDBE5] md:pl-5 dark:md:border-[#57575B]" : ""} ${index < content.points.length - 1 ? "md:pr-5" : ""}`}
+              >
+                {"label" in point ? (
+                  <span className="font-semibold text-[var(--text)]">
+                    {point.label}{" "}
+                  </span>
+                ) : null}
+                {point.body}
+              </p>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className="!mb-0 !mt-4 border-t border-[#DBDBE5] pt-3 text-sm leading-[1.55] text-[var(--text-secondary)] dark:border-[#57575B]">
+          {content.points.map((point) => (
+            <React.Fragment key={point.body}>
+              {"label" in point ? (
+                <span className="font-semibold text-[var(--text)]">
+                  {point.label}{" "}
+                </span>
+              ) : null}
+              <span>{point.body} </span>
+            </React.Fragment>
+          ))}
+        </p>
+      )}
+
+      <span aria-live="polite" className="sr-only">
+        {copyState === "copied"
+          ? "Prompt copied"
+          : copyState === "error"
+            ? "Prompt copy failed. Try again."
+            : ""}
+      </span>
+    </section>
+  );
+}

--- a/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
@@ -6,11 +6,8 @@ hideTOC: true
 ---
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Agent Spec to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_agent_spec_quickstart"
 />
 
@@ -545,4 +542,3 @@ Follow per-adapter tutorials: [LangGraph integration](/agent-spec/langgraph) and
 - Agent Spec docs: https://oracle.github.io/agent-spec/development/docs_home.html
 - Agent Spec x AG-UI tutorial: https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html
 - Agent Spec Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
-

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship A2A to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_a2a_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship ADK to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_adk_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
@@ -7,6 +7,11 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
+<IntelligenceOnboardingPrompt
+  feature="learning"
+  surface="docs_ag2_quickstart"
+/>
+
 ## Introduction
 
 This quickstart guide shows how to build a **Weather Agent** using AG2 and CopilotKit. In just minutes, you'll have a working application where users can ask for real-time weather conditions in any city worldwide — powered by AG2's `AGUIStream` over the AG-UI protocol and rendered with CopilotKit's chat UI.
@@ -24,14 +29,6 @@ npx copilotkit@latest init
 ```
 
 Follow the prompts to pick AG2 and the features you want, then run the install/start commands it prints.
-
-<OpsPlatformCTA
-  variant="card"
-  title="Ship AG2 to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
-  surface="docs_ag2_quickstart"
-/>
 
 ## Prerequisites
 

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -6,11 +6,8 @@ hideTOC: true
 ---
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Agent Spec to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_agent_spec_quickstart"
 />
 
@@ -545,4 +542,3 @@ Follow per-adapter tutorials: [LangGraph integration](/agent-spec/langgraph) and
 - Agent Spec docs: https://oracle.github.io/agent-spec/development/docs_home.html
 - Agent Spec x AG-UI tutorial: https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html
 - Agent Spec Tracing: https://oracle.github.io/agent-spec/development/agentspec/tracing.html
-

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Agno to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_agno_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship AWS Strands to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_aws_strands_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -16,11 +16,8 @@ import {
 } from "lucide-react";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship the Built-in Agent to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_built_in_agent_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/claude-sdk-python/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/claude-sdk-python/quickstart.mdx
@@ -7,6 +7,11 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
+<IntelligenceOnboardingPrompt
+  feature="learning"
+  surface="docs_claude_sdk_python_quickstart"
+/>
+
 This quickstart gives you two working paths:
 
 - **Start from scratch** to scaffold the full Claude Agent SDK Python showcase.

--- a/showcase/shell-docs/src/content/docs/integrations/claude-sdk-typescript/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/claude-sdk-typescript/quickstart.mdx
@@ -7,6 +7,11 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
+<IntelligenceOnboardingPrompt
+  feature="learning"
+  surface="docs_claude_sdk_typescript_quickstart"
+/>
+
 This quickstart gives you two working paths:
 
 - **Start from scratch** to scaffold the full Claude Agent SDK TypeScript showcase.

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -8,11 +8,8 @@ doc_type: tutorial
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship CrewAI Flows to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_crewai_flows_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
@@ -5,11 +5,8 @@ icon: "lucide/Rocket"
 ---
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Deep Agents to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_deepagents_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship LangGraph to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_langgraph_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship LlamaIndex to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_llamaindex_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -29,11 +29,8 @@ import {
 } from "lucide-react";
 import CopilotUI from "@/snippets/copilot-ui.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Mastra to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_mastra_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Microsoft Agent Framework to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_microsoft_agent_framework_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -7,11 +7,8 @@ hideTOC: true
 
 import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.mdx";
 
-<OpsPlatformCTA
-  variant="card"
-  title="Ship Pydantic AI to production"
-  body="Add persistent threads and the inspector with CopilotKit Intelligence."
-  ctaLabel="Create a free account"
+<IntelligenceOnboardingPrompt
+  feature="learning"
   surface="docs_pydantic_ai_quickstart"
 />
 

--- a/showcase/shell-docs/src/content/docs/premium/threads-explained.mdx
+++ b/showcase/shell-docs/src/content/docs/premium/threads-explained.mdx
@@ -5,10 +5,8 @@ icon: "lucide/MessageSquareMore"
 doc_type: explanation
 ---
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Want to see threads in your own app?"
-  body="Persistent threads ship with CopilotKit Intelligence on the free Developer tier."
+<IntelligenceOnboardingPrompt
+  feature="threads"
   surface="docs_learn_threads"
 />
 

--- a/showcase/shell-docs/src/content/snippets/shared/threads/headless-threads.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/headless-threads.mdx
@@ -2,10 +2,8 @@
 
 CopilotKit Rich Threads enable persistent, resumable multi-turn conversations. The `useThreads` hook lists, creates, renames, archives, and deletes CopilotKit Intelligence threads with realtime synchronization via WebSocket. Threads work with any agent framework — CopilotKit Intelligence stores conversation history server-side, so users can close their browser and pick up where they left off. It does not list or mutate native LangGraph, ADK, or other framework stores unless your backend explicitly bridges those systems. Thread metadata updates (renames, archives, new threads) appear on connected clients without polling.
 
-<OpsPlatformCTA
-  variant="inline"
-  title="Threads run in CopilotKit Intelligence"
-  body="Get persistent threads and realtime sync on the free Developer tier."
+<IntelligenceOnboardingPrompt
+  feature="threads"
   surface="docs_threads"
 />
 

--- a/showcase/shell-docs/src/content/snippets/shared/threads/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/overview.mdx
@@ -1,6 +1,11 @@
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 import InspectorPaneThreads from "@/snippets/shared/inspector/open-inspector-pane-threads.mdx";
 
+<IntelligenceOnboardingPrompt
+  feature="threads"
+  surface="docs_threads_overview"
+/>
+
 <div
   aria-label="A support workspace using Threads Drawer to move between customer conversations while CopilotChat renders the selected case details."
   className="shell-docs-radius-surface relative mb-4 overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0px_16px_24px_-8px_rgba(1,5,7,0.12)] ring-1 ring-inset ring-white/70 dark:shadow-[0px_16px_32px_-10px_rgba(0,0,0,0.45)] dark:ring-white/10"
@@ -87,14 +92,6 @@ With Rich Threads, users can close the browser, return on another device, reopen
 Built on portable AG-UI event history, Rich Threads restore messages, generative UI, multimodal inputs, tool activity, state, and live-run continuity instead of saving only a chat transcript.
 
 Without CopilotKit Rich Threads, your team has to design the storage model, replay historical events and generative UI, persist multimodal inputs, reconnect live streams, synchronize thread lists, coordinate concurrent runs, and build lifecycle APIs before you can ship the conversation experience itself. CopilotKit Intelligence handles that infrastructure so you can focus on your agent and product UI.
-
-<OpsPlatformCTA
-  variant="inline"
-  title="Ship persistent conversations without building the backend"
-  body="CopilotKit Intelligence handles durable history, replay, realtime sync, and thread lifecycle on the free Developer tier."
-  ctaLabel="Get CopilotKit Intelligence free"
-  surface="docs_threads_overview"
-/>
 
 Rich Threads provide:
 

--- a/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/inspector-docs.test.ts
@@ -88,12 +88,13 @@ test("every web integration quickstart imports the Open Inspector step", () => {
   }
 });
 
-test("Intelligence signup CTA still names Inspector beside the Open Inspector step", () => {
+test("Intelligence onboarding prompt appears beside the Open Inspector step", () => {
   const langgraph = read("docs/integrations/langgraph/quickstart.mdx");
   const deepAgents = read("docs/integrations/deepagents/quickstart.mdx");
 
   for (const source of [langgraph, deepAgents]) {
-    expect(source).toContain("<OpsPlatformCTA");
+    expect(source).toContain("<IntelligenceOnboardingPrompt");
+    expect(source).toContain('feature="learning"');
     expect(source.toLowerCase()).toContain("inspector");
     expect(source).toContain("<OpenInspectorStep");
   }
@@ -132,13 +133,12 @@ test("mapped feature pages import the matching Inspector Callout", () => {
   );
 });
 
-test("Inspector Callout snippets name the shipped pane and skip unshipped work", () => {
+test("Inspector Callout snippets name shipped panes and skip retired controls", () => {
   const snippets = listMdx(SNIPPETS_DIR);
   expect(snippets.length).toBeGreaterThan(0);
 
   for (const path of snippets) {
     const source = readFileSync(path, "utf8");
-    expect(source).not.toMatch(/\bPlayground\b/);
     expect(source).not.toMatch(/\bFork from here\b/);
     expect(source).not.toMatch(/\bEmit events\b/);
   }

--- a/showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts
+++ b/showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts
@@ -1,0 +1,50 @@
+const RUN_ID_PLACEHOLDER = "<run-id>";
+
+export const INTELLIGENCE_ONBOARDING_EVENTS = {
+  promptCopied: "docs.intelligence_onboarding_prompt_copied",
+} as const;
+
+/**
+ * The coding-agent prompt used by Intelligence, Inspector, and Shell Docs.
+ *
+ * Keep this byte-identical to `INTELLIGENCE_ONBOARDING_PROMPT` in
+ * Intelligence's `intelligence-home.tsx` and `ONBOARDING_PROMPT_TEMPLATE` in
+ * the Inspector. The CLI prompt graph decides the correct path after it
+ * inspects the repository; the docs CTA only changes the feature promise.
+ */
+export const INTELLIGENCE_ONBOARDING_PROMPT =
+  "Identify which coding-agent product you are, using a short slug such as " +
+  "`codex` or `claude-code`. From the root of the project where you want " +
+  "CopilotKit, run `npx --yes copilotkit@latest onboard start --run " +
+  `${RUN_ID_PLACEHOLDER}` +
+  " --coding-agent <coding-agent-slug>`. Follow the Markdown instructions it " +
+  "prints until onboarding is complete.";
+
+const RUN_ID_LENGTH = 12;
+
+/** Mint the telemetry identifier shared by the docs CTA and CLI run. */
+export function createOnboardingRunId(): string {
+  const webCrypto = globalThis.crypto;
+
+  if (typeof webCrypto?.randomUUID === "function") {
+    return webCrypto.randomUUID().replaceAll("-", "").slice(0, RUN_ID_LENGTH);
+  }
+
+  if (typeof webCrypto?.getRandomValues === "function") {
+    const bytes = webCrypto.getRandomValues(new Uint8Array(RUN_ID_LENGTH / 2));
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+      "",
+    );
+  }
+
+  let id = "";
+  while (id.length < RUN_ID_LENGTH) {
+    id += Math.floor(Math.random() * 16).toString(16);
+  }
+  return id.slice(0, RUN_ID_LENGTH);
+}
+
+/** Bind one run id into the canonical prompt. */
+export function createIntelligenceOnboardingPrompt(runId: string): string {
+  return INTELLIGENCE_ONBOARDING_PROMPT.replace(RUN_ID_PLACEHOLDER, runId);
+}


### PR DESCRIPTION
## Summary

- replace the homepage Channels activation block with an Intelligence onboarding prompt focused on Learning
- place the same onboarding prompt across framework quickstarts, with feature-specific copy for Learning and Rich Threads
- generate the CLI run ID only when the prompt is copied and record successful copies in PostHog
- use existing local Lucide icons with no additional package or external font dependency

## Experiment

The CTA uses one canonical agentic onboarding prompt everywhere while changing the product promise by surface. Learning placements explain Rich Threads, Learning, and support for new or existing agents. Threads placements focus on persistent conversations.

Successful copies emit `docs.intelligence_onboarding_prompt_copied` with `feature`, `from_path`, `run_id`, and `surface`. The same `run_id` is embedded in the copied CLI command.

## Validation

- `pnpm exec oxfmt --check` on changed TypeScript files
- `npm run lint` in `showcase/shell-docs` (no errors; existing warnings remain)
- `npm run typecheck` in `showcase/shell-docs`
- `vitest run src/lib/__tests__/inspector-docs.test.ts --maxWorkers=1` (10/10 passed)
- memory-capped `npm run build` in `showcase/shell-docs`
- manual desktop, mobile, light-mode, and dark-mode checks on `/`, `/threads`, and a framework quickstart

The full Shell Docs test command currently also reports failures unrelated to this change, including unhydrated Git LFS image fixtures and generated-doc baselines on current `main`. The affected Inspector docs test passes independently.
