### PR TITLE
fix(agentcore): collapse the duplicate @copilotkit/shared in the lambda lock (refs OSS-1029)

### DIFF
--- a/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/package-lock.json
+++ b/examples/integrations/agentcore/infra-cdk/lambdas/copilotkit-runtime/package-lock.json
@@ -498,15 +498,6 @@
         "zod-to-json-schema": "^3.25.1"
       }
     },
-    "node_modules/@copilotkit/channels-slack/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@copilotkit/channels-teams": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@copilotkit/channels-teams/-/channels-teams-0.9.0.tgz",
@@ -527,15 +518,6 @@
         "zod-to-json-schema": "^3.25.1"
       }
     },
-    "node_modules/@copilotkit/channels-teams/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@copilotkit/channels-ui": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@copilotkit/channels-ui/-/channels-ui-0.9.0.tgz",
@@ -546,12 +528,13 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.68.1.tgz",
-      "integrity": "sha512-TfSkcyfrTVJJyf6HBDnZ73vqIzXuU75emetsx7IeObXuPaJWLES8Ksj10kTdCUd3H9cYeEgIxFWb16xDDMrB6A==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.70.0.tgz",
+      "integrity": "sha512-l9hABFMzQZlDHCcDygO9wG8GCOp4gvk7asSfb1Enp0wP7YPwJ1ir5hmyPSKzWvuUoNPZGMu9Ohkr3yv76gQ4GA==",
+      "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
-        "@copilotkit/shared": "1.68.1",
+        "@ag-ui/client": "0.0.59",
+        "@copilotkit/shared": "1.70.0",
         "@tanstack/pacer": "^0.20.1",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
@@ -696,27 +679,6 @@
         "rxjs": "7.8.1"
       }
     },
-    "node_modules/@copilotkit/runtime/node_modules/@copilotkit/shared": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.70.0.tgz",
-      "integrity": "sha512-RuZ6ZaaLu2aXcbJskKsz//ZkGsqTCtb7DqvKrWVmklZkBbel0VWRMsvhfvh93gLH2WwFBsjLmVpNEondh0AFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ag-ui/client": "0.0.59",
-        "@copilotkit/license-verifier": "~0.5.0",
-        "@segment/analytics-node": "^2.1.2",
-        "@standard-schema/spec": "^1.0.0",
-        "chalk": "4.1.2",
-        "graphql": "^16.8.1",
-        "partial-json": "^0.1.7",
-        "uuid": "^11.1.0",
-        "zod": "^3.23.3",
-        "zod-to-json-schema": "^3.23.5"
-      },
-      "peerDependencies": {
-        "@ag-ui/core": ">=0.0.48"
-      }
-    },
     "node_modules/@copilotkit/runtime/node_modules/@types/express": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
@@ -772,12 +734,12 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.68.1",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.68.1.tgz",
-      "integrity": "sha512-RCDGd+va5QU8rza2/TJXanrP+AukuzPp0TZ1+Zc1e+GX476KBQN2K/CrR8GRXvwkhLIyfZXjzxjR+hKDtJySyg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.70.0.tgz",
+      "integrity": "sha512-RuZ6ZaaLu2aXcbJskKsz//ZkGsqTCtb7DqvKrWVmklZkBbel0VWRMsvhfvh93gLH2WwFBsjLmVpNEondh0AFsA==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/client": "0.0.57",
+        "@ag-ui/client": "0.0.59",
         "@copilotkit/license-verifier": "~0.5.0",
         "@segment/analytics-node": "^2.1.2",
         "@standard-schema/spec": "^1.0.0",


### PR DESCRIPTION
Stacked on #6188 — base is `agent/intelligence-starter-templates`, one commit on top of `56c2378ff5`. Fold it in or merge it; it is not meaningful against `main`.

Follow-up to [my comment on #6188](https://github.com/CopilotKit/CopilotKit/pull/6188#issuecomment-5485622011). One file, 10 insertions / 48 deletions.

## The problem

`064c5ed910 chore(examples): update CLI starters to CopilotKit 1.70.0` leaves the AgentCore lambda lock with two copies of `@copilotkit/shared`, plus a stale `@copilotkit/core`:

```
node_modules/@copilotkit/runtime/node_modules/@copilotkit/shared   1.70.0
node_modules/@copilotkit/shared                                    1.68.1   <-- hoisted
node_modules/@copilotkit/core                                      1.68.1   <-- stale
```

The frontend lock is clean; this is only the lambda.

## Why it happens

`runtime@1.70.0` pins `@copilotkit/shared` to exactly `1.70.0`. The transitive `@copilotkit/channels-*@0.9.0` packages ask for `^1.68.0`, which the pre-existing `1.68.1` resolution already satisfies. A `--package-lock-only` bump has no reason to move a range that is already satisfied, so npm hoists `1.68.1` for the channels packages and nests `1.70.0` under `runtime`.

`npm dedupe --package-lock-only` does **not** collapse it. What does:

```
npm update @copilotkit/shared @copilotkit/core --package-lock-only
```

That is the entire change.

## The alternative worth not taking

Deleting the lock and regenerating also produces one clean copy — and sweeps 89 unrelated packages along with it, including `@graphql-tools/executor` 1.5.1 → **2.0.0**, `@graphql-tools/utils` 10 → 11, `debug` 2 → 4, and a `@types/express` 5 → 4 *downgrade*, on a Lambda that ships to AWS. Recording it here so the next person doesn't reach for it.

## Validation

On top of `56c2378ff5`:

- exactly one copy of every `@copilotkit/*` and `@ag-ui/*` package in the lock afterwards, none left on a 1.6x line
- `npm install` + `tsc -p tsconfig.json` → exit 0, `dist/` emitted
- nothing else in the lock moves — the diff is confined to the three `@copilotkit` entries and the hoisting that follows

## Unrelated, still flagging

`runtime@1.70.0` declares `@ag-ui/*` at `0.0.59`; the lambda's `overrides` block holds them at `0.0.58`. Left alone — it was already overriding the declared version before this bump, and it builds — but it may have a shelf life.

Refs OSS-1029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)