### PR TITLE
feat(angular): add explicitEffect helper with explicit dependency tracking

### DIFF
--- a/packages/angular/src/lib/active-thread-connector.ts
+++ b/packages/angular/src/lib/active-thread-connector.ts
@@ -1,7 +1,8 @@
-import { effect, untracked, type Signal } from "@angular/core";
+import { type Signal } from "@angular/core";
 import { HttpAgent, type AbstractAgent } from "@ag-ui/client";
 import type { AgentStore } from "./agent";
 import type { CopilotChatConfiguration } from "./chat-configuration";
+import { explicitEffect } from "./explicit-effect";
 
 /**
  * Signature of `CopilotKitCore.connectAgent`, injected for testability.
@@ -61,9 +62,9 @@ export interface ConnectActiveThreadCursorHooks {
  *   initial mount nor on an agent-store swap that leaves the thread id unchanged
  *   (which would otherwise wipe a resumed/shared agent's existing history).
  *
- * Tracked reads happen in the effect's reactive scope; all mutation and the
- * connect call run inside `untracked()` so they do not register as
- * dependencies (mirrors the effect/untracked idiom in `threads.ts`).
+ * Tracked reads (`threadId`, explicit flag, store) are declared in the
+ * {@link explicitEffect} tracker; all mutation and the connect call run
+ * untracked so they do not register as dependencies.
  *
  * @param config - The chat configuration exposing the resolved thread signals.
  * @param agentStore - Signal yielding the current {@link AgentStore}.
@@ -82,11 +83,13 @@ export function connectActiveThread(
   // unchanged. Clearing only on a real transition prevents wiping a
   // resumed/shared agent's existing message history.
   let lastThreadId: string | undefined;
-  effect((onCleanup) => {
-    const threadId = config.threadId();
-    const explicit = config.hasExplicitThreadId();
-    const store = agentStore();
-    untracked(() => {
+  explicitEffect(
+    () => ({
+      threadId: config.threadId(),
+      explicit: config.hasExplicitThreadId(),
+      store: agentStore(),
+    }),
+    ({ threadId, explicit, store }, onCleanup) => {
       const agent = store.agent;
       agent.threadId = threadId;
       if (explicit) {
@@ -127,6 +130,6 @@ export function connectActiveThread(
         agent.setMessages([]);
       }
       lastThreadId = threadId;
-    });
-  });
+    },
+  );
 }

--- a/packages/angular/src/lib/explicit-effect.spec.ts
+++ b/packages/angular/src/lib/explicit-effect.spec.ts
@@ -1,0 +1,84 @@
+import { runInInjectionContext, signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { test, expect, vi } from "vitest";
+import { explicitEffect } from "./explicit-effect";
+
+function setup() {
+  TestBed.configureTestingModule({});
+}
+
+test("re-runs when a tracked signal changes", async () => {
+  setup();
+  const source = signal("a");
+  const seen: string[] = [];
+
+  TestBed.runInInjectionContext(() => {
+    explicitEffect(
+      () => source(),
+      (value) => {
+        seen.push(value);
+      },
+    );
+  });
+  TestBed.flushEffects();
+  await Promise.resolve();
+
+  source.set("b");
+  TestBed.flushEffects();
+  await Promise.resolve();
+
+  expect(seen).toEqual(["a", "b"]);
+});
+
+test("ignores signals read only inside run", async () => {
+  setup();
+  const tracked = signal(1);
+  const ignored = signal("x");
+  const run = vi.fn();
+
+  TestBed.runInInjectionContext(() => {
+    explicitEffect(
+      () => tracked(),
+      () => {
+        // Reading `ignored` here must not subscribe the effect to it.
+        void ignored();
+        run();
+      },
+    );
+  });
+  TestBed.flushEffects();
+  await Promise.resolve();
+
+  ignored.set("y");
+  TestBed.flushEffects();
+  await Promise.resolve();
+
+  expect(run).toHaveBeenCalledTimes(1);
+});
+
+test("runs cleanup before re-running and on destroy", async () => {
+  setup();
+  const source = signal(0);
+  const cleaned: number[] = [];
+
+  const ref = TestBed.runInInjectionContext(() =>
+    explicitEffect(
+      () => source(),
+      (value, onCleanup) => {
+        onCleanup(() => {
+          cleaned.push(value);
+        });
+      },
+    ),
+  );
+  TestBed.flushEffects();
+  await Promise.resolve();
+
+  source.set(1);
+  TestBed.flushEffects();
+  await Promise.resolve();
+  expect(cleaned).toEqual([0]);
+
+  ref.destroy();
+  expect(cleaned).toEqual([0, 1]);
+});

--- a/packages/angular/src/lib/explicit-effect.ts
+++ b/packages/angular/src/lib/explicit-effect.ts
@@ -1,0 +1,30 @@
+import {
+  effect,
+  untracked,
+  type EffectCleanupRegisterFn,
+  type EffectRef,
+} from "@angular/core";
+
+/**
+ * Runs an Angular effect with explicit dependency tracking.
+ *
+ * Signals read inside `track` are the effect's only dependencies; `run`
+ * always executes in an untracked context, so signals read there never
+ * trigger a re-run. This makes the reactive inputs visible at the call site
+ * instead of hiding them inside a large effect body.
+ *
+ * @param track - Reactive computation returning the value `run` receives.
+ * Any signals read here are tracked.
+ * @param run - Imperative execution receiving the tracked value and the
+ * effect's `onCleanup` hook. Always runs untracked.
+ * @returns The underlying {@link EffectRef}.
+ */
+export function explicitEffect<T>(
+  track: () => T,
+  run: (tracked: T, onCleanup: EffectCleanupRegisterFn) => void,
+): EffectRef {
+  return effect((onCleanup) => {
+    const tracked = track();
+    untracked(() => run(tracked, onCleanup));
+  });
+}

