### PR TITLE
feat(react-core): MCP Apps ui/request-display-mode host handler (inline/fullscreen)

### DIFF
--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import { z } from "zod";
 import type { AbstractAgent, RunAgentResult } from "@ag-ui/client";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -240,6 +240,25 @@ const MCP_OPEN_LINK_BLOCKED_SCHEMES = new Set([
  */
 export const MCPAppsActivityType = "mcp-apps";
 
+// Ref-counted body scroll lock shared across renderer instances, so two widgets
+// in fullscreen at once don't let the first one to exit unlock the page while
+// the second is still open.
+let fullscreenLockCount = 0;
+let bodyOverflowBeforeLock = "";
+function acquireBodyScrollLock(): void {
+  if (fullscreenLockCount === 0) {
+    bodyOverflowBeforeLock = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  fullscreenLockCount += 1;
+}
+function releaseBodyScrollLock(): void {
+  fullscreenLockCount = Math.max(0, fullscreenLockCount - 1);
+  if (fullscreenLockCount === 0) {
+    document.body.style.overflow = bodyOverflowBeforeLock;
+  }
+}
+
 // Zod schema for activity content validation (middleware 0.0.2 format)
 export const MCPAppsActivityContentSchema = z.object({
   result: z.object({
@@ -342,6 +361,83 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
 
     // ext-apps host bridge for this widget instance (owns the app<->host protocol).
     const bridgeRef = useRef<AppBridge | null>(null);
+
+    // Current MCP Apps display mode. Host supports "inline" and "fullscreen";
+    // "pip" (and unknown) is never granted.
+    const [displayMode, setDisplayMode] = useState<
+      "inline" | "fullscreen" | "pip"
+    >("inline");
+    // Latest displayMode for the bridge request handler (assigned once in setup).
+    const displayModeRef = useRef(displayMode);
+    displayModeRef.current = displayMode;
+    const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+    // Inform the widget of the current display mode. `setHostContext` merges the
+    // partial context and emits ui/notifications/host-context-changed, and also
+    // refreshes the bridge's cached hostContext (so the app SDK's getHostContext
+    // sees it). Emitted for BOTH host- and widget-initiated changes. Entering
+    // fullscreen also advertises the available render surface via
+    // containerDimensions.
+    const notifyDisplayMode = useCallback(
+      (mode: "inline" | "fullscreen" | "pip") => {
+        // ext-apps `setHostContext` REPLACES the bridge's cached host context
+        // (it only diffs to decide what to notify), so pass the FULL context —
+        // otherwise theme/platform/availableDisplayModes would be dropped from
+        // the cache on a mode change. The emitted host-context-changed still
+        // carries only the changed fields (the bridge computes that diff).
+        const hostContext: Record<string, unknown> = {
+          theme: "light",
+          platform: "web",
+          availableDisplayModes: ["inline", "fullscreen"],
+          displayMode: mode,
+        };
+        if (mode === "fullscreen") {
+          hostContext.containerDimensions = {
+            width: Math.round(window.innerWidth),
+            height: Math.round(window.innerHeight),
+          };
+        }
+        bridgeRef.current?.setHostContext(hostContext);
+      },
+      [],
+    );
+
+    // Apply a display mode and inform the widget. Single source of truth for both
+    // the widget-initiated ui/request-display-mode and the host-initiated exit.
+    const applyDisplayMode = useCallback(
+      (mode: "inline" | "fullscreen" | "pip") => {
+        setDisplayMode(mode);
+        notifyDisplayMode(mode);
+      },
+      [notifyDisplayMode],
+    );
+
+    // Host-initiated exit from fullscreen (close button or Escape key).
+    const exitFullscreen = useCallback(() => {
+      applyDisplayMode("inline");
+    }, [applyDisplayMode]);
+
+    // While fullscreen: move focus to the close button, allow Escape to exit,
+    // keep containerDimensions in sync on viewport resize, and lock the
+    // background page scroll (ref-counted so concurrent fullscreen widgets don't
+    // unlock the page early). Escape will not fire while focus is inside the
+    // sandboxed iframe, so the close (X) button is the primary exit path.
+    useEffect(() => {
+      if (displayMode !== "fullscreen") return;
+      closeButtonRef.current?.focus();
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") exitFullscreen();
+      };
+      const onResize = () => notifyDisplayMode("fullscreen");
+      window.addEventListener("keydown", onKeyDown);
+      window.addEventListener("resize", onResize);
+      acquireBodyScrollLock();
+      return () => {
+        window.removeEventListener("keydown", onKeyDown);
+        window.removeEventListener("resize", onResize);
+        releaseBodyScrollLock();
+      };
+    }, [displayMode, exitFullscreen, notifyDisplayMode]);
 
     // Ref to track fetch state - survives StrictMode remounts
     const fetchStateRef = useRef<{
@@ -539,10 +635,18 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
             // Seed the host context at construction (before connect) so it is
             // already in place when the widget's ui/initialize is handled. Doing
             // this via setHostContext after connect would only win the race by
-            // luck (it depends on the notification landing before initialize),
-            // and #6689 relies on this seam to advertise displayMode /
-            // availableDisplayModes at initialize.
-            { hostContext: { theme: "light", platform: "web" } },
+            // luck (it depends on the notification landing before initialize).
+            // The host renders "inline" and "fullscreen"; advertise both and the
+            // current mode here so request-display-mode is negotiated at
+            // initialize rather than after a race.
+            {
+              hostContext: {
+                theme: "light",
+                platform: "web",
+                displayMode: displayModeRef.current,
+                availableDisplayModes: ["inline", "fullscreen"],
+              },
+            },
           );
 
           // Sandbox handshake: when the proxy is ready, load the widget HTML into
@@ -670,6 +774,35 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
             return (runResult.result as CallToolResult) || { content: [] };
           };
 
+          // ui/request-display-mode: the widget asks to switch display mode.
+          // ext-apps host behavior:
+          // - A mode is available only if the host supports it AND, when the app
+          //   declared appCapabilities.availableDisplayModes, it also appears
+          //   there (the host MUST NOT switch to a mode outside that list).
+          // - If the requested mode is not available, the host does NOT switch
+          //   and returns the CURRENT display mode (not a hardcoded fallback).
+          // The host supports "inline" and "fullscreen"; "pip" is never granted.
+          bridge.onrequestdisplaymode = async ({ mode }) => {
+            const hostSupported = ["inline", "fullscreen"] as const;
+            const declaredByApp =
+              bridge?.getAppCapabilities()?.availableDisplayModes ?? null;
+            const isAvailable =
+              hostSupported.includes(
+                mode as (typeof hostSupported)[number],
+              ) &&
+              (declaredByApp === null || declaredByApp.includes(mode));
+            if (isAvailable) {
+              // Apply AND emit host-context-changed (via applyDisplayMode ->
+              // setHostContext): the app SDK caches hostContext from the
+              // notification, not from this response, so a widget-driven toggle
+              // needs the notification to observe the new mode later.
+              applyDisplayMode(mode);
+              return { mode };
+            }
+            // Not available: leave the mode unchanged and report the current one.
+            return { mode: displayModeRef.current };
+          };
+
           // --- App -> host notifications ---
           bridge.onsizechange = (p) => {
             if (!mounted) return;
@@ -692,8 +825,9 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
             await bridge.close();
             return;
           }
-          // Host context was seeded at construction (see the AppBridge options
-          // above), so it is already advertised by the time ui/initialize runs.
+          // Host context (theme/platform + displayMode/availableDisplayModes)
+          // was seeded at construction (see the AppBridge options above), so it
+          // is already advertised by the time ui/initialize runs.
           bridgeRef.current = bridge;
         } catch (err) {
           console.error("[MCPAppsRenderer] Setup error:", err);
@@ -715,21 +849,30 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
         }
         iframeRef.current = null;
       };
-    }, [isLoading, fetchedResource, copilotkit]);
+    }, [isLoading, fetchedResource, copilotkit, applyDisplayMode]);
 
