### PR TITLE
fix(a2ui): report a generative-UI result that renders nothing (closes OSS-1048)

### DIFF
--- a/packages/a2ui-renderer/src/a2ui-types.ts
+++ b/packages/a2ui-renderer/src/a2ui-types.ts
@@ -22,3 +22,14 @@ export interface A2UIClientEventMessage {
 
 /** Default surface ID when none is specified */
 export const DEFAULT_SURFACE_ID = "default";
+
+/**
+ * The component id every renderer starts from when it walks a surface.
+ *
+ * A2UI v0.9 gives a payload no way to name its own entry point — `createSurface`
+ * carries only `surfaceId`, `catalogId` and `theme` — so the id is fixed here
+ * instead. A surface whose components do not include this id has nothing to
+ * begin from and paints only the not-yet-arrived placeholder, which is why
+ * `A2UIMessageRenderer` reports that state once operations have stopped.
+ */
+export const ROOT_COMPONENT_ID = "root";

--- a/packages/a2ui-renderer/src/index.ts
+++ b/packages/a2ui-renderer/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export * from "./react-renderer/index.js";
-export { DEFAULT_SURFACE_ID } from "./a2ui-types.js";
+export { DEFAULT_SURFACE_ID, ROOT_COMPONENT_ID } from "./a2ui-types.js";
 export type { Theme, A2UIClientEventMessage } from "./a2ui-types.js";
 
 // Backward compat: viewerTheme (v0.9 themes handled internally)

--- a/packages/a2ui-renderer/src/react-renderer/a2ui-react/A2uiSurface.tsx
+++ b/packages/a2ui-renderer/src/react-renderer/a2ui-react/A2uiSurface.tsx
@@ -15,12 +15,10 @@
  */
 
 import React, { useSyncExternalStore, memo, useMemo, useCallback } from "react";
-import {
-  type SurfaceModel,
-  ComponentContext,
-  type ComponentModel,
-} from "@a2ui/web_core/v0_9";
+import { ComponentContext } from "@a2ui/web_core/v0_9";
+import type { SurfaceModel, ComponentModel } from "@a2ui/web_core/v0_9";
 import type { ReactComponentImplementation } from "./adapter";
+import { ROOT_COMPONENT_ID } from "../../a2ui-types.js";
 
 const ResolvedChild = memo(
   ({
@@ -149,6 +147,8 @@ DeferredChild.displayName = "DeferredChild";
 export const A2uiSurface: React.FC<{
   surface: SurfaceModel<ReactComponentImplementation>;
 }> = ({ surface }) => {
-  // The root component always has ID 'root' and base path '/'
-  return <DeferredChild surface={surface} id="root" basePath="/" />;
+  // Walking starts at the fixed root id (see ROOT_COMPONENT_ID) and base path '/'
+  return (
+    <DeferredChild surface={surface} id={ROOT_COMPONENT_ID} basePath="/" />
+  );
 };

--- a/packages/a2ui-renderer/src/web-components/__tests__/web-components.test.ts
+++ b/packages/a2ui-renderer/src/web-components/__tests__/web-components.test.ts
@@ -196,6 +196,74 @@ describe("A2UI Lit Web Components", () => {
     expect(element.querySelector('[data-surface-id="default"]')).toBeTruthy();
   });
 
+  // Both renderer paths have to resolve a surface id by the same rule, or the
+  // same payload groups one way in React and another way here. (OSS-1048)
+  it("prefers a nested surface id over a top-level one", async () => {
+    const element = createSurfaceElement();
+    element.operations = [
+      {
+        version: "v0.9",
+        surfaceId: "top-level",
+        createSurface: {
+          surfaceId: "nested",
+          catalogId: BASIC_CATALOG_ID,
+        },
+      },
+      {
+        version: "v0.9",
+        surfaceId: "top-level",
+        updateComponents: {
+          surfaceId: "nested",
+          components: [
+            {
+              id: "root",
+              component: "Text",
+              text: "Nested wins",
+            },
+          ],
+        },
+      },
+    ];
+
+    await waitForRender(element);
+
+    expect(element.textContent).toContain("Nested wins");
+    expect(element.querySelector('[data-surface-id="nested"]')).toBeTruthy();
+    expect(element.querySelector('[data-surface-id="top-level"]')).toBeNull();
+  });
+
+  it("falls back to a top-level surface id when the payload carries none", async () => {
+    const element = createSurfaceElement();
+    element.operations = [
+      {
+        version: "v0.9",
+        surfaceId: "top-level",
+        createSurface: {
+          catalogId: BASIC_CATALOG_ID,
+        },
+      },
+      {
+        version: "v0.9",
+        surfaceId: "top-level",
+        updateComponents: {
+          components: [
+            {
+              id: "root",
+              component: "Text",
+              text: "Top-level id",
+            },
+          ],
+        },
+      },
+    ];
+
+    await waitForRender(element);
+
+    expect(element.textContent).toContain("Top-level id");
+    expect(element.querySelector('[data-surface-id="top-level"]')).toBeTruthy();
+    expect(element.querySelector('[data-surface-id="default"]')).toBeNull();
+  });
+
   it("exports minimal, basic, and full catalogs", () => {
     expect(minimalCatalog.components.has("Text")).toBe(true);
     expect(minimalCatalog.components.has("TextField")).toBe(true);

--- a/packages/a2ui-renderer/src/web-components/constants.ts
+++ b/packages/a2ui-renderer/src/web-components/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Runtime constants for the Lit renderer.
+ *
+ * `web-components` is built as its own unbundled entry into `dist/web-components`,
+ * so it cannot reach back into `../a2ui-types.ts` without emitting outside that
+ * output directory. The values here therefore mirror their React-side twins —
+ * the same reason `surface.ts` keeps its own `DEFAULT_SURFACE_ID`.
+ */
+
+/**
+ * The component id this renderer starts from when it walks a surface.
+ * Mirrors `ROOT_COMPONENT_ID` in `../a2ui-types.ts`; keep the two in step.
+ */
+export const ROOT_COMPONENT_ID = "root";

--- a/packages/a2ui-renderer/src/web-components/node.ts
+++ b/packages/a2ui-renderer/src/web-components/node.ts
@@ -2,6 +2,7 @@ import { html, LitElement, nothing } from "lit";
 import { ComponentContext } from "@a2ui/web_core/v0_9";
 import type { SurfaceModel } from "@a2ui/web_core/v0_9";
 import type { LitComponentImplementation } from "./types";
+import { ROOT_COMPONENT_ID } from "./constants";
 
 type SubscriptionLike = { unsubscribe: () => void };
 
@@ -13,7 +14,7 @@ export class CpkA2uiNode extends LitElement {
   };
 
   surface?: SurfaceModel<LitComponentImplementation>;
-  componentId = "root";
+  componentId = ROOT_COMPONENT_ID;
   basePath = "/";
   private subscriptions: SubscriptionLike[] = [];
   private subscribedSurface?: SurfaceModel<LitComponentImplementation>;

--- a/packages/a2ui-renderer/src/web-components/surface.ts
+++ b/packages/a2ui-renderer/src/web-components/surface.ts
@@ -3,6 +3,7 @@ import { MessageProcessor } from "@a2ui/web_core/v0_9";
 import type { A2uiMessage, Catalog } from "@a2ui/web_core/v0_9";
 import { basicCatalog } from "./catalog/basic";
 import type { LitComponentImplementation, LitRenderable } from "./types";
+import { ROOT_COMPONENT_ID } from "./constants";
 
 const DEFAULT_SURFACE_ID = "default";
 const BASIC_CATALOG_ID =
@@ -416,7 +417,7 @@ export class CpkA2uiSurface extends LitElement {
               >
                 <cpk-a2ui-node
                   .surface=${surface}
-                  .componentId=${"root"}
+                  .componentId=${ROOT_COMPONENT_ID}
                   .basePath=${"/"}
                 ></cpk-a2ui-node>
               </div>

--- a/packages/a2ui-renderer/src/web-components/surface.ts
+++ b/packages/a2ui-renderer/src/web-components/surface.ts
@@ -36,10 +36,29 @@ function getBooleanProperty(
   return typeof value === "boolean" ? value : undefined;
 }
 
-function getSurfaceId(payload: Record<string, unknown> | undefined): string {
-  return payload
-    ? (getStringProperty(payload, "surfaceId") ?? DEFAULT_SURFACE_ID)
-    : DEFAULT_SURFACE_ID;
+/**
+ * Resolves the surface an operation addresses.
+ *
+ * The nested payload's `surfaceId` is the v0.9 shape and wins, because that is
+ * the id `MessageProcessor` creates the surface under — grouping by anything
+ * else files operations against a surface that never exists, which paints
+ * nothing. A top-level `surfaceId` beside the payload is not the v0.9 shape, so
+ * it is honoured only when the payload carries no id of its own. The React path
+ * in `@copilotkit/react-core` resolves it in the same order; the two disagreeing
+ * is what OSS-1048 recorded.
+ *
+ * @param payload - The operation's nested payload (`createSurface`, etc).
+ * @param operation - The whole operation, consulted only as a fallback.
+ * @returns The surface id, defaulting to `"default"`.
+ */
+function getSurfaceId(
+  payload: Record<string, unknown> | undefined,
+  operation: Record<string, unknown>,
+): string {
+  const nested = payload ? getStringProperty(payload, "surfaceId") : undefined;
+  return (
+    nested ?? getStringProperty(operation, "surfaceId") ?? DEFAULT_SURFACE_ID
+  );
 }
 
 function getOperationSurfaceId(operation: A2uiMessage): string {
@@ -64,7 +83,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         createSurface: {
-          surfaceId: getSurfaceId(createSurface),
+          surfaceId: getSurfaceId(createSurface, operation),
           catalogId: getStringProperty(createSurface, "catalogId") ?? catalogId,
           theme: createSurface.theme ?? {},
           sendDataModel: getBooleanProperty(createSurface, "sendDataModel"),
@@ -79,7 +98,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         updateComponents: {
-          surfaceId: getSurfaceId(updateComponents),
+          surfaceId: getSurfaceId(updateComponents, operation),
           components: Array.isArray(components)
             ? components.map(normalizeComponent)
             : [],
@@ -93,7 +112,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         updateDataModel: {
-          surfaceId: getSurfaceId(updateDataModel),
+          surfaceId: getSurfaceId(updateDataModel, operation),
           path: getStringProperty(updateDataModel, "path") ?? "/",
           value: updateDataModel.value,
         },
@@ -106,7 +125,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         deleteSurface: {
-          surfaceId: getSurfaceId(deleteSurface),
+          surfaceId: getSurfaceId(deleteSurface, operation),
         },
       } satisfies A2uiMessage;
       return [message];
@@ -117,7 +136,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         createSurface: {
-          surfaceId: getSurfaceId(beginRendering),
+          surfaceId: getSurfaceId(beginRendering, operation),
           catalogId,
           theme: beginRendering.styles ?? {},
           sendDataModel: getBooleanProperty(beginRendering, "sendDataModel"),
@@ -132,7 +151,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         updateComponents: {
-          surfaceId: getSurfaceId(surfaceUpdate),
+          surfaceId: getSurfaceId(surfaceUpdate, operation),
           components: Array.isArray(components)
             ? components.map(normalizeComponent)
             : [],
@@ -146,7 +165,7 @@ function normalizeOperations(
       const message = {
         version: "v0.9",
         updateDataModel: {
-          surfaceId: getSurfaceId(dataModelUpdate),
+          surfaceId: getSurfaceId(dataModelUpdate, operation),
           path: getStringProperty(dataModelUpdate, "path") ?? "/",
           value: dataModelUpdate.value ?? dataModelUpdate.contents,
         },

--- a/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
+++ b/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
@@ -447,6 +447,206 @@ describe("A2UIMessageRenderer — reporting a card that renders nothing", () => 
     );
   });
 
+  // Both renderers start walking a surface at the component with id "root" and
+  // show an animated placeholder for an id they cannot find. A payload that
+  // names its entry point anything else is complete, accepted, and permanently
+  // a grey box: the surface exists, nothing throws, the component type is never
+  // reached, and `surfaceHasRenderableContent` says yes, so `onReady` fires and
+  // the never-painted report above is deliberately suppressed. (OSS-1057)
+  it("reports a payload whose components never name a root", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: {
+                surfaceId: "rootless",
+                catalogId: BASIC_CATALOG,
+              },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "rootless",
+                components: [
+                  {
+                    id: "card",
+                    component: "Text",
+                    text: { path: "/headline" },
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+            {
+              version: "v0.9",
+              updateDataModel: {
+                surfaceId: "rootless",
+                value: { headline: "Hello World" },
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    const report = messages.find((message) =>
+      message.includes('A2UI surface "rootless" has no "root" component'),
+    );
+    expect(report).toBeDefined();
+    expect(report).toContain('the components it received are named "card"');
+    expect(report).toContain('rename the entry-point component to "root"');
+    expect(report).toContain(
+      "Operations received: createSurface, updateComponents, updateDataModel",
+    );
+
+    // The payload is renderable on paper, so the never-painted report stays out
+    // of the way rather than reporting the same card twice.
+    expect(messages.filter((m) => m.includes("never painted"))).toEqual([]);
+  });
+
+  // A root that WAS sent and still is not in the model is a different fault with
+  // a different fix, so the report says which of the two it is.
+  it("distinguishes a root that was sent from one that was never named", async () => {
+    const { warnAboutUnresolvedRoot } =
+      await import("../a2ui/A2UIMessageRenderer.js");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const operations = [
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "dropped",
+          components: [{ id: "root", component: "Text", text: "Hello World" }],
+        },
+      },
+    ];
+
+    warnAboutUnresolvedRoot("dropped", operations, {
+      componentsModel: { get: () => undefined },
+    });
+
+    const report = warn.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes('A2UI surface "dropped"'));
+    expect(report).toBeDefined();
+    expect(report).toContain('a component with id "root" WAS sent');
+    expect(report).toContain("did not reach the surface's model");
+    expect(report).not.toContain("rename the entry-point component");
+  });
+
+  it("stays silent about the root when the surface resolves one", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: { surfaceId: "rooted", catalogId: BASIC_CATALOG },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "rooted",
+                components: [
+                  {
+                    id: "root",
+                    component: "Text",
+                    text: "Hello World",
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes('no "root" component'))).toEqual(
+      [],
+    );
+  });
+
+  // Components stream in, so the snapshot that carries the root can arrive after
+  // one that does not. The deadline runs from the LAST operations to land, so the
+  // early snapshot must not be reported.
+  it("stays silent when the root arrives in a later snapshot", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    const createSurface = {
+      version: "v0.9",
+      createSurface: { surfaceId: "late-root", catalogId: BASIC_CATALOG },
+    };
+    const withoutRoot = {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "late-root",
+        components: [{ id: "card", component: "Text", text: "Hello World" }],
+      },
+    };
+    const withRoot = {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "late-root",
+        components: [
+          { id: "card", component: "Text", text: "Hello World" },
+          { id: "root", component: "Text", text: "Hello World" },
+        ],
+      },
+    };
+
+    const { rerender } = render(
+      <RenderComponent
+        content={{ a2ui_operations: [createSurface, withoutRoot] }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS / 2);
+    });
+
+    rerender(
+      <RenderComponent
+        content={{ a2ui_operations: [createSurface, withRoot] }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes('no "root" component'))).toEqual(
+      [],
+    );
+  });
+
   it("reports operations addressed to a surface that was never created", async () => {
     const RenderComponent = await loadRenderer();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
+++ b/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, act, waitFor } from "@testing-library/react";
 import React, { useState } from "react";
 import type { Theme } from "@copilotkit/a2ui-renderer";
@@ -298,5 +298,254 @@ describe("runA2UIAction onAction interceptor", () => {
     expect(copilotkit.runAgent).toHaveBeenCalledWith({ agent: "my-agent" });
     const forwarded = copilotkit.setProperties.mock.calls[0][0];
     expect(forwarded.a2uiAction).toBe(message);
+  });
+});
+const BASIC_CATALOG = "https://a2ui.org/specification/v0_9/basic_catalog.json";
+
+/** Mirrors PAINT_FALLBACK_MS in the renderer. */
+const PAINT_FALLBACK_MS = 8000;
+
+/**
+ * A generative-UI card that does not paint is silent by default: the operations
+ * are accepted, the loader drops, and the only trace is an empty placeholder
+ * above the reply. These cover the two reports that break that silence.
+ */
+describe("A2UIMessageRenderer — reporting a card that renders nothing", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function loadRenderer() {
+    const { createA2UIMessageRenderer } =
+      await import("../a2ui/A2UIMessageRenderer.js");
+    return createA2UIMessageRenderer({ theme: {} as Theme })
+      .render as React.FC<any>;
+  }
+
+  it("reports a surface that received operations and never painted", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: {
+                surfaceId: "never-paints",
+                catalogId: BASIC_CATALOG,
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    const report = messages.find((message) =>
+      message.includes('A2UI surface "never-paints" received operations'),
+    );
+    expect(report).toBeDefined();
+    expect(report).toContain("never painted");
+    expect(report).toContain("no updateComponents operation arrived");
+    expect(report).toContain("Operations received: createSurface");
+  });
+
+  it("names the missing data model when bound components drew empty", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: { surfaceId: "bound", catalogId: BASIC_CATALOG },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "bound",
+                components: [
+                  {
+                    id: "root",
+                    component: "Text",
+                    text: { path: "/headline" },
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const report = warn.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes('A2UI surface "bound"'));
+    expect(report).toBeDefined();
+    expect(report).toContain("no updateDataModel carried a non-empty value");
+  });
+
+  it("stays silent about paint when the surface does paint", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: { surfaceId: "healthy", catalogId: BASIC_CATALOG },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "healthy",
+                components: [
+                  {
+                    id: "root",
+                    component: "Text",
+                    text: "Hello World",
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes("never painted"))).toEqual([]);
+    expect(messages.filter((m) => m.includes("no surface by that id"))).toEqual(
+      [],
+    );
+  });
+
+  it("reports operations addressed to a surface that was never created", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: { surfaceId: "created", catalogId: BASIC_CATALOG },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "addressed",
+                components: [
+                  {
+                    id: "root",
+                    component: "Text",
+                    text: "Hello World",
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    // Deferred one macrotask so a mid-stream snapshot is not reported.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const report = warn.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes('addressed to surface "addressed"'));
+    expect(report).toBeDefined();
+    expect(report).toContain("no surface by that id exists");
+    expect(report).toContain('A createSurface for "addressed"');
+  });
+
+  // Operations stream in, so a snapshot can reach the processor before the
+  // createSurface that gives them somewhere to go. Reporting that snapshot would
+  // make the warning fire on healthy runs, which is worse than staying quiet.
+  it("stays silent when the createSurface arrives in a later snapshot", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const components = [
+      {
+        id: "root",
+        component: "Text",
+        text: "Hello World",
+        variant: "body",
+      },
+    ];
+
+    const control: { publish?: (content: any) => void } = {};
+    const Wrapper = () => {
+      const [content, setContent] = useState<any>({
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            updateComponents: { surfaceId: "late", components },
+          },
+        ],
+      });
+      control.publish = setContent;
+      return <RenderComponent content={content} agent={null} />;
+    };
+
+    render(<Wrapper />);
+
+    // The createSurface lands before the deferred check gets to run.
+    await act(async () => {
+      control.publish!({
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: "late", catalogId: BASIC_CATALOG },
+          },
+          {
+            version: "v0.9",
+            updateComponents: { surfaceId: "late", components },
+          },
+        ],
+      });
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes("no surface by that id"))).toEqual(
+      [],
+    );
   });
 });

