### PR TITLE
docs(examples): note that the integration tool card needs a Tailwind build

### DIFF
--- a/examples/integrations/claude-sdk-python/src/components/tool-rendering.tsx
+++ b/examples/integrations/claude-sdk-python/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/claude-sdk-python/src/components/tool-rendering.tsx
+++ b/examples/integrations/claude-sdk-python/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";

--- a/examples/integrations/claude-sdk-typescript/src/components/tool-rendering.tsx
+++ b/examples/integrations/claude-sdk-typescript/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/claude-sdk-typescript/src/components/tool-rendering.tsx
+++ b/examples/integrations/claude-sdk-typescript/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";

--- a/examples/integrations/langgraph-fastapi/src/components/tool-rendering.tsx
+++ b/examples/integrations/langgraph-fastapi/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/langgraph-fastapi/src/components/tool-rendering.tsx
+++ b/examples/integrations/langgraph-fastapi/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";

--- a/examples/integrations/langgraph-js/src/components/tool-rendering.tsx
+++ b/examples/integrations/langgraph-js/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/langgraph-js/src/components/tool-rendering.tsx
+++ b/examples/integrations/langgraph-js/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";

--- a/examples/integrations/langgraph-python/src/components/tool-rendering.tsx
+++ b/examples/integrations/langgraph-python/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/langgraph-python/src/components/tool-rendering.tsx
+++ b/examples/integrations/langgraph-python/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";

--- a/examples/integrations/strands-python/src/components/tool-rendering.tsx
+++ b/examples/integrations/strands-python/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/strands-python/src/components/tool-rendering.tsx
+++ b/examples/integrations/strands-python/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";

--- a/examples/integrations/strands-typescript/src/components/tool-rendering.tsx
+++ b/examples/integrations/strands-typescript/src/components/tool-rendering.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+/**
+ * Example tool-call card, styled with Tailwind CSS utility classes such as
+ * `flex`, `items-center`, `gap-2`, `list-none`, and `h-3 w-3`. This example
+ * compiles them through `@import "tailwindcss"` in `src/app/globals.css`,
+ * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
+ * `postcss.config.mjs`.
+ *
+ * If you copy this file into a project that does not compile Tailwind, every
+ * class resolves to nothing. The `<summary>` row then loses `flex` and falls
+ * back to block layout, so the icons and the tool name stack in one column.
+ * Two details confirm that cause:
+ *
+ *   - the native `<details>` triangle is visible, because `list-none` is gone
+ *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
+ *
+ * Set Tailwind up in the target project, or replace these class names with
+ * your own styles. Reported as CopilotKit issue #4777.
+ */
+
 import { useEffect, useRef } from "react";
 import { Wrench, Check, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";

--- a/examples/integrations/strands-typescript/src/components/tool-rendering.tsx
+++ b/examples/integrations/strands-typescript/src/components/tool-rendering.tsx
@@ -7,16 +7,8 @@
  * `tailwindcss` and `@tailwindcss/postcss` in `package.json`, and
  * `postcss.config.mjs`.
  *
- * If you copy this file into a project that does not compile Tailwind, every
- * class resolves to nothing. The `<summary>` row then loses `flex` and falls
- * back to block layout, so the icons and the tool name stack in one column.
- * Two details confirm that cause:
- *
- *   - the native `<details>` triangle is visible, because `list-none` is gone
- *   - the icons sit at the lucide default of 24px, not the 12px of `h-3 w-3`
- *
- * Set Tailwind up in the target project, or replace these class names with
- * your own styles. Reported as CopilotKit issue #4777.
+ * Copying this file into another project requires the same Tailwind build, or
+ * your own styles in place of these class names. See CopilotKit issue #4777.
  */
 
 import { useEffect, useRef } from "react";


### PR DESCRIPTION
## What

Adds a file header to `src/components/tool-rendering.tsx` in all seven integration examples, recording that the card's layout depends on a Tailwind build.

## Why

`#4777` reported the tool-call icons rendering vertically instead of in a row. It is not a CopilotKit component bug: `ToolReasoning` styles its `<summary>` row with unprefixed Tailwind utilities (`flex`, `items-center`, `gap-2`, `list-none`, `h-3 w-3`), and the reporter had copied the file into an app that does not compile Tailwind. With no `flex`, the `<summary>` falls back to block layout and every child stacks.

The earlier community attempt at this (#5485) patched `DefaultToolCallRenderer` in `packages/react-core`, which is not on the reported render path. It was closed unmerged. Nothing in library code needs to change here; the gap is that the example never says what it needs.

So the header states the dependency and stops there — it names the classes, points at the three files that make the build work, and links #4777 for anyone diagnosing from the symptom end. A reader who skips the Tailwind setup does not need the resulting layout enumerated for them.

`#4777` stays open until this lands.

## Scope

Comment-only. No runtime code, no styling, no package changes, no changeset.

`src/components/tool-rendering.tsx` is a parity-tracked verbatim file with `langgraph-python` as north-star, so four instances were propagated with `parity:sync --all`. `claude-sdk-python` and `claude-sdk-typescript` list this path in `allowedDivergence` (they carry `args?: unknown` rather than `args?: object | unknown`), so those two were annotated by hand and their divergence is preserved.

## Testing

Baseline `parity:verify` on `origin/main` before the change — 0 errors, 5 warnings per instance (pre-existing `threads-drawer`/`next-env.d.ts` patterns that match nothing in the north-star):

```
langgraph-js — 74 ok, 5 warn, 0 error
claude-sdk-python — 72 ok, 5 warn, 0 error
claude-sdk-typescript — 72 ok, 5 warn, 0 error
```

After the change — same 0 errors, same 5 warnings, no new drift:

```
langgraph-js — 79 ok, 5 warn, 0 error
langgraph-fastapi — 84 ok, 5 warn, 0 error
strands-python — 81 ok, 5 warn, 0 error
strands-typescript — 78 ok, 5 warn, 0 error
claude-sdk-python — 72 ok, 5 warn, 0 error
claude-sdk-typescript — 72 ok, 5 warn, 0 error
```

All seven files carry the note exactly once, and the `claude-sdk` divergence survived the sync:

```
$ grep -c '#4777' examples/integrations/*/src/components/tool-rendering.tsx
claude-sdk-python/...:1   claude-sdk-typescript/...:1   langgraph-fastapi/...:1
langgraph-js/...:1        langgraph-python/...:1        strands-python/...:1
strands-typescript/...:1

$ grep -n 'args?:' examples/integrations/*/src/components/tool-rendering.tsx
claude-sdk-python/...:28:      args?: unknown;
claude-sdk-typescript/...:28:  args?: unknown;
langgraph-*/, strands-*/:28:   args?: object | unknown;
```

Format and lint, re-run after the trim:

```
$ npx oxfmt --check examples/integrations/*/src/components/tool-rendering.tsx
All matched files use the correct format.  Finished in 45ms on 7 files

$ npx oxlint examples/integrations/*/src/components/tool-rendering.tsx
Found 0 warnings and 0 errors.  Finished in 449ms on 7 files with 177 rules
```

The header sits after `"use client"`, so the directive is untouched. Confirmed by parsing all seven with the TypeScript parser — 0 parse errors, and `"use client"` is still statement 0 in each:

```
OK  parseErrors=0  useClientFirst=true   (x7)
```

Net diff is 7 files, +11 lines each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance to integration examples explaining the Tailwind CSS requirements for the tool-rendering component.
  - Documented the necessary build configuration and dependencies for reproducing the component’s styling in another project.
  - Clarified that equivalent styling or the same Tailwind setup is required when copying the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->