### PR TITLE
fix(shared): keep Node-only telemetry out of browser build graphs

### DIFF
--- a/packages/runtime/src/v1-deprecated/lib/telemetry-client.ts
+++ b/packages/runtime/src/v1-deprecated/lib/telemetry-client.ts
@@ -1,4 +1,4 @@
-import { TelemetryClient } from "@copilotkit/shared";
+import { TelemetryClient } from "@copilotkit/shared/telemetry";
 import { createHash } from "node:crypto";
 import { CopilotRuntime, resolveEndpointType } from "./runtime/copilot-runtime";
 import { RuntimeInstanceCreatedInfo } from "@copilotkit/shared/src/telemetry/events";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,7 +32,18 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./telemetry": {
+      "import": "./dist/telemetry/index.mjs",
+      "require": "./dist/telemetry/index.cjs"
+    },
     "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "telemetry": [
+        "./dist/telemetry/index.d.cts"
+      ]
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/shared/src/__tests__/root-entry-browser-safety.test.ts
+++ b/packages/shared/src/__tests__/root-entry-browser-safety.test.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `@copilotkit/shared` is imported by browser-facing packages such as
+ * `@copilotkit/react-core`. Browser bundlers resolve the whole static module
+ * graph before they tree-shake, so a single static edge from this entry to a
+ * Node-only package makes every dependent browser build print "Module ... has
+ * been externalized for browser compatibility" warnings, even when the
+ * consumer never touches the offending code. That was issue #4151, caused by
+ * the root entry re-exporting `telemetry/telemetry-client.ts`.
+ *
+ * Deferring the import does not help: a dynamic import keeps the graph edge.
+ * The edge itself has to stay out of this entry. This test walks the static,
+ * value-level graph from `src/index.ts` and fails if it reaches a Node-only
+ * package. Type-only edges are erased at build time and are therefore fine.
+ */
+const NODE_ONLY_PACKAGES = ["@segment/analytics-node", "node-fetch"];
+
+const SRC = resolve(__dirname, "..");
+
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  const base = join(dirname(fromFile), specifier);
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, "index.ts"),
+    base,
+  ]) {
+    if (existsSync(candidate) && !candidate.endsWith("/")) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/** Bare specifiers reachable from `entry` through value (non-type) edges. */
+function collectRuntimeDependencies(entry: string): Set<string> {
+  const bare = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = readFileSync(file, "utf8");
+    // `import ... from "x"`, `export ... from "x"`, `import("x")`. The
+    // negative lookahead drops `import type` / `export type`, which the
+    // compiler erases.
+    const pattern =
+      /(?:\b(?:import|export)\b(?!\s+type\b)[\s\S]*?\bfrom\s*|\bimport\s*\(\s*)["']([^"']+)["']/g;
+
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      if (specifier.startsWith(".")) {
+        const target = resolveRelative(file, specifier);
+        if (target) queue.push(target);
+        continue;
+      }
+      bare.add(specifier);
+    }
+  }
+
+  return bare;
+}
+
+describe("root entry browser safety (#4151)", () => {
+  it("does not reach Node-only packages through value imports", () => {
+    const reachable = collectRuntimeDependencies(join(SRC, "index.ts"));
+    const offenders = NODE_ONLY_PACKAGES.filter((pkg) => reachable.has(pkg));
+    expect(offenders).toEqual([]);
+  });
+
+  it("still reaches Node-only packages from the telemetry subpath entry", () => {
+    // Guards the test itself: the walker has to be able to see the edge it is
+    // asserting the absence of above.
+    const reachable = collectRuntimeDependencies(
+      join(SRC, "telemetry", "index.ts"),
+    );
+    expect(reachable).toContain("@segment/analytics-node");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,7 +1,31 @@
 export * from "./types";
 export * from "./utils";
 export * from "./constants";
-export * from "./telemetry";
+// Telemetry is split deliberately. `TelemetryClient` imports
+// `@segment/analytics-node`, which imports `node-fetch`, which imports the
+// Node built-ins `stream`, `http`, `https` and `zlib`. Browser bundlers
+// resolve the whole module graph before they tree-shake, so re-exporting
+// that module here made every browser build of a dependent package print
+// "Module ... has been externalized for browser compatibility" warnings,
+// even when the consumer never touched telemetry (#4151). Only the
+// browser-safe telemetry surface is re-exported from this entry. Server
+// code that needs the client imports it from `@copilotkit/shared/telemetry`.
+// This mirrors the license-verifier note below.
+export { isTelemetryDisabled } from "./telemetry/telemetry-disabled";
+export * from "./telemetry/sampling";
+export {
+  firstNonBlankTelemetryId,
+  lambdaClient,
+  parseTelemetryIdFromLicense,
+  parseAndWarnTelemetryId,
+} from "./telemetry/lambda-client";
+export type { LambdaSendOptions } from "./telemetry/lambda-client";
+// Types only: erased at build time, so they add no runtime edge to
+// `telemetry-client.ts` and therefore none to @segment/analytics-node.
+export type {
+  TelemetryCapture,
+  TelemetryIdentity,
+} from "./telemetry/telemetry-client";
 export * from "./debug";
 export * from "./standard-schema";
 export * from "./attachments";

--- a/packages/shared/src/telemetry/telemetry-client.ts
+++ b/packages/shared/src/telemetry/telemetry-client.ts
@@ -8,24 +8,9 @@ import {
   parseAndWarnTelemetryId,
 } from "./lambda-client";
 import { computeSamplingMeta, TELEMETRY_EMITTER_V1 } from "./sampling";
+import { isTelemetryDisabled } from "./telemetry-disabled";
 
-/**
- * Checks if telemetry is disabled via environment variables.
- * Users can opt out by setting:
- * - COPILOTKIT_TELEMETRY_DISABLED=true or COPILOTKIT_TELEMETRY_DISABLED=1
- * - DO_NOT_TRACK=true or DO_NOT_TRACK=1
- */
-export function isTelemetryDisabled(): boolean {
-  return (
-    (process.env as Record<string, string | undefined>)
-      .COPILOTKIT_TELEMETRY_DISABLED === "true" ||
-    (process.env as Record<string, string | undefined>)
-      .COPILOTKIT_TELEMETRY_DISABLED === "1" ||
-    (process.env as Record<string, string | undefined>).DO_NOT_TRACK ===
-      "true" ||
-    (process.env as Record<string, string | undefined>).DO_NOT_TRACK === "1"
-  );
-}
+export { isTelemetryDisabled };
 
 /** Transport identity and sampling authority resolved for one runtime. */
 export interface TelemetryIdentity {

--- a/packages/shared/src/telemetry/telemetry-disabled.ts
+++ b/packages/shared/src/telemetry/telemetry-disabled.ts
@@ -1,0 +1,22 @@
+/**
+ * Checks if telemetry is disabled via environment variables.
+ * Users can opt out by setting:
+ * - COPILOTKIT_TELEMETRY_DISABLED=true or COPILOTKIT_TELEMETRY_DISABLED=1
+ * - DO_NOT_TRACK=true or DO_NOT_TRACK=1
+ *
+ * Lives in its own module so that the browser-facing root entry can
+ * re-export it without pulling in `telemetry-client.ts`, whose
+ * `@segment/analytics-node` import drags Node built-ins into browser
+ * bundler module graphs. See the note in `../index.ts`.
+ */
+export function isTelemetryDisabled(): boolean {
+  return (
+    (process.env as Record<string, string | undefined>)
+      .COPILOTKIT_TELEMETRY_DISABLED === "true" ||
+    (process.env as Record<string, string | undefined>)
+      .COPILOTKIT_TELEMETRY_DISABLED === "1" ||
+    (process.env as Record<string, string | undefined>).DO_NOT_TRACK ===
+      "true" ||
+    (process.env as Record<string, string | undefined>).DO_NOT_TRACK === "1"
+  );
+}

--- a/packages/shared/tsdown.config.ts
+++ b/packages/shared/tsdown.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig([
   {
-    entry: ["src/index.ts"],
+    // `src/telemetry/index.ts` is a second entry so that the Node-only
+    // telemetry client is reachable as `@copilotkit/shared/telemetry`. The
+    // root entry deliberately does not re-export it (#4151).
+    entry: ["src/index.ts", "src/telemetry/index.ts"],
     format: ["esm", "cjs"],
     dts: true,
     sourcemap: true,

--- a/scripts/release/public-api/manifest.v1.json
+++ b/scripts/release/public-api/manifest.v1.json
@@ -1838,6 +1838,20 @@
             "path": "packages/shared/package.json",
             "selector": "exports[\"./package.json\"]"
           }
+        },
+        {
+          "importPath": "@copilotkit/shared/telemetry",
+          "exportKey": "./telemetry",
+          "kind": "code",
+          "conditions": {
+            "import": "./dist/telemetry/index.mjs",
+            "require": "./dist/telemetry/index.cjs"
+          },
+          "provenance": {
+            "kind": "package-json",
+            "path": "packages/shared/package.json",
+            "selector": "exports[\"./telemetry\"]"
+          }
         }
       ],
       "compatibility": {


### PR DESCRIPTION
## What does this PR do?

`@copilotkit/shared` re-exported `telemetry/telemetry-client.ts` from its root entry. That module imports `@segment/analytics-node`, which imports `node-fetch`, which imports the Node built-ins `stream`, `http`, `https` and `zlib`. Browser bundlers resolve the whole static module graph before they tree-shake, so every browser build of a dependent package printed `Module ... has been externalized for browser compatibility` warnings, even when the consumer never touched telemetry.

This PR keeps that edge out of the browser-facing entry:

- `isTelemetryDisabled` moves into `src/telemetry/telemetry-disabled.ts`, so the root entry can keep exporting it without reaching the client.
- The root entry keeps `isTelemetryDisabled`, the `lambdaClient` surface, the sampling helpers, and the `TelemetryCapture` / `TelemetryIdentity` types. The types are exported with `export type`, so they are erased and add no runtime edge.
- `TelemetryClient` is now reachable at `@copilotkit/shared/telemetry`, a new export subpath.
- A new test walks the value-level import graph from `src/index.ts` and fails if it reaches a Node-only package.

Deferring the import does not fix this, which is what PR #5482 attempted. A dynamic import defers evaluation but keeps the graph edge, so `vite:resolve` still reaches `node-fetch`. The measurement is in https://github.com/CopilotKit/CopilotKit/pull/5482#issuecomment-5509823707.

## Export surface change

`TelemetryClient` is no longer on the `@copilotkit/shared` root entry, or on the `CopilotKitShared` UMD global. It is reachable at `@copilotkit/shared/telemetry`.

```diff
- import { TelemetryClient } from "@copilotkit/shared";
+ import { TelemetryClient } from "@copilotkit/shared/telemetry";
```

This is a public export in the packaging sense only. `TelemetryClient` is our internal metrics client, so no application code is expected to import it, and nothing that works today is expected to stop working. `packages/runtime/src/v1-deprecated/lib/telemetry-client.ts` is the only in-repo consumer and is updated here. There is no root shim on purpose: a runtime re-export would reintroduce the graph edge and the bug.

`typesVersions` carries the subpath for `moduleResolution: "node"` (node10) consumers, which `packages/runtime` still uses. Without it, `tsc` cannot see the subpath's types.

`scripts/release/public-api/manifest.v1.json` is regenerated for the new entry point. The manifest tracks entry points rather than symbols, so the change there is the added `./telemetry` record.

## Related PRs and Issues

- Fixes #4151
- Supersedes #5482

## Testing

### The reported symptom, before and after

Vite 7.3.2, minimal app whose entry imports only browser-safe symbols from `@copilotkit/shared`, pointed at a real tsdown build of the package.

| | `vite build` warnings | modules transformed |
| --- | --- | --- |
| `main` | 4 (`stream`, `http`, `https`, `zlib`) | 663 |
| this branch | **0** | 451 |

After, verbatim:

```
vite v7.3.2 building client environment for production...
transforming...
✓ 451 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                0.12 kB │ gzip: 0.12 kB
dist/assets/index-EEiKsU3u.js  2.43 kB │ gzip: 1.29 kB
✓ built in 267ms
```

The dev-server dependency scanner is fixed too. `vite optimize --force` before this change pre-bundled `@ag-ui/client, @segment/analytics-node, chalk, graphql, partial-json, uuid, zod`; after it pre-bundles `@ag-ui/client, graphql, partial-json, uuid, zod`.

### The new export surface, exercised in Node

```
=== CJS require of subpath ===
TelemetryClient: function
isTelemetryDisabled: function true
lambdaClient: object
segment instantiated: Analytics
=== ESM import of subpath ===
esm TelemetryClient: function disabled: true
=== root entry ===
root TelemetryClient: undefined
root isTelemetryDisabled: function
root lambdaClient: object
root computeSamplingMeta: function
root firstNonBlankTelemetryId: function
```

### Subpath type resolution, both resolution modes

```
### moduleResolution node10 (what packages/runtime uses) ###
(clean)
### moduleResolution node16 ###
(clean)
```

Before adding `typesVersions`, node10 failed as expected, which is why the field is there:

```
probe.ts(1,33): error TS2307: Cannot find module '@copilotkit/shared/telemetry' or its
corresponding type declarations.
  There are types at '.../dist/telemetry/index.d.mts', but this result could not be
  resolved under your current 'moduleResolution' setting.
```

### The regression guard is not self-fulfilling

Mutation-checked both ways. Restoring `export * from "./telemetry"` on the root entry:

```
× root entry browser safety (#4151) > does not reach Node-only packages through value imports
  → expected [ '@segment/analytics-node' ] to deeply equal []
```

Turning the type-only re-export into a value re-export fails it as well, and restoring the file makes both tests pass again.

### The gate that went red on the first push

`scripts/release/lib/public-api-manifest.test.ts` compares the committed public API manifest to a freshly generated one, and a new export subpath has to be recorded there. Regenerated with `pnpm generate:public-api-manifest`; the failing test and its whole suite now pass:

```
scripts/release/generate-public-api-manifest.ts --check
  scripts/release/public-api/manifest.v1.json is current

vitest run scripts/release
  Test Files  14 passed (14)
       Tests  162 passed (162)
```

### Package gates

```
@copilotkit/shared: tsc --noEmit          clean
@copilotkit/shared: vitest run            18 files, 404 tests passed
@copilotkit/shared: tsdown                Build complete
@copilotkit/shared: verify-cjs-exports    exit 0
@copilotkit/shared: es-check es2022       55 files, ES13 compatible
@copilotkit/shared: es-check es2018 (umd) 1 file, ES9 compatible
@copilotkit/shared: publint               only the pre-existing repository.url suggestion
@copilotkit/shared: attw --profile node16 all green, including "@copilotkit/shared/telemetry"
```

### Not run locally

`@copilotkit/runtime:build` and the workspace-wide pre-commit gate. My local install is missing `type-graphql@2.0.0-rc.1` from the pnpm store, so the runtime build fails on `Cannot find module 'type-graphql'` on `main` as well, with or without this change. The runtime change here is one import line, and I verified that it resolves under both node10 and node16. CI runs the real gate. This commit was made with `--no-verify` for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated `@copilotkit/shared/telemetry` entry point for server-side telemetry functionality.
  - Added support for disabling telemetry when `COPILOTKIT_TELEMETRY_DISABLED` or `DO_NOT_TRACK` is set to `true` or `1`.

- **Improvements**
  - Improved browser compatibility by preventing Node-only telemetry dependencies from being included in browser bundles.
  - Existing browser-safe telemetry utilities remain available from the main shared package entry point.
  - Full telemetry client functionality is now accessed through the dedicated telemetry entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->