### PR TITLE
docs(showcase): state the frontend-tool requirement for the last nine frameworks (closes OSS-1036)

### DIFF
--- a/.github/workflows/test_integration-docs.yml
+++ b/.github/workflows/test_integration-docs.yml
@@ -6,6 +6,17 @@ on:
       - "showcase/shell-docs/src/content/**"
       - "showcase/shell-docs/model-allowlist.json"
       - "showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts"
+      # The setup-concept gate below reads snippets owned by the integration
+      # packages and by the docs-only snippet tree, so a new or edited snippet
+      # has to trigger this workflow. Before OSS-1036 neither path was listed,
+      # and the coverage ratchet never ran in CI at all.
+      - "showcase/integrations/*/docs/setup/**"
+      - "showcase/integrations/*/manifest.yaml"
+      - "showcase/shell-docs/src/lib/setup-content.ts"
+      - "showcase/shell-docs/src/lib/setup-concept.tsx"
+      - "showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts"
+      - "showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts"
+      - "showcase/scripts/bundle-setup-content.ts"
       - "showcase/shell-docs/package.json"
       - "showcase/shell-docs/package-lock.json"
       - "examples/integrations/ms-agent-framework-dotnet/**"
@@ -18,6 +29,17 @@ on:
       - "showcase/shell-docs/src/content/**"
       - "showcase/shell-docs/model-allowlist.json"
       - "showcase/shell-docs/src/lib/__tests__/ms-agent-dotnet-provider.test.ts"
+      # The setup-concept gate below reads snippets owned by the integration
+      # packages and by the docs-only snippet tree, so a new or edited snippet
+      # has to trigger this workflow. Before OSS-1036 neither path was listed,
+      # and the coverage ratchet never ran in CI at all.
+      - "showcase/integrations/*/docs/setup/**"
+      - "showcase/integrations/*/manifest.yaml"
+      - "showcase/shell-docs/src/lib/setup-content.ts"
+      - "showcase/shell-docs/src/lib/setup-concept.tsx"
+      - "showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts"
+      - "showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts"
+      - "showcase/scripts/bundle-setup-content.ts"
       - "showcase/shell-docs/package.json"
       - "showcase/shell-docs/package-lock.json"
       - "examples/integrations/ms-agent-framework-dotnet/**"
@@ -71,6 +93,47 @@ jobs:
       - name: Check Microsoft Agent Framework .NET guidance
         working-directory: showcase/shell-docs
         run: npm exec -- vitest run src/lib/__tests__/ms-agent-dotnet-provider.test.ts
+
+  setup-concept-coverage:
+    name: Framework setup-concept coverage
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # zizmor: ignore[undocumented-permissions] Depot runner OIDC.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: showcase/shell-docs/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd showcase/scripts && npm ci --ignore-scripts
+          cd ../shell-docs && npm ci --ignore-scripts
+      # `generate-registry.ts` imports the catalog fold out of the harness tree,
+      # which resolves `js-yaml` by walking up from `showcase/harness/`. Point
+      # that at the already-installed scripts tree instead of installing the
+      # harness package a second time. Same step as showcase/shell-docs/Dockerfile.
+      - name: Link harness module scope
+        run: ln -s ../scripts/node_modules showcase/harness/node_modules
+      # The bundled snippets live in `src/data/setup-content.json`, which is
+      # gitignored, so the tests cannot run until it is generated.
+      - name: Generate registry and bundled content
+        working-directory: showcase/shell-docs
+        run: npm run pretypecheck
+      # Scoped to the two setup-concept files on purpose. The whole shell-docs
+      # suite is not green on main, so running it here would gate every snippet
+      # change on unrelated failures.
+      - name: Check every framework states its frontend-tool requirement
+        working-directory: showcase/shell-docs
+        run: |
+          npm exec -- vitest run \
+            src/lib/__tests__/frontend-tools-setup-coverage.test.ts \
+            src/lib/__tests__/setup-concept.test.ts
 
   doc-tests:
     runs-on: depot-ubuntu-24.04-4

