### PR TITLE
fix(runtime): accept Marketplace entitlement source

### DIFF
--- a/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/get-runtime-info.test.ts
@@ -168,6 +168,29 @@ test("maps active Runtime entitlements to the compatible valid license status", 
   expect(getRuntimeEntitlements).toHaveBeenCalledOnce();
 });
 
+test("keeps an inactive AWS Marketplace entitlement authoritative over a legacy license", async () => {
+  const marketplaceEntitlements = {
+    status: "ready",
+    entitlement: {
+      source: "awsMarketplaceDeploymentLicense",
+      active: false,
+      features: {},
+      limits: {},
+    },
+  } as const;
+  const getRuntimeEntitlements = vi
+    .fn()
+    .mockResolvedValue(marketplaceEntitlements);
+  const { data, response } = await requestRuntimeInfoWithLookup(
+    getRuntimeEntitlements,
+    { licenseToken: INVALID_LEGACY_LICENSE_TOKEN },
+  );
+
+  expect(response.status).toBe(200);
+  expect(data.runtimeEntitlements).toEqual(marketplaceEntitlements);
+  expect(data.licenseStatus).toBe("none");
+});
+
 test.each([
   {
     label: "degraded",

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -42,7 +42,11 @@ function resolveCompatibilityLicenseStatus(
   runtimeEntitlements: RuntimeEntitlementResponse | undefined,
 ): RuntimeLicenseStatus {
   if (runtimeEntitlements?.status === "ready") {
-    if (runtimeEntitlements.entitlement.source === "managedOrgSubscription") {
+    if (
+      runtimeEntitlements.entitlement.source === "managedOrgSubscription" ||
+      runtimeEntitlements.entitlement.source ===
+        "awsMarketplaceDeploymentLicense"
+    ) {
       return runtimeEntitlements.entitlement.active ? "valid" : "none";
     }
 

--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -149,6 +149,24 @@ test("getRuntimeEntitlements normalizes an inactive self-hosted App API response
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
+test("getRuntimeEntitlements accepts an AWS Marketplace App API response", async () => {
+  const client = runtimeEntitlementsClient();
+  const response = {
+    status: "ready",
+    entitlement: {
+      source: "awsMarketplaceDeploymentLicense",
+      active: true,
+      features: { deployment_via_helm_chart: true },
+      limits: { "threads.max_count": 25_000 },
+      planCode: "enterprise",
+    },
+  } as const;
+  fetchMock.mockReturnValue(jsonResponse(response));
+
+  await expect(client.getRuntimeEntitlements()).resolves.toEqual(response);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
 test("recursive forbidden-key control detects identity and credential leaks", () => {
   const leakedProjection = {
     organizationId: "org-leaked",

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -34,7 +34,11 @@ function isRetryableRuntimeEntitlementStatus(status: number): boolean {
 const runtimeEntitlementSchema = z
   .object({
     active: z.boolean(),
-    source: z.enum(["managedOrgSubscription", "selfHostedDeploymentLicense"]),
+    source: z.enum([
+      "managedOrgSubscription",
+      "selfHostedDeploymentLicense",
+      "awsMarketplaceDeploymentLicense",
+    ]),
     features: z.record(z.string(), z.boolean()),
     limits: z.record(z.string(), z.number()),
     planCode: z.string().optional(),

--- a/packages/shared/src/__tests__/license-context.test.ts
+++ b/packages/shared/src/__tests__/license-context.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "vitest";
 import { createLicenseContextValue } from "../index";
-import type { RuntimeLicenseStatus } from "../utils/types";
+import type {
+  RuntimeEntitlementResponse,
+  RuntimeLicenseStatus,
+} from "../utils/types";
 
 test("license context fails open when no status is known", () => {
   for (const status of [null, undefined] as const) {
@@ -159,6 +162,24 @@ test("license context denies features and limits for a ready inactive entitlemen
   });
 
   expect(ctx.checkFeature("chat")).toBe(false);
+  expect(ctx.getLimit("threads")).toBeNull();
+});
+
+test("license context does not fall back for an inactive AWS Marketplace entitlement", () => {
+  const marketplaceEntitlements = {
+    status: "ready",
+    entitlement: {
+      active: false,
+      source: "awsMarketplaceDeploymentLicense",
+      features: {},
+      limits: {},
+    },
+  } as const satisfies RuntimeEntitlementResponse;
+
+  const ctx = createLicenseContextValue("valid", marketplaceEntitlements);
+
+  expect(ctx.status).toBe("none");
+  expect(ctx.checkFeature("threads")).toBe(false);
   expect(ctx.getLimit("threads")).toBeNull();
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -106,7 +106,8 @@ export function createLicenseContextValue(
   const activeEntitlement = featureAuthority?.active ? featureAuthority : null;
   const resolvedStatus = activeEntitlement
     ? "valid"
-    : readyEntitlement?.source === "managedOrgSubscription"
+    : readyEntitlement?.source === "managedOrgSubscription" ||
+        readyEntitlement?.source === "awsMarketplaceDeploymentLicense"
       ? "none"
       : featureAuthority
         ? (status ?? "none")

--- a/packages/shared/src/utils/types.ts
+++ b/packages/shared/src/utils/types.ts
@@ -51,7 +51,10 @@ interface RuntimeEntitlement {
   /** Whether the resolved entitlement currently grants product access. */
   active: boolean;
   /** Deployment authority that produced this entitlement. */
-  source: "managedOrgSubscription" | "selfHostedDeploymentLicense";
+  source:
+    | "managedOrgSubscription"
+    | "selfHostedDeploymentLicense"
+    | "awsMarketplaceDeploymentLicense";
   /** Boolean feature grants keyed by stable feature id. */
   features: Record<string, boolean>;
   /** Numeric limits keyed by stable feature id. */


### PR DESCRIPTION
## Summary

- accept the sanitized `awsMarketplaceDeploymentLicense` entitlement source produced by Intelligence
- project active Marketplace authority into the existing `/info` compatibility license status
- treat an inactive Marketplace entitlement as authoritative so legacy local-license fallback cannot re-enable access

## Architecture

Intelligence/App API remains the licensing authority. This change does not call AWS, evaluate Marketplace agreements, or move entitlement logic back into `CopilotRuntime`. The runtime only parses the sanitized entitlement response (`active`, `plan`, and `source`) and preserves the existing compatibility projection for consumers of `/info`.

AWS identifiers, License Manager responses, seller metadata, and agreement details remain server-side.

## Verification

- runtime package suite: 151 files / 2,252 tests passed
- shared package suite: 17 files / 403 tests passed
- runtime and shared typechecks/builds: passed
- repository pre-commit gate: passed (lint, package tests/checks, Intelligence env validation)
- branch contains one commit based directly on current `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for AWS Marketplace deployment-license entitlements in runtime licensing.
  - AWS Marketplace entitlements are now recognized when determining entitlement status and access.

- **Bug Fixes**
  - Inactive AWS Marketplace entitlements no longer fall back to legacy license information.
  - When an AWS Marketplace entitlement is inactive, the license status is reported as unavailable, and associated features and usage limits are not granted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->