### PR TITLE
feat(core): expose webmcp-enabled frontend tools to browser agents

### DIFF
--- a/packages/angular/src/lib/tools.ts
+++ b/packages/angular/src/lib/tools.ts
@@ -1,6 +1,7 @@
 import { DestroyRef, Injector, Signal, Type, inject } from "@angular/core";
 import type { AbstractAgent } from "@ag-ui/client";
 import { FrontendTool, FrontendToolHandlerContext } from "@copilotkit/core";
+import type { WebMCPToolConfig } from "@copilotkit/core";
 import type { StandardSchemaV1 } from "@copilotkit/shared";
 import { CopilotKit } from "./copilotkit";
 
@@ -103,6 +104,12 @@ export interface FrontendToolConfig<
   ) => Promise<unknown>;
   followUp?: boolean;
   agentId?: string;
+  /**
+   * Also expose this tool to browser agents through the WebMCP API
+   * (`document.modelContext`). `true` uses default annotations;
+   * `{ annotations }` provides WebMCP annotations.
+   */
+  webmcp?: boolean | WebMCPToolConfig;
 }
 
 /**

--- a/packages/core/src/core/__tests__/run-handler-webmcp.test.ts
+++ b/packages/core/src/core/__tests__/run-handler-webmcp.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { logger } from "@copilotkit/shared";
+import type { FrontendToolHandlerContext } from "../../types";
+import { RunHandler } from "../run-handler";
+import type { CopilotKitCore } from "../core";
+
+/**
+ * Minimal WebMCP `document.modelContext` double. Mirrors the spec's
+ * registration semantics: a duplicate name rejects, and aborting the
+ * registration signal unregisters the tool.
+ */
+function createFakeModelContext() {
+  const registered = new Map<string, { tool: any; signal: AbortSignal }>();
+  const registerTool = vi.fn(
+    async (tool: any, options: { signal: AbortSignal }) => {
+      if (registered.has(tool.name)) {
+        throw new DOMException(
+          `A tool with name '${tool.name}' is already registered`,
+          "InvalidStateError",
+        );
+      }
+      registered.set(tool.name, { tool, signal: options.signal });
+      options.signal.addEventListener("abort", () => {
+        registered.delete(tool.name);
+      });
+    },
+  );
+  return { registered, registerTool };
+}
+
+function stubWebMCP() {
+  const modelContext = createFakeModelContext();
+  vi.stubGlobal("document", { modelContext });
+  return modelContext;
+}
+
+function createRunHandler(): RunHandler {
+  return new RunHandler({} as CopilotKitCore);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("RunHandler WebMCP registration", () => {
+  it("registers a webmcp-enabled tool on document.modelContext", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "sayHello",
+      description: "Say hello",
+      webmcp: true,
+    });
+
+    expect(modelContext.registerTool).toHaveBeenCalledTimes(1);
+    const entry = modelContext.registered.get("sayHello");
+    expect(entry).toBeDefined();
+    expect(entry!.tool.name).toBe("sayHello");
+    expect(entry!.tool.description).toBe("Say hello");
+    expect(entry!.tool.inputSchema).toEqual({
+      type: "object",
+      properties: {},
+    });
+  });
+
+  it("does not register tools without webmcp set", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({ name: "plainTool", description: "No webmcp" });
+    runHandler.addTool({
+      name: "optOutTool",
+      description: "webmcp false",
+      webmcp: false,
+    });
+
+    expect(modelContext.registerTool).not.toHaveBeenCalled();
+    expect(modelContext.registered.size).toBe(0);
+  });
+
+  it("is a no-op without WebMCP support (SSR, React Native)", () => {
+    const runHandler = createRunHandler();
+
+    expect(() => {
+      runHandler.addTool({
+        name: "sayHello",
+        description: "Say hello",
+        webmcp: true,
+      });
+    }).not.toThrow();
+  });
+
+  it("passes webmcp annotations through to the registration", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "searchDocs",
+      description: "Search the docs",
+      webmcp: {
+        annotations: { readOnlyHint: true, untrustedContentHint: true },
+      },
+    });
+
+    const entry = modelContext.registered.get("searchDocs");
+    expect(entry!.tool.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: true,
+    });
+  });
+
+  it("builds inputSchema from the tool parameters", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "createProject",
+      description: "Create a project",
+      parameters: z.object({
+        name: z.string().describe("Project name"),
+      }),
+      webmcp: true,
+    });
+
+    const entry = modelContext.registered.get("createProject");
+    expect(entry!.tool.inputSchema.type).toBe("object");
+    expect(entry!.tool.inputSchema.properties.name.type).toBe("string");
+  });
+
+  it("unregisters the tool when removeTool aborts the registration signal", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "sayHello",
+      description: "Say hello",
+      webmcp: true,
+    });
+    expect(modelContext.registered.has("sayHello")).toBe(true);
+
+    runHandler.removeTool("sayHello");
+
+    expect(modelContext.registered.has("sayHello")).toBe(false);
+  });
+
+  it("treats a re-registered tool object as a new definition", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "sayHello",
+      description: "Say hello",
+      webmcp: true,
+    });
+    runHandler.removeTool("sayHello");
+    runHandler.addTool({
+      name: "sayHello",
+      description: "Say hello, updated",
+      webmcp: { annotations: { readOnlyHint: true } },
+    });
+
+    const entry = modelContext.registered.get("sayHello");
+    expect(entry!.tool.description).toBe("Say hello, updated");
+    expect(entry!.tool.annotations).toEqual({ readOnlyHint: true });
+  });
+
+  it("applies the same availability rules as the agent tool list", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "hiddenTool",
+      description: "available false",
+      available: false,
+      webmcp: true,
+    });
+    runHandler.addTool({
+      name: "disabledTool",
+      description: "available disabled",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      available: "disabled" as any,
+      webmcp: true,
+    });
+    runHandler.addTool({
+      name: "inspectorDisabled",
+      description: "disabled via setToolEnabled",
+      webmcp: true,
+    });
+    runHandler.setToolEnabled("inspectorDisabled", false);
+    runHandler.addTool({
+      name: "*",
+      description: "wildcard",
+      webmcp: true,
+    });
+
+    // The only registration (inspectorDisabled, before it was disabled) is
+    // gone again; everything else was filtered out before registering.
+    expect(modelContext.registered.size).toBe(0);
+
+    runHandler.setToolEnabled("inspectorDisabled", true);
+
+    expect(modelContext.registered.has("inspectorDisabled")).toBe(true);
+  });
+
+  it("keeps the first registration when two agent-scoped tools share a name", () => {
+    const modelContext = stubWebMCP();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "dup",
+      description: "global",
+      webmcp: true,
+    });
+    runHandler.addTool({
+      name: "dup",
+      description: "scoped",
+      agentId: "a",
+      webmcp: true,
+    });
+
+    expect(modelContext.registered.size).toBe(1);
+    expect(modelContext.registered.get("dup")!.tool.description).toBe("global");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("share the name 'dup'"),
+    );
+  });
+
+  it("skips tools without a description (WebMCP rejects empty descriptions)", () => {
+    const modelContext = stubWebMCP();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({ name: "noDescription", webmcp: true });
+
+    expect(modelContext.registerTool).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("requires a description"),
+    );
+  });
+
+  it("warns instead of throwing when registerTool rejects", async () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+    runHandler.addTool({
+      name: "sayHello",
+      description: "Say hello",
+      webmcp: true,
+    });
+    expect(modelContext.registered.has("sayHello")).toBe(true);
+
+    // A second handler registers the same name against the same page context;
+    // the duplicate-name rejection is warned, not thrown.
+    const second = createRunHandler();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    second.addTool({
+      name: "sayHello",
+      description: "Say hello again",
+      webmcp: true,
+    });
+
+    await vi.waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "WebMCP registration failed for tool 'sayHello'",
+        ),
+      );
+    });
+    expect(second.tools.map((t) => t.name)).toContain("sayHello");
+  });
+
+  it("executes the tool handler when a browser agent calls the tool", async () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+    const handler = vi.fn(
+      async (args: { name: string }, _context: FrontendToolHandlerContext) => ({
+        greeting: `Hello ${args.name}`,
+      }),
+    );
+
+    runHandler.addTool({
+      name: "sayHello",
+      description: "Say hello",
+      parameters: z.object({ name: z.string() }),
+      handler,
+      webmcp: true,
+    });
+
+    const entry = modelContext.registered.get("sayHello");
+    const result = await entry!.tool.execute(
+      { name: "Ada" },
+      { signal: new AbortController().signal },
+    );
+
+    expect(result).toEqual({ greeting: "Hello Ada" });
+    expect(handler).toHaveBeenCalledWith(
+      { name: "Ada" },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    const [handlerArgs, context] = handler.mock.calls[0]!;
+    expect(context.agent).toBeUndefined();
+    expect(context.toolCall.function.name).toBe("sayHello");
+    expect(JSON.parse(context.toolCall.function.arguments)).toEqual(
+      handlerArgs,
+    );
+  });
+
+  it("returns an empty string for a display-only tool without a handler", async () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    runHandler.addTool({
+      name: "showCard",
+      description: "Show a card",
+      webmcp: true,
+    });
+
+    const entry = modelContext.registered.get("showCard");
+    const result = await entry!.tool.execute({}, {});
+    expect(result).toBe("");
+  });
+
+  it("re-registers provider tools after a setTools re-sync", () => {
+    const modelContext = stubWebMCP();
+    const runHandler = createRunHandler();
+
+    const original = {
+      name: "providerTool",
+      description: "from props",
+      webmcp: true,
+    };
+    runHandler.initialize([original]);
+    expect(modelContext.registered.get("providerTool")!.tool.description).toBe(
+      "from props",
+    );
+
+    // The provider re-derives its tool list and re-syncs with a fresh object.
+    runHandler.setTools([{ ...original, description: "from props, updated" }]);
+
+    expect(modelContext.registered.get("providerTool")!.tool.description).toBe(
+      "from props, updated",
+    );
+  });
+});

