### PR TITLE
fix(react-core): register frontend tools before sibling effects run

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-timing.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-timing.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * `useFrontendTool` must register its tool before any sibling's `useEffect`
+ * runs, not merely before some siblings'.
+ *
+ * React flushes passive effects (`useEffect`) child-first in tree order, so a
+ * consumer mounted BEFORE the registering component sees an empty tool list.
+ * That is the cross-page-navigation failure: a page mounts `CopilotChat` and
+ * its tool-registering components in one commit, `CopilotChat`'s connect
+ * effect fires first, and the connect request carries no frontend tools.
+ *
+ * Layout effects run during commit, ahead of every passive effect regardless
+ * of order, so registering in `useLayoutEffect` closes the window.
+ *
+ * The consumer is deliberately mounted FIRST here. Mounting it second passes
+ * with either hook and proves nothing.
+ */
+import React, { useEffect, useRef } from "react";
+import { waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { useFrontendTool } from "../use-frontend-tool";
+import { useCopilotKit } from "../../providers/CopilotKitProvider";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+} from "../../__tests__/utils/test-helpers";
+
+describe("useFrontendTool registration timing", () => {
+  it("registers the tool before an earlier-mounted sibling's useEffect runs", async () => {
+    const agent = new MockStepwiseAgent();
+    const observed: string[][] = [];
+
+    /** Mounted FIRST — stands in for CopilotChat's connect effect. */
+    function EarlyConsumer() {
+      const { copilotkit } = useCopilotKit();
+      const done = useRef(false);
+      useEffect(() => {
+        if (done.current) return;
+        done.current = true;
+        observed.push(copilotkit.tools.map((t) => t.name));
+      }, [copilotkit]);
+      return null;
+    }
+
+    /** Mounted SECOND — stands in for a page's tool-registering component. */
+    function LateRegistrar() {
+      useFrontendTool({
+        name: "timingTestTool",
+        description: "Tool for timing test",
+        parameters: z.object({}),
+        handler: async () => "ok",
+      });
+      return null;
+    }
+
+    renderWithCopilotKit({
+      agent,
+      children: (
+        <>
+          <EarlyConsumer />
+          <LateRegistrar />
+        </>
+      ),
+    });
+
+    await waitFor(() => expect(observed.length).toBeGreaterThanOrEqual(1));
+    expect(observed[0]).toContain("timingTestTool");
+  });
+});

--- a/packages/react-core/src/v2/hooks/use-frontend-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-frontend-tool.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { useCopilotKit } from "../context";
 import type { ReactFrontendTool } from "../types/frontend-tool";
 
@@ -10,7 +10,7 @@ export function useFrontendTool<
   const { copilotkit } = useCopilotKit();
   const extraDeps = deps ?? EMPTY_DEPS;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const name = tool.name;
 
     // Always register/override the tool for this name on mount

--- a/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
+++ b/packages/react-core/src/v2/hooks/use-human-in-the-loop.tsx
@@ -3,7 +3,7 @@ import type { ReactFrontendTool } from "../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../types/human-in-the-loop";
 import type { ReactToolCallRenderer } from "../types/react-tool-call-renderer";
 import { ToolCallStatus } from "@copilotkit/core";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 import React from "react";
 import { useFrontendTool } from "./use-frontend-tool";
 
@@ -113,8 +113,16 @@ export function useHumanInTheLoop<
   useFrontendTool(frontendTool, deps);
 
   // Human-in-the-loop tools should remove their renderer on unmount
