### PR TITLE
ci(telemetry): name the cause when the registry install fails

### DIFF
--- a/.github/workflows/telemetry-docs-fragment.yml
+++ b/.github/workflows/telemetry-docs-fragment.yml
@@ -96,6 +96,15 @@ jobs:
         working-directory: p2p
         run: |
           pnpm --ignore-workspace install --frozen-lockfile
+          # Name the cause here. If the registry's own dependencies did not
+          # install, `reconcile` fails as a cascade of TS2307/TS2304 errors
+          # pointing at the registry's source (`Cannot find module 'node:fs'`,
+          # `Cannot find name '__dirname'`), which reads as a registry bug
+          # rather than a failed install.
+          if [ ! -x node_modules/.bin/ts-node ]; then
+            echo "::error::Registry dependencies were not installed in p2p/node_modules — check the pnpm install step above."
+            exit 1
+          fi
           pnpm --ignore-workspace run reconcile
 
       - name: Open fragment PR

--- a/.github/workflows/telemetry-runtime-fragment.yml
+++ b/.github/workflows/telemetry-runtime-fragment.yml
@@ -97,6 +97,15 @@ jobs:
         working-directory: p2p
         run: |
           pnpm --ignore-workspace install --frozen-lockfile
+          # Name the cause here. If the registry's own dependencies did not
+          # install, `reconcile` fails as a cascade of TS2307/TS2304 errors
+          # pointing at the registry's source (`Cannot find module 'node:fs'`,
+          # `Cannot find name '__dirname'`), which reads as a registry bug
+          # rather than a failed install.
+          if [ ! -x node_modules/.bin/ts-node ]; then
+            echo "::error::Registry dependencies were not installed in p2p/node_modules — check the pnpm install step above."
+            exit 1
+          fi
           pnpm --ignore-workspace run reconcile
 
       - name: Open fragment PR


### PR DESCRIPTION
## Problem

The telemetry fragment workflows regenerate the canonical registry by running, in the nested `p2p` checkout:

```
pnpm --ignore-workspace install --frozen-lockfile
pnpm --ignore-workspace run reconcile     # -> ts-node telemetry-registry/reconcile/index.ts
```

If that install does not put the registry's own dependencies in place, `reconcile` does not say so. It fails as a cascade of TypeScript errors pointing at the registry's source:

```
error TS2307: Cannot find module 'node:fs' or its corresponding type declarations.
error TS2307: Cannot find module 'node:path' or its corresponding type declarations.
error TS2304: Cannot find name 'structuredClone'.
error TS2304: Cannot find name '__dirname'.
```

That reads as a bug in oss-path-to-production. It isn't — it's a failed install. Three `telemetry-docs-fragment` runs failed exactly this way on 2026-08-28 (e.g. run `33216460960`) before #6621 fixed the underlying cause.

## Change

#6621 fixed the *cause* (pnpm was resolving CopilotKit's parent workspace instead of the registry's lockfile — visible in the log as `Scope: all 70 workspace projects`). This adds the missing diagnostic so a *future* recurrence, from any cause, names itself:

```bash
if [ ! -x node_modules/.bin/ts-node ]; then
  echo "::error::Registry dependencies were not installed in p2p/node_modules — check the pnpm install step above."
  exit 1
fi
```

Applied to both `telemetry-docs-fragment.yml` and `telemetry-runtime-fragment.yml`. No behavior change on the success path.

`ts-node` is the right thing to probe: it is the binary `reconcile` invokes, and the registry declares it (`ts-node: ^10.9.2`).

## Testing

**1. YAML parses, guard is wired into the intended step**
```
telemetry-docs-fragment: OK, 10 steps, guard present in 1 step(s)
telemetry-runtime-fragment: OK, 10 steps, guard present in 1 step(s)
```

**2. Guard fires when ts-node is absent** (empty dir, no `node_modules`)
```
::error::Registry dependencies were not installed in p2p/node_modules — check the pnpm install step above.
exit=1
```

**3. Guard passes through when ts-node is present** (`node_modules/.bin/ts-node`, executable)
```
guard passed — would run reconcile
exit=0
```

**4. Probe target confirmed against the real registry checkout**
```
reconcile script: ts-node telemetry-registry/reconcile/index.ts
ts-node declared: ^10.9.2
ts-node present in this checkout's node_modules: yes
```

**5. Formatting**
```
oxfmt --check ... -> All matched files use the correct format.
```

Not provable locally: the workflows themselves only run on their schedule/dispatch against a real cross-repo token, so the first end-to-end exercise is their next scheduled run.

## Credit

The guard is lifted from **onsclom's #6435**, which I closed as otherwise superseded — its telemetry half by #6621 and its Inspector-flake half by `669132d731`. This piece was the part neither of those carries.
