### PR TITLE
feat(runtime): project Enterprise marketplace entitlement

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -59,30 +59,44 @@ describe("handleGetRuntimeInfo", () => {
     }) as unknown as CopilotRuntimeLike;
   const createIntelligenceRuntimeLike = (
     overrides: Partial<CopilotIntelligenceRuntimeLike> = {},
-  ): CopilotIntelligenceRuntimeLike => ({
-    agents: {},
-    transcriptionService: undefined,
-    beforeRequestMiddleware: undefined,
-    afterRequestMiddleware: undefined,
-    runner: createRunner(),
-    a2ui: undefined,
-    mcpApps: undefined,
-    openGenerativeUI: undefined,
-    mode: "intelligence",
-    debug: { enabled: false, events: false, lifecycle: false, verbose: false },
-    forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
-    intelligence: new CopilotKitIntelligence({
+  ): CopilotIntelligenceRuntimeLike => {
+    const intelligence = new CopilotKitIntelligence({
       apiUrl: "https://runtime.example",
       wsUrl: "wss://runtime.example",
       apiKey: "test-key",
-    }),
-    identifyUser: vi.fn().mockResolvedValue({ id: "user-1", name: "User One" }),
-    generateThreadNames: true,
-    lockTtlSeconds: 20,
-    lockHeartbeatIntervalSeconds: 15,
-    channels: [],
-    ...overrides,
-  });
+    });
+    vi.spyOn(intelligence, "getRuntimeEntitlement").mockResolvedValue({
+      kind: "notSupported",
+    });
+
+    return {
+      agents: {},
+      transcriptionService: undefined,
+      beforeRequestMiddleware: undefined,
+      afterRequestMiddleware: undefined,
+      runner: createRunner(),
+      a2ui: undefined,
+      mcpApps: undefined,
+      openGenerativeUI: undefined,
+      mode: "intelligence",
+      debug: {
+        enabled: false,
+        events: false,
+        lifecycle: false,
+        verbose: false,
+      },
+      forwardHeadersPolicy: resolveForwardHeadersPolicy(undefined),
+      intelligence,
+      identifyUser: vi
+        .fn()
+        .mockResolvedValue({ id: "user-1", name: "User One" }),
+      generateThreadNames: true,
+      lockTtlSeconds: 20,
+      lockHeartbeatIntervalSeconds: 15,
+      channels: [],
+      ...overrides,
+    };
+  };
 
   it("should return runtime info with audioFileTranscriptionEnabled=false when no transcription service", async () => {
     const runtime = new CopilotRuntime({
@@ -579,6 +593,61 @@ describe("handleGetRuntimeInfo", () => {
       message: "Failed to get agents",
     });
   });
+
+  test.each([
+    [{ kind: "ok", entitlement: { active: true } }, "valid"],
+    [{ kind: "ok", entitlement: { active: false } }, "invalid"],
+    [{ kind: "unavailable" }, "unknown"],
+  ] as const)(
+    "projects Intelligence entitlement result %# into licenseStatus=%s",
+    async (result, expectedStatus) => {
+      const runtime = createIntelligenceRuntimeLike();
+      vi.mocked(runtime.intelligence.getRuntimeEntitlement).mockResolvedValue(
+        result.kind === "ok"
+          ? {
+              kind: "ok",
+              entitlement: {
+                organizationId: "7",
+                source: "awsMarketplaceDeploymentLicense",
+                active: result.entitlement.active,
+                features: { msteams: true },
+                limits: { "threads.max_count": 25_000 },
+                planCode: "team_deployment",
+                entitlementSource: "must-not-reach-browser",
+              },
+            }
+          : result,
+      );
+
+      const response = await handleGetRuntimeInfo({
+        runtime,
+        request: mockRequest,
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.licenseStatus).toBe(expectedStatus);
+      expect(JSON.stringify(data)).not.toMatch(
+        /organizationId|source|features|limits|planCode|entitlementSource|awsMarketplace/iu,
+      );
+    },
+  );
+
+  it("falls back to the unchanged local checker only when Intelligence lacks the endpoint", async () => {
+    const runtime = createIntelligenceRuntimeLike({
+      licenseChecker: {
+        getStatus: () => ({ warningSeverity: "none" }),
+      } as CopilotIntelligenceRuntimeLike["licenseChecker"],
+    });
+
+    const response = await handleGetRuntimeInfo({
+      runtime,
+      request: mockRequest,
+    });
+    const data = await response.json();
+
+    expect(data.licenseStatus).toBe("valid");
+  });
 });
 
 test("get-runtime-info advertises inspector metadata without fetching it", async () => {
@@ -588,6 +657,9 @@ test("get-runtime-info advertises inspector metadata without fetching it", async
     apiKey: "server-api-key",
   });
   const getInspectorMetadata = vi.spyOn(intelligence, "getInspectorMetadata");
+  vi.spyOn(intelligence, "getRuntimeEntitlement").mockResolvedValue({
+    kind: "notSupported",
+  });
   const runtime = new CopilotRuntime({
     agents: {},
     intelligence,

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -608,13 +608,20 @@ describe("handleGetRuntimeInfo", () => {
           ? {
               kind: "ok",
               entitlement: {
-                organizationId: "7",
                 source: "awsMarketplaceDeploymentLicense",
                 active: result.entitlement.active,
-                features: { msteams: true },
-                limits: { "threads.max_count": 25_000 },
-                planCode: "team_deployment",
-                entitlementSource: "must-not-reach-browser",
+                features: {
+                  "sdk.angular": true,
+                  analytics: true,
+                  self_learning: true,
+                  memory: true,
+                  managed_channels: true,
+                },
+                limits: {
+                  "threads.max_count": 0,
+                  "managed_channels.max_channels": 0,
+                },
+                planCode: "enterprise",
               },
             }
           : result,
@@ -629,10 +636,10 @@ describe("handleGetRuntimeInfo", () => {
       expect(response.status).toBe(200);
       expect(data.licenseStatus).toBe(expectedStatus);
       expect(
-        createLicenseContextValue(data.licenseStatus).checkFeature("msteams"),
+        createLicenseContextValue(data.licenseStatus).checkFeature("analytics"),
       ).toBe(expectedStatus === "valid");
       expect(JSON.stringify(data)).not.toMatch(
-        /organizationId|source|features|limits|planCode|entitlementSource|awsMarketplace/iu,
+        /organizationId|source|features|limits|planCode|entitlementSource|awsMarketplace|enterprise/iu,
       );
     },
   );

--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -10,6 +10,7 @@ import { CopilotKitIntelligence } from "../intelligence-platform";
 import { TranscriptionService } from "../transcription-service/transcription-service";
 import { describe, it, expect, test, vi, beforeEach, afterEach } from "vitest";
 import type { AbstractAgent } from "@ag-ui/client";
+import { createLicenseContextValue } from "@copilotkit/shared";
 
 // Mock transcription service
 class MockTranscriptionService extends TranscriptionService {
@@ -597,7 +598,7 @@ describe("handleGetRuntimeInfo", () => {
   test.each([
     [{ kind: "ok", entitlement: { active: true } }, "valid"],
     [{ kind: "ok", entitlement: { active: false } }, "invalid"],
-    [{ kind: "unavailable" }, "unknown"],
+    [{ kind: "unavailable" }, "invalid"],
   ] as const)(
     "projects Intelligence entitlement result %# into licenseStatus=%s",
     async (result, expectedStatus) => {
@@ -627,6 +628,9 @@ describe("handleGetRuntimeInfo", () => {
 
       expect(response.status).toBe(200);
       expect(data.licenseStatus).toBe(expectedStatus);
+      expect(
+        createLicenseContextValue(data.licenseStatus).checkFeature("msteams"),
+      ).toBe(expectedStatus === "valid");
       expect(JSON.stringify(data)).not.toMatch(
         /organizationId|source|features|limits|planCode|entitlementSource|awsMarketplace/iu,
       );

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -15,7 +15,7 @@ import { VERSION } from "../core/runtime";
 import { isTelemetryDisabled } from "../telemetry/telemetry-client";
 import { supportsLocalThreadEndpoints } from "../runner/agent-runner";
 
-function resolveLicenseStatus(
+function resolveLocalLicenseStatus(
   runtime: CopilotRuntimeLike,
 ): RuntimeLicenseStatus {
   if (!runtime.licenseChecker) return "none";
@@ -26,6 +26,27 @@ function resolveLicenseStatus(
   if (status.error) return "invalid";
   if (status.warningSeverity === "info") return "none";
   return "unknown";
+}
+
+async function resolveLicenseStatus(
+  runtime: CopilotRuntimeLike,
+): Promise<RuntimeLicenseStatus> {
+  if (!isIntelligenceRuntime(runtime)) {
+    return resolveLocalLicenseStatus(runtime);
+  }
+
+  try {
+    const result = await runtime.intelligence.getRuntimeEntitlement();
+    if (result.kind === "ok") {
+      return result.entitlement.active ? "valid" : "invalid";
+    }
+    if (result.kind === "unavailable") {
+      return "unknown";
+    }
+    return resolveLocalLicenseStatus(runtime);
+  } catch {
+    return "unknown";
+  }
 }
 
 interface HandleGetRuntimeInfoParameters {
@@ -76,6 +97,9 @@ export async function handleGetRuntimeInfo({
 
     const agentsDict: Record<string, AgentDescription> =
       Object.fromEntries(agentEntries);
+    const licenseStatus = isIntelligenceRuntime(runtime)
+      ? await resolveLicenseStatus(runtime)
+      : undefined;
 
     const runtimeInfo: RuntimeInfo = {
       version: VERSION,
@@ -115,9 +139,7 @@ export async function handleGetRuntimeInfo({
           }
         : {}),
       openGenerativeUIEnabled: webEnabled && !!runtime.openGenerativeUI,
-      ...(isIntelligenceRuntime(runtime)
-        ? { licenseStatus: resolveLicenseStatus(runtime) }
-        : {}),
+      ...(isIntelligenceRuntime(runtime) ? { licenseStatus } : {}),
       telemetryDisabled: isTelemetryDisabled(),
     };
 

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -41,11 +41,11 @@ async function resolveLicenseStatus(
       return result.entitlement.active ? "valid" : "invalid";
     }
     if (result.kind === "unavailable") {
-      return "unknown";
+      return "invalid";
     }
     return resolveLocalLicenseStatus(runtime);
   } catch {
-    return "unknown";
+    return "invalid";
   }
 }
 

--- a/packages/runtime/src/v2/runtime/index.ts
+++ b/packages/runtime/src/v2/runtime/index.ts
@@ -17,6 +17,8 @@ export {
   type SubscribeToThreadsRequest,
   type SubscribeToThreadsResponse,
   type UpdateThreadRequest,
+  type RuntimeEntitlement,
+  type RuntimeEntitlementResult,
 } from "./intelligence-platform";
 
 // Re-export `@ai-sdk/mcp` stable types so consumers don't need to depend on

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -1383,3 +1383,21 @@ test("runtime-entitlement client aborts and fails closed when authority stalls",
     vi.useRealTimers();
   }
 });
+
+test("runtime-entitlement client aborts and fails closed when the response body stalls", async () => {
+  vi.useFakeTimers();
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockResolvedValue(new Response(new ReadableStream<Uint8Array>()));
+
+  try {
+    const request = client.getRuntimeEntitlement();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(request).resolves.toEqual({ kind: "unavailable" });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.signal.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -1289,18 +1289,34 @@ test("inspector-metadata client rejects invalid and unknown schemas", async () =
 });
 
 const activeRuntimeEntitlement = {
-  organizationId: "7",
   source: "awsMarketplaceDeploymentLicense" as const,
   active: true,
-  features: { msteams: true, deployment_via_helm_chart: true },
-  limits: { "threads.max_count": 25_000 },
-  planCode: "team_deployment",
+  features: {
+    "sdk.angular": true,
+    deployment_via_helm_chart: true,
+    analytics: true,
+    self_learning: true,
+    memory: true,
+    managed_channels: true,
+  },
+  limits: {
+    "threads.max_count": 0,
+    "managed_channels.max_channels": 0,
+  },
+  planCode: "enterprise",
+};
+
+const activeRuntimeEntitlementResponse = {
+  status: "ready" as const,
+  entitlement: activeRuntimeEntitlement,
 };
 
 test("runtime-entitlement client authenticates and accepts only the sanitized contract", async () => {
   const { client } = setupInspectorMetadataClient();
   fetchMock.mockResolvedValue(
-    new Response(JSON.stringify(activeRuntimeEntitlement), { status: 200 }),
+    new Response(JSON.stringify(activeRuntimeEntitlementResponse), {
+      status: 200,
+    }),
   );
 
   await expect(client.getRuntimeEntitlement()).resolves.toEqual({
@@ -1339,14 +1355,50 @@ test("runtime-entitlement client fails closed without retaining provider bodies"
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            ...activeRuntimeEntitlement,
-            consumptionToken: sensitiveMarker,
+            ...activeRuntimeEntitlementResponse,
+            entitlement: {
+              ...activeRuntimeEntitlement,
+              consumptionToken: sensitiveMarker,
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(activeRuntimeEntitlement), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ...activeRuntimeEntitlementResponse,
+            organizationId: "must-not-cross-runtime-boundary",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: "ready",
+            entitlement: {
+              ...activeRuntimeEntitlement,
+              active: false,
+            },
           }),
           { status: 200 },
         ),
       )
       .mockResolvedValueOnce(new Response("{", { status: 200 }));
 
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
     await expect(client.getRuntimeEntitlement()).resolves.toEqual({
       kind: "unavailable",
     });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -1287,3 +1287,99 @@ test("inspector-metadata client rejects invalid and unknown schemas", async () =
   await expect(client.getInspectorMetadata()).resolves.toBeUndefined();
   await expect(client.getInspectorMetadata()).resolves.toBeUndefined();
 });
+
+const activeRuntimeEntitlement = {
+  organizationId: "7",
+  source: "awsMarketplaceDeploymentLicense" as const,
+  active: true,
+  features: { msteams: true, deployment_via_helm_chart: true },
+  limits: { "threads.max_count": 25_000 },
+  planCode: "team_deployment",
+};
+
+test("runtime-entitlement client authenticates and accepts only the sanitized contract", async () => {
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify(activeRuntimeEntitlement), { status: 200 }),
+  );
+
+  await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+    kind: "ok",
+    entitlement: activeRuntimeEntitlement,
+  });
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://api.example.com/api/entitlements/runtime",
+    {
+      method: "GET",
+      headers: { Authorization: "Bearer server-api-key" },
+      signal: expect.any(AbortSignal),
+    },
+  );
+});
+
+test("runtime-entitlement client treats 404 as compatible absence", async () => {
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+
+  await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+    kind: "notSupported",
+  });
+});
+
+test("runtime-entitlement client fails closed without retaining provider bodies", async () => {
+  const { client } = setupInspectorMetadataClient();
+  const sensitiveMarker = "aws-secret-provider-body-9a77";
+  const loggerError = vi
+    .spyOn(logger, "error")
+    .mockImplementation(() => undefined);
+
+  try {
+    fetchMock
+      .mockResolvedValueOnce(new Response(sensitiveMarker, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            ...activeRuntimeEntitlement,
+            consumptionToken: sensitiveMarker,
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("{", { status: 200 }));
+
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+    await expect(client.getRuntimeEntitlement()).resolves.toEqual({
+      kind: "unavailable",
+    });
+
+    expect(JSON.stringify(loggerError.mock.calls)).not.toContain(
+      sensitiveMarker,
+    );
+  } finally {
+    loggerError.mockRestore();
+  }
+});
+
+test("runtime-entitlement client aborts and fails closed when authority stalls", async () => {
+  vi.useFakeTimers();
+  const { client } = setupInspectorMetadataClient();
+  fetchMock.mockImplementation(() => new Promise<Response>(() => undefined));
+
+  try {
+    const request = client.getRuntimeEntitlement();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(request).resolves.toEqual({ kind: "unavailable" });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.signal.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -60,7 +60,6 @@ const RUNTIME_ENTITLEMENT_SOURCES = new Set([
 ] as const);
 
 export interface RuntimeEntitlement {
-  organizationId: string;
   source:
     | "managedOrgSubscription"
     | "selfHostedDeploymentLicense"
@@ -779,7 +778,9 @@ export class CopilotKitIntelligence {
       }
 
       const body = await Promise.race([response.text(), timeout]);
-      const entitlement = parseRuntimeEntitlement(JSON.parse(body) as unknown);
+      const entitlement = parseRuntimeEntitlementResponse(
+        JSON.parse(body) as unknown,
+      );
       if (!entitlement) {
         logger.error(
           { path, reason: "invalid-contract" },
@@ -1463,11 +1464,24 @@ function configuredUrl(url: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function parseRuntimeEntitlementResponse(
+  input: unknown,
+): RuntimeEntitlement | null {
+  if (!isRecord(input)) return null;
+
+  const allowedEnvelopeKeys = new Set(["status", "entitlement"]);
+  if (Object.keys(input).some((key) => !allowedEnvelopeKeys.has(key))) {
+    return null;
+  }
+  if (input.status !== "ready") return null;
+
+  return parseRuntimeEntitlement(input.entitlement);
+}
+
 function parseRuntimeEntitlement(input: unknown): RuntimeEntitlement | null {
   if (!isRecord(input)) return null;
 
   const allowedKeys = new Set([
-    "organizationId",
     "source",
     "active",
     "features",
@@ -1479,8 +1493,6 @@ function parseRuntimeEntitlement(input: unknown): RuntimeEntitlement | null {
 
   const source = input.source;
   if (
-    typeof input.organizationId !== "string" ||
-    input.organizationId.length === 0 ||
     typeof source !== "string" ||
     !RUNTIME_ENTITLEMENT_SOURCES.has(source as RuntimeEntitlement["source"]) ||
     typeof input.active !== "boolean" ||
@@ -1492,8 +1504,17 @@ function parseRuntimeEntitlement(input: unknown): RuntimeEntitlement | null {
     return null;
   }
 
+  if (
+    !input.active &&
+    (Object.keys(input.features).length > 0 ||
+      Object.keys(input.limits).length > 0 ||
+      input.planCode !== undefined ||
+      input.entitlementSource !== undefined)
+  ) {
+    return null;
+  }
+
   return {
-    organizationId: input.organizationId,
     source: source as RuntimeEntitlement["source"],
     active: input.active,
     features: input.features,

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -50,6 +50,33 @@ const MANAGED_INTELLIGENCE_WS_URL = "wss://realtime.intelligence.copilotkit.ai";
 /** Maximum time spent on the optional Inspector metadata provider request. */
 const INSPECTOR_METADATA_REQUEST_TIMEOUT_MS = 5_000;
 
+/** Maximum time spent consulting the deployment entitlement authority. */
+const RUNTIME_ENTITLEMENT_REQUEST_TIMEOUT_MS = 5_000;
+
+const RUNTIME_ENTITLEMENT_SOURCES = new Set([
+  "managedOrgSubscription",
+  "selfHostedDeploymentLicense",
+  "awsMarketplaceDeploymentLicense",
+] as const);
+
+export interface RuntimeEntitlement {
+  organizationId: string;
+  source:
+    | "managedOrgSubscription"
+    | "selfHostedDeploymentLicense"
+    | "awsMarketplaceDeploymentLicense";
+  active: boolean;
+  features: Record<string, boolean>;
+  limits: Record<string, number>;
+  planCode?: string;
+  entitlementSource?: string;
+}
+
+export type RuntimeEntitlementResult =
+  | { kind: "ok"; entitlement: RuntimeEntitlement }
+  | { kind: "notSupported" }
+  | { kind: "unavailable" };
+
 /**
  * Error thrown when a CopilotKit Intelligence HTTP request returns a non-2xx
  * status. Carries the HTTP {@link status} code so callers can branch on
@@ -703,6 +730,74 @@ export class CopilotKitIntelligence {
         );
       }
       throw error;
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  /**
+   * Read the deployment's server-authoritative runtime entitlement.
+   *
+   * A 404 preserves compatibility with Intelligence deployments predating the
+   * endpoint. Every other failure returns `unavailable`, allowing callers to
+   * fail closed without exposing provider response bodies or identifiers.
+   */
+  async getRuntimeEntitlement(): Promise<RuntimeEntitlementResult> {
+    const path = "/api/entitlements/runtime";
+    const abortController = new AbortController();
+    const timeoutMarker = Symbol("runtime-entitlement-timeout");
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(timeoutMarker);
+        abortController.abort();
+      }, RUNTIME_ENTITLEMENT_REQUEST_TIMEOUT_MS);
+    });
+
+    try {
+      const response = await Promise.race([
+        fetch(`${this.#apiUrl}${path}`, {
+          method: "GET",
+          headers: { Authorization: `Bearer ${this.#apiKey}` },
+          signal: abortController.signal,
+        }),
+        timeout,
+      ]);
+
+      if (response.status === 404) {
+        return { kind: "notSupported" };
+      }
+
+      if (!response.ok) {
+        logger.error(
+          { status: response.status, path },
+          "Intelligence runtime entitlement request failed",
+        );
+        return { kind: "unavailable" };
+      }
+
+      const body = await Promise.race([response.text(), timeout]);
+      const entitlement = parseRuntimeEntitlement(JSON.parse(body) as unknown);
+      if (!entitlement) {
+        logger.error(
+          { path, reason: "invalid-contract" },
+          "Intelligence runtime entitlement request failed",
+        );
+        return { kind: "unavailable" };
+      }
+
+      return { kind: "ok", entitlement };
+    } catch (error) {
+      logger.warn(
+        {
+          path,
+          reason: error === timeoutMarker ? "timeout" : "request-failed",
+        },
+        "Intelligence runtime entitlement request unavailable",
+      );
+      return { kind: "unavailable" };
     } finally {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
@@ -1366,6 +1461,72 @@ export class CopilotKitIntelligence {
 function configuredUrl(url: string | undefined): string | undefined {
   const trimmed = url?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function parseRuntimeEntitlement(input: unknown): RuntimeEntitlement | null {
+  if (!isRecord(input)) return null;
+
+  const allowedKeys = new Set([
+    "organizationId",
+    "source",
+    "active",
+    "features",
+    "limits",
+    "planCode",
+    "entitlementSource",
+  ]);
+  if (Object.keys(input).some((key) => !allowedKeys.has(key))) return null;
+
+  const source = input.source;
+  if (
+    typeof input.organizationId !== "string" ||
+    input.organizationId.length === 0 ||
+    typeof source !== "string" ||
+    !RUNTIME_ENTITLEMENT_SOURCES.has(source as RuntimeEntitlement["source"]) ||
+    typeof input.active !== "boolean" ||
+    !isBooleanRecord(input.features) ||
+    !isNumberRecord(input.limits) ||
+    !isOptionalNonEmptyString(input.planCode) ||
+    !isOptionalNonEmptyString(input.entitlementSource)
+  ) {
+    return null;
+  }
+
+  return {
+    organizationId: input.organizationId,
+    source: source as RuntimeEntitlement["source"],
+    active: input.active,
+    features: input.features,
+    limits: input.limits,
+    ...(input.planCode === undefined ? {} : { planCode: input.planCode }),
+    ...(input.entitlementSource === undefined
+      ? {}
+      : { entitlementSource: input.entitlementSource }),
+  };
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function isBooleanRecord(input: unknown): input is Record<string, boolean> {
+  return (
+    isRecord(input) &&
+    Object.values(input).every((value) => typeof value === "boolean")
+  );
+}
+
+function isNumberRecord(input: unknown): input is Record<string, number> {
+  return (
+    isRecord(input) &&
+    Object.values(input).every(
+      (value) => typeof value === "number" && Number.isFinite(value),
+    )
+  );
+}
+
+function isOptionalNonEmptyString(input: unknown): input is string | undefined {
+  return input === undefined || (typeof input === "string" && input.length > 0);
 }
 
 /**

--- a/packages/runtime/src/v2/runtime/intelligence-platform/index.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/index.ts
@@ -7,4 +7,6 @@ export {
   type SubscribeToThreadsRequest,
   type SubscribeToThreadsResponse,
   type UpdateThreadRequest,
+  type RuntimeEntitlement,
+  type RuntimeEntitlementResult,
 } from "./client";

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,4 @@
+# Lessons
+
+- Treat informational updates as context, not authorization. Do not mutate repositories,
+  cloud accounts, listings, or external systems until the user explicitly asks for action.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -28,5 +28,5 @@
       the browser payload.
 - [x] Run focused client and `/info` tests under Node 22, then the full runtime test, typecheck,
       build, formatting, and `git diff --check` targets.
-- [ ] Push a replacement draft PR linked to Intelligence PR #1072, rebase force-free onto the
+- [x] Push a replacement draft PR linked to Intelligence PR #1072, rebase force-free onto the
       latest GitHub `main`, and watch required CI until green.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,8 @@
 # Enterprise Marketplace Runtime Entitlement Plan
 
-- [ ] Port the provider-neutral authenticated Intelligence entitlement read from commits
+- [x] Port the provider-neutral authenticated Intelligence entitlement read from commits
       `2efcd18928`, `61e5becd75`, and `839a160980` onto current `origin/main`.
-- [ ] Write a failing client contract test for the current Intelligence response:
+- [x] Write a failing client contract test for the current Intelligence response:
 
   ```ts
   {
@@ -20,13 +20,13 @@
   The parser must reject unknown fields, flat legacy Marketplace bodies, identity fields, AWS
   identifiers, tokens, malformed grants, and invalid diagnostic envelopes.
 
-- [ ] Make the client return `ok`, `notSupported`, or `unavailable` without copying response
+- [x] Make the client return `ok`, `notSupported`, or `unavailable` without copying response
       bodies into errors. A 404 retains the existing local-license fallback; every other authority
       failure stays fail-closed.
-- [ ] Write `/info` tests proving active Enterprise authority maps to `valid`, inactive or
+- [x] Write `/info` tests proving active Enterprise authority maps to `valid`, inactive or
       unavailable authority maps to `invalid`, and no plan/features/limits/provider identifiers enter
       the browser payload.
-- [ ] Run focused client and `/info` tests under Node 22, then the full runtime test, typecheck,
+- [x] Run focused client and `/info` tests under Node 22, then the full runtime test, typecheck,
       build, formatting, and `git diff --check` targets.
 - [ ] Push a replacement draft PR linked to Intelligence PR #1072, rebase force-free onto the
       latest GitHub `main`, and watch required CI until green.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,32 @@
+# Enterprise Marketplace Runtime Entitlement Plan
+
+- [ ] Port the provider-neutral authenticated Intelligence entitlement read from commits
+      `2efcd18928`, `61e5becd75`, and `839a160980` onto current `origin/main`.
+- [ ] Write a failing client contract test for the current Intelligence response:
+
+  ```ts
+  {
+    status: "ready",
+    entitlement: {
+      source: "awsMarketplaceDeploymentLicense",
+      active: true,
+      features: { analytics: true, memory: true },
+      limits: { "threads.max_count": 0 },
+      planCode: "enterprise",
+    },
+  }
+  ```
+
+  The parser must reject unknown fields, flat legacy Marketplace bodies, identity fields, AWS
+  identifiers, tokens, malformed grants, and invalid diagnostic envelopes.
+
+- [ ] Make the client return `ok`, `notSupported`, or `unavailable` without copying response
+      bodies into errors. A 404 retains the existing local-license fallback; every other authority
+      failure stays fail-closed.
+- [ ] Write `/info` tests proving active Enterprise authority maps to `valid`, inactive or
+      unavailable authority maps to `invalid`, and no plan/features/limits/provider identifiers enter
+      the browser payload.
+- [ ] Run focused client and `/info` tests under Node 22, then the full runtime test, typecheck,
+      build, formatting, and `git diff --check` targets.
+- [ ] Push a replacement draft PR linked to Intelligence PR #1072, rebase force-free onto the
+      latest GitHub `main`, and watch required CI until green.


### PR DESCRIPTION
## Summary

- read the authenticated, sanitized Intelligence deployment entitlement
- project active Enterprise Marketplace authority into the existing `/info` license status
- fail closed when entitlement authority is unavailable without adding Marketplace data to browser payloads

## Contract and compatibility

The producer is CopilotKit/Intelligence#1072. An active `enterprise_deployment` agreement maps to the canonical `enterprise` plan with unlimited seats. AWS identifiers, seller metadata, grants, limits, and provider response bodies remain server-side.

A 404 from an older Intelligence deployment preserves the existing local-license fallback. Every other authority failure maps to an invalid license status.

## Verification

- full runtime suite: 146 files and 2,105 tests passed under Node 22
- focused entitlement client tests: 70 tests passed
- focused `/info` tests: 28 tests passed
- runtime typecheck, build, declaration check, publint, precommit lint, environment-name check, and `git diff --check` passed

All GitHub checks are green, and the branch is based on the latest GitHub `main`. This PR supersedes the now-closed #6610.