--- a/packages/core/src/core/__tests__/run-handler-webmcp.test.ts
+++ b/packages/core/src/core/__tests__/run-handler-webmcp.test.ts
@@ -272,6 +272,63 @@ describe("RunHandler WebMCP registration", () => {
     expect(second.tools.map((t) => t.name)).toContain("sayHello");
   });
 
+  it("keeps the replacement when a stale registration rejects late", async () => {
+    const registered = new Map<string, { tool: any; signal: AbortSignal }>();
+    let rejectFirst!: (error: unknown) => void;
+    const registerTool = vi.fn(
+      async (tool: any, options: { signal: AbortSignal }) => {
+        if (registered.has(tool.name)) {
+          throw new DOMException("duplicate", "InvalidStateError");
+        }
+        registered.set(tool.name, { tool, signal: options.signal });
+        options.signal.addEventListener("abort", () => {
+          registered.delete(tool.name);
+        });
+        if (tool.description === "first") {
+          // Defer this registration's outcome; the test rejects it after a
+          // replacement has already been registered.
+          await new Promise((_resolve, reject) => {
+            rejectFirst = reject;
+          });
+        }
+      },
+    );
+    vi.stubGlobal("document", { modelContext: { registerTool } });
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    const runHandler = createRunHandler();
+    runHandler.addTool({
+      name: "sayHello",
+      description: "first",
+      webmcp: true,
+    });
+
+    // Replace the tool object: the stale registration is aborted and a new
+    // one takes over while the first is still pending.
+    runHandler.removeTool("sayHello");
+    runHandler.addTool({
+      name: "sayHello",
+      description: "second",
+      webmcp: true,
+    });
+    await vi.waitFor(() => {
+      expect(registerTool).toHaveBeenCalledTimes(2);
+    });
+    expect(registered.get("sayHello")!.tool.description).toBe("second");
+
+    // The stale registration rejects after the replacement is registered.
+    // The guard must ignore it silently: the rejection belongs to a
+    // registration that was deliberately replaced.
+    rejectFirst(new Error("late failure"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // The replacement's bookkeeping survived: removeTool aborts the live
+    // registration's own signal, so the browser entry goes away.
+    runHandler.removeTool("sayHello");
+    expect(registered.has("sayHello")).toBe(false);
+  });
+
   it("executes the tool handler when a browser agent calls the tool", async () => {
     const modelContext = stubWebMCP();
     const runHandler = createRunHandler();

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -4,3 +4,4 @@ export * from "./context-store";
 export * from "./suggestion-engine";
 export * from "./run-handler";
 export * from "./state-manager";
+export * from "./webmcp";

--- a/packages/core/src/core/run-handler.ts
+++ b/packages/core/src/core/run-handler.ts
@@ -7,8 +7,7 @@ import type {
   Tool,
   ToolCall,
 } from "@ag-ui/client";
-import { randomUUID, logger, schemaToJsonSchema } from "@copilotkit/shared";
-import { zodToJsonSchema } from "zod-to-json-schema";
+import { randomUUID, logger } from "@copilotkit/shared";
 import type { CopilotKitCore, CopilotKitCoreFriendsAccess } from "./core";
 import { CopilotKitCoreErrorCode } from "./core";
 import { AgentThreadLockedError } from "../intelligence-agent";
@@ -16,6 +15,8 @@ import type { FrontendTool } from "../types";
 import { isAbortError } from "../utils/abort-error";
 import type { CopilotKitCoreContinuationHandoff } from "./state-manager";
 import { isForwardedToClientPlaceholder } from "./tool-result-content";
+import { createToolSchema } from "./tool-schema";
+import { WebMCPRegistry } from "./webmcp";
 
 export interface CopilotKitCoreRunAgentParams {
   agent: AbstractAgent;
@@ -187,6 +188,13 @@ export class RunHandler {
   private _runDepth = 0;
 
   /**
+   * Keeps tools that opt in via `webmcp` registered on the page's WebMCP model
+   * context (`document.modelContext`), in addition to the normal agent
+   * registration. Reconciled on every tool registry mutation.
+   */
+  private _webmcpRegistry = new WebMCPRegistry();
+
+  /**
    * Tracks the threadId of the most recent `connectAgent` call so we
    * can distinguish a fresh thread restore (different threadId than
    * last time — chat is rebuilding state from scratch, must clear
@@ -282,6 +290,7 @@ export class RunHandler {
     // the array the provider passed in.)
     this._propTools = [...tools];
     this._cachedMergedTools = null;
+    this.syncWebMCP();
   }
 
   /**
@@ -305,6 +314,7 @@ export class RunHandler {
 
     this._hookTools.set(key, tool);
     this._cachedMergedTools = null;
+    this.syncWebMCP();
   }
 
   /**
@@ -321,6 +331,7 @@ export class RunHandler {
       return !(tool.name === id && !tool.agentId);
     });
     this._cachedMergedTools = null;
+    this.syncWebMCP();
   }
 
   /**
@@ -353,6 +364,7 @@ export class RunHandler {
   setTools(tools: FrontendTool<any>[]): void {
     this._propTools = [...tools];
     this._cachedMergedTools = null;
+    this.syncWebMCP();
   }
 
   /**
@@ -1248,6 +1260,7 @@ export class RunHandler {
     } else {
       this._disabledToolKeys.add(key);
     }
+    this.syncWebMCP();
   }
 
   /** Whether a tool is currently enabled (not overridden off). Defaults true. */
@@ -1276,6 +1289,47 @@ export class RunHandler {
         description: tool.description ?? "",
         parameters: createToolSchema(tool),
       }));
+  }
+
+  /**
+   * Reconcile the WebMCP registrations with the current tool registry. Tools
+   * opt in via `webmcp: true` or `webmcp: { annotations }`; the same
+   * availability rules as `buildFrontendTools` apply. WebMCP tools are
+   * page-level, so unlike the agent tool list they are not filtered by
+   * agentId — a name collision across agentIds keeps the first registration.
+   */
+  private syncWebMCP(): void {
+    const desired = new Map<string, FrontendTool<any>>();
+    const warnedCollisions = new Set<string>();
+    for (const tool of this.tools) {
+      if (!tool.webmcp) {
+        continue;
+      }
+      if (tool.name === WILDCARD_TOOL_NAME) {
+        continue;
+      }
+      if (
+        tool.available === false ||
+        (tool.available as boolean | string | undefined) === "disabled"
+      ) {
+        continue;
+      }
+      if (!this.isToolEnabled(tool.name, tool.agentId)) {
+        continue;
+      }
+      if (desired.has(tool.name)) {
+        if (!warnedCollisions.has(tool.name)) {
+          warnedCollisions.add(tool.name);
+          logger.warn(
+            `[CopilotKit] Multiple WebMCP tools share the name '${tool.name}'. ` +
+              `Only the first registration is exposed to browser agents.`,
+          );
+        }
+        continue;
+      }
+      desired.set(tool.name, tool);
+    }
+    this._webmcpRegistry.sync(desired);
   }
 
   /**
@@ -1351,68 +1405,6 @@ export class RunHandler {
         );
       },
     };
-  }
-}
-
-/**
- * Empty tool schema constant
- */
-const EMPTY_TOOL_SCHEMA = {
-  type: "object",
-  properties: {},
-} as const satisfies Record<string, unknown>;
-
-/**
- * Create a JSON schema from a tool's parameters
- */
-function createToolSchema(tool: FrontendTool<any>): Record<string, unknown> {
-  if (!tool.parameters) {
-    return { ...EMPTY_TOOL_SCHEMA };
-  }
-
-  const rawSchema = schemaToJsonSchema(tool.parameters, {
-    zodToJsonSchema: (schema, options) =>
-      zodToJsonSchema(
-        schema as Parameters<typeof zodToJsonSchema>[0],
-        options as Parameters<typeof zodToJsonSchema>[1],
-      ),
-  });
-
-  if (!rawSchema || typeof rawSchema !== "object") {
-    return { ...EMPTY_TOOL_SCHEMA };
-  }
-
-  const { $schema: _$schema, ...schema } = rawSchema as Record<string, unknown>;
-
-  if (typeof schema.type !== "string") {
-    schema.type = "object";
-  }
-  if (typeof schema.properties !== "object" || schema.properties === null) {
-    schema.properties = {};
-  }
-
-  stripAdditionalProperties(schema);
-  return schema;
-}
-
-function stripAdditionalProperties(schema: unknown): void {
-  if (!schema || typeof schema !== "object") {
-    return;
-  }
-
-  if (Array.isArray(schema)) {
-    schema.forEach(stripAdditionalProperties);
-    return;
-  }
-
-  const record = schema as Record<string, unknown>;
-
-  if (record.additionalProperties !== undefined) {
-    delete record.additionalProperties;
-  }
-
-  for (const value of Object.values(record)) {
-    stripAdditionalProperties(value);
   }
 }
 

--- a/packages/core/src/core/tool-schema.ts
+++ b/packages/core/src/core/tool-schema.ts
@@ -45,6 +45,10 @@ export function createToolSchema(
   return schema;
 }
 
+/**
+ * Remove every `additionalProperties` key from a JSON schema tree, in place.
+ * Some LLM providers reject schemas that carry it.
+ */
 function stripAdditionalProperties(schema: unknown): void {
   if (!schema || typeof schema !== "object") {
     return;

--- a/packages/core/src/core/tool-schema.ts
+++ b/packages/core/src/core/tool-schema.ts
@@ -1,0 +1,67 @@
+import { schemaToJsonSchema } from "@copilotkit/shared";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { FrontendTool } from "../types";
+
+/**
+ * Empty tool schema constant
+ */
+const EMPTY_TOOL_SCHEMA = {
+  type: "object",
+  properties: {},
+} as const satisfies Record<string, unknown>;
+
+/**
+ * Create a JSON schema from a tool's parameters
+ */
+export function createToolSchema(
+  tool: FrontendTool<any>,
+): Record<string, unknown> {
+  if (!tool.parameters) {
+    return { ...EMPTY_TOOL_SCHEMA };
+  }
+
+  const rawSchema = schemaToJsonSchema(tool.parameters, {
+    zodToJsonSchema: (schema, options) =>
+      zodToJsonSchema(
+        schema as Parameters<typeof zodToJsonSchema>[0],
+        options as Parameters<typeof zodToJsonSchema>[1],
+      ),
+  });
+
+  if (!rawSchema || typeof rawSchema !== "object") {
+    return { ...EMPTY_TOOL_SCHEMA };
+  }
+
+  const { $schema: _$schema, ...schema } = rawSchema as Record<string, unknown>;
+
+  if (typeof schema.type !== "string") {
+    schema.type = "object";
+  }
+  if (typeof schema.properties !== "object" || schema.properties === null) {
+    schema.properties = {};
+  }
+
+  stripAdditionalProperties(schema);
+  return schema;
+}
+
+function stripAdditionalProperties(schema: unknown): void {
+  if (!schema || typeof schema !== "object") {
+    return;
+  }
+
+  if (Array.isArray(schema)) {
+    schema.forEach(stripAdditionalProperties);
+    return;
+  }
+
+  const record = schema as Record<string, unknown>;
+
+  if (record.additionalProperties !== undefined) {
+    delete record.additionalProperties;
+  }
+
+  for (const value of Object.values(record)) {
+    stripAdditionalProperties(value);
+  }
+}

--- a/packages/core/src/core/webmcp.ts
+++ b/packages/core/src/core/webmcp.ts
@@ -1,0 +1,165 @@
+import type { ToolCall } from "@ag-ui/client";
+import { logger, randomUUID } from "@copilotkit/shared";
+import type { FrontendTool, WebMCPToolAnnotations } from "../types";
+import { createToolSchema } from "./tool-schema";
+
+/**
+ * The subset of the WebMCP `ModelContext` API
+ * (https://webmachinelearning.github.io/webmcp/) that the registry depends on.
+ * Kept structural so the code works against the real browser API and test
+ * doubles alike. Aborting the registration signal unregisters the tool.
+ */
+export interface WebMCPModelContext {
+  registerTool(
+    tool: {
+      name: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+      execute: (
+        args: Record<string, unknown>,
+        options: { signal?: AbortSignal },
+      ) => Promise<unknown>;
+      annotations?: WebMCPToolAnnotations;
+    },
+    options: { signal: AbortSignal },
+  ): Promise<undefined>;
+}
+
+/**
+ * Return the page's `document.modelContext`, or null when WebMCP is not
+ * available (SSR, React Native, browsers without the API enabled).
+ */
+export function getWebMCPModelContext(): WebMCPModelContext | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const modelContext = (
+    document as Document & { modelContext?: WebMCPModelContext }
+  ).modelContext;
+  return modelContext ?? null;
+}
+
+interface WebMCPRegistryEntry {
+  tool: FrontendTool<any>;
+  controller: AbortController;
+}
+
+/**
+ * Keeps a set of frontend tools registered on the page's WebMCP model context.
+ *
+ * `sync(desired)` reconciles the registrations with the desired set: tools that
+ * are gone (or were re-registered with a new tool object) are unregistered by
+ * aborting their registration signal, and new tools are registered with an
+ * `execute` that delegates to the frontend tool's own handler.
+ *
+ * All WebMCP-API constraints live here so callers only supply the desired set:
+ * a tool without a description is skipped with a warning (the spec rejects
+ * empty descriptions), and failures from `registerTool` (duplicate name,
+ * unsupported context, ...) are warned rather than thrown.
+ */
+export class WebMCPRegistry {
+  private entries = new Map<string, WebMCPRegistryEntry>();
+  private warnedNames = new Set<string>();
+
+  /** Names currently kept registered on the model context. */
+  get registeredNames(): string[] {
+    return [...this.entries.keys()];
+  }
+
+  /** Reconcile the registered tools with the desired set. */
+  sync(desired: Map<string, FrontendTool<any>>): void {
+    const modelContext = getWebMCPModelContext();
+    if (!modelContext) {
+      return;
+    }
+
+    for (const [name, entry] of [...this.entries]) {
+      if (desired.get(name) !== entry.tool) {
+        entry.controller.abort();
+        this.entries.delete(name);
+      }
+    }
+
+    for (const [name, tool] of desired) {
+      if (this.entries.has(name)) {
+        continue;
+      }
+      if (!tool.description) {
+        this.warnOnce(
+          name,
+          `Skipping WebMCP registration for tool '${name}': WebMCP requires a description.`,
+        );
+        continue;
+      }
+
+      const controller = new AbortController();
+      this.entries.set(name, { tool, controller });
+      modelContext
+        .registerTool(
+          this.buildModelContextTool(
+            tool as FrontendTool<any> & { description: string },
+          ),
+          { signal: controller.signal },
+        )
+        .catch((error) => {
+          // Registration failed (duplicate name, insecure context, permission
+          // policy, ...). Drop the bookkeeping; the browser never registered.
+          this.entries.delete(name);
+          const message =
+            error instanceof Error ? error.message : String(error);
+          this.warnOnce(
+            name,
+            `WebMCP registration failed for tool '${name}': ${message}`,
+          );
+        });
+    }
+  }
+
+  private buildModelContextTool(
+    tool: FrontendTool<any> & { description: string },
+  ): {
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    execute: (
+      args: Record<string, unknown>,
+      options: { signal?: AbortSignal },
+    ) => Promise<unknown>;
+    annotations?: WebMCPToolAnnotations;
+  } {
+    const annotations =
+      typeof tool.webmcp === "object" ? tool.webmcp.annotations : undefined;
+    return {
+      name: tool.name,
+      description: tool.description,
+      inputSchema: createToolSchema(tool),
+      execute: async (args, options) => {
+        if (!tool.handler) {
+          // Mirrors core's empty tool result for a display-only tool.
+          return "";
+        }
+        const toolCall: ToolCall = {
+          id: randomUUID(),
+          type: "function",
+          function: {
+            name: tool.name,
+            arguments: JSON.stringify(args ?? {}),
+          },
+        };
+        return await tool.handler(args as any, {
+          toolCall,
+          signal: options?.signal,
+        });
+      },
+      ...(annotations ? { annotations } : {}),
+    };
+  }
+
+  private warnOnce(name: string, message: string): void {
+    if (this.warnedNames.has(name)) {
+      return;
+    }
+    this.warnedNames.add(name);
+    logger.warn(`[CopilotKit] ${message}`);
+  }
+}

--- a/packages/core/src/core/webmcp.ts
+++ b/packages/core/src/core/webmcp.ts
@@ -104,6 +104,12 @@ export class WebMCPRegistry {
         .catch((error) => {
           // Registration failed (duplicate name, insecure context, permission
           // policy, ...). Drop the bookkeeping; the browser never registered.
+          // Only delete while this is still the active registration: an
+          // aborted registration can reject after a newer one already replaced
+          // it, and that replacement's bookkeeping must survive.
+          if (this.entries.get(name)?.controller !== controller) {
+            return;
+          }
           this.entries.delete(name);
           const message =
             error instanceof Error ? error.message : String(error);
@@ -115,6 +121,11 @@ export class WebMCPRegistry {
     }
   }
 
+  /**
+   * Build the WebMCP model-context tool for a frontend tool. The `execute`
+   * callback delegates to the frontend tool's own handler, so a browser agent
+   * call runs the same application code as an agent call.
+   */
   private buildModelContextTool(
     tool: FrontendTool<any> & { description: string },
   ): {
@@ -155,6 +166,7 @@ export class WebMCPRegistry {
     };
   }
 
+  /** Log `message` once per tool name. Repeated syncs must not spam the log. */
   private warnOnce(name: string, message: string): void {
     if (this.warnedNames.has(name)) {
       return;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,10 +31,41 @@ export type {
  */
 export type FrontendToolHandlerContext = {
   toolCall: ToolCall;
-  agent: AbstractAgent;
+  /**
+   * The agent that invoked the tool. Absent when the tool is invoked through
+   * the WebMCP browser API (`document.modelContext`), which has no agent.
+   */
+  agent?: AbstractAgent;
   /** Aborted when `stopAgent()` is called. Handlers can check `signal.aborted`
    *  or pass the signal to fetch/setTimeout to cooperatively cancel. */
   signal?: AbortSignal;
+};
+
+/**
+ * Annotations for a WebMCP tool, passed through to
+ * `document.modelContext.registerTool`. Mirrors the WebMCP spec's tool
+ * annotations. These are hints for browser agents only — they do not enforce
+ * any policy on their own.
+ */
+export type WebMCPToolAnnotations = {
+  /**
+   * Hint that the tool does not modify state. Defaults to false.
+   * Set it for read-only tools (search, status lookup, ...).
+   */
+  readOnlyHint?: boolean;
+  /**
+   * Hint that the tool's output may contain untrusted content
+   * (e.g. user-generated or external content). Defaults to false.
+   */
+  untrustedContentHint?: boolean;
+};
+
+/**
+ * WebMCP registration options for a frontend tool.
+ */
+export type WebMCPToolConfig = {
+  /** Hints that tell browser agents how the tool behaves. */
+  annotations?: WebMCPToolAnnotations;
 };
 
 export type FrontendTool<
@@ -56,6 +87,19 @@ export type FrontendTool<
    * Defaults to true when not specified.
    */
   available?: boolean;
+  /**
+   * Also expose this tool to browser agents through the WebMCP API
+   * (`document.modelContext`) while keeping the normal agent registration.
+   *
+   * - `true` — register with default annotations.
+   * - `{ annotations }` — register with the given WebMCP annotations.
+   * - `false` / `undefined` — do not register.
+   *
+   * The tool's `handler` runs when a browser agent calls the tool; the handler
+   * context then has no `agent`. No-op in environments without WebMCP support
+   * (e.g. React Native, or browsers without the API enabled).
+   */
+  webmcp?: boolean | WebMCPToolConfig;
 };
 
 export type Suggestion = {

--- a/packages/react-core/src/v1-deprecated/hooks/use-frontend-tool.ts
+++ b/packages/react-core/src/v1-deprecated/hooks/use-frontend-tool.ts
@@ -69,7 +69,13 @@ export type UseFrontendToolArgs<T extends Parameter[] | [] = []> = {
   available?: "disabled" | "enabled";
 } & Pick<
   FrontendAction<T>,
-  "name" | "description" | "parameters" | "handler" | "followUp" | "render"
+  | "name"
+  | "description"
+  | "parameters"
+  | "handler"
+  | "followUp"
+  | "render"
+  | "webmcp"
 >;
 
 /**
@@ -95,7 +101,8 @@ export function useFrontendTool<const T extends Parameter[] = []>(
   tool: UseFrontendToolArgs<T>,
   dependencies?: any[],
 ) {
-  const { name, description, parameters, render, followUp, available } = tool;
+  const { name, description, parameters, render, followUp, available, webmcp } =
+    tool;
   const zodParameters = getZodParameters(parameters);
 
   const renderRef = useRef<typeof render>(render);
@@ -158,5 +165,6 @@ export function useFrontendTool<const T extends Parameter[] = []>(
     followUp,
     render: normalizedRender,
     available: available === undefined ? undefined : available !== "disabled",
+    webmcp,
   });
 }

--- a/packages/react-core/src/v1-deprecated/types/frontend-action.ts
+++ b/packages/react-core/src/v1-deprecated/types/frontend-action.ts
@@ -74,6 +74,7 @@
  */
 
 import { ActionInputAvailability } from "@copilotkit/runtime-client-gql";
+import type { WebMCPToolConfig } from "@copilotkit/core";
 import type {
   Action,
   Parameter,
@@ -237,6 +238,12 @@ export type FrontendAction<
   available?: FrontendActionAvailability;
   pairedAction?: string;
   followUp?: boolean;
+  /**
+   * Also expose this action to browser agents through the WebMCP API
+   * (`document.modelContext`). `true` uses default annotations;
+   * `{ annotations }` provides WebMCP annotations.
+   */
+  webmcp?: boolean | WebMCPToolConfig;
 } & (
     | {
         render?:

--- a/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx
@@ -194,7 +194,9 @@ describe("useFrontendTool webmcp flag", () => {
         (t) => t.name === "scopedTool" && t.agentId === "alpha",
       );
       expect(alphaTool).toBeDefined();
-      expect(alphaTool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+      expect(alphaTool!.webmcp).toEqual({
+        annotations: { readOnlyHint: true },
+      });
       const betaTool = coreRef!.tools.find(
         (t) => t.name === "scopedTool" && t.agentId === "beta",
       );
@@ -205,9 +207,9 @@ describe("useFrontendTool webmcp flag", () => {
     ui.unmount();
 
     await waitFor(() => {
-      expect(
-        coreRef!.tools.filter((t) => t.name === "scopedTool").length,
-      ).toBe(0);
+      expect(coreRef!.tools.filter((t) => t.name === "scopedTool").length).toBe(
+        0,
+      );
     });
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx
@@ -6,7 +6,6 @@ import { useCopilotKit } from "../../providers/CopilotKitProvider";
 import { ReactFrontendTool } from "../../types";
 import { CopilotKitCoreReact } from "../../lib/react-core";
 import { renderWithCopilotKit } from "../../__tests__/utils/test-helpers";
-
 /**
  * Component that captures the copilotkit core ref for test assertions.
  */
@@ -110,7 +109,9 @@ describe("useFrontendTool webmcp flag", () => {
         parameters: z.object({ data: z.string() }),
         handler: async () => ({ ok: true }),
       };
-      useFrontendTool(tool, [readOnly]);
+      // No deps: the re-registration must come from the webmcp dependency
+      // alone, not from an explicit dependency on the same state.
+      useFrontendTool(tool);
 
       return (
         <button
@@ -151,5 +152,62 @@ describe("useFrontendTool webmcp flag", () => {
     });
 
     ui.unmount();
+  });
+
+  it("registers and cleans up agent-scoped webmcp tools on the core", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolComponent: React.FC = () => {
+      useFrontendTool({
+        name: "scopedTool",
+        description: "A WebMCP tool scoped to alpha",
+        agentId: "alpha",
+        webmcp: { annotations: { readOnlyHint: true } },
+        handler: async () => ({ ok: true }),
+      });
+      useFrontendTool({
+        name: "scopedTool",
+        description: "A WebMCP tool scoped to beta",
+        agentId: "beta",
+        webmcp: true,
+        handler: async () => ({ ok: true }),
+      });
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const alphaTool = coreRef!.tools.find(
+        (t) => t.name === "scopedTool" && t.agentId === "alpha",
+      );
+      expect(alphaTool).toBeDefined();
+      expect(alphaTool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+      const betaTool = coreRef!.tools.find(
+        (t) => t.name === "scopedTool" && t.agentId === "beta",
+      );
+      expect(betaTool).toBeDefined();
+      expect(betaTool!.webmcp).toBe(true);
+    });
+
+    ui.unmount();
+
+    await waitFor(() => {
+      expect(
+        coreRef!.tools.filter((t) => t.name === "scopedTool").length,
+      ).toBe(0);
+    });
   });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useState } from "react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useFrontendTool } from "../use-frontend-tool";
+import { useCopilotKit } from "../../providers/CopilotKitProvider";
+import { ReactFrontendTool } from "../../types";
+import { CopilotKitCoreReact } from "../../lib/react-core";
+import { renderWithCopilotKit } from "../../__tests__/utils/test-helpers";
+
+/**
+ * Component that captures the copilotkit core ref for test assertions.
+ */
+const CoreCapture: React.FC<{
+  onCore: (core: CopilotKitCoreReact) => void;
+}> = ({ onCore }) => {
+  const { copilotkit } = useCopilotKit();
+  useEffect(() => {
+    onCore(copilotkit);
+  }, [copilotkit, onCore]);
+  return null;
+};
+
+describe("useFrontendTool webmcp flag", () => {
+  it("registers tool with webmcp: true on the core", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolComponent: React.FC = () => {
+      const tool: ReactFrontendTool<{ msg: string }> = {
+        name: "webmcpTool",
+        description: "A WebMCP-exposed tool",
+        webmcp: true,
+        parameters: z.object({ msg: z.string() }),
+        handler: async () => ({ result: "ok" }),
+      };
+      useFrontendTool(tool);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find((t) => t.name === "webmcpTool");
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toBe(true);
+    });
+
+    ui.unmount();
+  });
+
+  it("registers tool with webmcp annotations on the core", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolComponent: React.FC = () => {
+      const tool: ReactFrontendTool<{ msg: string }> = {
+        name: "annotatedTool",
+        description: "A WebMCP-exposed tool with annotations",
+        webmcp: { annotations: { readOnlyHint: true } },
+        parameters: z.object({ msg: z.string() }),
+        handler: async () => ({ result: "ok" }),
+      };
+      useFrontendTool(tool);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find((t) => t.name === "annotatedTool");
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+    });
+
+    ui.unmount();
+  });
+
+  it("re-registers tool when the webmcp config changes", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolWithToggle: React.FC = () => {
+      const [readOnly, setReadOnly] = useState(false);
+
+      const tool: ReactFrontendTool<{ data: string }> = {
+        name: "toggleWebmcpTool",
+        description: "A tool with a toggleable WebMCP config",
+        webmcp: { annotations: { readOnlyHint: readOnly } },
+        parameters: z.object({ data: z.string() }),
+        handler: async () => ({ ok: true }),
+      };
+      useFrontendTool(tool, [readOnly]);
+
+      return (
+        <button
+          data-testid="toggle-btn"
+          onClick={() => setReadOnly((prev) => !prev)}
+        >
+          {readOnly ? "Read-write" : "Read-only"}
+        </button>
+      );
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolWithToggle />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find((t) => t.name === "toggleWebmcpTool");
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: false } });
+    });
+
+    fireEvent.click(screen.getByTestId("toggle-btn"));
+
+    await waitFor(() => {
+      const tool = coreRef!.tools.find((t) => t.name === "toggleWebmcpTool");
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+    });
+
+    ui.unmount();
+  });
+});

--- a/packages/react-core/src/v2/hooks/use-frontend-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-frontend-tool.tsx
@@ -42,5 +42,13 @@ export function useFrontendTool<
     // Depend on stable keys by default and allow callers to opt into
     // additional dependencies for dynamic tool configuration.
     // tool.available is included so toggling availability re-registers the tool.
-  }, [tool.name, tool.available, copilotkit, JSON.stringify(extraDeps)]);
+    // tool.webmcp is compared by value (it is commonly an object literal), so
+    // a changed WebMCP config re-registers without churning on identity.
+  }, [
+    tool.name,
+    tool.available,
+    copilotkit,
+    JSON.stringify(extraDeps),
+    JSON.stringify(tool.webmcp ?? null),
+  ]);
 }