-    // Effect 2: Update iframe size when it changes
+    // Effect 2: Update iframe size when it changes.
+    // In fullscreen the iframe must fill the overlay (100% of the fixed
+    // container), otherwise it would keep its widget-reported inline height and
+    // render as a small widget inside a full-viewport panel.
     useEffect(() => {
-      if (iframeRef.current) {
-        if (iframeSize.width !== undefined) {
-          // Use minWidth with min() to allow expansion but cap at 100%
-          iframeRef.current.style.minWidth = `min(${iframeSize.width}px, 100%)`;
-          iframeRef.current.style.width = "100%";
-        }
-        if (iframeSize.height !== undefined) {
-          iframeRef.current.style.height = `${iframeSize.height}px`;
-        }
+      const iframe = iframeRef.current;
+      if (!iframe) return;
+      if (displayMode === "fullscreen") {
+        iframe.style.minWidth = "100%";
+        iframe.style.width = "100%";
+        iframe.style.height = "100%";
+        return;
       }
-    }, [iframeSize]);
+      if (iframeSize.width !== undefined) {
+        // Use minWidth with min() to allow expansion but cap at 100%
+        iframe.style.minWidth = `min(${iframeSize.width}px, 100%)`;
+        iframe.style.width = "100%";
+      }
+      if (iframeSize.height !== undefined) {
+        iframe.style.height = `${iframeSize.height}px`;
+      }
+    }, [iframeSize, displayMode]);
 
     // Effect 3: Send tool input when iframe ready
     useEffect(() => {
@@ -761,18 +904,72 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
           }
         : {};
 
+    const isFullscreen = displayMode === "fullscreen";
+
+    // NOTE: the fullscreen overlay uses `position: fixed` rather than a
+    // React portal on purpose. The iframe is created imperatively and appended
+    // to this container; portaling would reparent it and reload the sandboxed
+    // srcdoc (losing widget state) on every fullscreen toggle. `position: fixed`
+    // keeps the iframe alive; the trade-off is that a transformed/filtered
+    // ancestor in a host app could re-anchor it (v2's own chat CSS does not).
     return (
       <div
         ref={containerRef}
-        style={{
-          width: "100%",
-          height: iframeSize.height ? `${iframeSize.height}px` : "auto",
-          minHeight: "100px",
-          overflow: "hidden",
-          position: "relative",
-          ...borderStyle,
-        }}
+        role={isFullscreen ? "dialog" : undefined}
+        aria-modal={isFullscreen ? true : undefined}
+        aria-label={isFullscreen ? "Fullscreen widget" : undefined}
+        style={
+          isFullscreen
+            ? {
+                position: "fixed",
+                inset: 0,
+                zIndex: 2147483000,
+                width: "100vw",
+                height: "100vh",
+                overflow: "auto",
+                // Theme-aware token so the overlay does not flash white in dark
+                // mode (v2 defines --background for light and .dark).
+                background: "var(--background, #fff)",
+              }
+            : {
+                width: "100%",
+                height: iframeSize.height ? `${iframeSize.height}px` : "auto",
+                minHeight: "100px",
+                overflow: "hidden",
+                position: "relative",
+                ...borderStyle,
+              }
+        }
       >
+        {isFullscreen && (
+          <button
+            ref={closeButtonRef}
+            type="button"
+            aria-label="Exit fullscreen"
+            onClick={exitFullscreen}
+            style={{
+              position: "absolute",
+              top: "8px",
+              right: "8px",
+              zIndex: 1,
+              width: "32px",
+              height: "32px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 0,
+              border: "none",
+              borderRadius: "50%",
+              background: "rgba(0, 0, 0, 0.6)",
+              color: "#fff",
+              fontSize: "18px",
+              lineHeight: 1,
+              cursor: "pointer",
+            }}
+          >
+            ×
+          </button>
+        )}
         {isLoading && (
           <div style={{ padding: "1rem", color: "#666" }}>Loading...</div>
         )}

--- a/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
+++ b/packages/react-core/src/v2/components/MCPAppsActivityRenderer.tsx
@@ -339,7 +339,7 @@ const CopilotKitUiMessageSchema = z.object({
 export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
   function MCPAppsActivityRenderer({ content, agent }) {
     const { copilotkit } = useCopilotKit();
-    const containerRef = useRef<HTMLDivElement>(null);
+    const containerRef = useRef<HTMLDialogElement>(null);
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const [iframeReady, setIframeReady] = useState(false);
     const [error, setError] = useState<Error | null>(null);
@@ -417,27 +417,55 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
       applyDisplayMode("inline");
     }, [applyDisplayMode]);
 
-    // While fullscreen: move focus to the close button, allow Escape to exit,
-    // keep containerDimensions in sync on viewport resize, and lock the
-    // background page scroll (ref-counted so concurrent fullscreen widgets don't
-    // unlock the page early). Escape will not fire while focus is inside the
-    // sandboxed iframe, so the close (X) button is the primary exit path.
+    // Tracks whether the dialog was opened modally, so we can transition modes
+    // without relying on the `:modal` pseudo-class (jsdom lacks it).
+    const dialogModalRef = useRef(false);
+
+    // Drive the native <dialog> open mode from displayMode. The iframe lives
+    // inside this dialog and is NEVER reparented, so toggling between inline
+    // (show, in normal flow) and fullscreen (showModal, top layer) preserves the
+    // widget's state (no srcdoc reload). Fullscreen relies on the top layer,
+    // which escapes ancestor containing blocks — v2's chat container uses
+    // `container-type`, which would otherwise trap a plain `position: fixed`
+    // overlay inside the chat panel instead of filling the viewport.
+    useEffect(() => {
+      const dlg = containerRef.current;
+      if (!dlg) return;
+      const wantModal = displayMode === "fullscreen";
+      // Environments without full <dialog> support (e.g. jsdom's top layer):
+      // just make sure the content renders.
+      if (
+        typeof dlg.showModal !== "function" ||
+        typeof dlg.show !== "function"
+      ) {
+        if (!dlg.open) dlg.setAttribute("open", "");
+        dialogModalRef.current = wantModal;
+        return;
+      }
+      if (dlg.open && dialogModalRef.current !== wantModal) {
+        dlg.close();
+      }
+      if (!dlg.open) {
+        if (wantModal) dlg.showModal();
+        else dlg.show();
+        dialogModalRef.current = wantModal;
+      }
+    }, [displayMode, isLoading, fetchedResource]);
+
+    // While fullscreen: keep containerDimensions in sync on viewport resize and
+    // lock the background page scroll (ref-counted so concurrent fullscreen
+    // widgets don't unlock the page early). Focus containment, focus restore, and
+    // Escape are handled natively by the modal <dialog> (showModal + onCancel).
     useEffect(() => {
       if (displayMode !== "fullscreen") return;
-      closeButtonRef.current?.focus();
-      const onKeyDown = (event: KeyboardEvent) => {
-        if (event.key === "Escape") exitFullscreen();
-      };
       const onResize = () => notifyDisplayMode("fullscreen");
-      window.addEventListener("keydown", onKeyDown);
       window.addEventListener("resize", onResize);
       acquireBodyScrollLock();
       return () => {
-        window.removeEventListener("keydown", onKeyDown);
         window.removeEventListener("resize", onResize);
         releaseBodyScrollLock();
       };
-    }, [displayMode, exitFullscreen, notifyDisplayMode]);
+    }, [displayMode, notifyDisplayMode]);
 
     // Ref to track fetch state - survives StrictMode remounts
     const fetchStateRef = useRef<{
@@ -787,9 +815,7 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
             const declaredByApp =
               bridge?.getAppCapabilities()?.availableDisplayModes ?? null;
             const isAvailable =
-              hostSupported.includes(
-                mode as (typeof hostSupported)[number],
-              ) &&
+              hostSupported.includes(mode as (typeof hostSupported)[number]) &&
               (declaredByApp === null || declaredByApp.includes(mode));
             if (isAvailable) {
               // Apply AND emit host-context-changed (via applyDisplayMode ->
@@ -819,16 +845,21 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
             console.log("[MCPAppsRenderer] App log:", p);
           };
 
+          // Publish the bridge BEFORE connecting so an app request that arrives
+          // during connect() (e.g. request-display-mode) sees it: otherwise the
+          // handler could apply a mode while notifyDisplayMode's
+          // bridgeRef.current is still null, skipping host-context-changed.
+          // Host context (theme/platform + displayMode/availableDisplayModes) was
+          // seeded at construction (see the AppBridge options above), so it is
+          // already advertised by the time ui/initialize runs.
+          bridgeRef.current = bridge;
           const transport = new PostMessageTransport(win, win);
           await bridge.connect(transport);
           if (!mounted) {
+            bridgeRef.current = null;
             await bridge.close();
             return;
           }
-          // Host context (theme/platform + displayMode/availableDisplayModes)
-          // was seeded at construction (see the AppBridge options above), so it
-          // is already advertised by the time ui/initialize runs.
-          bridgeRef.current = bridge;
         } catch (err) {
           console.error("[MCPAppsRenderer] Setup error:", err);
           if (mounted) {
@@ -871,6 +902,11 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
       }
       if (iframeSize.height !== undefined) {
         iframe.style.height = `${iframeSize.height}px`;
+      } else {
+        // No widget-reported height: restore the initial inline height. Without
+        // this, a widget that never sent size-changed keeps the `100%` set while
+        // fullscreen after returning to inline.
+        iframe.style.height = "100px";
       }
     }, [iframeSize, displayMode]);
 
