### PR TITLE
chore(react-textarea): mark CopilotTextarea declarations as deprecated

### DIFF
--- a/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
+++ b/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
@@ -121,8 +121,17 @@ import { useMakeStandardInsertionOrEditingFunction } from "../../hooks/make-auto
 import merge from "lodash.merge";
 import type { AutosuggestionsConfigUserSpecified } from "../../types/autosuggestions-config/autosuggestions-config-user-specified";
 
-// Like the base copilot textarea props,
-// but with baseAutosuggestionsConfig replaced with autosuggestionsConfig.
+/**
+ * Like the base copilot textarea props,
+ * but with baseAutosuggestionsConfig replaced with autosuggestionsConfig.
+ *
+ * @deprecated Since 1.68.2. The v1 SDK is deprecated. Use v2 instead.
+ * No 1:1 v2 replacement is available.
+ * Start with `@copilotkit/react-core/v2`.
+ * V2 docs: https://docs.copilotkit.ai/
+ * V2 reference docs: https://docs.copilotkit.ai/reference/v2
+ * Migration guide: https://docs.copilotkit.ai/migrate/v2
+ */
 export interface CopilotTextareaProps extends Omit<
   BaseCopilotTextareaProps,
   "baseAutosuggestionsConfig"
@@ -191,6 +200,13 @@ export interface CopilotTextareaProps extends Omit<
 
 /**
  * A copilot textarea that uses the standard autosuggestions function.
+ *
+ * @deprecated Since 1.68.2. The v1 SDK is deprecated. Use v2 instead.
+ * No 1:1 v2 replacement is available.
+ * Start with `@copilotkit/react-core/v2`.
+ * V2 docs: https://docs.copilotkit.ai/
+ * V2 reference docs: https://docs.copilotkit.ai/reference/v2
+ * Migration guide: https://docs.copilotkit.ai/migrate/v2
  */
 export const CopilotTextarea = React.forwardRef(
   (props: CopilotTextareaProps, ref: React.Ref<HTMLCopilotTextAreaElement>) => {


### PR DESCRIPTION
Closes #6819

## Problem

`@copilotkit/react-textarea` is a deprecated v1 package. `scripts/deprecations/v1-source-notices.mjs` already writes two things for it:

- a **file-level** `/* V1 SDK DEPRECATED */` block comment at the top of `copilot-textarea.tsx` — attached to no symbol, so no IDE reacts to it;
- per-symbol `@deprecated` JSDoc on the **re-export specifiers** in `packages/react-textarea/src/index.tsx`.

The declarations of `CopilotTextarea` and `CopilotTextareaProps` had no `@deprecated` tag of their own. That has a bigger consequence than the issue anticipated.

**In-repo:** resolving either symbol through the components barrel, or hovering it at its definition, produced no deprecation warning.

**For npm consumers: nothing warned at all, including through the package root.** The dts bundler collapses the tagged specifiers in `index.tsx` into a single bare re-export line, so the tags never reach the shipped declarations:

```
// dist/index.d.cts on main, last line
export { type AutosuggestionsBareFunction, ..., CopilotTextarea, type CopilotTextareaProps, ... };
```

A build of `main` emits **zero** `@deprecated` tags into `dist/index.d.cts` and `dist/index.d.mts`.

## Change

Add `@deprecated` JSDoc to both declarations, using the exact text `renderDeprecationJsDoc` emits for an export with no 1:1 v2 replacement (`scripts/deprecations/v1-public-api.mjs:888`). `CopilotTextareaProps` had a `//` line comment; it is promoted to JSDoc so the tag binds to the declaration, with its original wording kept.

Comments only. No runtime behavior changes, no exports added, renamed, or removed.

## Testing

**1. The warning now resolves at every import path — with a before/after mutation check.**

Probe built on the TypeScript API, walking the alias chain the way tsserver does when it decides to strike a symbol through. Run against `HEAD` (baseline) and against this branch:

```
===== BEFORE (main) =====
DEPRECATED      CopilotTextarea       <-  package root (src/index.tsx)
DEPRECATED      CopilotTextareaProps  <-  package root (src/index.tsx)
NOT DEPRECATED  CopilotTextarea       <-  components barrel (src/components/index.ts)
NOT DEPRECATED  CopilotTextareaProps  <-  components barrel (src/components/index.ts)
NOT DEPRECATED  CopilotTextarea       <-  deep path (copilot-textarea.tsx)
NOT DEPRECATED  CopilotTextareaProps  <-  deep path (copilot-textarea.tsx)

4 SITE(S) DO NOT WARN

===== AFTER (this branch) =====
DEPRECATED      CopilotTextarea       <-  package root (src/index.tsx)
DEPRECATED      CopilotTextareaProps  <-  package root (src/index.tsx)
DEPRECATED      CopilotTextarea       <-  components barrel (src/components/index.ts)
DEPRECATED      CopilotTextareaProps  <-  components barrel (src/components/index.ts)
DEPRECATED      CopilotTextarea       <-  deep path (copilot-textarea.tsx)
DEPRECATED      CopilotTextareaProps  <-  deep path (copilot-textarea.tsx)

ALL SITES WARN
```

The root row is the control: it warns in both runs, so the probe is reading real resolution rather than reporting a constant.

**2. Emitted declarations retain the tags** (the issue's third scope item).

```
$ ./node_modules/.bin/tsdown && grep -c "@deprecated" dist/index.d.cts dist/index.d.mts
# on main:        0   0
# on this branch: 2   2
```

Both land directly on the declarations:

```
dist/index.d.cts:260-261
 */
interface CopilotTextareaProps extends Omit<BaseCopilotTextareaProps, "baseAutosuggestionsConfig"> {

dist/index.d.cts:332-333
 */
declare const CopilotTextarea: React$1.ForwardRefExoticComponent<...>;
```

**3. The generator stays clean and regeneration is a no-op for this file.**

`v1-source-notices.mjs` rebuilds a source file as `notice + "\n\n" + body`, stripping only the leading notice block, so JSDoc further down survives. Confirmed empirically:

```
$ node scripts/deprecations/v1-source-notices.mjs --check | grep -i textarea
(no output — react-textarea is not among the stale files)
```

The 11 files that script does report stale are pre-existing on `main` and untouched here.

**4. Package build and type checks pass.**

```
$ ./node_modules/.bin/tsc --noEmit
tsc-exit=0

$ ./node_modules/.bin/tsdown
✔ Build complete in 1014ms   (CJS, UMD, ESM, d.cts, d.mts)
build-exit=0

$ ./node_modules/.bin/vitest run
 ✓ src/lib/utils.test.ts (1 test) 1ms
 ✓ src/esm-compat.test.ts (1 test) 1ms
 Test Files  2 passed (2)
      Tests  2 passed (2)

$ oxfmt --check packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
All matched files use the correct format.
```

## Not in this PR

The same gap affects the other 12 exports of this entrypoint — `BaseCopilotTextarea`, `AutosuggestionsConfig`, and the rest also ship no `@deprecated` tag in `dist`. #6819 scopes to the two `CopilotTextarea` symbols, so this PR does too.

The durable fix is for `v1-source-notices.mjs` to emit per-symbol `@deprecated` JSDoc onto the declarations, not only onto entrypoint specifiers — worth a follow-up issue, since hand-tagging 96 declaration files across react-core, react-ui, runtime, and react-textarea does not scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation guidance for the Copilot Textarea component.
  * Included links to version 2 documentation and the migration guide.
  * Clarified that there is no direct version 2 replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->