--- a/packages/vue/src/hooks/__tests__/use-frontend-tool-webmcp.test.ts
+++ b/packages/vue/src/hooks/__tests__/use-frontend-tool-webmcp.test.ts
@@ -1,0 +1,113 @@
+import { defineComponent, ref, watch } from "vue";
+import { screen, fireEvent, waitFor } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+import { useFrontendTool } from "../use-frontend-tool";
+import { useCopilotKit } from "../../v2/providers/useCopilotKit";
+import type { CopilotKitCoreVue } from "../../v2/lib/vue-core";
+import { renderWithCopilotKit } from "../../v2/__tests__/utils/test-helpers";
+
+/**
+ * Component that captures the copilotkit core ref for test assertions.
+ */
+const CoreCapture = defineComponent({
+  props: {
+    onCore: {
+      type: Function as () => (core: CopilotKitCoreVue) => void,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { copilotkit } = useCopilotKit();
+    watch(
+      copilotkit,
+      (core) => {
+        if (core) {
+          props.onCore(core);
+        }
+      },
+      { immediate: true },
+    );
+    return {};
+  },
+  template: `<div />`,
+});
+
+describe("useFrontendTool v1 webmcp pass-through", () => {
+  it("re-registers tool when a reactive webmcp getter changes", async () => {
+    let coreRef: CopilotKitCoreVue | null = null;
+
+    const ToolComponent = defineComponent({
+      setup() {
+        const readOnly = ref(false);
+
+        useFrontendTool(
+          {
+            name: "v1WebmcpTool",
+            description: "A v1 WebMCP-exposed tool",
+            handler: async () => ({ ok: true }),
+            // Expose webmcp as a getter over reactive state: the registration
+            // must re-read it when it changes, not capture the initial value.
+            get webmcp() {
+              return { annotations: { readOnlyHint: readOnly.value } };
+            },
+          },
+          [readOnly],
+        );
+
+        return {
+          readOnly,
+          toggle: () => {
+            readOnly.value = !readOnly.value;
+          },
+        };
+      },
+      template: `
+        <button data-testid="toggle-btn" @click="toggle">
+          {{ readOnly ? "Read-write" : "Read-only" }}
+        </button>
+      `,
+    });
+
+    const Host = defineComponent({
+      components: { ToolComponent, CoreCapture },
+      setup() {
+        return {
+          setCore: (core: CopilotKitCoreVue) => {
+            coreRef = core;
+          },
+        };
+      },
+      template: `
+        <div>
+          <ToolComponent />
+          <CoreCapture :on-core="setCore" />
+        </div>
+      `,
+    });
+
+    const ui = renderWithCopilotKit({
+      children: Host,
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find(
+        (entry) => entry.name === "v1WebmcpTool",
+      );
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: false } });
+    });
+
+    await fireEvent.click(screen.getByTestId("toggle-btn"));
+
+    await waitFor(() => {
+      const tool = coreRef!.tools.find(
+        (entry) => entry.name === "v1WebmcpTool",
+      );
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+    });
+
+    ui.unmount();
+  });
+});