@@ -906,37 +942,55 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
 
     const isFullscreen = displayMode === "fullscreen";
 
-    // NOTE: the fullscreen overlay uses `position: fixed` rather than a
-    // React portal on purpose. The iframe is created imperatively and appended
-    // to this container; portaling would reparent it and reload the sandboxed
-    // srcdoc (losing widget state) on every fullscreen toggle. `position: fixed`
-    // keeps the iframe alive; the trade-off is that a transformed/filtered
-    // ancestor in a host app could re-anchor it (v2's own chat CSS does not).
+    // The widget surface is a native <dialog>. Fullscreen opens it modally
+    // (showModal → browser top layer), which fills the viewport regardless of
+    // ancestor containing blocks — v2's chat container uses `container-type`,
+    // which would trap a plain `position: fixed` overlay inside the chat panel.
+    // Inline opens it non-modally (show) in normal flow. The iframe lives inside
+    // this dialog and is never reparented, so toggling modes preserves widget
+    // state (no srcdoc reload). Open mode is driven by the effect above; Escape,
+    // focus containment, and focus restore come from the modal dialog natively.
     return (
-      <div
+      <dialog
         ref={containerRef}
-        role={isFullscreen ? "dialog" : undefined}
-        aria-modal={isFullscreen ? true : undefined}
         aria-label={isFullscreen ? "Fullscreen widget" : undefined}
+        onCancel={(e) => {
+          // Escape on the modal dialog: exit to inline via the host path
+          // (keeps React state in sync and emits host-context-changed).
+          e.preventDefault();
+          exitFullscreen();
+        }}
         style={
           isFullscreen
             ? {
                 position: "fixed",
                 inset: 0,
-                zIndex: 2147483000,
+                margin: 0,
+                padding: 0,
+                border: "none",
+                maxWidth: "none",
+                maxHeight: "none",
                 width: "100vw",
                 height: "100vh",
                 overflow: "auto",
+                zIndex: 2147483000,
                 // Theme-aware token so the overlay does not flash white in dark
                 // mode (v2 defines --background for light and .dark).
                 background: "var(--background, #fff)",
               }
             : {
+                // Neutralize the UA <dialog> styles so inline renders like a
+                // normal in-flow block in the chat.
+                position: "static",
+                margin: 0,
+                padding: 0,
+                border: "none",
+                maxWidth: "none",
                 width: "100%",
                 height: iframeSize.height ? `${iframeSize.height}px` : "auto",
                 minHeight: "100px",
                 overflow: "hidden",
-                position: "relative",
+                background: "transparent",
                 ...borderStyle,
               }
         }
@@ -978,6 +1032,6 @@ export const MCPAppsActivityRenderer: React.FC<MCPAppsActivityRendererProps> =
             Error: {error.message}
           </div>
         )}
