### PR TITLE
fix: accept ag_ui fallback for A2UI state key

### DIFF
--- a/sdk-python/copilotkit/copilotkit_lg_middleware.py
+++ b/sdk-python/copilotkit/copilotkit_lg_middleware.py
@@ -479,8 +479,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         ``catalog_id`` binds generated surfaces to the frontend's catalog (so
         BYOC custom catalogs render their own components, not the basic one).
         """
-        # AG-UI native path.
-        ag_ui = state.get("ag-ui") or {}
+        # AG-UI native path. LangGraph may normalize "ag-ui" to "ag_ui"
+        # (see #5463) — accept either.
+        ag_ui = state.get("ag-ui") or state.get("ag_ui") or {}
         a2ui_schema = ag_ui.get("a2ui_schema")
         if a2ui_schema:
             catalog_id = None
@@ -528,7 +529,9 @@ class CopilotKitMiddleware(AgentMiddleware[StateSchema, Any]):
         means no signal at all (off, or no A2UI middleware in the pipeline), in
         which case we do not auto-inject.
         """
-        return (state.get("ag-ui") or {}).get("inject_a2ui_tool")
+        # LangGraph may normalize "ag-ui" to "ag_ui" (see #5463).
+        ag_ui = state.get("ag-ui") or state.get("ag_ui") or {}
+        return ag_ui.get("inject_a2ui_tool")
 
     def _maybe_build_a2ui_tool(self, request: ModelRequest) -> Any | None:
         """Build a ``generate_a2ui`` tool bound to the agent's own model when

--- a/sdk-python/copilotkit/langgraph_agui_agent.py
+++ b/sdk-python/copilotkit/langgraph_agui_agent.py
@@ -451,7 +451,13 @@ class LangGraphAGUIAgent(LangGraphAgent):
         """Override to add CopilotKit actions to the state"""
         merged_state = super().langgraph_default_merge_state(state, messages, input)
         # Extract tools from the merged state and add them as CopilotKit actions
-        agui_properties = merged_state.get("ag-ui", {}) or merged_state
+        # LangGraph may normalize the hyphenated "ag-ui" key to "ag_ui"
+        # (see #5463) — accept either.
+        agui_properties = (
+            merged_state.get("ag-ui", {})
+            or merged_state.get("ag_ui", {})
+            or merged_state
+        )
 
         return {
             **merged_state,

--- a/sdk-python/tests/test_agui_agent.py
+++ b/sdk-python/tests/test_agui_agent.py
@@ -380,6 +380,21 @@ class TestLanggraphDefaultMergeState:
 
         assert result["copilotkit"]["context"] == context
 
+    def test_copilotkit_actions_from_ag_ui_underscore_fallback(self, agent):
+        """Underscore ag_ui key (LangGraph normalization, see #5463) is accepted."""
+        tools = [{"name": "tool1"}]
+        with patch.object(
+            AGUIBase,
+            "langgraph_default_merge_state",
+            return_value={
+                "ag_ui": {"tools": tools, "context": []},
+                "messages": [],
+            },
+        ):
+            result = agent.langgraph_default_merge_state({}, [], MagicMock())
+
+        assert result["copilotkit"]["actions"] == tools
+
     def test_no_agui_key_no_crash(self, agent):
         """If no ag-ui key in state, should use merged_state as fallback without crashing."""
         with patch.object(

--- a/sdk-python/tests/test_copilotkit_lg_middleware.py
+++ b/sdk-python/tests/test_copilotkit_lg_middleware.py
@@ -2194,6 +2194,21 @@ class TestAutoA2UI:
     def test_resolve_catalog_none_when_absent(self):
         assert CopilotKitMiddleware._resolve_a2ui_catalog({"messages": []}) is None
 
+    def test_resolve_catalog_from_underscore_key(self):
+        """Underscore ag_ui key fallback (LangGraph normalization, see #5463)."""
+        schema, catalog_id = CopilotKitMiddleware._resolve_a2ui_catalog(
+            {
+                "ag_ui": {
+                    "a2ui_schema": json.dumps(
+                        {"catalogId": "cat-u", "components": []}
+                    )
+                }
+            }
+        )
+        # Native path: toolkit reads a2ui_schema from state, so no guide needed.
+        assert schema is None
+        assert catalog_id == "cat-u"
+
     # --- A2UI injectA2UITool flag (forwarded → ag-ui state) ------------------
 
     def test_inject_decision_reads_ag_ui_flag(self):
@@ -2204,6 +2219,20 @@ class TestAutoA2UI:
         # No flag at all → None (opt-in: no injection).
         assert read({"ag-ui": {}}) is None
         assert read({"messages": []}) is None
+        # Underscore fallback (LangGraph normalizes "ag-ui" → "ag_ui", see #5463).
+        assert read({"ag_ui": {"inject_a2ui_tool": True}}) is True
+        assert read({"ag_ui": {"inject_a2ui_tool": "render_x"}}) == "render_x"
+        assert read({"ag_ui": {}}) is None
+        # Hyphenated key wins when both are present.
+        assert (
+            read(
+                {
+                    "ag-ui": {"inject_a2ui_tool": False},
+                    "ag_ui": {"inject_a2ui_tool": True},
+                }
+            )
+            is False
+        )
 
     def test_render_tool_dropped_when_ours_injected(self):
         """When we inject generate_a2ui, the runtime's render_a2ui (forwarded as


### PR DESCRIPTION
Fixes #5463.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with LangGraph state normalization.
  - AG-UI tools and properties are now recognized when state keys use either `ag-ui` or `ag_ui`.
  - A2UI catalogs and tool-injection settings are correctly detected regardless of key format.
  - When both formats are present, the standard `ag-ui` key remains the preferred source.

- **Tests**
  - Added coverage for normalized AG-UI state handling and key precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->