--- a/packages/vue/src/hooks/use-copilot-action.ts
+++ b/packages/vue/src/hooks/use-copilot-action.ts
@@ -5,6 +5,7 @@
  * v2 composable (useFrontendTool, useHumanInTheLoop, or useRenderTool).
  */
 import type { WatchSource } from "vue";
+import type { WebMCPToolConfig } from "@copilotkit/core";
 import type { Parameter, MappedParameterTypes } from "@copilotkit/shared";
 import { getZodParameters, parseJson } from "@copilotkit/shared";
 import { useFrontendTool as useFrontendToolV2 } from "../v2/hooks/use-frontend-tool";
@@ -38,6 +39,12 @@ export interface FrontendAction<T extends Parameter[] | [] = []> {
   renderAndWaitForResponse?: VueFrontendTool<MappedParameterTypes<T>>["render"];
   renderAndWait?: VueFrontendTool<MappedParameterTypes<T>>["render"];
   agentId?: string;
+  /**
+   * Also expose this action to browser agents through the WebMCP API
+   * (`document.modelContext`). `true` uses default annotations;
+   * `{ annotations }` provides WebMCP annotations.
+   */
+  webmcp?: boolean | WebMCPToolConfig;
 }
 
 export interface CatchAllFrontendAction {
@@ -162,6 +169,7 @@ export function useCopilotAction<const T extends Parameter[] | [] = []>(
       render: wrapRenderWithJsonResult(typedAction.render),
       available: normalizedAvailable,
       agentId: typedAction.agentId,
+      webmcp: typedAction.webmcp,
     },
     deps,
   );

