### PR TITLE
docs(crewai): document how a CrewAI Flow reads the context the page shares (closes OSS-1051)

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/agent-app-context.mdx
@@ -1,0 +1,184 @@
+---
+title: Agent App Context
+icon: "lucide/BookA"
+description: Share app specific context with your CrewAI Flow.
+---
+
+## What is this?
+
+One of the most common use cases for CopilotKit is to register app state and context using `useAgentContext`.
+This way, you can notify your agent of what is going on in your app in real time.
+
+Some examples might be: the current user, the current page, the rows currently on screen.
+
+## When should I use this?
+
+Use this when the agent's answer has to be about data your application holds rather than data the
+user retypes into the chat. A queue, a selection, a cart, a filtered table: the page already has it,
+and `useAgentContext` is how the agent gets it.
+
+<Callout type="warn" title="CrewAI needs a field on your state class">
+    Unlike the [built-in agent](/built-in-agent/agent-app-context), a CrewAI Flow does **not** receive
+    this context automatically, and the gap is easy to miss because it does not look like a missing
+    field. The AG-UI adapter writes your entries into the run state under a `context` key — but
+    `CopilotKitState` does not declare `context`, and a Flow state is a Pydantic model, so the key is
+    dropped on validation before any `@start()` method runs.
+
+    That means `self.state.context` does not exist in the shape the quickstart shows, and reading it
+    raises nothing — it is simply never there. Your crew still answers, fluently and in the right
+    shape, from nothing. Step 2 below declares the field so the value survives, and step 3 puts it in
+    front of the model.
+</Callout>
+
+## Implementation
+
+<Steps>
+    <Step>
+        ### Share data with your agent
+
+        The [`useAgentContext` hook](/reference/v2/hooks/useAgentContext) adds data as context to the Copilot.
+
+        ```tsx title="YourComponent.tsx" showLineNumbers
+        "use client" // only necessary if you are using Next.js with the App Router. // [!code highlight]
+        import { useAgentContext } from "@copilotkit/react-core/v2"; // [!code highlight]
+        import { useState } from 'react';
+
+        export function YourComponent() {
+            // Create colleagues state with some sample data
+            const [colleagues, setColleagues] = useState([
+                { id: 1, name: "John Doe", role: "Developer" },
+                { id: 2, name: "Jane Smith", role: "Designer" },
+                { id: 3, name: "Bob Wilson", role: "Product Manager" }
+            ]);
+
+            // Define agent context
+            // [!code highlight:4]
+            useAgentContext({
+                description: "The current user's colleagues",
+                value: colleagues,
+            });
+            return (
+                // Your custom UI component
+                <>...</>
+            );
+        }
+        ```
+    </Step>
+
+    <Step>
+        ### Declare `context` on your state class
+
+        This is the step that is easy to skip, because nothing fails loudly without it. Subclass
+        `CopilotKitState` as usual and add the field yourself.
+
+        ```python title="flow.py"
+        from typing import Any
+
+        from ag_ui_crewai import CopilotKitState
+        from pydantic import Field
+
+        class ColleaguesState(CopilotKitState):
+            # Without this field Pydantic drops the entries the adapter just wrote.
+            context: list[dict[str, Any]] = Field(default_factory=list) # [!code highlight]
+        ```
+
+        Each entry is a plain dict with the `description` and `value` you registered on the frontend.
+        `value` arrives JSON-encoded as a string for anything that is not already a string.
+    </Step>
+
+    <Step>
+        ### Render the context into the crew's work
+
+        Declaring the field makes the data reachable. It does not put it in the prompt. Fold the
+        entries into the text your crew actually reads, the same way you fold in the user's message.
+
+        ```python title="flow.py"
+        import json
+
+        from crewai import Agent, Crew, LLM, Process, Task
+        from crewai.flow.flow import Flow, start
+
+        BASE_BACKSTORY = """You are a helpful assistant that can help emailing colleagues.
+
+        Answer only about the colleagues the page below sent you. If that list is empty, say the
+        page sent no colleagues. If it holds colleagues but none of them match what the user asked
+        about, say so and name the ones the page did send. Never invent a colleague."""
+
+
+        def render_context(entries: list[dict[str, Any]]) -> str:
+            """Turn the entries the frontend sent into prompt text."""
+            if not entries:
+                return "The page sent no context entries."
+
+            blocks = []
+            for entry in entries:
+                description = entry.get("description", "(no description)")
+                value = entry.get("value", "")
+                if not isinstance(value, str):
+                    value = json.dumps(value, ensure_ascii=False)
+                blocks.append(f"### {description}\n{value}")
+            return "\n\n".join(blocks)
+
+
+        class ColleaguesFlow(Flow[ColleaguesState]):
+            @start()
+            async def answer(self) -> str:
+                question = "\n".join(
+                    str(message.get("content", ""))
+                    for message in self.state.messages
+                    if message.get("role") == "user"
+                ).strip()
+
+                # The field declared in step 2 is what makes this readable.
+                page_context = render_context(self.state.context) # [!code highlight]
+
+                agent = Agent(
+                    role="Colleague assistant",
+                    goal="Answer about the colleagues the page sent, and nothing else.",
+                    backstory=BASE_BACKSTORY,
+                    llm=LLM(model="openai/gpt-4.1-mini"),
+                )
+                task = Task(
+                    description=(
+                        "## Context from the page\n\n{page_context}\n\n"
+                        "## The user asked\n\n{question}"
+                    ),
+                    expected_output="A direct answer grounded only in the context above.",
+                    agent=agent,
+                )
+                crew = Crew(agents=[agent], tasks=[task], process=Process.sequential)
+                result = await crew.kickoff_async(
+                    # [!code highlight:2]
+                    inputs={"page_context": page_context, "question": question},
+                )
+
+                # A Flow's return value is not sent to the UI. Append the answer to
+                # `messages` or the turn finishes with nothing rendered.
+                # [!code highlight:2]
+                self.state.messages.append({"role": "assistant", "content": str(result)})
+                return str(result)
+        ```
+
+        <Callout>
+            Pass the rendered context through `inputs` rather than formatting it into the
+            `description` string yourself. CrewAI interpolates `{placeholder}` in a task description
+            from `inputs`, so context full of JSON braces stays verbatim instead of being read as
+            more placeholders.
+        </Callout>
+    </Step>
+
+    <Step>
+        ### Give it a try!
+
+        Ask your agent a question about the context. It should be able to answer.
+
+        Then check the answer against your own records, because this integration fails quietly. The
+        reliable check is a control: send the same request once with the context and once with an
+        empty context. Two answers that describe the same record mean the context changed nothing,
+        and the agent is answering from its own invention.
+
+        A crew whose backstory forbids invention refuses instead of inventing, which looks safer and
+        is the same defect — it is still answering with nothing. Compare against the empty control
+        either way.
+    </Step>
+</Steps>

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/meta.json
@@ -30,6 +30,7 @@
     "---App Control---",
     "frontend-tools",
     "shared-state",
