### PR TITLE
chore(agentcore): repin @copilotkit packages to 1.70.0 (refs OSS-1029)

### DIFF
--- a/examples/integrations/agentcore/frontend/package-lock.json
+++ b/examples/integrations/agentcore/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fullstack-agentcore-solution-template-frontend",
       "version": "0.4.0",
       "dependencies": {
-        "@copilotkit/react-core": "1.68.1",
+        "@copilotkit/react-core": "1.70.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.17",
@@ -60,12 +60,12 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.3.tgz",
-      "integrity": "sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.4.tgz",
+      "integrity": "sha512-imSwulOeDQodRy/olQmVEo2PiY6ntjkZ9eiGdw6lMYylh/tay9b7MusyJBmEnkL8GiKRKr6ltr+D42mY5bd8Bg==",
       "license": "MIT",
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependenciesMeta": {
         "graphql": {
@@ -93,13 +93,14 @@
       "license": "MIT"
     },
     "node_modules/@ag-ui/client": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.57.tgz",
-      "integrity": "sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.59.tgz",
+      "integrity": "sha512-d7++r8sBAq6z9G/D/WKrMznQ1Mdvew14pCqOVATReFIvl06mCi1BPqTwmos3zCDGAIiSgcvxc/8m472rYQgFFQ==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.57",
-        "@ag-ui/encoder": "0.0.57",
-        "@ag-ui/proto": "0.0.57",
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/encoder": "0.0.59",
+        "@ag-ui/proto": "0.0.59",
         "@types/uuid": "^10.0.0",
         "compare-versions": "^6.1.1",
         "fast-json-patch": "^3.1.1",
@@ -110,28 +111,31 @@
       }
     },
     "node_modules/@ag-ui/core": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.57.tgz",
-      "integrity": "sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.59.tgz",
+      "integrity": "sha512-hDgy4ipTqXieT8YG8Mr917Y+FD/f11VK1GefZ5CwTDCuNqS/oTwjJ5l/DZkicThgS8hQW/Y7wPylPBMBJ8BkUg==",
+      "license": "MIT",
       "dependencies": {
         "zod": "^3.22.4"
       }
     },
     "node_modules/@ag-ui/encoder": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.57.tgz",
-      "integrity": "sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.59.tgz",
+      "integrity": "sha512-wQCzBsStyZMm8nzhTdTx1G0B1C8yv5rbzZLnz1ka/l5LcJEsK3KTounU8CR9l+7QtcpOUUDJKd0xAbyI6gNcSw==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.57",
-        "@ag-ui/proto": "0.0.57"
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/proto": "0.0.59"
       }
     },
     "node_modules/@ag-ui/proto": {
-      "version": "0.0.57",
-      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.57.tgz",
-      "integrity": "sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.59.tgz",
+      "integrity": "sha512-X+uvDaegLEHw5kJu8tv2eSqHH8ouat+JCfFokGV1uuMquY8qCEQSlGsM7xzexwX9fujuxgHOWumg5kJDqa0+RA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/core": "0.0.57",
+        "@ag-ui/core": "0.0.59",
         "@bufbuild/protobuf": "^2.2.5",
         "@protobuf-ts/protoc": "^2.11.1"
       }
@@ -2298,9 +2302,9 @@
       "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
