### PR TITLE
docs(shell-docs): add WebMCP prompt CTA

### DIFF
--- a/showcase/shell-docs/src/components/docs-page-tools.tsx
+++ b/showcase/shell-docs/src/components/docs-page-tools.tsx
@@ -7,11 +7,11 @@
 // whole nav tree, so asserting the row's contents through it would mean
 // standing up most of the docs pipeline.
 //
-// Every page that renders this row gets the onboarding button. `DocsPageView`
-// is only reached by docs surfaces, and the button's offer — set CopilotKit up
-// in this project — holds on all of them. Earlier revisions gated it on the
-// caller naming a framework, which made identical pages behave differently
-// depending on the URL the reader arrived through.
+// Pages get the onboarding button by default. A page with its own focused
+// prompt CTA can hide that one action while keeping the Markdown and LLM
+// tools. Earlier revisions gated it on the caller naming a framework, which
+// made identical pages behave differently depending on the URL the reader
+// arrived through.
 
 import React from "react";
 import {
@@ -41,6 +41,8 @@ export interface DocsPageToolsProps {
    * framework, so the CLI's graph has to ask for neither selection.
    */
   onboardingFrontend?: { id: string; name: string };
+  /** Hide the generic onboarding prompt when the page provides its own CTA. */
+  hideOnboardingPrompt?: boolean;
 }
 
 /**
@@ -66,15 +68,18 @@ export function DocsPageTools({
   githubUrl,
   onboardingFramework,
   onboardingFrontend,
+  hideOnboardingPrompt = false,
 }: DocsPageToolsProps): React.JSX.Element {
   const markdownUrl = docsMarkdownUrl(slugHrefPrefix, slugPath);
   return (
     <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
-      <OnboardingPromptCopyButton
-        framework={onboardingFramework}
-        frontend={onboardingFrontend}
-        markdownUrl={markdownUrl}
-      />
+      {!hideOnboardingPrompt && (
+        <OnboardingPromptCopyButton
+          framework={onboardingFramework}
+          frontend={onboardingFrontend}
+          markdownUrl={markdownUrl}
+        />
+      )}
       <MarkdownCopyButton markdownUrl={markdownUrl} />
       <ViewOptionsPopover markdownUrl={markdownUrl} githubUrl={githubUrl} />
     </div>

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -320,6 +320,7 @@ export async function DocsPageView({
               githubUrl={buildGitHubUrl(doc.filePath)}
               onboardingFramework={onboardingFramework}
               onboardingFrontend={onboardingFrontend}
+              hideOnboardingPrompt={slugPath === "webmcp"}
             />
 
             {/* Thin divider between the page-actions row and the page body

--- a/showcase/shell-docs/src/components/webmcp-setup-prompt.tsx
+++ b/showcase/shell-docs/src/components/webmcp-setup-prompt.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React from "react";
+import { ChevronRight } from "lucide-react";
+
+export const WEBMCP_SETUP_PROMPT =
+  "Set up WebMCP in this project using https://docs.copilotkit.ai/webmcp. First inspect the app and extend its existing CopilotKit setup if present; do not add a backend agent solely for WebMCP. If I haven’t specified a tool, ask what I want to expose. If I don’t have one in mind, add a small, read-only demo tool that fits the app. Finish by verifying that a compatible browser can discover and call it.";
+
+type CopyState = "idle" | "copied" | "error";
+
+export function WebMCPSetupPrompt(): React.JSX.Element {
+  const [copyState, setCopyState] = React.useState<CopyState>("idle");
+  const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  React.useEffect(
+    () => () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    },
+    [],
+  );
+
+  async function copyPrompt(): Promise<void> {
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+
+    try {
+      await navigator.clipboard.writeText(WEBMCP_SETUP_PROMPT);
+      setCopyState("copied");
+      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 1800);
+    } catch {
+      setCopyState("error");
+      resetTimerRef.current = setTimeout(() => setCopyState("idle"), 2600);
+    }
+  }
+
+  return (
+    <div
+      className="shell-docs-radius-surface not-prose my-6 flex flex-col gap-4 border border-[var(--border)] bg-[var(--bg-surface)] px-4 py-3 shadow-[var(--shadow-control)] sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+      data-docs-copy-surface="docs_webmcp_setup_prompt"
+    >
+      <div className="flex min-w-0 items-center gap-3 text-[var(--text-secondary)]">
+        <ChevronRight
+          aria-hidden="true"
+          className="h-5 w-5 shrink-0 text-[var(--text-muted)]"
+        />
+        <p className="m-0 text-base leading-relaxed">
+          Use this pre-built prompt to get WebMCP running faster.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={copyPrompt}
+        className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center bg-[var(--text)] px-5 text-sm font-semibold text-[var(--bg)] transition-opacity hover:opacity-85 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
+      >
+        {copyState === "copied"
+          ? "Copied"
+          : copyState === "error"
+            ? "Copy blocked"
+            : "Copy prompt"}
+      </button>
+
+      <span aria-live="polite" className="sr-only">
+        {copyState === "copied"
+          ? "Prompt copied"
+          : copyState === "error"
+            ? "Prompt copy failed. Try again."
+            : ""}
+      </span>
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/webmcp-setup-prompt.tsx
+++ b/showcase/shell-docs/src/components/webmcp-setup-prompt.tsx
@@ -9,6 +9,8 @@ export const WEBMCP_SETUP_PROMPT =
 type CopyState = "idle" | "copied" | "error";
 
 export function WebMCPSetupPrompt(): React.JSX.Element {
+  const promptId = React.useId();
+  const [isExpanded, setIsExpanded] = React.useState(false);
   const [copyState, setCopyState] = React.useState<CopyState>("idle");
   const resetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -36,30 +38,53 @@ export function WebMCPSetupPrompt(): React.JSX.Element {
 
   return (
     <div
-      className="shell-docs-radius-surface not-prose my-6 flex flex-col gap-4 border border-[var(--border)] bg-[var(--bg-surface)] px-4 py-3 shadow-[var(--shadow-control)] sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+      className="shell-docs-radius-surface not-prose my-6 overflow-hidden border border-[var(--nav-control-border)] bg-[var(--bg-surface)] shadow-[var(--shadow-control)]"
       data-docs-copy-surface="docs_webmcp_setup_prompt"
     >
-      <div className="flex min-w-0 items-center gap-3 text-[var(--text-secondary)]">
-        <ChevronRight
-          aria-hidden="true"
-          className="h-5 w-5 shrink-0 text-[var(--text-muted)]"
-        />
-        <p className="m-0 text-base leading-relaxed">
+      <div className="grid min-h-17 grid-cols-[2.75rem_minmax(0,1fr)] items-center gap-x-3 gap-y-3 p-3 sm:grid-cols-[2.75rem_minmax(0,1fr)_auto] sm:gap-x-4 sm:pr-4">
+        <button
+          type="button"
+          aria-controls={promptId}
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+          className="shell-docs-radius-control inline-flex h-11 w-11 cursor-pointer items-center justify-center border border-[var(--nav-control-border)] bg-[var(--accent-dim)] text-[var(--accent)] transition-colors hover:border-[var(--accent)] hover:bg-[var(--accent-light)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:outline-none sm:col-start-1"
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={`h-5 w-5 transition-transform duration-200 ${isExpanded ? "rotate-90" : ""}`}
+          />
+          <span className="sr-only">
+            {isExpanded ? "Hide prompt text" : "Show prompt text"}
+          </span>
+        </button>
+
+        <span className="block text-base leading-relaxed sm:col-start-2">
           Use this pre-built prompt to get WebMCP running faster.
-        </p>
+        </span>
+
+        <button
+          type="button"
+          onClick={copyPrompt}
+          className="shell-docs-radius-control col-span-2 inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center border border-[var(--accent)] bg-[var(--accent)] px-5 text-sm font-semibold text-[var(--primary-foreground)] shadow-[var(--shadow-control)] transition-colors hover:bg-[var(--accent-strong)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:col-span-1 sm:col-start-3 sm:w-auto"
+        >
+          {copyState === "copied"
+            ? "Copied"
+            : copyState === "error"
+              ? "Copy blocked"
+              : "Copy prompt"}
+        </button>
       </div>
 
-      <button
-        type="button"
-        onClick={copyPrompt}
-        className="shell-docs-radius-control inline-flex min-h-11 w-full shrink-0 cursor-pointer items-center justify-center bg-[var(--text)] px-5 text-sm font-semibold text-[var(--bg)] transition-opacity hover:opacity-85 focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-surface)] focus-visible:outline-none sm:w-auto"
-      >
-        {copyState === "copied"
-          ? "Copied"
-          : copyState === "error"
-            ? "Copy blocked"
-            : "Copy prompt"}
-      </button>
+      {isExpanded && (
+        <div
+          id={promptId}
+          className="border-t border-[var(--nav-control-border)] bg-[var(--accent-dim)] px-5 py-4"
+        >
+          <div className="whitespace-pre-wrap break-words font-mono text-sm leading-relaxed text-[var(--text-secondary)]">
+            {WEBMCP_SETUP_PROMPT}
+          </div>
+        </div>
+      )}
 
       <span aria-live="polite" className="sr-only">
         {copyState === "copied"

--- a/showcase/shell-docs/src/content/docs/webmcp.mdx
+++ b/showcase/shell-docs/src/content/docs/webmcp.mdx
@@ -7,11 +7,7 @@ frontend: universal
 
 import { WebMCPSetupPrompt } from "@/components/webmcp-setup-prompt";
 
-## Setup with a coding agent
-
-Use this pre-built prompt to add WebMCP to your project. Your coding agent will adapt the implementation to your app and verify that a compatible browser can discover and call the tool.
-
-<WebMCPSetupPrompt />
+## Overview
 
 WebMCP lets your website tell compatible browser agents what they can do. Instead of guessing which buttons to click, an agent discovers a named tool with a description, a typed input schema, and a JavaScript handler.
 
@@ -25,6 +21,12 @@ CopilotKit can publish an existing frontend tool to [`document.modelContext`](ht
   [current Chrome setup instructions](https://developer.chrome.com/docs/ai/webmcp)
   before testing.
 </Callout>
+
+## Setup with a coding agent
+
+Use this pre-built prompt to add WebMCP to your project. Your coding agent will adapt the implementation to your app and verify that a compatible browser can discover and call the tool.
+
+<WebMCPSetupPrompt />
 
 ## Do I need an agent?
 

--- a/showcase/shell-docs/src/content/docs/webmcp.mdx
+++ b/showcase/shell-docs/src/content/docs/webmcp.mdx
@@ -5,6 +5,22 @@ description: Expose browser-side actions as structured tools that compatible age
 frontend: universal
 ---
 
+<Accordion
+  featured
+  title="Copy this prompt"
+  description="Paste it into your coding agent from the root of your project."
+>
+
+<DocsTrackedCopy surface="docs_webmcp_setup_prompt">
+
+```text
+Set up WebMCP in this project using https://docs.copilotkit.ai/webmcp. First inspect the app and extend its existing CopilotKit setup if present; do not add a backend agent solely for WebMCP. If I haven’t specified a tool, ask what I want to expose. If I don’t have one in mind, add a small, read-only demo tool that fits the app. Finish by verifying that a compatible browser can discover and call it.
+```
+
+</DocsTrackedCopy>
+
+</Accordion>
+
 WebMCP lets your website tell compatible browser agents what they can do. Instead of guessing which buttons to click, an agent discovers a named tool with a description, a typed input schema, and a JavaScript handler.
 
 CopilotKit can publish an existing frontend tool to [`document.modelContext`](https://webmachinelearning.github.io/webmcp/). The same handler then works for your CopilotKit agent and for WebMCP-aware browser agents.

--- a/showcase/shell-docs/src/content/docs/webmcp.mdx
+++ b/showcase/shell-docs/src/content/docs/webmcp.mdx
@@ -5,21 +5,13 @@ description: Expose browser-side actions as structured tools that compatible age
 frontend: universal
 ---
 
-<Accordion
-  featured
-  title="Copy this prompt"
-  description="Paste it into your coding agent from the root of your project."
->
+import { WebMCPSetupPrompt } from "@/components/webmcp-setup-prompt";
 
-<DocsTrackedCopy surface="docs_webmcp_setup_prompt">
+## Setup with a coding agent
 
-```text
-Set up WebMCP in this project using https://docs.copilotkit.ai/webmcp. First inspect the app and extend its existing CopilotKit setup if present; do not add a backend agent solely for WebMCP. If I haven’t specified a tool, ask what I want to expose. If I don’t have one in mind, add a small, read-only demo tool that fits the app. Finish by verifying that a compatible browser can discover and call it.
-```
+Use this pre-built prompt to add WebMCP to your project. Your coding agent will adapt the implementation to your app and verify that a compatible browser can discover and call the tool.
 
-</DocsTrackedCopy>
-
-</Accordion>
+<WebMCPSetupPrompt />
 
 WebMCP lets your website tell compatible browser agents what they can do. Instead of guessing which buttons to click, an agent discovers a named tool with a description, a typed input schema, and a JavaScript handler.
 

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -33,6 +33,7 @@ import { DocsLandingNext } from "@/components/docs-landing-next";
 import { WhenFrameworkHas } from "@/components/when-framework-has";
 import { WhenAngularBackend } from "@/components/when-angular-backend";
 import { AgentCoreCommandTabs } from "@/components/agentcore-command-tabs";
+import { WebMCPSetupPrompt } from "@/components/webmcp-setup-prompt";
 import { DemoSource } from "@/components/demo-source";
 import { AngularFeatureCatalog } from "@/components/angular-feature-catalog";
 import { AngularSnippet } from "@/components/angular-snippet";
@@ -270,6 +271,7 @@ export const docsComponents = {
   SignupLink,
   DocsTrackedCopy,
   DocsTrackedLink,
+  WebMCPSetupPrompt,
   FeatureIntegrations: ({ feature }: { feature?: string }) => {
     if (!feature) {
       warnSilentNull("FeatureIntegrations", "no `feature` prop provided");


### PR DESCRIPTION
## Summary

- Add a focused one-click prompt CTA at the top of the WebMCP guide.
- Hide the generic onboarding prompt action on the WebMCP page only.

## Why

The WebMCP launch CTA needs a short, standalone prompt that sends developers directly to the WebMCP guide without funneling them through the broader CopilotKit onboarding flow.

## How

- Add a Setup with a coding agent section modeled on the compact prompt row used in the supplied reference.
- Copy the approved WebMCP setup prompt verbatim and expose clear copied and error states.
- Keep the existing Copy Markdown and Open actions while suppressing Copy agent prompt for every WebMCP route.
- Verify shell-docs lint, typecheck, prompt interaction, desktop and mobile rendering, and the Impeccable design scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expandable, copyable WebMCP setup prompt with success and error feedback.
  * Added accessible status announcements and clear copy-button states.
  * Added a dedicated “Setup with a coding agent” section to the WebMCP documentation.

* **Documentation**
  * Reorganized the WebMCP page with an Overview section and clearer setup guidance.
  * The onboarding prompt is hidden on the WebMCP documentation page while remaining available elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->