### PR TITLE
feat(react-core): upload attachments concurrently

### DIFF
--- a/packages/react-core/skills/react-core/references/attachments.md
+++ b/packages/react-core/skills/react-core/references/attachments.md
@@ -143,7 +143,9 @@ Multi-file selections upload three at a time by default; the rest start as slots
 free up, and the whole selection is queued as `status: "uploading"` right away.
 `onUpload` is therefore called concurrently and must not assume the previous file
 finished. Set `maxConcurrentUploads` to change the pool — `1` restores
-one-at-a-time uploads for an endpoint that needs it.
+one-at-a-time uploads for an endpoint that needs it, `Infinity` lifts the limit.
+The pool is per hook, not per call, so a paste landing mid-upload shares the same
+slots instead of opening its own.
 
 ```tsx
 useAttachments({

--- a/packages/react-core/skills/react-core/references/attachments.md
+++ b/packages/react-core/skills/react-core/references/attachments.md
@@ -137,6 +137,24 @@ useAttachments({
 });
 ```
 
+### Upload concurrency
+
+Multi-file selections upload three at a time by default; the rest start as slots
+free up, and the whole selection is queued as `status: "uploading"` right away.
+`onUpload` is therefore called concurrently and must not assume the previous file
+finished. Set `maxConcurrentUploads` to change the pool — `1` restores
+one-at-a-time uploads for an endpoint that needs it.
+
+```tsx
+useAttachments({
+  config: {
+    enabled: true,
+    maxConcurrentUploads: 6,
+    onUpload: async (file) => uploadToStorage(file),
+  },
+});
+```
+
 ### Feedback on failed uploads
 
 ```tsx

--- a/packages/react-core/skills/react-core/references/attachments.md
+++ b/packages/react-core/skills/react-core/references/attachments.md
@@ -139,13 +139,13 @@ useAttachments({
 
 ### Upload concurrency
 
-Multi-file selections upload three at a time by default; the rest start as slots
-free up, and the whole selection is queued as `status: "uploading"` right away.
-`onUpload` is therefore called concurrently and must not assume the previous file
-finished. Set `maxConcurrentUploads` to change the pool — `1` restores
-one-at-a-time uploads for an endpoint that needs it, `Infinity` lifts the limit.
-The pool is per hook, not per call, so a paste landing mid-upload shares the same
-slots instead of opening its own.
+Multi-file selections upload one file at a time by default, and the whole
+selection is queued as `status: "uploading"` right away. Raise
+`maxConcurrentUploads` to run several together — the rest then start as slots
+free up, `Infinity` lifts the limit, and `onUpload` may be called concurrently,
+so above `1` it must not assume the previous file finished. The pool is per hook,
+not per call, so a paste landing mid-upload shares the same slots instead of
+opening its own.
 
 ```tsx
 useAttachments({

--- a/packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx
@@ -310,6 +310,65 @@ describe("useAttachments", () => {
       expect(peak()).toBe(1);
     });
 
+    it("uploads every file at once when maxConcurrentUploads is Infinity", async () => {
+      const { files, gates, started, onUpload, peak } = gatedUploads(5);
+      const { result } = renderHook(() =>
+        useAttachments({
+          config: { enabled: true, onUpload, maxConcurrentUploads: Infinity },
+        }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      // No limit means every picked file, and never a worker per nothing.
+      expect(started).toHaveLength(5);
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+
+      expect(peak()).toBe(5);
+      expect(result.current.attachments.map((a) => a.status)).toEqual(
+        Array(5).fill("ready"),
+      );
+    });
+
+    it("holds the limit across overlapping processFiles calls", async () => {
+      const { files, gates, started, onUpload, peak } = gatedUploads(6);
+      const { result } = renderHook(() =>
+        useAttachments({
+          config: { enabled: true, onUpload, maxConcurrentUploads: 2 },
+        }),
+      );
+
+      // A drop and a paste landing together share the slots — two uploads in flight in
+      // total, not two per call.
+      let first!: Promise<void>;
+      let second!: Promise<void>;
+      await act(async () => {
+        first = result.current.processFiles(files.slice(0, 3));
+        second = result.current.processFiles(files.slice(3));
+      });
+
+      expect(started).toEqual(["file-0.png", "file-1.png"]);
+      expect(result.current.attachments).toHaveLength(6);
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await Promise.all([first, second]);
+      });
+
+      expect(peak()).toBe(2);
+      expect(started).toHaveLength(6);
+      expect(result.current.attachments.map((a) => a.status)).toEqual(
+        Array(6).fill("ready"),
+      );
+    });
+
     it("keeps uploading the rest when one file fails", async () => {
       const consoleError = vi
         .spyOn(console, "error")

--- a/packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx
@@ -1,7 +1,19 @@
 import React, { useRef, useEffect } from "react";
 import { renderHook, act } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "@copilotkit/shared";
 import { useAttachments } from "../use-attachments";
+
+/** A promise a test settles by hand, to hold an upload open or fail it on cue. */
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("useAttachments", () => {
   // -----------------------------------------------------------------------
@@ -143,6 +155,195 @@ describe("useAttachments", () => {
       });
 
       expect(consumed!).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Upload concurrency
+  // -----------------------------------------------------------------------
+
+  describe("upload concurrency", () => {
+    // setupTests mocks `randomUUID` to a constant, which would give every queued file
+    // the same attachment id — and each upload settles its own placeholder by id.
+    beforeEach(() => {
+      let nextId = 0;
+      vi.mocked(randomUUID).mockImplementation(() => `attachment-${nextId++}`);
+    });
+
+    afterEach(() => {
+      vi.mocked(randomUUID).mockReturnValue("mock-thread-id");
+    });
+
+    /**
+     * A set of image files plus one gate per file, so a test decides when each
+     * upload finishes and can observe how many are in flight meanwhile.
+     */
+    function gatedUploads(count: number) {
+      const files = Array.from(
+        { length: count },
+        (_, i) => new File(["x"], `file-${i}.png`, { type: "image/png" }),
+      );
+      const gates = files.map(() => deferred());
+      const started: string[] = [];
+      let inFlight = 0;
+      let peakInFlight = 0;
+
+      const onUpload = async (file: File) => {
+        const index = files.indexOf(file);
+        started.push(file.name);
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        try {
+          await gates[index].promise;
+        } finally {
+          inFlight--;
+        }
+        return {
+          type: "data" as const,
+          value: "dGVzdA==",
+          mimeType: file.type,
+        };
+      };
+
+      return {
+        files,
+        gates,
+        started,
+        onUpload,
+        peak: () => peakInFlight,
+      };
+    }
+
+    it("uploads three files at a time by default", async () => {
+      const { files, gates, started, onUpload, peak } = gatedUploads(7);
+      const { result } = renderHook(() =>
+        useAttachments({ config: { enabled: true, onUpload } }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      // Three in flight, the rest waiting for a slot.
+      expect(started).toEqual(["file-0.png", "file-1.png", "file-2.png"]);
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+
+      expect(peak()).toBe(3);
+      expect(started).toHaveLength(7);
+      expect(result.current.attachments.map((a) => a.status)).toEqual(
+        Array(7).fill("ready"),
+      );
+    });
+
+    it("queues every picked file immediately, in pick order", async () => {
+      const { files, gates, onUpload } = gatedUploads(5);
+      const { result } = renderHook(() =>
+        useAttachments({ config: { enabled: true, onUpload } }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      // All five are visible as "uploading" even though only three have started.
+      expect(result.current.attachments.map((a) => a.filename)).toEqual(
+        files.map((f) => f.name),
+      );
+      expect(result.current.attachments.map((a) => a.status)).toEqual(
+        Array(5).fill("uploading"),
+      );
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+    });
+
+    it("uploads one at a time when maxConcurrentUploads is 1", async () => {
+      const { files, gates, started, onUpload, peak } = gatedUploads(4);
+      const { result } = renderHook(() =>
+        useAttachments({
+          config: { enabled: true, onUpload, maxConcurrentUploads: 1 },
+        }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      expect(started).toEqual(["file-0.png"]);
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+
+      expect(peak()).toBe(1);
+      expect(started).toHaveLength(4);
+    });
+
+    it("treats a non-positive maxConcurrentUploads as one at a time", async () => {
+      const { files, gates, onUpload, peak } = gatedUploads(3);
+      const { result } = renderHook(() =>
+        useAttachments({
+          config: { enabled: true, onUpload, maxConcurrentUploads: 0 },
+        }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+
+      expect(peak()).toBe(1);
+    });
+
+    it("keeps uploading the rest when one file fails", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const onUploadFailed = vi.fn();
+      const { files, gates, onUpload } = gatedUploads(3);
+      const { result } = renderHook(() =>
+        useAttachments({ config: { enabled: true, onUpload, onUploadFailed } }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      await act(async () => {
+        gates[1].reject(new Error("storage rejected the file"));
+        gates[0].resolve();
+        gates[2].resolve();
+        await processing;
+      });
+
+      // The failed file leaves the queue; the other two are still sendable.
+      expect(result.current.attachments.map((a) => a.filename)).toEqual([
+        "file-0.png",
+        "file-2.png",
+      ]);
+      expect(onUploadFailed).toHaveBeenCalledTimes(1);
+      expect(onUploadFailed.mock.calls[0][0]).toMatchObject({
+        reason: "upload-failed",
+        message: "storage rejected the file",
+      });
+
+      consoleError.mockRestore();
     });
   });
 

--- a/packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx
@@ -214,10 +214,63 @@ describe("useAttachments", () => {
       };
     }
 
-    it("uploads three files at a time by default", async () => {
+    it("uploads one at a time by default", async () => {
       const { files, gates, started, onUpload, peak } = gatedUploads(7);
       const { result } = renderHook(() =>
         useAttachments({ config: { enabled: true, onUpload } }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      // Concurrency is opt-in: one upload in flight, the rest waiting for the slot.
+      expect(started).toEqual(["file-0.png"]);
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+
+      expect(peak()).toBe(1);
+      expect(started).toHaveLength(7);
+      expect(result.current.attachments.map((a) => a.status)).toEqual(
+        Array(7).fill("ready"),
+      );
+    });
+
+    it("queues every picked file immediately, in pick order", async () => {
+      const { files, gates, onUpload } = gatedUploads(5);
+      const { result } = renderHook(() =>
+        useAttachments({ config: { enabled: true, onUpload } }),
+      );
+
+      let processing!: Promise<void>;
+      await act(async () => {
+        processing = result.current.processFiles(files);
+      });
+
+      // All five are visible as "uploading" even though only the first has started.
+      expect(result.current.attachments.map((a) => a.filename)).toEqual(
+        files.map((f) => f.name),
+      );
+      expect(result.current.attachments.map((a) => a.status)).toEqual(
+        Array(5).fill("uploading"),
+      );
+
+      await act(async () => {
+        gates.forEach((gate) => gate.resolve());
+        await processing;
+      });
+    });
+
+    it("uploads three at a time when maxConcurrentUploads is 3", async () => {
+      const { files, gates, started, onUpload, peak } = gatedUploads(7);
+      const { result } = renderHook(() =>
+        useAttachments({
+          config: { enabled: true, onUpload, maxConcurrentUploads: 3 },
+        }),
       );
 
       let processing!: Promise<void>;
@@ -238,55 +291,6 @@ describe("useAttachments", () => {
       expect(result.current.attachments.map((a) => a.status)).toEqual(
         Array(7).fill("ready"),
       );
-    });
-
-    it("queues every picked file immediately, in pick order", async () => {
-      const { files, gates, onUpload } = gatedUploads(5);
-      const { result } = renderHook(() =>
-        useAttachments({ config: { enabled: true, onUpload } }),
-      );
-
-      let processing!: Promise<void>;
-      await act(async () => {
-        processing = result.current.processFiles(files);
-      });
-
-      // All five are visible as "uploading" even though only three have started.
-      expect(result.current.attachments.map((a) => a.filename)).toEqual(
-        files.map((f) => f.name),
-      );
-      expect(result.current.attachments.map((a) => a.status)).toEqual(
-        Array(5).fill("uploading"),
-      );
-
-      await act(async () => {
-        gates.forEach((gate) => gate.resolve());
-        await processing;
-      });
-    });
-
-    it("uploads one at a time when maxConcurrentUploads is 1", async () => {
-      const { files, gates, started, onUpload, peak } = gatedUploads(4);
-      const { result } = renderHook(() =>
-        useAttachments({
-          config: { enabled: true, onUpload, maxConcurrentUploads: 1 },
-        }),
-      );
-
-      let processing!: Promise<void>;
-      await act(async () => {
-        processing = result.current.processFiles(files);
-      });
-
-      expect(started).toEqual(["file-0.png"]);
-
-      await act(async () => {
-        gates.forEach((gate) => gate.resolve());
-        await processing;
-      });
-
-      expect(peak()).toBe(1);
-      expect(started).toHaveLength(4);
     });
 
     it("treats a non-positive maxConcurrentUploads as one at a time", async () => {

--- a/packages/react-core/src/v2/hooks/use-attachments.tsx
+++ b/packages/react-core/src/v2/hooks/use-attachments.tsx
@@ -22,12 +22,25 @@ const DEFAULT_MAX_SIZE = 20 * 1024 * 1024;
  */
 const DEFAULT_MAX_CONCURRENT_UPLOADS = 3;
 
-/** At least one upload at a time, whole files only; anything unusable falls back to the default. */
+/**
+ * At least one upload at a time, whole files only; `NaN` or a non-number falls back to the
+ * default, and `Infinity` means "no limit" — bounded in practice by how many files are queued.
+ */
 function resolveMaxConcurrentUploads(configured: number | undefined): number {
   if (typeof configured !== "number" || Number.isNaN(configured)) {
     return DEFAULT_MAX_CONCURRENT_UPLOADS;
   }
   return Math.max(1, Math.floor(configured));
+}
+
+/** One file waiting for, or holding, an upload slot. */
+interface QueuedUpload {
+  file: File;
+  placeholder: Attachment;
+  /** The config as it was when this file was picked, so a later config change can't retarget it. */
+  cfg: AttachmentsConfig | undefined;
+  /** Resolves the `processFiles` call that queued this file once the upload has settled. */
+  settle: () => void;
 }
 
 export interface UseAttachmentsReturn {
@@ -82,6 +95,11 @@ export function useAttachments({
   configRef.current = config;
   const attachmentsRef = useRef<Attachment[]>([]);
   attachmentsRef.current = attachments;
+
+  // The upload queue is the hook's, not one `processFiles` call's, so a paste landing while a
+  // drop is still uploading shares the same slots instead of opening its own set.
+  const uploadQueueRef = useRef<QueuedUpload[]>([]);
+  const activeWorkersRef = useRef(0);
 
   // Upload one queued file and settle its placeholder: the source it uploaded to on success,
   // gone from the queue on failure. Resolves either way, so one bad file among many neither
@@ -141,6 +159,30 @@ export function useAttachments({
     [],
   );
 
+  // One worker: take the next queued file, upload it, repeat until the queue is empty, then
+  // give the slot back. Workers are counted rather than owned by a call, which is what keeps
+  // the limit global.
+  const drainUploadQueue = useCallback(async () => {
+    activeWorkersRef.current++;
+    try {
+      for (;;) {
+        const item = uploadQueueRef.current.shift();
+        if (!item) return;
+        try {
+          await uploadFile(item.file, item.placeholder, item.cfg);
+        } catch (error) {
+          // `uploadFile` reports its own failures; this is the belt for an unexpected throw,
+          // so one file can't strand everything queued behind it.
+          console.error("[CopilotKit] Upload worker error:", error);
+        } finally {
+          item.settle();
+        }
+      }
+    } finally {
+      activeWorkersRef.current--;
+    }
+  }, [uploadFile]);
+
   // Stable processFiles — reads config from ref, never changes identity
   const processFiles = useCallback(
     async (files: File[]) => {
@@ -193,24 +235,34 @@ export function useAttachments({
       // waiting for a free slot is already visible rather than appearing later.
       setAttachments((prev) => [...prev, ...queued.map((q) => q.placeholder)]);
 
-      // Bounded fan-out: this many workers pull from one shared cursor, so at most that many
-      // uploads are in flight and the rest start as slots free up. Reading and advancing the
-      // cursor happens without an await between, so no two workers take the same file.
-      const workers = Math.min(
-        queued.length,
-        resolveMaxConcurrentUploads(cfg?.maxConcurrentUploads),
+      // Hand the files to the shared queue, each with the promise this call waits on, so
+      // `processFiles` still resolves when its own files have settled and no sooner.
+      const settled = queued.map(
+        ({ file, placeholder }) =>
+          new Promise<void>((resolve) => {
+            uploadQueueRef.current.push({
+              file,
+              placeholder,
+              cfg,
+              settle: resolve,
+            });
+          }),
       );
-      let next = 0;
-      await Promise.all(
-        Array.from({ length: workers }, async () => {
-          while (next < queued.length) {
-            const { file, placeholder } = queued[next++];
-            await uploadFile(file, placeholder, cfg);
-          }
-        }),
+
+      // Top the pool up to the limit rather than starting a fresh one: whatever is already
+      // draining counts against it, so overlapping selections never exceed the limit together.
+      const limit = resolveMaxConcurrentUploads(cfg?.maxConcurrentUploads);
+      const toSpawn = Math.min(
+        uploadQueueRef.current.length,
+        Math.max(0, limit - activeWorkersRef.current),
       );
+      for (let i = 0; i < toSpawn; i++) {
+        void drainUploadQueue();
+      }
+
+      await Promise.all(settled);
     },
-    [uploadFile],
+    [drainUploadQueue],
   );
 
   const handleFileUpload = useCallback(

--- a/packages/react-core/src/v2/hooks/use-attachments.tsx
+++ b/packages/react-core/src/v2/hooks/use-attachments.tsx
@@ -14,6 +14,22 @@ export interface UseAttachmentsProps {
   config?: AttachmentsConfig;
 }
 
+const DEFAULT_MAX_SIZE = 20 * 1024 * 1024;
+
+/**
+ * How many uploads run at once when `maxConcurrentUploads` is unset. Three keeps
+ * a multi-file selection quick without opening a connection per file.
+ */
+const DEFAULT_MAX_CONCURRENT_UPLOADS = 3;
+
+/** At least one upload at a time, whole files only; anything unusable falls back to the default. */
+function resolveMaxConcurrentUploads(configured: number | undefined): number {
+  if (typeof configured !== "number" || Number.isNaN(configured)) {
+    return DEFAULT_MAX_CONCURRENT_UPLOADS;
+  }
+  return Math.max(1, Math.floor(configured));
+}
+
 export interface UseAttachmentsReturn {
   /** Currently selected attachments (uploading + ready). */
   attachments: Attachment[];
@@ -67,50 +83,15 @@ export function useAttachments({
   const attachmentsRef = useRef<Attachment[]>([]);
   attachmentsRef.current = attachments;
 
-  // Stable processFiles — reads config from ref, never changes identity
-  const processFiles = useCallback(async (files: File[]) => {
-    const cfg = configRef.current;
-    const accept = cfg?.accept ?? "*/*";
-    const maxSize = cfg?.maxSize ?? 20 * 1024 * 1024;
-
-    const rejectedFiles = files.filter(
-      (file) => !matchesAcceptFilter(file, accept),
-    );
-    for (const file of rejectedFiles) {
-      cfg?.onUploadFailed?.({
-        reason: "invalid-type",
-        file,
-        message: `File "${file.name}" is not accepted. Supported types: ${accept}`,
-      });
-    }
-
-    const validFiles = files.filter((file) =>
-      matchesAcceptFilter(file, accept),
-    );
-
-    for (const file of validFiles) {
-      if (exceedsMaxSize(file, maxSize)) {
-        cfg?.onUploadFailed?.({
-          reason: "file-too-large",
-          file,
-          message: `File "${file.name}" exceeds the maximum size of ${formatFileSize(maxSize)}`,
-        });
-        continue;
-      }
-
-      const modality = getModalityFromMimeType(file.type);
-      const placeholderId = randomUUID();
-      const placeholder: Attachment = {
-        id: placeholderId,
-        type: modality,
-        source: { type: "data", value: "", mimeType: file.type },
-        filename: file.name,
-        size: file.size,
-        status: "uploading",
-      };
-
-      setAttachments((prev) => [...prev, placeholder]);
-
+  // Upload one queued file and settle its placeholder: the source it uploaded to on success,
+  // gone from the queue on failure. Resolves either way, so one bad file among many neither
+  // rejects nor stops the rest.
+  const uploadFile = useCallback(
+    async (
+      file: File,
+      placeholder: Attachment,
+      cfg: AttachmentsConfig | undefined,
+    ) => {
       try {
         let source: Attachment["source"];
         let uploadMetadata: Record<string, unknown> | undefined;
@@ -125,13 +106,13 @@ export function useAttachments({
         }
 
         let thumbnail: string | undefined;
-        if (modality === "video") {
+        if (placeholder.type === "video") {
           thumbnail = await generateVideoThumbnail(file);
         }
 
         setAttachments((prev) =>
           prev.map((att) =>
-            att.id === placeholderId
+            att.id === placeholder.id
               ? {
                   ...att,
                   source,
@@ -144,7 +125,7 @@ export function useAttachments({
         );
       } catch (error) {
         setAttachments((prev) =>
-          prev.filter((att) => att.id !== placeholderId),
+          prev.filter((att) => att.id !== placeholder.id),
         );
         console.error(`[CopilotKit] Failed to upload "${file.name}":`, error);
         cfg?.onUploadFailed?.({
@@ -156,8 +137,81 @@ export function useAttachments({
               : `Failed to upload "${file.name}"`,
         });
       }
-    }
-  }, []);
+    },
+    [],
+  );
+
+  // Stable processFiles — reads config from ref, never changes identity
+  const processFiles = useCallback(
+    async (files: File[]) => {
+      const cfg = configRef.current;
+      const accept = cfg?.accept ?? "*/*";
+      const maxSize = cfg?.maxSize ?? DEFAULT_MAX_SIZE;
+
+      const rejectedFiles = files.filter(
+        (file) => !matchesAcceptFilter(file, accept),
+      );
+      for (const file of rejectedFiles) {
+        cfg?.onUploadFailed?.({
+          reason: "invalid-type",
+          file,
+          message: `File "${file.name}" is not accepted. Supported types: ${accept}`,
+        });
+      }
+
+      const validFiles = files.filter((file) =>
+        matchesAcceptFilter(file, accept),
+      );
+
+      const queued: { file: File; placeholder: Attachment }[] = [];
+      for (const file of validFiles) {
+        if (exceedsMaxSize(file, maxSize)) {
+          cfg?.onUploadFailed?.({
+            reason: "file-too-large",
+            file,
+            message: `File "${file.name}" exceeds the maximum size of ${formatFileSize(maxSize)}`,
+          });
+          continue;
+        }
+
+        queued.push({
+          file,
+          placeholder: {
+            id: randomUUID(),
+            type: getModalityFromMimeType(file.type),
+            source: { type: "data", value: "", mimeType: file.type },
+            filename: file.name,
+            size: file.size,
+            status: "uploading",
+          },
+        });
+      }
+
+      if (queued.length === 0) return;
+
+      // The whole selection joins the queue at once, in the order it was picked, so a file
+      // waiting for a free slot is already visible rather than appearing later.
+      setAttachments((prev) => [...prev, ...queued.map((q) => q.placeholder)]);
+
+      // Bounded fan-out: this many workers pull from one shared cursor, so at most that many
+      // uploads are in flight and the rest start as slots free up. Reading and advancing the
+      // cursor happens without an await between, so no two workers take the same file.
+      const workers = Math.min(
+        queued.length,
+        resolveMaxConcurrentUploads(cfg?.maxConcurrentUploads),
+      );
+      let next = 0;
+      await Promise.all(
+        Array.from({ length: workers }, async () => {
+          while (next < queued.length) {
+            const { file, placeholder } = queued[next++];
+            await uploadFile(file, placeholder, cfg);
+          }
+        }),
+      );
+    },
+    [uploadFile],
+  );
 
   const handleFileUpload = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/react-core/src/v2/hooks/use-attachments.tsx
+++ b/packages/react-core/src/v2/hooks/use-attachments.tsx
@@ -17,10 +17,11 @@ export interface UseAttachmentsProps {
 const DEFAULT_MAX_SIZE = 20 * 1024 * 1024;
 
 /**
- * How many uploads run at once when `maxConcurrentUploads` is unset. Three keeps
- * a multi-file selection quick without opening a connection per file.
+ * How many uploads run at once when `maxConcurrentUploads` is unset. One, because
+ * `onUpload` is a public callback an app may have written expecting the previous
+ * file to have finished — concurrency is something the app asks for.
  */
-const DEFAULT_MAX_CONCURRENT_UPLOADS = 3;
+const DEFAULT_MAX_CONCURRENT_UPLOADS = 1;
 
 /**
  * At least one upload at a time, whole files only; `NaN` or a non-number falls back to the

--- a/packages/shared/src/attachments/types.ts
+++ b/packages/shared/src/attachments/types.ts
@@ -44,6 +44,12 @@ export interface AttachmentsConfig {
   accept?: string;
   /** Maximum file size in bytes, default 20MB (20 * 1024 * 1024) */
   maxSize?: number;
+  /**
+   * How many files may upload at the same time, default 3. Files past that wait
+   * for a free slot; `1` uploads one file at a time. Honored by the React
+   * `useAttachments` hook — the Vue and Angular bindings still upload serially.
+   */
+  maxConcurrentUploads?: number;
   /** Custom upload handler. Return an InputContentSource with optional metadata. */
   onUpload?: (
     file: File,

--- a/packages/shared/src/attachments/types.ts
+++ b/packages/shared/src/attachments/types.ts
@@ -46,8 +46,11 @@ export interface AttachmentsConfig {
   maxSize?: number;
   /**
    * How many files may upload at the same time, default 3. Files past that wait
-   * for a free slot; `1` uploads one file at a time. Honored by the React
-   * `useAttachments` hook — the Vue and Angular bindings still upload serially.
+   * for a free slot; `1` uploads one file at a time and `Infinity` lifts the
+   * limit. The limit covers everything in flight, so two selections dropped or
+   * pasted at once share the slots rather than each taking the full number.
+   * Honored by the React `useAttachments` hook — the Vue and Angular bindings
+   * still upload serially.
    */
   maxConcurrentUploads?: number;
   /** Custom upload handler. Return an InputContentSource with optional metadata. */

--- a/packages/shared/src/attachments/types.ts
+++ b/packages/shared/src/attachments/types.ts
@@ -45,10 +45,11 @@ export interface AttachmentsConfig {
   /** Maximum file size in bytes, default 20MB (20 * 1024 * 1024) */
   maxSize?: number;
   /**
-   * How many files may upload at the same time, default 3. Files past that wait
-   * for a free slot; `1` uploads one file at a time and `Infinity` lifts the
-   * limit. The limit covers everything in flight, so two selections dropped or
-   * pasted at once share the slots rather than each taking the full number.
+   * How many files may upload at the same time, default 1 — `onUpload` is not
+   * called concurrently unless you raise this. Files past the limit wait for a
+   * free slot; `Infinity` lifts it. The limit covers everything in flight, so
+   * two selections dropped or pasted at once share the slots rather than each
+   * taking the full number.
    * Honored by the React `useAttachments` hook — the Vue and Angular bindings
    * still upload serially.
    */

--- a/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
+++ b/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
@@ -145,6 +145,8 @@ Set `maxConcurrentUploads` to change how many run together — raise it for smal
 />
 ```
 
+The limit covers every upload in flight, not each batch: if a paste lands while a dropped selection is still uploading, both share the same slots. `Infinity` lifts the limit entirely.
+
 Your `onUpload` handler is called once per file and may be called concurrently, so it must not rely on the previous file having finished.
 
 ## Handling upload errors

--- a/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
+++ b/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
@@ -42,6 +42,7 @@ The `attachments` prop accepts an `AttachmentsConfig` object:
 | `enabled` | `boolean` | — | Enable file attachments in the chat input. |
 | `accept` | `string` | `"*/*"` | MIME type filter. Supports patterns like `"image/*"`, `".pdf,.docx"`, or comma-separated lists. |
 | `maxSize` | `number` | `20 * 1024 * 1024` | Maximum file size in bytes. |
+| `maxConcurrentUploads` | `number` | `3` | How many files upload at the same time. See [Upload concurrency](#upload-concurrency). |
 | `onUpload` | `(file: File) => AttachmentUploadResult \| Promise<...>` | — | Custom upload handler. See [Custom upload handler](#custom-upload-handler). |
 | `onUploadFailed` | `(error: AttachmentUploadError) => void` | — | Called when a file fails validation or upload. See [Handling upload errors](#handling-upload-errors). |
 
@@ -127,6 +128,24 @@ onUpload: async (file) => {
 ```
 
 The filename is always included in metadata automatically — you don't need to add it yourself.
+
+## Upload concurrency
+
+When a user attaches several files at once, three of them upload at the same time and the rest start as slots free up. Every picked file shows in the attachment queue immediately, whether or not its upload has started.
+
+Set `maxConcurrentUploads` to change how many run together — raise it for small files, or set it to `1` if your upload endpoint expects one request at a time:
+
+```tsx
+<CopilotChat
+  attachments={{
+    enabled: true,
+    maxConcurrentUploads: 1, // one file at a time
+    onUpload: async (file) => uploadToStorage(file),
+  }}
+/>
+```
+
+Your `onUpload` handler is called once per file and may be called concurrently, so it must not rely on the previous file having finished.
 
 ## Handling upload errors
 

--- a/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
+++ b/showcase/shell-docs/src/content/docs/multimodal-attachments.mdx
@@ -42,7 +42,7 @@ The `attachments` prop accepts an `AttachmentsConfig` object:
 | `enabled` | `boolean` | — | Enable file attachments in the chat input. |
 | `accept` | `string` | `"*/*"` | MIME type filter. Supports patterns like `"image/*"`, `".pdf,.docx"`, or comma-separated lists. |
 | `maxSize` | `number` | `20 * 1024 * 1024` | Maximum file size in bytes. |
-| `maxConcurrentUploads` | `number` | `3` | How many files upload at the same time. See [Upload concurrency](#upload-concurrency). |
+| `maxConcurrentUploads` | `number` | `1` | How many files upload at the same time. See [Upload concurrency](#upload-concurrency). |
 | `onUpload` | `(file: File) => AttachmentUploadResult \| Promise<...>` | — | Custom upload handler. See [Custom upload handler](#custom-upload-handler). |
 | `onUploadFailed` | `(error: AttachmentUploadError) => void` | — | Called when a file fails validation or upload. See [Handling upload errors](#handling-upload-errors). |
 
@@ -131,15 +131,15 @@ The filename is always included in metadata automatically — you don't need to 
 
 ## Upload concurrency
 
-When a user attaches several files at once, three of them upload at the same time and the rest start as slots free up. Every picked file shows in the attachment queue immediately, whether or not its upload has started.
+When a user attaches several files at once, they upload one at a time by default. Every picked file shows in the attachment queue immediately, whether or not its upload has started.
 
-Set `maxConcurrentUploads` to change how many run together — raise it for small files, or set it to `1` if your upload endpoint expects one request at a time:
+Set `maxConcurrentUploads` to upload several together — worth raising when your upload endpoint handles parallel requests:
 
 ```tsx
 <CopilotChat
   attachments={{
     enabled: true,
-    maxConcurrentUploads: 1, // one file at a time
+    maxConcurrentUploads: 3, // three files at a time
     onUpload: async (file) => uploadToStorage(file),
   }}
 />
@@ -147,7 +147,7 @@ Set `maxConcurrentUploads` to change how many run together — raise it for smal
 
 The limit covers every upload in flight, not each batch: if a paste lands while a dropped selection is still uploading, both share the same slots. `Infinity` lifts the limit entirely.
 
-Your `onUpload` handler is called once per file and may be called concurrently, so it must not rely on the previous file having finished.
+Above `1`, your `onUpload` handler may be called concurrently, so it must not rely on the previous file having finished.
 
 ## Handling upload errors
 

--- a/skills/react-core/references/attachments.md
+++ b/skills/react-core/references/attachments.md
@@ -143,7 +143,9 @@ Multi-file selections upload three at a time by default; the rest start as slots
 free up, and the whole selection is queued as `status: "uploading"` right away.
 `onUpload` is therefore called concurrently and must not assume the previous file
 finished. Set `maxConcurrentUploads` to change the pool — `1` restores
-one-at-a-time uploads for an endpoint that needs it.
+one-at-a-time uploads for an endpoint that needs it, `Infinity` lifts the limit.
+The pool is per hook, not per call, so a paste landing mid-upload shares the same
+slots instead of opening its own.
 
 ```tsx
 useAttachments({

--- a/skills/react-core/references/attachments.md
+++ b/skills/react-core/references/attachments.md
@@ -137,6 +137,24 @@ useAttachments({
 });
 ```
 
+### Upload concurrency
+
+Multi-file selections upload three at a time by default; the rest start as slots
+free up, and the whole selection is queued as `status: "uploading"` right away.
+`onUpload` is therefore called concurrently and must not assume the previous file
+finished. Set `maxConcurrentUploads` to change the pool — `1` restores
+one-at-a-time uploads for an endpoint that needs it.
+
+```tsx
+useAttachments({
+  config: {
+    enabled: true,
+    maxConcurrentUploads: 6,
+    onUpload: async (file) => uploadToStorage(file),
+  },
+});
+```
+
 ### Feedback on failed uploads
 
 ```tsx

--- a/skills/react-core/references/attachments.md
+++ b/skills/react-core/references/attachments.md
@@ -139,13 +139,13 @@ useAttachments({
 
 ### Upload concurrency
 
-Multi-file selections upload three at a time by default; the rest start as slots
-free up, and the whole selection is queued as `status: "uploading"` right away.
-`onUpload` is therefore called concurrently and must not assume the previous file
-finished. Set `maxConcurrentUploads` to change the pool — `1` restores
-one-at-a-time uploads for an endpoint that needs it, `Infinity` lifts the limit.
-The pool is per hook, not per call, so a paste landing mid-upload shares the same
-slots instead of opening its own.
+Multi-file selections upload one file at a time by default, and the whole
+selection is queued as `status: "uploading"` right away. Raise
+`maxConcurrentUploads` to run several together — the rest then start as slots
+free up, `Infinity` lifts the limit, and `onUpload` may be called concurrently,
+so above `1` it must not assume the previous file finished. The pool is per hook,
+not per call, so a paste landing mid-upload shares the same slots instead of
+opening its own.
 
 ```tsx
 useAttachments({


### PR DESCRIPTION
## What does this PR do?

Attachment uploads can run concurrently instead of one file at a time, bounded by a new `maxConcurrentUploads` option on `AttachmentsConfig`.

`processFiles` walked the valid files in a `for` loop and awaited each upload inside it, so `onUpload` was called for one file only after the previous had finished. For an app whose `onUpload` posts to object storage, attaching 8 files cost 8 sequential round trips, with no way to ask for anything else.

Now `processFiles` validates and queues the whole selection first, then drains it with a bounded worker pool — worker loops pulling from one shared cursor, so at most N uploads are in flight and the rest start as slots free up. The pool lives on the hook rather than in a call, so a paste landing mid-upload shares the slots instead of opening its own. The per-file body moved into a `uploadFile` helper, unchanged except that it settles its placeholder by object rather than a closed-over id. All three entry points (picker, drag-and-drop, paste) benefit, since they all route through `processFiles`.

```tsx
<CopilotChat
  attachments={{
    enabled: true,
    maxConcurrentUploads: 3, // default is 1 — one file at a time
    onUpload: async (file) => uploadToStorage(file),
  }}
/>
```

**Defaults and behavior**

1. **The default is `1`, so nothing changes unless an app asks for it.** `onUpload` is a public callback, and a handler written when uploads were serial could otherwise start seeing the next file begin before the previous one finished — a change in when a public callback fires, with no code change on the user's side and no signal that anything moved. Raising `maxConcurrentUploads` is the opt-in; `Infinity` lifts the limit entirely. (This started out defaulting to 3; changed to `1` at review.)
2. **The whole selection is queued up front, at every limit.** Files past the limit would otherwise be invisible until a slot freed, so every picked file joins the queue as `status: "uploading"` immediately — a visibility improvement rather than a contract change. It also means all `file-too-large` rejections fire before any upload starts, where previously they interleaved.

`maxConcurrentUploads` is clamped to at least 1 and floored; a non-numeric or `NaN` value falls back to the default, and `Infinity` is capped by how many files are actually queued.

### Scope

`react-core` and the shared config type only. The Vue and Angular bindings read the same `AttachmentsConfig` and still upload serially — the field's doc comment says so rather than leaving it silent, and I'm glad to follow up with those plus `react-native` (which has its own config interface) in a separate PR.

### Tests

Seven cases in `packages/react-core/src/v2/hooks/__tests__/use-attachments.test.tsx`, using gated uploads to observe in-flight counts:

- one at a time by default,
- `maxConcurrentUploads: 3` really runs three,
- every file queued immediately in pick order,
- a non-positive value clamps to 1,
- `Infinity` uploads every queued file at once,
- the limit holds across overlapping `processFiles` calls (two uploads in flight in total, not two per call),
- and one failing file leaves the queue while the others still finish.

One note for reviewers: `setupTests.ts` mocks `randomUUID` to a constant, which gives every placeholder the same attachment id — since each upload settles its placeholder by id, these tests need unique ids, so that `describe` overrides the mock. The collision existed before this change too, just invisibly. If you'd prefer that global mock removed instead, I'm happy to do that in a follow-up.

Docs updated: the `maxConcurrentUploads` row plus an "Upload concurrency" section in `multimodal-attachments.mdx`, and the same in the `react-core` skill reference (with its mirror synced via `scripts/sync-plugin-skills.ts`).

### Known gap, happy to take it here or later

`CopilotChatAttachmentQueue.tsx:46` renders the remove button at any status, so a user can click X on a file still waiting for a slot; the upload still runs and still burns a slot. On `main` those files had no chip at all, so the gap is new — flagged by @BenTaylorDev as non-blocking.

## Related PRs and Issues

- Closes #6843

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - React attachment uploads now process one file at a time by default.
  - Added `maxConcurrentUploads` to configure parallel uploads, including sequential uploads with `1` or unlimited uploads with `Infinity`.
  - Additional files are queued across overlapping selections and uploaded as slots become available.
  - Failed uploads no longer prevent remaining queued files from continuing.

- **Documentation**
  - Updated attachment documentation with upload queue behavior, concurrency settings, and configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