--- a/showcase/integrations/ag2/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/ag2/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,44 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    AG2's AG-UI stream surfaces frontend-registered tools to the model on every
+    run, so the agent declares none of its own. A component registered with
+    `useComponent` reaches the model through the AG-UI request payload, and the
+    model calls it by name. Leave `functions` empty when the only tools in play
+    are frontend ones.
+
+    ```python title="src/agents/chart_agent.py"
+    from autogen import ConversableAgent, LLMConfig
+    from autogen.ag_ui import AGUIStream
+
+    chart_agent = ConversableAgent(
+        name="chart_agent",
+        system_message=SYSTEM_PROMPT,
+        llm_config=LLMConfig({"model": "gpt-4o-mini", "stream": True}),
+        human_input_mode="NEVER",
+        functions=[],
+    )
+
+    chart_stream = AGUIStream(chart_agent)
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in `system_message` and say what it is for.
+
+    ```python title="src/agents/chart_agent.py"
+    SYSTEM_PROMPT = (
+        "You are a data visualization assistant. "
+        "When the user asks for a chart, call `render_bar_chart` with a "
+        "concise title and a `data` array of `{label, value}` items. "
+        "Keep chat responses brief and let the chart do the talking."
+    )
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/agno/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/agno/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,62 @@
+<Steps>
+  <Step>
+    ### Declare the component as an external tool
+
+    Agno's AG-UI interface does not forward the request's tool definitions to
+    the model. The model only sees tools declared on the `Agent`, so a
+    component registered with `useComponent` needs a matching declaration
+    whose body stays empty. Mark it `external_execution=True`: Agno pauses the
+    run, the browser renders the component, and the run resumes with the
+    result.
+
+    The name and the arguments have to match the `useComponent` registration
+    exactly. The docstring is what the model reads, so describe when to call
+    it there.
+
+    ```python title="src/agents/chart_agent.py"
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+    from agno.tools import tool
+
+
+    @tool(external_execution=True)
+    def render_bar_chart(title: str, data: list[dict]):
+        """
+        Render a bar chart in the chat.
+
+        Call this whenever the user asks for a chart or a comparison.
+
+        Args:
+            title (str): A concise chart title.
+            data (list[dict]): Items shaped `{label, value}`.
+        """
+
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o"),
+        db=db,
+        tools=[render_bar_chart],
+        instructions=SYSTEM_PROMPT,
+    )
+    ```
+
+  </Step>
+  <Step>
+    ### Give the agent somewhere to store the paused run
+
+    Agno stores the paused run before the browser can return its result, so
+    the `Agent` that owns the external tool needs a database. An agent with an
+    external tool and no `db` cannot resume after the browser answers.
+
+    ```python title="src/agents/chart_agent.py"
+    from agno.db.sqlite import SqliteDb
+
+    db = SqliteDb(db_file="tmp/agno.db")
+    ```
+
+    `SqliteDb` needs `sqlalchemy` installed. For production use durable shared
+    storage such as `PgDb`, because an ephemeral container file cannot resume a
+    run on another instance.
+
+  </Step>
+</Steps>

--- a/showcase/integrations/built-in-agent/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/built-in-agent/docs/setup/frontend-tools-setup.mdx
@@ -16,6 +16,10 @@
     });
     ```
 
+    Keep the `useComponent` name distinct from every tool in `config.tools`.
+    The runtime layers the configured tools over the forwarded ones, so a
+    shared name resolves to the backend tool and the component never renders.
+
   </Step>
   <Step>
     ### In factory mode you pass the tools yourself
@@ -45,8 +49,9 @@
     });
     ```
 
-    Keep the `useComponent` name distinct from every backend tool name. Where
-    the two collide, the server executor wins and the component is dropped.
+    The factory owns precedence here. Nothing merges the two lists for you, so
+    a backend tool and a `useComponent` registration that share a name is your
+    conflict to resolve. Keep the names distinct.
 
   </Step>
   <Step>

