### PR TITLE
fix(ci): avoid runtime tsx download in image ref gate

### DIFF
--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -386,7 +386,7 @@ jobs:
 
   check-lockfile:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -885,7 +885,7 @@ jobs:
     needs: [detect-changes, build]
     if: ${{ !cancelled() && needs.detect-changes.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/showcase_build.yml
+++ b/.github/workflows/showcase_build.yml
@@ -422,7 +422,7 @@ jobs:
       - name: Verify Railway image refs
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: npx tsx showcase/scripts/verify-railway-image-refs.ts
+        run: node --experimental-strip-types showcase/scripts/verify-railway-image-refs.ts
 
   # Build one browser bundle for every selected integration image. Staging
   # redeploys these GHCR images directly; production promotion pins the same

--- a/showcase/scripts/verify-railway-image-refs.ts
+++ b/showcase/scripts/verify-railway-image-refs.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env -S node --experimental-strip-types
 /**
  * verify-railway-image-refs.ts — Per-env drift assertion for Railway
  * showcase image refs.
@@ -26,7 +26,7 @@
  * before a bad deploy goes out.
  *
  * Usage:
- *   npx tsx showcase/scripts/verify-railway-image-refs.ts
+ *   node --experimental-strip-types showcase/scripts/verify-railway-image-refs.ts
  *
  * Requires: RAILWAY_TOKEN env var or ~/.railway/config.json
  * Exit: 0 when every env-scoped instance matches; 1 on any violation.
@@ -38,13 +38,16 @@ import {
   PROJECT_ID,
   SERVICES,
   repoNameFor,
-} from "./railway-envs";
-import type { EnvName } from "./railway-envs";
+} from "./railway-envs.ts";
+import type { EnvName } from "./railway-envs.ts";
 import {
   RAILWAY_GRAPHQL_ENDPOINT,
   sanitizeErrorBody,
-} from "./lib/railway-graphql";
-import { RailwayTokenError, resolveRailwayToken } from "./lib/railway-token";
+} from "./lib/railway-graphql.ts";
+import {
+  RailwayTokenError,
+  resolveRailwayToken,
+} from "./lib/railway-token.ts";
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
 


### PR DESCRIPTION
## Problem

Showcase preflight jobs were exhausting their hard timeouts while bootstrapping package tooling on fresh GitHub-hosted runners. The image-reference gate invoked `npx tsx`, causing an implicit package download before validation, while the lockfile and result-aggregation jobs had less time than observed `pnpm/action-setup` latency.

## Why

The Railway gate only needs Node 22, which the job already installs. Node 22 can execute erasable TypeScript directly, so downloading a separate runtime is unnecessary. The jobs that genuinely require pnpm still need enough budget to survive temporary registry latency.

## Fix

- Run the Railway image-ref check with Node's built-in TypeScript stripping and explicit `.ts` imports.
- Increase the lockfile and build-result aggregation timeout budgets to 10 minutes.

The native image-ref gate completed successfully in 11 seconds on the follow-up staging run. Local verification covered Node 22 syntax checking, native module loading, and a representative image validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the showcase image-reference verification workflow to run consistently with Node.js.
  * Increased workflow time limits to allow lockfile checks and build-result aggregation more time to complete.
  * Updated the verification script’s command-line usage and import references to support the revised execution method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->