### PR TITLE
feat(docs): refine content page layout

### DIFF
--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -60,10 +60,12 @@ describe("globals.css docs headings", () => {
 });
 
 describe("globals.css docs media breakouts", () => {
-  it("keeps standard tables aligned to the prose measure", () => {
-    expect(globalsCss).toContain("> :is(img, figure.shiki)");
+  it("keeps standard tables and code blocks aligned to the prose measure", () => {
+    expect(globalsCss).toContain(
+      ".docs-article-content .reference-content > img",
+    );
     expect(globalsCss).not.toMatch(
-      /\.reference-content\s*>\s*:is\([^)]*table/,
+      /\.reference-content\s*>\s*:is\([^)]*(?:table|figure\.shiki)/,
     );
   });
 });

--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -87,10 +87,20 @@ describe("globals.css docs page actions", () => {
     expect(normalizedGlobalsCss).toContain(
       normalizeWhitespace(`
         .docs-page-actions-primary:hover,
-        .docs-page-actions-trigger:hover {
+        .docs-page-actions-trigger:hover,
+        .docs-page-actions-trigger[data-state="open"] {
           border-color: var(--accent) !important;
-          background-color: var(--accent-strong) !important;
+          background-color: var(--docs-page-actions-hover) !important;
         }
+      `),
+    );
+    expect(normalizedGlobalsCss).toContain(
+      normalizeWhitespace(`
+        --docs-page-actions-hover: color-mix(
+          in oklch,
+          var(--accent) 68%,
+          black
+        );
       `),
     );
   });

--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -70,6 +70,22 @@ describe("globals.css docs media breakouts", () => {
   });
 });
 