--- a/packages/vue/src/hooks/use-copilot-action.ts
+++ b/packages/vue/src/hooks/use-copilot-action.ts
@@ -169,7 +169,12 @@ export function useCopilotAction<const T extends Parameter[] | [] = []>(
       render: wrapRenderWithJsonResult(typedAction.render),
       available: normalizedAvailable,
       agentId: typedAction.agentId,
-      webmcp: typedAction.webmcp,
+      // Read webmcp at watch time: the action object may expose it as a getter
+      // over reactive state, and capturing the initial value here would
+      // re-register a stale configuration.
+      get webmcp() {
+        return typedAction.webmcp;
+      },
     },
     deps,
   );

--- a/packages/vue/src/hooks/use-frontend-tool.ts
+++ b/packages/vue/src/hooks/use-frontend-tool.ts
@@ -45,7 +45,6 @@ export function useFrontendTool<const T extends Parameter[] = []>(
     available,
     render,
     agentId,
-    webmcp,
   } = tool;
   const zodParameters = getZodParameters(parameters);
 
@@ -78,7 +77,12 @@ export function useFrontendTool<const T extends Parameter[] = []>(
       render: normalizedRender,
       available: available === undefined ? undefined : available !== "disabled",
       agentId,
-      webmcp,
+      // Read webmcp at watch time: the v1 args may expose it as a getter over
+      // reactive state, and capturing the initial value here would re-register
+      // a stale configuration.
+      get webmcp() {
+        return tool.webmcp;
+      },
     },
     deps,
   );

