### PR TITLE
fix(showcase): redirect the legacy premium inspector and guides URLs

### DIFF
--- a/showcase/harness/src/probes/drivers/seo-redirects.ts
+++ b/showcase/harness/src/probes/drivers/seo-redirects.ts
@@ -378,6 +378,35 @@ const SPECIFIC_FRAMEWORK: RedirectEntry[] = [
     source: "/direct-to-llm/guides/mcp",
     destination: "/built-in-agent/coding-agents",
   },
+  // `/direct-to-llm/guides/premium/*` pages were deleted in cc8c945893
+  // ("refactor(docs): optimize structure, content and navigability",
+  // 2026-02-23) without redirects. The R16 `/direct-to-llm/:path*` wildcard
+  // strips the prefix and the remainder falls through to the docs home, so
+  // the page is lost rather than 404'd — quieter and harder to notice.
+  // Exact entries land each one on its current equivalent in one hop.
+  {
+    id: "INTEL-d2l-guides-overview",
+    source: "/direct-to-llm/guides/premium/overview",
+    destination: "/intelligence/overview",
+  },
+  {
+    id: "INTEL-d2l-guides-headless-ui",
+    source: "/direct-to-llm/guides/premium/headless-ui",
+    destination: "/intelligence/headless-ui",
+  },
+  {
+    // The observability page is retired; the overview is its standing
+    // destination everywhere else (INTEL-observability-*).
+    id: "INTEL-d2l-guides-observability",
+    source: "/direct-to-llm/guides/premium/observability",
+    destination: "/intelligence/overview",
+  },
+  {
+    // Inspector moved out of the Intelligence folder rather than retiring.
+    id: "INTEL-d2l-guides-inspector",
+    source: "/direct-to-llm/guides/premium/inspector",
+    destination: "/inspector",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -706,6 +735,15 @@ const RETIRED_INTELLIGENCE_REDIRECTS: RedirectEntry[] = [
     id: "INTEL-observability-root",
     source: "/premium/observability",
     destination: "/intelligence/overview",
+  },
+  // Same reason, different cause: the inspector page moved out of the folder
+  // in cc8c945893 instead of retiring, and never got a redirect. Without this
+  // entry P7 renames the legacy shell URL into a docs-host
+  // `/intelligence/inspector` that does not exist.
+  {
+    id: "INTEL-inspector-root",
+    source: "/premium/inspector",
+    destination: "/inspector",
   },
 ];
 

--- a/showcase/harness/test/fixtures/redirect-decommission/cli-stdout-human.txt
+++ b/showcase/harness/test/fixtures/redirect-decommission/cli-stdout-human.txt
@@ -1,8 +1,8 @@
 === SEO Redirect Decommission Report (last 30 days) ===
-Total redirects defined: 390
+Total redirects defined: 395
 Total hits: 12,537
 Redirects with hits: 13
-Zero-hit candidates: 377
+Zero-hit candidates: 382
 
 Top 10 most-hit redirects:
   D1                        5,432 hits
@@ -97,6 +97,11 @@ Decommission candidates (zero hits):
   FI-premium                /premium → /intelligence/overview
   FI-reference              /reference → /reference/v2
   FI-troubleshooting        /troubleshooting → /troubleshooting/common-issues
+  INTEL-d2l-guides-headless-ui /direct-to-llm/guides/premium/headless-ui → /intelligence/headless-ui
+  INTEL-d2l-guides-inspector /direct-to-llm/guides/premium/inspector → /inspector
+  INTEL-d2l-guides-observability /direct-to-llm/guides/premium/observability → /intelligence/overview
+  INTEL-d2l-guides-overview /direct-to-llm/guides/premium/overview → /intelligence/overview
+  INTEL-inspector-root      /premium/inspector → /inspector
   INTEL-observability-root  /premium/observability → /intelligence/overview
   L10                       /coagents/tutorials → /langgraph-python/tutorials
   L11                       /coagents/videos → /langgraph-python/videos

--- a/showcase/harness/test/fixtures/redirect-decommission/cli-stdout.txt
+++ b/showcase/harness/test/fixtures/redirect-decommission/cli-stdout.txt
@@ -1,8 +1,8 @@
 :bar_chart: *SEO Redirect Decommission Report* (last 30 days)
