### PR TITLE
docs(showcase): rename docs_premium_* CTA surfaces to intelligence

### DIFF
--- a/showcase/shell-docs/src/content/docs/intelligence/intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/intelligence-platform.mdx
@@ -15,7 +15,7 @@ For a product-level map of features and hosting options, start with the [Copilot
   body="Create a hosted project, get a project API key, and inspect persistent threads before deciding whether self-hosting is required."
   ctaLabel="Start managed onboarding"
   href="https://dashboard.operations.copilotkit.ai/"
-  surface="docs_premium_intelligence_architecture_intro"
+  surface="docs_intelligence_architecture_intro"
 />
 
 ## Runtime and platform roles

--- a/showcase/shell-docs/src/content/docs/intelligence/managed-intelligence-platform.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/managed-intelligence-platform.mdx
@@ -15,7 +15,7 @@ Cloud-hosted CopilotKit Intelligence is the CopilotKit-operated deployment of th
   body="Sign up or sign in, finish organization onboarding, then return to the CLI or hosted app to select a project."
   ctaLabel="Start managed onboarding"
   href="https://dashboard.operations.copilotkit.ai/"
-  surface="docs_premium_managed_intelligence_platform_intro"
+  surface="docs_intelligence_managed_platform_intro"
 />
 
 ## What the cloud-hosted version provides

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/headless-ui.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/headless-ui.mdx
@@ -12,7 +12,7 @@ import {
   title="Headless UI requires a CopilotKit Intelligence license key"
   body="Sign up for a free account to get a public license key and unlock the headless hooks."
   ctaLabel="Create a free account"
-  surface="docs_premium_headless_ui"
+  surface="docs_intelligence_headless_ui"
 />
 
 ## Overview
@@ -25,7 +25,7 @@ from the ground up while still utilizing CopilotKit's core features and ease-of-
   title="Headless UI requires a CopilotKit Intelligence license key"
   body="Sign up for a free account to get a publicLicenseKey and unlock the headless hooks."
   ctaLabel="Create a free account"
-  surface="docs_premium_headless_ui"
+  surface="docs_intelligence_headless_ui"
 />
 
 ## Navigation

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
@@ -36,7 +36,7 @@ Self-hosted access is available on the Team self-hosted plan or a custom Enterpr
   variant="inline"
   title="Create a free CopilotKit Intelligence account"
   body="Start with the cloud-hosted Developer tier, create a project, and inspect persistent threads from the web app."
-  surface="docs_premium_overview"
+  surface="docs_intelligence_overview"
 />
 
 ## Which page should I read next?

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/self-hosting.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/self-hosting.mdx
@@ -15,7 +15,7 @@ CopilotKit Intelligence — the platform that powers threads, shared state, and 
   title="Planning a self-hosted CopilotKit Intelligence deployment?"
   body="Self-hosting is available on the Team self-hosted plan or a custom Enterprise plan for VPC, on-prem, and data-residency deployments."
   ctaLabel="Talk to an engineer"
-  surface="docs_premium_self_hosting_intro"
+  surface="docs_intelligence_self_hosting_intro"
   href="https://copilotkit.ai/talk-to-an-engineer"
   analyticsEvent="talk_to_us_clicked"
 />


### PR DESCRIPTION
#6818 moved the Intelligence docs from `/premium/` to `/intelligence/` but deliberately left the CTA `surface` identifiers alone. This renames the six occurrences (five distinct values):

- `docs_premium_overview` → `docs_intelligence_overview`
- `docs_premium_headless_ui` → `docs_intelligence_headless_ui` (two occurrences)
- `docs_premium_self_hosting_intro` → `docs_intelligence_self_hosting_intro`
- `docs_premium_managed_intelligence_platform_intro` → `docs_intelligence_managed_platform_intro`
- `docs_premium_intelligence_architecture_intro` → `docs_intelligence_architecture_intro`

## Why this needed a paired change first

Each value reaches PostHog twice: as the `location` property on `try_for_free_clicked` / `talk_to_us_clicked`, and as `utm_content` on the outbound signup link, which sticks as a person property. Two saved insights — both named "Which Docs Pages Drive Signups?", on the Kiteline EGG and North Star 2 dashboards — map that person property to display labels with a `CASE`. Unmapped values fall through to a prettifying `ELSE`, so a rename would not have zeroed anything: each affected docs page would have quietly become two rows in a table sorted by signup count, each ranking lower than the combined page.

Both insights were extended before this branch, so every retired identifier and its replacement now resolve to the same label and each page stays one row across the deploy. That includes `docs_premium_observability`, which exists in history (4 clicks, 1 attributed signup) but no longer has a CTA in the docs. Person properties are frozen at ingestion time, so historical rows keep the retired value permanently — the mapping is the only way to keep the history joined.

Nothing else consumes these values: no alert, no subscription, no cohort, saved view, action or pipeline function, and zero hits across 374k `analytics_postgres_funnel_events` rows.

## Verification

- `npm run lint` and `npm run typecheck` in `showcase/shell-docs`: clean (only pre-existing warnings, none in the touched files)
- `npm run build`: passes, 226 static pages
- `npm exec -- vitest run src/lib/__tests__/ms-agent-dotnet-provider.test.ts` (the docs test CI gates): 5 passed
- `pnpm tsx scripts/validate-doc-model-names.ts`: passes
- Full `showcase/shell-docs` vitest suite: 6 failures in 3 files (`public-assets`, `angular-docs-content`, `llm-text`), byte-identical with and without this change, so pre-existing. That suite is not run by CI.

## Not in scope

OSS-1085 covers what is left: the `@copilotkit/shared` console message that still says "premium features", and the stale `/premium/*` links in published packages. Those all still resolve through the 301s added in #6818.

Refs OSS-1084


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated analytics tracking identifiers for Intelligence documentation CTAs.
  * Standardized CTA tracking across architecture, managed platform, headless UI, overview, and self-hosting pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->