--- a/packages/vue/src/hooks/use-frontend-tool.ts
+++ b/packages/vue/src/hooks/use-frontend-tool.ts
@@ -5,6 +5,7 @@
  * then delegates to the v2 composable.
  */
 import type { WatchSource } from "vue";
+import type { WebMCPToolConfig } from "@copilotkit/core";
 import {
   type Parameter,
   type MappedParameterTypes,
@@ -23,6 +24,12 @@ export interface UseFrontendToolArgs<T extends Parameter[] | [] = []> {
   available?: "disabled" | "enabled";
   render?: VueFrontendTool<MappedParameterTypes<T>>["render"];
   agentId?: string;
+  /**
+   * Also expose this tool to browser agents through the WebMCP API
+   * (`document.modelContext`). `true` uses default annotations;
+   * `{ annotations }` provides WebMCP annotations.
+   */
+  webmcp?: boolean | WebMCPToolConfig;
 }
 
 export function useFrontendTool<const T extends Parameter[] = []>(
@@ -38,6 +45,7 @@ export function useFrontendTool<const T extends Parameter[] = []>(
     available,
     render,
     agentId,
+    webmcp,
   } = tool;
   const zodParameters = getZodParameters(parameters);
 
@@ -70,6 +78,7 @@ export function useFrontendTool<const T extends Parameter[] = []>(
       render: normalizedRender,
       available: available === undefined ? undefined : available !== "disabled",
       agentId,
+      webmcp,
     },
     deps,
   );

--- a/packages/vue/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.ts
@@ -209,4 +209,74 @@ describe("useFrontendTool webmcp flag", () => {
 
     ui.unmount();
   });
+
+  it("registers and cleans up agent-scoped webmcp tools on the core", async () => {
+    let coreRef: CopilotKitCoreVue | null = null;
+
+    const ToolComponent = defineComponent({
+      setup() {
+        useFrontendTool({
+          name: "scopedTool",
+          description: "A WebMCP tool scoped to alpha",
+          agentId: "alpha",
+          webmcp: { annotations: { readOnlyHint: true } },
+          handler: async () => ({ ok: true }),
+        });
+        useFrontendTool({
+          name: "scopedTool",
+          description: "A WebMCP tool scoped to beta",
+          agentId: "beta",
+          webmcp: true,
+          handler: async () => ({ ok: true }),
+        });
+        return {};
+      },
+      template: `<div />`,
+    });
+
+    const Host = defineComponent({
+      components: { ToolComponent, CoreCapture },
+      setup() {
+        return {
+          setCore: (core: CopilotKitCoreVue) => {
+            coreRef = core;
+          },
+        };
+      },
+      template: `
+        <div>
+          <ToolComponent />
+          <CoreCapture :on-core="setCore" />
+        </div>
+      `,
+    });
+
+    const ui = renderWithCopilotKit({
+      children: Host,
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const alphaTool = coreRef!.tools.find(
+        (entry) => entry.name === "scopedTool" && entry.agentId === "alpha",
+      );
+      expect(alphaTool).toBeDefined();
+      expect(alphaTool!.webmcp).toEqual({
+        annotations: { readOnlyHint: true },
+      });
+      const betaTool = coreRef!.tools.find(
+        (entry) => entry.name === "scopedTool" && entry.agentId === "beta",
+      );
+      expect(betaTool).toBeDefined();
+      expect(betaTool!.webmcp).toBe(true);
+    });
+
+    ui.unmount();
+
+    await waitFor(() => {
+      expect(
+        coreRef!.tools.filter((entry) => entry.name === "scopedTool").length,
+      ).toBe(0);
+    });
+  });
 });

--- a/packages/vue/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.ts
@@ -1,0 +1,212 @@
+import { defineComponent, ref, watch } from "vue";
+import { screen, fireEvent, waitFor } from "@testing-library/vue";
+import { z } from "zod";
+import { describe, it, expect } from "vitest";
+import { useFrontendTool } from "../use-frontend-tool";
+import { useCopilotKit } from "../../providers/useCopilotKit";
+import type { VueFrontendTool } from "../../types";
+import type { CopilotKitCoreVue } from "../../lib/vue-core";
+import { renderWithCopilotKit } from "../../__tests__/utils/test-helpers";
+
+/**
+ * Component that captures the copilotkit core ref for test assertions.
+ */
+const CoreCapture = defineComponent({
+  props: {
+    onCore: {
+      type: Function as () => (core: CopilotKitCoreVue) => void,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { copilotkit } = useCopilotKit();
+    watch(
+      copilotkit,
+      (core) => {
+        if (core) {
+          props.onCore(core);
+        }
+      },
+      { immediate: true },
+    );
+    return {};
+  },
+  template: `<div />`,
+});
+
+describe("useFrontendTool webmcp flag", () => {
+  it("registers tool with webmcp: true on the core", async () => {
+    let coreRef: CopilotKitCoreVue | null = null;
+
+    const ToolComponent = defineComponent({
+      setup() {
+        const tool: VueFrontendTool<{ msg: string }> = {
+          name: "webmcpTool",
+          description: "A WebMCP-exposed tool",
+          webmcp: true,
+          parameters: z.object({ msg: z.string() }),
+          handler: async () => ({ result: "ok" }),
+        };
+        useFrontendTool(tool);
+        return {};
+      },
+      template: `<div />`,
+    });
+
+    const Host = defineComponent({
+      components: { ToolComponent, CoreCapture },
+      setup() {
+        return {
+          setCore: (core: CopilotKitCoreVue) => {
+            coreRef = core;
+          },
+        };
+      },
+      template: `
+        <div>
+          <ToolComponent />
+          <CoreCapture :on-core="setCore" />
+        </div>
+      `,
+    });
+
+    const ui = renderWithCopilotKit({
+      children: Host,
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find((entry) => entry.name === "webmcpTool");
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toBe(true);
+    });
+
+    ui.unmount();
+  });
+
+  it("registers tool with webmcp annotations on the core", async () => {
+    let coreRef: CopilotKitCoreVue | null = null;
+
+    const ToolComponent = defineComponent({
+      setup() {
+        const tool: VueFrontendTool<{ msg: string }> = {
+          name: "annotatedTool",
+          description: "A WebMCP-exposed tool with annotations",
+          webmcp: { annotations: { readOnlyHint: true } },
+          parameters: z.object({ msg: z.string() }),
+          handler: async () => ({ result: "ok" }),
+        };
+        useFrontendTool(tool);
+        return {};
+      },
+      template: `<div />`,
+    });
+
+    const Host = defineComponent({
+      components: { ToolComponent, CoreCapture },
+      setup() {
+        return {
+          setCore: (core: CopilotKitCoreVue) => {
+            coreRef = core;
+          },
+        };
+      },
+      template: `
+        <div>
+          <ToolComponent />
+          <CoreCapture :on-core="setCore" />
+        </div>
+      `,
+    });
+
+    const ui = renderWithCopilotKit({
+      children: Host,
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find(
+        (entry) => entry.name === "annotatedTool",
+      );
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+    });
+
+    ui.unmount();
+  });
+
+  it("re-registers tool when the webmcp config changes", async () => {
+    let coreRef: CopilotKitCoreVue | null = null;
+
+    const ToolWithToggle = defineComponent({
+      setup() {
+        const readOnly = ref(false);
+
+        const tool: VueFrontendTool<{ data: string }> = {
+          name: "toggleWebmcpTool",
+          description: "A tool with a toggleable WebMCP config",
+          get webmcp() {
+            return { annotations: { readOnlyHint: readOnly.value } };
+          },
+          parameters: z.object({ data: z.string() }),
+          handler: async () => ({ ok: true }),
+        };
+        useFrontendTool(tool, [readOnly]);
+
+        return {
+          readOnly,
+          toggle: () => {
+            readOnly.value = !readOnly.value;
+          },
+        };
+      },
+      template: `
+        <button data-testid="toggle-btn" @click="toggle">
+          {{ readOnly ? "Read-write" : "Read-only" }}
+        </button>
+      `,
+    });
+
+    const Host = defineComponent({
+      components: { ToolWithToggle, CoreCapture },
+      setup() {
+        return {
+          setCore: (core: CopilotKitCoreVue) => {
+            coreRef = core;
+          },
+        };
+      },
+      template: `
+        <div>
+          <ToolWithToggle />
+          <CoreCapture :on-core="setCore" />
+        </div>
+      `,
+    });
+
+    const ui = renderWithCopilotKit({
+      children: Host,
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      const tool = coreRef!.tools.find(
+        (entry) => entry.name === "toggleWebmcpTool",
+      );
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: false } });
+    });
+
+    await fireEvent.click(screen.getByTestId("toggle-btn"));
+
+    await waitFor(() => {
+      const tool = coreRef!.tools.find(
+        (entry) => entry.name === "toggleWebmcpTool",
+      );
+      expect(tool).toBeDefined();
+      expect(tool!.webmcp).toEqual({ annotations: { readOnlyHint: true } });
+    });
+
+    ui.unmount();
+  });
+});