--- a/showcase/integrations/built-in-agent/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/built-in-agent/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,71 @@
+<Steps>
+  <Step>
+    ### Nothing to wire in config mode
+
+    A `BuiltInAgent` built from configuration merges the request's tool
+    definitions into the tool list it hands the model, so the agent declares
+    none of its own. A component registered with `useComponent` reaches the
+    model by name with no extra wiring.
+
+    ```ts title="app/api/copilotkit/[[...slug]]/route.ts"
+    import { BuiltInAgent } from "@copilotkit/runtime/v2";
+
+    const builtInAgent = new BuiltInAgent({
+      model: "openai:gpt-5.4-mini",
+      prompt: SYSTEM_PROMPT,
+    });
+    ```
+
+  </Step>
+  <Step>
+    ### In factory mode you pass the tools yourself
+
+    A factory owns the model call, so `BuiltInAgent` ignores `config.tools` and
+    forwards nothing on your behalf. Read the tools off `input` and pass them
+    to the model, or the component never renders.
+
+    ```ts title="app/api/copilotkit/factory.ts"
+    import {
+      BuiltInAgent,
+      convertMessagesToVercelAISDKMessages,
+      convertToolsToVercelAITools,
+    } from "@copilotkit/runtime/v2";
+    import { openai } from "@ai-sdk/openai";
+    import { streamText } from "ai";
+
+    const agent = new BuiltInAgent({
+      type: "aisdk",
+      factory: ({ input, abortSignal }) =>
+        streamText({
+          model: openai("gpt-4o"),
+          messages: convertMessagesToVercelAISDKMessages(input.messages),
+          tools: convertToolsToVercelAITools(input.tools),
+          abortSignal,
+        }),
+    });
+    ```
+
+    Keep the `useComponent` name distinct from every backend tool name. Where
+    the two collide, the server executor wins and the component is dropped.
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in the prompt and say what it is for.
+
+    ```ts title="app/api/copilotkit/prompts.ts"
+    export const SYSTEM_PROMPT = `You are a data visualization assistant.
+
+    When the user asks for a chart, call \`render_bar_chart\` with a concise
+    title and a \`data\` array of \`{label, value}\` items.
+
+    If the user names a subject but supplies no numbers, invent plausible
+    sample values and render the chart on the first turn. Never reply with a
+    clarifying question asking for the data.`;
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/mastra/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/mastra/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,43 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    The AG-UI Mastra adapter turns the request's tool definitions into Mastra
+    client tools and passes them to `agent.stream()` on every run, so the agent
+    declares none of its own. Register the component with `useComponent` and
+    leave `tools` to your real backend tools.
+
+    ```ts title="src/mastra/agents/chart-agent.ts"
+    import { Agent } from "@mastra/core/agent";
+    import { openai } from "@ai-sdk/openai";
+
+    // `render_bar_chart` is intentionally NOT declared here. It is a
+    // frontend-only tool registered via `useComponent`, and the adapter
+    // forwards it as a client tool on every run.
+    export const chartAgent = new Agent({
+      id: "chart-agent",
+      name: "Chart Agent",
+      model: openai("gpt-4o"),
+      instructions: SYSTEM_PROMPT,
+    });
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in `instructions` and say what it is for.
+
+    ```ts title="src/mastra/agents/chart-agent.ts"
+    const SYSTEM_PROMPT = `You are a data visualization assistant.
+
+    When the user asks for a chart, call the frontend \`render_bar_chart\` tool
+    with a concise title and a \`data\` array of \`{label, value}\` items.
+
+    Keep chat responses brief and let the chart do the talking.`;
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/ms-agent-dotnet/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/ms-agent-dotnet/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,41 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    The AG-UI hosting layer merges the request's tool definitions into the tool
+    list the model sees, so the agent declares none of its own. A component
+    registered with `useComponent` reaches the model by name. Leave `tools`
+    empty when the only tools in play are frontend ones.
+
+    ```csharp title="agent/ChartAgent.cs"
+    using Microsoft.Agents.AI;
+
+    public AIAgent CreateChartAgent()
+    {
+        return new ChatClientAgent(
+            _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient(),
+            name: "ChartAgent",
+            instructions: SystemPrompt,
+            tools: []);
+    }
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in `instructions` and say what it is for.
+
+    ```csharp title="agent/ChartAgent.cs"
+    private const string SystemPrompt = """
+        You are a data visualization assistant.
+        When the user asks for a chart, call render_bar_chart with a concise
+        title, description, and data array of {label, value} items.
+        Keep final chat responses brief.
+        """;
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/ms-agent-dotnet/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/ms-agent-dotnet/docs/setup/frontend-tools-setup.mdx
@@ -9,6 +9,7 @@
 
     ```csharp title="agent/ChartAgent.cs"
     using Microsoft.Agents.AI;
+    using Microsoft.Extensions.AI;
 
     public AIAgent CreateChartAgent()
     {

--- a/showcase/integrations/ms-agent-harness-dotnet/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/ms-agent-harness-dotnet/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,54 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    The AG-UI hosting layer merges the request's tool definitions into the tool
+    list the model sees, so the agent declares none of its own. A component
+    registered with `useComponent` reaches the model by name. The harness takes
+    its tool list through `ChatOptions`, and leaving `Tools` empty is correct
+    when the only tools in play are frontend ones.
+
+    ```csharp title="agent/ChartAgent.cs"
+    using Microsoft.Agents.AI;
+    using Microsoft.Agents.AI.Harness;
+
+    public AIAgent CreateChartAgent()
+    {
+        var chatClient = _openAiClient.GetChatClient("gpt-4o-mini").AsIChatClient();
+
+        return chatClient.AsHarnessAgent(
+            HarnessMaxContextWindowTokens,
+            HarnessMaxOutputTokens,
+            new HarnessAgentOptions
+            {
+                Name = "ChartAgent",
+                Description = "Renders charts from data.",
+                ChatOptions = new ChatOptions
+                {
+                    Instructions = SystemPrompt,
+                    MaxOutputTokens = HarnessMaxOutputTokens,
+                    Tools = [],
+                },
+            });
+    }
+    ```
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in `Instructions` and say what it is for.
+
+    ```csharp title="agent/ChartAgent.cs"
+    private const string SystemPrompt = """
+        You are a data visualization assistant.
+        When the user asks for a chart, call render_bar_chart with a concise
+        title, description, and data array of {label, value} items.
+        Keep final chat responses brief.
+        """;
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/ms-agent-harness-dotnet/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/ms-agent-harness-dotnet/docs/setup/frontend-tools-setup.mdx
@@ -10,7 +10,10 @@
 
     ```csharp title="agent/ChartAgent.cs"
     using Microsoft.Agents.AI;
-    using Microsoft.Agents.AI.Harness;
+    using Microsoft.Extensions.AI;
+
+    private const int HarnessMaxContextWindowTokens = 128_000;
+    private const int HarnessMaxOutputTokens = 8_192;
 
     public AIAgent CreateChartAgent()
     {

--- a/showcase/integrations/strands-typescript/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/strands-typescript/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,49 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    On every run the AG-UI Strands adapter registers a proxy tool in the
+    agent's tool registry for each tool the request carries, so the agent
+    declares none of its own. A component registered with `useComponent`
+    reaches the model by name, and the browser executes the call.
+
+    ```ts title="src/agent/agent.ts"
+    import { Agent } from "@strands-agents/sdk";
+    import { StrandsAgent } from "@ag-ui/aws-strands";
+
+    const strandsAgent = new Agent({
+      model: await createModel(),
+      systemPrompt: SYSTEM_PROMPT,
+      tools: [],
+    });
+
+    export const aguiAgent = new StrandsAgent({
+      agent: strandsAgent,
+      name: "chart_agent",
+      description: "Renders charts from data.",
+    });
+    ```
+
+    A backend tool that already owns the name wins: the adapter never replaces
+    a native tool with a proxy. Keep the `useComponent` name distinct from
+    every tool in `tools`.
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in `systemPrompt` and say what it is for.
+
+    ```ts title="src/agent/prompts.ts"
+    export const SYSTEM_PROMPT = `You are a data visualization assistant.
+
+    When the user asks for a chart, call the frontend \`render_bar_chart\` tool
+    with a concise title and a \`data\` array of \`{label, value}\` items.
+
+    Keep chat responses brief and let the chart do the talking.`;
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/integrations/strands/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/strands/docs/setup/frontend-tools-setup.mdx
@@ -1,0 +1,52 @@
+<Steps>
+  <Step>
+    ### Nothing to wire on the agent
+
+    On every run the AG-UI Strands adapter registers a proxy tool in the
+    agent's tool registry for each tool the request carries, so the agent
+    declares none of its own. A component registered with `useComponent`
+    reaches the model by name, and the browser executes the call.
+
+    ```python title="src/agents/chart_agent.py"
+    from strands import Agent
+    from strands.models.openai import OpenAIModel
+
+    from ag_ui_strands import StrandsAgent
+
+    strands_agent = Agent(
+        model=OpenAIModel(model_id="gpt-4o"),
+        system_prompt=SYSTEM_PROMPT,
+        tools=[],
+    )
+
+    agui_agent = StrandsAgent(
+        agent=strands_agent,
+        name="chart_agent",
+        description="Renders charts from data.",
+    )
+    ```
+
+    A backend tool that already owns the name wins: the adapter never replaces
+    a native tool with a proxy. Keep the `useComponent` name distinct from
+    every tool in `tools=`.
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    This is the part that is easy to miss. The tool arrives on every run, but a
+    model with no instruction about it will answer in prose and never call it.
+    Name the tool in `system_prompt` and say what it is for.
+
+    ```python title="src/agents/chart_agent.py"
+    SYSTEM_PROMPT = (
+        "You are a data visualization assistant.\n"
+        "When the user asks for a chart, call the frontend `render_bar_chart` "
+        "tool with a concise title and a `data` array of `{label, value}` "
+        "items.\n"
+        "Keep chat responses brief and let the chart do the talking."
+    )
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/shell-docs/src/content/snippets/setup/deepagents/frontend-tools-setup.mdx
+++ b/showcase/shell-docs/src/content/snippets/setup/deepagents/frontend-tools-setup.mdx
@@ -1,0 +1,45 @@
+<Steps>
+  <Step>
+    ### Wire CopilotKit middleware into your agent
+
+    Deep Agents compile to LangGraph graphs, and `CopilotKitMiddleware` is the
+    bridge. It reads the forwarded tools off the request and merges them into
+    the tool list the model sees, so a component registered with `useComponent`
+    only reaches the model when the middleware is present.
+
+    ```python title="agent.py"
+    from deepagents import create_deep_agent
+    from copilotkit import CopilotKitMiddleware
+
+    agent = create_deep_agent(
+        model="openai:gpt-5.4",
+        tools=[],  # Backend tools go here
+        middleware=[CopilotKitMiddleware()],
+        system_prompt=SYSTEM_PROMPT,
+    )
+    ```
+
+    Without the middleware the run still completes, and the component never
+    renders, because the model was never told the tool exists.
+
+  </Step>
+  <Step>
+    ### Tell the model when to call it
+
+    The forwarded tool arrives on every run, but a model with no instruction
+    about it will answer in prose and never call it. Name the tool in
+    `system_prompt` and say what it is for.
+
+    ```python title="agent.py"
+    SYSTEM_PROMPT = """
+    You are a data visualization assistant.
+
+    When the user asks for a chart, call `render_bar_chart` with a concise
+    title and a `data` array of `{label, value}` items.
+
+    Keep chat responses brief and let the chart do the talking.
+    """
+    ```
+
+  </Step>
+</Steps>

--- a/showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts
@@ -17,24 +17,12 @@ const CONCEPT = "frontend-tools-setup";
  * framework needs no agent-side wiring" from "it needs some and nobody wrote it down"
  * (OSS-1036).
  *
- * Every name here is unfinished work, not an exemption on the merits. Establishing the
- * answer means reading the framework's AG-UI adapter and its own `gen-ui-tool-based`
- * demo agent, then writing the snippet — including when the snippet's content is
- * "nothing is required", which is a real and common answer worth stating.
- *
- * Removing a name is the whole job. Adding one needs a reason in the pull request.
+ * The list is empty: every framework serving the page now states its requirement.
+ * Keep it that way. A new framework arriving without a snippet fails the first test
+ * below, and the fix is the snippet, not a name here. Adding one needs a reason in the
+ * pull request, and it is unfinished work rather than an exemption on the merits.
  */
-const REQUIREMENT_NOT_ESTABLISHED = [
-  "ag2",
-  "agno",
-  "built-in-agent",
-  "deepagents",
-  "mastra",
-  "ms-agent-dotnet",
-  "ms-agent-harness-dotnet",
-  "strands",
-  "strands-typescript",
-] as const;
+const REQUIREMENT_NOT_ESTABLISHED: readonly string[] = [] as const;
 
 function frameworksServingToolBased(): string[] {
   return getIntegrations()
@@ -47,9 +35,7 @@ test("every framework either documents its frontend-tool requirement or is a nam
   const missing = frameworksServingToolBased().filter(
     (slug) =>
       resolveBundledSetupConcept(slug, CONCEPT, setupContent) === null &&
-      !REQUIREMENT_NOT_ESTABLISHED.includes(
-        slug as (typeof REQUIREMENT_NOT_ESTABLISHED)[number],
-      ),
+      !REQUIREMENT_NOT_ESTABLISHED.includes(slug),
   );
 
   expect(
@@ -78,6 +64,19 @@ test("a snippet says what the framework's own demo agent proves about it", () =>
     "pydantic-ai",
     "llamaindex",
     "ms-agent-python",
+    // Added by OSS-1036. Each verdict was read out of the pinned adapter, not the
+    // docs: ag2 `run_stream` builds `client_tools` from `incoming.tools`; the Mastra
+    // adapter reduces `input.tools` into `clientTools` for `agent.stream()`; both
+    // Strands adapters register a proxy tool per forwarded tool in the agent's tool
+    // registry. The two .NET columns rest on their own demo agents, which render
+    // charts with an empty `tools` list, because no .NET SDK was available to read
+    // `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore` directly.
+    "ag2",
+    "mastra",
+    "strands",
+    "strands-typescript",
+    "ms-agent-dotnet",
+    "ms-agent-harness-dotnet",
   ];
   for (const slug of forwardsAutomatically) {
     const source = resolveBundledSetupConcept(slug, CONCEPT, setupContent);
@@ -109,6 +108,58 @@ test("a snippet says what the framework's own demo agent proves about it", () =>
     ).toContain("copilotkit_stream");
     expect(source, `${slug}: names the tool_choice lever`).toContain(
       "tool_choice",
+    );
+  }
+
+  // Deep Agents compile to LangGraph graphs, so the forwarded tools reach the model
+  // only through `CopilotKitMiddleware`, which merges `copilotkit.actions` into
+  // `request.tools` in `wrap_model_call`. Drop the middleware and the run still
+  // succeeds while the component never renders, which is the exact failure an empty
+  // section used to hide.
+  {
+    const source = resolveBundledSetupConcept(
+      "deepagents",
+      CONCEPT,
+      setupContent,
+    );
+    expect(source, "deepagents").not.toBeNull();
+    expect(source, "deepagents: names the bridge").toContain(
+      "CopilotKitMiddleware()",
+    );
+    expect(source, "deepagents: puts it in the middleware list").toContain(
+      "middleware=[",
+    );
+  }
+
+  // Agno is the one framework here whose AG-UI interface never reads
+  // `RunAgentInput.tools` (checked against agno 2.6.19: the only tool path out of
+  // `agno/os/interfaces/agui` is `RunPausedEvent.tools_awaiting_external_execution`).
+  // So the component needs a declared stub, and the paused run needs somewhere to live.
+  {
+    const source = resolveBundledSetupConcept("agno", CONCEPT, setupContent);
+    expect(source, "agno").not.toBeNull();
+    expect(source, "agno: declares the component as an external tool").toContain(
+      "external_execution=True",
+    );
+    expect(source, "agno: gives the paused run a database").toContain("db=db");
+  }
+
+  // The built-in agent is the only mode-dependent answer, and it is also the root
+  // framework, so this snippet is what the unscoped default page renders. Config mode
+  // merges `input.tools` for you; a factory owns the model call and forwards nothing.
+  // Saying only one half would be wrong for half the readers.
+  {
+    const source = resolveBundledSetupConcept(
+      "built-in-agent",
+      CONCEPT,
+      setupContent,
+    );
+    expect(source, "built-in-agent").not.toBeNull();
+    expect(source, "built-in-agent: config mode needs no wiring").toContain(
+      "Nothing to wire in config mode",
+    );
+    expect(source, "built-in-agent: factory mode passes them itself").toContain(
+      "convertToolsToVercelAITools(input.tools)",
     );
   }
 });

--- a/showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts
@@ -138,9 +138,10 @@ test("a snippet says what the framework's own demo agent proves about it", () =>
   {
     const source = resolveBundledSetupConcept("agno", CONCEPT, setupContent);
     expect(source, "agno").not.toBeNull();
-    expect(source, "agno: declares the component as an external tool").toContain(
-      "external_execution=True",
-    );
+    expect(
+      source,
+      "agno: declares the component as an external tool",
+    ).toContain("external_execution=True");
     expect(source, "agno: gives the paused run a database").toContain("db=db");
   }
 

--- a/showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts
@@ -111,9 +111,14 @@ test.each([
 // `FrameworkSetup` returning `null`, so a rendering defect shipped looking exactly like a
 // deliberate omission — the only trace a `console.error` nobody reads in production
 // (OSS-1036). Absence is a real state and stays quiet; a broken snippet is not.
+//
+// The unbundled case is pinned with a concept name that is deliberately never bundled,
+// not with a framework slug. Naming a real gap made this test depend on that gap staying
+// open: it was `ag2`, and closing the last nine `frontend-tools-setup` gaps (OSS-1036)
+// would have turned it red for the right reason.
 test("a concept nobody bundled for this framework renders nothing, quietly", async () => {
   const result = await FrameworkSetup({
-    concept: "frontend-tools-setup",
+    concept: "concept-that-is-never-bundled",
     currentFramework: "ag2",
   });
 


### PR DESCRIPTION
## Problem

`generative-ui/tool-based` is the terminal page every onboarding run fetches, on every framework route (OSS-1034). Its `## How it works in code` section is one `<FrameworkSetup concept="frontend-tools-setup" />` call that resolves a per-framework snippet. Nine frameworks shipped no snippet, so the section rendered nothing and the `.md` output emitted `<!-- setup skipped: ... -->`. That silence meant two different things at once: "this framework needs no agent-side wiring" and "it needs wiring and nobody wrote it down".

