### PR TITLE
docs(adk): document how an ADK agent reads the context the page shares

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx
@@ -66,8 +66,8 @@ and `useAgentContext` is how the agent gets it.
         ### Read the context in your ADK agent
 
         Pass an [`InstructionProvider`](https://google.github.io/adk-docs/agents/llm-agents/#instructions)
-        instead of a string. A provider receives a `ReadonlyContext`, and `ctx.state` is the only place
-        the CopilotKit context exists.
+        instead of a string. A provider receives a `ReadonlyContext`, and the adapter leaves the
+        CopilotKit context at `ctx.state[CONTEXT_STATE_KEY]`.
 
         ```python title="agent.py"
         import json
@@ -121,11 +121,22 @@ and `useAgentContext` is how the agent gets it.
         ```
 
         <Callout>
-            A provider is the right form here for a second reason. `canonical_instruction` reports
-            `bypass_state_injection=True` for a provider and `False` for a string, and the rendered
-            context above is full of JSON braces. Under a string instruction ADK reads every `{...}`
-            as a `{state_key}` placeholder and tries to resolve it. A provider hands back final text,
-            so the braces survive verbatim.
+            `ctx.state` is the form to reach for because it works on every `ag-ui-adk` version. On
+            `ag-ui-adk` 0.7.0 with `google-adk` 1.22.0 or later the adapter also copies the same
+            entries into `RunConfig.custom_metadata`, so
+            `ctx.run_config.custom_metadata["ag_ui_context"]` reads them too. Neither path puts them
+            in the prompt on its own — that is still the provider's job.
+        </Callout>
+
+        <Callout>
+            A provider is also the safer form for the braces. Under a string instruction ADK runs
+            `inject_session_state` over the text; its regex matches any `{...}` run, but substitutes
+            only when the contents are a valid state name. JSON such as `{"id": 1}` is therefore left
+            verbatim, while an identifier-shaped block — a `{status}` inside one of your context
+            values — is looked up in session state and raises `KeyError` when it is not there. A
+            provider reports `bypass_state_injection=True` from `canonical_instruction` (a string
+            reports `False`), so the rendered context is never scanned at all. Checked against
+            `google-adk` at the `>=1.28.1` floor `ag-ui-adk` 0.7.0 requires.
         </Callout>
     </Step>
 

--- a/showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/agent-app-context.mdx
@@ -1,0 +1,160 @@
+---
+title: Agent App Context
+icon: "lucide/BookA"
+description: Share app specific context with your ADK agent.
+---
+
+## What is this?
+
+One of the most common use cases for CopilotKit is to register app state and context using `useAgentContext`.
+This way, you can notify your agent of what is going on in your app in real time.
+
+Some examples might be: the current user, the current page, the rows currently on screen.
+
+## When should I use this?
+
+Use this when the agent's answer has to be about data your application holds rather than data the
+user retypes into the chat. A queue, a selection, a cart, a filtered table: the page already has it,
+and `useAgentContext` is how the agent gets it.
+
+<Callout type="warn" title="ADK needs one line on the agent side">
+    Unlike the [built-in agent](/built-in-agent/agent-app-context), an ADK agent does **not** receive
+    this context automatically. The AG-UI adapter stores it in ADK session state under
+    `CONTEXT_STATE_KEY` (`"_ag_ui_context"`) and stops there. Nothing puts it in the prompt.
+
+    An `LlmAgent` built with a plain string `instruction` therefore never sees it. The agent still
+    answers, fluently and in the right shape, from nothing — which reads like a working integration
+    until you check the answer against your own records. Step 2 below is the step that connects them.
+</Callout>
+
+## Implementation
+
+<Steps>
+    <Step>
+        ### Share data with your agent
+
+        The [`useAgentContext` hook](/reference/v2/hooks/useAgentContext) adds data as context to the Copilot.
+
+        ```tsx title="YourComponent.tsx" showLineNumbers
+        "use client" // only necessary if you are using Next.js with the App Router. // [!code highlight]
+        import { useAgentContext } from "@copilotkit/react-core/v2"; // [!code highlight]
+        import { useState } from 'react';
+
+        export function YourComponent() {
+            // Create colleagues state with some sample data
+            const [colleagues, setColleagues] = useState([
+                { id: 1, name: "John Doe", role: "Developer" },
+                { id: 2, name: "Jane Smith", role: "Designer" },
+                { id: 3, name: "Bob Wilson", role: "Product Manager" }
+            ]);
+
+            // Define agent context
+            // [!code highlight:4]
+            useAgentContext({
+                description: "The current user's colleagues",
+                value: colleagues,
+            });
+            return (
+                // Your custom UI component
+                <>...</>
+            );
+        }
+        ```
+    </Step>
+
+    <Step>
+        ### Read the context in your ADK agent
+
+        Pass an [`InstructionProvider`](https://google.github.io/adk-docs/agents/llm-agents/#instructions)
+        instead of a string. A provider receives a `ReadonlyContext`, and `ctx.state` is the only place
+        the CopilotKit context exists.
+
+        ```python title="agent.py"
+        import json
+
+        from ag_ui_adk import ADKAgent, CONTEXT_STATE_KEY, add_adk_fastapi_endpoint # [!code highlight]
+        from google.adk.agents import LlmAgent
+        from google.adk.agents.readonly_context import ReadonlyContext
+
+        BASE_INSTRUCTION = """You are a helpful assistant that can help emailing colleagues.
+
+        Answer only about the colleagues the page below sent you. If that list is empty, say the
+        page sent no colleagues. If it holds colleagues but none of them match what the user asked
+        about, say so and name the ones the page did send. Never invent a colleague."""
+
+
+        def render_context(state) -> str:
+            """Turn the entries the frontend sent into prompt text."""
+            entries = state.get(CONTEXT_STATE_KEY) or [] # [!code highlight]
+            if not entries:
+                return "The page sent no context entries."
+
+            blocks = []
+            for entry in entries:
+                description = entry.get("description", "(no description)")
+                value = entry.get("value", "")
+                # `value` arrives already JSON-encoded as a string. Anything else is encoded
+                # here so a dict never reaches the prompt as a Python repr.
+                if not isinstance(value, str):
+                    value = json.dumps(value, ensure_ascii=False)
+                blocks.append(f"### {description}\n{value}")
+            return "\n\n".join(blocks)
+
+
+        # An InstructionProvider, not a string. // [!code highlight]
+        def build_instruction(ctx: ReadonlyContext) -> str:
+            return f"{BASE_INSTRUCTION}\n\n## Context from the page\n\n{render_context(ctx.state)}\n"
+
+
+        colleagues_agent = LlmAgent(
+            name="colleagues_agent",
+            model="gemini-2.5-flash",
+            instruction=build_instruction, # [!code highlight]
+        )
+
+        adk_agent = ADKAgent(
+            adk_agent=colleagues_agent,
+            app_name="demo_app",
+            user_id="demo_user",
+            use_in_memory_services=True,
+        )
+        ```
+
+        <Callout>
+            A provider is the right form here for a second reason. `canonical_instruction` reports
+            `bypass_state_injection=True` for a provider and `False` for a string, and the rendered
+            context above is full of JSON braces. Under a string instruction ADK reads every `{...}`
+            as a `{state_key}` placeholder and tries to resolve it. A provider hands back final text,
+            so the braces survive verbatim.
+        </Callout>
+    </Step>
+
+    <Step>
+        ### Or read it inside a tool
+
+        The same entries reach any tool through `tool_context.state`, which is the better fit when
+        only one tool needs the data rather than the whole prompt.
+
+        ```python title="tools.py"
+        from ag_ui_adk import CONTEXT_STATE_KEY
+        from google.adk.tools import ToolContext
+
+        def find_colleague(tool_context: ToolContext, name: str) -> dict:
+            """Look up one colleague among the ones the page sent."""
+            entries = tool_context.state.get(CONTEXT_STATE_KEY) or [] # [!code highlight]
+            # ... read the entry whose `description` matches the one you registered
+            return {"found": False}
+        ```
+    </Step>
+
+    <Step>
+        ### Give it a try!
+
+        Ask your agent a question about the context. It should be able to answer.
+
+        Then check the answer against your own records, because this is the one integration that
+        fails quietly. The reliable check is a control: send the same request once with the context
+        and once with an empty context. Two answers that describe the same record mean the context
+        changed nothing, and the agent is answering from its own invention.
+    </Step>
+</Steps>

--- a/showcase/shell-docs/src/content/docs/integrations/adk/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/meta.json
@@ -8,6 +8,7 @@
     "---App Control---",
     "frontend-tools",
     "shared-state",
+    "agent-app-context",
     "---Deploy---",
     "deploy-langsmith",
     "---Intelligence---",

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/agent-app-context.mdx
@@ -4,7 +4,14 @@ icon: "lucide/BookA"
 description: "Share app-specific context with your Built-in Agent."
 ---
 
-Share your application's state and context with the Built-in Agent using the `useAgentContext` hook. The agent automatically receives this context — no backend configuration needed.
+Share your application's state and context with the Built-in Agent using the `useAgentContext` hook. The Built-in Agent receives this context automatically, with no backend configuration.
+
+<Callout>
+    That last part is specific to the Built-in Agent. An agent you host yourself receives the same
+    entries on the AG-UI run input, and each framework decides what reaches the model from there —
+    see your framework's own Agent App Context page, such as [ADK](/adk/agent-app-context),
+    [LangGraph](/langgraph/agent-app-context) or [Mastra](/mastra/agent-app-context).
+</Callout>
 
 ## What is this?
 


### PR DESCRIPTION
## What

- Adds `integrations/adk/agent-app-context.mdx`, the page ADK was missing.
- Lists it under **App Control** in `adk/meta.json`, beside `frontend-tools` and `shared-state`, matching Mastra.
- Scopes the built-in-agent page's "no backend configuration needed" to the built-in agent, and points at the per-framework pages.

## Why

`ag_ui_adk` stores `RunAgentInput.context` in ADK session state under `CONTEXT_STATE_KEY` (`"_ag_ui_context"`) and stops there. Its own docstring says so:

> Context from RunAgentInput is always stored in session state under the `_ag_ui_context` key (CONTEXT_STATE_KEY), making it accessible to both tools (via `tool_context.state`) and instruction providers (via `ctx.state`).

Nothing in the package puts it in front of the model — `CONTEXT_STATE_KEY` is read in exactly one place, `a2ui_tool.py`, for the A2UI catalog entry. ADK's `inject_session_state` substitutes only explicit `{key}` placeholders, so an `LlmAgent` built with a plain string `instruction` (the form every ADK quickstart shows) never sees what `useAgentContext` sent.

The agent still answers. Probing one such agent with the page's full queue in `context` and then with `context: []`:

| context sent | report the model passed to its own tool |
| -- | -- |
| full queue | `"The payment gateway is returning 500 errors for 40% of checkout requests…"` |
| full queue, repeated | `"The production payment service is returning 500 errors for 80%…"` |
| **empty** | `"Database connection pool exhausted on us-east-1 production cluster…"` |

Three inventions, and the empty-context run is indistinguishable from the two full ones. Nothing errors, nothing is missing from the UI, and the answer is well formed — which is exactly why a page is the right fix rather than a troubleshooting note.

Mastra and LangGraph both document their retrieval step. ADK had none, and `langgraph/programmatic-control.mdx` already links to a sibling page that did not exist for ADK.

The page covers both retrieval forms — an `InstructionProvider` reaching `ctx.state` (with the note that `canonical_instruction` reports `bypass_state_injection=True` for a provider, so JSON braces in the rendered context survive), and `tool_context.state` when only one tool needs the data — and closes with the empty-context control as the way to check the wiring.

## Testing

- Both `.mdx` files compile under `@mdx-js/mdx`.
- `adk/meta.json` parses, and `agent-app-context` sits in the group Mastra puts it in.
- Internal links use the repo's own convention (`/adk/…`, `/langgraph/agent-app-context`, `/mastra/agent-app-context`), matching links already in the tree.
- `<Callout type="warn" title="…">` matches existing usage.
- The docs site build was not run locally — the worktree has no install. Leaving that to CI.

Filed as OSS-1045 internally, a sibling of OSS-1027 (Pydantic AI's adapter drops the same field outright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ADK integration guidance for sharing application context with agents, including setup steps and access from instructions and tools.
  * Updated documentation navigation to include the new ADK application context page.
  * Clarified how built-in and self-hosted agents receive and process application context, with links to framework-specific guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->