-      </div>
+      </dialog>
     );
   };

--- a/packages/react-core/src/v2/components/chat/__tests__/MCPAppsRequestDisplayMode.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/MCPAppsRequestDisplayMode.e2e.test.tsx
@@ -185,10 +185,9 @@ type OutgoingMessage = Record<string, any>;
  * iframe.contentWindow.postMessage).
  */
 function spyOnHostMessages(iframe: HTMLIFrameElement) {
-  return vi.spyOn(
-    iframe.contentWindow as Window,
-    "postMessage",
-  ) as unknown as { mock: { calls: any[][] } };
+  return vi.spyOn(iframe.contentWindow as Window, "postMessage") as unknown as {
+    mock: { calls: any[][] };
+  };
 }
 
 function outgoing(spy: { mock: { calls: any[][] } }): OutgoingMessage[] {
@@ -286,7 +285,9 @@ describe("MCP Apps ui/request-display-mode", () => {
     const spy = spyOnHostMessages(iframe);
 
     // Enter fullscreen first, then request the unsupported "pip".
-    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
     const pipId = await sendRequest(iframe, "ui/request-display-mode", {
       mode: "pip",
     });
@@ -320,13 +321,42 @@ describe("MCP Apps ui/request-display-mode", () => {
     ).toHaveLength(0);
   });
 
+  it("grants fullscreen when the View declares it in appCapabilities", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-appcaps-grant";
+    const iframe = await setupMCPActivity(agent, "rdm-appcaps-grant");
+    const spy = spyOnHostMessages(iframe);
+
+    // The View explicitly declares it supports both modes.
+    await sendInitialize(iframe, {
+      availableDisplayModes: ["inline", "fullscreen"],
+    });
+
+    // fullscreen is host-supported AND declared by the View -> granted.
+    const fsId = await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
+
+    expect(responseFor(spy, fsId)?.result).toEqual({ mode: "fullscreen" });
+    expect(
+      await screen.findByRole("button", { name: "Exit fullscreen" }),
+    ).toBeDefined();
+    expect(
+      notificationsFor(spy, "ui/notifications/host-context-changed").map(
+        (n) => n.params.displayMode,
+      ),
+    ).toContain("fullscreen");
+  });
+
   it("emits host-context-changed for widget-initiated changes (fullscreen then inline)", async () => {
     const agent = new MockMCPProxyAgent();
     agent.agentId = "rdm-roundtrip";
     const iframe = await setupMCPActivity(agent, "rdm-roundtrip");
     const spy = spyOnHostMessages(iframe);
 
-    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
     const backId = await sendRequest(iframe, "ui/request-display-mode", {
       mode: "inline",
     });
@@ -377,7 +407,9 @@ describe("MCP Apps ui/request-display-mode", () => {
     const iframe = await setupMCPActivity(agent, "rdm-close-button");
     const spy = spyOnHostMessages(iframe);
 
-    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
 
     const closeButton = await screen.findByRole("button", {
       name: "Exit fullscreen",
@@ -412,11 +444,21 @@ describe("MCP Apps ui/request-display-mode", () => {
     const iframe = await setupMCPActivity(agent, "rdm-escape");
     const spy = spyOnHostMessages(iframe);
 
-    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
     await screen.findByRole("button", { name: "Exit fullscreen" });
 
+    // Escape on a modal <dialog> fires the native `cancel` event; the host maps
+    // that to the inline exit. (jsdom does not translate a raw keydown into the
+    // dialog cancel, so dispatch the event the browser would emit.)
+    const dialogEl = iframe.closest("dialog");
+    expect(dialogEl).not.toBeNull();
     await act(async () => {
-      fireEvent.keyDown(window, { key: "Escape", code: "Escape" });
+      fireEvent(
+        dialogEl!,
+        new Event("cancel", { bubbles: false, cancelable: true }),
+      );
       await new Promise((resolve) => setTimeout(resolve, 50));
     });
 
@@ -442,7 +484,9 @@ describe("MCP Apps ui/request-display-mode", () => {
     const iframe = await setupMCPActivity(agent, "rdm-surface");
     const spy = spyOnHostMessages(iframe);
 
-    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
 
     const notifs = notificationsFor(
       spy,
@@ -467,7 +511,9 @@ describe("MCP Apps ui/request-display-mode", () => {
 
     expect(document.body.style.overflow).toBe("");
 
-    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
     expect(document.body.style.overflow).toBe("hidden");
 
     const closeButton = await screen.findByRole("button", {

--- a/packages/react-core/src/v2/components/chat/__tests__/MCPAppsRequestDisplayMode.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/MCPAppsRequestDisplayMode.e2e.test.tsx
@@ -1,0 +1,483 @@
+/**
+ * Tests for the MCP Apps ui/request-display-mode host handler, on the ext-apps
+ * AppBridge base.
+ *
+ * Verifies (ext-apps 2026-01-26):
+ * - ui/request-display-mode returns the mode actually applied.
+ * - "fullscreen" is granted; "pip" is not supported and returns the current mode.
+ * - Host advertises displayMode + availableDisplayModes in hostContext.
+ * - The host MUST NOT switch to a mode outside the View-declared
+ *   appCapabilities.availableDisplayModes.
+ * - Widget-initiated changes emit ui/notifications/host-context-changed (the app
+ *   SDK caches hostContext from the notification, not the response).
+ * - Fullscreen renders a host close (X) button; clicking it OR pressing Escape
+ *   returns to inline AND emits host-context-changed.
+ * - The background page scroll is locked while fullscreen and restored on exit.
+ */
+import { fireEvent, screen, waitFor, act } from "@testing-library/react";
+import { vi } from "vitest";
+import {
+  activitySnapshotEvent,
+  renderWithCopilotKit,
+  runFinishedEvent,
+  runStartedEvent,
+  testId,
+} from "../../../__tests__/utils/test-helpers";
+import { MCPAppsActivityType } from "../../../components/MCPAppsActivityRenderer";
+import type { RunAgentInput, RunAgentResult, BaseEvent } from "@ag-ui/client";
+import { AbstractAgent, EventType } from "@ag-ui/client";
+import type { Observable } from "rxjs";
+import { Subject } from "rxjs";
+
+const PROTOCOL_VERSION = "2026-01-26";
+
+/**
+ * Minimal MockMCPProxyAgent, mirroring MCPAppsUiMessage.e2e.test.tsx: it only
+ * needs to answer resources/read so the iframe is created and the host bridge
+ * is connected.
+ */
+class MockMCPProxyAgent extends AbstractAgent {
+  private subject = new Subject<BaseEvent>();
+  private runAgentResponses: Map<string, unknown> = new Map();
+
+  setRunAgentResponse(method: string, response: unknown) {
+    this.runAgentResponses.set(method, response);
+  }
+
+  emit(event: BaseEvent) {
+    if (event.type === EventType.RUN_STARTED) {
+      this.isRunning = true;
+    } else if (
+      event.type === EventType.RUN_FINISHED ||
+      event.type === EventType.RUN_ERROR
+    ) {
+      this.isRunning = false;
+    }
+    act(() => {
+      this.subject.next(event);
+    });
+  }
+
+  async detachActiveRun(): Promise<void> {}
+
+  run(_input: RunAgentInput): Observable<BaseEvent> {
+    return this.subject.asObservable();
+  }
+
+  async runAgent(input?: Partial<RunAgentInput>): Promise<RunAgentResult> {
+    const proxiedRequest = input?.forwardedProps?.__proxiedMCPRequest as
+      | { method: string; params?: Record<string, unknown> }
+      | undefined;
+
+    if (proxiedRequest) {
+      const response = this.runAgentResponses.get(proxiedRequest.method);
+      if (response !== undefined) {
+        return { result: response, newMessages: [] };
+      }
+      if (proxiedRequest.method === "resources/read") {
+        return {
+          result: {
+            contents: [
+              {
+                uri: proxiedRequest.params?.uri,
+                mimeType: "text/html",
+                text: "<html><body>Test content</body></html>",
+              },
+            ],
+          },
+          newMessages: [],
+        };
+      }
+      return { result: {}, newMessages: [] };
+    }
+
+    return super.runAgent(input);
+  }
+}
+
+function mcpAppsActivityContent() {
+  return {
+    resourceUri: "ui://test/app",
+    serverHash: "test-hash",
+    toolInput: {},
+    result: {
+      content: [{ type: "text", text: "Tool output" }],
+      isError: false,
+    },
+  };
+}
+
+/**
+ * Render, emit MCP activity, wait for iframe creation, then simulate
+ * sandbox-proxy-ready so the host bridge connects to the sandbox.
+ */
+async function setupMCPActivity(
+  agent: MockMCPProxyAgent,
+  agentId: string,
+): Promise<HTMLIFrameElement> {
+  agent.setRunAgentResponse("resources/read", {
+    contents: [
+      {
+        uri: "ui://test/app",
+        mimeType: "text/html",
+        text: "<html><body>App</body></html>",
+      },
+    ],
+  });
+
+  const threadId = testId("thread");
+
+  renderWithCopilotKit({
+    agents: { [agentId]: agent },
+    agentId,
+    threadId,
+  });
+
+  const input = await screen.findByRole("textbox");
+  fireEvent.change(input, { target: { value: "display mode test" } });
+  fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+  await waitFor(() => {
+    expect(screen.getByText("display mode test")).toBeDefined();
+  });
+
+  agent.emit(runStartedEvent());
+  agent.emit(
+    activitySnapshotEvent({
+      messageId: testId("mcp-activity"),
+      activityType: MCPAppsActivityType,
+      content: mcpAppsActivityContent(),
+    }),
+  );
+  agent.emit(runFinishedEvent());
+
+  let iframe: HTMLIFrameElement | null = null;
+  await waitFor(
+    () => {
+      iframe = document.querySelector("iframe[srcdoc]");
+      expect(iframe).not.toBeNull();
+    },
+    { timeout: 3000 },
+  );
+
+  const readyEvent = new MessageEvent("message", {
+    data: {
+      jsonrpc: "2.0",
+      method: "ui/notifications/sandbox-proxy-ready",
+    },
+    source: iframe!.contentWindow,
+    origin: "",
+  });
+
+  await act(async () => {
+    window.dispatchEvent(readyEvent);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  });
+
+  return iframe!;
+}
+
+type OutgoingMessage = Record<string, any>;
+
+/**
+ * Spy on the messages the host bridge posts to the iframe (responses +
+ * notifications flow through the PostMessage transport, i.e.
+ * iframe.contentWindow.postMessage).
+ */
+function spyOnHostMessages(iframe: HTMLIFrameElement) {
+  return vi.spyOn(
+    iframe.contentWindow as Window,
+    "postMessage",
+  ) as unknown as { mock: { calls: any[][] } };
+}
+
+function outgoing(spy: { mock: { calls: any[][] } }): OutgoingMessage[] {
+  return spy.mock.calls.map((c) => c[0] as OutgoingMessage);
+}
+
+/**
+ * Dispatch a JSON-RPC request from the iframe and wait for the host to handle it.
+ */
+async function sendRequest(
+  iframe: HTMLIFrameElement,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<string> {
+  const id = testId("req");
+  const msg = new MessageEvent("message", {
+    data: { jsonrpc: "2.0", id, method, params },
+    source: iframe.contentWindow,
+    origin: "",
+  });
+  await act(async () => {
+    window.dispatchEvent(msg);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  });
+  return id;
+}
+
+/**
+ * Send a well-formed ui/initialize (the bridge validates params against the
+ * spec schema: appInfo + appCapabilities + protocolVersion are required).
+ */
+async function sendInitialize(
+  iframe: HTMLIFrameElement,
+  appCapabilities: Record<string, unknown> = {},
+): Promise<string> {
+  return sendRequest(iframe, "ui/initialize", {
+    appInfo: { name: "test-app", version: "1.0.0" },
+    appCapabilities,
+    protocolVersion: PROTOCOL_VERSION,
+  });
+}
+
+function responseFor(
+  spy: { mock: { calls: any[][] } },
+  id: string,
+): OutgoingMessage | undefined {
+  return outgoing(spy).find((m) => m.id === id && "result" in m);
+}
+
+function notificationsFor(
+  spy: { mock: { calls: any[][] } },
+  method: string,
+): OutgoingMessage[] {
+  return outgoing(spy).filter((m) => m.method === method && !("id" in m));
+}
+
+describe("MCP Apps ui/request-display-mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.style.overflow = "";
+  });
+
+  it("grants fullscreen and replies with the applied mode", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-fullscreen";
+    const iframe = await setupMCPActivity(agent, "rdm-fullscreen");
+    const spy = spyOnHostMessages(iframe);
+
+    const id = await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
+
+    expect(responseFor(spy, id)?.result).toEqual({ mode: "fullscreen" });
+    // No error field on the response.
+    expect(responseFor(spy, id)).not.toHaveProperty("error");
+  });
+
+  it("returns the current mode for the unsupported pip mode", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-pip";
+    const iframe = await setupMCPActivity(agent, "rdm-pip");
+    const spy = spyOnHostMessages(iframe);
+
+    const id = await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "pip",
+    });
+
+    expect(responseFor(spy, id)?.result).toEqual({ mode: "inline" });
+  });
+
+  it("returns the CURRENT mode (not inline) when an unavailable mode is requested", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-current";
+    const iframe = await setupMCPActivity(agent, "rdm-current");
+    const spy = spyOnHostMessages(iframe);
+
+    // Enter fullscreen first, then request the unsupported "pip".
+    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    const pipId = await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "pip",
+    });
+
+    // Spec: an unavailable request must not switch and returns the current mode.
+    expect(responseFor(spy, pipId)?.result).toEqual({ mode: "fullscreen" });
+  });
+
+  it("does not switch to a mode the View did not declare in appCapabilities", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-appcaps";
+    const iframe = await setupMCPActivity(agent, "rdm-appcaps");
+    const spy = spyOnHostMessages(iframe);
+
+    // The View declares it only supports inline.
+    await sendInitialize(iframe, { availableDisplayModes: ["inline"] });
+
+    // Requesting fullscreen must be declined (Host MUST NOT switch to a mode
+    // outside the View's declared availableDisplayModes): returns current mode
+    // and emits no host-context-changed.
+    const fsId = await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "fullscreen",
+    });
+
+    expect(responseFor(spy, fsId)?.result).toEqual({ mode: "inline" });
+    expect(
+      screen.queryByRole("button", { name: "Exit fullscreen" }),
+    ).toBeNull();
+    expect(
+      notificationsFor(spy, "ui/notifications/host-context-changed"),
+    ).toHaveLength(0);
+  });
+
+  it("emits host-context-changed for widget-initiated changes (fullscreen then inline)", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-roundtrip";
+    const iframe = await setupMCPActivity(agent, "rdm-roundtrip");
+    const spy = spyOnHostMessages(iframe);
+
+    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    const backId = await sendRequest(iframe, "ui/request-display-mode", {
+      mode: "inline",
+    });
+
+    expect(responseFor(spy, backId)?.result).toEqual({ mode: "inline" });
+
+    // The app SDK caches hostContext only from the notification, so a
+    // widget-initiated change must ALSO emit host-context-changed (not just the
+    // response) or the widget's own toggle can never return to inline.
+    const notifs = notificationsFor(
+      spy,
+      "ui/notifications/host-context-changed",
+    );
+    expect(notifs.map((n) => n.params.displayMode)).toEqual([
+      "fullscreen",
+      "inline",
+    ]);
+    // Entering fullscreen advertises the available render surface.
+    expect(notifs[0].params.containerDimensions).toEqual(
+      expect.objectContaining({
+        width: expect.any(Number),
+        height: expect.any(Number),
+      }),
+    );
+    // Inline carries no container dimensions.
+    expect(notifs[1].params.containerDimensions).toBeUndefined();
+  });
+
+  it("advertises displayMode and availableDisplayModes at ui/initialize", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-initialize";
+    const iframe = await setupMCPActivity(agent, "rdm-initialize");
+    const spy = spyOnHostMessages(iframe);
+
+    const id = await sendInitialize(iframe);
+
+    const hostContext = responseFor(spy, id)?.result?.hostContext;
+    expect(hostContext?.displayMode).toBe("inline");
+    expect(hostContext?.availableDisplayModes).toEqual([
+      "inline",
+      "fullscreen",
+    ]);
+  });
+
+  it("shows a close button in fullscreen; clicking it exits and notifies the widget", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-close-button";
+    const iframe = await setupMCPActivity(agent, "rdm-close-button");
+    const spy = spyOnHostMessages(iframe);
+
+    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+
+    const closeButton = await screen.findByRole("button", {
+      name: "Exit fullscreen",
+    });
+    expect(closeButton).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(closeButton);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    // Back to inline: the close button is gone.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Exit fullscreen" }),
+      ).toBeNull();
+    });
+
+    // One notification for entering fullscreen, one for the host-initiated exit.
+    const notifications = notificationsFor(
+      spy,
+      "ui/notifications/host-context-changed",
+    );
+    expect(notifications).toHaveLength(2);
+    expect(notifications[0].params.displayMode).toBe("fullscreen");
+    expect(notifications[1].params).toEqual({ displayMode: "inline" });
+  });
+
+  it("exits fullscreen on Escape and notifies the widget", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-escape";
+    const iframe = await setupMCPActivity(agent, "rdm-escape");
+    const spy = spyOnHostMessages(iframe);
+
+    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    await screen.findByRole("button", { name: "Exit fullscreen" });
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Escape", code: "Escape" });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Exit fullscreen" }),
+      ).toBeNull();
+    });
+
+    // One notification for entering fullscreen, one for the Escape-driven exit.
+    const notifications = notificationsFor(
+      spy,
+      "ui/notifications/host-context-changed",
+    );
+    expect(notifications).toHaveLength(2);
+    expect(notifications[0].params.displayMode).toBe("fullscreen");
+    expect(notifications[1].params).toEqual({ displayMode: "inline" });
+  });
+
+  it("advertises containerDimensions and fills the iframe in fullscreen", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-surface";
+    const iframe = await setupMCPActivity(agent, "rdm-surface");
+    const spy = spyOnHostMessages(iframe);
+
+    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+
+    const notifs = notificationsFor(
+      spy,
+      "ui/notifications/host-context-changed",
+    );
+    expect(notifs[0].params.displayMode).toBe("fullscreen");
+    expect(notifs[0].params.containerDimensions).toEqual(
+      expect.objectContaining({
+        width: expect.any(Number),
+        height: expect.any(Number),
+      }),
+    );
+    // The iframe must fill the overlay, not keep its widget-reported height.
+    expect(iframe.style.height).toBe("100%");
+  });
+
+  it("locks the background scroll while fullscreen and restores it on exit", async () => {
+    const agent = new MockMCPProxyAgent();
+    agent.agentId = "rdm-scroll-lock";
+    const iframe = await setupMCPActivity(agent, "rdm-scroll-lock");
+    spyOnHostMessages(iframe);
+
+    expect(document.body.style.overflow).toBe("");
+
+    await sendRequest(iframe, "ui/request-display-mode", { mode: "fullscreen" });
+    expect(document.body.style.overflow).toBe("hidden");
+
+    const closeButton = await screen.findByRole("button", {
+      name: "Exit fullscreen",
+    });
+    await act(async () => {
+      fireEvent.click(closeButton);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(document.body.style.overflow).toBe("");
+  });
+});


