### PR TITLE
docs: name the selected frontend in the copied onboarding prompt

### DIFF
--- a/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/[framework]/[[...slug]]/page.tsx
@@ -61,6 +61,7 @@ import { resolveChannelGuideRoute } from "@/lib/channel-guide-routes";
 import type { ChannelFrontend } from "@/lib/channel-guide-routes";
 import { transformerMeta } from "@/lib/rehype-code-meta";
 import { onboardingFrameworkFor } from "@/lib/docs-onboarding-framework";
+import { onboardingFrontendFor } from "@/lib/docs-onboarding-frontend";
 import {
   CONTENT_DIR,
   buildFrameworkNav,
@@ -670,6 +671,9 @@ export default async function FrameworkScopedDocsPage({
           )}
           frameworkOverride={resolution.framework}
           onboardingFramework={onboardingFrameworkFor(resolution.framework)}
+          // `framework` is the URL's first segment and this branch has already
+          // narrowed it to `angular`, so the URL is what names the frontend.
+          onboardingFrontend={onboardingFrontendFor(`/${framework}`)}
           frontendOverride="angular"
           navTree={getAngularDocsNavTree(activeBackendFramework)}
           sidebarBannerSlot={<FrontendSidebarBanner frontend={framework} />}
@@ -717,6 +721,9 @@ export default async function FrameworkScopedDocsPage({
           onboardingFramework={onboardingFrameworkFor(
             activeBackendFramework ?? ROOT_FRAMEWORK,
           )}
+          // Inside `isFrontendPageId(framework)`, so the URL's first segment
+          // is the frontend the reader selected.
+          onboardingFrontend={onboardingFrontendFor(`/${framework}`)}
           frontendOverride={framework}
           navTree={getFrontendQuickstartNavTree(framework)}
           sidebarBannerSlot={<FrontendSidebarBanner frontend={framework} />}
@@ -955,6 +962,12 @@ export default async function FrameworkScopedDocsPage({
       slugHrefPrefix={scopedSlugHrefPrefix ?? `/${scopedFramework}`}
       frameworkOverride={scopedFramework}
       onboardingFramework={onboardingFrameworkFor(scopedFramework)}
+      // The page's own URL prefix: `/vue/mastra` on a frontend route,
+      // `/mastra` off one. Only its first segment can name a frontend, so a
+      // backend-only prefix resolves to the default React frontend.
+      onboardingFrontend={onboardingFrontendFor(
+        scopedSlugHrefPrefix ?? `/${scopedFramework}`,
+      )}
       frontendOverride={activeFrontendPage ?? undefined}
       navTree={
         activeFrontendPage
@@ -996,6 +1009,9 @@ function ChannelGuideDocsPage({
       onboardingFramework={onboardingFrameworkFor(
         activeBackendFramework ?? ROOT_FRAMEWORK,
       )}
+      // `frontend` is the URL's first segment on every route that reaches
+      // these components, so this is the frontend the URL asserts.
+      onboardingFrontend={onboardingFrontendFor(`/${frontend}`)}
       frontendOverride={frontend}
       navTree={getFrontendQuickstartNavTree(frontend)}
       sidebarBannerSlot={<FrontendSidebarBanner frontend={frontend} />}
@@ -1033,6 +1049,9 @@ function FrontendQuickstartDocsPage({
       onboardingFramework={onboardingFrameworkFor(
         activeBackendFramework ?? ROOT_FRAMEWORK,
       )}
+      // `frontend` is the URL's first segment on every route that reaches
+      // these components, so this is the frontend the URL asserts.
+      onboardingFrontend={onboardingFrontendFor(`/${frontend}`)}
       frontendOverride={frontend}
       navTree={navTree ?? getFrontendQuickstartNavTree(frontend)}
       sidebarBannerSlot={<FrontendSidebarBanner frontend={frontend} />}
@@ -1064,6 +1083,9 @@ function FrontendGuidanceDocsPage({
       onboardingFramework={onboardingFrameworkFor(
         activeBackendFramework ?? ROOT_FRAMEWORK,
       )}
+      // `frontend` is the URL's first segment on every route that reaches
+      // these components, so this is the frontend the URL asserts.
+      onboardingFrontend={onboardingFrontendFor(`/${frontend}`)}
       frontendOverride={frontend}
       navTree={navTree ?? getFrontendQuickstartNavTree(frontend)}
       sidebarBannerSlot={<FrontendSidebarBanner frontend={frontend} />}
@@ -1152,6 +1174,9 @@ async function FrameworkRootPage({
         slugHrefPrefix={slugHrefPrefix}
         frameworkOverride={framework}
         onboardingFramework={onboardingFrameworkFor(framework)}
+        // `slugHrefPrefix` is this page's own URL prefix — `/angular/mastra`
+        // when a frontend route delegated here, `/<framework>` otherwise.
+        onboardingFrontend={onboardingFrontendFor(slugHrefPrefix)}
         frontendOverride={frontendOverride}
         navTree={navTree}
         sidebarBannerSlot={sidebarBannerSlot}
@@ -1287,6 +1312,9 @@ async function FrameworkRootPage({
         slugHrefPrefix={slugHrefPrefix}
         frameworkOverride={framework}
         onboardingFramework={onboardingFrameworkFor(framework)}
+        // `slugHrefPrefix` is this page's own URL prefix — `/angular/mastra`
+        // when a frontend route delegated here, `/<framework>` otherwise.
+        onboardingFrontend={onboardingFrontendFor(slugHrefPrefix)}
         frontendOverride={frontendOverride}
         navTree={navTree}
         sidebarBannerSlot={sidebarBannerSlot}

--- a/showcase/shell-docs/src/app/cookbook/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/cookbook/[...slug]/page.tsx
@@ -10,6 +10,7 @@ import { notFound } from "next/navigation";
 import { DocsPageView } from "@/components/docs-page-view";
 import { buildCookbookNavTree } from "@/lib/cookbook-nav";
 import { onboardingFrameworkFor } from "@/lib/docs-onboarding-framework";
+import { onboardingFrontendFor } from "@/lib/docs-onboarding-frontend";
 import { loadDoc } from "@/lib/docs-render";
 import { ROOT_FRAMEWORK } from "@/lib/registry";
 import { buildDocMetadata } from "@/lib/seo-metadata";
@@ -48,6 +49,8 @@ export default async function CookbookSlugPage({
       // Root surface, so the Built-in Agent is the framework this recipe is
       // read with — the same one `/<framework>/cookbook/<slug>` names.
       onboardingFramework={onboardingFrameworkFor(ROOT_FRAMEWORK)}
+      // No frontend segment in the URL: the default React frontend.
+      onboardingFrontend={onboardingFrontendFor("")}
       navTree={buildCookbookNavTree()}
       sidebarBannerSlot={null}
       sidebarClassName="shell-docs-sidebar-cookbook"

--- a/showcase/shell-docs/src/app/cookbook/cookbook-onboarding.test.tsx
+++ b/showcase/shell-docs/src/app/cookbook/cookbook-onboarding.test.tsx
@@ -12,6 +12,9 @@ import CookbookLandingPage from "./page";
 import CookbookSlugPage from "./[...slug]/page";
 
 const BIA = { slug: "built-in-agent", name: "Built-in" };
+// The cookbook URL carries no frontend segment, which is how the docs spell
+// their default frontend — the one the frontend selector shows as active here.
+const REACT = { id: "react", name: "React" };
 
 describe("cookbook onboarding framework", () => {
   it("names the Built-in Agent on the cookbook landing page", () => {
@@ -21,6 +24,7 @@ describe("cookbook onboarding framework", () => {
 
     expect(element.props.slugPath).toBe("cookbook");
     expect(element.props.onboardingFramework).toEqual(BIA);
+    expect(element.props.onboardingFrontend).toEqual(REACT);
   });
 
   it("names the Built-in Agent on a cookbook recipe", async () => {
@@ -30,5 +34,6 @@ describe("cookbook onboarding framework", () => {
 
     expect(element.props.slugPath).toBe("cookbook/arcade");
     expect(element.props.onboardingFramework).toEqual(BIA);
+    expect(element.props.onboardingFrontend).toEqual(REACT);
   });
 });

--- a/showcase/shell-docs/src/app/cookbook/page.tsx
+++ b/showcase/shell-docs/src/app/cookbook/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { DocsPageView } from "@/components/docs-page-view";
 import { buildCookbookNavTree } from "@/lib/cookbook-nav";
 import { onboardingFrameworkFor } from "@/lib/docs-onboarding-framework";
+import { onboardingFrontendFor } from "@/lib/docs-onboarding-frontend";
 import { loadDoc } from "@/lib/docs-render";
 import { ROOT_FRAMEWORK } from "@/lib/registry";
 import { buildDocMetadata } from "@/lib/seo-metadata";
@@ -28,6 +29,10 @@ export default function CookbookLandingPage() {
       // framework in the copied prompt. Naming the Built-in Agent here is what
       // keeps the two from disagreeing about the same recipe.
       onboardingFramework={onboardingFrameworkFor(ROOT_FRAMEWORK)}
+      // The cookbook has no frontend segment in its URL, which is how the
+      // docs spell the default React frontend — the same one the frontend
+      // selector shows as active here.
+      onboardingFrontend={onboardingFrontendFor("")}
       navTree={buildCookbookNavTree()}
       sidebarBannerSlot={null}
       sidebarClassName="shell-docs-sidebar-cookbook"

--- a/showcase/shell-docs/src/components/__tests__/page-actions-onboarding-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/page-actions-onboarding-prompt.test.tsx
@@ -16,6 +16,10 @@ import {
   onboardingFrameworkSlug,
 } from "@/lib/intelligence-onboarding-framework";
 import {
+  frontendPromptSuffix,
+  onboardingFrontendSlug,
+} from "@/lib/intelligence-onboarding-frontend";
+import {
   createIntelligenceOnboardingPrompt,
   createOnboardingRunId,
   INTELLIGENCE_ONBOARDING_EVENTS,
@@ -62,6 +66,19 @@ const MASTRA = { slug: "mastra", name: "Mastra" };
  * is "" and `agent_framework` is left off the event entirely.
  */
 const SPRING_AI = { slug: "spring-ai", name: "Spring AI" };
+
+/**
+ * The docs' default frontend, which the graph spells `nextjs` — the one pair
+ * where the docs display name and the graph slug differ.
+ */
+const REACT = { id: "react", name: "React" };
+
+/**
+ * A docs frontend the graph has NO node for: Slack is a chat channel, not an
+ * application frontend. The frontend sentence is "" and `frontend` is left off
+ * the event entirely.
+ */
+const SLACK = { id: "slack", name: "Slack" };
 const PAGE_MARKDOWN_URL = "/mastra/generative-ui.mdx";
 const PAGE_SENTENCE = ` The developer copied this prompt from ${DOCS_ORIGIN}${PAGE_MARKDOWN_URL}.`;
 
@@ -486,4 +503,161 @@ it("mints a valid run id on all three createOnboardingRunId code paths", () => {
   // 3. No web crypto at all — the `Math.random` last resort.
   vi.stubGlobal("crypto", undefined);
   expect(createOnboardingRunId()).toMatch(shape);
+});
+
+// ---------------------------------------------------------------------------
+// The frontend sentence (OSS-1071). It sits between the framework sentence and
+// the page sentence, which is the order the CLI's graph works in: it settles
+// the agent framework first, then the frontend. Each of the two selections can
+// be absent independently, so all four combinations are asserted whole —
+// a stray double space or a missing separator has to fail here.
+// ---------------------------------------------------------------------------
+
+it("copies framework, frontend and page sentences in the graph's order", async () => {
+  const writeText = stubClipboard();
+
+  // Guards: if either mapping were lost, the concatenation below would still
+  // pass on an empty suffix and quietly assert nothing.
+  const frameworkSentence = frameworkPromptSuffix(MASTRA.slug, MASTRA.name);
+  const frontendSentence = frontendPromptSuffix(REACT.id, REACT.name);
+  expect(frameworkSentence).not.toBe("");
+  expect(frontendSentence).not.toBe("");
+
+  renderButton({ frontend: REACT });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  expect(writeText.mock.calls[0][0]).toBe(
+    createIntelligenceOnboardingPrompt(reportedRunId()) +
+      frameworkSentence +
+      frontendSentence +
+      PAGE_SENTENCE,
+  );
+});
+
+it("names the React frontend by its docs name and the graph's slug", async () => {
+  // The one pair where the two spellings differ. The docs call this frontend
+  // React; the graph's node is `nextjs`, because its own prompt
+  // (`onboarding-prompts/frontend/nextjs.md`) documents itself with the
+  // unprefixed `https://docs.copilotkit.ai/quickstart.md`.
+  const writeText = stubClipboard();
+
+  renderButton({ frontend: REACT });
+  clickCopy();
+
+  await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+  expect(writeText.mock.calls[0][0]).toContain(
+    " The developer selected the React frontend (`nextjs`).",
+  );
+});
+
+it("appends no frontend sentence for a frontend the graph does not know", async () => {
+  // Slack is a channel the graph has no frontend node for. The framework
+  // sentence and the page sentence close ranks with no double space between
+  // them, which is why this asserts the whole string rather than a substring.
+  const writeText = stubClipboard();
+
+  expect(frontendPromptSuffix(SLACK.id, SLACK.name)).toBe("");
+
+  renderButton({ frontend: SLACK });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  expect(writeText.mock.calls[0][0]).toBe(
+    createIntelligenceOnboardingPrompt(reportedRunId()) +
+      frameworkPromptSuffix(MASTRA.slug, MASTRA.name) +
+      PAGE_SENTENCE,
+  );
+});
+
+it("carries the frontend sentence alone when the graph knows no framework", async () => {
+  // `spring-ai` has no graph node, `react` does. The frontend sentence has to
+  // read correctly with nothing in front of it but the canonical prompt.
+  const writeText = stubClipboard();
+
+  renderButton({ framework: SPRING_AI, frontend: REACT });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  expect(writeText.mock.calls[0][0]).toBe(
+    createIntelligenceOnboardingPrompt(reportedRunId()) +
+      " The developer selected the React frontend (`nextjs`)." +
+      PAGE_SENTENCE,
+  );
+});
+
+it("falls back to the page sentence alone when neither is mappable", async () => {
+  // Both empty: the page sentence has to stand entirely on its own, which is
+  // why it names the page rather than referring back to anything.
+  const writeText = stubClipboard();
+
+  renderButton({ framework: SPRING_AI, frontend: SLACK });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  expect(writeText.mock.calls[0][0]).toBe(
+    createIntelligenceOnboardingPrompt(reportedRunId()) + PAGE_SENTENCE,
+  );
+});
+
+it("reports the frontend property with the graph's slug", async () => {
+  stubClipboard();
+
+  renderButton({ frontend: REACT });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  // The GRAPH slug, so this property joins the value the CLI records for the
+  // same run — `nextjs`, not the docs id `react`.
+  expect(onboardingFrontendSlug(REACT.id)).toBe("nextjs");
+  expect(analytics.capture.mock.calls[0][1]).toEqual({
+    from_path: "/mastra/generative-ui",
+    onboarding_run_id: expect.stringMatching(/^[A-Za-z0-9_-]{12}$/),
+    surface: "docs_page_tools_onboarding_prompt",
+    agent_framework: "mastra",
+    frontend: "nextjs",
+  });
+});
+
+it("omits the frontend property entirely when the graph has no slug", async () => {
+  // Absence of the key, not an `undefined` value: a key present with no value
+  // still shows up as a row in a PostHog breakdown. Same rule as
+  // `agent_framework`.
+  stubClipboard();
+
+  renderButton({ frontend: SLACK });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  const properties = analytics.capture.mock.calls[0][1] as Record<
+    string,
+    unknown
+  >;
+  expect(properties).not.toHaveProperty("frontend");
+  expect(Object.keys(properties).sort()).toEqual([
+    "agent_framework",
+    "from_path",
+    "onboarding_run_id",
+    "surface",
+  ]);
+});
+
+it("omits the frontend property when the caller names no frontend", async () => {
+  // A surface that passes no frontend at all — the prompt names none, and the
+  // event reports none.
+  stubClipboard();
+
+  renderButton({ frontend: undefined });
+  clickCopy();
+
+  await waitFor(() => expect(analytics.capture).toHaveBeenCalled());
+
+  expect(analytics.capture.mock.calls[0][1]).not.toHaveProperty("frontend");
 });

--- a/showcase/shell-docs/src/components/__tests__/unscoped-docs-page-onboarding.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/unscoped-docs-page-onboarding.test.tsx
@@ -26,6 +26,9 @@ import { describe, expect, it } from "vitest";
 import { UnscopedDocsPage } from "@/components/unscoped-docs-page";
 
 const BIA = { slug: "built-in-agent", name: "Built-in" };
+// This component only serves URLs whose first segment is not a frontend id, so
+// every one of its branches resolves to the docs' default React frontend.
+const REACT = { id: "react", name: "React" };
 
 async function docsPageViewProps(
   slugPath: string,
@@ -45,6 +48,7 @@ describe("UnscopedDocsPage onboarding framework", () => {
     );
     expect(props.frameworkOverride).toBe("built-in-agent");
     expect(props.onboardingFramework).toEqual(BIA);
+    expect(props.onboardingFrontend).toEqual(REACT);
   });
 
   it("names the Built-in Agent on an agnostic page with a snippet cell", async () => {
@@ -55,6 +59,7 @@ describe("UnscopedDocsPage onboarding framework", () => {
     expect(props.contentSlugPath).toBeUndefined();
     expect(props.frameworkOverride).toBe("built-in-agent");
     expect(props.onboardingFramework).toEqual(BIA);
+    expect(props.onboardingFrontend).toEqual(REACT);
   });
 
   it("names the Built-in Agent on a page with no cell and no BIA override", async () => {
@@ -68,6 +73,7 @@ describe("UnscopedDocsPage onboarding framework", () => {
       // button no longer follows this prop.
       expect(props.frameworkOverride).toBeUndefined();
       expect(props.onboardingFramework).toEqual(BIA);
+      expect(props.onboardingFrontend).toEqual(REACT);
     }
   });
 });

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -23,6 +23,10 @@ import {
   onboardingFrameworkSlug,
 } from "@/lib/intelligence-onboarding-framework";
 import {
+  frontendPromptSuffix,
+  onboardingFrontendSlug,
+} from "@/lib/intelligence-onboarding-frontend";
+import {
   createIntelligenceOnboardingPrompt,
   createOnboardingRunId,
   INTELLIGENCE_ONBOARDING_EVENTS,
@@ -175,11 +179,17 @@ const ONBOARDING_COPY_SURFACE = "docs_page_tools_onboarding_prompt";
  * straight into their coding agent.
  *
  * The copied string is `createIntelligenceOnboardingPrompt(runId)` followed by
- * two sentences of page context: which agent framework the reader is reading
- * about, and which page they copied from. Both are statements of fact for the
- * receiving agent, never instructions — the prompt itself is the only thing
- * that tells the agent what to do, and the sibling copies in the Intelligence
- * repo and the Inspector have to keep matching that part byte for byte.
+ * three sentences of page context: which agent framework the reader is reading
+ * about, which frontend they have selected, and which page they copied from.
+ * All three are statements of fact for the receiving agent, never instructions
+ * — the prompt itself is the only thing that tells the agent what to do, and
+ * the sibling copies in the Intelligence repo and the Inspector have to keep
+ * matching that part byte for byte.
+ *
+ * Framework before frontend because that is the order the CLI's graph works
+ * in: it settles the agent framework first, then the frontend. Each sentence
+ * leads with its own subject and can be "" independently, so all four
+ * combinations read correctly.
  *
  * The run id is minted per click (not per page load), matching
  * `components/intelligence-onboarding-prompt.tsx`: one clipboard write is one
@@ -188,6 +198,7 @@ const ONBOARDING_COPY_SURFACE = "docs_page_tools_onboarding_prompt";
  */
 export function OnboardingPromptCopyButton({
   framework,
+  frontend,
   markdownUrl,
   ...props
 }: ComponentProps<"button"> & {
@@ -204,6 +215,19 @@ export function OnboardingPromptCopyButton({
    * for are handled downstream by `frameworkPromptSuffix`.
    */
   framework?: { slug: string; name: string };
+  /**
+   * The frontend the docs URL selects: `id` is the docs frontend id, `name`
+   * its display name. Resolved server-side from the pathname by
+   * `onboardingFrontendFor` and passed in — never derived here from
+   * `usePathname()` — so the prompt names what the URL asserts rather than
+   * what this component happens to observe after a navigation.
+   *
+   * Optional for the same reason `framework` is: a surface that has no
+   * frontend to name still gets the button, and the prompt simply names none.
+   * Frontends the graph has no node for (`slack`, `teams`) are handled
+   * downstream by `frontendPromptSuffix`.
+   */
+  frontend?: { id: string; name: string };
   /**
    * The page's `.mdx` URL as a site-root-relative path — the same value the
    * page-tools row hands `MarkdownCopyButton`. Passed in rather than derived
@@ -272,20 +296,28 @@ export function OnboardingPromptCopyButton({
     const frameworkSentence = framework
       ? frameworkPromptSuffix(framework.slug, framework.name)
       : "";
+    // Built the same way, from the frontend the URL selects, and appended
+    // after the framework sentence because the graph settles the framework
+    // first. "" for `slack` and `teams`, which are channels the graph has no
+    // frontend node for.
+    const frontendSentence = frontend
+      ? frontendPromptSuffix(frontend.id, frontend.name)
+      : "";
     // `getClientBaseUrl()` is read HERE, inside the handler, and never during
     // render: on the server it returns the SSR placeholder (see the module
     // comment on that function), so a render-time read would put a different
     // URL in the server HTML than in the hydrated client and mismatch.
     // Trailing slash trimmed because `markdownUrl` already leads with one.
     const pageUrl = `${getClientBaseUrl().replace(/\/+$/, "")}${markdownUrl}`;
-    // Stands on its own when `frameworkSentence` is "", which is why it names
-    // the page rather than referring back to it.
+    // Stands on its own when both sentences above are "", which is why it
+    // names the page rather than referring back to it.
     const pageSentence = ` The developer copied this prompt from ${pageUrl}.`;
 
     try {
       await navigator.clipboard.writeText(
         createIntelligenceOnboardingPrompt(runId) +
           frameworkSentence +
+          frontendSentence +
           pageSentence,
       );
     } catch (err) {
@@ -315,6 +347,11 @@ export function OnboardingPromptCopyButton({
     const graphFramework = framework
       ? onboardingFrameworkSlug(framework.slug)
       : undefined;
+    // Same rule for the frontend, under the matching property name: the graph
+    // slug, and omitted entirely when the graph has no equivalent.
+    const graphFrontend = frontend
+      ? onboardingFrontendSlug(frontend.id)
+      : undefined;
 
     try {
       posthog?.capture(INTELLIGENCE_ONBOARDING_EVENTS.promptCopied, {
@@ -326,6 +363,7 @@ export function OnboardingPromptCopyButton({
         // distinction it would carry lives in `surface` instead.
         surface: ONBOARDING_COPY_SURFACE,
         ...(graphFramework ? { agent_framework: graphFramework } : {}),
+        ...(graphFrontend ? { frontend: graphFrontend } : {}),
       });
     } catch {
       // Analytics must never break the copy the reader actually asked for.

--- a/showcase/shell-docs/src/components/docs-page-tools.tsx
+++ b/showcase/shell-docs/src/components/docs-page-tools.tsx
@@ -35,6 +35,12 @@ export interface DocsPageToolsProps {
    * the button still renders there, its prompt simply names no framework.
    */
   onboardingFramework?: { slug: string; name: string };
+  /**
+   * The frontend the page's URL selects, resolved server-side by
+   * `onboardingFrontendFor`. Named in the copied prompt right after the
+   * framework, so the CLI's graph has to ask for neither selection.
+   */
+  onboardingFrontend?: { id: string; name: string };
 }
 
 /**
@@ -59,12 +65,14 @@ export function DocsPageTools({
   slugHrefPrefix,
   githubUrl,
   onboardingFramework,
+  onboardingFrontend,
 }: DocsPageToolsProps): React.JSX.Element {
   const markdownUrl = docsMarkdownUrl(slugHrefPrefix, slugPath);
   return (
     <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
       <OnboardingPromptCopyButton
         framework={onboardingFramework}
+        frontend={onboardingFrontend}
         markdownUrl={markdownUrl}
       />
       <MarkdownCopyButton markdownUrl={markdownUrl} />

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -101,6 +101,18 @@ export interface DocsPageViewProps {
    * framework in the prompt without resolving its content framework-scoped.
    */
   onboardingFramework?: { slug: string; name: string };
+  /**
+   * The frontend the page's URL selects: `id` is the docs frontend id, `name`
+   * its display name. Resolved from the pathname by `onboardingFrontendFor`,
+   * and named in the copied prompt right after the framework so the CLI's
+   * graph has to ask for neither selection.
+   *
+   * Deliberately separate from `frontendOverride` below, for the same reason
+   * `onboardingFramework` is separate from `frameworkOverride`: that one is a
+   * content concern (which frontend's snippets to render) and is legitimately
+   * absent on pages that still have a frontend selected in the URL.
+   */
+  onboardingFrontend?: { id: string; name: string };
   /** Frontend selected by the URL. Defaults to React on the root surface. */
   frontendOverride?: FrontendId;
   /** Pre-built nav tree. When omitted, defaults to the full docs tree. */
@@ -157,6 +169,7 @@ export async function DocsPageView({
   slugHrefPrefix,
   frameworkOverride,
   onboardingFramework,
+  onboardingFrontend,
   frontendOverride,
   navTree,
   bannerSlot,
@@ -306,6 +319,7 @@ export async function DocsPageView({
               slugHrefPrefix={slugHrefPrefix}
               githubUrl={buildGitHubUrl(doc.filePath)}
               onboardingFramework={onboardingFramework}
+              onboardingFrontend={onboardingFrontend}
             />
 
             {/* Thin divider between the page-actions row and the page body

--- a/showcase/shell-docs/src/components/unscoped-docs-page.tsx
+++ b/showcase/shell-docs/src/components/unscoped-docs-page.tsx
@@ -22,6 +22,7 @@ import React from "react";
 import { notFound } from "next/navigation";
 import { DocsPageView } from "@/components/docs-page-view";
 import { onboardingFrameworkFor } from "@/lib/docs-onboarding-framework";
+import { onboardingFrontendFor } from "@/lib/docs-onboarding-frontend";
 import { buildRootSurfaceNav, loadDoc } from "@/lib/docs-render";
 import { getDocsFolder, getDocsMode, ROOT_FRAMEWORK } from "@/lib/registry";
 
@@ -49,6 +50,12 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
   // and only pages that carry framework-scoped content get it. The two props
   // answer different questions and are no longer expected to agree.
   const onboardingFramework = onboardingFrameworkFor(ROOT_FRAMEWORK);
+  // This component only ever serves URLs whose first segment is not a
+  // frontend id — `/quickstart`, `/concepts/architecture` — which is how the
+  // docs spell the default React frontend. Resolved once for the whole
+  // component, like the framework above, so the two branches below cannot
+  // disagree about the same page.
+  const onboardingFrontend = onboardingFrontendFor("");
 
   // BIA-authored page for this slug → render it BIA-scoped at the root
   // URL: BIA snippet resolution, root-relative hrefs.
@@ -62,6 +69,7 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
         slugHrefPrefix=""
         frameworkOverride={frameworkOverride}
         onboardingFramework={onboardingFramework}
+        onboardingFrontend={onboardingFrontend}
         navTree={navTree}
       />
     );
@@ -83,6 +91,7 @@ export async function UnscopedDocsPage({ slugPath }: { slugPath: string }) {
       slugHrefPrefix=""
       frameworkOverride={frameworkOverride}
       onboardingFramework={onboardingFramework}
+      onboardingFrontend={onboardingFrontend}
       navTree={navTree}
     />
   );

--- a/showcase/shell-docs/src/lib/__tests__/docs-onboarding-frontend.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-onboarding-frontend.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { onboardingFrontendFor } from "../docs-onboarding-frontend";
+import { frontendPromptSuffix } from "../intelligence-onboarding-frontend";
+
+describe("onboardingFrontendFor", () => {
+  it.each([
+    ["/vue/generative-ui", "vue", "Vue"],
+    ["/angular/mastra", "angular", "Angular"],
+    ["/react-spa", "react-spa", "React SPA"],
+    ["/react-native/quickstart", "react-native", "React Native"],
+    ["/slack/connect", "slack", "Slack"],
+    ["/teams", "teams", "Teams"],
+  ])("reads %s as the %s frontend", (pathname, id, name) => {
+    expect(onboardingFrontendFor(pathname)).toEqual({ id, name });
+  });
+
+  it.each([
+    ["", "the root surface"],
+    ["/", "the docs home"],
+    ["/quickstart", "an unprefixed page"],
+    ["/mastra/generative-ui", "a backend-scoped page"],
+    ["/cookbook/human-in-the-loop", "the cookbook"],
+  ])("reads %s (%s) as the default React frontend", (pathname) => {
+    expect(onboardingFrontendFor(pathname)).toEqual({
+      id: "react",
+      name: "React",
+    });
+  });
+
+  it("applies the same rule the frontend selector applies", () => {
+    // `FrameworkSelector` computes `urlFrontend ?? "react"`. Choosing another
+    // frontend navigates to another URL, so the URL is what asserts the
+    // selection — not a stored preference, which can disagree with the page
+    // the reader is actually looking at.
+    expect(onboardingFrontendFor("/vue").id).toBe("vue");
+    expect(onboardingFrontendFor("/not-a-frontend").id).toBe("react");
+  });
+
+  it("hands the prompt a name and id that compose into the sentence", () => {
+    const { id, name } = onboardingFrontendFor("/quickstart");
+    expect(frontendPromptSuffix(id, name)).toBe(
+      " The developer selected the React frontend (`nextjs`).",
+    );
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-onboarding-frontend.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-onboarding-frontend.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { FRONTEND_OPTIONS } from "@/lib/frontend-options";
+import {
+  frontendPromptSuffix,
+  onboardingFrontendSlug,
+} from "../intelligence-onboarding-frontend";
+
+/**
+ * Docs frontends with no graph equivalent. Keeping the list here means adding
+ * a frontend the graph does not know is a conscious edit, not an accident.
+ *
+ * Slack and Teams are chat channels rather than application frontends. The
+ * graph has no node for either, so naming one would promise a path the CLI
+ * cannot walk.
+ */
+const DELIBERATELY_UNMAPPED = ["slack", "teams"];
+
+describe("onboardingFrontendSlug", () => {
+  it("maps the docs' default React frontend to the graph's `nextjs`", () => {
+    // Not a guess: each graph frontend prompt under
+    // `apps/cli/onboarding-prompts/frontend/` names the docs page it belongs
+    // to, and `nextjs.md` is the only one pointing at the UNPREFIXED
+    // `https://docs.copilotkit.ai/quickstart.md` — the docs' `react` frontend.
+    // Every other prompt points at its own prefixed page.
+    expect(onboardingFrontendSlug("react")).toBe("nextjs");
+  });
+
+  it.each([
+    ["react-spa", "react-spa"],
+    ["vue", "vue"],
+    ["angular", "angular"],
+    ["react-native", "react-native"],
+  ])("passes through %s, which both sides spell the same", (docsId, slug) => {
+    expect(onboardingFrontendSlug(docsId)).toBe(slug);
+  });
+
+  it.each(DELIBERATELY_UNMAPPED)(
+    "leaves %s unmapped so the prompt promises nothing the CLI cannot do",
+    (docsId) => {
+      expect(onboardingFrontendSlug(docsId)).toBeUndefined();
+      expect(frontendPromptSuffix(docsId, "Some Frontend")).toBe("");
+    },
+  );
+
+  it("returns undefined for an id in neither set instead of throwing", () => {
+    expect(onboardingFrontendSlug("not-a-frontend")).toBeUndefined();
+    expect(frontendPromptSuffix("not-a-frontend", "Not A Frontend")).toBe("");
+  });
+});
+
+describe("frontendPromptSuffix", () => {
+  it("appends the exact sentence the CLI graph reads", () => {
+    expect(frontendPromptSuffix("vue", "Vue")).toBe(
+      " The developer selected the Vue frontend (`vue`).",
+    );
+  });
+
+  it("pairs the docs display name with the graph slug for React", () => {
+    // The one pair where the two names differ. The docs call this frontend
+    // React and the graph calls it `nextjs`; the sentence says both, exactly
+    // as the framework sentence pairs a display name with a graph slug.
+    expect(frontendPromptSuffix("react", "React")).toBe(
+      " The developer selected the React frontend (`nextjs`).",
+    );
+  });
+
+  it.each([
+    [
+      "react-spa",
+      "React SPA",
+      " The developer selected the React SPA frontend (`react-spa`).",
+    ],
+    [
+      "angular",
+      "Angular",
+      " The developer selected the Angular frontend (`angular`).",
+    ],
+    [
+      "react-native",
+      "React Native",
+      " The developer selected the React Native frontend (`react-native`).",
+    ],
+  ])("renders the whole sentence for %s", (docsId, name, sentence) => {
+    expect(frontendPromptSuffix(docsId, name)).toBe(sentence);
+  });
+});
+
+describe("docs frontend registry coverage", () => {
+  it("maps every docs frontend or lists it as deliberately unmapped", () => {
+    // `FRONTEND_OPTIONS`, the same list the selector and every route read, so
+    // this guard cannot go blind to an entry the app does show. Adding a
+    // frontend to the registry without deciding what the prompt says about it
+    // fails here rather than silently producing no sentence.
+    const undecided = FRONTEND_OPTIONS.map(({ id }) => id).filter(
+      (id) =>
+        onboardingFrontendSlug(id) === undefined &&
+        !DELIBERATELY_UNMAPPED.includes(id),
+    );
+
+    expect(undecided).toEqual([]);
+  });
+
+  it("lists nothing as deliberately unmapped that is not a docs frontend", () => {
+    // The other direction: a frontend removed from the registry must not leave
+    // a stale entry here propping the guard above up.
+    const ids = FRONTEND_OPTIONS.map(({ id }) => String(id));
+    expect(DELIBERATELY_UNMAPPED.filter((id) => !ids.includes(id))).toEqual([]);
+  });
+});

--- a/showcase/shell-docs/src/lib/docs-onboarding-frontend.ts
+++ b/showcase/shell-docs/src/lib/docs-onboarding-frontend.ts
@@ -1,0 +1,36 @@
+// The `onboardingFrontend` prop every route hands to `DocsPageView`: the docs
+// frontend id plus the display name the copied onboarding prompt should call
+// that frontend.
+//
+// The sibling of `docs-onboarding-framework.ts`, and shared by the same
+// routes, so the two selections a reader can make in the docs — agent
+// framework and frontend — reach the prompt through the same shape.
+//
+// Resolved from the URL, never from a stored preference: choosing a frontend
+// navigates to a different URL, so the URL is what asserts the selection. This
+// is the rule `FrameworkSelector` itself applies (`urlFrontend ?? "react"`),
+// and the same standard the framework sentence already holds to.
+
+import {
+  frontendFromPathname,
+  getFrontendOption,
+} from "@/lib/frontend-options";
+import type { FrontendId } from "@/lib/frontend-options";
+
+/**
+ * The `onboardingFrontend` prop for a `DocsPageView`, resolved from the docs
+ * URL — or from any leading part of it, since only the first path segment
+ * names a frontend.
+ *
+ * Always returns a value: a URL with no frontend segment is the docs' default
+ * `react` frontend, not the absence of a selection — exactly what the frontend
+ * selector shows a reader standing on such a page. Frontends the graph has no
+ * node for are handled downstream by `frontendPromptSuffix`.
+ */
+export function onboardingFrontendFor(pathname: string): {
+  id: FrontendId;
+  name: string;
+} {
+  const id: FrontendId = frontendFromPathname(pathname) ?? "react";
+  return { id, name: getFrontendOption(id).name };
+}

--- a/showcase/shell-docs/src/lib/intelligence-onboarding-frontend.ts
+++ b/showcase/shell-docs/src/lib/intelligence-onboarding-frontend.ts
@@ -1,0 +1,69 @@
+/**
+ * Frontend slugs the CLI's onboarding graph accepts.
+ *
+ * Source of truth: `ONBOARDING_FRONTENDS` in the Intelligence repo at
+ * `apps/cli/src/services/onboarding-classification.ts`. Duplicated as a
+ * literal here because the two repos ship separately; re-check that file when
+ * the graph gains or loses a frontend.
+ *
+ * The sibling of `intelligence-onboarding-framework.ts`, built the same way:
+ * the graph settles the agent framework first and the frontend second, and
+ * the copied prompt names both so it has to ask neither.
+ */
+const ONBOARDING_FRONTENDS = new Set([
+  "angular",
+  "nextjs",
+  "react-native",
+  "react-spa",
+  "vue",
+]);
+
+/**
+ * Docs frontend ids the graph spells differently. Every other id is passed
+ * through unchanged and then checked against the graph's set, so only the
+ * genuine disagreements need listing.
+ *
+ * `react` is the docs' default frontend, served at the unprefixed root
+ * (`/quickstart`), and the graph calls that same frontend `nextjs`: its
+ * `onboarding-prompts/frontend/nextjs.md` is the only frontend prompt whose
+ * documentation link is the unprefixed `https://docs.copilotkit.ai/quickstart.md`
+ * — every other one points at its own prefixed page (`/vue.md`, `/angular.md`,
+ * `/react-spa.md`, `/react-native.md`). Same frontend, spelled differently on
+ * each side.
+ */
+const DOCS_FRONTEND_RENAMES: Record<string, string> = {
+  react: "nextjs",
+};
+
+/**
+ * Maps a docs frontend id to the onboarding graph's frontend slug. Returns
+ * undefined when the graph has no equivalent.
+ *
+ * Frontends the graph does not know (today `slack` and `teams`) deliberately
+ * map to nothing: they are chat channels rather than application frontends,
+ * the graph has no node for either, and naming them in the prompt would
+ * promise a path the CLI cannot walk. Silence lets the graph ask instead.
+ */
+export function onboardingFrontendSlug(docsId: string): string | undefined {
+  const candidate = DOCS_FRONTEND_RENAMES[docsId] ?? docsId;
+  return ONBOARDING_FRONTENDS.has(candidate) ? candidate : undefined;
+}
+
+/**
+ * The sentence appended to the canonical onboarding prompt so the graph does
+ * not have to ask which frontend to configure. Returns "" when the frontend
+ * has no graph equivalent.
+ *
+ * Shaped exactly like `frameworkPromptSuffix`, and appended straight after it,
+ * because the graph reads the two selections in that order.
+ */
+export function frontendPromptSuffix(
+  docsId: string,
+  displayName: string,
+): string {
+  const graphSlug = onboardingFrontendSlug(docsId);
+  if (graphSlug === undefined) {
+    return "";
+  }
+  return ` The developer selected the ${displayName} frontend (\`${graphSlug}\`).`;
+}


### PR DESCRIPTION
The onboarding prompt copied from the docs already names the agent framework the page is scoped to. The docs have a second selector in the top left, though, and the CLI's prompt graph has a matching set of frontend nodes — so it was still asking a question the page could already answer.

The prompt now names the frontend too:

> … Follow the Markdown instructions it prints until onboarding is complete. The developer selected the Mastra agent framework (`mastra`). **The developer selected the React frontend (`nextjs`).** The developer copied this prompt from https://docs.copilotkit.ai/mastra/generative-ui.mdx.

Closes OSS-1071.

## How the mapping was established

`react → nextjs` is not inferred by elimination. Each frontend prompt the graph ships names the docs page it belongs to, and `nextjs.md` is the only one pointing at the unprefixed root quickstart — which is exactly what the docs' default `react` frontend serves. It also states "Record Next.js as the selected frontend" in its own body. Every other frontend points at its own prefixed page and maps one to one:

| docs | graph |
| --- | --- |
| react | `nextjs` |
| react-spa | `react-spa` |
| vue | `vue` |
| angular | `angular` |
| react-native | `react-native` |
| slack, teams | *nothing* |

Slack and Teams are chat channels, not application frontends; the graph has no node for either, so the sentence is omitted rather than naming a path the CLI cannot walk — the same rule the framework sentence follows for `langroid` and `spring-ai`.

A guard test walks the docs frontend registry and fails when a frontend is neither mapped nor listed as deliberately unmapped, so adding one forces a decision instead of silently dropping the sentence. The framework-side equivalent of that guard originally read the raw registry JSON and was blind to docs-only entries; this one reads the same source the app itself uses.

## Shape and wording

The sentence sits between the framework sentence and the page sentence, matching the order the graph works in — it settles the agent framework first, then the frontend. All four combinations of present/absent neighbours are asserted as whole strings, so a stray separator fails a test.

It pairs the docs display name with the graph slug, exactly as the framework sentence does. For `react`/`nextjs` those two are further apart than elsewhere and read a little oddly to someone who knows the docs list "React" and "React SPA" separately. Kept deliberately: the sentence reports what the developer selected, and that option is labelled React. The graph keys on the backtick slug.

The frontend is resolved from the URL, never from a stored preference — choosing another frontend navigates, so the URL is what asserts the selection. It is resolved server-side and passed down like `onboardingFramework`; nothing reads `usePathname()` in the client component for this.

## Telemetry

`docs.intelligence_onboarding_prompt_copied` gains a `frontend` property carrying the graph slug, omitted entirely when there is no equivalent — same treatment as `agent_framework`. The name matches the field on the graph's own `OnboardingClassification`, so the two join without translation.

## Testing

`npm run typecheck` clean. `npm run lint` byte-identical to the `origin/main` baseline. `npm run test`: 632 passing with the same 6 pre-existing failures as main (`public-assets` ×3, `angular-docs-content` ×2, `llm-text` ×1); 36 new tests.

Verified in a running dev server across every branch of the mapping: `/mastra/generative-ui` (React), `/vue/mastra`, `/angular/mastra/quickstart`, `/react-native/mastra`, `/faq` (root surface, Built-in Agent + React), `/slack/connect` (frontend sentence correctly absent) and `/a2a/quickstart` (framework sentence absent, frontend present). Double-click still produces exactly one clipboard write and one event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Onboarding prompts now include the relevant frontend context, alongside framework and page details.
  - Frontend context is detected automatically from documentation URLs, including Vue, Angular, React, React Native, Slack, and Teams pages.
  - Unscoped documentation and Cookbook pages default to the React frontend.
  - Frontend information is included in onboarding tracking when a supported frontend is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->