### PR TITLE
fix(runtime): reject a blank Intelligence API key at construction (closes OSS-1095)

### DIFF
--- a/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/__tests__/client.test.ts
@@ -423,6 +423,48 @@ describe("CopilotKitIntelligence", () => {
     expect(c.ɵgetChannelsWsUrl()).toBe("wss://ws.example.com/channels");
   });
 
+  describe("apiKey validation", () => {
+    it.each([
+      ["an absent key", undefined],
+      ["an empty key", ""],
+      ["a whitespace-only key", "   "],
+    ])("rejects %s at construction, naming the variable", (_label, apiKey) => {
+      expect(
+        () =>
+          new CopilotKitIntelligence({
+            apiKey: apiKey as unknown as string,
+          }),
+      ).toThrow(/CPK_INTELLIGENCE_API_KEY/);
+    });
+
+    it("names the command that provisions a key", () => {
+      expect(() => new CopilotKitIntelligence({ apiKey: "" })).toThrow(
+        /copilotkit project select/,
+      );
+    });
+
+    it("does not echo the rejected key value", () => {
+      // The key is a `cpk-…` secret end to end, so the message must name the
+      // variable and never the value — see `parseProjectIdFromApiKey`, which
+      // omits it for the same reason.
+      const construct = () => new CopilotKitIntelligence({ apiKey: "\t\t" });
+      let message = "";
+      try {
+        construct();
+      } catch (error) {
+        message = (error as Error).message;
+      }
+      expect(message).toMatch(/CPK_INTELLIGENCE_API_KEY/);
+      expect(message).not.toContain("\t\t");
+    });
+
+    it("accepts a non-blank key", () => {
+      expect(
+        new CopilotKitIntelligence({ apiKey: "cpk-1_key" }),
+      ).toBeInstanceOf(CopilotKitIntelligence);
+    });
+  });
+
   describe("managed platform URL defaults", () => {
     it("defaults apiUrl to the managed Intelligence API host", async () => {
       const c = new CopilotKitIntelligence({ apiKey: "k" });

--- a/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
+++ b/packages/runtime/src/v2/runtime/intelligence-platform/client.ts
@@ -665,6 +665,7 @@ export class CopilotKitIntelligence {
         "CopilotKitIntelligence `getLearningContainerId` must be a callback",
       );
     }
+    assertConfiguredApiKey(config.apiKey);
     const configuredApiUrl = configuredUrl(config.apiUrl);
     const configuredWsUrl = configuredUrl(config.wsUrl);
     warnOnPartialHostOverride(configuredApiUrl, configuredWsUrl);
@@ -1650,6 +1651,35 @@ export class CopilotKitIntelligence {
 function configuredUrl(url: string | undefined): string | undefined {
   const trimmed = url?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Reject an Intelligence project API key that carries no credential.
+ *
+ * `apiKey` is required on the config type, so TypeScript catches an absent
+ * property. It does not catch an empty one, and the common shape is a
+ * `process.env` read that TypeScript is told to trust — `?? ""` in the starter
+ * wiring block, `!` in this file's own examples. When the variable is unset,
+ * both produce a blank key that is sent verbatim as `Authorization: Bearer `
+ * and fails much later as a 401 that points at nothing.
+ *
+ * A runtime with no credential cannot serve managed Intelligence, so this
+ * throws at construction: callers build the client during boot, which puts the
+ * error at startup rather than on a user's first message.
+ */
+function assertConfiguredApiKey(apiKey: string): void {
+  if (typeof apiKey === "string" && apiKey.trim() !== "") {
+    return;
+  }
+  // The whole key is a `cpk-…` secret, so name the variable that carries it
+  // and echo none of the value — the same rule `parseProjectIdFromApiKey`
+  // follows for a malformed key.
+  throw new Error(
+    "CopilotKitIntelligence `apiKey` is required and cannot be blank. It is " +
+      "the CopilotKit Intelligence project API key, normally read from the " +
+      "CPK_INTELLIGENCE_API_KEY environment variable. Run `copilotkit " +
+      "project select` to provision one for your project.",
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

`new CopilotKitIntelligence({ apiKey })` performed no validation. The constructor assigned the value (`client.ts:683`) and every authenticated call sent it verbatim as a Bearer credential (`:822`, `:934`, `:1006`, `:1401`). An empty string produced `Authorization: Bearer ` and failed later as a 401 with nothing pointing back at the missing environment variable.

`apiKey: string` is required on the config type, so TypeScript catches a *missing* property. It does not catch an empty one, and it does not catch the shape that actually happens — a `process.env` read TypeScript is told to trust:

- `process.env.CPK_INTELLIGENCE_API_KEY!` — what this file's own JSDoc examples use (`client.ts:619`, `:640`)
- `process.env.CPK_INTELLIGENCE_API_KEY ?? ""` — what the canonical starter wiring block uses

When the variable is unset, both are blank at runtime and typed as `string`. Construction succeeds, and the failure appears later, in a different place, wearing a different name.

## Change

Throw from the constructor when `apiKey` is absent, empty, or whitespace-only. A runtime with no credential cannot serve managed Intelligence, and every caller constructs the client during boot, so the error lands at startup rather than on a user's first message.

The message names `CPK_INTELLIGENCE_API_KEY` and tells the reader that `copilotkit project select` provisions a key. It echoes **none** of the key value — the same rule `parseProjectIdFromApiKey` follows for a malformed key, since the whole `cpk-…` string is a secret.

This mirrors `configuredUrl`, which already treats a blank `apiUrl`/`wsUrl` as unset for exactly the same `?? ""` reason.

## Acceptance criteria

- [x] Constructing with an absent, empty, or whitespace-only `apiKey` throws
- [x] The message names `CPK_INTELLIGENCE_API_KEY` and the command that provisions it
- [x] The error does not include the key value, blank or not
- [x] A test covers each of the three rejected inputs and one accepted one
- [x] No existing test constructs the client with a blank key and expects it to succeed

On the last point: the two `apiKey: ""` hits in the repo are a string literal fed to a static source-contract checker (`integration-intelligence-migration.test.ts:2837`) and unrelated LangGraph agent state (`scene-creator`). Neither constructs a real client.

## Blast radius

Every production construction site is already safe — the starter block and the AgentCore/Angular runtimes gate on the key or the license token, and the Slack/Teams examples call a `requiredIntelligenceKey()` helper. That helper is itself evidence for this change: developers keep hand-rolling the check the platform should perform.

No documentation teaches a blank-tolerant Intelligence key. The seven `apiKey: … ?? ""` hits in docs are all `OPENAI_API_KEY` or a generic name.

## Verification

- `vitest run …/client.test.ts -t "apiKey validation"` — RED `5 failed | 1 passed` before the fix, every failure the constructor not throwing; GREEN `6 passed` after
- `nx test @copilotkit/runtime` — 152 files, **2262 passed**, exit 0
- `nx check-types @copilotkit/runtime` — clean
- `vitest run` over the three `scripts/__tests__` suites that touch this client — **171 passed**
- `oxfmt --check`, `oxlint`, `pnpm check:intelligence-env-names` — clean
- All five lefthook gates green on commit (`test`, `publint`, `attw` across 7 projects)

## Follow-up, deliberately not in this PR

The canonical starter wiring block still reads `apiKey: process.env.CPK_INTELLIGENCE_API_KEY ?? ""`, which now reads as if blank were acceptable. Changing it touches 21 byte-identical starters plus `validate-intelligence-wiring-block`, so it belongs in its own change.

Related: OSS-1091 settled `CPK_INTELLIGENCE_API_KEY` as the canonical name. This is the second half — the naming fix removed the common way to end up with an empty key, not the reason an empty key is expensive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added early validation for the Intelligence API key during startup.
  * Blank, missing, or whitespace-only keys now produce a clear error with setup guidance instead of causing a later authorization failure.
  * Error messages do not expose the rejected key value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->