Verified on the live host before the change: all nine emitted the skip comment, at ~2.4KB per page.

One of the nine is `built-in-agent`, which is `ROOT_FRAMEWORK`. So the page carrying the gap included the unscoped default, `https://docs.copilotkit.ai/generative-ui/tool-based.md`.

## Solution

A snippet for each of the nine. Each verdict was read out of the pinned adapter rather than out of the docs, which is what the ticket asked for.

**Nothing to wire on the agent** — confirmed in the adapter:

| framework | the line that decides it |
| --- | --- |
| `ag2` | `autogen/ag_ui/adapter.py` `run_stream` builds `client_tools` from `command.incoming.tools` |
| `mastra` | `@ag-ui/mastra@1.1.0` reduces `input.tools` into `clientTools` for `agent.stream()` |
| `strands` | `ag_ui_strands@0.2.2` calls `sync_proxy_tools(agent.tool_registry, input_data.tools, ...)` |
| `strands-typescript` | `@ag-ui/aws-strands@0.2.3` registers a proxy tool per forwarded tool in `toolRegistry` |

Both Strands adapters refuse to overwrite a native tool of the same name, so each snippet says to keep the `useComponent` name distinct.

**Real wiring:**

- `agno`. Its AG-UI interface never reads `RunAgentInput.tools`. Checked against `agno==2.6.19`: the only tool path out of `agno/os/interfaces/agui/` is `RunPausedEvent.tools_awaiting_external_execution`. So a component needs a declared `@tool(external_execution=True)` stub and the `Agent` needs a `db` to hold the paused run.
- `deepagents`. `sdk-python/copilotkit/copilotkit_lg_middleware.py` merges `copilotkit.actions` into `request.tools` inside `wrap_model_call`, so `middleware=[CopilotKitMiddleware()]` is load-bearing. Its snippet lives in the docs-only tree, because `deepagents` has no integration package.