-      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.1.tgz",
+      "integrity": "sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@chevrotain/types": {
@@ -2310,9 +2314,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.68.1.tgz",
-      "integrity": "sha512-2BFlqNEoVdDBQjN7juTzUWW5rxKxJPpJFrxJfEhjPo9mJhiCCtyWPCWp5ozCPuoqisj74rtoPFntmtQQRMfOFg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.70.0.tgz",
+      "integrity": "sha512-4tbiQMciQ9rv6BoggPunr2HrQYuoOs0c6evKDzBsl2yOdgRwEq//YuCRebTZCA6+HlF9lMP69Rniz5FtY6CDfw==",
       "license": "MIT",
       "dependencies": {
         "@a2ui/web_core": "0.10.4",
@@ -2335,12 +2339,13 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.68.1.tgz",
-      "integrity": "sha512-TfSkcyfrTVJJyf6HBDnZ73vqIzXuU75emetsx7IeObXuPaJWLES8Ksj10kTdCUd3H9cYeEgIxFWb16xDDMrB6A==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.70.0.tgz",
+      "integrity": "sha512-l9hABFMzQZlDHCcDygO9wG8GCOp4gvk7asSfb1Enp0wP7YPwJ1ir5hmyPSKzWvuUoNPZGMu9Ohkr3yv76gQ4GA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
-        "@copilotkit/shared": "1.68.1",
+        "@ag-ui/client": "0.0.59",
+        "@copilotkit/shared": "1.70.0",
         "@tanstack/pacer": "^0.20.1",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
@@ -2357,21 +2362,20 @@
       "license": "MIT"
     },
     "node_modules/@copilotkit/react-core": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.68.1.tgz",
-      "integrity": "sha512-wPCLu+9Szs/t88+6uQ66KzfLzN6dP8mV/i5QvgZzDhEdkowAdT58os64wIeyr937hTMg1jB1sUNphPtV2gbuCA==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.70.0.tgz",
+      "integrity": "sha512-/xj/AWKB5vCvKw6zDRRpHsDP+QxTnRm/Ste5v0HuEUqErMGfu4MwXXA88kQzg8PPof5+Ty7/NXmavrVB64YCcQ==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
-        "@ag-ui/core": "0.0.57",
-        "@copilotkit/a2ui-renderer": "1.68.1",
-        "@copilotkit/core": "1.68.1",
-        "@copilotkit/runtime-client-gql": "1.68.1",
-        "@copilotkit/shared": "1.68.1",
-        "@copilotkit/web-components": "1.68.1",
-        "@copilotkit/web-inspector": "1.68.1",
+        "@ag-ui/client": "0.0.59",
+        "@ag-ui/core": "0.0.59",
+        "@copilotkit/a2ui-renderer": "1.70.0",
+        "@copilotkit/core": "1.70.0",
+        "@copilotkit/runtime-client-gql": "1.70.0",
+        "@copilotkit/shared": "1.70.0",
+        "@copilotkit/web-components": "1.70.0",
+        "@copilotkit/web-inspector": "1.70.0",
         "@jetbrains/websandbox": "^1.1.3",
-        "@lit-labs/react": "^2.0.2",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -3150,12 +3154,12 @@
       }
     },
     "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.68.1.tgz",
-      "integrity": "sha512-BsCHk+At/lhvE8J/TdkkCnmvdADnCivJ9OVFhypkNg4NTtPi++VpVMkH4c5QGn/7Us/9rvMTlfV3tVz3jyOYuQ==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.70.0.tgz",
+      "integrity": "sha512-RGm+0FTE78DmF0eEVV2uQzM89E5t2mWpAUcL3x6SqKPvV+50l6l99PcSNwJgBQ87vFgZGbK1GaFh7YDhJHfisQ==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "1.68.1",
+        "@copilotkit/shared": "1.70.0",
         "@urql/core": "^5.0.3",
         "untruncate-json": "^0.0.1",
         "urql": "^4.1.0"
@@ -3165,12 +3169,12 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.68.1.tgz",
-      "integrity": "sha512-RCDGd+va5QU8rza2/TJXanrP+AukuzPp0TZ1+Zc1e+GX476KBQN2K/CrR8GRXvwkhLIyfZXjzxjR+hKDtJySyg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.70.0.tgz",
+      "integrity": "sha512-RuZ6ZaaLu2aXcbJskKsz//ZkGsqTCtb7DqvKrWVmklZkBbel0VWRMsvhfvh93gLH2WwFBsjLmVpNEondh0AFsA==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
+        "@ag-ui/client": "0.0.59",
         "@copilotkit/license-verifier": "~0.5.0",
         "@segment/analytics-node": "^2.1.2",
         "@standard-schema/spec": "^1.0.0",
@@ -3186,9 +3190,9 @@
       }
     },
     "node_modules/@copilotkit/web-components": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-components/-/web-components-1.68.1.tgz",
-      "integrity": "sha512-wzdxhiv8yLfwowPq6aY5Ca/SfhSjOmfyM2QddD1tWmcLRQiS+7Y95MGJvrEuWWlx/QqEbyv1nwTGAIDkbB64/w==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-components/-/web-components-1.70.0.tgz",
+      "integrity": "sha512-mwl8FSkTNr0pta3JlBujhkAT7ccCiKQ9KfUZMePXrDpp7K9Zu4nMl4yd97fCSye06jxllE8ZDETJSXCBhVi5PA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3198,13 +3202,14 @@
       }
     },
     "node_modules/@copilotkit/web-inspector": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.68.1.tgz",
-      "integrity": "sha512-3+ixkJDzR6WN0ljVJABUBCxMLHqtfFEtM1RvNfLx2FmqETQC5FtHPs9bVP5p58JsSGjDFOrMI5iwUkkbP2lu9A==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.70.0.tgz",
+      "integrity": "sha512-LIq2nAdV7H0ZlzXI/7LXPwml7oVUInRNtqVrG3Ho4NyT/sUVd423zGZrmK636xsLa/IDHiTqNu9XhVV0lauynA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
-        "@copilotkit/core": "1.68.1",
-        "@copilotkit/shared": "1.68.1",
+        "@ag-ui/client": "0.0.59",
+        "@copilotkit/core": "1.70.0",
+        "@copilotkit/shared": "1.70.0",
         "lit": "^3.2.0",
         "lucide": "^0.525.0",
         "marked": "^12.0.2"