-Total redirects defined: 390
+Total redirects defined: 395
 Total hits: 12,537
 
-:warning: *377 redirect(s) with zero hits — decommission candidates:*
+:warning: *382 redirect(s) with zero hits — decommission candidates:*
   • B1
   • B2
   • B3
@@ -59,6 +59,11 @@ Total hits: 12,537
   • FI-premium
   • FI-reference
   • FI-troubleshooting
+  • INTEL-d2l-guides-headless-ui
+  • INTEL-d2l-guides-inspector
+  • INTEL-d2l-guides-observability
+  • INTEL-d2l-guides-overview
+  • INTEL-inspector-root
   • INTEL-observability-root
   • L10
   • L11

--- a/showcase/shell-docs/src/lib/__tests__/seo-redirects.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/seo-redirects.test.ts
@@ -113,6 +113,76 @@ describe("seoRedirects", () => {
     );
   });
 
+  it("redirects the moved Intelligence inspector page instead of 404ing", () => {
+    // cc8c945893 renamed `(root)/premium/inspector.mdx` to
+    // `(root)/inspector.mdx` and added no redirect, so `/premium/inspector`
+    // 404'd from 2026-02-23 on. The page still exists, so these forward to it
+    // rather than falling back to the overview.
+    expect(seoRedirects).toEqual(
+      expect.arrayContaining([
+        {
+          id: "INTEL-inspector-root",
+          source: "/premium/inspector",
+          destination: "/inspector",
+        },
+        {
+          id: "INTEL-inspector×langgraph-python",
+          source: "/langgraph-python/premium/inspector",
+          destination: "/langgraph-python/inspector",
+        },
+        {
+          // Built-in Agent is served at the root, so its destination carries
+          // no framework prefix.
+          id: "INTEL-inspector×built-in-agent",
+          source: "/built-in-agent/premium/inspector",
+          destination: "/inspector",
+        },
+      ]),
+    );
+  });
+
+  it("redirects the deleted /direct-to-llm/guides/premium pages to their current equivalents", () => {
+    // Deleted in cc8c945893 without redirects. The R16
+    // `/direct-to-llm/:path*` wildcard drops them on the docs home, which
+    // reads as a working link while serving the wrong page.
+    expect(seoRedirects).toEqual(
+      expect.arrayContaining([
+        {
+          id: "INTEL-d2l-guides-overview",
+          source: "/direct-to-llm/guides/premium/overview",
+          destination: "/intelligence/overview",
+        },
+        {
+          id: "INTEL-d2l-guides-headless-ui",
+          source: "/direct-to-llm/guides/premium/headless-ui",
+          destination: "/intelligence/headless-ui",
+        },
+        {
+          id: "INTEL-d2l-guides-observability",
+          source: "/direct-to-llm/guides/premium/observability",
+          destination: "/intelligence/overview",
+        },
+        {
+          id: "INTEL-d2l-guides-inspector",
+          source: "/direct-to-llm/guides/premium/inspector",
+          destination: "/inspector",
+        },
+      ]),
+    );
+  });
+
+  it("matches the new exact sources before the premium rename wildcard", () => {
+    // The whole point of exact entries here: INTEL-rename-wild would rewrite
+    // these to `/intelligence/inspector`, which does not exist.
+    expect(matchesSeoRedirectSource("/premium/inspector")).toBe(true);
+    expect(
+      matchesSeoRedirectSource("/langgraph-python/premium/inspector"),
+    ).toBe(true);
+    expect(
+      matchesSeoRedirectSource("/direct-to-llm/guides/premium/headless-ui"),
+    ).toBe(true);
+  });
+
   it("serves the Built-in Agent docs at the root: no redirect may capture a bare BIA page URL", () => {
     // These bare URLs render BIA-authored pages directly now. A
     // middleware entry whose source matches one of them would either

--- a/showcase/shell-docs/src/lib/seo-redirects.ts
+++ b/showcase/shell-docs/src/lib/seo-redirects.ts
@@ -465,6 +465,35 @@ const SPECIFIC_FRAMEWORK: RedirectEntry[] = [
     source: "/direct-to-llm/guides/mcp",
     destination: "/build-with-agents",
   },
+  // `/direct-to-llm/guides/premium/*` pages were deleted in cc8c945893
+  // ("refactor(docs): optimize structure, content and navigability",
+  // 2026-02-23) without redirects. The R16 `/direct-to-llm/:path*` wildcard
+  // strips the prefix and the remainder falls through to the docs home, so
+  // the page is lost rather than 404'd — quieter and harder to notice.
+  // Exact entries land each one on its current equivalent in one hop.
+  {
+    id: "INTEL-d2l-guides-overview",
+    source: "/direct-to-llm/guides/premium/overview",
+    destination: "/intelligence/overview",
+  },
+  {
+    id: "INTEL-d2l-guides-headless-ui",
+    source: "/direct-to-llm/guides/premium/headless-ui",
+    destination: "/intelligence/headless-ui",
+  },
+  {
+    // The observability page is retired; the overview is its standing
+    // destination everywhere else (INTEL-observability-*).
+    id: "INTEL-d2l-guides-observability",
+    source: "/direct-to-llm/guides/premium/observability",
+    destination: "/intelligence/overview",
+  },
+  {
+    // Inspector moved out of the Intelligence folder rather than retiring.
+    id: "INTEL-d2l-guides-inspector",
+    source: "/direct-to-llm/guides/premium/inspector",
+    destination: "/inspector",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -1023,6 +1052,22 @@ const RETIRED_INTELLIGENCE_REDIRECTS: RedirectEntry[] = [
       canonicalSlug(framework),
       "intelligence/overview",
     ),
+  })),
+  // The inspector page MOVED out of the Intelligence folder — it was not
+  // retired. cc8c945893 renamed `(root)/premium/inspector.mdx` to
+  // `(root)/inspector.mdx` (R100, identical content) and added no redirect,
+  // so `/premium/inspector` has 404'd ever since. It needs an exact entry for
+  // the same reason observability does: INTEL-rename-wild would rewrite it to
+  // a nonexistent `/intelligence/inspector`.
+  {
+    id: "INTEL-inspector-root",
+    source: "/premium/inspector",
+    destination: "/inspector",
+  },
+  ...PREMIUM_URL_FRAMEWORKS.map((framework) => ({
+    id: `INTEL-inspector×${framework}`,
+    source: `/${framework}/premium/inspector`,
+    destination: destinationPath(canonicalSlug(framework), "inspector"),
   })),
 ];
 