-  // since they can't respond to user interactions anymore
-  useEffect(() => {
+  // since they can't respond to user interactions anymore.
+  //
+  // This MUST stay a layout effect to match `useFrontendTool`, which registers
+  // the renderer in its own layout effect. React runs every cleanup in a phase
+  // before any effect of that same phase, but it runs the whole layout phase
+  // ahead of the whole passive phase. If this teardown were passive while the
+  // registration is layout, a keyed remount would order the outgoing
+  // instance's removal *after* the incoming instance's registration and delete
+  // the renderer that had just been added, leaving the tool unrenderable.
+  useLayoutEffect(() => {
     return () => {
       copilotkit.removeHookRenderToolCall(tool.name, tool.agentId);
     };


### PR DESCRIPTION
Re-derived against current main from **#4259** (mxmzb), which diagnosed this in April. That branch is 7,386 commits behind and conflicts, so this ports the mechanism rather than rebasing it.

## The bug

`useFrontendTool` registered its tool inside a `useEffect`. React flushes passive effects **child-first in tree order**, so a component mounted *before* the registering component runs its own `useEffect` against an empty tool list.

That is the cross-page-navigation failure: a page mounts `CopilotChat` and its tool-registering components in one commit, `CopilotChat`'s connect effect fires first, and the connect request goes out carrying no frontend tools.

## The fix

Register in `useLayoutEffect`. Layout effects run during commit, ahead of every passive effect regardless of tree order, closing the window.

This is not a new pattern here — **`useAgentContext` already registers via `useLayoutEffect`** (`use-agent-context.tsx:2`). The context half of this hook family was fixed; the tool half was not. This makes them consistent.

## Testing

### The original test did not detect the bug

Worth recording. #4259 shipped `use-frontend-tool-timing.test.tsx`, which mounts the tool registrar **before** the observing component. I ported it verbatim and ran it against unmodified main:

```
✓ src/v2/hooks/__tests__/use-frontend-tool-timing.test.tsx (1 test) 10ms
  Test Files  1 passed (1)
```

It passes without the fix. React runs the registrar's effect first in that order, so the observer always sees the tool. The PR's own comment concedes the point — *"the result depends on component ordering and may be absent."*

The test here mounts the consumer **first**, which is the shape that actually breaks, and says so in the file so nobody reorders it back.

### RED → GREEN on the real surface

**RED** (current main, `useEffect`):
```
× registers the tool before an earlier-mounted sibling's useEffect runs
AssertionError: expected [] to include 'timingTestTool'
  Tests  1 failed (1)
```
The empty array is the bug: the consumer's effect saw no tools.

**GREEN** (`useLayoutEffect`):
```
✓ src/v2/hooks/__tests__/use-frontend-tool-timing.test.tsx (1 test) 12ms
  Tests  1 passed (1)
```

### No regressions

Full `src/v2/hooks` suite, same environment, with and without the change:

| | Test files | Tests |
|---|---|---|
| without fix | 8 failed / 29 passed | **37 failed** / 283 passed |
| with fix | 7 failed / 30 passed | **36 failed** / 284 passed |

The delta is exactly the new test. The remaining 36 failures are pre-existing in my local worktree (stale cross-package `dist` resolution), identical on both sides.

## Notes

- **SSR:** `useLayoutEffect` warns during server rendering. These hooks run inside `CopilotKitProvider`'s client context, and the sibling `useAgentContext` already uses a bare `useLayoutEffect`, so this follows the established pattern rather than introducing an isomorphic wrapper.
- **Scope:** #4259 also carried a second, independent mechanism — an `ensureToolMiddleware` fallback that injects tools/context into direct `agent.runAgent()` calls bypassing `copilotkit.runAgent()` (`run-handler.ts` +44, plus `core.ts`, `agent-registry.ts`, Angular's `agent.ts`, `use-agent.tsx`). That addresses a **different** failure and deserves its own PR, tests and review. It is deliberately **not** included here and should not be considered resolved by this.

Credit to @mxmzb for the diagnosis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frontend tools are now registered earlier, ensuring availability before the interface is displayed.
  * Improved consistency when components access frontend tools during initial effects.
  * Renderer cleanup now occurs at the appropriate stage when components are removed.

* **Tests**
  * Added coverage verifying frontend tools are available to earlier-mounted components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->