### PR TITLE
fix(deps): widen @ag-ui/client, core and encoder pins so consumers dedupe

### DIFF
--- a/packages/agentcore-runner/package.json
+++ b/packages/agentcore-runner/package.json
@@ -32,7 +32,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -55,8 +55,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",

--- a/packages/channels-core/package.json
+++ b/packages/channels-core/package.json
@@ -56,8 +56,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-ui": "workspace:~",
     "@copilotkit/core": "workspace:^",
     "@copilotkit/shared": "workspace:^",

--- a/packages/channels-discord/package.json
+++ b/packages/channels-discord/package.json
@@ -41,7 +41,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "discord.js": "^14.16.0",

--- a/packages/channels-intelligence/package.json
+++ b/packages/channels-intelligence/package.json
@@ -41,7 +41,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-slack": "workspace:^",
     "@copilotkit/channels-teams": "workspace:^",
@@ -49,7 +49,7 @@
     "phoenix": "^1.8.4"
   },
   "devDependencies": {
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/typescript-config": "workspace:^",
     "@types/node": "^22.10.0",
     "@types/phoenix": "^1.6.6",

--- a/packages/channels-slack/package.json
+++ b/packages/channels-slack/package.json
@@ -51,8 +51,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "@copilotkit/core": "workspace:^",

--- a/packages/channels-teams/package.json
+++ b/packages/channels-teams/package.json
@@ -48,8 +48,8 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "@copilotkit/core": "workspace:^",

--- a/packages/channels-telegram/package.json
+++ b/packages/channels-telegram/package.json
@@ -42,7 +42,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^",
     "grammy": "^1.30.0",

--- a/packages/channels-whatsapp/package.json
+++ b/packages/channels-whatsapp/package.json
@@ -42,7 +42,7 @@
     "attw": "attw --pack . --profile esm-only"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/channels-core": "workspace:^",
     "@copilotkit/channels-ui": "workspace:^"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/shared": "workspace:*",
     "@tanstack/pacer": "^0.20.1",
     "phoenix": "^1.8.4",

--- a/packages/demo-agents/package.json
+++ b/packages/demo-agents/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "openai": "^4.85.1",
     "rxjs": "^7.8.1"
   },

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -74,8 +74,8 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/a2ui-renderer": "workspace:*",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/runtime-client-gql": "workspace:*",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -85,7 +85,7 @@
     "size:headless": "node scripts/measure-headless.mjs"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/react-core": "workspace:*",
     "@copilotkit/shared": "workspace:*",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -78,9 +78,9 @@
   },
   "dependencies": {
     "@ag-ui/a2ui-middleware": "0.0.10",
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
-    "@ag-ui/encoder": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
+    "@ag-ui/encoder": ">=0.0.59 <0.1.0",
     "@ag-ui/langgraph": "0.0.43",
     "@ag-ui/mcp-apps-middleware": "^0.1.1",
     "@ag-ui/mcp-middleware": "0.0.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,7 +61,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/license-verifier": "~0.5.0",
     "@segment/analytics-node": "^2.1.2",
     "@standard-schema/spec": "^1.0.0",

--- a/packages/sqlite-runner/package.json
+++ b/packages/sqlite-runner/package.json
@@ -32,7 +32,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/runtime": "workspace:*",
     "rxjs": "7.8.1"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -78,8 +78,8 @@
   },
   "dependencies": {
     "@a2ui/web_core": "0.10.4",
-    "@ag-ui/client": "0.0.59",
-    "@ag-ui/core": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
+    "@ag-ui/core": ">=0.0.59 <0.1.0",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "@copilotkit/web-components": "workspace:*",

--- a/packages/web-inspector/package.json
+++ b/packages/web-inspector/package.json
@@ -39,7 +39,7 @@
     "attw": "attw --pack . --profile node16"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.59",
+    "@ag-ui/client": ">=0.0.59 <0.1.0",
     "@copilotkit/core": "workspace:*",
     "@copilotkit/shared": "workspace:*",
     "lit": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2078,7 +2078,7 @@ importers:
   packages/agentcore-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/runtime':
         specifier: workspace:*
@@ -2106,10 +2106,10 @@ importers:
   packages/angular:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
@@ -2291,10 +2291,10 @@ importers:
   packages/channels-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-ui':
         specifier: workspace:~
@@ -2328,7 +2328,7 @@ importers:
   packages/channels-discord:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-core':
         specifier: workspace:^
@@ -2359,7 +2359,7 @@ importers:
   packages/channels-intelligence:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-core':
         specifier: workspace:^
@@ -2378,7 +2378,7 @@ importers:
         version: 1.8.4
     devDependencies:
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/typescript-config':
         specifier: workspace:^
@@ -2402,10 +2402,10 @@ importers:
   packages/channels-slack:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-core':
         specifier: workspace:^
@@ -2454,10 +2454,10 @@ importers:
   packages/channels-teams:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-core':
         specifier: workspace:^
@@ -2509,7 +2509,7 @@ importers:
   packages/channels-telegram:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-core':
         specifier: workspace:^
@@ -2559,7 +2559,7 @@ importers:
   packages/channels-whatsapp:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/channels-core':
         specifier: workspace:^
@@ -2584,7 +2584,7 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/shared':
         specifier: workspace:*
@@ -2642,7 +2642,7 @@ importers:
   packages/demo-agents:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       openai:
         specifier: ^4.85.1
@@ -2670,10 +2670,10 @@ importers:
   packages/react-core:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/a2ui-renderer':
         specifier: workspace:*
@@ -2845,7 +2845,7 @@ importers:
   packages/react-native:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/core':
         specifier: workspace:*
@@ -3106,13 +3106,13 @@ importers:
         specifier: 0.0.10
         version: 0.0.10(@ag-ui/client@0.0.59)(rxjs@7.8.1)
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/encoder':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/langgraph':
         specifier: 0.0.43
@@ -3468,7 +3468,7 @@ importers:
   packages/shared:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
         specifier: '>=0.0.48'
@@ -3532,7 +3532,7 @@ importers:
   packages/sqlite-runner:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/runtime':
         specifier: workspace:*
@@ -3604,10 +3604,10 @@ importers:
         specifier: 0.10.4
         version: 0.10.4
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@ag-ui/core':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/core':
         specifier: workspace:*
@@ -3758,7 +3758,7 @@ importers:
   packages/web-inspector:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.59
+        specifier: '>=0.0.59 <0.1.0'
         version: 0.0.59
       '@copilotkit/core':
         specifier: workspace:*


### PR DESCRIPTION
Fixes #6673.

## Problem

`@ag-ui/client`, `@ag-ui/core` and `@ag-ui/encoder` are pinned to the **exact** version `0.0.57` in all 18 workspace packages that depend on them. Because the pin is exact, a consumer who depends on any other release of `@ag-ui/client` cannot get a deduped tree — every `@copilotkit/*` package receives its own nested `0.0.57` copy.

`AbstractAgent` declares a private field (`_debug`), and TypeScript compares private members **nominally**, not structurally. So the consumer's `HttpAgent` and the runtime's `AbstractAgent` become mutually unassignable, and the public `CopilotRuntime({ agents })` surface (`Record<string, AbstractAgent>`, `packages/runtime/src/v2/runtime/core/runtime.ts:117`) rejects the agent:

```
error TS2769: No overload matches this call.
  Type 'HttpAgent' is not assignable to type 'AbstractAgent'.
    Types have separate declarations of a private property '_debug'.
```

Note that widening to `^0.0.57` would **not** work — under semver, caret on a `0.0.x` version does not admit `0.0.58`.

## Change

Replace the exact pins with the range `>=0.0.57 <0.1.0`, so package managers can collapse the tree onto a single instance. The upper bound keeps the pre-1.0 `0.1.x` line out, so adopting it stays a deliberate bump.

This matches the convention AG-UI already uses for its own packages that surface `AbstractAgent` in their public API — `@ag-ui/a2ui-middleware` and `@ag-ui/mcp-apps-middleware` both declare `@ag-ui/client: ">=0.0.40"` — and the `@ag-ui/core: ">=0.0.48"` peer range already present in `@copilotkit/shared`.

I kept these as `dependencies` rather than converting them to `peerDependencies`. A peer range would also guarantee a single instance, but it makes installation the consumer's responsibility, and Yarn 4 (which the reporter uses) does not auto-install peers. The range achieves the dedupe with no consumer action.

`@ag-ui/langgraph`, `@ag-ui/a2ui-middleware` and the MCP middlewares are left on their exact pins — they are on independent version lines and already declare wide peer ranges of their own.

## Verification

**Resolution in this repo is unchanged.** The lockfile still selects `0.0.57`, and the only lockfile diff is the 27 `specifier:` lines matching the 27 `package.json` edits — no version churn:

```
$ pnpm install --frozen-lockfile
Done in 6.6s
$ git diff --stat pnpm-lock.yaml
 pnpm-lock.yaml | 54 ++++++++++++++---------------
```

Full pre-commit gate passed (`test`, `publint`, `attw` across 26 projects), plus `build`, `check-types` and `test` for `@copilotkit/{shared,core,runtime}` — 2096 tests, all passing.

**End-to-end consumer reproduction.** I packed the changed packages from this branch with `pnpm pack` and installed the tarballs into a fresh project matching the reporter's setup (`@ag-ui/client@0.0.58` + `CopilotRuntime`, the exact snippet from the issue).

Against the currently published `@copilotkit/runtime@1.69.3`:

```
0.0.58  node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/runtime/node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/shared/node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/core/node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/channels-core/node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/channels-intelligence/node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/channels-slack/node_modules/@ag-ui/client
0.0.57  node_modules/@copilotkit/channels-teams/node_modules/@ag-ui/client
0.0.54  node_modules/@ag-ui/mcp-middleware/node_modules/@ag-ui/client
```
→ 9 copies, `tsc` fails with the reported `TS2769`.

Against tarballs built from this branch:

```
0.0.58  node_modules/@ag-ui/client
0.0.54  node_modules/@ag-ui/mcp-middleware/node_modules/@ag-ui/client
```
→ `tsc --noEmit` exits **0**. The reported error is gone.

## One known remainder

`@ag-ui/mcp-middleware@0.0.1` hard-pins `@ag-ui/client@0.0.54` as a regular dependency, so that nested copy survives. It does not affect the reported error — the type of the `agents` argument comes from `@copilotkit/runtime`'s own resolution — but it is a latent version of the same hazard, and the fix belongs upstream in `ag-ui` (the sibling middlewares already use a peer range instead). This repo already carries a dev-only `pnpm.overrides` entry for it. Happy to open an upstream issue if useful.

---

I noticed @Jokasa7 commented on the issue proposing an approach and asking which direction you'd prefer, with no reply yet — I don't want to step on that. This PR is the narrower of the two options they raised (widen the version contract, no peer-dependency migration); glad to close it if they'd rather carry it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated package compatibility to accept AG-UI 0.0.x releases from version 0.0.59 up to, but not including, 0.1.0.
  - Replaced exact dependency pins with compatible version ranges across supported integrations, runtimes, frameworks, and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->