--- a/showcase/shell/src/lib/seo-redirects.ts
+++ b/showcase/shell/src/lib/seo-redirects.ts
@@ -414,6 +414,35 @@ const SPECIFIC_FRAMEWORK: RedirectEntry[] = [
     source: "/direct-to-llm/guides/mcp",
     destination: "/built-in-agent/coding-agents",
   },
+  // `/direct-to-llm/guides/premium/*` pages were deleted in cc8c945893
+  // ("refactor(docs): optimize structure, content and navigability",
+  // 2026-02-23) without redirects. The R16 `/direct-to-llm/:path*` wildcard
+  // strips the prefix and the remainder falls through to the docs home, so
+  // the page is lost rather than 404'd — quieter and harder to notice.
+  // Exact entries land each one on its current equivalent in one hop.
+  {
+    id: "INTEL-d2l-guides-overview",
+    source: "/direct-to-llm/guides/premium/overview",
+    destination: "/intelligence/overview",
+  },
+  {
+    id: "INTEL-d2l-guides-headless-ui",
+    source: "/direct-to-llm/guides/premium/headless-ui",
+    destination: "/intelligence/headless-ui",
+  },
+  {
+    // The observability page is retired; the overview is its standing
+    // destination everywhere else (INTEL-observability-*).
+    id: "INTEL-d2l-guides-observability",
+    source: "/direct-to-llm/guides/premium/observability",
+    destination: "/intelligence/overview",
+  },
+  {
+    // Inspector moved out of the Intelligence folder rather than retiring.
+    id: "INTEL-d2l-guides-inspector",
+    source: "/direct-to-llm/guides/premium/inspector",
+    destination: "/inspector",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -708,6 +737,15 @@ const RETIRED_INTELLIGENCE_REDIRECTS: RedirectEntry[] = [
     id: "INTEL-observability-root",
     source: "/premium/observability",
     destination: "/intelligence/overview",
+  },
+  // Same reason, different cause: the inspector page moved out of the folder
+  // in cc8c945893 instead of retiring, and never got a redirect. Without this
+  // entry P7 renames the legacy shell URL into a docs-host
+  // `/intelligence/inspector` that does not exist.
+  {
+    id: "INTEL-inspector-root",
+    source: "/premium/inspector",
+    destination: "/inspector",
   },
 ];
 


