### PR TITLE
fix(a2ui): report a surface whose root component never resolves (closes OSS-1057)

### DIFF
--- a/packages/a2ui-renderer/src/a2ui-types.ts
+++ b/packages/a2ui-renderer/src/a2ui-types.ts
@@ -22,3 +22,14 @@ export interface A2UIClientEventMessage {
 
 /** Default surface ID when none is specified */
 export const DEFAULT_SURFACE_ID = "default";
+
+/**
+ * The component id every renderer starts from when it walks a surface.
+ *
+ * A2UI v0.9 gives a payload no way to name its own entry point — `createSurface`
+ * carries only `surfaceId`, `catalogId` and `theme` — so the id is fixed here
+ * instead. A surface whose components do not include this id has nothing to
+ * begin from and paints only the not-yet-arrived placeholder, which is why
+ * `A2UIMessageRenderer` reports that state once operations have stopped.
+ */
+export const ROOT_COMPONENT_ID = "root";

--- a/packages/a2ui-renderer/src/index.ts
+++ b/packages/a2ui-renderer/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export * from "./react-renderer/index.js";
-export { DEFAULT_SURFACE_ID } from "./a2ui-types.js";
+export { DEFAULT_SURFACE_ID, ROOT_COMPONENT_ID } from "./a2ui-types.js";
 export type { Theme, A2UIClientEventMessage } from "./a2ui-types.js";
 
 // Backward compat: viewerTheme (v0.9 themes handled internally)

--- a/packages/a2ui-renderer/src/react-renderer/a2ui-react/A2uiSurface.tsx
+++ b/packages/a2ui-renderer/src/react-renderer/a2ui-react/A2uiSurface.tsx
@@ -15,12 +15,10 @@
  */
 
 import React, { useSyncExternalStore, memo, useMemo, useCallback } from "react";
-import {
-  type SurfaceModel,
-  ComponentContext,
-  type ComponentModel,
-} from "@a2ui/web_core/v0_9";
+import { ComponentContext } from "@a2ui/web_core/v0_9";
+import type { SurfaceModel, ComponentModel } from "@a2ui/web_core/v0_9";
 import type { ReactComponentImplementation } from "./adapter";
+import { ROOT_COMPONENT_ID } from "../../a2ui-types.js";
 
 const ResolvedChild = memo(
   ({
@@ -149,6 +147,8 @@ DeferredChild.displayName = "DeferredChild";
 export const A2uiSurface: React.FC<{
   surface: SurfaceModel<ReactComponentImplementation>;
 }> = ({ surface }) => {
-  // The root component always has ID 'root' and base path '/'
-  return <DeferredChild surface={surface} id="root" basePath="/" />;
+  // Walking starts at the fixed root id (see ROOT_COMPONENT_ID) and base path '/'
+  return (
+    <DeferredChild surface={surface} id={ROOT_COMPONENT_ID} basePath="/" />
+  );
 };

--- a/packages/a2ui-renderer/src/web-components/constants.ts
+++ b/packages/a2ui-renderer/src/web-components/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Runtime constants for the Lit renderer.
+ *
+ * `web-components` is built as its own unbundled entry into `dist/web-components`,
+ * so it cannot reach back into `../a2ui-types.ts` without emitting outside that
+ * output directory. The values here therefore mirror their React-side twins —
+ * the same reason `surface.ts` keeps its own `DEFAULT_SURFACE_ID`.
+ */
+
+/**
+ * The component id this renderer starts from when it walks a surface.
+ * Mirrors `ROOT_COMPONENT_ID` in `../a2ui-types.ts`; keep the two in step.
+ */
+export const ROOT_COMPONENT_ID = "root";

--- a/packages/a2ui-renderer/src/web-components/node.ts
+++ b/packages/a2ui-renderer/src/web-components/node.ts
@@ -2,6 +2,7 @@ import { html, LitElement, nothing } from "lit";
 import { ComponentContext } from "@a2ui/web_core/v0_9";
 import type { SurfaceModel } from "@a2ui/web_core/v0_9";
 import type { LitComponentImplementation } from "./types";
+import { ROOT_COMPONENT_ID } from "./constants";
 
 type SubscriptionLike = { unsubscribe: () => void };
 
@@ -13,7 +14,7 @@ export class CpkA2uiNode extends LitElement {
   };
 
   surface?: SurfaceModel<LitComponentImplementation>;
-  componentId = "root";
+  componentId = ROOT_COMPONENT_ID;
   basePath = "/";
   private subscriptions: SubscriptionLike[] = [];
   private subscribedSurface?: SurfaceModel<LitComponentImplementation>;

--- a/packages/a2ui-renderer/src/web-components/surface.ts
+++ b/packages/a2ui-renderer/src/web-components/surface.ts
@@ -3,6 +3,7 @@ import { MessageProcessor } from "@a2ui/web_core/v0_9";
 import type { A2uiMessage, Catalog } from "@a2ui/web_core/v0_9";
 import { basicCatalog } from "./catalog/basic";
 import type { LitComponentImplementation, LitRenderable } from "./types";
+import { ROOT_COMPONENT_ID } from "./constants";
 
 const DEFAULT_SURFACE_ID = "default";
 const BASIC_CATALOG_ID =
@@ -416,7 +417,7 @@ export class CpkA2uiSurface extends LitElement {
               >
                 <cpk-a2ui-node
                   .surface=${surface}
-                  .componentId=${"root"}
+                  .componentId=${ROOT_COMPONENT_ID}
                   .basePath=${"/"}
                 ></cpk-a2ui-node>
               </div>

--- a/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
+++ b/packages/react-core/src/v2/__tests__/A2UIMessageRenderer.test.tsx
@@ -447,6 +447,206 @@ describe("A2UIMessageRenderer — reporting a card that renders nothing", () => 
     );
   });
 
+  // Both renderers start walking a surface at the component with id "root" and
+  // show an animated placeholder for an id they cannot find. A payload that
+  // names its entry point anything else is complete, accepted, and permanently
+  // a grey box: the surface exists, nothing throws, the component type is never
+  // reached, and `surfaceHasRenderableContent` says yes, so `onReady` fires and
+  // the never-painted report above is deliberately suppressed. (OSS-1057)
+  it("reports a payload whose components never name a root", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: {
+                surfaceId: "rootless",
+                catalogId: BASIC_CATALOG,
+              },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "rootless",
+                components: [
+                  {
+                    id: "card",
+                    component: "Text",
+                    text: { path: "/headline" },
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+            {
+              version: "v0.9",
+              updateDataModel: {
+                surfaceId: "rootless",
+                value: { headline: "Hello World" },
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    const report = messages.find((message) =>
+      message.includes('A2UI surface "rootless" has no "root" component'),
+    );
+    expect(report).toBeDefined();
+    expect(report).toContain('the components it received are named "card"');
+    expect(report).toContain('rename the entry-point component to "root"');
+    expect(report).toContain(
+      "Operations received: createSurface, updateComponents, updateDataModel",
+    );
+
+    // The payload is renderable on paper, so the never-painted report stays out
+    // of the way rather than reporting the same card twice.
+    expect(messages.filter((m) => m.includes("never painted"))).toEqual([]);
+  });
+
+  // A root that WAS sent and still is not in the model is a different fault with
+  // a different fix, so the report says which of the two it is.
+  it("distinguishes a root that was sent from one that was never named", async () => {
+    const { warnAboutUnresolvedRoot } =
+      await import("../a2ui/A2UIMessageRenderer.js");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const operations = [
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "dropped",
+          components: [{ id: "root", component: "Text", text: "Hello World" }],
+        },
+      },
+    ];
+
+    warnAboutUnresolvedRoot("dropped", operations, {
+      componentsModel: { get: () => undefined },
+    });
+
+    const report = warn.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes('A2UI surface "dropped"'));
+    expect(report).toBeDefined();
+    expect(report).toContain('a component with id "root" WAS sent');
+    expect(report).toContain("did not reach the surface's model");
+    expect(report).not.toContain("rename the entry-point component");
+  });
+
+  it("stays silent about the root when the surface resolves one", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    render(
+      <RenderComponent
+        content={{
+          a2ui_operations: [
+            {
+              version: "v0.9",
+              createSurface: { surfaceId: "rooted", catalogId: BASIC_CATALOG },
+            },
+            {
+              version: "v0.9",
+              updateComponents: {
+                surfaceId: "rooted",
+                components: [
+                  {
+                    id: "root",
+                    component: "Text",
+                    text: "Hello World",
+                    variant: "body",
+                  },
+                ],
+              },
+            },
+          ],
+        }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes('no "root" component'))).toEqual(
+      [],
+    );
+  });
+
+  // Components stream in, so the snapshot that carries the root can arrive after
+  // one that does not. The deadline runs from the LAST operations to land, so the
+  // early snapshot must not be reported.
+  it("stays silent when the root arrives in a later snapshot", async () => {
+    const RenderComponent = await loadRenderer();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    const createSurface = {
+      version: "v0.9",
+      createSurface: { surfaceId: "late-root", catalogId: BASIC_CATALOG },
+    };
+    const withoutRoot = {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "late-root",
+        components: [{ id: "card", component: "Text", text: "Hello World" }],
+      },
+    };
+    const withRoot = {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId: "late-root",
+        components: [
+          { id: "card", component: "Text", text: "Hello World" },
+          { id: "root", component: "Text", text: "Hello World" },
+        ],
+      },
+    };
+
+    const { rerender } = render(
+      <RenderComponent
+        content={{ a2ui_operations: [createSurface, withoutRoot] }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS / 2);
+    });
+
+    rerender(
+      <RenderComponent
+        content={{ a2ui_operations: [createSurface, withRoot] }}
+        agent={null}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAINT_FALLBACK_MS);
+    });
+
+    const messages = warn.mock.calls.map((call) => String(call[0]));
+    expect(messages.filter((m) => m.includes('no "root" component'))).toEqual(
+      [],
+    );
+  });
+
   it("reports operations addressed to a surface that was never created", async () => {
     const RenderComponent = await loadRenderer();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
+++ b/packages/react-core/src/v2/a2ui/A2UIMessageRenderer.tsx
@@ -10,6 +10,7 @@ import {
   initializeDefaultCatalog,
   injectStyles,
   DEFAULT_SURFACE_ID,
+  ROOT_COMPONENT_ID,
 } from "@copilotkit/a2ui-renderer";
 import type { Theme, A2UIClientEventMessage } from "@copilotkit/a2ui-renderer";
 import {
@@ -160,6 +161,83 @@ function warnAboutUnpaintedSurfaces(grouped: Map<string, any[]>): void {
         `client wiring. This warning is development-only.`,
     );
   }
+}
+
+/**
+ * Names the component ids a surface was sent, for a warning about the one id
+ * that is missing.
+ *
+ * @param operations - The operations grouped under one surface.
+ * @returns A quoted, comma-separated list of ids, or "none".
+ */
+function describeComponentIds(operations: any[]): string {
+  const ids: string[] = [];
+  for (const operation of operations) {
+    const components = operation?.updateComponents?.components;
+    if (!Array.isArray(components)) continue;
+    for (const component of components) {
+      const id = component?.id;
+      if (typeof id === "string" && !ids.includes(id)) ids.push(id);
+    }
+  }
+  return ids.length === 0 ? "none" : ids.map((id) => `"${id}"`).join(", ");
+}
+
+/**
+ * Reports a surface that is still waiting for its {@link ROOT_COMPONENT_ID}
+ * component once its operations have stopped arriving.
+ *
+ * Both renderers begin walking a surface at that one id, and treat an id they
+ * cannot find as not arrived yet — an animated placeholder. That is right while
+ * operations stream. Once they have stopped it is not waiting, it is stuck, and
+ * every other check calls it healthy: the surface exists, `processMessages` did
+ * not throw, the component types were never reached, and
+ * `surfaceHasRenderableContent` says yes on the strength of components plus a
+ * data model, so `onReady` fires and the never-painted report is suppressed.
+ * A complete, accepted payload therefore animates a grey box forever in silence.
+ *
+ * Reads the live components model rather than scanning the operations for the
+ * id, so it covers every way the root can fail to resolve — not only a payload
+ * that never named one.
+ *
+ * @param surfaceId - The surface the operations were addressed to.
+ * @param operations - The operations processed for that surface.
+ * @param surface - The live surface model, already known to exist.
+ */
+export function warnAboutUnresolvedRoot(
+  surfaceId: string,
+  operations: any[],
+  surface: any,
+): void {
+  if (surface?.componentsModel?.get?.(ROOT_COMPONENT_ID)) return;
+
+  // No components at all is the never-painted report's case, and it names the
+  // cause better than this one can. Reporting both would say it twice.
+  const componentOps = operations.filter((o) => o?.updateComponents);
+  if (componentOps.length === 0) return;
+
+  const rootWasSent = componentOps.some((o) =>
+    o.updateComponents?.components?.some?.(
+      (c: any) => c?.id === ROOT_COMPONENT_ID,
+    ),
+  );
+
+  const cause = rootWasSent
+    ? `a component with id "${ROOT_COMPONENT_ID}" WAS sent, so the components ` +
+      `did not reach the surface's model — check for an A2UI render error above, ` +
+      `or a catalog that took none of them`
+    : `the components it received are named ${describeComponentIds(operations)}, ` +
+      `and none of them is "${ROOT_COMPONENT_ID}" — rename the entry-point ` +
+      `component to "${ROOT_COMPONENT_ID}", and make every other component ` +
+      `reachable from it through child/children`;
+
+  console.warn(
+    `[CopilotKit] A2UI surface "${surfaceId}" has no "${ROOT_COMPONENT_ID}" ` +
+      `component ${String(PAINT_FALLBACK_MS)}ms after its last operations were ` +
+      `processed, so it is showing the placeholder for a component that has not ` +
+      `arrived yet and will keep showing it: ${cause}. Operations received: ` +
+      `${describeOperationKinds(operations)}. This warning is development-only.`,
+  );
 }
 
 export function createA2UIMessageRenderer(
@@ -509,6 +587,9 @@ function SurfaceMessageProcessor({
     // are renderable from components alone. Latency-independent. (OSS-162)
     if (onReady && surfaceHasRenderableContent(operations)) onReady();
 
+    // Everything below only reports; it never changes what renders.
+    if (!IS_DEVELOPMENT) return;
+
     // `processMessages` is synchronous, so a surface missing right after it was
     // never created. A2UIRenderer renders its `fallback` for an unknown surface
     // id, and that defaults to null — nothing on screen and nothing logged. The
@@ -519,19 +600,30 @@ function SurfaceMessageProcessor({
     // without its createSurface yet is not reported as a failure. The cleanup
     // cancels a pending check whenever new operations land, which debounces this
     // to the last snapshot of a stream.
-    if (!IS_DEVELOPMENT || getSurface(surfaceId)) return;
-    const missingSurfaceCheck = setTimeout(() => {
-      if (getSurface(surfaceId)) return;
-      console.warn(
-        `[CopilotKit] A2UI processed ${String(ops.length)} operation(s) addressed ` +
-          `to surface "${surfaceId}" and no surface by that id exists, so this ` +
-          `card rendered nothing. Operations received: ` +
-          `${describeOperationKinds(ops)}. A createSurface for "${surfaceId}" has ` +
-          `to arrive before, or with, the operations that target it. ` +
-          `This warning is development-only.`,
-      );
-    }, 0);
-    return () => clearTimeout(missingSurfaceCheck);
+    if (!getSurface(surfaceId)) {
+      const missingSurfaceCheck = setTimeout(() => {
+        if (getSurface(surfaceId)) return;
+        console.warn(
+          `[CopilotKit] A2UI processed ${String(ops.length)} operation(s) addressed ` +
+            `to surface "${surfaceId}" and no surface by that id exists, so this ` +
+            `card rendered nothing. Operations received: ` +
+            `${describeOperationKinds(ops)}. A createSurface for "${surfaceId}" has ` +
+            `to arrive before, or with, the operations that target it. ` +
+            `This warning is development-only.`,
+        );
+      }, 0);
+      return () => clearTimeout(missingSurfaceCheck);
+    }
+
+    // The surface exists, so the report above does not apply. What can still be
+    // silently wrong is the one component both renderers start from: absent, the
+    // card animates a placeholder forever. The deadline is measured from the last
+    // operations to land, so a root still missing when it expires is a root that
+    // is not coming — the cleanup re-arms the timer on every new snapshot.
+    const unresolvedRootCheck = setTimeout(() => {
+      warnAboutUnresolvedRoot(surfaceId, operations, getSurface(surfaceId));
+    }, PAINT_FALLBACK_MS);
+    return () => clearTimeout(unresolvedRootCheck);
   }, [processMessages, getSurface, surfaceId, operations, onReady]);
 
   return null;


### PR DESCRIPTION
Stacked on #6802 — base is `ben1/oss-1048-a-generative-ui-result-that-never-paints-reports-nothing-no`, because this reuses that PR's `PAINT_FALLBACK_MS` and `describeOperationKinds`. **Review #6802 first; retarget this to `main` once it lands.**

Closes OSS-1057.

## The defect

Both renderers begin walking a surface at the component with id `root` — `A2uiSurface.tsx:153`, `web-components/surface.ts:419`, `node.ts:16` — and treat an id they cannot find as *not arrived yet*, painting an animated shimmer. That is correct while operations stream. It is also what you get **permanently** when the components never contain that id.

Every check we have calls that healthy, and it is worth being precise about why:

- `surfaceHasRenderableContent` returns **true** — `updateComponents` is present and the data model is non-empty — so `onReady` fires, `readyRef` is set, and #6802's never-painted report is suppressed by its own `!readyRef.current` guard.
- The surface **does** exist, so the missing-surface report never runs.
- `processMessages` does not throw, so `A2UISurfaceOrError` shows nothing.
- The component *type* is never reached, so neither renderer's red *"Unknown component: X"* branch can fire. Worth stating because it is the obvious suspect and it is not this one.

A complete, well-formed, accepted payload therefore animates a grey box forever, with no error, no console output, and nothing to distinguish it from a slow stream.

## Confirmed in the wild

This is what `sweep4/4` hit (`p0-phase1-empty-crewai-nextjs`). The schema on disk in that scaffold today has a proper root — but that is the **repaired** revision, written at 12:05 local. The failing run was 11:57. The revision live during it, recovered verbatim from the Codex rollout transcript:

```json
[{ "id": "incident-triage-card",
   "component": { "IncidentTriageResult": { "incident_summary": {"path": "/incident_summary"}, … } } }]
```

`@a2ui/web_core`'s `message-processor.js` destructures `{ id, component, ...properties }`; `id` is truthy and `component` is a truthy *object*, so the component registers under the wrong key, nothing throws, and `componentsModel.get("root")` stays undefined. Reproduced against the installed processor:

```
gen1 (as scaffolded):      threw=no surfaceExists=true rootPresent=false ids=[result-card,result-content,…]
gen2 (the 11:57 failing run): threw=no surfaceExists=true rootPresent=false ids=[incident-triage-card]
gen3 (repaired):           threw=no surfaceExists=true rootPresent=true  ids=[root]
```

The proof artifact agrees: a small empty placeholder above the plain answer, 0 console errors, no field labels in the DOM (`step6-web-surface-final.md`, `step6-body-text-retry.json`). The repairing agent's own note said it outright — *"the persisted payload used a non-root component ID and legacy nested component shape."*

## What this changes

**1. A report on a deadline.** The shimmer means "waiting", so it needs one: a surface still waiting on `root` once operations have stopped arriving is not waiting, it is broken. A third check in `SurfaceMessageProcessor` (the only place with `getSurface`) arms at `PAINT_FALLBACK_MS`, measured from the **last** operations to land — the effect cleanup re-arms it on every new snapshot, so a mid-stream snapshot that has not received its root yet is never reported.

It reads the **live components model** rather than scanning the operations for `id: "root"`. That matters: it covers every way a root can fail to resolve — including the nested-envelope case above, which a static scan for that id would miss — and the message says which of the two faults it is:

- root never sent → names the ids that *were* (`the components it received are named "incident-triage-card"`), and what to rename.
- root sent but absent from the model → says the components did not reach the surface, and where to look.

It stays quiet when there is no `updateComponents` at all; #6802's never-painted report already names that cause better.

**2. One `ROOT_COMPONENT_ID` constant** replacing the literal at the three renderer sites, so they and the new report agree by construction.

## Why the hard-coded root stays

A2UI **v0.9 has no notion of a root component**. v0_8 carried `surface.rootComponentId = message.root`; v0_9 dropped it, and `createSurface` is `{ surfaceId, catalogId, theme }` — verified, there is no `"root"` string anywhere in the shipped `@a2ui/web_core` v0_9 dist. A payload has no slot to declare its own entry point, so the id has to live on the client.

Deriving it — "the component nobody references as child/children" — is ambiguous the moment more than one component is unreferenced, and would silently pick a wrong one: trading a *reported* failure for an unreported *wrong render*. Rejecting root-less payloads at acceptance is also wrong, because mid-stream snapshots legitimately arrive before the root does. A deadline report is the right instrument.

The contract is already stated to the model in `packages/shared/src/a2ui-prompts.ts:29` and `sdk-python/copilotkit/a2ui.py:117`, including this exact symptom (*"the surface renders an empty loading placeholder"*). This PR makes the client say so too.

The Lit side gets its own `web-components/constants.ts`: that entry builds unbundled into its own `outDir`, so it cannot reach `../a2ui-types.ts` — the same reason `surface.ts` already keeps a local `DEFAULT_SURFACE_ID`.

## Testing

Run in a worktree symlinked at main, so cross-package deps resolve to main's built dist. Two large pre-existing failure sets are called out and attributed below.

**1. `A2UIMessageRenderer.test.tsx` — 4 new tests, whole file green**

```
✓ src/v2/__tests__/A2UIMessageRenderer.test.tsx (18 tests) 676ms
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

New cases: reports a payload whose components never name a root (and asserts the never-painted report stays silent, so one card is not reported twice); distinguishes a root that was sent from one that was never named; stays silent when the surface resolves a root; stays silent when the root arrives in a later snapshot.

**2. Mutation checks — every new test is load-bearing**

| Mutation | Expected to fail | Result |
|---|---|---|
| Gut the model read (`if (true) return`) | the 2 reporting tests | `× reports a payload whose components never name a root` · `× distinguishes a root that was sent…` — 2 failed / 16 passed |
| Warn unconditionally (`if (false) return`) | the 2 silence tests | `× stays silent about the root when the surface resolves one` · `× stays silent when the root arrives in a later snapshot` — 3 failed / 15 passed |
| Drop the deadline to `0` | the late-snapshot test | `× stays silent when the root arrives in a later snapshot` — 1 failed / 17 passed |

A fourth check came free: with the dependency's `dist` un-rebuilt, `ROOT_COMPONENT_ID` resolves `undefined` and 3 tests fail — the tests genuinely depend on the constant.

**3. a2ui-renderer suites covering the three touched renderer files**

```
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

**4. react-core A2UI-adjacent suites** (`A2UIMessageRenderer`, `A2UIRecoveryStates`, `use-render-tool-call`)

```
 Test Files  3 passed (3)
      Tests  39 passed (39)
```

**5. Full react-core suite — delta against the same worktree with the change stashed**

```
before (stashed):  Tests  803 failed | 762 passed (1565)
after  (applied):  Tests  803 failed | 766 passed (1569)
```

Identical failure count, +4 passing. The 803 are the worktree's stale cross-package dist (`@copilotkit/core` / `shared` / `web-inspector` resolving to main's older build); CI builds in dependency order and does not see them.

**6. Typecheck** — `tsc --noEmit` on both packages: a2ui-renderer exits 0; react-core reports 21 errors, all stale-dist artifacts (`Module '@copilotkit/core' has no exported member 'emitInspectorViewThread'`, etc.), **none** in the touched files (grep for `A2UIMessageRenderer|a2ui/` returns empty).

**7. Formatting** — `oxfmt` on all 8 touched files, then both suites re-run green.

**Attributed, not mine:** a2ui-renderer's two `openurl-scheme` suites fail (5 tests) in this worktree because it resolves `@a2ui/web_core@0.9.0` while `pnpm-lock.yaml` pins `0.10.4` — 0.9.0 predates the GHSA-72qq-p3r5-f7wq fix those tests guard, and main's install has no 0.10.4 to repoint at. Reproduced with the change reverted in the same worktree, and the reference worktree (0.10.4 installed) passes 24/24.

## Follow-up, not in this PR

Nothing validates the `updateComponents` shape where operations are accepted. `tryParseA2UIOperations` only checks each op is a non-array object, and the middleware's `typeof item.component === "string"` check applies only to the injected-tool streaming path (off in that scaffold via `injectA2UITool: false`). So the legacy nested envelope passes silently. This PR reports the symptom for every cause; a type check at acceptance would catch that cause for every payload shape. Worth its own issue.