--- a/packages/vue/src/v2/hooks/use-frontend-tool.ts
+++ b/packages/vue/src/v2/hooks/use-frontend-tool.ts
@@ -32,6 +32,9 @@ export function useFrontendTool<T extends Record<string, unknown>>(
     [
       () => tool.name,
       () => tool.available,
+      // webmcp is commonly an object literal, so compare it by value to avoid
+      // re-registering on identity churn while still reacting to real changes.
+      () => JSON.stringify(tool.webmcp ?? null),
       () => extraDeps.length,
       ...extraDeps,
     ],

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
@@ -97,6 +97,15 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
     Optional agent scope. When set, the tool is only offered to the agent with
     this id. Cleanup on destroy is scoped to the same `agentId`.
   </PropertyReference>
+
+  <PropertyReference name="webmcp" type="boolean | { annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean } }">
+    Also expose the tool to browser agents through the WebMCP API
+    (`document.modelContext`). Pass `true` to register with default
+    annotations, or an object to register with WebMCP annotations. The same
+    `handler` runs when a browser agent calls the tool; the context then has
+    no `agent`. This is a no-op where WebMCP is not available (browsers
+    without the API enabled).
+  </PropertyReference>
 </PropertyReference>
 
 ## Return Value
@@ -112,6 +121,7 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
   renderers with the same `name` and optional `agentId`. Registrations sharing
   that key are removed together.
 - **Optional renderer.** When you pass a `component`, it is registered alongside the tool so the chat can render the tool call's progress and result.
+- **WebMCP registration.** With `webmcp` set, the tool is also registered on `document.modelContext` for as long as the owning injector is alive. The tool needs a `description` for this (WebMCP rejects tools without one).
 
 ## Usage
 

--- a/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/angular/functions/registerFrontendTool.mdx
@@ -69,8 +69,9 @@ function registerFrontendTool<Args extends Record<string, unknown>>(
       The raw AG-UI tool call metadata, including the tool call `id`.
     </PropertyReference>
 
-    <PropertyReference name="context.agent" type="AbstractAgent">
-      The agent instance that invoked the tool.
+    <PropertyReference name="context.agent" type="AbstractAgent | undefined">
+      The agent instance that invoked the tool. Absent when the tool is invoked
+      through WebMCP.
     </PropertyReference>
 
     <PropertyReference name="context.signal" type="AbortSignal | undefined">

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
@@ -69,6 +69,15 @@ function useFrontendTool<T extends Record<string, unknown>>(
   <PropertyReference name="available" type='"enabled" | "disabled" | "remote"' default='"enabled"'>
     Controls tool availability. Set to `"disabled"` to temporarily prevent the agent from calling the tool, or `"remote"` to indicate the tool is handled server-side.
   </PropertyReference>
+
+  <PropertyReference name="webmcp" type="boolean | { annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean } }">
+    Also expose the tool to browser agents through the WebMCP API
+    (`document.modelContext`). Pass `true` to register with default
+    annotations, or an object to register with WebMCP annotations. The same
+    `handler` runs when a browser agent calls the tool; the context then has
+    no `agent`. This is a no-op where WebMCP is not available (SSR, React
+    Native, or browsers without the API enabled).
+  </PropertyReference>
 </PropertyReference>
 
 <PropertyReference name="deps" type="ReadonlyArray<unknown>">
@@ -185,6 +194,33 @@ function AdminPanel({ isAdmin }: { isAdmin: boolean }) {
 }
 ```
 
+### Expose a Tool to Browser Agents (WebMCP)
+
+Pass `webmcp` to also register the tool on `document.modelContext`. Browser
+agents that support [WebMCP](https://developer.chrome.com/docs/ai/webmcp) can
+then discover and call the tool while the page is open.
+
+```tsx
+function OrderSearch() {
+  useFrontendTool({
+    name: "searchOrders",
+    description: "Search the signed-in user's orders by status",
+    parameters: z.object({
+      status: z.enum(["open", "shipped", "delivered"]),
+    }),
+    handler: async ({ status }) => {
+      const orders = await searchOrders(status);
+      return JSON.stringify(orders);
+    },
+    webmcp: {
+      annotations: { readOnlyHint: true },
+    },
+  });
+
+  return null;
+}
+```
+
 ## LangGraph agents: description vs. system_prompt
 
 For simple UI-control tools (e.g. toggling a theme), the `description` field is usually enough for a LangGraph agent to discover and call the tool at the right time. For **mandatory** tools — ones where the agent must call the tool before answering rather than reasoning from stale context — pair a clear `description` with an explicit instruction in the agent's `system_prompt`.
@@ -211,6 +247,7 @@ See [Ensuring your agent reliably calls frontend tools](/integrations/langgraph/
 - **Duplicate detection**: If a tool with the same `name` is already registered, the hook logs a warning. Only one tool per name is active at a time.
 - **Mount/Unmount lifecycle**: The tool and its optional render component are registered on mount and removed on unmount.
 - **Dependency tracking**: When `deps` is provided, the tool registration is refreshed whenever any dependency value changes, similar to `useEffect`.
+- **WebMCP registration**: With `webmcp` set, the tool is also registered on `document.modelContext` and unregistered on unmount. The tool needs a `description` for this (WebMCP rejects tools without one).
 - **Render component lifecycle**: If a `render` function is provided, it is added to the internal render tool calls registry. It receives streaming `args` (partial during `InProgress`, complete during `Executing` and `Complete`).
 - **No return value**: The hook returns `void`.
 

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
@@ -43,16 +43,20 @@ function useFrontendTool<T extends Record<string, unknown>>(
 
 <PropertyReference
   name="handler"
-  type="(args: T, context?: { toolCall, agent?, signal? }) => Promise<string>"
+  type="(args: T, context: FrontendToolHandlerContext) => Promise<unknown>"
   required
 >
   An async function that executes when the agent calls the tool. Receives the
-  validated, typed arguments and an optional context object: - `toolCall` -- the
-  raw tool call metadata - `agent` -- the agent instance that invoked the tool;
-  absent when the tool is invoked through WebMCP - `signal` -- an `AbortSignal`
-  that is aborted when the user stops the agent (via `stopAgent()` or
-  `agent.abortRun()`). Long-running handlers can check `signal.aborted` to exit
-  early.
+  validated, typed arguments and the context object:
+
+  - `toolCall` (`ToolCall`) -- the raw tool call metadata
+  - `agent` (`AbstractAgent | undefined`) -- the agent instance that invoked
+    the tool; absent when the tool is invoked through WebMCP
+  - `signal` (`AbortSignal | undefined`) -- an `AbortSignal` that is aborted
+    when the user stops the agent (via `stopAgent()` or `agent.abortRun()`).
+    Long-running handlers can check `signal.aborted` to exit early.
+
+  `FrontendToolHandlerContext` is exported from `@copilotkit/core`.
 </PropertyReference>
 
 <PropertyReference

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx
@@ -43,15 +43,16 @@ function useFrontendTool<T extends Record<string, unknown>>(
 
 <PropertyReference
   name="handler"
-  type="(args: T, context?: { toolCall, agent, signal? }) => Promise<string>"
+  type="(args: T, context?: { toolCall, agent?, signal? }) => Promise<string>"
   required
 >
   An async function that executes when the agent calls the tool. Receives the
   validated, typed arguments and an optional context object: - `toolCall` -- the
-  raw tool call metadata - `agent` -- the agent instance that invoked the tool -
-  `signal` -- an `AbortSignal` that is aborted when the user stops the agent
-  (via `stopAgent()` or `agent.abortRun()`). Long-running handlers can check
-  `signal.aborted` to exit early.
+  raw tool call metadata - `agent` -- the agent instance that invoked the tool;
+  absent when the tool is invoked through WebMCP - `signal` -- an `AbortSignal`
+  that is aborted when the user stops the agent (via `stopAgent()` or
+  `agent.abortRun()`). Long-running handlers can check `signal.aborted` to exit
+  early.
 </PropertyReference>
 
 <PropertyReference

--- a/showcase/shell-docs/src/content/reference/vue/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/vue/hooks/useFrontendTool.mdx
@@ -52,12 +52,13 @@ function useFrontendTool<T extends Record<string, unknown>>(
 
   <PropertyReference
     name="handler"
-    type="(args: T, context: { toolCall, agent, signal? }) => Promise<unknown>"
+    type="(args: T, context: { toolCall, agent?, signal? }) => Promise<unknown>"
   >
     An async function that executes when the agent calls the tool. Receives the
     validated, typed arguments and a context object: `toolCall` (the raw tool
-    call metadata), `agent` (the agent instance that invoked the tool), and
-    `signal` (an `AbortSignal` that is aborted when the user stops the agent).
+    call metadata), `agent` (the agent instance that invoked the tool; absent
+    when the tool is invoked through WebMCP), and `signal` (an `AbortSignal`
+    that is aborted when the user stops the agent).
     Long-running handlers can check `signal.aborted` or pass `signal` to
     `fetch` to cancel cooperatively. The resolved value is surfaced back to the
     agent as the tool result.

--- a/showcase/shell-docs/src/content/reference/vue/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/vue/hooks/useFrontendTool.mdx
@@ -91,6 +91,15 @@ function useFrontendTool<T extends Record<string, unknown>>(
     Whether the agent should automatically continue the run after the tool
     result is returned.
   </PropertyReference>
+
+  <PropertyReference name="webmcp" type="boolean | { annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean } }">
+    Also expose the tool to browser agents through the WebMCP API
+    (`document.modelContext`). Pass `true` to register with default
+    annotations, or an object to register with WebMCP annotations. The same
+    `handler` runs when a browser agent calls the tool; the context then has
+    no `agent`. This is a no-op where WebMCP is not available (SSR, or
+    browsers without the API enabled).
+  </PropertyReference>
 </PropertyReference>
 
 <PropertyReference name="deps" type="WatchSource<unknown>[]">
@@ -107,6 +116,7 @@ function useFrontendTool<T extends Record<string, unknown>>(
 - **Duplicate handling.** If a tool with the same `name` already exists for the same `agentId`, the previous registration is removed, the new one is added, and an override warning is logged. Only one tool per name (per agent) is active at a time.
 - **Renderer registration.** When `render` is provided, it is registered as a tool call renderer. The renderer is registered even when `parameters` is omitted, so parameter-free tools (for example confirm dialogs) can still render UI in the chat.
 - **Reactivity.** The registration re-runs when `tool.name`, `tool.available`, or any `deps` watch source changes. Pass changing reactive values through `deps`.
+- **WebMCP registration.** With `webmcp` set, the tool is also registered on `document.modelContext` and removed with the tool. The tool needs a `description` for this (WebMCP rejects tools without one).
 - **Automatic cleanup.** The tool is removed when the watch cleans up, including when the owning component scope is disposed. A `render` registered alongside the tool is intentionally left in place so earlier chat history can still render it.
 - **No return value.** The composable returns `void`.
 

--- a/showcase/shell-docs/src/content/reference/vue/hooks/useFrontendTool.mdx
+++ b/showcase/shell-docs/src/content/reference/vue/hooks/useFrontendTool.mdx
@@ -52,16 +52,17 @@ function useFrontendTool<T extends Record<string, unknown>>(
 
   <PropertyReference
     name="handler"
-    type="(args: T, context: { toolCall, agent?, signal? }) => Promise<unknown>"
+    type="(args: T, context: FrontendToolHandlerContext) => Promise<unknown>"
   >
     An async function that executes when the agent calls the tool. Receives the
-    validated, typed arguments and a context object: `toolCall` (the raw tool
+    validated, typed arguments and the context object: `toolCall` (the raw tool
     call metadata), `agent` (the agent instance that invoked the tool; absent
     when the tool is invoked through WebMCP), and `signal` (an `AbortSignal`
     that is aborted when the user stops the agent).
     Long-running handlers can check `signal.aborted` or pass `signal` to
     `fetch` to cancel cooperatively. The resolved value is surfaced back to the
-    agent as the tool result.
+    agent as the tool result. `FrontendToolHandlerContext` is exported from
+    `@copilotkit/core`.
   </PropertyReference>
 
   <PropertyReference


### PR DESCRIPTION
## What does this PR do?

Hooks can now expose a frontend tool to browser agents through the WebMCP browser API, next to the normal agent registration. Set `webmcp: true`, or pass `{ annotations }` for WebMCP hints:

```ts
useFrontendTool({
  name: "searchOrders",
  description: "Search the signed-in user's orders by status",
  parameters: z.object({ status: z.enum(["open", "shipped", "delivered"]) }),
  handler: async ({ status }) => searchOrders(status),
  webmcp: { annotations: { readOnlyHint: true } },
});
```

How it works:

1. `FrontendTool` in `@copilotkit/core` gains the `webmcp` option. A new `WebMCPRegistry` registers the tool on `document.modelContext` with its name, description, input schema, and annotations. `execute` runs the tool's own handler. The handler context has no `agent` there.
2. Every tool registry change in `RunHandler` reconciles the WebMCP registrations. The same availability rules apply as for the agent tool list. Removing a tool aborts its registration signal, and the browser then unregisters it.
3. Each adapter picks the option up from core: v2 `useFrontendTool` (React, Vue, React Native), the v1 `useCopilotAction` and `useFrontendTool` wrappers (React, Vue), and Angular's `registerFrontendTool`. Where WebMCP is not available (SSR, React Native, browsers without the API), registration is a no-op.

The `webmcp` prop is documented on the React, Vue, and Angular reference pages in shell-docs.

## Related PRs and Issues

- None.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [ ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

## Testing

**Commands run**

- `pnpm nx run-many -t check-types --projects=@copilotkit/core,@copilotkit/react-core,@copilotkit/vue,@copilotkit/angular` — all pass.
- Full test suites: core (829 tests), vue (103), and angular pass. react-core passes standalone (1589 tests). Under the lefthook pre-commit hook, react-core flakes on pre-existing e2e tests (A2UI, MCP Apps) that do not touch this code. Those tests pass when run alone.

**Manual test**

Requires Chrome 149+ with the WebMCP origin trial, or the testing flag.

1. Enable `chrome://flags/#enable-webmcp-testing`, then relaunch Chrome.
2. In an app that uses CopilotKit, register a tool with `webmcp: true`.
3. Run `await document.modelContext.getTools()` in DevTools. The tool is listed with its schema and annotations.
4. Unmount the hook. Run the command again. The tool is gone.

**How this PR makes testing easy**

The behavior has automated tests on this branch:

- `packages/core/src/core/__tests__/run-handler-webmcp.test.ts` — 15 tests with a `document.modelContext` stub: registration, annotations, unregistration, availability rules, name collisions, stale-rejection races, and handler execution.
- `packages/react-core/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.tsx` and the mirrored `packages/vue/src/v2/hooks/__tests__/use-frontend-tool-webmcp.test.ts` — pass-through, re-registration, and agent-scoped cases at the hook level.
- `packages/vue/src/hooks/__tests__/use-frontend-tool-webmcp.test.ts` — reactive `webmcp` getters through the v1 Vue API.

## Risk / rollback

Low. The feature is opt-in per tool. Without `webmcp`, no code path changes. Where WebMCP is unsupported, registration is a no-op. Revert this PR to roll back.

## Public API change

New optional `webmcp` prop on frontend tool registrations. Existing call sites do not change.

**Before**

```ts
useFrontendTool({
  name: "searchOrders",
  description: "Search orders by status",
  parameters: z.object({ status: z.string() }),
  handler: async ({ status }) => searchOrders(status),
});
```

**After**

```ts
useFrontendTool({
  name: "searchOrders",
  description: "Search orders by status",
  parameters: z.object({ status: z.string() }),
  handler: async ({ status }) => searchOrders(status),
  webmcp: { annotations: { readOnlyHint: true } },
});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can now be exposed to browser agents through WebMCP.
  * Added support for custom annotations and automatic parameter schema generation.
  * WebMCP registrations stay synchronized as tools are added, removed, enabled, or updated.
  * Available across Angular, React, and Vue tool APIs.
  * WebMCP reuses existing handlers and safely does nothing when unavailable.

* **Documentation**
  * Added usage guidance and examples for configuring WebMCP-enabled tools.
  * Documented that WebMCP invocations do not include an agent context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->