@@ -4166,29 +4171,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lit-labs/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/react": "^1.0.3"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
       "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@lit/react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
-      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "@types/react": "17 || 18 || 19"
-      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
@@ -15952,9 +15939,9 @@
       "license": "MIT"
     },
     "node_modules/phoenix": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.11.tgz",
-      "integrity": "sha512-MbS8y0+8lYNjOYRIorek1GzMFS3nKvycetLlLxB/DZOFRu0yLI0PCvvm8wg+7aEORbmWuioe95+7uoyNKlErZg==",
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.13.tgz",
+      "integrity": "sha512-5UByH7ejdsPLd6eihwzV3L3i6YX4mHUtFjLaE8S1YuA+3aBj37rzH6KDjxBuPlB04o9ZHVz+PKRiUg3aYYvzmQ==",
       "license": "MIT"
     },
     "node_modules/picocolors": {

--- a/examples/integrations/agentcore/frontend/package.json
+++ b/examples/integrations/agentcore/frontend/package.json
@@ -12,7 +12,7 @@
     "clean": "rm -rf build/ node_modules/ .vite/"
   },
   "dependencies": {
-    "@copilotkit/react-core": "1.68.1",
+    "@copilotkit/react-core": "1.70.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.17",

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/package-lock.json
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ag-ui/client": "0.0.58",
         "@ag-ui/mcp-apps-middleware": "^0.0.3",
-        "@copilotkit/runtime": "1.68.1",
+        "@copilotkit/runtime": "1.70.0",
         "@hono/node-server": "^1.13.7",
         "hono": "^4.11.4",
         "rxjs": "^7.8.2"
@@ -498,15 +498,6 @@
         "zod-to-json-schema": "^3.25.1"
       }
     },
-    "node_modules/@copilotkit/channels-slack/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@copilotkit/channels-teams": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.9.0.tgz",
@@ -527,15 +518,6 @@
         "zod-to-json-schema": "^3.25.1"
       }
     },
-    "node_modules/@copilotkit/channels-teams/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@copilotkit/channels-ui": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.9.0.tgz",
@@ -546,12 +528,13 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.68.1.tgz",
-      "integrity": "sha512-TfSkcyfrTVJJyf6HBDnZ73vqIzXuU75emetsx7IeObXuPaJWLES8Ksj10kTdCUd3H9cYeEgIxFWb16xDDMrB6A==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.70.0.tgz",
+      "integrity": "sha512-l9hABFMzQZlDHCcDygO9wG8GCOp4gvk7asSfb1Enp0wP7YPwJ1ir5hmyPSKzWvuUoNPZGMu9Ohkr3yv76gQ4GA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
-        "@copilotkit/shared": "1.68.1",
+        "@ag-ui/client": "0.0.59",
+        "@copilotkit/shared": "1.70.0",
         "@tanstack/pacer": "^0.20.1",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
@@ -577,15 +560,15 @@
       "license": "MIT"
     },
     "node_modules/@copilotkit/runtime": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.68.1.tgz",
-      "integrity": "sha512-jEzy6a6Hkh1ssQLyfNpQA3TMZg1gnPmaEd6lLmXSlz76byUC1zFlQSFLTgTUZapqvHVA7CDM87zHSu3BAHl1Zg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.70.0.tgz",
+      "integrity": "sha512-6azGv1V2ndwPu/A1D33i7KUOQLW+LPDGyIfg+ypaqQxPGI20iJG1phnmcjNC2VWT5o5eyGfMBslmaaZb7XnjHQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/a2ui-middleware": "0.0.10",
-        "@ag-ui/client": "0.0.57",
-        "@ag-ui/core": "0.0.57",
-        "@ag-ui/encoder": "0.0.57",
+        "@ag-ui/client": "0.0.59",
+        "@ag-ui/core": "0.0.59",
+        "@ag-ui/encoder": "0.0.59",
         "@ag-ui/langgraph": "0.0.42",
         "@ag-ui/mcp-apps-middleware": "0.0.3",
         "@ag-ui/mcp-middleware": "0.0.1",
@@ -597,13 +580,15 @@
         "@copilotkit/channels-core": "^0.9.0",
         "@copilotkit/channels-intelligence": "0.9.0",
         "@copilotkit/license-verifier": "~0.5.0",
-        "@copilotkit/shared": "1.68.1",
+        "@copilotkit/shared": "1.70.0",
         "@graphql-yoga/plugin-defer-stream": "^3.3.1",
         "@hono/node-server": "^1.13.5",
         "@modelcontextprotocol/sdk": "^1.18.2",
         "@remix-run/node-fetch-server": "^0.13.0",
         "@scarf/scarf": "^1.3.0",
         "@segment/analytics-node": "^2.1.2",