### PR DESCRIPTION
Two legacy docs URLs have been dead ends for six months. Neither has anything to do with the recent `premium/` → `intelligence/` rename — they are older, and the rename only moved where they fail.

## `/premium/inspector` — 404

`cc8c945893` ("refactor(docs): optimize structure, content and navigability", 2026-02-23) renamed `(root)/premium/inspector.mdx` to `(root)/inspector.mdx` as an `R100` rename — identical content. The page still exists and `/inspector` serves it. Only the old URL was left behind, and it has 404'd ever since. It shows up in `analytics_postgres_contacts.hs_analytics_source_data_1` as a HubSpot first-touch page, so it had real traffic.

## `/direct-to-llm/guides/premium/*` — wrong page, 200

All four pages under that path (overview, headless-ui, observability, inspector) were deleted in the same commit. The `R16` `/direct-to-llm/:path*` wildcard strips the prefix and the remainder falls through to the docs home, so the reader gets a 200 and the wrong page. That is why it went unnoticed longer than a 404 would have — nothing looks broken. `/direct-to-llm/guides/premium/headless-ui` is also in the HubSpot first-touch data.

`cc8c945893` had no redirect config to update: `seo-redirects.ts` did not exist yet. The gap is that nobody back-filled these when it was built.

## What this adds

33 exact entries:

- `INTEL-inspector-root`: `/premium/inspector` → `/inspector`
- `INTEL-inspector×<fw>`: `/<fw>/premium/inspector` → `/<canonical-fw>/inspector`, expanded over `PREMIUM_URL_FRAMEWORKS` exactly as the observability entries are
- `INTEL-d2l-guides-*`: the four `/direct-to-llm/guides/premium/*` pages, each to its current equivalent (the retired observability page goes to the overview, matching `INTEL-observability-*`)

Both hosts get them, plus the harness copy. `P7` renames `/premium/*` to a docs-host `/intelligence/*` on the way across, so without the shell entry the legacy shell URL would 301 into a docs-host 404 — the same reasoning the `INTEL-observability-root` comment already spells out. The harness driver is the declared intentional copy of the shell list and moves with it.

## Why exact entries

Middleware builds `exactMap` from every source without `:path*` and checks it before the wildcard list. `INTEL-rename-wild` would otherwise rewrite `/premium/inspector` to a nonexistent `/intelligence/inspector`. Same mechanism that makes the observability entries work today.

## Verification

- All 24 distinct destinations probed against staging: 22 return 200. `/langroid/inspector` and `/spring-ai/inspector` 404 — those two framework surfaces are not served at all, their bare roots and quickstarts 404 too, and the existing observability entries carry the same property. No reachable URL changes behavior.
- Catalogue check over all 463 exact sources: no duplicate source, no self-loop, no wildcard among the new entries.
- `showcase-harness`: 177 test files, 3728 tests pass. `showcase-scripts`: 78 files, 2543 tests pass. shell-docs lint and typecheck clean; its redirect suite goes from 10 to 13 tests.
- Decommission fixtures regenerated through the CLI with `--events-json`, not through the core module, so the byte-for-byte cross-check between CLI and core keeps its meaning. The diff is 390 → 395 defined, 377 → 382 zero-hit, plus the five new ids.

## Not verifiable in production yet

`docs.copilotkit.ai` has not been promoted since #6818 merged, so production has no `/intelligence/*` tree and serves `/premium/*` directly. Everything above was measured on staging, where the rename and its redirects are live. Reviewing these URLs against production will show the old behavior until `shell-docs` is promoted.

## Left alone

- `/integrations/direct-to-llm/guides/premium/headless-ui` also 404s, but there is no `/integrations/direct-to-llm/:path*` rule at all, so that is a wider gap about the `/integrations/*` prefix rather than this one.
- `docs/superpowers/plans/2026-08-03-ent-1173-…md` still names the old content path. It is a record of a finished plan and describes what was true then.