--- a/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
+++ b/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
@@ -549,3 +549,74 @@ describe("A2UIMessageRenderer — reporting a card that renders nothing", () => 
     );
   });
 });
+
+/**
+ * `MessageProcessor` creates a surface under the id nested in the operation's
+ * payload, so grouping has to resolve the same id or the operations are filed
+ * against a surface that never exists — a card that paints nothing. The
+ * web-components path in `@copilotkit/a2ui-renderer` resolves it by the same
+ * rule. (OSS-1048)
+ */
+describe("A2UIMessageRenderer — resolving which surface an operation addresses", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("groups by the nested surface id, not a top-level one", async () => {
+    const { createA2UIMessageRenderer } =
+      await import("../a2ui/A2UIMessageRenderer.js");
+    const RenderComponent = createA2UIMessageRenderer({ theme: {} as Theme })
+      .render as React.FC<any>;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { container } = render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              surfaceId: "top-level",
+              createSurface: {
+                surfaceId: "nested",
+                catalogId: BASIC_CATALOG,
+              },
+            },
+            {
+              version: "v0.9",
+              surfaceId: "top-level",
+              updateComponents: {
+                surfaceId: "nested",
+                components: [
+                  {
+                    id: "root",
+                    component: "Text",
+                    text: "Nested wins",
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        container.querySelector("[data-surface-id='nested']"),
+      ).not.toBeNull();
+    });
+    expect(container.querySelector("[data-surface-id='top-level']")).toBeNull();
+
+    // Grouping under "top-level" would file the operations against a surface
+    // createSurface never made, which is the silence the report names.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes("no surface by that id"))).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
+++ b/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
@@ -560,21 +560,38 @@ function surfaceHasRenderableContent(operations: any[]): boolean {
   });
 }
 
+/**
+ * Resolves the surface an operation addresses.
+ *
+ * The nested v0.9 `surfaceId` wins, because that is the id `MessageProcessor`
+ * creates the surface under. Grouping by a top-level `surfaceId` instead files
+ * the operations against a surface that never exists, which paints nothing —
+ * the silence the missing-surface report above now names. A top-level
+ * `surfaceId` is not the v0.9 shape, so it is honoured only when no nested id is
+ * present. `getSurfaceId` in `@copilotkit/a2ui-renderer`'s web-components path
+ * resolves it in the same order; the two disagreeing is what OSS-1048 recorded.
+ *
+ * @param operation - One A2UI operation, of any shape.
+ * @returns The surface id, or null when the operation names none.
+ */
 function getOperationSurfaceId(operation: any): string | null {
   if (!operation || typeof operation !== "object") {
     return null;
+  }
+
+  // v0.9 message keys
+  const nested =
+    operation?.createSurface?.surfaceId ??
+    operation?.updateComponents?.surfaceId ??
+    operation?.updateDataModel?.surfaceId ??
+    operation?.deleteSurface?.surfaceId;
+  if (typeof nested === "string") {
+    return nested;
   }
 
   if (typeof operation.surfaceId === "string") {
     return operation.surfaceId;
   }
 
-  // v0.9 message keys
-  return (
-    operation?.createSurface?.surfaceId ??
-    operation?.updateComponents?.surfaceId ??
-    operation?.updateDataModel?.surfaceId ??
-    operation?.deleteSurface?.surfaceId ??
-    null
-  );
+  return null;
 }

--- a/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
+++ b/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
@@ -10,6 +10,7 @@ import {
   initializeDefaultCatalog,
   injectStyles,
   DEFAULT_SURFACE_ID,
+  ROOT_COMPONENT_ID,
 } from "@copilotkit/a2ui-renderer";
 import type { Theme, A2UIClientEventMessage } from "@copilotkit/a2ui-renderer";
 import {
@@ -160,6 +161,83 @@ function warnAboutUnpaintedSurfaces(grouped: Map<string, any[]>): void {
         `client wiring. This warning is development-only.`,
     );
   }
+}
+
+/**
+ * Names the component ids a surface was sent, for a warning about the one id
+ * that is missing.
+ *
+ * @param operations - The operations grouped under one surface.
+ * @returns A quoted, comma-separated list of ids, or "none".
+ */
+function describeComponentIds(operations: any[]): string {
+  const ids: string[] = [];
+  for (const operation of operations) {
+    const components = operation?.updateComponents?.components;
+    if (!Array.isArray(components)) continue;
+    for (const component of components) {
+      const id = component?.id;
+      if (typeof id === "string" && !ids.includes(id)) ids.push(id);
+    }
+  }
+  return ids.length === 0 ? "none" : ids.map((id) => `"${id}"`).join(", ");
+}
+
+/**
+ * Reports a surface that is still waiting for its {@link ROOT_COMPONENT_ID}
+ * component once its operations have stopped arriving.
+ *
+ * Both renderers begin walking a surface at that one id, and treat an id they
+ * cannot find as not arrived yet — an animated placeholder. That is right while
+ * operations stream. Once they have stopped it is not waiting, it is stuck, and
+ * every other check calls it healthy: the surface exists, `processMessages` did
+ * not throw, the component types were never reached, and
+ * `surfaceHasRenderableContent` says yes on the strength of components plus a
+ * data model, so `onReady` fires and the never-painted report is suppressed.
+ * A complete, accepted payload therefore animates a grey box forever in silence.
+ *
+ * Reads the live components model rather than scanning the operations for the
+ * id, so it covers every way the root can fail to resolve — not only a payload
+ * that never named one.
+ *
+ * @param surfaceId - The surface the operations were addressed to.
+ * @param operations - The operations processed for that surface.
+ * @param surface - The live surface model, already known to exist.
+ */
+export function warnAboutUnresolvedRoot(
+  surfaceId: string,
+  operations: any[],
+  surface: any,
+): void {
+  if (surface?.componentsModel?.get?.(ROOT_COMPONENT_ID)) return;
+
+  // No components at all is the never-painted report's case, and it names the
+  // cause better than this one can. Reporting both would say it twice.
+  const componentOps = operations.filter((o) => o?.updateComponents);
+  if (componentOps.length === 0) return;
+
+  const rootWasSent = componentOps.some((o) =>
+    o.updateComponents?.components?.some?.(
+      (c: any) => c?.id === ROOT_COMPONENT_ID,
+    ),
+  );
+
+  const cause = rootWasSent
+    ? `a component with id "${ROOT_COMPONENT_ID}" WAS sent, so the components ` +
+      `did not reach the surface's model — check for an A2UI render error above, ` +
+      `or a catalog that took none of them`
+    : `the components it received are named ${describeComponentIds(operations)}, ` +
+      `and none of them is "${ROOT_COMPONENT_ID}" — rename the entry-point ` +
+      `component to "${ROOT_COMPONENT_ID}", and make every other component ` +
+      `reachable from it through child/children`;
+
+  console.warn(
+    `[CopilotKit] A2UI surface "${surfaceId}" has no "${ROOT_COMPONENT_ID}" ` +
+      `component ${String(PAINT_FALLBACK_MS)}ms after its last operations were ` +
+      `processed, so it is showing the placeholder for a component that has not ` +
+      `arrived yet and will keep showing it: ${cause}. Operations received: ` +
+      `${describeOperationKinds(operations)}. This warning is development-only.`,
+  );
 }
 
 export function createA2UIMessageRenderer(
@@ -509,6 +587,9 @@ function SurfaceMessageProcessor({
     // are renderable from components alone. Latency-independent. (OSS-162)
     if (onReady && surfaceHasRenderableContent(operations)) onReady();
 
+    // Everything below only reports; it never changes what renders.
+    if (!IS_DEVELOPMENT) return;
+
     // `processMessages` is synchronous, so a surface missing right after it was
     // never created. A2UIRenderer renders its `fallback` for an unknown surface
     // id, and that defaults to null — nothing on screen and nothing logged. The
@@ -519,19 +600,30 @@ function SurfaceMessageProcessor({
     // without its createSurface yet is not reported as a failure. The cleanup
     // cancels a pending check whenever new operations land, which debounces this
     // to the last snapshot of a stream.
-    if (!IS_DEVELOPMENT || getSurface(surfaceId)) return;
-    const missingSurfaceCheck = setTimeout(() => {
-      if (getSurface(surfaceId)) return;
-      console.warn(
-        `[CopilotKit] A2UI processed ${String(ops.length)} operation(s) addressed ` +
-          `to surface "${surfaceId}" and no surface by that id exists, so this ` +
-          `card rendered nothing. Operations received: ` +
-          `${describeOperationKinds(ops)}. A createSurface for "${surfaceId}" has ` +
-          `to arrive before, or with, the operations that target it. ` +
-          `This warning is development-only.`,
-      );
-    }, 0);
-    return () => clearTimeout(missingSurfaceCheck);
+    if (!getSurface(surfaceId)) {
+      const missingSurfaceCheck = setTimeout(() => {
+        if (getSurface(surfaceId)) return;
+        console.warn(
+          `[CopilotKit] A2UI processed ${String(ops.length)} operation(s) addressed ` +
+            `to surface "${surfaceId}" and no surface by that id exists, so this ` +
+            `card rendered nothing. Operations received: ` +
+            `${describeOperationKinds(ops)}. A createSurface for "${surfaceId}" has ` +
+            `to arrive before, or with, the operations that target it. ` +
+            `This warning is development-only.`,
+        );
+      }, 0);
+      return () => clearTimeout(missingSurfaceCheck);
+    }
+
+    // The surface exists, so the report above does not apply. What can still be
+    // silently wrong is the one component both renderers start from: absent, the
+    // card animates a placeholder forever. The deadline is measured from the last
+    // operations to land, so a root still missing when it expires is a root that
+    // is not coming — the cleanup re-arms the timer on every new snapshot.
+    const unresolvedRootCheck = setTimeout(() => {
+      warnAboutUnresolvedRoot(surfaceId, operations, getSurface(surfaceId));
+    }, PAINT_FALLBACK_MS);
+    return () => clearTimeout(unresolvedRootCheck);
   }, [processMessages, getSurface, surfaceId, operations, onReady]);
 
   return null;

--- a/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
+++ b/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
@@ -102,6 +102,66 @@ const A2UISurfaceContentSchema = z
   })
   .passthrough();
 
+const IS_DEVELOPMENT = process.env.NODE_ENV !== "production";
+
+/**
+ * How long to wait for a surface to report its first paint before giving up on
+ * the loader cross-over. Reaching it also means `onReady` never fired, which is
+ * the signal the warning below reports.
+ */
+const PAINT_FALLBACK_MS = 8000;
+
+/**
+ * Names the operation kinds a surface received, for a warning that has to say
+ * what did arrive as well as what did not.
+ *
+ * @param operations - The operations grouped under one surface.
+ * @returns A comma-separated list of operation keys, or "none".
+ */
+function describeOperationKinds(operations: any[]): string {
+  const kinds = new Set<string>();
+  for (const operation of operations) {
+    if (!operation || typeof operation !== "object") continue;
+    for (const key of Object.keys(operation)) {
+      if (key !== "version") kinds.add(key);
+    }
+  }
+  return kinds.size === 0 ? "none" : Array.from(kinds).join(", ");
+}
+
+/**
+ * Reports surfaces that received operations and never painted.
+ *
+ * Reaching {@link PAINT_FALLBACK_MS} with no `onReady` means the operations were
+ * accepted, were not malformed enough to raise the provider's error state, and
+ * still put nothing on screen. Left alone that is invisible: the loader drops,
+ * the turn finishes, and the only trace is an empty placeholder above the reply.
+ *
+ * `surfaceHasRenderableContent` already knows which half is missing, so the
+ * warning says which rather than making the reader re-derive it.
+ *
+ * @param grouped - Operations grouped by surface id.
+ */
+function warnAboutUnpaintedSurfaces(grouped: Map<string, any[]>): void {
+  for (const [surfaceId, operations] of grouped) {
+    if (surfaceHasRenderableContent(operations)) continue;
+
+    const componentOps = operations.filter((o) => o?.updateComponents);
+    const cause =
+      componentOps.length === 0
+        ? "no updateComponents operation arrived, so the surface was never given anything to draw"
+        : 'its components address their values by "path" and no updateDataModel carried a non-empty value, so every bound component drew empty';
+
+    console.warn(
+      `[CopilotKit] A2UI surface "${surfaceId}" received operations and never ` +
+        `painted after ${String(PAINT_FALLBACK_MS)}ms: ${cause}. ` +
+        `Operations received: ${describeOperationKinds(operations)}. ` +
+        `The payload was accepted, so check what the agent sent rather than the ` +
+        `client wiring. This warning is development-only.`,
+    );
+  }
+}
+
 export function createA2UIMessageRenderer(
   options: A2UIMessageRendererOptions,
 ): ReactActivityMessageRenderer<any> {
@@ -152,6 +212,12 @@ export function createA2UIMessageRenderer(
       }, [operations]);
 
       const hasOps = groupedOperations.size > 0;
+
+      // Read by the paint-fallback timer below, whose effect deliberately does
+      // not depend on the grouping (see there). Assigned during render, like
+      // `lastLoaderContentRef` further down.
+      const groupedOperationsRef = useRef(groupedOperations);
+      groupedOperationsRef.current = groupedOperations;
 
       // Renders the pre-paint lifecycle state for a given content snapshot.
       const renderLifecycle = (c: any) => {
@@ -211,7 +277,15 @@ export function createA2UIMessageRenderer(
           readyRef.current = false;
           return;
         }
-        const t = setTimeout(() => setSurfaceReady(true), 8000); // fallback only
+        const t = setTimeout(() => {
+          setSurfaceReady(true); // fallback only
+          // Reaching the fallback means `onReady` never fired. The timer is not
+          // cleared when a surface does paint, so `readyRef` is what separates a
+          // late tick after a healthy paint from a surface that never painted.
+          if (IS_DEVELOPMENT && !readyRef.current) {
+            warnAboutUnpaintedSurfaces(groupedOperationsRef.current);
+          }
+        }, PAINT_FALLBACK_MS);
         return () => clearTimeout(t);
       }, [hasOps]);
 