**Mode-dependent:**

- `built-in-agent`. Config mode merges `input.tools` for you (`packages/runtime/src/agent/index.ts`). A factory owns the model call and forwards nothing, so it has to pass them itself. Both halves are in the snippet, plus the collision rule: a frontend tool whose name matches a server tool is dropped in favor of the server executor.

**In-repo evidence only:**

- `ms-agent-dotnet`, `ms-agent-harness-dotnet`. Their own `gen-ui-tool-based` agents render charts with an empty tool list (`tools: []` / `Tools = []`) and their instructions name the chart tools. No .NET SDK was available here to read `Microsoft.Agents.AI.Hosting.AGUI.AspNetCore` directly.

Six of the nine snippets also carry the "Tell the model when to call it" step, which is not filler. `GEN_UI_TOOL_BASED_PROMPT` in `showcase/integrations/built-in-agent/src/lib/factory/demo-prompts.ts` records what happens without it: the model emits `value: 0` for every point and renders a chart with no bars.

## Tests

- `REQUIREMENT_NOT_ESTABLISHED` is now empty, and the docblock says a new framework arriving without a snippet is fixed with a snippet, not with a name.
- The shape test pins all six auto-forwarding frameworks, plus the three that do not fit that shape (`agno`, `deepagents`, `built-in-agent`).
- `setup-concept.test.ts` used `ag2` as its example of an unbundled concept, so closing the last gap would have turned it red for the right reason. It now uses a concept name that is deliberately never bundled.

