### PR TITLE
fix(react-core): wait for the user on humanInTheLoop provider tools

### DIFF
--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -2,8 +2,10 @@
 
 import type { AbstractAgent } from "@ag-ui/client";
 import type { FrontendTool } from "@copilotkit/core";
+import { ToolCallStatus } from "@copilotkit/core";
 import type React from "react";
 import {
+  createElement,
   useMemo,
   useCallback,
   useEffect,
@@ -88,6 +90,12 @@ const COPILOT_CLOUD_CHAT_URL = "https://api.cloud.copilotkit.ai/copilotkit/v1";
 const EMPTY_HEADERS: Readonly<Record<string, string>> = Object.freeze({});
 const EMPTY_PROPERTIES: Readonly<Record<string, unknown>> = Object.freeze({});
 const EMPTY_AGENTS: Readonly<Record<string, AbstractAgent>> = Object.freeze({});
+/** Registration name of a catch-all tool: handles any otherwise-unhandled call. */
+const WILDCARD_TOOL_NAME = "*";
+// Same message `useHumanInTheLoop` rejects with, so an aborted interrupt reads
+// identically whichever registration path declared the tool (see #5554).
+const HUMAN_IN_THE_LOOP_ABORTED_MESSAGE =
+  "Human-in-the-loop interaction aborted";
 const DEFAULT_DESIGN_SKILL = `When generating UI with generateSandboxedUi, follow these design principles inspired by shadcn/ui:
 
 - Use a minimal, flat aesthetic. Avoid drop shadows and gradients — rely on subtle borders (1px solid, light gray like #e5e7eb) to define surfaces.
@@ -506,6 +514,17 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
     frontendTools,
     "frontendTools must be a stable array. If you want to dynamically add or remove tools, use `useFrontendTool` instead.",
   );
+  /**
+   * A `humanInTheLoop` prop tool call that is parked, waiting on the user.
+   * Keyed by tool call id, so parallel calls of one tool stay independent.
+   */
+  const pendingHumanInTheLoopRef = useRef<
+    Map<
+      string,
+      { resolve: (result: unknown) => void; detachAbort?: () => void }
+    >
+  >(new Map());
+
   const humanInTheLoopList = useStableArrayProp<ReactHumanInTheLoop>(
     humanInTheLoop,
     "humanInTheLoop must be a stable array. If you want to dynamically add or remove human-in-the-loop tools, use `useHumanInTheLoop` instead.",
@@ -530,27 +549,75 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
         parameters: tool.parameters,
         followUp: tool.followUp,
         ...(tool.agentId && { agentId: tool.agentId }),
-        handler: async () => {
-          // This handler will be replaced by the hook when it runs
-          // For provider-level tools, we create a basic handler that waits for user interaction
-          return new Promise((resolve) => {
-            // The actual implementation will be handled by the render component
-            // This is a placeholder that the hook will override
-            console.warn(
-              `Human-in-the-loop tool '${tool.name}' called but no interactive handler is set up.`,
-            );
-            resolve(undefined);
+        // Park the tool call until the render calls `respond`, matching
+        // `useHumanInTheLoop`. Resolving here would hand the agent an empty
+        // result and leave the render stranded at `Complete`.
+        handler: async (_args, context) => {
+          const signal = context?.signal;
+          const key = context?.toolCall?.id ?? tool.name;
+
+          return new Promise((resolve, reject) => {
+            // Aborted before the handler ran: reject so core records an
+            // explicit error tool result instead of an empty success.
+            if (signal?.aborted) {
+              reject(new Error(HUMAN_IN_THE_LOOP_ABORTED_MESSAGE));
+              return;
+            }
+
+            const pending: {
+              resolve: (result: unknown) => void;
+              detachAbort?: () => void;
+            } = { resolve };
+            pendingHumanInTheLoopRef.current.set(key, pending);
+
+            if (signal) {
+              const onAbort = () => {
+                pendingHumanInTheLoopRef.current.delete(key);
+                reject(new Error(HUMAN_IN_THE_LOOP_ABORTED_MESSAGE));
+              };
+              signal.addEventListener("abort", onAbort, { once: true });
+              pending.detachAbort = () => {
+                signal.removeEventListener("abort", onAbort);
+              };
+            }
           });
         },
       };
       processedTools.push(frontendTool);
 
-      // Add the render component to renderToolCalls
+      // Add the render component to renderToolCalls, wrapped so it receives the
+      // full human-in-the-loop prop contract the hook path also provides.
       if (tool.render) {
+        const ToolComponent = tool.render as React.ComponentType<any>;
+        const RenderComponent: React.ComponentType<any> = (props) =>
+          createElement(ToolComponent, {
+            ...props,
+            // `props.name` is the tool actually invoked. It equals `tool.name`
+            // for a named registration; for a catch-all it is the only place
+            // the real name exists, which is what lets one render serve N tools.
+            name: tool.name === WILDCARD_TOOL_NAME ? props.name : tool.name,
+            description: tool.description || "",
+            agentId: tool.agentId,
+            // `respond` is live only while the call is executing — the one
+            // phase with a promise waiting on the user.
+            respond:
+              props.status === ToolCallStatus.Executing
+                ? async (result: unknown) => {
+                    const pending = pendingHumanInTheLoopRef.current.get(
+                      props.toolCallId,
+                    );
+                    if (!pending) return;
+                    pending.detachAbort?.();
+                    pendingHumanInTheLoopRef.current.delete(props.toolCallId);
+                    pending.resolve(result);
+                  }
+                : undefined,
+          });
+
         processedRenderToolCalls.push({
           name: tool.name,
           args: tool.parameters,
-          render: tool.render as React.ComponentType<any>,
+          render: RenderComponent,
           ...(tool.agentId && { agentId: tool.agentId }),
         });
       }

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.hitl.e2e.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.hitl.e2e.test.tsx
@@ -1,0 +1,299 @@
+import React, { useEffect } from "react";
+import { screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
+import type { ReactHumanInTheLoop } from "../../types";
+import { CopilotChat } from "../../components/chat/CopilotChat";
+import { useCopilotKit } from "../../context";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+  runStartedEvent,
+  runFinishedEvent,
+  toolCallChunkEvent,
+  testId,
+} from "../../__tests__/utils/test-helpers";
+
+/**
+ * The `humanInTheLoop` prop on the provider is a second registration path
+ * beside the `useHumanInTheLoop` hook, and it has to honor the same contract:
+ * the tool call waits for the user, `respond` is live only while the call is
+ * executing, and an aborted run rejects rather than resolving empty.
+ *
+ * These tests mount the real pipeline (CopilotChat -> tool calls view -> the
+ * provider's registered renderer) rather than invoking the renderer directly,
+ * so a mismatch between the key the handler parks under and the tool call id
+ * the pipeline supplies cannot pass.
+ */
+describe("CopilotKitProvider humanInTheLoop prop E2E", () => {
+  const bookCall = (
+    overrides: Partial<ReactHumanInTheLoop<any>> = {},
+  ): ReactHumanInTheLoop<any> => ({
+    name: "book_call",
+    description: "Pick a time slot",
+    parameters: z.object({ topic: z.string() }),
+    render: ({ status, args, result, respond, name }) => (
+      <div data-testid="hitl">
+        <div data-testid="hitl-name">{name}</div>
+        <div data-testid="hitl-status">{status}</div>
+        <div data-testid="hitl-topic">{args?.topic ?? ""}</div>
+        {result ? <div data-testid="hitl-result">{result}</div> : null}
+        {respond ? (
+          <button
+            data-testid="hitl-respond"
+            onClick={() => respond(JSON.stringify({ slot: "Tue 14:00" }))}
+          >
+            Pick
+          </button>
+        ) : null}
+      </div>
+    ),
+    ...overrides,
+  });
+
+  async function driveToolCall(
+    agent: MockStepwiseAgent,
+    toolCallName: string,
+    args: Record<string, unknown> = { topic: "waterfall project" },
+  ) {
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "book a call" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("book a call")).toBeDefined();
+    });
+
+    agent.emit(runStartedEvent());
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId: testId("tc"),
+        toolCallName,
+        parentMessageId: testId("msg"),
+        delta: JSON.stringify(args),
+      }),
+    );
+  }
+
+  it("waits for the user and completes with the response", async () => {
+    const agent = new MockStepwiseAgent();
+
+    renderWithCopilotKit({
+      agent,
+      humanInTheLoop: [bookCall()],
+      children: (
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      ),
+    });
+
+    await driveToolCall(agent, "book_call");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hitl-status").textContent).toBe(
+        ToolCallStatus.InProgress,
+      );
+      expect(screen.getByTestId("hitl-topic").textContent).toBe(
+        "waterfall project",
+      );
+    });
+
+    // The stream ends here, which is where the reported bug showed itself: the
+    // render must stay on screen and interactive, waiting on the user.
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    const respondButton = await screen.findByTestId("hitl-respond");
+    expect(screen.getByTestId("hitl-status").textContent).toBe(
+      ToolCallStatus.Executing,
+    );
+
+    fireEvent.click(respondButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hitl-status").textContent).toBe(
+        ToolCallStatus.Complete,
+      );
+      expect(screen.getByTestId("hitl-result").textContent).toContain(
+        "Tue 14:00",
+      );
+    });
+  });
+
+  it("passes the invoked tool name to a wildcard registration", async () => {
+    const agent = new MockStepwiseAgent();
+
+    renderWithCopilotKit({
+      agent,
+      humanInTheLoop: [bookCall({ name: "*" })],
+      children: (
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      ),
+    });
+
+    await driveToolCall(agent, "deleteFile", { topic: "cleanup" });
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    await screen.findByTestId("hitl-respond");
+    // A catch-all registration is named "*", which is not the name of anything
+    // the agent called. The render has to see the tool it is approving.
+    expect(screen.getByTestId("hitl-name").textContent).toBe("deleteFile");
+  });
+
+  it("hands off from one call of a tool to the next, resolving each on its own", async () => {
+    const agent = new MockStepwiseAgent();
+    const firstId = testId("tc-a");
+    const secondId = testId("tc-b");
+
+    renderWithCopilotKit({
+      agent,
+      humanInTheLoop: [
+        {
+          ...bookCall(),
+          render: ({ status, args, result, respond }: any) => (
+            <div data-testid={`hitl-${args?.topic ?? "none"}`}>
+              <div data-testid={`status-${args?.topic}`}>{status}</div>
+              {result ? (
+                <div data-testid={`result-${args?.topic}`}>{result}</div>
+              ) : null}
+              {respond ? (
+                <button
+                  data-testid={`respond-${args?.topic}`}
+                  onClick={() =>
+                    respond(JSON.stringify({ picked: args.topic }))
+                  }
+                >
+                  Pick
+                </button>
+              ) : null}
+            </div>
+          ),
+        },
+      ],
+      children: (
+        <div style={{ height: 400 }}>
+          <CopilotChat welcomeScreen={false} />
+        </div>
+      ),
+    });
+
+    const input = await screen.findByRole("textbox");
+    fireEvent.change(input, { target: { value: "book two calls" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+    await waitFor(() => {
+      expect(screen.getByText("book two calls")).toBeDefined();
+    });
+
+    const parentMessageId = testId("msg");
+    agent.emit(runStartedEvent());
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId: firstId,
+        toolCallName: "book_call",
+        parentMessageId,
+        delta: JSON.stringify({ topic: "alpha" }),
+      }),
+    );
+    agent.emit(
+      toolCallChunkEvent({
+        toolCallId: secondId,
+        toolCallName: "book_call",
+        parentMessageId,
+        delta: JSON.stringify({ topic: "beta" }),
+      }),
+    );
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    // Core executes the tool calls of one message in order, so only the first
+    // is waiting on the user at this point.
+    const alphaButton = await screen.findByTestId("respond-alpha");
+    expect(screen.queryByTestId("respond-beta")).toBeNull();
+    expect(screen.getByTestId("status-beta").textContent).toBe(
+      ToolCallStatus.InProgress,
+    );
+
+    fireEvent.click(alphaButton);
+
+    // Answering the first call resolves that call and hands off to the second,
+    // which then gets its own live respond. A resolver keyed by anything but
+    // the tool call id would either resolve the wrong promise here or strand
+    // the second call with no way to answer it.
+    await waitFor(() => {
+      expect(screen.getByTestId("status-alpha").textContent).toBe(
+        ToolCallStatus.Complete,
+      );
+      expect(screen.getByTestId("result-alpha").textContent).toContain("alpha");
+    });
+
+    const betaButton = await screen.findByTestId("respond-beta");
+    expect(screen.getByTestId("status-beta").textContent).toBe(
+      ToolCallStatus.Executing,
+    );
+
+    fireEvent.click(betaButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-beta").textContent).toBe(
+        ToolCallStatus.Complete,
+      );
+      expect(screen.getByTestId("result-beta").textContent).toContain("beta");
+    });
+  });
+
+  it("rejects the parked promise with an error tool result when the run is aborted", async () => {
+    // Same contract as #5554 on the hook path: an abort while the user is being
+    // waited on must record an explicit error, not an empty success.
+    const agent = new MockStepwiseAgent();
+    const toolExecutionEnds: Array<{ result: string; error?: string }> = [];
+
+    const Subscriber: React.FC = () => {
+      const { copilotkit } = useCopilotKit();
+      useEffect(() => {
+        const subscription = copilotkit.subscribe({
+          onToolExecutionEnd: ({ result, error }) => {
+            toolExecutionEnds.push({ result, error });
+          },
+        });
+        return () => subscription.unsubscribe();
+      }, [copilotkit]);
+      return null;
+    };
+
+    renderWithCopilotKit({
+      agent,
+      humanInTheLoop: [bookCall()],
+      children: (
+        <>
+          <Subscriber />
+          <div style={{ height: 400 }}>
+            <CopilotChat welcomeScreen={false} />
+          </div>
+        </>
+      ),
+    });
+
+    await driveToolCall(agent, "book_call");
+
+    agent.emit(runFinishedEvent());
+    agent.complete();
+
+    await screen.findByTestId("hitl-respond");
+
+    act(() => {
+      agent.abortRun();
+    });
+
+    await waitFor(() => {
+      expect(toolExecutionEnds.length).toBeGreaterThan(0);
+      const last = toolExecutionEnds[toolExecutionEnds.length - 1];
+      expect(last.error).toBeDefined();
+      expect(last.error).toContain("aborted");
+    });
+  });
+});

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from "react-dom/client";
 import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
 import { HttpAgent } from "@ag-ui/client";
@@ -359,10 +360,23 @@ describe("CopilotKitProvider", () => {
         (rc) => rc.name === "approvalTool",
       );
       expect(approvalTool).toBeDefined();
-      expect(approvalTool?.render).toBe(TestComponent);
+      // The registered render is a wrapper that supplies the human-in-the-loop
+      // prop contract, so assert that it renders the caller's component rather
+      // than comparing identity.
+      const Registered = approvalTool!.render;
+      const { getByText } = render(
+        <Registered
+          name="approvalTool"
+          toolCallId="tc-1"
+          args={{}}
+          status={ToolCallStatus.InProgress}
+          result={undefined}
+        />,
+      );
+      expect(getByText("Test")).toBeDefined();
     });
 
-    it("creates placeholder handlers for humanInTheLoop tools", async () => {
+    it("keeps a humanInTheLoop tool call waiting instead of resolving it", async () => {
       const TestComponent: React.FC<any> = () => <div>Test</div>;
       const humanInTheLoopTools: ReactHumanInTheLoop[] = [
         {
@@ -388,19 +402,18 @@ describe("CopilotKitProvider", () => {
       })?.handler;
       expect(handler).toBeDefined();
 
-      // Call the handler and check for warning
-      const handlerPromise = handler!({ data: "test" }, {} as any);
+      const settled = vi.fn();
+      void handler!({ data: "test" }, {
+        toolCall: { id: "tc-1", function: { name: "interactiveTool" } },
+      } as any).then(settled, settled);
 
-      await waitFor(() => {
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          expect.stringContaining(
-            "Human-in-the-loop tool 'interactiveTool' called",
-          ),
-        );
-      });
-
-      const result2 = await handlerPromise;
-      expect(result2).toBeUndefined();
+      // The handler parks until the render calls `respond`. It must not settle
+      // on its own, and it must not warn: waiting is the contract, not a gap.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(settled).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("no interactive handler is set up"),
+      );
     });
 
     it("warns when humanInTheLoop prop changes", async () => {
@@ -575,8 +588,20 @@ describe("CopilotKitProvider", () => {
       expect(directRenderTool).toBeDefined();
 
       expect(frontendRenderTool?.render).toBe(TestComponent1);
-      expect(humanRenderTool?.render).toBe(TestComponent2);
       expect(directRenderTool?.render).toBe(TestComponent3);
+      // A humanInTheLoop render is wrapped to receive `respond`, so check that
+      // the wrapper renders the caller's component instead of its identity.
+      const HumanRender = humanRenderTool!.render;
+      const { getByText } = render(
+        <HumanRender
+          name="humanRenderTool"
+          toolCallId="tc-1"
+          args={{}}
+          status={ToolCallStatus.InProgress}
+          result={undefined}
+        />,
+      );
+      expect(getByText("Test2")).toBeDefined();
     });
   });
 

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.wildcard.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.wildcard.test.tsx
@@ -1,7 +1,8 @@
-import { renderHook } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
 import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { ToolCallStatus } from "@copilotkit/core";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
 import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
@@ -118,8 +119,11 @@ describe("CopilotKitProvider - Wildcard Tool", () => {
 
   describe("Wildcard Human-in-the-Loop", () => {
     it("should register wildcard human-in-the-loop tool", () => {
-      const WildcardComponent: React.FC<any> = ({ args }) => (
-        <div>Unknown interaction: {args.toolName}</div>
+      const WildcardComponent: React.FC<any> = ({ name, respond }) => (
+        <div>
+          <span data-testid="wildcard-name">{name}</span>
+          <span data-testid="wildcard-respond">{typeof respond}</span>
+        </div>
       );
 
       const wildcardHitl: ReactHumanInTheLoop = {
@@ -147,7 +151,21 @@ describe("CopilotKitProvider - Wildcard Tool", () => {
         (rc) => rc.name === "*",
       );
       expect(wildcardRender).toBeDefined();
-      expect(wildcardRender?.render).toBe(WildcardComponent);
+      // The registered render is the provider's wrapper, which supplies
+      // `respond` and forwards the invoked tool name. Assert both, since the
+      // invoked name is the whole point of a catch-all registration.
+      const Registered = wildcardRender!.render;
+      const { getByTestId } = render(
+        <Registered
+          name="deleteFile"
+          toolCallId="tc-1"
+          args={{ toolName: "deleteFile", args: {} }}
+          status={ToolCallStatus.Executing}
+          result={undefined}
+        />,
+      );
+      expect(getByTestId("wildcard-name").textContent).toBe("deleteFile");
+      expect(getByTestId("wildcard-respond").textContent).toBe("function");
     });
 
     it("should support wildcard human-in-the-loop with agentId", () => {


### PR DESCRIPTION
## Summary

A human-in-the-loop tool declared through the `humanInTheLoop` **prop** on `<CopilotKitProvider>` never waited for the user. The handler resolved `undefined` the moment the agent invoked it, and the renderer was registered unwrapped, so it never received a working `respond`. The card appeared once at `Complete` over dead controls while the agent was told the tool had succeeded.

This is not a regression. The placeholder handler is unchanged since the first v2 provider commit (`a2ef51aaf3`, #2794), so this documented prop has never waited. The reference page describes it as self-sufficient: "Declarative human-in-the-loop tool definitions. Each becomes both a tool handler and a tool call renderer." The `useHumanInTheLoop` hook path is unaffected and has always worked.

## Changes

`packages/react-core/src/v2/providers/CopilotKitProvider.tsx`, matching `useHumanInTheLoop`:

- park the tool call until the render calls `respond`, keyed by tool call id so one call of a tool cannot resolve another
- wrap the registered renderer so it receives the full prop contract, with `respond` live only while the status is `Executing`
- reject with `Human-in-the-loop interaction aborted` on abort, so core records an explicit error tool result rather than an empty success (#5554)
- keep the invoked tool's name for a wildcard (`"*"`) registration instead of overwriting it with `"*"`

Two existing unit tests asserted the placeholder behavior (the `console.warn`, and render identity). They now assert the waiting contract and that the wrapper renders the caller's component.

## Testing

**New: `CopilotKitProvider.hitl.e2e.test.tsx` (4 tests).** These mount the real pipeline — `CopilotChat` -> tool calls view -> the provider's registered renderer — rather than calling the renderer directly, so a mismatch between the key the handler parks under and the tool call id the pipeline supplies cannot pass.

All four fail on `main` for the right reason (`Unable to find an element by: [data-testid="hitl-respond"]` — the respond button never appears), and pass with the change.

Each mechanism was mutation-checked separately:

| Mutation | Result |
| -- | -- |
| handler resolves immediately (the old placeholder) | all 4 fail |
| renderer registered unwrapped | all 4 fail |
| wildcard branch removed | only the wildcard test fails |
| park under the tool name instead of the tool call id | the 2 tests needing a live `respond` fail |

**Suite, types, format**

```
$ node ../../node_modules/vitest/vitest.mjs run src/v2/providers/__tests__/
 Test Files  17 passed (17)
      Tests  173 passed (173)

$ tsc --noEmit
(clean)
```

`oxfmt` applied to every changed file. The full `react-core` run also has 7 failures across `CopilotChatView.pinToSend.test.tsx` and `use-pin-to-send.test.tsx` (`ResizeObserver is not a constructor`). Those are pre-existing: I removed this change from the working tree and ran those two files on clean `main`, and they fail identically.

**Live, in `examples/v2/react/demo` against a real agent and a rebuilt dist**

| Page | Before | After |
| -- | -- | -- |
| provider prop, multi-route REST | card at `complete`, `respond` undefined, console warned, agent said "Please pick a time slot in the scheduler UI to confirm" over disabled buttons | parks at `executing` with live buttons for 17s, then "Booked a call with Sam about the Waterfall project meeting for Tue 14:00" |
| provider prop, single route | same, and worse: "…has been scheduled" before anyone approved | parks, then reports the slot actually chosen (Wed 09:30) |
| `useHumanInTheLoop` hook, multi-route REST | already correct | unchanged: `inProgress` -> `executing` -> `complete` with the chosen slot reaching the agent |

## Credit

@Tushar-Khandelwal-2004 diagnosed this path and implemented the parking handler and the abort semantics first, in #4955. That PR predates the wildcard-name work and the current `main`, and its review asks were still open, so this lands the same fix rebased on `main` with the wildcard branch and pipeline-level tests added. #4955 is now closed in favor of this PR, with the credit staying with them.

## Related

- #4955 — the earlier implementation of this fix (closed in favor of this PR)
- #6527 — the identical Vue defect; the two changes agree on semantics
- #4953 — the reporter hit the hook path, which does not reproduce on `main`; this is the confirmed provider-prop half of that report

Angular already implements this path (`addHumanInTheLoop` -> `#hitl.onResult`), so React was the last framework missing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-in-the-loop tool calls now pause until a user responds.
  * Interactive renderers receive tool metadata and a callback for submitting responses.
  * Wildcard tools display the specific tool name that was invoked.
  * Aborted tool calls now return a clear error result.

* **Bug Fixes**
  * Multiple pending tool calls can be resolved independently by their call ID.
  * Interactive handlers no longer emit an unnecessary warning while awaiting a response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