@@ -428,11 +502,36 @@ function SurfaceMessageProcessor({
 
     // Error handling is done inside A2UIProvider.processMessages
     processMessages(ops);
+
     // Signal the cross-over to swap ONLY once the surface can actually paint a
     // card. A data-bound list renders nothing until its data model arrives, so
     // for those we wait for the first non-empty updateDataModel; static surfaces
     // are renderable from components alone. Latency-independent. (OSS-162)
     if (onReady && surfaceHasRenderableContent(operations)) onReady();
+
+    // `processMessages` is synchronous, so a surface missing right after it was
+    // never created. A2UIRenderer renders its `fallback` for an unknown surface
+    // id, and that defaults to null — nothing on screen and nothing logged. The
+    // usual cause is operations addressed to one surface id while the surface
+    // was created under another.
+    //
+    // Deferred a task, and re-checked, so a snapshot that arrives mid-stream
+    // without its createSurface yet is not reported as a failure. The cleanup
+    // cancels a pending check whenever new operations land, which debounces this
+    // to the last snapshot of a stream.
+    if (!IS_DEVELOPMENT || getSurface(surfaceId)) return;
+    const missingSurfaceCheck = setTimeout(() => {
+      if (getSurface(surfaceId)) return;
+      console.warn(
+        `[CopilotKit] A2UI processed ${String(ops.length)} operation(s) addressed ` +
+          `to surface "${surfaceId}" and no surface by that id exists, so this ` +
+          `card rendered nothing. Operations received: ` +
+          `${describeOperationKinds(ops)}. A createSurface for "${surfaceId}" has ` +
+          `to arrive before, or with, the operations that target it. ` +
+          `This warning is development-only.`,
+      );
+    }, 0);
+    return () => clearTimeout(missingSurfaceCheck);
   }, [processMessages, getSurface, surfaceId, operations, onReady]);
 
   return null;