## The gate never ran in CI

Second commit. No workflow runs the shell-docs vitest suite: `test_integration-docs.yml` runs exactly one test file, `test_unit-showcase.yml` covers harness and shell-dashboard only, and `showcase_build_check.yml` matches `showcase/**` but only builds images. Neither path filter listed the snippet files either. So the ratchet added in #6777 was local-only.

Added a scoped job and widened both filters. The job runs only the two setup-concept files on purpose: the full shell-docs suite is not green on `main`, and gating every snippet change on unrelated failures would be worse than no gate.

## Verification

Ran against a local `shell-docs` dev server on this branch. Expected `setup skipped` count is 0 everywhere:

```
ag2                        skip=0 bytes=3825
agno                       skip=0 bytes=4299
deepagents                 skip=0 bytes=3786
mastra                     skip=0 bytes=3857
ms-agent-dotnet            skip=0 bytes=3706
ms-agent-harness-dotnet    skip=0 bytes=4236
strands                    skip=0 bytes=4026
strands-typescript         skip=0 bytes=4001
built-in-agent (root path) skip=0 bytes=4723
```

`vitest run` on the two setup-concept files: 12 passed. `npm run typecheck` and `npm run lint` both exit 0.

Four tests fail in the full shell-docs suite (`llm-text.test.ts` mastra tool-rendering, three in `angular-docs-content.test.ts`). All four fail identically at the pre-change baseline in the same worktree, so they are pre-existing on `main` and untouched by this branch.