### PR DESCRIPTION
## What

Implements the MCP Apps `ui/request-display-mode` host handler in react-core, on top of the ext-apps `AppBridge` migration (#6707). A widget can request `inline` or `fullscreen`; the host applies the mode, renders a fullscreen overlay with a close control, and keeps the widget in sync via `host-context-changed`.

This is the display-mode feature originally prototyped in #6689, re-based onto the ext-apps bridge instead of the (now-removed) hand-rolled protocol, per the sequencing agreed on #6707 ("land the migration first, then rebase display-mode on top"). One item from the #6824 conformance tracker.

## Behavior

- `bridge.onrequestdisplaymode`: grants `inline` / `fullscreen`; `pip` (and anything the View did not declare in `appCapabilities.availableDisplayModes`) is refused, returning the **current** mode unchanged (spec: the host MUST NOT switch to an unavailable mode).
- Widget- and host-initiated changes both go through `setHostContext`, which emits `ui/notifications/host-context-changed` (the app SDK caches host context from the notification, not from the request response). Fullscreen advertises `containerDimensions`.
- Host context advertises `displayMode` + `availableDisplayModes` **at construction** (the deterministic seam added in #6707), so the mode is negotiated at `ui/initialize` rather than after a race.
- Fullscreen UX: `position: fixed` overlay (so the iframe is not reparented / reloaded on toggle), a close (X) button, `Escape` to exit, and a ref-counted background scroll lock. a11y: `role="dialog"` + `aria-modal` + labelled control. Dark-mode-aware overlay background.

## Notes

- `setHostContext` in ext-apps 1.7.5 **replaces** the bridge's cached host context (it only diffs to decide what to notify), so `notifyDisplayMode` passes the full context to avoid dropping `theme` / `platform` / `availableDisplayModes` from the cache; the emitted notification still carries only the changed fields.

## Testing

- `MCPAppsRequestDisplayMode.e2e.test.tsx` (10 tests): grant fullscreen; refuse `pip` / undeclared modes and return the current mode; emit `host-context-changed` on widget- and host-initiated changes with `containerDimensions` in fullscreen; advertise `displayMode` / `availableDisplayModes` at initialize; close button and `Escape` exit; background scroll lock/restore.
- Full MCP Apps e2e green (44 tests), `check-types` clean, oxlint clean.

Refs: #6707, #6689, #6824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added fullscreen display mode for embedded apps, with support for entering and exiting via an on-screen button or the Escape key.
  - Embedded apps can now request supported display modes and receive updates when the mode changes.
  - Fullscreen mode expands the app to fill the viewport and temporarily disables background page scrolling.

- **Bug Fixes**
  - Unsupported or undeclared display modes are safely rejected without changing the current view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->