+        "@types/cors": "^2.8.17",
+        "@types/express": "^4.17.21",
         "ai": "^6.0.104",
         "clarinet": "^0.12.4",
         "class-transformer": "^0.5.1",
@@ -694,6 +679,51 @@
         "rxjs": "7.8.1"
       }
     },
+    "node_modules/@copilotkit/runtime/node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@copilotkit/runtime/node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
     "node_modules/@copilotkit/runtime/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -704,12 +734,12 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.68.1.tgz",
-      "integrity": "sha512-RCDGd+va5QU8rza2/TJXanrP+AukuzPp0TZ1+Zc1e+GX476KBQN2K/CrR8GRXvwkhLIyfZXjzxjR+hKDtJySyg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.70.0.tgz",
+      "integrity": "sha512-RuZ6ZaaLu2aXcbJskKsz//ZkGsqTCtb7DqvKrWVmklZkBbel0VWRMsvhfvh93gLH2WwFBsjLmVpNEondh0AFsA==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
+        "@ag-ui/client": "0.0.59",
         "@copilotkit/license-verifier": "~0.5.0",
         "@segment/analytics-node": "^2.1.2",
         "@standard-schema/spec": "^1.0.0",
@@ -2125,7 +2155,6 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2136,7 +2165,15 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2170,8 +2207,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2188,6 +2224,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2208,15 +2250,13 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",

--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/package.json
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@ag-ui/client": "0.0.58",
     "@ag-ui/mcp-apps-middleware": "^0.0.3",
-    "@copilotkit/runtime": "1.68.1",
+    "@copilotkit/runtime": "1.70.0",
     "@hono/node-server": "^1.13.7",
     "hono": "^4.11.4",
     "rxjs": "^7.8.2"


### PR DESCRIPTION
**Step 3 of #6188's landing order.** That PR states: *"1. Merge #6098. 2. Publish `@copilotkit/runtime` and `@copilotkit/react-core` with managed entitlement support. 3. Update the two AgentCore pins from `1.68.1` to that release. 4. Merge this PR. Do not merge this PR before step 3."*

Steps 1 and 2 completed today:

- #6098 merged at 18:55Z (`b07b1320f2`)
- `@copilotkit/runtime@1.70.0` published 20:24:51Z, `@copilotkit/react-core@1.70.0` at 20:26:32Z; `dist-tags.latest` is `1.70.0` for both
- `git merge-base --is-ancestor b07b1320f2 v1.70.0` confirms the managed Intelligence authority is actually *in* the release — a 1.70.0 without #6098 would have satisfied the version bump but not the step

This is step 3, so #6188 is no longer blocked on the release train.

## The locks are bumped minimally, not regenerated

Worth a look, because the obvious approach is wrong in two different directions.

**A plain `npm install --package-lock-only` leaves a duplicate.** The lambda ended up with two copies of `@copilotkit/shared` — `1.70.0` nested under `runtime`, and `1.68.1` still hoisted at the top level for the `@copilotkit/channels-*@0.9.0` packages, which ask for `^1.68.0` and were already satisfied. `npm dedupe` does not collapse it. `npm update @copilotkit/shared @copilotkit/core --package-lock-only` does.

**A full regeneration is far too broad.** Deleting the lock and rebuilding it produces a single clean copy, but sweeps 89 unrelated packages along with it — including `@graphql-tools/executor` 1.5.1 → **2.0.0**, `@graphql-tools/utils` 10 → 11, `debug` 2 → 4, and a `@types/express` 5 → 4 *downgrade*. That is a dependency sweep on a Lambda that ships to AWS, not a repin, so it was rejected.

What landed changes exactly three resolved versions in the lambda lock (`@copilotkit/core`, `runtime`, `shared`, all 1.68.1 → 1.70.0) plus the type-package hoisting that follows from runtime 1.70.0's own tree, and seven in the frontend lock.

## One thing left deliberately alone

The lambda's `overrides` block pins `@ag-ui/{client,core,encoder,proto}` to `0.0.58`, while `runtime@1.70.0` declares `0.0.59`. I left it as-is — it was already overriding runtime's declared version before this change, so the override goes on doing what it did. Flagging it in case that pin has a shelf life.

## Validation

- lambda `npm install` + `tsc -p tsconfig.json` → exit 0, `dist/` emitted
- frontend `npm install` + `tsc && vite build` → exit 0, built in 11.14s
- exactly one copy of every `@copilotkit/*` and `@ag-ui/*` package in both locks, none left on a 1.6x line
- no remaining `1.68.1` under `examples/integrations/agentcore`

Note `1.68.1` is pinned across ~20 other `examples/integrations/*/package.json`. Those are deliberately untouched — the landing order names only the two AgentCore pins.

Refs OSS-1029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AgentCore integration to the latest CopilotKit release.
  * Keeps the frontend and runtime components aligned for improved compatibility and access to the latest fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->