### PR TITLE
feat(docs): add signed-in account menu links

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/brand-nav.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/brand-nav.test.tsx
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { expect, test, vi } from "vitest";
 
@@ -17,20 +18,40 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: vi.fn() }),
 }));
 
-vi.mock("@clerk/nextjs", () => ({
-  useUser: () => {
-    if (clerkState.shouldThrow) throw new Error("Clerk unavailable");
+vi.mock("@clerk/nextjs", () => {
+  const UserButton = Object.assign(
+    ({ children }: { children?: ReactNode }) => (
+      <div>
+        <button type="button">Account menu</button>
+        {children}
+      </div>
+    ),
+    {
+      MenuItems: ({ children }: { children?: ReactNode }) => children,
+      Link: ({ href, label }: { href: string; label: string }) => (
+        <a href={href}>{label}</a>
+      ),
+    },
+  );
 
-    return {
-      isLoaded: clerkState.isLoaded,
-      isSignedIn: clerkState.isSignedIn,
-    };
-  },
-  UserButton: () => <button type="button">Account menu</button>,
-}));
+  return {
+    useUser: () => {
+      if (clerkState.shouldThrow) throw new Error("Clerk unavailable");
+
+      return {
+        isLoaded: clerkState.isLoaded,
+        isSignedIn: clerkState.isSignedIn,
+      };
+    },
+    UserButton,
+  };
+});
 
 import { BrandNav, buildDocsAuthEntryHref } from "../brand-nav";
-import { DocsAuthFallbackBoundary } from "../docs-public-auth-control";
+import {
+  buildDocsUserMenuHref,
+  DocsAuthFallbackBoundary,
+} from "../docs-public-auth-control";
 
 const brandNavSource = readFileSync(
   new URL("../brand-nav.tsx", import.meta.url),
@@ -83,7 +104,30 @@ test("BrandNav renders Clerk's user button in the desktop auth slot", () => {
   const markup = renderToStaticMarkup(<BrandNav />);
 
   expect(markup).toContain("Account menu");
+  expect(markup).toContain(
+    'href="https://dashboard.operations.copilotkit.ai/intelligence"',
+  );
+  expect(markup).toContain("Intelligence");
+  expect(markup).toContain(
+    'href="https://dashboard.operations.copilotkit.ai/pricing"',
+  );
+  expect(markup).toContain("Manage your plan");
   expect(markup).not.toContain("Get CopilotKit Intelligence free");
+});
+
+test("BrandNav uses the environment-specific Ops origin for user menu links", () => {
+  expect(
+    buildDocsUserMenuHref(
+      "/intelligence",
+      "https://dashboard.staging.operations.copilotkit.ai",
+    ),
+  ).toBe("https://dashboard.staging.operations.copilotkit.ai/intelligence");
+  expect(
+    buildDocsUserMenuHref(
+      "/pricing",
+      "https://dashboard.staging.operations.copilotkit.ai",
+    ),
+  ).toBe("https://dashboard.staging.operations.copilotkit.ai/pricing");
 });
 
 test("BrandNav sends public auth entry to Intelligence onboarding", () => {

--- a/showcase/shell-docs/src/components/docs-public-auth-control.tsx
+++ b/showcase/shell-docs/src/components/docs-public-auth-control.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { UserButton, useUser } from "@clerk/nextjs";
+import { Brain, CreditCard } from "lucide-react";
 import type { ReactNode } from "react";
 import { Component } from "react";
 import { buildIntelligenceAuthEntryHref } from "@/lib/docs-cta-href";
@@ -13,6 +14,13 @@ export function buildDocsAuthEntryHref(
   opsPublicUrl = "https://dashboard.operations.copilotkit.ai",
 ): string {
   return buildIntelligenceAuthEntryHref(opsPublicUrl, { surface: "navbar" });
+}
+
+export function buildDocsUserMenuHref(
+  path: "/intelligence" | "/pricing",
+  opsPublicUrl = "https://dashboard.operations.copilotkit.ai",
+): string {
+  return new URL(path, opsPublicUrl).toString();
 }
 
 export function useDocsAuthEntryHref(): string {
@@ -51,12 +59,29 @@ export class DocsAuthFallbackBoundary extends Component<
 
 function ClerkDocsAuthControl({ fallback }: { fallback: ReactNode }) {
   const { isLoaded, isSignedIn } = useUser();
+  const opsPublicUrl = usePublicOpsUrl();
 
   if (!isLoaded || !isSignedIn) return <>{fallback}</>;
 
+  const intelligenceHref = buildDocsUserMenuHref("/intelligence", opsPublicUrl);
+  const pricingHref = buildDocsUserMenuHref("/pricing", opsPublicUrl);
+
   return (
     <div className="flex h-10 min-w-10 shrink-0 items-center justify-center">
-      <UserButton />
+      <UserButton>
+        <UserButton.MenuItems>
+          <UserButton.Link
+            href={intelligenceHref}
+            label="Intelligence"
+            labelIcon={<Brain size={16} aria-hidden="true" />}
+          />
+          <UserButton.Link
+            href={pricingHref}
+            label="Manage your plan"
+            labelIcon={<CreditCard size={16} aria-hidden="true" />}
+          />
+        </UserButton.MenuItems>
+      </UserButton>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add **Intelligence** and **Manage your plan** to the signed-in Docs Clerk menu.
- Route both links through the matching environment Ops origin at `/intelligence` and `/pricing`.
- Keep Clerk built-in **Manage account** and **Sign out** actions, plus the existing signed-out and unavailable-Clerk fallbacks.
- Cover the rendered menu and non-production URL construction.

This mirrors [Website PR #544](https://github.com/CopilotKit/website/pull/544) in Docs, following [Sam’s request](https://copilotkit.slack.com/archives/C0BR0V2P4QJ/p1788200519340669).

## Validation

- `npm test -- src/components/__tests__/brand-nav.test.tsx` — 9 passed
- `npm run typecheck` — passed
- `npm run lint` — passed with existing warnings only
- `npm run build` — passed

Full `npm test` currently reports three unrelated generated-content failures: two in `angular-docs-content.test.ts` and one in `llm-text.test.ts`. The focused account-menu suite passes.