### PR TITLE
fix(docs): name the onboarding run id the way every other surface does (refs OSS-1060)

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/intelligence-onboarding-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/intelligence-onboarding-prompt.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { IntelligenceOnboardingPrompt } from "../intelligence-onboarding-prompt";
+import { INTELLIGENCE_ONBOARDING_EVENTS } from "@/lib/intelligence-onboarding-prompt";
+
+const analytics = vi.hoisted(() => ({ capture: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/quickstart",
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => analytics,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("names the copied run id the same way every other onboarding surface does", async () => {
+  // The docs surface was the lone outlier: it minted a run id and reported it as
+  // `run_id`, while the managed-service and inspector copy events and all six
+  // `cli.onboarding.*` events call the same value `onboarding_run_id`. A join
+  // written against the canonical name found nothing here, which is what made
+  // this surface read as unmeasurable (OSS-1060 defect 6).
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  render(
+    <IntelligenceOnboardingPrompt
+      feature="threads"
+      surface="docs-quickstart"
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  const [event, properties] = analytics.capture.mock.calls[0] as [
+    string,
+    Record<string, unknown>,
+  ];
+  expect(event).toBe(INTELLIGENCE_ONBOARDING_EVENTS.promptCopied);
+  expect(properties).not.toHaveProperty("run_id");
+  expect(properties.onboarding_run_id).toEqual(expect.any(String));
+  // The id must be the one actually pasted into the prompt, or the join is to a
+  // run that never existed.
+  expect(writeText.mock.calls[0][0]).toContain(properties.onboarding_run_id);
+});

--- a/showcase/shell-docs/src/components/intelligence-onboarding-prompt.tsx
+++ b/showcase/shell-docs/src/components/intelligence-onboarding-prompt.tsx
@@ -83,7 +83,7 @@ export function IntelligenceOnboardingPrompt({
     capture(INTELLIGENCE_ONBOARDING_EVENTS.promptCopied, {
       feature,
       from_path: pathname,
-      run_id: runId,
+      onboarding_run_id: runId,
       surface,
     });
     setTimeout(() => setCopyState("idle"), 1800);


### PR DESCRIPTION
## Problem

Three surfaces mint an onboarding run id and report it to PostHog:

| surface | event | property |
|---|---|---|
| managed-service Home | `managed_service.onboarding_prompt_copied` | `onboarding_run_id` |
| web inspector | `oss.inspector.home_prompt_copied` | `onboarding_run_id` |
| **docs CTA** | `docs.intelligence_onboarding_prompt_copied` | **`run_id`** |

All six `cli.onboarding.*` events also use `onboarding_run_id`. The docs CTA was the lone outlier.

**The cost was not cosmetic.** A join written against the canonical name found nothing on `managed_service.onboarding_prompt_copied`, which is how that surface came to be described in OSS-1060 as unmeasurable, with 70 stranded runs. It is not: it carries the id on 100% of copies and joins fine. The unmeasurable surface was this one, by name only.

With both names read correctly, the comparison the ticket wanted is available — and the finding survives, sharper:

| surface | run ids copied | became a run | classified | completed |
|---|---|---|---|---|
| managed | 157 | **41 (26%)** | 15 | 10 |
| docs | 31 | **2 (6%)** | 0 | 0 |

This is solution item 8 of OSS-1060.

## Change

One line: `run_id` → `onboarding_run_id`, so all three surfaces agree.

Adds a test for the copy handler, which had none — it asserts the canonical property name, the absence of the old one, and that the reported id is the one actually pasted into the prompt (otherwise the join points at a run that never existed).

## Validation

- new test passes; RED first (`expected { … } to not have property "run_id"`)
- `src/components` suite: 48 passed. 6 files fail to collect on missing gitignored `src/data/*.json` — **verified identical on unmodified `origin/main`** (47 passed, same 6 files), so this change adds one passing test and breaks nothing.

## Querying across this change

The 31 docs copy events from 2026-08-28 to 08-31 carry `run_id`. A window spanning this commit needs `coalesce(properties.onboarding_run_id, properties.run_id)`. I kept the canonical name rather than dual-emitting, since the surface is days old and low-volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected analytics tracking for copied onboarding prompts by recording the onboarding run ID under the standardized property name.
  * Preserved existing clipboard behavior, error handling, and copy-state updates.

* **Tests**
  * Added coverage confirming the tracked run ID matches the value copied to the clipboard and uses the correct event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->