--- a/packages/angular/src/lib/threads.ts
+++ b/packages/angular/src/lib/threads.ts
@@ -26,6 +26,7 @@ import type {
   ɵThreadStore,
 } from "@copilotkit/core";
 import { CopilotKit } from "./copilotkit";
+import { explicitEffect } from "./explicit-effect";
 
 /**
  * A conversation thread managed by CopilotKit Intelligence.
@@ -321,10 +322,9 @@ export class ThreadsStore implements InjectThreadsResult {
     // route realtime/agent-driven thread updates to it. Re-runs when the agent
     // id changes; the previous registration is cleared first.
     let registeredAgentId: string | undefined;
-    effect(() => {
-      const nextAgentId = agentId();
-      const enabled = isEnabled();
-      untracked(() => {
+    explicitEffect(
+      () => ({ nextAgentId: agentId(), enabled: isEnabled() }),
+      ({ nextAgentId, enabled }) => {
         // Disabled (e.g. unlicensed): ensure this store is NOT registered. The
         // registry is single-slot/last-writer-wins, so an inert store claiming
         // the agentId slot would evict — and on destroy tear down — a co-mounted
@@ -344,8 +344,8 @@ export class ThreadsStore implements InjectThreadsResult {
         }
         this.#copilotkit.core.registerThreadStore(nextAgentId, this.#store);
         registeredAgentId = nextAgentId;
-      });
-    });
+      },
+    );
 
     // Sync the runtime context. Defer until the runtime reports Connected so
     // the initial context carries `intelligence.wsUrl` and avoids a redundant


### PR DESCRIPTION
Fixes #6561.

Adds an internal xplicitEffect(track, run) helper to @copilotkit/angular: signals read in 	rack are the effect's only dependencies, while un always executes untracked receiving the tracked value and onCleanup.

Converts two call sites as proof (thread-store registration in 	hreads.ts, active-thread connector) with identical behavior, and adds xplicit-effect.spec.ts (re-runs on tracked change, ignores run-only reads, cleanup on re-run/destroy). Internal only: not exported from public-api.ts. No deps installed locally, so relying on CI for type checks and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Angular `explicitEffect` utility that lets developers declare reactive dependencies separately from effect execution.
  * Effect callbacks now avoid unintended subscriptions to signals read during execution.

* **Improvements**
  * Updated thread and active-thread handling to use explicit dependency tracking while preserving existing connection, registration, cleanup, and disabled-state behavior.

* **Tests**
  * Added coverage for tracked updates, ignored incidental signal reads, and cleanup during reruns and destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->