+describe("globals.css docs page actions", () => {
+  it("keeps split-button borders neutral on hover", () => {
+    const normalizedGlobalsCss = normalizeWhitespace(globalsCss);
+
+    expect(normalizedGlobalsCss).toContain(
+      normalizeWhitespace(`
+        .docs-page-actions-primary:hover,
+        .docs-page-actions-trigger:hover {
+          border-color: var(--border);
+          background-color: var(--bg-elevated);
+        }
+      `),
+    );
+  });
+});
+
 describe("globals.css cookbook sidebar", () => {
   it("removes the empty cookbook sidebar banner and aligns the recipe list", () => {
     const normalizedGlobalsCss = normalizeWhitespace(globalsCss);

--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -78,6 +78,7 @@ describe("globals.css docs page actions", () => {
       normalizeWhitespace(`
         .docs-page-actions-primary,
         .docs-page-actions-trigger {
+          cursor: pointer;
           border-color: var(--accent) !important;
           background-color: var(--accent) !important;
           color: var(--primary-foreground) !important;

--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -71,18 +71,37 @@ describe("globals.css docs media breakouts", () => {
 });
 
 describe("globals.css docs page actions", () => {
-  it("keeps split-button borders neutral on hover", () => {
+  it("styles the split control as one purple primary action", () => {
     const normalizedGlobalsCss = normalizeWhitespace(globalsCss);
 
     expect(normalizedGlobalsCss).toContain(
       normalizeWhitespace(`
-        .docs-page-actions-primary:hover,
-        .docs-page-actions-trigger:hover {
-          border-color: var(--border);
-          background-color: var(--bg-elevated);
+        .docs-page-actions-primary,
+        .docs-page-actions-trigger {
+          border-color: var(--accent) !important;
+          background-color: var(--accent) !important;
+          color: var(--primary-foreground) !important;
         }
       `),
     );
+    expect(normalizedGlobalsCss).toContain(
+      normalizeWhitespace(`
+        .docs-page-actions-primary:hover,
+        .docs-page-actions-trigger:hover {
+          border-color: var(--accent) !important;
+          background-color: var(--accent-strong) !important;
+        }
+      `),
+    );
+  });
+
+  it("gives the primary action a reduced-motion-safe shimmer", () => {
+    expect(globalsCss).toContain("@keyframes docs-page-actions-shimmer");
+    expect(globalsCss).toContain(
+      "animation: docs-page-actions-shimmer 4.5s ease-in-out infinite;",
+    );
+    expect(globalsCss).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(globalsCss).toContain("animation: none;");
   });
 });
 

--- a/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
+++ b/showcase/shell-docs/src/app/__tests__/globals-css.test.ts
@@ -59,6 +59,15 @@ describe("globals.css docs headings", () => {
   });
 });
 
+describe("globals.css docs media breakouts", () => {
+  it("keeps standard tables aligned to the prose measure", () => {
+    expect(globalsCss).toContain("> :is(img, figure.shiki)");
+    expect(globalsCss).not.toMatch(
+      /\.reference-content\s*>\s*:is\([^)]*table/,
+    );
+  });
+});
+
 describe("globals.css cookbook sidebar", () => {
   it("removes the empty cookbook sidebar banner and aligns the recipe list", () => {
     const normalizedGlobalsCss = normalizeWhitespace(globalsCss);

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1053,6 +1053,11 @@ figure.shiki > div:first-child[class*="border-b"] {
 }
 
 .docs-page-tools {
+  --docs-page-actions-hover: color-mix(
+    in oklch,
+    var(--accent) 68%,
+    black
+  );
   position: relative;
   isolation: isolate;
   flex: 0 0 auto;
@@ -1121,9 +1126,10 @@ figure.shiki > div:first-child[class*="border-b"] {
 }
 
 .docs-page-actions-primary:hover,
-.docs-page-actions-trigger:hover {
+.docs-page-actions-trigger:hover,
+.docs-page-actions-trigger[data-state="open"] {
   border-color: var(--accent) !important;
-  background-color: var(--accent-strong) !important;
+  background-color: var(--docs-page-actions-hover) !important;
 }
 
 @keyframes docs-page-actions-shimmer {

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1084,6 +1084,12 @@ figure.shiki > div:first-child[class*="border-b"] {
   z-index: 1;
 }
 
+.docs-page-actions-primary:hover,
+.docs-page-actions-trigger:hover {
+  border-color: var(--border);
+  background-color: var(--bg-elevated);
+}
+
 .docs-page-description {
   max-width: var(--docs-reading-width);
   margin-top: 0.75rem;

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1053,10 +1053,34 @@ figure.shiki > div:first-child[class*="border-b"] {
 }
 
 .docs-page-tools {
+  position: relative;
+  isolation: isolate;
   flex: 0 0 auto;
   flex-wrap: nowrap;
   gap: 0;
   margin: 0;
+  border-radius: var(--shell-docs-radius-control);
+}
+
+/* One low-contrast light pass gives the primary page action a little energy
+ * without turning a reading surface into a looping attention trap. The long
+ * hold between passes keeps it quieter than an indeterminate loading state. */
+.docs-page-tools::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  border-radius: inherit;
+  background: linear-gradient(
+    110deg,
+    transparent 32%,
+    color-mix(in srgb, white 22%, transparent) 48%,
+    transparent 64%
+  );
+  background-position: 130% 0;
+  background-size: 260% 100%;
+  pointer-events: none;
+  animation: docs-page-actions-shimmer 4.5s ease-in-out infinite;
 }
 
 .docs-page-tools > * {
@@ -1067,6 +1091,18 @@ figure.shiki > div:first-child[class*="border-b"] {
 .docs-page-actions-primary {
   border-radius: var(--shell-docs-radius-control) 0 0
     var(--shell-docs-radius-control) !important;
+}
+
+.docs-page-actions-primary,
+.docs-page-actions-trigger {
+  border-color: var(--accent) !important;
+  background-color: var(--accent) !important;
+  color: var(--primary-foreground) !important;
+}
+
+.docs-page-actions-primary svg,
+.docs-page-actions-trigger svg {
+  color: currentColor !important;
 }
 
 .docs-page-actions-trigger {
@@ -1086,8 +1122,26 @@ figure.shiki > div:first-child[class*="border-b"] {
 
 .docs-page-actions-primary:hover,
 .docs-page-actions-trigger:hover {
-  border-color: var(--border);
-  background-color: var(--bg-elevated);
+  border-color: var(--accent) !important;
+  background-color: var(--accent-strong) !important;
+}
+
+@keyframes docs-page-actions-shimmer {
+  0%,
+  68% {
+    background-position: 130% 0;
+  }
+  88%,
+  100% {
+    background-position: -80% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-page-tools::after {
+    background: none;
+    animation: none;
+  }
 }
 
 .docs-page-description {

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1053,11 +1053,7 @@ figure.shiki > div:first-child[class*="border-b"] {
 }
 
 .docs-page-tools {
-  --docs-page-actions-hover: color-mix(
-    in oklch,
-    var(--accent) 68%,
-    black
-  );
+  --docs-page-actions-hover: color-mix(in oklch, var(--accent) 68%, black);
   position: relative;
   isolation: isolate;
   flex: 0 0 auto;

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1543,13 +1543,14 @@ samp {
   margin: 1.5rem 0;
 }
 
-/* Dense media benefits from a wider canvas than prose. Direct diagrams,
- * tables, and standalone code blocks first fill the 760px outer content lane,
- * then gain one further step when both navigation rails leave enough room. */
+/* Diagrams and standalone code blocks benefit from a wider canvas than prose.
+ * Standard tables stay on the reading measure so their section heading and
+ * content share one clear axis; genuinely wide tables should opt into their
+ * own overflow treatment rather than inheriting a viewport breakpoint. */
 @media (min-width: 1280px) {
   .docs-article-content
     .reference-content
-    > :is(img, table, figure.shiki) {
+    > :is(img, figure.shiki) {
     width: min(var(--docs-breakout-width), calc(100% + 5rem));
     max-width: min(var(--docs-breakout-width), calc(100% + 5rem));
     margin-right: 0;
@@ -1561,7 +1562,7 @@ samp {
 @media (min-width: 1440px) {
   .docs-article-content
     .reference-content
-    > :is(img, table, figure.shiki) {
+    > :is(img, figure.shiki) {
     width: min(var(--docs-breakout-width), calc(100% + 8.75rem));
     max-width: min(var(--docs-breakout-width), calc(100% + 8.75rem));
   }

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1055,13 +1055,33 @@ figure.shiki > div:first-child[class*="border-b"] {
 .docs-page-tools {
   flex: 0 0 auto;
   flex-wrap: nowrap;
-  gap: 0.375rem;
+  gap: 0;
   margin: 0;
 }
 
 .docs-page-tools > * {
   flex: none;
   white-space: nowrap;
+}
+
+.docs-page-actions-primary {
+  border-radius: var(--shell-docs-radius-control) 0 0
+    var(--shell-docs-radius-control) !important;
+}
+
+.docs-page-actions-trigger {
+  align-self: stretch;
+  min-width: 2rem;
+  margin-left: -1px;
+  padding-inline: 0.5rem !important;
+  border-radius: 0 var(--shell-docs-radius-control)
+    var(--shell-docs-radius-control) 0 !important;
+}
+
+.docs-page-actions-primary:focus-visible,
+.docs-page-actions-trigger:focus-visible {
+  position: relative;
+  z-index: 1;
 }
 
 .docs-page-description {

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1543,14 +1543,11 @@ samp {
   margin: 1.5rem 0;
 }
 
-/* Diagrams and standalone code blocks benefit from a wider canvas than prose.
- * Standard tables stay on the reading measure so their section heading and
- * content share one clear axis; genuinely wide tables should opt into their
- * own overflow treatment rather than inheriting a viewport breakpoint. */
+/* Direct diagrams benefit from a wider canvas than prose. Standard tables and
+ * code blocks stay on the reading measure so their section heading and content
+ * share one clear axis; both already own their dense-content overflow. */
 @media (min-width: 1280px) {
-  .docs-article-content
-    .reference-content
-    > :is(img, figure.shiki) {
+  .docs-article-content .reference-content > img {
     width: min(var(--docs-breakout-width), calc(100% + 5rem));
     max-width: min(var(--docs-breakout-width), calc(100% + 5rem));
     margin-right: 0;
@@ -1560,9 +1557,7 @@ samp {
 }
 
 @media (min-width: 1440px) {
-  .docs-article-content
-    .reference-content
-    > :is(img, figure.shiki) {
+  .docs-article-content .reference-content > img {
     width: min(var(--docs-breakout-width), calc(100% + 8.75rem));
     max-width: min(var(--docs-breakout-width), calc(100% + 8.75rem));
   }

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -1100,6 +1100,7 @@ figure.shiki > div:first-child[class*="border-b"] {
 
 .docs-page-actions-primary,
 .docs-page-actions-trigger {
+  cursor: pointer;
   border-color: var(--accent) !important;
   background-color: var(--accent) !important;
   color: var(--primary-foreground) !important;

--- a/showcase/shell-docs/src/app/globals.css
+++ b/showcase/shell-docs/src/app/globals.css
@@ -35,6 +35,9 @@
   --shell-docs-layout-width: calc(97rem + 11px);
   --shell-docs-grid-gutter: 0px;
   --shell-docs-grid-top-offset: 0px;
+  --docs-reading-width: 42.5rem;
+  --docs-breakout-width: 51.25rem;
+  --docs-content-gutter: 1rem;
   --radius: 0.875rem;
   --shell-docs-radius: var(--radius);
   --shell-docs-radius-control: var(--radius);
@@ -71,6 +74,7 @@
       0px,
       calc((100% - var(--shell-docs-layout-width)) / 2)
     );
+    --docs-content-gutter: 2.5rem;
   }
 }
 
@@ -902,7 +906,7 @@ figure.shiki > div:first-child[class*="border-b"] {
   min-width: 0 !important;
   max-width: 100% !important;
   padding-top: 0 !important;
-  padding-left: 0.75rem !important;
+  padding-inline: 0.75rem !important;
   margin-top: 0 !important;
 }
 #nd-page > article > *:first-child {
@@ -936,6 +940,17 @@ figure.shiki > div:first-child[class*="border-b"] {
   padding-right: 16px !important;
 }
 
+/* Product-guide pages use one stable reading measure regardless of whether
+ * the right-rail TOC is present. The outer lane owns responsive gutters; the
+ * prose measure below owns line length. Keeping those roles separate avoids
+ * consuming the nominal max-width with hidden nested padding. */
+.docs-article-content {
+  max-width: calc(
+    var(--docs-reading-width) + 2 * var(--docs-content-gutter)
+  ) !important;
+  padding-inline: var(--docs-content-gutter) !important;
+}
+
 /* Tablet/sidebar-visible layouts can put the content column directly
  * against the sidebar edge. Add a small extra left inset there without
  * spending precious horizontal space on phone-sized screens. */
@@ -951,8 +966,13 @@ figure.shiki > div:first-child[class*="border-b"] {
  * right). */
 @media (min-width: 1280px) {
   .docs-inner-content {
-    padding-left: 49px !important;
-    padding-right: 49px !important;
+    padding-left: var(--docs-content-gutter) !important;
+    padding-right: var(--docs-content-gutter) !important;
+  }
+
+  #nd-docs-layout {
+    --fd-sidebar-width: 248px !important;
+    --fd-toc-width: 232px !important;
   }
 }
 
@@ -969,6 +989,113 @@ figure.shiki > div:first-child[class*="border-b"] {
 }
 #nd-docs-layout:not(:has(#nd-toc)) .docs-inner-content {
   max-width: min(1100px, 100%);
+}
+
+#nd-docs-layout:not(:has(#nd-toc)) .docs-article-content {
+  max-width: calc(
+    var(--docs-reading-width) + 2 * var(--docs-content-gutter)
+  ) !important;
+}
+
+/* Content-page header — one compact reading cluster rather than four stacked
+ * bands. The title remains the dominant element; utility actions stay neutral
+ * and share its row when the real copy fits, then wrap naturally as a group. */
+.docs-page-header {
+  margin-bottom: 2.75rem;
+}
+
+.docs-page-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+}
+
+.docs-page-breadcrumb a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 120ms ease;
+}
+
+.docs-page-breadcrumb a:hover {
+  color: var(--accent);
+}
+
+.docs-page-breadcrumb a:focus-visible {
+  border-radius: 0.25rem;
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.docs-page-heading-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+}
+
+.docs-page-title {
+  min-width: 0;
+  flex: 1 1 18rem;
+  color: var(--text);
+  font-size: clamp(2rem, 3vw, 2.25rem);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1.22;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
+}
+
+.docs-page-tools {
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  gap: 0.375rem;
+  margin: 0;
+}
+
+.docs-page-tools > * {
+  flex: none;
+  white-space: nowrap;
+}
+
+.docs-page-description {
+  max-width: var(--docs-reading-width);
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 1.125rem;
+  line-height: 1.5556;
+  text-wrap: pretty;
+}
+
+@media (max-width: 767px) {
+  .docs-page-header {
+    margin-bottom: 2.25rem;
+  }
+
+  .docs-page-heading-row {
+    align-items: flex-start;
+  }
+
+  .docs-page-title {
+    flex-basis: 100%;
+  }
+
+  .docs-page-tools {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 0.125rem;
+    scrollbar-width: none;
+  }
+
+  .docs-page-tools::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* Tablet/mobile: the docs grid keeps 5 columns (sidebar / sidebar / main /
@@ -1260,8 +1387,10 @@ samp {
  * The reference uses fumadocs' default prose scale: body ~15px, h2 ~1.5rem
  * with tighter tracking, and tonally-darker headings than body. */
 .reference-content {
-  font-size: 0.9375rem; /* 15px */
-  line-height: 1.65;
+  max-width: var(--docs-reading-width);
+  margin-inline: auto;
+  font-size: 1rem;
+  line-height: 1.75;
   color: var(--text-secondary);
 }
 
@@ -1269,8 +1398,8 @@ samp {
   font-size: 1.5rem;
   font-weight: 600;
   color: var(--text);
-  margin-top: 2.5rem;
-  margin-bottom: 0.75rem;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
   padding-bottom: 0;
   letter-spacing: normal;
 }
@@ -1279,8 +1408,8 @@ samp {
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--text);
-  margin-top: 2rem;
-  margin-bottom: 0.5rem;
+  margin-top: 2.25rem;
+  margin-bottom: 0.75rem;
   letter-spacing: -0.01em;
 }
 
@@ -1293,10 +1422,10 @@ samp {
 }
 
 .reference-content p {
-  font-size: 0.9375rem;
+  font-size: 1rem;
   color: var(--text-secondary);
-  line-height: 1.7;
-  margin-bottom: 1rem;
+  line-height: 1.75;
+  margin-bottom: 1.25rem;
 }
 
 /* prose-no-margin (used by fumadocs Callout and Table) lives in @layer utilities,
@@ -1311,15 +1440,15 @@ samp {
 
 .reference-content ul,
 .reference-content ol {
-  font-size: 0.9375rem;
+  font-size: 1rem;
   color: var(--text-secondary);
   padding-left: 1.5rem;
-  margin-bottom: 1rem;
-  line-height: 1.65;
+  margin-bottom: 1.25rem;
+  line-height: 1.75;
 }
 
 .reference-content li {
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.5rem;
 }
 
 .reference-content ul {
@@ -1412,6 +1541,30 @@ samp {
   border: none;
   border-top: 1px solid var(--border);
   margin: 1.5rem 0;
+}
+
+/* Dense media benefits from a wider canvas than prose. Direct diagrams,
+ * tables, and standalone code blocks first fill the 760px outer content lane,
+ * then gain one further step when both navigation rails leave enough room. */
+@media (min-width: 1280px) {
+  .docs-article-content
+    .reference-content
+    > :is(img, table, figure.shiki) {
+    width: min(var(--docs-breakout-width), calc(100% + 5rem));
+    max-width: min(var(--docs-breakout-width), calc(100% + 5rem));
+    margin-right: 0;
+    margin-left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
+@media (min-width: 1440px) {
+  .docs-article-content
+    .reference-content
+    > :is(img, table, figure.shiki) {
+    width: min(var(--docs-breakout-width), calc(100% + 8.75rem));
+    max-width: min(var(--docs-breakout-width), calc(100% + 8.75rem));
+  }
 }
 
 /* Reference prop rows are authored as individual <PropertyReference> MDX

--- a/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
+++ b/showcase/shell-docs/src/app/reference/[...slug]/page.tsx
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
 import type React from "react";
-import { Fragment } from "react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import matter from "gray-matter";
-import { ChevronRight, LinkIcon } from "lucide-react";
+import { LinkIcon } from "lucide-react";
 import remarkGfm from "remark-gfm";
 import {
   rehypeCode,
@@ -21,18 +20,11 @@ import {
   Accordions,
   Accordion,
 } from "@/components/mdx-components";
-import {
-  MarkdownCopyButton,
-  ViewOptionsPopover,
-} from "@/components/ai/page-actions";
 import { OpsPlatformCTA } from "@/components/react/ops-platform-cta";
-import {
-  DocsPage,
-  DocsBody,
-  DocsTitle,
-  DocsDescription,
-} from "fumadocs-ui/page";
+import { DocsPage, DocsBody } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
+import { DocsContentHeader } from "@/components/docs-content-header";
+import { DocsPageTools } from "@/components/docs-page-tools";
 import { ReferenceVersionSelector } from "@/components/reference-version-selector";
 import {
   REFERENCE_VERSIONS,
@@ -159,7 +151,6 @@ export default async function ReferenceSlugPage({
   const description =
     typeof data.description === "string" ? data.description : undefined;
   const pageTree = buildReferencePageTree(version);
-  const markdownUrl = `${referenceHref(version, pageSlug).replace(/\/$/, "")}.mdx`;
   const versionOptions = REFERENCE_VERSIONS.map((referenceVersion) => ({
     version: referenceVersion,
     href: referenceVersionHref(referenceVersion, pageSlug),
@@ -189,45 +180,22 @@ export default async function ReferenceSlugPage({
         breadcrumb={{ enabled: false }}
         footer={{ enabled: false }}
       >
-        <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-          <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
-            {breadcrumbs.map((crumb, i) => {
-              const isLast = i === breadcrumbs.length - 1;
-              const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
-              return (
-                <Fragment key={`${crumb.label}-${i}`}>
-                  {i > 0 && (
-                    <ChevronRight
-                      className="size-3 shrink-0"
-                      aria-hidden="true"
-                    />
-                  )}
-                  {crumb.href && !isLast ? (
-                    <Link
-                      href={crumb.href}
-                      className={`${labelClass} transition-opacity hover:opacity-80`}
-                    >
-                      {crumb.label}
-                    </Link>
-                  ) : (
-                    <span className={labelClass}>{crumb.label}</span>
-                  )}
-                </Fragment>
-              );
-            })}
-          </nav>
-
-          <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-            {title}
-          </DocsTitle>
-          {description && (
-            <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-              {description}
-            </DocsDescription>
-          )}
+        <div className="docs-inner-content docs-article-content mx-auto px-4 pb-6 pt-2 md:px-6 md:pt-3 xl:pt-4">
+          <DocsContentHeader
+            ancestorBreadcrumbs={breadcrumbs}
+            title={title}
+            description={description}
+          >
+            <DocsPageTools
+              slugPath={pageSlug}
+              slugHrefPrefix={`/reference/${version}`}
+              githubUrl={buildGitHubUrl(filePath)}
+              hideOnboardingPrompt
+            />
+          </DocsContentHeader>
 
           {version === "v1" && (
-            <div className="my-6">
+            <div className="mb-6">
               <Callout type="warning">
                 <strong>{V1_DEPRECATION_NOTICE_USE_V2_INSTEAD.title}</strong>{" "}
                 {V1_DEPRECATION_NOTICE_USE_V2_INSTEAD.summary}{" "}
@@ -245,16 +213,6 @@ export default async function ReferenceSlugPage({
               </Callout>
             </div>
           )}
-
-          <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
-            <MarkdownCopyButton markdownUrl={markdownUrl} />
-            <ViewOptionsPopover
-              markdownUrl={markdownUrl}
-              githubUrl={buildGitHubUrl(filePath)}
-            />
-          </div>
-
-          <hr className="border-t border-[var(--border)] mt-2 mb-6" />
 
           <DocsBody className="reference-content">
             <MDXRemote

--- a/showcase/shell-docs/src/app/reference/page.tsx
+++ b/showcase/shell-docs/src/app/reference/page.tsx
@@ -1,10 +1,6 @@
-import {
-  DocsPage,
-  DocsBody,
-  DocsTitle,
-  DocsDescription,
-} from "fumadocs-ui/page";
+import { DocsPage, DocsBody } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
+import { DocsContentHeader } from "@/components/docs-content-header";
 import { Cards, Card } from "@/components/mdx-components";
 import { ReferenceVersionSelector } from "@/components/reference-version-selector";
 import {
@@ -102,15 +98,14 @@ export default function ReferencePage() {
         breadcrumb={{ enabled: false }}
         footer={{ enabled: false }}
       >
-        <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-          <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-            Overview
-          </DocsTitle>
-          <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-            {intro}
-          </DocsDescription>
+        <div className="docs-inner-content docs-article-content mx-auto px-4 pb-6 pt-2 md:px-6 md:pt-3 xl:pt-4">
+          <DocsContentHeader
+            ancestorBreadcrumbs={[{ label: "Reference", href: null }]}
+            title="Overview"
+            description={intro}
+          />
 
-          <DocsBody className="reference-content prose-sm mt-8">
+          <DocsBody className="reference-content">
             <section>
               <h2>Choose your SDK</h2>
               <Cards>

--- a/showcase/shell-docs/src/components/__tests__/docs-content-header.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-content-header.test.tsx
@@ -35,9 +35,7 @@ it("composes ancestor breadcrumbs and actions around the page title", () => {
 });
 
 it("does not render empty breadcrumb chrome", () => {
-  render(
-    <DocsContentHeader ancestorBreadcrumbs={[]} title="Introduction" />,
-  );
+  render(<DocsContentHeader ancestorBreadcrumbs={[]} title="Introduction" />);
 
   expect(screen.queryByRole("navigation", { name: "Breadcrumb" })).toBeNull();
 });

--- a/showcase/shell-docs/src/components/__tests__/docs-content-header.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-content-header.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { DocsContentHeader } from "../docs-content-header";
+
+afterEach(cleanup);
+
+it("composes ancestor breadcrumbs and actions around the page title", () => {
+  render(
+    <DocsContentHeader
+      ancestorBreadcrumbs={[
+        { label: "Reference", href: "/reference" },
+        { label: "Components", href: null },
+      ]}
+      title="CopilotChatInput"
+      description="Primary text input for chat interactions."
+    >
+      <button type="button">Copy page</button>
+    </DocsContentHeader>,
+  );
+
+  expect(
+    screen.getByRole("navigation", { name: "Breadcrumb" }).textContent,
+  ).toContain("Reference");
+  expect(
+    screen.getByRole("link", { name: "Reference" }).getAttribute("href"),
+  ).toBe("/reference");
+  expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+    "CopilotChatInput",
+  );
+  expect(screen.getByRole("button", { name: "Copy page" })).toBeTruthy();
+  expect(screen.getByText(/Primary text input/)).toBeTruthy();
+});
+
+it("does not render empty breadcrumb chrome", () => {
+  render(
+    <DocsContentHeader ancestorBreadcrumbs={[]} title="Introduction" />,
+  );
+
+  expect(screen.queryByRole("navigation", { name: "Breadcrumb" })).toBeNull();
+});

--- a/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
@@ -55,7 +55,7 @@ function renderRow(onboardingFramework?: { slug: string; name: string }): void {
   );
 }
 
-it("still renders the onboarding button when no framework is passed", () => {
+it("renders one split CTA with copy prompt as its root action", async () => {
   // The surfaces that omit the prop are `a2a` and `agent-spec`: documented
   // like frameworks, but absent from the registry, so there is no display
   // name to put in the prompt. They are docs pages all the same, and the
@@ -67,9 +67,21 @@ it("still renders the onboarding button when no framework is passed", () => {
   expect(
     screen.getByRole("button", { name: /copy prompt/i }),
   ).toBeTruthy();
-  // The rest of the row is untouched.
-  expect(screen.getByRole("button", { name: /copy page/i })).toBeTruthy();
-  expect(screen.getByRole("button", { name: /^open$/i })).toBeTruthy();
+  expect(screen.queryByRole("button", { name: /copy page/i })).toBeNull();
+  expect(screen.queryByRole("button", { name: /^open$/i })).toBeNull();
+
+  fireEvent.click(
+    screen.getByRole("button", { name: /more page actions/i }),
+  );
+
+  expect(
+    await screen.findByRole("button", { name: /copy page/i }),
+  ).toBeTruthy();
+  expect(screen.getByRole("separator")).toBeTruthy();
+  expect(
+    screen.getByRole("link", { name: /open in github/i }),
+  ).toBeTruthy();
+  expect(screen.queryByRole("link", { name: /view as markdown/i })).toBeNull();
 });
 
 it("renders the onboarding button when a framework is passed", () => {

--- a/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
@@ -62,32 +62,24 @@ it("renders one split CTA with copy prompt as its root action", async () => {
   // regardless of what the prompt says.
   renderRow();
 
-  expect(
-    screen.getByRole("button", { name: /copy prompt/i }),
-  ).toBeTruthy();
+  expect(screen.getByRole("button", { name: /copy prompt/i })).toBeTruthy();
   expect(screen.queryByRole("button", { name: /copy page/i })).toBeNull();
   expect(screen.queryByRole("button", { name: /^open$/i })).toBeNull();
 
-  fireEvent.click(
-    screen.getByRole("button", { name: /more page actions/i }),
-  );
+  fireEvent.click(screen.getByRole("button", { name: /more page actions/i }));
 
   expect(
     await screen.findByRole("button", { name: /copy page/i }),
   ).toBeTruthy();
   expect(screen.getByRole("separator")).toBeTruthy();
-  expect(
-    screen.getByRole("link", { name: /open in github/i }),
-  ).toBeTruthy();
+  expect(screen.getByRole("link", { name: /open in github/i })).toBeTruthy();
   expect(screen.queryByRole("link", { name: /view as markdown/i })).toBeNull();
 });
 
 it("renders the onboarding button when a framework is passed", () => {
   renderRow({ slug: "mastra", name: "Mastra" });
 
-  expect(
-    screen.getByRole("button", { name: /copy prompt/i }),
-  ).toBeTruthy();
+  expect(screen.getByRole("button", { name: /copy prompt/i })).toBeTruthy();
 });
 
 it("gives the onboarding button the same .mdx URL as the markdown button", async () => {

--- a/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
@@ -65,10 +65,10 @@ it("still renders the onboarding button when no framework is passed", () => {
   renderRow();
 
   expect(
-    screen.getByRole("button", { name: /copy agent prompt/i }),
+    screen.getByRole("button", { name: /copy prompt/i }),
   ).toBeTruthy();
   // The rest of the row is untouched.
-  expect(screen.getByRole("button", { name: /copy markdown/i })).toBeTruthy();
+  expect(screen.getByRole("button", { name: /copy page/i })).toBeTruthy();
   expect(screen.getByRole("button", { name: /^open$/i })).toBeTruthy();
 });
 
@@ -76,7 +76,7 @@ it("renders the onboarding button when a framework is passed", () => {
   renderRow({ slug: "mastra", name: "Mastra" });
 
   expect(
-    screen.getByRole("button", { name: /copy agent prompt/i }),
+    screen.getByRole("button", { name: /copy prompt/i }),
   ).toBeTruthy();
 });
 
@@ -87,7 +87,7 @@ it("gives the onboarding button the same .mdx URL as the markdown button", async
   Object.assign(navigator, { clipboard: { writeText } });
 
   renderRow({ slug: "mastra", name: "Mastra" });
-  fireEvent.click(screen.getByRole("button", { name: /copy agent prompt/i }));
+  fireEvent.click(screen.getByRole("button", { name: /copy prompt/i }));
 
   await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -84,12 +84,15 @@ async function fetchMarkdown(url: string): Promise<string> {
  */
 export function MarkdownCopyButton({
   markdownUrl,
+  appearance = "button",
   ...props
 }: ComponentProps<"button"> & {
   /**
    * A URL to fetch the raw Markdown/MDX content of page
    */
   markdownUrl: string;
+  /** Render as a full-width popover action instead of standalone chrome. */
+  appearance?: "button" | "menu-item";
 }) {
   const [isLoading, setLoading] = useState(false);
   const pathname = usePathname();
@@ -148,11 +151,14 @@ export function MarkdownCopyButton({
       disabled={isLoading}
       onClick={onClick}
       className={cn(
-        buttonVariants({
-          color: "secondary",
-          size: "sm",
-          className: "gap-2 [&_svg]:size-3.5 [&_svg]:text-[var(--text-muted)]",
-        }),
+        appearance === "menu-item"
+          ? "shell-docs-radius-control inline-flex w-full items-center gap-2 p-2 text-left text-sm font-normal text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:text-[var(--text-muted)]"
+          : buttonVariants({
+              color: "secondary",
+              size: "sm",
+              className:
+                "gap-2 [&_svg]:size-3.5 [&_svg]:text-[var(--text-muted)]",
+            }),
         props.className,
       )}
     >
@@ -439,6 +445,8 @@ export function OnboardingPromptCopyButton({
 export function ViewOptionsPopover({
   markdownUrl,
   githubUrl,
+  condensed = false,
+  includeCopyPage = false,
   ...props
 }: ComponentProps<typeof PopoverTrigger> & {
   /**
@@ -450,6 +458,12 @@ export function ViewOptionsPopover({
    * Source file URL on GitHub
    */
   githubUrl?: string;
+
+  /** Use an icon-only trigger designed to join a split primary action. */
+  condensed?: boolean;
+
+  /** Put the Markdown copy action at the top of the condensed menu. */
+  includeCopyPage?: boolean;
 }) {
   const pathname = usePathname();
   const posthog = usePostHog();
@@ -477,7 +491,7 @@ export function ViewOptionsPopover({
           </svg>
         ),
       },
-      markdownUrl && {
+      !condensed && markdownUrl && {
         title: "View as Markdown",
         target: "view-as-markdown",
         href: markdownUrl,
@@ -553,25 +567,50 @@ export function ViewOptionsPopover({
         })}`,
       },
     ].filter((v) => !!v);
-  }, [githubUrl, markdownUrl, pathname]);
+  }, [condensed, githubUrl, markdownUrl, pathname]);
 
   return (
     <Popover>
       <PopoverTrigger
         {...props}
+        aria-label={
+          condensed
+            ? (props["aria-label"] ?? "More page actions")
+            : props["aria-label"]
+        }
         className={cn(
           buttonVariants({
             color: "secondary",
             size: "sm",
           }),
           "gap-2 data-[state=open]:border-[var(--accent)] data-[state=open]:bg-[var(--accent-dim)] data-[state=open]:text-[var(--accent)]",
+          condensed && "docs-page-actions-trigger",
           props.className,
         )}
       >
-        {props.children ?? "Open"}
+        {!condensed && (props.children ?? "Open")}
         <ChevronDown className="size-3.5 text-[var(--text-muted)]" />
       </PopoverTrigger>
-      <PopoverContent className="flex flex-col">
+      <PopoverContent
+        align={condensed ? "end" : "center"}
+        className={cn("flex flex-col", condensed && "w-72 p-1.5")}
+      >
+        {includeCopyPage && markdownUrl && (
+          <>
+            <MarkdownCopyButton
+              markdownUrl={markdownUrl}
+              appearance="menu-item"
+              title="Copy page as Markdown"
+            >
+              Copy page
+            </MarkdownCopyButton>
+            <div
+              role="separator"
+              aria-orientation="horizontal"
+              className="mx-2 my-1 border-t border-[var(--border)]"
+            />
+          </>
+        )}
         {items.map((item) => (
           <a
             key={item.href}

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -491,12 +491,13 @@ export function ViewOptionsPopover({
           </svg>
         ),
       },
-      !condensed && markdownUrl && {
-        title: "View as Markdown",
-        target: "view-as-markdown",
-        href: markdownUrl,
-        icon: <TextIcon />,
-      },
+      !condensed &&
+        markdownUrl && {
+          title: "View as Markdown",
+          target: "view-as-markdown",
+          href: markdownUrl,
+          icon: <TextIcon />,
+        },
       {
         title: "Open in Windsurf",
         target: "windsurf",

--- a/showcase/shell-docs/src/components/ai/page-actions.tsx
+++ b/showcase/shell-docs/src/components/ai/page-actions.tsx
@@ -395,9 +395,10 @@ export function OnboardingPromptCopyButton({
         onClick={copyPrompt}
         className={cn(
           buttonVariants({
-            // The primary action of the row — the two neighbours are
-            // deliberately `secondary`. `size: "sm"` keeps the heights equal.
-            color: "primary",
+            // Page reading is the primary task. Keep this useful action at the
+            // same visual weight as its neighbours so it does not compete with
+            // the article title for attention.
+            color: "secondary",
             size: "sm",
             className: "gap-2 [&_svg]:size-3.5",
           }),

--- a/showcase/shell-docs/src/components/docs-content-header.tsx
+++ b/showcase/shell-docs/src/components/docs-content-header.tsx
@@ -43,10 +43,7 @@ export function DocsContentHeader({
               key={`${crumb.label}-${crumb.href ?? "current"}-${index}`}
             >
               {index > 0 && (
-                <ChevronRight
-                  className="size-3 shrink-0"
-                  aria-hidden="true"
-                />
+                <ChevronRight className="size-3 shrink-0" aria-hidden="true" />
               )}
               {crumb.href ? (
                 <Link href={crumb.href}>{crumb.label}</Link>

--- a/showcase/shell-docs/src/components/docs-content-header.tsx
+++ b/showcase/shell-docs/src/components/docs-content-header.tsx
@@ -1,0 +1,70 @@
+import type React from "react";
+import { Fragment } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { DocsDescription, DocsTitle } from "fumadocs-ui/page";
+
+export type DocsContentHeaderBreadcrumb = {
+  label: string;
+  href: string | null;
+};
+
+export interface DocsContentHeaderProps {
+  /** Ancestors only; the current page is represented by the title below. */
+  ancestorBreadcrumbs: DocsContentHeaderBreadcrumb[];
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Page-level actions composed into the title row. */
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared visual header for guide and reference content pages.
+ *
+ * Routes keep ownership of breadcrumb construction and page actions because
+ * their URL/content rules differ. This component owns only the common
+ * hierarchy, alignment, typography, and responsive wrapping behavior.
+ */
+export function DocsContentHeader({
+  ancestorBreadcrumbs,
+  title,
+  description,
+  children,
+}: DocsContentHeaderProps): React.JSX.Element {
+  return (
+    <header className="docs-page-header">
+      {ancestorBreadcrumbs.length > 0 && (
+        <nav aria-label="Breadcrumb" className="docs-page-breadcrumb">
+          {ancestorBreadcrumbs.map((crumb, index) => (
+            <Fragment
+              key={`${crumb.label}-${crumb.href ?? "current"}-${index}`}
+            >
+              {index > 0 && (
+                <ChevronRight
+                  className="size-3 shrink-0"
+                  aria-hidden="true"
+                />
+              )}
+              {crumb.href ? (
+                <Link href={crumb.href}>{crumb.label}</Link>
+              ) : (
+                <span>{crumb.label}</span>
+              )}
+            </Fragment>
+          ))}
+        </nav>
+      )}
+
+      <div className="docs-page-heading-row">
+        <DocsTitle className="docs-page-title">{title}</DocsTitle>
+        {children}
+      </div>
+
+      {description && (
+        <DocsDescription className="docs-page-description">
+          {description}
+        </DocsDescription>
+      )}
+    </header>
+  );
+}

--- a/showcase/shell-docs/src/components/docs-page-tools.tsx
+++ b/showcase/shell-docs/src/components/docs-page-tools.tsx
@@ -1,6 +1,6 @@
-// DocsPageTools — the page-tools row that sits under a docs page's title:
-// "Copy prompt", "Copy page", and the "Open in <LLM>" popover.
-// Fumadocs's upstream LLM page-actions feature.
+// DocsPageTools — the compact split action that sits beside a docs page title.
+// "Copy prompt" is the default action; its chevron progressively discloses
+// "Copy page" and the existing "Open in <LLM>" destinations.
 //
 // Extracted from `docs-page-view.tsx` so the row sits in a component small
 // enough to unit-test. `DocsPageView` itself loads MDX off disk and builds the
@@ -72,23 +72,35 @@ export function DocsPageTools({
 }: DocsPageToolsProps): React.JSX.Element {
   const markdownUrl = docsMarkdownUrl(slugHrefPrefix, slugPath);
   return (
-    <div className="docs-page-tools flex min-w-0 flex-row flex-wrap items-center gap-2">
-      {!hideOnboardingPrompt && (
+    <div
+      className="docs-page-tools flex min-w-0 flex-row items-center"
+      role="group"
+      aria-label="Page actions"
+    >
+      {hideOnboardingPrompt ? (
+        <MarkdownCopyButton
+          markdownUrl={markdownUrl}
+          title="Copy page as Markdown"
+          className="docs-page-actions-primary"
+        >
+          Copy page
+        </MarkdownCopyButton>
+      ) : (
         <OnboardingPromptCopyButton
           framework={onboardingFramework}
           frontend={onboardingFrontend}
           markdownUrl={markdownUrl}
+          className="docs-page-actions-primary"
         >
           Copy prompt
         </OnboardingPromptCopyButton>
       )}
-      <MarkdownCopyButton
+      <ViewOptionsPopover
         markdownUrl={markdownUrl}
-        title="Copy page as Markdown"
-      >
-        Copy page
-      </MarkdownCopyButton>
-      <ViewOptionsPopover markdownUrl={markdownUrl} githubUrl={githubUrl} />
+        githubUrl={githubUrl}
+        condensed
+        includeCopyPage={!hideOnboardingPrompt}
+      />
     </div>
   );
 }

--- a/showcase/shell-docs/src/components/docs-page-tools.tsx
+++ b/showcase/shell-docs/src/components/docs-page-tools.tsx
@@ -1,5 +1,5 @@
 // DocsPageTools — the page-tools row that sits under a docs page's title:
-// "Copy agent prompt", "Copy Markdown", and the "Open in <LLM>" popover.
+// "Copy prompt", "Copy page", and the "Open in <LLM>" popover.
 // Fumadocs's upstream LLM page-actions feature.
 //
 // Extracted from `docs-page-view.tsx` so the row sits in a component small
@@ -72,15 +72,22 @@ export function DocsPageTools({
 }: DocsPageToolsProps): React.JSX.Element {
   const markdownUrl = docsMarkdownUrl(slugHrefPrefix, slugPath);
   return (
-    <div className="flex min-w-0 flex-row flex-wrap gap-2 items-center my-6">
+    <div className="docs-page-tools flex min-w-0 flex-row flex-wrap items-center gap-2">
       {!hideOnboardingPrompt && (
         <OnboardingPromptCopyButton
           framework={onboardingFramework}
           frontend={onboardingFrontend}
           markdownUrl={markdownUrl}
-        />
+        >
+          Copy prompt
+        </OnboardingPromptCopyButton>
       )}
-      <MarkdownCopyButton markdownUrl={markdownUrl} />
+      <MarkdownCopyButton
+        markdownUrl={markdownUrl}
+        title="Copy page as Markdown"
+      >
+        Copy page
+      </MarkdownCopyButton>
       <ViewOptionsPopover markdownUrl={markdownUrl} githubUrl={githubUrl} />
     </div>
   );

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -9,20 +9,15 @@
 
 import React from "react";
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import {
   rehypeCode,
   rehypeCodeDefaultOptions,
 } from "fumadocs-core/mdx-plugins";
-import {
-  DocsPage,
-  DocsBody,
-  DocsTitle,
-  DocsDescription,
-} from "fumadocs-ui/page";
+import { DocsPage, DocsBody } from "fumadocs-ui/page";
 import { ShellDocsLayout } from "@/components/shell-docs-layout";
+import { DocsContentHeader } from "@/components/docs-content-header";
 import { SidebarFrameworkSelector } from "@/components/sidebar-framework-selector";
 import { EarlyAccessGate } from "@/components/early-access-gate";
 import { getEarlyAccessGate } from "@/lib/early-access";
@@ -59,6 +54,8 @@ import {
   convertTablesInJSX,
   inlineSnippets,
   loadDoc,
+  navSectionTitleForSlug,
+  visibleGuideBreadcrumbs,
   CONTENT_DIR,
 } from "@/lib/docs-render";
 import {
@@ -242,6 +239,11 @@ export async function DocsPageView({
     rootHref: slugHrefPrefix || "/",
     slugHrefPrefix,
   });
+  const sectionTitle = navSectionTitleForSlug(tree, slugPath);
+  const ancestorBreadcrumbs = visibleGuideBreadcrumbs(
+    breadcrumbs,
+    sectionTitle,
+  );
 
   // Bridge shell-docs's NavNode tree + headings into Fumadocs's shapes
   // so DocsLayout (sidebar) and DocsPage (right-rail TOC) can render them.
@@ -268,59 +270,22 @@ export async function DocsPageView({
       >
         <MaybeEarlyAccessGate gate={doc.fm.earlyAccess}>
           <div className="docs-inner-content docs-article-content mx-auto px-4 pb-6 pt-2 md:px-6 md:pt-3 xl:pt-4">
-            <header className="docs-page-header">
-              {/* Keep breadcrumbs as quiet navigation and omit the current
-               * page, whose title immediately follows. This preserves useful
-               * hierarchy without repeating the H1 as decorative chrome. */}
-              {breadcrumbs.length > 1 && (
-                <nav
-                  aria-label="Breadcrumb"
-                  className="docs-page-breadcrumb"
-                >
-                  {breadcrumbs.slice(0, -1).map((crumb, i) => (
-                    <React.Fragment key={i}>
-                      {i > 0 && (
-                        <ChevronRight
-                          className="size-3 shrink-0"
-                          aria-hidden="true"
-                        />
-                      )}
-                      {crumb.href ? (
-                        <Link href={crumb.href}>{crumb.label}</Link>
-                      ) : (
-                        <span>{crumb.label}</span>
-                      )}
-                    </React.Fragment>
-                  ))}
-                </nav>
-              )}
-
-              <div className="docs-page-heading-row">
-                <DocsTitle className="docs-page-title">
-                  {doc.fm.title}
-                </DocsTitle>
-
-                {/* Page actions (Copy prompt / Copy page / Open in
-                 * <LLM>) stay beside the title when space allows and wrap as
-                 * a single group on narrower pages. This keeps the article's
-                 * utility chrome available without inserting a separate band
-                 * between the description and the body. */}
-                <DocsPageTools
-                  slugPath={slugPath}
-                  slugHrefPrefix={slugHrefPrefix}
-                  githubUrl={buildGitHubUrl(doc.filePath)}
-                  onboardingFramework={onboardingFramework}
-                  onboardingFrontend={onboardingFrontend}
-                  hideOnboardingPrompt={slugPath === "webmcp"}
-                />
-              </div>
-
-              {doc.fm.description && (
-                <DocsDescription className="docs-page-description">
-                  {doc.fm.description}
-                </DocsDescription>
-              )}
-            </header>
+            <DocsContentHeader
+              ancestorBreadcrumbs={ancestorBreadcrumbs}
+              title={doc.fm.title}
+              description={doc.fm.description}
+            >
+              {/* Page actions stay beside the title when space allows and
+               * wrap as one group on narrower pages. */}
+              <DocsPageTools
+                slugPath={slugPath}
+                slugHrefPrefix={slugHrefPrefix}
+                githubUrl={buildGitHubUrl(doc.filePath)}
+                onboardingFramework={onboardingFramework}
+                onboardingFrontend={onboardingFrontend}
+                hideOnboardingPrompt={slugPath === "webmcp"}
+              />
+            </DocsContentHeader>
 
             {bannerSlot}
 

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -264,71 +264,63 @@ export async function DocsPageView({
         toc={fumadocsToc}
         breadcrumb={{ enabled: false }}
         footer={{ enabled: false }}
-        tableOfContentPopover={{ enabled: false }}
+        tableOfContentPopover={{ enabled: true }}
       >
         <MaybeEarlyAccessGate gate={doc.fm.earlyAccess}>
-          <div className="docs-inner-content max-w-[900px] mx-auto px-4 md:px-6 pt-2 pb-6 md:pt-3 xl:pt-4">
-            {/* Breadcrumb styling tracks canonical fumadocs PageBreadcrumb,
-             * but tighter: this should read as quiet page chrome, not a
-             * second title row above the H1. */}
-            <nav className="mb-2 flex flex-wrap items-center gap-1 text-[11px] font-medium leading-none text-[var(--text-muted)]">
-              {breadcrumbs.map((crumb, i) => {
-                const isLast = i === breadcrumbs.length - 1;
-                const labelClass = `truncate ${isLast ? "text-[var(--text)] font-medium" : ""}`;
-                return (
-                  <React.Fragment key={i}>
-                    {i > 0 && (
-                      <ChevronRight
-                        className="size-3 shrink-0"
-                        aria-hidden="true"
-                      />
-                    )}
-                    {crumb.href ? (
-                      <Link
-                        href={crumb.href}
-                        className={`${labelClass} transition-opacity hover:opacity-80`}
-                      >
-                        {crumb.label}
-                      </Link>
-                    ) : (
-                      <span className={labelClass}>{crumb.label}</span>
-                    )}
-                  </React.Fragment>
-                );
-              })}
-            </nav>
+          <div className="docs-inner-content docs-article-content mx-auto px-4 pb-6 pt-2 md:px-6 md:pt-3 xl:pt-4">
+            <header className="docs-page-header">
+              {/* Keep breadcrumbs as quiet navigation and omit the current
+               * page, whose title immediately follows. This preserves useful
+               * hierarchy without repeating the H1 as decorative chrome. */}
+              {breadcrumbs.length > 1 && (
+                <nav
+                  aria-label="Breadcrumb"
+                  className="docs-page-breadcrumb"
+                >
+                  {breadcrumbs.slice(0, -1).map((crumb, i) => (
+                    <React.Fragment key={i}>
+                      {i > 0 && (
+                        <ChevronRight
+                          className="size-3 shrink-0"
+                          aria-hidden="true"
+                        />
+                      )}
+                      {crumb.href ? (
+                        <Link href={crumb.href}>{crumb.label}</Link>
+                      ) : (
+                        <span>{crumb.label}</span>
+                      )}
+                    </React.Fragment>
+                  ))}
+                </nav>
+              )}
 
-            <DocsTitle className="text-[32px] md:text-[40px] font-medium leading-[1.2]">
-              {doc.fm.title}
-            </DocsTitle>
-            {doc.fm.description && (
-              <DocsDescription className="text-lg text-[var(--text-muted)] mt-5 leading-relaxed">
-                {doc.fm.description}
-              </DocsDescription>
-            )}
+              <div className="docs-page-heading-row">
+                <DocsTitle className="docs-page-title">
+                  {doc.fm.title}
+                </DocsTitle>
 
-            {/* Page actions (Copy agent prompt / Copy Markdown / Open in
-              <LLM>) — fumadocs's upstream LLM page-actions feature. The
-              markdown URL resolves through the `/:path*.mdx` rewrite to the
-              route handler at `app/llms-mdx/[[...slug]]/route.ts`, which
-              serves the raw MDX via the same `loadDoc()` the page uses. The
-              GitHub URL is computed from `doc.filePath` (absolute fs path)
-              by slicing from the `/showcase/` segment. */}
-            <DocsPageTools
-              slugPath={slugPath}
-              slugHrefPrefix={slugHrefPrefix}
-              githubUrl={buildGitHubUrl(doc.filePath)}
-              onboardingFramework={onboardingFramework}
-              onboardingFrontend={onboardingFrontend}
-              hideOnboardingPrompt={slugPath === "webmcp"}
-            />
+                {/* Page actions (Copy prompt / Copy page / Open in
+                 * <LLM>) stay beside the title when space allows and wrap as
+                 * a single group on narrower pages. This keeps the article's
+                 * utility chrome available without inserting a separate band
+                 * between the description and the body. */}
+                <DocsPageTools
+                  slugPath={slugPath}
+                  slugHrefPrefix={slugHrefPrefix}
+                  githubUrl={buildGitHubUrl(doc.filePath)}
+                  onboardingFramework={onboardingFramework}
+                  onboardingFrontend={onboardingFrontend}
+                  hideOnboardingPrompt={slugPath === "webmcp"}
+                />
+              </div>
 
-            {/* Thin divider between the page-actions row and the page body
-              (banner / content). Visually separates the page metadata
-              chrome (title + page actions) from the page content
-              underneath. Uses the project's `--border` token so it tracks
-              the rest of the page chrome in light and dark modes. */}
-            <hr className="border-t border-[var(--border)] mt-2 mb-6" />
+              {doc.fm.description && (
+                <DocsDescription className="docs-page-description">
+                  {doc.fm.description}
+                </DocsDescription>
+              )}
+            </header>
 
             {bannerSlot}
 

--- a/showcase/shell-docs/src/content/docs/concepts/architecture.mdx
+++ b/showcase/shell-docs/src/content/docs/concepts/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: How CopilotKit's pieces fit together — a frontend, a runtime in your app server, and an agent backend, all talking AG-UI.
+description: How CopilotKit's pieces fit together
 icon: "lucide/Boxes"
 doc_type: explanation
 ---

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -680,7 +680,7 @@ describe("framework nav", () => {
     expect(navTree.some((node) => node.title === "Enterprise")).toBe(false);
     expect(hasSectionPage(navTree, "Basics", "Headless Threads")).toBe(true);
     expect(sectionPages(navTree, "Intelligence")).toEqual([
-      "CopilotKit Intelligence",
+      "Overview",
       "Quickstart",
       "Cloud-hosted CopilotKit Intelligence",
       "Connect your runtime to Intelligence",

--- a/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/frontend-options.test.ts
@@ -28,7 +28,12 @@ import {
   getFrontendQuickstartNavTree,
   getFrontendUsingTheseDocsPath,
 } from "../frontend-page-content";
-import { buildBreadcrumbs, loadDoc } from "../docs-render";
+import {
+  buildBreadcrumbs,
+  loadDoc,
+  navSectionTitleForSlug,
+  visibleGuideBreadcrumbs,
+} from "../docs-render";
 import type { NavNode } from "../docs-render";
 import { resolveFrontendDocPage } from "../frontend-doc-policy";
 import { resolveDocsHref } from "../docs-link-rewrite";
@@ -527,6 +532,72 @@ test("does not link breadcrumbs for section-only paths", () => {
     { label: "Docs", href: "/angular" },
     { label: "Runtime", href: null },
     { label: "Copilot Runtime", href: null },
+  ]);
+});
+
+test("omits only the generic Docs root from visible guide breadcrumbs", () => {
+  expect(
+    visibleGuideBreadcrumbs([
+      { label: "Docs", href: "/" },
+      { label: "Concepts", href: null },
+      { label: "Architecture", href: null },
+    ]),
+  ).toEqual([{ label: "Concepts", href: null }]);
+
+  expect(
+    visibleGuideBreadcrumbs([
+      { label: "LangGraph", href: "/langgraph" },
+      { label: "Concepts", href: null },
+      { label: "Architecture", href: null },
+    ]),
+  ).toEqual([
+    { label: "LangGraph", href: "/langgraph" },
+    { label: "Concepts", href: null },
+  ]);
+
+  expect(
+    visibleGuideBreadcrumbs([
+      { label: "Docs", href: "/" },
+      { label: "Cookbook", href: "/cookbook" },
+      { label: "Recipe", href: null },
+    ]),
+  ).toEqual([{ label: "Cookbook", href: "/cookbook" }]);
+});
+
+test("keeps the sidebar section in nested guide breadcrumbs", () => {
+  const navTree = [
+    { type: "section" as const, title: "Concepts" },
+    {
+      type: "group" as const,
+      title: "Agentic Protocols",
+      slug: "agentic-protocols",
+      children: [
+        {
+          type: "page" as const,
+          title: "AG-UI",
+          slug: "agentic-protocols/ag-ui",
+        },
+      ],
+    },
+  ];
+  const sectionTitle = navSectionTitleForSlug(
+    navTree,
+    "agentic-protocols/ag-ui",
+  );
+
+  expect(sectionTitle).toBe("Concepts");
+  expect(
+    visibleGuideBreadcrumbs(
+      [
+        { label: "Docs", href: "/" },
+        { label: "Agentic Protocols", href: "/agentic-protocols" },
+        { label: "AG-UI", href: null },
+      ],
+      sectionTitle,
+    ),
+  ).toEqual([
+    { label: "Concepts", href: null },
+    { label: "Agentic Protocols", href: "/agentic-protocols" },
   ]);
 });
 

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -1861,14 +1861,17 @@ export function loadDoc(
 
 export type Breadcrumb = { label: string; href: string | null };
 
+function normalizeNavSlug(slug: string): string {
+  return slug.replace(/\/index$/, "");
+}
+
 function navNodeContainsSlug(node: NavNode, slugPath: string): boolean {
   if (node.type === "section") return false;
   if (node.type === "group") {
     return node.children.some((child) => navNodeContainsSlug(child, slugPath));
   }
 
-  const normalize = (slug: string) => slug.replace(/\/index$/, "");
-  return normalize(node.slug) === normalize(slugPath);
+  return normalizeNavSlug(node.slug) === normalizeNavSlug(slugPath);
 }
 
 /** Return the sidebar section that contains a guide page. */

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -1855,6 +1855,61 @@ export function loadDoc(
 
 export type Breadcrumb = { label: string; href: string | null };
 
+function navNodeContainsSlug(node: NavNode, slugPath: string): boolean {
+  if (node.type === "section") return false;
+  if (node.type === "group") {
+    return node.children.some((child) => navNodeContainsSlug(child, slugPath));
+  }
+
+  const normalize = (slug: string) => slug.replace(/\/index$/, "");
+  return normalize(node.slug) === normalize(slugPath);
+}
+
+/** Return the sidebar section that contains a guide page. */
+export function navSectionTitleForSlug(
+  navTree: NavNode[],
+  slugPath: string,
+): string | null {
+  let currentSection: string | null = null;
+  for (const node of navTree) {
+    if (node.type === "section") {
+      currentSection = node.title;
+    } else if (navNodeContainsSlug(node, slugPath)) {
+      return currentSection;
+    }
+  }
+  return null;
+}
+
+/**
+ * Turn a guide page's full breadcrumb trail into the ancestors shown above
+ * its title. The title already represents the current page, and the generic
+ * "Docs" root adds no information inside the guide surface. Named framework
+ * roots and first-level sections such as Cookbook remain visible. When a
+ * URL-level folder belongs to a broader sidebar section, prepend that section
+ * so paths such as AG-UI retain the visible Concepts hierarchy.
+ */
+export function visibleGuideBreadcrumbs(
+  breadcrumbs: Breadcrumb[],
+  sectionTitle?: string | null,
+): Breadcrumb[] {
+  const ancestors = breadcrumbs.slice(0, -1);
+  const hasGenericRoot = ancestors[0]?.label === "Docs";
+  const visible = hasGenericRoot ? ancestors.slice(1) : ancestors;
+  const isCookbook = breadcrumbs[1]?.label === "Cookbook";
+
+  if (
+    !hasGenericRoot ||
+    !sectionTitle ||
+    isCookbook ||
+    visible[0]?.label === sectionTitle
+  ) {
+    return visible;
+  }
+
+  return [{ label: sectionTitle, href: null }, ...visible];
+}
+
 export function buildBreadcrumbs(
   slugPath: string,
   opts: { rootLabel: string; rootHref: string | null; slugHrefPrefix: string },


### PR DESCRIPTION
## Summary

- Refines guide and Reference content pages around a consistent reading measure and shared header.
- Consolidates copy and open actions into a purple split CTA with accessible motion and interaction states.
- Aligns tables and code blocks, improves breadcrumbs, and preserves Reference and Cookbook hierarchy.

## Why

The docs content pages had uneven hierarchy, misaligned dense content, and inconsistent headers and actions across guide and Reference surfaces.

## How

- Introduces a shared content header and centralized content-width styling.
- Condenses copy and open controls with tested responsive, hover, focus, pointer, and reduced-motion behavior.
- Keeps prose, tables, and standalone code aligned while allowing diagrams to use a wider visual lane.
- Adds focused component, CSS, and navigation regression coverage.
- Validated with typecheck, lint, focused tests, a production build, and desktop/mobile browser QA. The complete shell-docs test command also reports four baseline failures in Angular and generated integration coverage; none of the failing sources are changed by this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned documentation page headers with responsive breadcrumbs, titles, descriptions, and page actions.
  - Added compact page-action controls, including Copy prompt, Copy page, and GitHub options.
  - Improved documentation navigation with clearer guide breadcrumbs and enabled table-of-contents access.
  - Added responsive layouts, refined typography, spacing, and mobile behavior.

- **Bug Fixes**
  - Prevented standard tables and code blocks from extending beyond the reading width while allowing reference images to break out appropriately.
  - Improved mobile action-button shimmer sizing and reduced-motion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->