### PR TITLE
docs(intelligence): add a landing page

### DIFF
--- a/.claude/docs/documentation.md
+++ b/.claude/docs/documentation.md
@@ -62,6 +62,9 @@ Before editing framework docs, check the framework's `docs_mode`.
   shared/root pages and framework-specific pages.
 - When adding, renaming, or removing an Inspector pane, follow
   `skills/inspector-docs/SKILL.md` so the matching docs Callout stays in sync.
+- When an Intelligence feature ships or Intelligence docs are added, renamed, or
+  removed, follow `skills/intelligence-docs/SKILL.md` so `/intelligence/overview`
+  stays in sync.
 - Inspector UI, chrome, and overlay work uses
   `skills/inspector-workbench/SKILL.md`. Start the standalone lab and take
   screenshots. Do not use a showcase app as the default host.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Before editing anything that looks like product docs, read [Documentation](.clau
 - For snippets, edit `showcase/shell-docs/src/content/snippets/`; snippets can feed root docs, authored framework pages, and showcase-driven framework pages.
 - When the task changes Inspector UI, chrome, panes, or overlay behavior, follow `skills/inspector-workbench/SKILL.md`. Start the standalone workbench and take screenshots after each visual change.
 - When adding, renaming, or removing an Inspector pane, follow `skills/inspector-docs/SKILL.md` so the matching docs Callout stays in sync.
+- When an Intelligence feature ships or Intelligence docs are added, renamed, or removed, follow `skills/intelligence-docs/SKILL.md` so `/intelligence/overview` stays in sync.
 - **AG-UI protocol docs** are canonical upstream in `ag-ui-protocol/ag-ui`. The `showcase/shell-docs/src/content/ag-ui/` tree is a downstream mirror; change AG-UI upstream first, then sync the mirror back.
 - **Do not recreate `docs/content/docs/`**. Top-level `docs/` is only a symlink to shell-docs. The retired Next app no longer publishes to `docs.copilotkit.ai`. Historical content is available from the archive branch/tag, not from `main`.
 - To run shell-docs locally, follow `showcase/shell-docs/README.md` and use the shell-docs npm commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ AI agent framework with three layers: **Frontend** (React/Angular/Vanilla) → *
 - **Worktrees** — always work in a git worktree for isolation. See [Git & PRs](.claude/docs/git.md) for the full workflow.
 - **Documentation lives in shell-docs** — author all CopilotKit docs in `showcase/shell-docs/src/content/`. The top-level `docs/` path is only a symlink to `showcase/shell-docs/`; never recreate the old `docs/content/docs/` tree. AG-UI protocol docs are authored upstream in `ag-ui-protocol/ag-ui`, not here. See [Documentation](.claude/docs/documentation.md).
 - **Inspector UI work** — follow `skills/inspector-workbench/SKILL.md`. Start the standalone workbench and take screenshots after each visual change. Pane add/rename/remove also uses `skills/inspector-docs/SKILL.md`.
+- **Intelligence docs** — when an Intelligence feature ships or Intelligence docs are added, renamed, or removed, follow `skills/intelligence-docs/SKILL.md` so `/intelligence/overview` stays in sync.
 
 ## Reference (read when relevant to your task)
 

--- a/scripts/__tests__/sync-plugin-skills.test.ts
+++ b/scripts/__tests__/sync-plugin-skills.test.ts
@@ -189,7 +189,8 @@ describe("syncPluginSkills", () => {
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("channels-setup");
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("inspector-docs");
     expect(RESERVED_LIFECYCLE_SLUGS).toContain("inspector-workbench");
-    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(13);
+    expect(RESERVED_LIFECYCLE_SLUGS).toContain("intelligence-docs");
+    expect(RESERVED_LIFECYCLE_SLUGS.size).toBe(14);
   });
 
   // Version sync — the plugin version tracks packages/runtime/package.json.

--- a/scripts/sync-plugin-skills.ts
+++ b/scripts/sync-plugin-skills.ts
@@ -21,6 +21,7 @@ export const RESERVED_LIFECYCLE_SLUGS: ReadonlySet<string> = new Set([
   "channels-setup",
   "inspector-docs",
   "inspector-workbench",
+  "intelligence-docs",
 ]);
 
 // Version sync — plugin version tracks this package's version.

--- a/showcase/shell-docs/src/components/__tests__/hero-start-commands.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/hero-start-commands.test.tsx
@@ -89,6 +89,22 @@ describe("HeroStartActions", () => {
 });
 
 describe("QuickstartLinkButton", () => {
+  it("renders a custom label when one is passed", () => {
+    render(
+      <QuickstartLinkButton
+        href="/intelligence/connect-your-runtime"
+        label="Connect an app"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /connect an app/i });
+
+    expect(link.getAttribute("href")).toBe(
+      "/intelligence/connect-your-runtime",
+    );
+    expect(screen.queryByRole("link", { name: /^quickstart$/i })).toBeNull();
+  });
+
   it("renders the accent primary treatment by default", () => {
     render(<QuickstartLinkButton href="/quickstart" />);
 

--- a/showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx
@@ -60,6 +60,35 @@ function setup(writeText = vi.fn().mockResolvedValue(undefined)): SetupResult {
   };
 }
 
+test("uses the shared expandable coding-agent prompt card", () => {
+  render(<RichThreadsSetupPrompt />);
+
+  try {
+    const region = screen.getByRole("region", {
+      name: "Use this pre-built prompt to finish Intelligence setup faster.",
+    });
+    expect(region.getAttribute("data-docs-copy-surface")).toBe(
+      "docs_rich_threads_setup_agent_prompt",
+    );
+    expect(screen.queryByText(RICH_THREADS_SETUP_PROMPT)).toBeNull();
+
+    const toggle = screen.getByRole("button", { name: "Show prompt text" });
+    const promptId = toggle.getAttribute("aria-controls");
+    fireEvent.click(toggle);
+
+    expect(document.getElementById(promptId ?? "")?.textContent).toBe(
+      RICH_THREADS_SETUP_PROMPT,
+    );
+    expect(
+      screen
+        .getByRole("button", { name: "Hide prompt text" })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+  } finally {
+    cleanup();
+  }
+});
+
 test("copies the canonical Rich Threads repair prompt and announces success", async () => {
   const { writeText, teardown } = setup();
 
@@ -155,7 +184,7 @@ test("does not schedule Rich Threads copy feedback after unmount", async () => {
   }
 });
 
-test("labels each Rich Threads prompt instance with its own title", () => {
+test("labels each Rich Threads prompt instance with its own summary", () => {
   render(
     <>
       <RichThreadsSetupPrompt />
@@ -165,7 +194,7 @@ test("labels each Rich Threads prompt instance with its own title", () => {
 
   try {
     const regions = screen.getAllByRole("region", {
-      name: "Finish setup with your coding agent",
+      name: "Use this pre-built prompt to finish Intelligence setup faster.",
     });
     const titleIds = regions.map((region) =>
       region.getAttribute("aria-labelledby"),

--- a/showcase/shell-docs/src/components/__tests__/webmcp-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/webmcp-setup-prompt.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  WEBMCP_SETUP_PROMPT,
+  WebMCPSetupPrompt,
+} from "../webmcp-setup-prompt";
+
+afterEach(() => {
+  cleanup();
+});
+
+test("configures the shared coding-agent prompt card for WebMCP", async () => {
+  const originalClipboard = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard",
+  );
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+
+  try {
+    render(<WebMCPSetupPrompt />);
+
+    const region = screen.getByRole("region", {
+      name: "Use this pre-built prompt to get WebMCP running faster.",
+    });
+    expect(region.getAttribute("data-docs-copy-surface")).toBe(
+      "docs_webmcp_setup_prompt",
+    );
+
+    const toggle = screen.getByRole("button", { name: "Show prompt text" });
+    const promptId = toggle.getAttribute("aria-controls");
+    fireEvent.click(toggle);
+    expect(document.getElementById(promptId ?? "")?.textContent).toBe(
+      WEBMCP_SETUP_PROMPT,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(WEBMCP_SETUP_PROMPT),
+    );
+    expect(screen.getByRole("button", { name: "Copied" })).toBeTruthy();
+  } finally {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  }
+});

--- a/showcase/shell-docs/src/components/__tests__/webmcp-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/webmcp-setup-prompt.test.tsx
@@ -9,10 +9,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
-import {
-  WEBMCP_SETUP_PROMPT,
-  WebMCPSetupPrompt,
-} from "../webmcp-setup-prompt";
+import { WEBMCP_SETUP_PROMPT, WebMCPSetupPrompt } from "../webmcp-setup-prompt";
 
 afterEach(() => {
   cleanup();

--- a/showcase/shell-docs/src/components/coding-agent-setup-prompt.tsx
+++ b/showcase/shell-docs/src/components/coding-agent-setup-prompt.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import React from "react";
+import { ChevronRight } from "lucide-react";
+
+type CopyState = "idle" | "copied" | "error";
+
+export interface CodingAgentSetupPromptProps {
+  /** Short task-specific copy shown in the collapsed prompt row. */
+  summary: string;
+  /** Full prompt copied to the clipboard and revealed on demand. */
+  prompt: string;
+  /** Stable analytics identifier for the page that owns this prompt. */
+  copySurface: string;
+}
+
+/** Shared expandable prompt card for docs setup flows driven by coding agents. */
+export function CodingAgentSetupPrompt({
+  summary,
+  prompt,
+  copySurface,
+}: CodingAgentSetupPromptProps): React.JSX.Element {
+  const summaryId = React.useId();
+  const promptId = React.useId();
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [copyState, setCopyState] = React.useState<CopyState>("idle");
+  const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const copyGenerationRef = React.useRef(0);
+  const mountedRef = React.useRef(true);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      copyGenerationRef.current += 1;
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    };
+  }, []);
+
+  async function copyPrompt(): Promise<void> {
+    const generation = (copyGenerationRef.current += 1);
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = null;
+    setCopyState("idle");
+
+    try {
+      await navigator.clipboard.writeText(prompt);
+    } catch {
+      if (!mountedRef.current || generation !== copyGenerationRef.current) {
+        return;
+      }
+      setCopyState("error");
+      resetTimerRef.current = setTimeout(() => {
+        if (mountedRef.current && generation === copyGenerationRef.current) {
+          setCopyState("idle");
+          resetTimerRef.current = null;
+        }
+      }, 2600);
+      return;
+    }
+
+    if (!mountedRef.current || generation !== copyGenerationRef.current) {
+      return;
+    }
+    setCopyState("copied");
+    resetTimerRef.current = setTimeout(() => {
+      if (mountedRef.current && generation === copyGenerationRef.current) {
+        setCopyState("idle");
+        resetTimerRef.current = null;
+      }
+    }, 1800);
+  }
+
+  return (
+    <section
+      aria-labelledby={summaryId}
+      className="shell-docs-radius-surface not-prose my-6 overflow-hidden border border-[var(--nav-control-border)] bg-[var(--bg-surface)] shadow-[var(--shadow-control)]"
+      data-docs-copy-surface={copySurface}
+    >
+      <div className="grid min-h-17 grid-cols-[2.75rem_minmax(0,1fr)] items-center gap-x-3 gap-y-3 p-3 sm:grid-cols-[2.75rem_minmax(0,1fr)_auto] sm:gap-x-4 sm:pr-4">
+        <button
+          type="button"
+          aria-controls={promptId}
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+          className="shell-docs-radius-control inline-flex h-11 w-11 cursor-pointer items-center justify-center border border-[var(--nav-control-border)] bg-[var(--accent-dim)] text-[var(--accent)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--accent-light)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none sm:col-start-1"
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={`h-5 w-5 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
+          />
+          <span className="sr-only">
+            {isExpanded ? "Hide prompt text" : "Show prompt text"}
+          </span>
+        </button>
+
+        <span
+          id={summaryId}
+          className="block text-base leading-relaxed sm:col-start-2"
+        >
+          {summary}
+        </span>
+
+        <button
+          type="button"
+          onClick={copyPrompt}
+          className="shell-docs-radius-control col-span-2 inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center border border-[var(--accent)] bg-[var(--accent)] px-5 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:col-span-1 sm:col-start-3 sm:w-auto"
+        >
+          {copyState === "copied"
+            ? "Copied"
+            : copyState === "error"
+              ? "Copy blocked"
+              : "Copy prompt"}
+        </button>
+      </div>
+
+      {isExpanded && (
+        <div
+          id={promptId}
+          className="border-t border-[var(--nav-control-border)] bg-[var(--accent-dim)] px-5 py-4"
+        >
+          <div className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-[var(--text-secondary)]">
+            {prompt}
+          </div>
+        </div>
+      )}
+
+      <span aria-live="polite" className="sr-only">
+        {copyState === "copied"
+          ? "Prompt copied"
+          : copyState === "error"
+            ? "Prompt copy failed. Try again."
+            : ""}
+      </span>
+    </section>
+  );
+}

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   INTELLIGENCE_SIZZLE_VIDEO_URL,
+  IntelligenceFeatureCards,
   IntelligenceOverview,
 } from "../intelligence-overview";
 
@@ -36,7 +37,7 @@ describe("IntelligenceOverview", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: "Ship durable agent experiences",
+        name: "Ship production grade agent experiences",
       }),
     ).toBeTruthy();
     expect(
@@ -60,10 +61,17 @@ describe("IntelligenceOverview", () => {
     expect(video.controls).toBe(true);
     expect(video.muted).toBe(true);
     expect(video.loop).toBe(true);
+
+    const prompt = screen.getByRole("button", {
+      name: /copy onboarding prompt/i,
+    });
+    expect(
+      video.compareDocumentPosition(prompt) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("links each feature card to its guide", () => {
-    render(<IntelligenceOverview />);
+    render(<IntelligenceFeatureCards />);
 
     expect(
       screen
@@ -91,15 +99,17 @@ describe("IntelligenceOverview", () => {
         .getByRole("link", { name: "Open the self-hosting guide" })
         .getAttribute("href"),
     ).toBe("/intelligence/self-hosting");
-  });
 
-  it("links pricing out to the public pricing page", () => {
-    render(<IntelligenceOverview />);
-
-    expect(
-      screen
-        .getByRole("link", { name: "See CopilotKit Intelligence pricing" })
-        .getAttribute("href"),
-    ).toBe("https://www.copilotkit.ai/pricing");
+    for (const title of [
+      "Rich Threads",
+      "Analytics",
+      "Automatic Learning",
+      "Self-hosting",
+    ]) {
+      const card = screen
+        .getByRole("heading", { name: title })
+        .closest("article");
+      expect(card?.querySelector("svg")).toBeTruthy();
+    }
   });
 });

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  INTELLIGENCE_SIZZLE_VIDEO_URL,
+  IntelligenceOverview,
+} from "../intelligence-overview";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/intelligence/overview",
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("IntelligenceOverview", () => {
+  it("renders the hero headline, copy prompt, and connect action", () => {
+    render(<IntelligenceOverview />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Ship durable agent experiences",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /copy onboarding prompt/i }),
+    ).toBeTruthy();
+
+    const connect = screen.getByRole("link", { name: /connect an app/i });
+    expect(connect.getAttribute("href")).toBe(
+      "/intelligence/connect-your-runtime",
+    );
+  });
+
+  it("renders the sizzle video with a pause control", () => {
+    render(<IntelligenceOverview />);
+
+    const video = screen.getByLabelText("CopilotKit Intelligence product demo");
+    if (!(video instanceof HTMLVideoElement)) {
+      throw new Error("expected a video element");
+    }
+    expect(video.getAttribute("src")).toBe(INTELLIGENCE_SIZZLE_VIDEO_URL);
+    expect(video.controls).toBe(true);
+    expect(video.muted).toBe(true);
+    expect(video.loop).toBe(true);
+  });
+
+  it("links each feature card to its guide", () => {
+    render(<IntelligenceOverview />);
+
+    expect(
+      screen
+        .getByRole("link", { name: "Open the Rich Threads guide" })
+        .getAttribute("href"),
+    ).toBe("/threads");
+    expect(
+      screen
+        .getByRole("link", { name: "See Analytics on the product page" })
+        .getAttribute("href"),
+    ).toBe(
+      "https://www.copilotkit.ai/copilotkit-intelligence#analytics-insights",
+    );
+    expect(
+      screen
+        .getByRole("link", {
+          name: "See Automatic Learning on the product page",
+        })
+        .getAttribute("href"),
+    ).toBe(
+      "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
+    );
+    expect(
+      screen
+        .getByRole("link", { name: "Open the self-hosting guide" })
+        .getAttribute("href"),
+    ).toBe("/intelligence/self-hosting");
+  });
+
+  it("links pricing out to the public pricing page", () => {
+    render(<IntelligenceOverview />);
+
+    expect(
+      screen
+        .getByRole("link", { name: "See CopilotKit Intelligence pricing" })
+        .getAttribute("href"),
+    ).toBe("https://www.copilotkit.ai/pricing");
+  });
+});

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
@@ -31,15 +31,13 @@ afterEach(() => {
 });
 
 describe("IntelligenceOverview", () => {
-  it("renders the hero headline, copy prompt, and connect action", () => {
+  it("renders the product demo and its actions without a duplicate page heading", () => {
     render(<IntelligenceOverview />);
 
+    expect(screen.queryByRole("heading")).toBeNull();
     expect(
-      screen.getByRole("heading", {
-        level: 1,
-        name: "Ship production grade agent experiences",
-      }),
-    ).toBeTruthy();
+      screen.queryByText(/CopilotKit Intelligence adds persistent threads/i),
+    ).toBeNull();
     expect(
       screen.getByRole("button", { name: /copy onboarding prompt/i }),
     ).toBeTruthy();
@@ -75,10 +73,7 @@ describe("IntelligenceOverview", () => {
       await waitFor(() => expect(play).toHaveBeenCalled());
       expect(rejections).toEqual([]);
       expect(
-        screen.getByRole("heading", {
-          level: 1,
-          name: "Ship production grade agent experiences",
-        }),
+        screen.getByLabelText("CopilotKit Intelligence product demo"),
       ).toBeTruthy();
     } finally {
       window.removeEventListener("unhandledrejection", onUnhandled);

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -45,9 +45,45 @@ describe("IntelligenceOverview", () => {
     ).toBeTruthy();
 
     const connect = screen.getByRole("link", { name: /connect an app/i });
-    expect(connect.getAttribute("href")).toBe(
-      "/intelligence/connect-your-runtime",
-    );
+    expect(connect.getAttribute("href")).toBe("/intelligence/quickstart");
+  });
+
+  it("swallows autoplay rejection so the page still renders", async () => {
+    const play = vi.fn().mockRejectedValue(new DOMException("blocked"));
+    const originalPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = play;
+
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as typeof window.matchMedia;
+
+    const rejections: unknown[] = [];
+    function onUnhandled(event: PromiseRejectionEvent) {
+      rejections.push(event.reason);
+    }
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    try {
+      render(<IntelligenceOverview />);
+      await waitFor(() => expect(play).toHaveBeenCalled());
+      expect(rejections).toEqual([]);
+      expect(
+        screen.getByRole("heading", {
+          level: 1,
+          name: "Ship production grade agent experiences",
+        }),
+      ).toBeTruthy();
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+      HTMLMediaElement.prototype.play = originalPlay;
+    }
   });
 
   it("renders the sizzle video with a pause control", () => {

--- a/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
@@ -99,16 +99,8 @@ function SizzleVideo() {
 export function IntelligenceOverview() {
   return (
     <div className="not-prose relative pb-2">
-      <header className="flex flex-col pb-6">
-        <h1 className="w-full text-[1.5rem] font-semibold leading-[1.15] tracking-[-0.015em] text-balance text-[var(--text)] sm:text-[1.75rem]">
-          Ship production grade agent experiences
-        </h1>
-        <p className="mt-2 w-full text-base leading-[1.55] text-pretty text-[var(--text-muted)] sm:text-lg">
-          CopilotKit Intelligence adds persistent threads, analytics, automatic
-          learning, and production operations on top of the runtime you already
-          run.
-        </p>
-        <div className="shell-docs-radius-surface relative mt-3 w-full overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
+      <div className="flex flex-col pb-6">
+        <div className="shell-docs-radius-surface relative w-full overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
           <SizzleVideo />
         </div>
         <div className="mt-5">
@@ -126,7 +118,7 @@ export function IntelligenceOverview() {
             }
           />
         </div>
-      </header>
+      </div>
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
@@ -19,7 +19,7 @@ import {
 export const INTELLIGENCE_SIZZLE_VIDEO_URL =
   "https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3";
 
-const CONNECT_HREF = "/intelligence/connect-your-runtime";
+const CONNECT_HREF = "/intelligence/quickstart";
 
 const FEATURES = [
   {
@@ -68,7 +68,7 @@ function SizzleVideo() {
         video.pause();
         return;
       }
-      void video.play();
+      void Promise.resolve(video.play()).catch(() => undefined);
     }
 
     applyReducedMotion(media.matches);

--- a/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+import { HeroOnboardingPromptButton } from "@/components/hero-onboarding-prompt-button";
+import {
+  HeroStartActions,
+  QuickstartLinkButton,
+} from "@/components/hero-start-commands";
+
+export const INTELLIGENCE_SIZZLE_VIDEO_URL =
+  "https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3";
+
+const CONNECT_HREF = "/intelligence/connect-your-runtime";
+const PRICING_HREF = "https://www.copilotkit.ai/pricing";
+
+const FEATURES = [
+  {
+    title: "Rich Threads",
+    body: "Keep messages, generative UI, and tool activity across reloads and devices.",
+    href: "/threads",
+    cta: "Open the Rich Threads guide",
+  },
+  {
+    title: "Analytics",
+    body: "See what your agents do and where users get value, from the same interaction data.",
+    href: "https://www.copilotkit.ai/copilotkit-intelligence#analytics-insights",
+    cta: "See Analytics on the product page",
+  },
+  {
+    title: "Automatic Learning",
+    body: "Agents improve from real usage. No fine-tuning pipeline required.",
+    href: "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
+    cta: "See Automatic Learning on the product page",
+  },
+  {
+    title: "Self-hosting",
+    body: "Run the same platform in your own cluster, VPC, or data boundary.",
+    href: "/intelligence/self-hosting",
+    cta: "Open the self-hosting guide",
+  },
+] as const;
+
+function SizzleVideo() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (typeof window.matchMedia !== "function") return;
+
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    function applyReducedMotion(reduce: boolean) {
+      if (!video) return;
+      if (reduce) {
+        video.pause();
+        return;
+      }
+      void video.play();
+    }
+
+    applyReducedMotion(media.matches);
+
+    function onChange(event: MediaQueryListEvent) {
+      applyReducedMotion(event.matches);
+    }
+
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, []);
+
+  return (
+    <video
+      ref={videoRef}
+      src={INTELLIGENCE_SIZZLE_VIDEO_URL}
+      className="block w-full"
+      autoPlay
+      muted
+      loop
+      playsInline
+      controls
+      aria-label="CopilotKit Intelligence product demo"
+    />
+  );
+}
+
+export function IntelligenceOverview() {
+  return (
+    <div className="relative pb-8">
+      <header className="grid items-center gap-8 pb-12 lg:grid-cols-12 lg:gap-12">
+        <div className="lg:col-span-5">
+          <h1 className="max-w-[20ch] text-[1.75rem] font-semibold leading-[1.1] tracking-[-0.02em] text-balance text-[var(--text)] sm:text-[2.25rem] md:text-[2.5rem]">
+            Ship durable agent experiences
+          </h1>
+          <p className="mt-4 max-w-[58ch] text-base leading-[1.55] text-pretty text-[var(--text-muted)] sm:text-lg">
+            CopilotKit Intelligence adds persistent threads, hosted inspection,
+            and production operations next to the runtime you already run.
+          </p>
+          <div className="mt-7">
+            <HeroStartActions
+              prompt={
+                <HeroOnboardingPromptButton surface="docs_intelligence_hero" />
+              }
+              quickstart={
+                <QuickstartLinkButton
+                  href={CONNECT_HREF}
+                  fromPath="/intelligence/overview"
+                  variant="secondary"
+                  label="Connect an app"
+                />
+              }
+            />
+          </div>
+        </div>
+        <div className="lg:col-span-7">
+          <div className="shell-docs-radius-surface relative overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
+            <SizzleVideo />
+          </div>
+        </div>
+      </header>
+
+      <section aria-labelledby="intelligence-features-heading">
+        <h2
+          id="intelligence-features-heading"
+          className="text-[1.5rem] font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-[1.75rem]"
+        >
+          What you can add next
+        </h2>
+        <ul
+          className="mt-6 grid list-none gap-4 p-0 sm:grid-cols-2"
+          role="list"
+        >
+          {FEATURES.map((feature) => (
+            <li
+              key={feature.title}
+              className="shell-docs-radius-surface border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-panel)]"
+            >
+              <h3 className="text-lg font-semibold text-[var(--text)]">
+                {feature.title}
+              </h3>
+              <p className="mt-2 text-[15px] leading-[1.6] text-[var(--text-muted)]">
+                {feature.body}
+              </p>
+              <Link
+                href={feature.href}
+                className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-[var(--accent)] no-underline hover:brightness-110"
+              >
+                {feature.cta}
+                <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <p className="mt-10 text-base text-[var(--text-muted)]">
+        Plans start on the free Developer tier.{" "}
+        <Link
+          href={PRICING_HREF}
+          className="font-medium text-[var(--accent)] no-underline hover:brightness-110"
+        >
+          See CopilotKit Intelligence pricing
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import {
+  ArrowRight,
+  BarChart3,
+  MessagesSquare,
+  Server,
+  Sparkles,
+} from "lucide-react";
 import { useEffect, useRef } from "react";
 
 import { HeroOnboardingPromptButton } from "@/components/hero-onboarding-prompt-button";
@@ -14,7 +20,6 @@ export const INTELLIGENCE_SIZZLE_VIDEO_URL =
   "https://github.com/user-attachments/assets/72b7b4f3-b6e7-460c-a932-5746fe3c8db3";
 
 const CONNECT_HREF = "/intelligence/connect-your-runtime";
-const PRICING_HREF = "https://www.copilotkit.ai/pricing";
 
 const FEATURES = [
   {
@@ -22,24 +27,28 @@ const FEATURES = [
     body: "Keep messages, generative UI, and tool activity across reloads and devices.",
     href: "/threads",
     cta: "Open the Rich Threads guide",
+    icon: MessagesSquare,
   },
   {
     title: "Analytics",
     body: "See what your agents do and where users get value, from the same interaction data.",
     href: "https://www.copilotkit.ai/copilotkit-intelligence#analytics-insights",
     cta: "See Analytics on the product page",
+    icon: BarChart3,
   },
   {
     title: "Automatic Learning",
     body: "Agents improve from real usage. No fine-tuning pipeline required.",
     href: "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
     cta: "See Automatic Learning on the product page",
+    icon: Sparkles,
   },
   {
     title: "Self-hosting",
     body: "Run the same platform in your own cluster, VPC, or data boundary.",
     href: "/intelligence/self-hosting",
     cta: "Open the self-hosting guide",
+    icon: Server,
   },
 ] as const;
 
@@ -89,83 +98,77 @@ function SizzleVideo() {
 
 export function IntelligenceOverview() {
   return (
-    <div className="relative pb-8">
-      <header className="grid items-center gap-8 pb-12 lg:grid-cols-12 lg:gap-12">
-        <div className="lg:col-span-5">
-          <h1 className="max-w-[20ch] text-[1.75rem] font-semibold leading-[1.1] tracking-[-0.02em] text-balance text-[var(--text)] sm:text-[2.25rem] md:text-[2.5rem]">
-            Ship durable agent experiences
-          </h1>
-          <p className="mt-4 max-w-[58ch] text-base leading-[1.55] text-pretty text-[var(--text-muted)] sm:text-lg">
-            CopilotKit Intelligence adds persistent threads, hosted inspection,
-            and production operations next to the runtime you already run.
-          </p>
-          <div className="mt-7">
-            <HeroStartActions
-              prompt={
-                <HeroOnboardingPromptButton surface="docs_intelligence_hero" />
-              }
-              quickstart={
-                <QuickstartLinkButton
-                  href={CONNECT_HREF}
-                  fromPath="/intelligence/overview"
-                  variant="secondary"
-                  label="Connect an app"
-                />
-              }
-            />
-          </div>
+    <div className="not-prose relative pb-2">
+      <header className="flex flex-col pb-6">
+        <h1 className="w-full text-[1.5rem] font-semibold leading-[1.15] tracking-[-0.015em] text-balance text-[var(--text)] sm:text-[1.75rem]">
+          Ship production grade agent experiences
+        </h1>
+        <p className="mt-2 w-full text-base leading-[1.55] text-pretty text-[var(--text-muted)] sm:text-lg">
+          CopilotKit Intelligence adds persistent threads, analytics, automatic
+          learning, and production operations on top of the runtime you already
+          run.
+        </p>
+        <div className="shell-docs-radius-surface relative mt-3 w-full overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
+          <SizzleVideo />
         </div>
-        <div className="lg:col-span-7">
-          <div className="shell-docs-radius-surface relative overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
-            <SizzleVideo />
-          </div>
+        <div className="mt-5">
+          <HeroStartActions
+            prompt={
+              <HeroOnboardingPromptButton surface="docs_intelligence_hero" />
+            }
+            quickstart={
+              <QuickstartLinkButton
+                href={CONNECT_HREF}
+                fromPath="/intelligence/overview"
+                variant="secondary"
+                label="Connect an app"
+              />
+            }
+          />
         </div>
       </header>
-
-      <section aria-labelledby="intelligence-features-heading">
-        <h2
-          id="intelligence-features-heading"
-          className="text-[1.5rem] font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-[1.75rem]"
-        >
-          What you can add next
-        </h2>
-        <ul
-          className="mt-6 grid list-none gap-4 p-0 sm:grid-cols-2"
-          role="list"
-        >
-          {FEATURES.map((feature) => (
-            <li
-              key={feature.title}
-              className="shell-docs-radius-surface border border-[var(--border)] bg-[var(--bg-surface)] p-5 shadow-[var(--shadow-panel)]"
-            >
-              <h3 className="text-lg font-semibold text-[var(--text)]">
-                {feature.title}
-              </h3>
-              <p className="mt-2 text-[15px] leading-[1.6] text-[var(--text-muted)]">
-                {feature.body}
-              </p>
-              <Link
-                href={feature.href}
-                className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-[var(--accent)] no-underline hover:brightness-110"
-              >
-                {feature.cta}
-                <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <p className="mt-10 text-base text-[var(--text-muted)]">
-        Plans start on the free Developer tier.{" "}
-        <Link
-          href={PRICING_HREF}
-          className="font-medium text-[var(--accent)] no-underline hover:brightness-110"
-        >
-          See CopilotKit Intelligence pricing
-        </Link>
-        .
-      </p>
     </div>
+  );
+}
+
+export function IntelligenceFeatureCards() {
+  return (
+    <section
+      aria-labelledby="intelligence-features-heading"
+      className="not-prose"
+    >
+      <h2
+        id="intelligence-features-heading"
+        className="text-[1.5rem] font-semibold tracking-[-0.015em] text-[var(--text)] sm:text-[1.75rem]"
+      >
+        What you can add next
+      </h2>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        {FEATURES.map((feature) => (
+          <article
+            key={feature.title}
+            className="shell-docs-radius-surface border border-[var(--border)] bg-[var(--bg-surface)] px-5 pb-5 pt-3 shadow-[var(--shadow-panel)]"
+          >
+            <h3 className="m-0 flex items-center gap-2 text-lg font-semibold leading-none text-[var(--text)]">
+              <feature.icon
+                className="size-[1em] shrink-0 text-[var(--accent)]"
+                aria-hidden="true"
+              />
+              <span>{feature.title}</span>
+            </h3>
+            <p className="mt-3 text-[15px] leading-[1.6] text-[var(--text-muted)]">
+              {feature.body}
+            </p>
+            <Link
+              href={feature.href}
+              className="mt-4 inline-flex items-center gap-1.5 text-[14px] font-medium text-[var(--accent)] no-underline hover:brightness-110"
+            >
+              {feature.cta}
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+          </article>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -298,13 +298,17 @@ export async function DocsPageView({
               })}
             </nav>
 
-            <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-              {doc.fm.title}
-            </DocsTitle>
-            {doc.fm.description && (
-              <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-                {doc.fm.description}
-              </DocsDescription>
+            {!doc.fm.hideHeader && (
+              <>
+                <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
+                  {doc.fm.title}
+                </DocsTitle>
+                {doc.fm.description && (
+                  <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
+                    {doc.fm.description}
+                  </DocsDescription>
+                )}
+              </>
             )}
 
             {/* Page actions (Copy agent prompt / Copy Markdown / Open in

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -311,28 +311,32 @@ export async function DocsPageView({
               </>
             )}
 
-            {/* Page actions (Copy agent prompt / Copy Markdown / Open in
-              <LLM>) — fumadocs's upstream LLM page-actions feature. The
-              markdown URL resolves through the `/:path*.mdx` rewrite to the
-              route handler at `app/llms-mdx/[[...slug]]/route.ts`, which
-              serves the raw MDX via the same `loadDoc()` the page uses. The
-              GitHub URL is computed from `doc.filePath` (absolute fs path)
-              by slicing from the `/showcase/` segment. */}
-            <DocsPageTools
-              slugPath={slugPath}
-              slugHrefPrefix={slugHrefPrefix}
-              githubUrl={buildGitHubUrl(doc.filePath)}
-              onboardingFramework={onboardingFramework}
-              onboardingFrontend={onboardingFrontend}
-              hideOnboardingPrompt={slugPath === "webmcp"}
-            />
+            {!doc.fm.hidePageActions && (
+              <>
+                {/* Page actions (Copy agent prompt / Copy Markdown / Open in
+                  <LLM>) — fumadocs's upstream LLM page-actions feature. The
+                  markdown URL resolves through the `/:path*.mdx` rewrite to
+                  the route handler at `app/llms-mdx/[[...slug]]/route.ts`,
+                  which serves the raw MDX via the same `loadDoc()` the page
+                  uses. The GitHub URL is computed from `doc.filePath`
+                  (absolute fs path) by slicing from the `/showcase/` segment. */}
+                <DocsPageTools
+                  slugPath={slugPath}
+                  slugHrefPrefix={slugHrefPrefix}
+                  githubUrl={buildGitHubUrl(doc.filePath)}
+                  onboardingFramework={onboardingFramework}
+                  onboardingFrontend={onboardingFrontend}
+                  hideOnboardingPrompt={slugPath === "webmcp"}
+                />
 
-            {/* Thin divider between the page-actions row and the page body
-              (banner / content). Visually separates the page metadata
-              chrome (title + page actions) from the page content
-              underneath. Uses the project's `--border` token so it tracks
-              the rest of the page chrome in light and dark modes. */}
-            <hr className="border-t border-[var(--border)] mt-2 mb-6" />
+                {/* Thin divider between the page-actions row and the page body
+                  (banner / content). Visually separates the page metadata
+                  chrome (title + page actions) from the page content
+                  underneath. Uses the project's `--border` token so it tracks
+                  the rest of the page chrome in light and dark modes. */}
+                <hr className="border-t border-[var(--border)] mt-2 mb-6" />
+              </>
+            )}
 
             {bannerSlot}
 

--- a/showcase/shell-docs/src/components/hero-start-commands.tsx
+++ b/showcase/shell-docs/src/components/hero-start-commands.tsx
@@ -45,12 +45,14 @@ export function QuickstartLinkButton({
   backend,
   fromPath,
   variant = "primary",
+  label = "Quickstart",
 }: {
   href: string;
   frontend?: string;
   backend?: string;
   fromPath?: string;
   variant?: QuickstartVariant;
+  label?: string;
 }) {
   const posthog = usePostHog();
 
@@ -74,7 +76,7 @@ export function QuickstartLinkButton({
       onClick={handleClick}
       className={`${QUICKSTART_BASE_CLASS} ${QUICKSTART_VARIANT_CLASS[variant]}`}
     >
-      Quickstart
+      {label}
       <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
     </Link>
   );

--- a/showcase/shell-docs/src/components/rich-threads-setup-prompt.tsx
+++ b/showcase/shell-docs/src/components/rich-threads-setup-prompt.tsx
@@ -1,110 +1,16 @@
-"use client";
-
 import React from "react";
-import { Copy, SquareTerminal } from "lucide-react";
+import { CodingAgentSetupPrompt } from "@/components/coding-agent-setup-prompt";
 import { RICH_THREADS_SETUP_PROMPT } from "@/lib/rich-threads-setup-prompt";
 
 export { RICH_THREADS_SETUP_PROMPT } from "@/lib/rich-threads-setup-prompt";
 
-type CopyState = "idle" | "copied" | "error";
-
 /** Copies the Inspector recovery prompt from the Runtime endpoints guide. */
 export function RichThreadsSetupPrompt(): React.JSX.Element {
-  const titleId = React.useId();
-  const [copyState, setCopyState] = React.useState<CopyState>("idle");
-  const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-  const copyGenerationRef = React.useRef(0);
-  const mountedRef = React.useRef(true);
-
-  React.useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      copyGenerationRef.current += 1;
-      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
-      resetTimerRef.current = null;
-    };
-  }, []);
-
-  async function copyPrompt(): Promise<void> {
-    const generation = (copyGenerationRef.current += 1);
-    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
-    resetTimerRef.current = null;
-    setCopyState("idle");
-
-    try {
-      await navigator.clipboard.writeText(RICH_THREADS_SETUP_PROMPT);
-    } catch {
-      if (!mountedRef.current || generation !== copyGenerationRef.current) {
-        return;
-      }
-      setCopyState("error");
-      resetTimerRef.current = setTimeout(() => {
-        if (mountedRef.current && generation === copyGenerationRef.current) {
-          setCopyState("idle");
-          resetTimerRef.current = null;
-        }
-      }, 2600);
-      return;
-    }
-
-    if (!mountedRef.current || generation !== copyGenerationRef.current) {
-      return;
-    }
-    setCopyState("copied");
-    resetTimerRef.current = setTimeout(() => {
-      if (mountedRef.current && generation === copyGenerationRef.current) {
-        setCopyState("idle");
-        resetTimerRef.current = null;
-      }
-    }, 1800);
-  }
-
   return (
-    <section
-      aria-labelledby={titleId}
-      className="shell-docs-radius-surface not-prose my-6 border border-[var(--border)] bg-[var(--bg-elevated)] p-4 shadow-[var(--shadow-control)]"
-      data-docs-copy-surface="docs_rich_threads_setup_agent_prompt"
-    >
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-        <div className="flex min-w-0 flex-1 items-start gap-3">
-          <SquareTerminal
-            aria-hidden="true"
-            className="mt-0.5 h-5 w-5 shrink-0 text-[var(--accent)]"
-          />
-          <div className="min-w-0">
-            <p id={titleId} className="m-0 font-semibold text-[var(--text)]">
-              Finish setup with your coding agent
-            </p>
-            <p className="mt-1 mb-0 max-w-[62ch] text-sm leading-relaxed text-[var(--text-muted)]">
-              Copy this prompt. Your agent will inspect your app, make the
-              required Runtime changes, and verify Rich Threads.
-            </p>
-          </div>
-        </div>
-
-        <button
-          type="button"
-          onClick={copyPrompt}
-          className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center gap-2 border border-[var(--accent)] bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
-        >
-          <Copy aria-hidden="true" className="h-4 w-4" />
-          {copyState === "copied"
-            ? "Copied"
-            : copyState === "error"
-              ? "Copy blocked"
-              : "Copy prompt"}
-        </button>
-      </div>
-      <span aria-live="polite" className="sr-only">
-        {copyState === "copied"
-          ? "Prompt copied"
-          : copyState === "error"
-            ? "Prompt copy failed. Try again."
-            : ""}
-      </span>
-    </section>
+    <CodingAgentSetupPrompt
+      summary="Use this pre-built prompt to finish Intelligence setup faster."
+      prompt={RICH_THREADS_SETUP_PROMPT}
+      copySurface="docs_rich_threads_setup_agent_prompt"
+    />
   );
 }

--- a/showcase/shell-docs/src/components/webmcp-setup-prompt.tsx
+++ b/showcase/shell-docs/src/components/webmcp-setup-prompt.tsx
@@ -1,98 +1,15 @@
-"use client";
-
 import React from "react";
-import { ChevronRight } from "lucide-react";
+import { CodingAgentSetupPrompt } from "@/components/coding-agent-setup-prompt";
 
 export const WEBMCP_SETUP_PROMPT =
   "Set up WebMCP in this project using https://docs.copilotkit.ai/webmcp. First inspect the app and extend its existing CopilotKit setup if present; do not add a backend agent solely for WebMCP. If I haven’t specified a tool, ask what I want to expose. If I don’t have one in mind, add a small, read-only demo tool that fits the app. Finish by verifying that a compatible browser can discover and call it.";
 
-type CopyState = "idle" | "copied" | "error";
-
 export function WebMCPSetupPrompt(): React.JSX.Element {
-  const promptId = React.useId();
-  const [isExpanded, setIsExpanded] = React.useState(false);
-  const [copyState, setCopyState] = React.useState<CopyState>("idle");
-  const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  React.useEffect(
-    () => () => {
-      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
-    },
-    [],
-  );
-
-  async function copyPrompt(): Promise<void> {
-    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
-
-    try {
-      await navigator.clipboard.writeText(WEBMCP_SETUP_PROMPT);
-      setCopyState("copied");
-      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
-    } catch {
-      setCopyState("error");
-      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 2600);
-    }
-  }
-
   return (
-    <div
-      className="shell-docs-radius-surface not-prose my-6 overflow-hidden border border-[var(--nav-control-border)] bg-[var(--bg-surface)] shadow-[var(--shadow-control)]"
-      data-docs-copy-surface="docs_webmcp_setup_prompt"
-    >
-      <div className="grid min-h-17 grid-cols-[2.75rem_minmax(0,1fr)] items-center gap-x-3 gap-y-3 p-3 sm:grid-cols-[2.75rem_minmax(0,1fr)_auto] sm:gap-x-4 sm:pr-4">
-        <button
-          type="button"
-          aria-controls={promptId}
-          aria-expanded={isExpanded}
-          onClick={() => setIsExpanded((expanded) => !expanded)}
-          className="shell-docs-radius-control inline-flex h-11 w-11 cursor-pointer items-center justify-center border border-[var(--nav-control-border)] bg-[var(--accent-dim)] text-[var(--accent)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--accent-light)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none sm:col-start-1"
-        >
-          <ChevronRight
-            aria-hidden="true"
-            className={`h-5 w-5 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
-          />
-          <span className="sr-only">
-            {isExpanded ? "Hide prompt text" : "Show prompt text"}
-          </span>
-        </button>
-
-        <span className="block text-base leading-relaxed sm:col-start-2">
-          Use this pre-built prompt to get WebMCP running faster.
-        </span>
-
-        <button
-          type="button"
-          onClick={copyPrompt}
-          className="shell-docs-radius-control col-span-2 inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center border border-[var(--accent)] bg-[var(--accent)] px-5 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:col-span-1 sm:col-start-3 sm:w-auto"
-        >
-          {copyState === "copied"
-            ? "Copied"
-            : copyState === "error"
-              ? "Copy blocked"
-              : "Copy prompt"}
-        </button>
-      </div>
-
-      {isExpanded && (
-        <div
-          id={promptId}
-          className="border-t border-[var(--nav-control-border)] bg-[var(--accent-dim)] px-5 py-4"
-        >
-          <div className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-[var(--text-secondary)]">
-            {WEBMCP_SETUP_PROMPT}
-          </div>
-        </div>
-      )}
-
-      <span aria-live="polite" className="sr-only">
-        {copyState === "copied"
-          ? "Prompt copied"
-          : copyState === "error"
-            ? "Prompt copy failed. Try again."
-            : ""}
-      </span>
-    </div>
+    <CodingAgentSetupPrompt
+      summary="Use this pre-built prompt to get WebMCP running faster."
+      prompt={WEBMCP_SETUP_PROMPT}
+      copySurface="docs_webmcp_setup_prompt"
+    />
   );
 }

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/intelligence/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 
 import Overview from "@/snippets/shared/intelligence/overview.mdx";

--- a/showcase/shell-docs/src/content/docs/integrations/agno/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/intelligence/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 
 <Overview />

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/intelligence/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 <Overview components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/intelligence/overview.mdx
@@ -1,7 +1,10 @@
 ---
 title: CopilotKit Intelligence
+nav_title: Overview
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
+hideTOC: true
+hidePageActions: true
 ---
 
 import Overview from "@/snippets/shared/intelligence/overview.mdx";

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/intelligence/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 
 <Overview components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/intelligence/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 <Overview />

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/intelligence/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 <Overview components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/intelligence/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 
 import Overview from "@/snippets/shared/intelligence/overview.mdx";

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/intelligence/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 
 <Overview components={props.components} />

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/intelligence/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: CopilotKit Intelligence
 icon: "lucide/Star"
-description: CopilotKit Intelligence capabilities.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 ---
 
 

--- a/showcase/shell-docs/src/content/docs/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/overview.mdx
@@ -1,9 +1,11 @@
 ---
 title: CopilotKit Intelligence
+nav_title: Overview
 icon: "lucide/Star"
-description: CopilotKit Intelligence overview for CopilotKit — features, cloud-hosted and self-hosted deployment options, threads, hosted inspection, and production operations.
+description: CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.
 doc_type: explanation
-hideHeader: true
+hideTOC: true
+hidePageActions: true
 ---
 
 import Overview from "@/snippets/shared/intelligence/overview.mdx";

--- a/showcase/shell-docs/src/content/docs/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/overview.mdx
@@ -3,6 +3,7 @@ title: CopilotKit Intelligence
 icon: "lucide/Star"
 description: CopilotKit Intelligence overview for CopilotKit — features, cloud-hosted and self-hosted deployment options, threads, hosted inspection, and production operations.
 doc_type: explanation
+hideHeader: true
 ---
 
 import Overview from "@/snippets/shared/intelligence/overview.mdx";

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
@@ -1,5 +1,7 @@
 import InspectorPaneLearning from "@/snippets/shared/inspector/open-inspector-pane-learning.mdx";
 
+<IntelligenceOverview />
+
 ## What is CopilotKit Intelligence?
 
 CopilotKit Intelligence is CopilotKit's production layer for durable threads, persistence, hosted inspection, and operational visibility. It sits beside your CopilotKit runtime and gives production agentic applications shared infrastructure without changing the frontend SDK, AG-UI protocol, or agent framework you use.

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
@@ -17,9 +17,17 @@ Ready to connect an existing app? Follow the [CopilotKit Intelligence quickstart
 | Capability | What it gives you | Deeper dive |
 |---|---|---|
 | Durable threads and persistence | Resumable conversations that survive reloads, devices, and browser sessions. | [Threads](/threads) and [Threads & Persistence Architecture](/intelligence/threads-explained) |
+| Analytics | See what your agents do and where users get value, from the same interaction data. | [Analytics](https://www.copilotkit.ai/copilotkit-intelligence#analytics-insights) |
+| Automatic learning | Agents improve from real usage. No fine-tuning pipeline required. | [Automatic Learning](https://www.copilotkit.ai/copilotkit-intelligence#self-improvement) |
 | Cloud-hosted Intelligence features | Projects, project API keys, conversation history, thread inspection, and plan management. | [Cloud-hosted CopilotKit Intelligence](/intelligence/managed-intelligence-platform) |
 | Platform-gated UI capabilities | Platform-gated UI surfaces such as Fully Headless Chat UI. | [Fully Headless Chat UI](/intelligence/headless-ui) |
 | Self-hosting | The same platform running inside your own Kubernetes cluster, VPC, or data boundary. | [Self-host CopilotKit Intelligence](/intelligence/self-hosting) |
+
+<IntelligenceFeatureCards />
+
+Follow the Intelligence quickstart to connect your runtime and confirm threads work.
+
+[Open the Intelligence quickstart](/intelligence/quickstart)
 
 ## Hosting options
 

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+import { expect, test } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function read(relativeFromSrc: string) {
+  return readFileSync(resolve(here, "../..", relativeFromSrc), "utf8");
+}
+
+test("the Intelligence overview hides the default docs header", () => {
+  const page = matter(read("content/docs/intelligence/overview.mdx"));
+  const parser = read("lib/docs-render.tsx");
+
+  expect(page.data.hideHeader).toBe(true);
+  expect(parser).toContain("const hideHeader = data.hideHeader === true");
+});
+
+test("the shared Intelligence overview mounts the landing then keeps platform copy", () => {
+  const snippet = read("content/snippets/shared/intelligence/overview.mdx");
+
+  expect(snippet).toContain("<IntelligenceOverview");
+  expect(snippet.indexOf("<IntelligenceOverview")).toBeLessThan(
+    snippet.indexOf("## What is CopilotKit Intelligence?"),
+  );
+  expect(snippet).toContain("## What the platform adds");
+  expect(snippet).toContain("## Hosting options");
+});
+
+test("the MDX registry and page view wire IntelligenceOverview and hideHeader", () => {
+  const registry = read("lib/mdx-registry.tsx");
+  const pageView = read("components/docs-page-view.tsx");
+
+  expect(registry).toContain(
+    'from "@/components/content/landing-pages/intelligence-overview"',
+  );
+  expect(registry).toContain("IntelligenceOverview,");
+  expect(pageView).toContain("!doc.fm.hideHeader");
+});

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -10,12 +10,30 @@ function read(relativeFromSrc: string) {
   return readFileSync(resolve(here, "../..", relativeFromSrc), "utf8");
 }
 
-test("the Intelligence overview hides the default docs header", () => {
+test("the Intelligence overview uses landing-page chrome", () => {
   const page = matter(read("content/docs/intelligence/overview.mdx"));
+  const routedPage = matter(
+    read("content/docs/integrations/built-in-agent/intelligence/overview.mdx"),
+  );
   const parser = read("lib/docs-render.tsx");
 
-  expect(page.data.hideHeader).toBe(true);
-  expect(parser).toContain("const hideHeader = data.hideHeader === true");
+  expect(page.data.title).toBe("CopilotKit Intelligence");
+  expect(page.data.nav_title).toBe("Overview");
+  expect(page.data.description).toBe(
+    "CopilotKit Intelligence adds persistent threads, analytics, automatic learning, and production operations on top of the runtime you already run.",
+  );
+  expect(page.data.hideHeader).toBeUndefined();
+  expect(page.data.hideTOC).toBe(true);
+  expect(page.data.hidePageActions).toBe(true);
+  expect(routedPage.data.title).toBe("CopilotKit Intelligence");
+  expect(routedPage.data.nav_title).toBe("Overview");
+  expect(routedPage.data.description).toBe(page.data.description);
+  expect(routedPage.data.hideTOC).toBe(true);
+  expect(routedPage.data.hidePageActions).toBe(true);
+  expect(parser).toContain("const hideTOC = data.hideTOC === true");
+  expect(parser).toContain(
+    "const hidePageActions = data.hidePageActions === true",
+  );
 });
 
 test("the shared Intelligence overview mounts the landing then keeps platform copy", () => {
@@ -52,7 +70,7 @@ test("the shared Intelligence overview mounts the landing then keeps platform co
   expect(snippet).toContain("## Hosting options");
 });
 
-test("the MDX registry and page view wire IntelligenceOverview and hideHeader", () => {
+test("the MDX registry and page view wire IntelligenceOverview and its chrome", () => {
   const registry = read("lib/mdx-registry.tsx");
   const pageView = read("components/docs-page-view.tsx");
 
@@ -62,4 +80,5 @@ test("the MDX registry and page view wire IntelligenceOverview and hideHeader", 
   expect(registry).toContain("IntelligenceOverview,");
   expect(registry).toContain("IntelligenceFeatureCards,");
   expect(pageView).toContain("!doc.fm.hideHeader");
+  expect(pageView).toContain("!doc.fm.hidePageActions");
 });

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -26,6 +26,22 @@ test("the shared Intelligence overview mounts the landing then keeps platform co
     snippet.indexOf("## What is CopilotKit Intelligence?"),
   );
   expect(snippet).toContain("## What the platform adds");
+  expect(snippet).toContain("| Analytics |");
+  expect(snippet).toContain("| Automatic learning |");
+  expect(snippet).toContain("<IntelligenceFeatureCards");
+  expect(snippet).toContain(
+    "Follow the Intelligence quickstart to connect your runtime and confirm threads work.",
+  );
+  expect(snippet).toContain("](/intelligence/quickstart)");
+  expect(snippet.indexOf("## What the platform adds")).toBeLessThan(
+    snippet.indexOf("<IntelligenceFeatureCards"),
+  );
+  expect(snippet.indexOf("<IntelligenceFeatureCards")).toBeLessThan(
+    snippet.indexOf("](/intelligence/quickstart)"),
+  );
+  expect(snippet.indexOf("](/intelligence/quickstart)")).toBeLessThan(
+    snippet.indexOf("## Hosting options"),
+  );
   expect(snippet).toContain("## Hosting options");
 });
 
@@ -37,5 +53,6 @@ test("the MDX registry and page view wire IntelligenceOverview and hideHeader", 
     'from "@/components/content/landing-pages/intelligence-overview"',
   );
   expect(registry).toContain("IntelligenceOverview,");
+  expect(registry).toContain("IntelligenceFeatureCards,");
   expect(pageView).toContain("!doc.fm.hideHeader");
 });

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
@@ -33,15 +33,22 @@ test("the shared Intelligence overview mounts the landing then keeps platform co
     "Follow the Intelligence quickstart to connect your runtime and confirm threads work.",
   );
   expect(snippet).toContain("](/intelligence/quickstart)");
+  expect(
+    existsSync(resolve(here, "../../content/docs/intelligence/quickstart.mdx")),
+  ).toBe(true);
   expect(snippet.indexOf("## What the platform adds")).toBeLessThan(
     snippet.indexOf("<IntelligenceFeatureCards"),
   );
   expect(snippet.indexOf("<IntelligenceFeatureCards")).toBeLessThan(
-    snippet.indexOf("](/intelligence/quickstart)"),
+    snippet.indexOf(
+      "Follow the Intelligence quickstart to connect your runtime and confirm threads work.",
+    ),
   );
-  expect(snippet.indexOf("](/intelligence/quickstart)")).toBeLessThan(
-    snippet.indexOf("## Hosting options"),
-  );
+  expect(
+    snippet.indexOf(
+      "Follow the Intelligence quickstart to connect your runtime and confirm threads work.",
+    ),
+  ).toBeLessThan(snippet.indexOf("## Hosting options"));
   expect(snippet).toContain("## Hosting options");
 });
 

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -1681,6 +1681,7 @@ export interface DocFrontmatter {
   defaultFramework?: string;
   defaultCell?: string;
   hideTOC?: boolean;
+  hideHeader?: boolean;
   frontend?: unknown;
   /**
    * Early-access gate id (see `src/lib/early-access.ts`). When set,
@@ -1830,6 +1831,7 @@ export function loadDoc(
   const defaultCell =
     typeof data.snippet_cell === "string" ? data.snippet_cell : undefined;
   const hideTOC = data.hideTOC === true;
+  const hideHeader = data.hideHeader === true;
   const frontend = data.frontend;
   const earlyAccess =
     typeof data.earlyAccess === "string" ? data.earlyAccess : undefined;
@@ -1843,6 +1845,7 @@ export function loadDoc(
       defaultFramework,
       defaultCell,
       hideTOC,
+      hideHeader,
       frontend,
       earlyAccess,
     },

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -1682,6 +1682,7 @@ export interface DocFrontmatter {
   defaultCell?: string;
   hideTOC?: boolean;
   hideHeader?: boolean;
+  hidePageActions?: boolean;
   frontend?: unknown;
   /**
    * Early-access gate id (see `src/lib/early-access.ts`). When set,
@@ -1832,6 +1833,7 @@ export function loadDoc(
     typeof data.snippet_cell === "string" ? data.snippet_cell : undefined;
   const hideTOC = data.hideTOC === true;
   const hideHeader = data.hideHeader === true;
+  const hidePageActions = data.hidePageActions === true;
   const frontend = data.frontend;
   const earlyAccess =
     typeof data.earlyAccess === "string" ? data.earlyAccess : undefined;
@@ -1846,6 +1848,7 @@ export function loadDoc(
       defaultCell,
       hideTOC,
       hideHeader,
+      hidePageActions,
       frontend,
       earlyAccess,
     },

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -41,7 +41,10 @@ import { UnsupportedBox } from "@/components/snippet";
 import { getRegistry } from "@/lib/registry";
 import { PartialLoader } from "@/lib/mdx-registry-loader";
 import { MdxFrameworkOverview } from "@/components/content/landing-pages/mdx-framework-overview";
-import { IntelligenceOverview } from "@/components/content/landing-pages/intelligence-overview";
+import {
+  IntelligenceFeatureCards,
+  IntelligenceOverview,
+} from "@/components/content/landing-pages/intelligence-overview";
 import { FrameworkSetup } from "@/lib/setup-concept";
 import {
   AdkIcon,
@@ -592,6 +595,7 @@ export const docsComponents = {
   // dropped on the floor as a children-passthrough used to do.
   FrameworkOverview: MdxFrameworkOverview,
   IntelligenceOverview,
+  IntelligenceFeatureCards,
   // Per-render override in DocsPageView binds `currentFramework` from
   // the URL — same closure pattern as MdxFrameworkOverview. The base
   // registration renders null when invoked without a framework slug

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -41,6 +41,7 @@ import { UnsupportedBox } from "@/components/snippet";
 import { getRegistry } from "@/lib/registry";
 import { PartialLoader } from "@/lib/mdx-registry-loader";
 import { MdxFrameworkOverview } from "@/components/content/landing-pages/mdx-framework-overview";
+import { IntelligenceOverview } from "@/components/content/landing-pages/intelligence-overview";
 import { FrameworkSetup } from "@/lib/setup-concept";
 import {
   AdkIcon,
@@ -590,6 +591,7 @@ export const docsComponents = {
   // features grid, architecture image, live demos) instead of being
   // dropped on the floor as a children-passthrough used to do.
   FrameworkOverview: MdxFrameworkOverview,
+  IntelligenceOverview,
   // Per-render override in DocsPageView binds `currentFramework` from
   // the URL — same closure pattern as MdxFrameworkOverview. The base
   // registration renders null when invoked without a framework slug

--- a/skills/intelligence-docs/SKILL.md
+++ b/skills/intelligence-docs/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: intelligence-docs
+description: >
+  Keeps the CopilotKit Intelligence landing page in sync when a new Intelligence
+  feature ships or when Intelligence docs are added, renamed, or removed. Use
+  when adding Intelligence capabilities, writing or moving pages under
+  docs/intelligence, editing IntelligenceFeatureCards, or changing
+  snippets/shared/intelligence/overview.mdx. Don't use for OSS-only frontend
+  docs, Inspector pane callouts, or marketing-site copy.
+---
+
+# Intelligence Landing Page
+
+`/intelligence/overview` is the product landing for CopilotKit Intelligence.
+New Intelligence features and new Intelligence docs pages must land on that
+page in the same change. Do not ship a guide that the landing does not name.
+
+## When To Use
+
+Load this skill when:
+
+- A new Intelligence feature ships (threads, analytics, learning, channels,
+  hosting, inspection, or a later pillar)
+- A page is added, renamed, or removed under
+  `showcase/shell-docs/src/content/docs/intelligence/`
+- The shared Intelligence overview snippet or feature cards change
+
+Do not load it for OSS frontend guides that do not use Intelligence, or for
+Inspector pane callouts (`inspector-docs`).
+
+## Landing sources
+
+Edit these in the same change as the feature or docs page:
+
+| Surface                         | File                                                                                                |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Hero and cards                  | `showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx`                |
+| Table, body, quickstart link    | `showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx`                         |
+| Section nav                     | `showcase/shell-docs/src/content/docs/intelligence/meta.json`                                       |
+| Root sidebar Intelligence group | `showcase/shell-docs/src/content/docs/meta.json`                                                    |
+| Card and CTA tests              | `showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx` |
+| Snippet order tests             | `showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts`                                |
+
+The root overview page only wraps the snippet. Do not duplicate landing copy
+in `docs/intelligence/overview.mdx`.
+
+## Procedures
+
+### Procedure 1: Add a feature or docs page
+
+1. Add or update the guide page under `docs/intelligence/` (or the existing
+   threads/channels path the feature already uses).
+2. Put the page in `intelligence/meta.json` and in the Intelligence group in
+   `docs/meta.json` when it belongs in the sidebar.
+3. Add a row to **What the platform adds** in the shared snippet. The deeper
+   dive must be a real URL.
+4. If the feature is a user-facing pillar, add a card to `FEATURES` in
+   `intelligence-overview.tsx` with a unique CTA label and the same URL.
+5. If the feature is a named pillar in the hero, add it to the subtitle.
+6. Extend the tests in the same commit. Pin the new CTA href as a literal.
+
+### Procedure 2: Rename or move a page
+
+1. Update every landing CTA that pointed at the old path: table row, card
+   `href`, quickstart link, and "Which page should I read next?".
+2. Update `meta.json` files.
+3. Update the tests that pin those hrefs.
+
+### Procedure 3: Remove a feature or page
+
+1. Remove the table row, card, subtitle mention, and nav entry.
+2. Remove the matching test assertions.
+3. Do not leave a landing link to a deleted page.
+
+## Decision Tree
+
+- New Intelligence feature or new Intelligence docs page: Procedure 1
+- Rename or move: Procedure 2
+- Remove: Procedure 3
+- Docs exist but landing does not name them: stop and run Procedure 1
+
+## Red Flags
+
+| Signal                                                   | What it means                   | Do instead                             |
+| -------------------------------------------------------- | ------------------------------- | -------------------------------------- |
+| Guide merged, landing unchanged                          | Readers cannot find the feature | Procedure 1 in the same PR             |
+| Card href and table href differ                          | Two stories for one feature     | Use one URL                            |
+| CTA points at the marketing site when a docs page exists | Landing skips the guide         | Point at the docs page                 |
+| Hero subtitle lists a pillar with no card or table row   | Copy without a path             | Add both, or drop the subtitle mention |
+
+## Error Handling
+
+- **No docs page yet:** do not invent a guide. You can still add a table row
+  that points at the current public product URL, and replace it when the
+  guide ships.
+- **Feature is Intelligence-only but lives outside `docs/intelligence/`:**
+  still add the landing CTA. Use the real path (`/threads`, `/channels`, and
+  similar).

--- a/skills/intelligence-docs/SKILL.md
+++ b/skills/intelligence-docs/SKILL.md
@@ -32,14 +32,14 @@ Inspector pane callouts (`inspector-docs`).
 
 Edit these in the same change as the feature or docs page:
 
-| Surface                         | File                                                                                                |
-| ------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Hero and cards                  | `showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx`                |
-| Table, body, quickstart link    | `showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx`                         |
-| Section nav                     | `showcase/shell-docs/src/content/docs/intelligence/meta.json`                                       |
-| Root sidebar Intelligence group | `showcase/shell-docs/src/content/docs/meta.json`                                                    |
-| Card and CTA tests              | `showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx` |
-| Snippet order tests             | `showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts`                                |
+| Surface                              | File                                                                                                |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Hero CTA (`CONNECT_HREF`) and cards  | `showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx`                |
+| Table, body, and MDX quickstart link | `showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx`                         |
+| Section nav                          | `showcase/shell-docs/src/content/docs/intelligence/meta.json`                                       |
+| Root sidebar Intelligence group      | `showcase/shell-docs/src/content/docs/meta.json`                                                    |
+| Card and CTA tests                   | `showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx` |
+| Snippet order tests                  | `showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts`                                |
 
 The root overview page only wraps the snippet. Do not duplicate landing copy
 in `docs/intelligence/overview.mdx`.


### PR DESCRIPTION
The Intelligence overview is now a landing page. Open `/intelligence/overview` to see a sizzle video, copy the onboarding prompt, and jump into threads, analytics, learning, self-hosting, or the Intelligence quickstart.

## What does this PR do?

Replace the text-only CopilotKit Intelligence overview with a landing page:

1. Full-width hero, video, and copy-onboarding prompt
2. "What the platform adds" table, including analytics and automatic learning
3. Feature cards for Rich Threads, Analytics, Automatic Learning, and Self-hosting
4. A quickstart link to `/intelligence/quickstart` (page ships in a sibling PR)

`/premium/overview` already redirects here.

## Related PRs and Issues

- Linear: https://linear.app/copilotkit/issue/OSS-1075/add-a-new-landing-page-for-intelligence
- Sibling: Intelligence quickstart (`OSS-1076`)

## Checklist

- [ ] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)

## Testing

1. **Commands run.** `npx vitest run` on `intelligence-overview.test.tsx`, `hero-start-commands.test.tsx`, and `intelligence-landing.test.ts` in `showcase/shell-docs`. All passed. I did not run `pnpm test:pr`.
2. **Manual test.**
   1. From `showcase/shell-docs`, run `npx next dev --port 3004 --hostname 127.0.0.1`
   2. Open http://127.0.0.1:3004/intelligence/overview
   3. Confirm the hero, video, copy prompt, Connect an app, feature cards, and quickstart link
   4. `/intelligence/quickstart` 404s until the sibling PR merges
3. **How this PR makes testing easy.** Unit tests pin the hero, CTAs, video, table rows, and section order.

## Risk / rollback

Low. Docs-only. Revert the PR to restore the old overview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Intelligence overview landing page with a demo video, onboarding prompt, quickstart link, and feature cards for key platform capabilities.
  - Added support for custom text on quickstart links.
  - Added reduced-motion support for the landing-page video.
  - Added an option to hide documentation page headers when configured.

- **Documentation**
  - Expanded Intelligence documentation with platform capabilities, feature cards, and quickstart guidance.
  - Added guidance for keeping Intelligence documentation and landing-page content synchronized.

- **Tests**
  - Added coverage for Intelligence page content, navigation, video configuration, documentation rendering, and custom quickstart labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->