### PR TITLE
docs: fix GitHub branding and hyphenation in troubleshooting

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/coagent-troubleshooting/common-coagent-issues.mdx
@@ -10,7 +10,7 @@ Welcome to the CoAgents Troubleshooting Guide! If you're having trouble getting 
     Have an issue not listed here? Open a ticket on [GitHub](https://github.com/CopilotKit/CopilotKit/issues) or reach out on [Discord](https://discord.com/invite/6dffbvGU3D)
     and we'll be happy to help.
 
-    We also highly encourage any open source contributors that want to add their own troubleshooting issues to [Github as a pull request](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
+    We also highly encourage any open-source contributors that want to add their own troubleshooting issues to [GitHub as a pull request](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
 
 </Callout>
 

--- a/showcase/shell-docs/src/content/snippets/shared/troubleshooting/common-issues.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/troubleshooting/common-issues.mdx
@@ -6,7 +6,7 @@ Welcome to the CopilotKit Troubleshooting Guide! Here, you can find answers to c
     Have an issue not listed here? Open a ticket on [GitHub](https://github.com/CopilotKit/CopilotKit/issues) or reach out on [Discord](https://discord.com/invite/6dffbvGU3D)
     and we'll be happy to help.
 
-    We also highly encourage any open source contributors that want to add their own troubleshooting issues to [Github as a pull request](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
+    We also highly encourage any open-source contributors that want to add their own troubleshooting issues to [GitHub as a pull request](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
 
 </Callout>
 


### PR DESCRIPTION
Fix GitHub branding (Github -> GitHub) and hyphenation open-source.
