### PR TITLE
chore(react-textarea): mark CopilotTextarea declarations as deprecated

### DIFF
--- a/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
+++ b/packages/react-textarea/src/components/copilot-textarea/copilot-textarea.tsx
@@ -123,6 +123,14 @@ import type { AutosuggestionsConfigUserSpecified } from "../../types/autosuggest
 
 // Like the base copilot textarea props,
 // but with baseAutosuggestionsConfig replaced with autosuggestionsConfig.
+/**
+ * @deprecated Since 1.68.2. The v1 SDK is deprecated. Use v2 instead.
+ * No 1:1 v2 replacement is available.
+ * Start with `@copilotkit/react-core/v2`.
+ * V2 docs: https://docs.copilotkit.ai/
+ * V2 reference docs: https://docs.copilotkit.ai/reference/v2
+ * Migration guide: https://docs.copilotkit.ai/migrate/v2
+ */
 export interface CopilotTextareaProps extends Omit<
   BaseCopilotTextareaProps,
   "baseAutosuggestionsConfig"
@@ -191,6 +199,13 @@ export interface CopilotTextareaProps extends Omit<
 
 /**
  * A copilot textarea that uses the standard autosuggestions function.
+ *
+ * @deprecated Since 1.68.2. The v1 SDK is deprecated. Use v2 instead.
+ * No 1:1 v2 replacement is available.
+ * Start with `@copilotkit/react-core/v2`.
+ * V2 docs: https://docs.copilotkit.ai/
+ * V2 reference docs: https://docs.copilotkit.ai/reference/v2
+ * Migration guide: https://docs.copilotkit.ai/migrate/v2
  */
 export const CopilotTextarea = React.forwardRef(
   (props: CopilotTextareaProps, ref: React.Ref<HTMLCopilotTextAreaElement>) => {


### PR DESCRIPTION
Fixes #6819.

The package root already emits generated deprecation notices, but the source declarations did not carry @deprecated JSDoc, so consumers on the components barrel or deep imports missed the IDE warning. This adds the exact existing notice (v1 deprecated since 1.68.2, no 1:1 v2 replacement, start with @copilotkit/react-core/v2 + docs links) to CopilotTextarea and CopilotTextareaProps in copilot-textarea.tsx. JSDoc only; no runtime change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the Copilot Textarea component and its props as deprecated.
  * Directed users to the version 2 replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->