### PR TITLE
chore: delete the stale changeset files

### DIFF
--- a/.changeset/enable-mcp-apps-tool-filters.md
+++ b/.changeset/enable-mcp-apps-tool-filters.md
@@ -1,7 +1,0 @@
----
-"@copilotkit/runtime": minor
----
-
-fix(runtime): reject unenforceable mcpApps tool policy instead of silently ignoring it
-
-Reject MCP Apps per-tool policy keys until the external middleware supports them, preventing silent configuration no-ops.

--- a/.changeset/expose-feedback-raw-event.md
+++ b/.changeset/expose-feedback-raw-event.md
@@ -1,6 +1,0 @@
----
-"@copilotkit/core": minor
-"@copilotkit/react-core": minor
----
-
-feat(react-core): expose raw event metadata to feedback callbacks


### PR DESCRIPTION
Nothing reads `.changeset/*.md`. Releases are built from conventional commit
subjects by `scripts/release/`, `@changesets/cli` is not a dependency,
CONTRIBUTING.md says not to add one, and `check-binaries` fails any PR that
does.

Two inert files were still sitting in `.changeset/` anyway, and that is enough
to make the convention look alive. Someone opening the directory finds it
populated, reasonably concludes a changeset is expected, writes one, and gets a
red check for following what the repo appeared to be doing. That happened on
#6826.

This deletes the two files so the directory stops contradicting the docs. The
CI check filters on added and modified paths only, so a PR that deletes stale
changesets still passes.

Package `CHANGELOG.md` history is untouched — it keeps the entries those
changesets produced when the tooling was still in use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed pending release notes for previously planned updates.
  * No user-visible features, fixes, or behavior changes are included in this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->