+    "agent-app-context",
     "---CrewAI Flows---",
     "advanced",
     "multi-agent-flows",


### PR DESCRIPTION
Sibling of #6796 (ADK). Same class of gap, one layer earlier.

## CrewAI does not behave either

OSS-1045 asked whether CrewAI behaves, since it was one of the two frameworks with no `agent-app-context` page. It does not, and its failure is worse than ADK's.

`ag_ui_crewai` 0.3.0 threads `RunAgentInput.context` into the run state, and its own comment says why:

> Thread `input.context` into the run so agent code and tools can read it from state.

But `CopilotKitState` declares `messages` and `copilotkit` — not `context`. A Flow state is a Pydantic model, and Pydantic drops unknown keys by default, so the key the endpoint just populated is discarded on validation before any `@start()` method runs:

```
CopilotKitState fields : ['agent_threads', 'copilotkit', 'current_user_message', 'ended',
                          'events', 'id', 'last_intent', 'last_user_message',
                          'messages', 'session_ready']
extra policy           : None
context survived?      : False  <<DROPPED>>
```

`self.state.context` does not exist in the shape every quickstart shows. ADK at least parks the value somewhere an integrator can reach (`ctx.state[CONTEXT_STATE_KEY]`).

## Proved with a control, not by reading one answer

The same run body sent three times to a CrewAI Flow agent, unmodified, on `ag-ui-crewai==0.3.0`. User message `Triage INC-2002.` throughout, with a three-incident operator queue in `context`:

| context sent | `incident_summary` | severity |
| -- | -- | -- |
| full queue | `"Triage INC-2002."` | low |
| full queue, repeated | `"Triage INC-2002."` | low |
| **empty** | `"Triage INC-2002."` | low |

The empty control is indistinguishable from both full-context runs. Declaring the field and rendering it separates them — the agent then names the incident the page actually holds ("A canary deploy of the search indexer is writing malformed documents…", severity medium).

Worth noting for anyone reading a CrewAI run: this fixture *refused* rather than fabricating, because its backstory forbids invention. That is a property of the prompt, not of the adapter. An agent without that line fabricates exactly as the ADK one did. The page says so.

## The page's snippets were run before shipping

Two corrections came out of that and are in the page because of it:

- The rendered context goes through `inputs` rather than being formatted into the task `description`, so JSON braces are not read as more `{placeholder}`s.
- The flow appends its answer to `self.state.messages`. Without that the turn completes, the crew runs, and **nothing renders** — the first draft of this page had that bug, and the probe caught it.

Final verification, against the page's own advice: with the colleagues context the agent answers "You should email Aisha Okonkwo, who is the Security Lead"; with `context: []` it answers "The page sent no colleagues" rather than inventing one.

## Also filed

The retrieval arguably belongs upstream rather than in every integrator's agent — for CrewAI it is not a design call but a defect, since the package's own base class discards what the package's own endpoint wrote. Filed on `ag-ui-protocol/ag-ui`; this page is the fix that works against the shipped version today.

Closes OSS-1051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for sharing app-specific context with CrewAI Flows.
  * Documented how to register app state, declare context in the flow state, and include it in prompts.
  * Added troubleshooting advice for silently missing context, including testing with an empty context.
  * Added the new guide to the CrewAI Flows documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->