### PR TITLE
fix(ci): resolve local tsx for promote import test

### DIFF
--- a/showcase/scripts/__tests__/sync-promote-service-options.test.ts
+++ b/showcase/scripts/__tests__/sync-promote-service-options.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -13,6 +14,7 @@ import { computeOptionTokens, SENTINEL } from "../sync-promote-service-options";
 import type { ServiceEntry } from "../railway-envs";
 
 const SCRIPT = resolve(__dirname, "..", "sync-promote-service-options.ts");
+const TSX_CLI = createRequire(import.meta.url).resolve("tsx/cli");
 
 // The REAL, committed workflow file that GitHub validates the `service`
 // workflow_dispatch choice against server-side. `gh workflow run` is rejected
@@ -543,9 +545,13 @@ describe("sync-promote-service-options", () => {
         `process.stdout.write("IMPORT_OK\\n");`,
       ].join("\n"),
     );
-    const result = spawnSync("npx", ["tsx", importer], {
+    // Resolve tsx from this workspace before switching to the isolated temp
+    // cwd. Running `npx tsx` from there can fall back to a registry download
+    // and hang offline CI instead of exercising the import guard.
+    const result = spawnSync(process.execPath, [TSX_CLI, importer], {
       encoding: "utf8",
       cwd: workDir,
+      timeout: 10_000,
     });
     // The import completed cleanly...
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Problem

Main’s Showcase Validate job times out in the sync-promote-service-options import-guard test, blocking the remaining validation steps.

## Why

The test launches `npx tsx` after changing into an isolated temp directory. From that directory, npx cannot reliably discover the workspace-installed tsx package and can fall back to a registry download, which hangs on an offline/restricted CI runner.

## Fix

Resolve `tsx/cli` from the workspace before changing directories, execute it with the current Node binary, and cap the subprocess at 10 seconds.

Verified with `pnpm nx run @copilotkit/showcase-scripts:test --skip-nx-cache`: 78 test files and 2,543 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability in offline or isolated environments by using the locally resolved TypeScript execution tool.
  - Added a timeout to prevent the test from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->