## Two findings this turned up, not fixed here

1. **The `agno` showcase demo contradicts its own snippet.** Every `useFrontendTool` tool in agno's demos has a matching `external_execution` stub, but the `useComponent` ones do not: `render_bar_chart`, `render_pie_chart`, `query_notes` and `highlight_note` have no backend declaration, and `_run_main_agent_hitl_aware` in `src/agent_server.py` cannot forward them. Its e2e spec cannot catch this, because it asserts only that an `svg` is visible inside an assistant message, which any icon satisfies.
2. **Four frameworks redirect the HTML page away.** For `ag2`, `agno`, `deepagents` and `mastra`, `/<slug>/generative-ui/tool-based` 301s to `/<slug>/generative-ui/tool-rendering`. Confirmed on the live host as well as locally, so it predates this branch. Their `.md` output serves the page normally, which is the path onboarding runs fetch, but a human browsing those four never reaches it.

Closes OSS-1036.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added frontend tool setup guides for AG2, Agno, Built-in Agent, Mastra, Microsoft Agent integrations, Strands, and Deep Agents.
  - Documented tool registration, prompting, execution behavior, persistence, and middleware configuration.

- **Tests**
  - Expanded coverage for frontend tool setup documentation across supported integrations.
  - Updated setup concept tests to use a stable, intentionally unbundled example.

- **Chores**
  - Added automated workflow coverage for setup documentation and related tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->