### PR TITLE
test(react-core): cover partial parallel tool rendering

### DIFF
--- a/packages/react-core/src/v1-deprecated/hooks/__tests__/use-lazy-tool-renderer.test.tsx
+++ b/packages/react-core/src/v1-deprecated/hooks/__tests__/use-lazy-tool-renderer.test.tsx
@@ -69,6 +69,35 @@ describe("useLazyToolRenderer", () => {
     expect(renderToolCall).toHaveBeenCalledTimes(2);
   });
 
+  it("renders a completed parallel tool call while another is still pending", () => {
+    const renderToolCall = vi.fn(({ toolCall, toolMessage }) => {
+      if (!toolMessage) return null;
+      return (
+        <div data-testid="tool-call">
+          {toolCall.function.name}:{toolMessage.content}
+        </div>
+      );
+    });
+    vi.mocked(useRenderToolCall).mockReturnValue(renderToolCall);
+
+    const messages = [
+      message,
+      {
+        id: "time-result",
+        role: "tool",
+        toolCallId: "time-call",
+        content: "noon",
+      },
+    ] as Message[];
+    const { result } = renderHook(() => useLazyToolRenderer());
+
+    render(result.current(message, messages)!());
+
+    expect(screen.getByText("get_time:noon")).toBeTruthy();
+    expect(screen.queryByText("get_weather:")).toBeNull();
+    expect(renderToolCall).toHaveBeenCalledTimes(2);
+  });
+
   it("returns null when none of the tool calls have a renderer", () => {
     vi.mocked(useRenderToolCall).mockReturnValue(vi.fn(() => null));
     const { result } = renderHook(() => useLazyToolRenderer());


### PR DESCRIPTION
## What does this PR do?

Add regression coverage for partial completion of parallel v1 tool calls, ensuring each call is evaluated and a completed result renders independently.

## Related PRs and Issues

- Related to #2051

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [ ] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

## Reviewers

- Ben Taylor
- Rainer Hahnekamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for parallel tool-call rendering scenarios.
  - Verified that completed tool calls continue displaying their results when another call is still pending.
  - Confirmed pending calls remain empty until results are available, while all calls are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->