--- a/packages/react-core/src/v2/hooks/__tests__/use-render-tool-call.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-render-tool-call.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import type { ToolCall } from "@ag-ui/core";
 
 import type { ReactToolCallRenderer } from "../../types/react-tool-call-renderer";
 import type { DefaultRenderProps } from "../use-default-render-tool";
 import { useRenderToolCall } from "../use-render-tool-call";
+import { useRenderTool } from "../use-render-tool";
 import { useDefaultRenderTool } from "../use-default-render-tool";
 import { useCopilotKit } from "../../context";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
@@ -128,5 +130,109 @@ describe("useRenderToolCall — opt-in default tool-call rendering", () => {
 
     expect(container.firstChild).toBeNull();
     expect(screen.queryByTestId("copilot-tool-render")).toBeNull();
+  });
+});
+/**
+ * The unmatched-tool-call warning is reported from a `setTimeout(..., 0)` so it
+ * lands after every effect in the tree, which is what keeps it from firing
+ * against a registry that has not settled yet. Tests must therefore let one
+ * macrotask elapse before asserting.
+ */
+async function flushWarningTask(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("useRenderToolCall — reporting a tool call that renders nothing", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseChatConfig.mockReturnValue(null);
+    mockUseCopilotKit.mockReturnValue({
+      copilotkit: createNotifyingCore(),
+      executingToolCallIds: new Set<string>(),
+    });
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("names the unmatched tool and the renderers that are registered", async () => {
+    function Harness() {
+      useRenderTool(
+        { name: "searchDocs", parameters: z.object({}), render: () => <div /> },
+        [],
+      );
+      return <ResolverProbe />;
+    }
+
+    render(<Harness />);
+    await flushWarningTask();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('"generate_a2ui"');
+    expect(message).toContain('Registered renderers: "searchDocs"');
+    expect(message).toContain("useDefaultRenderTool()");
+  });
+
+  it("says so explicitly when no renderers are registered at all", async () => {
+    render(<ResolverProbe />);
+    await flushWarningTask();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain(
+      "No tool-call renderers are registered",
+    );
+  });
+
+  // The registration effect lives in the component that renders the chat, and
+  // React runs child effects before parent ones — so the resolver's own effect
+  // sees an empty registry on the first commit even though the app did register
+  // a renderer. Warning at effect time would make this case a false positive.
+  it("stays silent when the app's renderer registers after the resolver's effect", async () => {
+    function Harness() {
+      useDefaultRenderTool();
+      return <ResolverProbe />;
+    }
+
+    render(<Harness />);
+    expect(await screen.findByTestId("copilot-tool-render")).toBeDefined();
+    await flushWarningTask();
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when a wildcard renderer covers the call", async () => {
+    function Harness() {
+      useRenderTool({ name: "*", render: () => <div data-testid="any" /> }, []);
+      return <ResolverProbe />;
+    }
+
+    render(<Harness />);
+    expect(await screen.findByTestId("any")).toBeDefined();
+    await flushWarningTask();
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once per tool name, not once per render", async () => {
+    function Harness() {
+      const [, forceRender] = React.useReducer((n: number) => n + 1, 0);
+      React.useEffect(() => {
+        forceRender();
+      }, []);
+      return <ResolverProbe />;
+    }
+
+    render(<Harness />);
+    await flushWarningTask();
+    await flushWarningTask();
+
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
+++ b/packages/react-core/src/v2/hooks/use-render-tool-call.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useSyncExternalStore } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 import type { ToolCall, ToolMessage } from "@ag-ui/core";
 import { ToolCallStatus } from "@copilotkit/core";
 import { useCopilotKit } from "../context";
@@ -102,6 +108,48 @@ const ToolCallRenderer = React.memo(
   },
 );
 
+const IS_DEVELOPMENT = process.env.NODE_ENV !== "production";
+
+/**
+ * Reports tool calls that resolved to no renderer.
+ *
+ * A tool call with no renderer paints an empty message container and says
+ * nothing else, so the only signal a developer gets today is a blank space in
+ * the chat. This names the call and the renderers that *are* registered, which
+ * is the whole diagnosis when the cause is a name that does not match.
+ *
+ * @param toolNames - The unmatched tool names collected during render.
+ * @param registered - The registry as it stands now, re-read at report time.
+ * @param alreadyWarned - Names already reported, mutated to keep this once per name.
+ */
+function warnAboutUnrenderedToolCalls(
+  toolNames: readonly string[],
+  registered: readonly { readonly name: string }[],
+  alreadyWarned: Set<string>,
+): void {
+  const registeredNames = Array.from(new Set(registered.map((rc) => rc.name)));
+  const hasWildcard = registeredNames.includes("*");
+
+  for (const toolName of toolNames) {
+    // Re-check against the current registry: a renderer registered after the
+    // render that recorded the miss makes the miss stale, not real.
+    if (hasWildcard || registeredNames.includes(toolName)) continue;
+    if (alreadyWarned.has(toolName)) continue;
+    alreadyWarned.add(toolName);
+
+    console.warn(
+      `[CopilotKit] The agent called the tool "${toolName}", and no renderer is ` +
+        `registered for it, so that message rendered nothing. ` +
+        (registeredNames.length === 0
+          ? "No tool-call renderers are registered. "
+          : `Registered renderers: ${registeredNames.map((name) => `"${name}"`).join(", ")}. `) +
+        `Register one with useRenderTool({ name: "${toolName}", ... }), or call ` +
+        `useDefaultRenderTool() for a built-in card that covers every tool the ` +
+        `agent calls. This warning is development-only.`,
+    );
+  }
+}
+
 /**
  * Hook that returns a function to render tool calls based on the render functions
  * defined in CopilotKitProvider.
@@ -112,6 +160,11 @@ export function useRenderToolCall() {
   const { copilotkit, executingToolCallIds } = useCopilotKit();
   const config = useCopilotChatConfiguration();
   const agentId = config?.agentId ?? DEFAULT_AGENT_ID;
+
+  // Development-only bookkeeping for the warning below. Collected during render
+  // and reported afterwards, because the registry is not settled during render.
+  const unrenderedToolNames = useRef<Set<string>>(new Set());
+  const warnedToolNames = useRef<Set<string>>(new Set());
 
   // Subscribe to render tool calls changes using useSyncExternalStore
   // This ensures we always have the latest value, even if subscriptions run in any order
@@ -160,6 +213,9 @@ export function useRenderToolCall() {
       // tool names plus raw args/result JSON into every app's chat in
       // production, so the card must be explicitly enabled.
       if (!renderConfig) {
+        if (IS_DEVELOPMENT) {
+          unrenderedToolNames.current.add(toolCall.function.name);
+        }
         return null;
       }
 
@@ -180,6 +236,33 @@ export function useRenderToolCall() {
     },
     [renderToolCalls, executingToolCallIds, agentId],
   );
+
+  // Report unmatched tool calls after the commit that rendered them, deferred
+  // one task past this subtree's effects. `useRenderTool` registers from an
+  // effect in the component that renders the chat, and React runs child effects
+  // before parent ones, so at effect time here a renderer the app does register
+  // may not be in the registry yet. A timeout puts the check after every effect
+  // in the tree, and `warnAboutUnrenderedToolCalls` re-reads the registry then.
+  //
+  // No dependency array on purpose: the misses live in a ref, so an effect that
+  // only reran when `renderToolCalls` changed would never flush the common case
+  // of a registry that never changes again.
+  useEffect(() => {
+    if (!IS_DEVELOPMENT) return;
+    if (unrenderedToolNames.current.size === 0) return;
+
+    const timer = setTimeout(() => {
+      const pending = Array.from(unrenderedToolNames.current);
+      unrenderedToolNames.current.clear();
+      warnAboutUnrenderedToolCalls(
+        pending,
+        copilotkit.renderToolCalls,
+        warnedToolNames.current,
+      );
+    }, 0);
+
+    return () => clearTimeout(timer);
+  });
 
   return renderToolCall;
 }


### PR DESCRIPTION
A generative-UI result that does not paint reports nothing today. The turn finishes, the input returns to idle, the network calls are all 200, and the console is byte-identical to what it held before the request. The only signal is a human noticing a blank space in a screenshot.

Three commits, each breaking one of those silences. Rendering behavior is unchanged throughout — every report is a development-only `console.warn`.

## A tool call with no renderer

`use-render-tool-call.tsx` resolves a renderer by name, then by agentId, then by wildcard, then returns `null`. The existing comment defends that choice well: auto-painting a default card would leak internal tool names plus raw args and result JSON into every app's production chat. That argument is about *painting*, and it does not cover *warning*.

The warning names the tool the agent called and lists the renderer names that are registered. When the cause is a name that does not match, that is the whole diagnosis.

It is deferred one task past the commit that recorded the miss, then re-checks the registry. `useRenderTool` registers from an effect in the component that renders the chat, and React runs child effects before parent ones, so at effect time the resolver can see an empty registry even though the app did register a renderer. Removing that re-check makes two of the new tests fail on exactly that false positive.

## An A2UI surface that gets operations and paints nothing

Two reports, both in `A2UIMessageRenderer.tsx`.

**Operations arrived and no paint followed.** The renderer already waits 8s for a surface to report its first paint before dropping the loader, so reaching that fallback is itself the signal. No new threshold was invented. `surfaceHasRenderableContent` already knows which half is missing, so the message says which: no `updateComponents` at all, or `"path"`-bound components whose `updateDataModel` never carried a value.

**Operations named a surface that was never created.** `A2UIRenderer` renders its `fallback` for an unknown surface id and that defaults to `null` — the card is absent and the log is empty. `processMessages` is synchronous, so a surface still missing after it was never created. This report is also deferred and re-checked, because operations stream and a snapshot can reach the processor before the `createSurface` that gives it somewhere to go.

## The two surface-id resolvers disagreed

React read a top-level `operation.surfaceId` first and only then the nested v0.9 keys. The web-components path read the nested keys only, via `normalizeOperations`, and never looked at a top-level id at all. One payload grouped under its own id in React and under `"default"` in the Lit and Angular renderers.

Nested wins in both now, with a top-level id as the fallback when the payload carries none.

Nested is the correct half of that choice, not a coin toss: `MessageProcessor` creates the surface from the nested id. Grouping by a top-level id files the operations against a surface `createSurface` never made, and an unknown surface id renders the `null` fallback above. So the old React order could *produce* the silence the second commit teaches the renderer to report — which is what the new test asserts, by requiring that the missing-surface warning stay quiet.

## What this does not cover

A surface that exists, holds complete components, and still draws nothing. `onReady` fires exactly when `surfaceHasRenderableContent` is true, so that case is invisible to the paint-fallback path by construction. Filed as OSS-1057 with a concrete mechanism: both renderers hard-code a root component id of `root`, and a components list without one shimmers forever.

The other item on OSS-1048 — a turn whose only output is generative UI recording a `tool` message with no assistant parent — is a different repo and a real design decision. Filed as OSS-1056.

## Verification

`react-core` 1565/1565, `a2ui-renderer` 24/24, both builds clean, lefthook green on all three commits.

Every new negative assertion was mutation-tested against the pre-change code. Two of them are guarded twice over, and removing either guard alone left the test green — so both had to be removed before the test would fail, which is what confirms it is not vacuous.

Closes OSS-1048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations now consistently target the correct surface, prioritizing nested surface identifiers and falling back to top-level identifiers when needed.
  * Improved handling of operations for surfaces that are created later.

* **Diagnostics**
  * Added development-time warnings when surfaces receive operations but render nothing.
  * Added warnings for operations targeting missing surfaces or unresolved root components, including likely causes.
  * Added warnings when tool calls have no matching renderer, with registered renderer details where available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->