### PR TITLE
Make docs search trustworthy and surface Intelligence for capability searches

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3985,6 +3985,9 @@ importers:
       glob:
         specifier: ^10.4.0
         version: 10.5.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       js-yaml:
         specifier: '>=4.1.1'
         version: 4.1.1
@@ -18972,6 +18975,10 @@ packages:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   groq-sdk@0.5.0:
     resolution: {integrity: sha512-RVmhW7qZ+XZoy5fIuSdx/LGQJONpL8MHgZEW7dFwTdgkzStub2XQx6OKv28CHogijdwH41J+Npj/z2jBPu3vmw==}
 
@@ -24408,6 +24415,10 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
@@ -25000,6 +25011,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -47948,6 +47963,13 @@ snapshots:
 
   graphql@16.12.0: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 4.1.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   groq-sdk@0.5.0(encoding@0.1.13):
     dependencies:
       '@types/node': 18.19.130
@@ -55856,6 +55878,11 @@ snapshots:
 
   scule@1.3.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   secure-json-parse@2.7.0: {}
 
   select-hose@2.0.0: {}
@@ -56747,6 +56774,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 

--- a/showcase/scripts/generate-search-index.ts
+++ b/showcase/scripts/generate-search-index.ts
@@ -358,6 +358,18 @@ function isFrontendDocsEntry(href: string): boolean {
 }
 
 async function main() {
+  // A content-free build may emit a stub, but a partially staged tree must
+  // never overwrite a complete search index with missing content families.
+  const contentRoots = ["docs", "reference", "ag-ui"].map((name) =>
+    path.join(CONTENT_ROOT, "content", name),
+  );
+  const missingRoots = contentRoots.filter((root) => !fs.existsSync(root));
+  if (missingRoots.length > 0 && missingRoots.length < contentRoots.length) {
+    throw new Error(
+      `[generate-search-index] incomplete content tree; missing: ${missingRoots.join(", ")}`,
+    );
+  }
+
   const entries: SearchEntry[] = [];
 
   // Static pages. `/` is the showcase front door — it is filtered out of

--- a/showcase/scripts/generate-search-index.ts
+++ b/showcase/scripts/generate-search-index.ts
@@ -4,12 +4,19 @@
  * Scans reference MDX files, AG-UI content, and registry data to produce
  * a search index JSON for the shell's Cmd-K search modal.
  *
+ * Docs pages are filtered to the ones a reader can actually reach from a
+ * sidebar — see shell-docs/src/lib/searchable-pages.ts.
+ *
  * Usage: npx tsx showcase/scripts/generate-search-index.ts
  *
- * Output: showcase/shell/src/data/search-index.json
+ * Output: showcase/shell-docs/src/data/search-index.json (docs app)
+ *         showcase/shell/src/data/search-index.json      (showcase app)
+ *         showcase/shell-docs/src/data/search-index-dropped.json (review)
  */
 
+import { spawnSync } from "child_process";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -22,14 +29,41 @@ const ROOT = path.resolve(__dirname, "..");
 // (which links to docs routes) stays functional — destinations 301 across
 // to docs.showcase.copilotkit.ai. We SCAN from shell-docs (source of truth)
 // and WRITE to both.
-const SHELL_DOCS_DIR = path.join(ROOT, "shell-docs", "src");
+const SHELL_DOCS_ROOT = path.join(ROOT, "shell-docs");
+const SHELL_DOCS_DIR = path.join(SHELL_DOCS_ROOT, "src");
 const SHELL_DIR = path.join(ROOT, "shell", "src");
 const CONTENT_ROOT = SHELL_DOCS_DIR;
 const SHARED_DIR = path.join(ROOT, "shared");
-const OUTPUT_PATHS = [
-  path.join(SHELL_DOCS_DIR, "data", "search-index.json"),
-  path.join(SHELL_DIR, "data", "search-index.json"),
+
+type OutputTarget = "shell-docs" | "shell";
+
+const OUTPUTS: ReadonlyArray<{ target: OutputTarget; path: string }> = [
+  {
+    target: "shell-docs",
+    path: path.join(SHELL_DOCS_DIR, "data", "search-index.json"),
+  },
+  { target: "shell", path: path.join(SHELL_DIR, "data", "search-index.json") },
 ];
+
+// Destinations that live on the showcase host rather than the docs host.
+// The showcase app IS the showcase and needs these rows; the docs app must
+// not offer them, because clicking one leaves the documentation.
+const SHOWCASE_HOST_DESTINATIONS = new Set(["/", "/integrations", "/matrix"]);
+
+// The list of dropped docs entries, for review. Lands in the gitignored
+// generated-data directory next to the index it explains.
+const DROPPED_REPORT_PATH = path.join(
+  SHELL_DOCS_DIR,
+  "data",
+  "search-index-dropped.json",
+);
+
+// Coverage floor for the docs portion of the shell-docs index. Measured at
+// 583 entries when the navigability filter was introduced; the floor sits
+// ~15% under that so ordinary content churn (a section retired, a folder
+// merged) passes while a broken navigation walk — which collapses the
+// union to near zero — fails the build instead of shipping an empty search.
+const MIN_DOCS_ENTRIES = 495;
 
 interface SearchEntry {
   type: "page" | "reference" | "ag-ui";
@@ -206,10 +240,130 @@ function normalizeDocsSearchEntry(entry: SearchEntry): SearchEntry[] {
   ];
 }
 
-function main() {
+interface SearchablePagesPayload {
+  slugs: string[];
+  navTitles: Record<string, string>;
+  fromNavigation: string[];
+  fromLinks: string[];
+  forcedIn: string[];
+  forcedOut: string[];
+  canonicalBySlug: Record<string, string>;
+}
+
+/**
+ * Ask shell-docs which docs pages a reader can reach.
+ *
+ * Run as a SUBPROCESS, not imported. This script is invoked from several
+ * working directories — shell-docs locally and in its Docker build, `shell`
+ * in its own build and in Validate Showcase — and the rules it needs live
+ * in shell-docs behind two things that do not survive a cross-directory
+ * import: the `@/…` path alias, which tsx resolves from whichever tsconfig
+ * it finds at startup, and `gray-matter`, which Node resolves from the
+ * importing package's tree. An earlier version pointed `process.chdir` at
+ * shell-docs and imported dynamically; that fixed neither, because alias
+ * resolution is fixed when tsx boots and dependency resolution follows the
+ * file, not the cwd. It passed locally (run from shell-docs) and failed in
+ * both CI build contexts.
+ *
+ * A child process with its own cwd and its own resolution root fixes both,
+ * and keeps the reachability rules defined exactly once.
+ *
+ * Throws when the toolchain is missing. It used to return null and let the
+ * caller ship an index with no docs rows, which was wrong: the `shell`
+ * Dockerfile copies `shell-docs/src/content/`, so that build HAS the docs
+ * tree and consumes the docs rows — its header search links across to the
+ * docs host. Degrading it to zero docs rows on a `console.warn` cost the
+ * showcase app its entire docs search while CI stayed green. Every build
+ * that has the content tree now either gets the real decision or fails.
+ */
+function loadSearchablePages(): SearchablePagesPayload {
+  const emitScript = path.join(
+    SHELL_DOCS_ROOT,
+    "scripts",
+    "emit-searchable-pages.ts",
+  );
+  const scriptsModules = path.join(__dirname, "node_modules");
+  // Prefer shell-docs' own install; fall back to this package's. The
+  // fallback is what makes a plain repo checkout work: `showcase/shell` can
+  // build without shell-docs ever being installed (it is outside the pnpm
+  // workspace and ships its own lockfile), and CI does exactly that.
+  const tsxCli = [
+    path.join(SHELL_DOCS_ROOT, "node_modules", "tsx", "dist", "cli.mjs"),
+    path.join(scriptsModules, "tsx", "dist", "cli.mjs"),
+  ].find((candidate) => fs.existsSync(candidate));
+
+  if (!tsxCli || !fs.existsSync(emitScript)) {
+    throw new Error(
+      `[generate-search-index] the shell-docs content tree is present but its ` +
+        `toolchain is not: expected ${emitScript} and a tsx CLI in either ` +
+        `${SHELL_DOCS_ROOT}/node_modules or ${scriptsModules}.\n` +
+        `Every build that ships docs rows needs the reachability decision, so ` +
+        `this cannot be skipped.\n` +
+        `A Docker build must stage shell-docs/src/lib, shell-docs/scripts and ` +
+        `shell-docs/tsconfig.json (see showcase/shell/Dockerfile).`,
+    );
+  }
+
+  const outputPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "searchable-pages-")),
+    "searchable-pages.json",
+  );
+
+  const result = spawnSync(process.execPath, [tsxCli, emitScript, outputPath], {
+    cwd: SHELL_DOCS_ROOT,
+    stdio: ["ignore", "inherit", "inherit"],
+    env: {
+      ...process.env,
+      // shell-docs' library imports `gray-matter`, which Node resolves by
+      // walking up from the importing FILE — so when shell-docs is not
+      // installed, its own tree carries nothing. This package declares
+      // gray-matter too; NODE_PATH is what lets the child find it there.
+      // Only meaningful for CommonJS resolution, which is what tsx uses for
+      // shell-docs (its package.json has no `"type": "module"`).
+      NODE_PATH: [scriptsModules, process.env.NODE_PATH]
+        .filter(Boolean)
+        .join(path.delimiter),
+    },
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `[generate-search-index] emit-searchable-pages failed with status ${result.status}. ` +
+        `Docs search would ship unfiltered, so this is fatal.`,
+    );
+  }
+
+  return JSON.parse(
+    fs.readFileSync(outputPath, "utf-8"),
+  ) as SearchablePagesPayload;
+}
+
+/**
+ * Channel guides are re-routed at runtime onto the Slack and Microsoft
+ * Teams surfaces by the search modal (`parseChannelDocsHref`), so their
+ * `/docs/channels…` hrefs are index keys rather than destinations and must
+ * not be measured against the docs navigation.
+ */
+function isChannelDocsEntry(href: string): boolean {
+  return href === "/docs/channels" || href.startsWith("/docs/channels/");
+}
+
+/**
+ * Frontend guidance pages are rewritten onto the per-frontend surfaces by
+ * `normalizeDocsSearchEntry` and navigate from those surfaces' own
+ * sidebars, not from the docs navigation tree.
+ */
+function isFrontendDocsEntry(href: string): boolean {
+  return href.startsWith("/docs/frontends/");
+}
+
+async function main() {
   const entries: SearchEntry[] = [];
 
-  // Static pages
+  // Static pages. `/` is the showcase front door — it is filtered out of
+  // the shell-docs index, where the docs index page already owns it. There
+  // is deliberately no static "API Reference" row: the reference index
+  // page (`content/reference/index.mdx`) already emits `/reference`.
   entries.push(
     {
       type: "page",
@@ -231,13 +385,6 @@ function main() {
       subtitle: "Compare features across integrations",
       section: "",
       href: "/matrix",
-    },
-    {
-      type: "page",
-      title: "API Reference",
-      subtitle: "CopilotKit components and hooks",
-      section: "",
-      href: "/reference",
     },
     {
       type: "page",
@@ -297,7 +444,12 @@ function main() {
     "drafts/meta-events",
     "tutorials/cursor",
     "tutorials/debugging",
-    "development/updates",
+    // "development/updates" is deliberately absent. It is titled "What's New"
+    // and carries a single entry from April 2025, and it renders an <Update>
+    // component this app does not provide, so opening it throws. Search must
+    // not offer it. The page itself is vendored AG-UI content whose canonical
+    // home is docs.ag-ui.com, so it is not fixed here — see the AG-UI mirror
+    // question in the OSS-1079 PR.
     "development/roadmap",
     "development/contributing",
     "sdk/js/core/overview",
@@ -337,16 +489,86 @@ function main() {
     scanDirsMissing.push(aguiDir);
   }
 
-  // CopilotKit Docs
+  // CopilotKit Docs — only index pages a reader can actually reach.
+  //
+  // The old behavior indexed every `.mdx` on disk, which offered pages
+  // that appear in no sidebar: leftovers from past reorganizations, with
+  // stale content and no surrounding context. `searchable-pages` derives
+  // the allowed set from the navigation the app renders instead. Reference
+  // and AG-UI are untouched — AG-UI has its own published-slug allowlist
+  // above and reference has its own frontmatter-driven navigation.
   const docsDir = path.join(CONTENT_ROOT, "content", "docs");
-  if (fs.existsSync(docsDir)) {
-    const docsEntries = scanMdxDir(docsDir, "/docs", "page").flatMap(
-      normalizeDocsSearchEntry,
-    );
+  let docsEntryCount = 0;
+  const droppedDocsEntries: SearchEntry[] = [];
+  const pages = fs.existsSync(docsDir) ? loadSearchablePages() : null;
+  if (pages) {
+    const searchableSlugs = new Set(pages.slugs);
+
+    const kept: SearchEntry[] = [];
+    const seenHrefs = new Set<string>();
+    for (const entry of scanMdxDir(docsDir, "/docs", "page")) {
+      // Canonicalize first: this strips route-group segments (`(other)`),
+      // which the middleware would otherwise 301-redirect, and collapses a
+      // trailing `/index` — so the emitted URL is the final one and the
+      // filter key matches the sidebar's own route-group-free slugs. The
+      // mapping is computed by shell-docs and shipped in the payload; see
+      // loadSearchablePages for why it is not imported.
+      const rawSlug = entry.href.replace(/^\/docs\/?/, "");
+      const slug = pages.canonicalBySlug[rawSlug] ?? rawSlug;
+      const href = slug ? `/docs/${slug}` : "/docs";
+      const canonical = { ...entry, href };
+
+      // Two files can canonicalize onto one URL (a stray `foo.mdx`
+      // alongside `foo/index.mdx`). Only one of them is ever served, so
+      // only one belongs in the index.
+      if (seenHrefs.has(href)) continue;
+      seenHrefs.add(href);
+
+      if (isChannelDocsEntry(href) || isFrontendDocsEntry(href)) {
+        kept.push(canonical);
+        continue;
+      }
+      if (!searchableSlugs.has(slug)) {
+        droppedDocsEntries.push(canonical);
+        continue;
+      }
+
+      // The sidebar renames some entries; search should name pages the way
+      // navigation names them so both surfaces speak the same language.
+      const navTitle = pages.navTitles[slug];
+      kept.push(navTitle ? { ...canonical, title: navTitle } : canonical);
+    }
+
+    const docsEntries = kept.flatMap(normalizeDocsSearchEntry);
     entries.push(...docsEntries);
-    console.log(`  Docs: ${docsEntries.length} entries`);
+    docsEntryCount = docsEntries.length;
+    console.log(
+      `  Docs: ${docsEntries.length} entries ` +
+        `(${droppedDocsEntries.length} dropped as unreachable from any sidebar; ` +
+        `${pages.fromNavigation.length} slugs in navigation, ` +
+        `${pages.fromLinks.length} kept by an inbound prose link, ` +
+        `${pages.forcedIn.length} forced in and ${pages.forcedOut.length} forced out by frontmatter)`,
+    );
+
+    fs.mkdirSync(path.dirname(DROPPED_REPORT_PATH), { recursive: true });
+    fs.writeFileSync(
+      DROPPED_REPORT_PATH,
+      JSON.stringify(
+        droppedDocsEntries
+          .map(({ href, title }) => ({ href, title }))
+          .sort((a, b) => a.href.localeCompare(b.href)),
+        null,
+        2,
+      ) + "\n",
+    );
+    console.log(`  Dropped-entry report: ${DROPPED_REPORT_PATH}`);
+
     scanDirsPresent.push(docsDir);
   } else {
+    // The content tree itself is absent. Some build contexts stage no docs
+    // content at all and only need the static-pages stub so a header search
+    // modal has something to render. A missing TOOLCHAIN is a different
+    // matter and throws in loadSearchablePages — see the note there.
     console.warn(
       `[generate-search-index] scan dir missing: ${docsDir} — docs entries will be empty`,
     );
@@ -377,13 +599,33 @@ function main() {
   entries.push(...angularFeatureEntries);
   console.log(`  Angular features: ${angularFeatureEntries.length} entries`);
 
-  // Write (dual-emit to shell-docs + shell)
-  const json = JSON.stringify(entries, null, 2) + "\n";
-  for (const outputPath of OUTPUT_PATHS) {
+  // Fail loudly rather than shipping a nearly empty search. Keyed on the
+  // content tree, not on whether the filter ran: an earlier version skipped
+  // this check whenever the filter had been skipped, which is exactly the
+  // combination that let the showcase app ship zero docs rows on a warning.
+  // If the docs content is staged, docs rows are expected.
+  if (fs.existsSync(docsDir) && docsEntryCount < MIN_DOCS_ENTRIES) {
+    throw new Error(
+      `[generate-search-index] docs coverage collapsed: ${docsEntryCount} ` +
+        `docs entries, expected at least ${MIN_DOCS_ENTRIES}. The navigation ` +
+        `walk in shell-docs/src/lib/searchable-pages is the likely cause — ` +
+        `a nearly empty search must not ship.`,
+    );
+  }
+
+  // Write (dual-emit to shell-docs + shell), filtered per target: the docs
+  // app must not offer rows that leave the documentation for the showcase
+  // host, while the showcase app keeps them because that app is the
+  // showcase and its own search needs them.
+  for (const { target, path: outputPath } of OUTPUTS) {
+    const payload =
+      target === "shell-docs"
+        ? entries.filter((entry) => !SHOWCASE_HOST_DESTINATIONS.has(entry.href))
+        : entries;
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-    fs.writeFileSync(outputPath, json);
-    console.log(`\nSearch index: ${outputPath} (${entries.length} entries)`);
+    fs.writeFileSync(outputPath, JSON.stringify(payload, null, 2) + "\n");
+    console.log(`\nSearch index: ${outputPath} (${payload.length} entries)`);
   }
 }
 
-main();
+await main();

--- a/showcase/scripts/package-lock.json
+++ b/showcase/scripts/package-lock.json
@@ -12,6 +12,7 @@
         "ajv-formats": "^3.0.1",
         "chalk": "^5.4.0",
         "glob": "^10.4.0",
+        "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "playwright": "^1.59.1",
         "prompts": "^2.4.2",
@@ -30,7 +31,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -40,7 +41,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -50,7 +51,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -66,7 +67,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -80,7 +81,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -115,6 +116,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -126,6 +128,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -136,6 +139,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -579,7 +583,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -596,7 +600,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -607,6 +611,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -663,6 +668,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,6 +685,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -695,6 +702,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -711,6 +719,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,6 +736,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,6 +753,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -759,6 +770,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -775,6 +787,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -791,6 +804,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -807,6 +821,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -823,6 +838,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -839,6 +855,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -855,6 +872,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -873,6 +891,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,6 +908,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -916,6 +936,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -958,7 +979,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -979,7 +1000,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
@@ -1196,7 +1217,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
       "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -1350,6 +1371,19 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1368,6 +1402,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1473,11 +1519,48 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1487,8 +1570,17 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1509,7 +1601,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -1519,7 +1611,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -1534,7 +1626,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -1563,7 +1655,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -1593,6 +1685,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -1640,6 +1741,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1660,6 +1762,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1680,6 +1783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1700,6 +1804,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1720,6 +1825,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1740,6 +1846,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1760,6 +1867,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1780,6 +1888,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1800,6 +1909,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1820,6 +1930,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1840,6 +1951,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1873,7 +1985,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -1885,7 +1997,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -2133,11 +2245,24 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2201,6 +2326,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -2312,11 +2443,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2373,6 +2513,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -2413,7 +2554,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -2498,6 +2639,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/showcase/scripts/package.json
+++ b/showcase/scripts/package.json
@@ -28,6 +28,7 @@
     "ajv-formats": "^3.0.1",
     "chalk": "^5.4.0",
     "glob": "^10.4.0",
+    "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
     "playwright": "^1.59.1",
     "prompts": "^2.4.2",

--- a/showcase/shell-docs/scripts/emit-searchable-pages.ts
+++ b/showcase/shell-docs/scripts/emit-searchable-pages.ts
@@ -1,0 +1,74 @@
+/**
+ * Emit the searchable-pages decision as JSON, from inside shell-docs.
+ *
+ * `generate-search-index.ts` lives in `showcase/scripts` and is invoked
+ * from several app directories (shell-docs locally and in its Docker
+ * build, shell in its own build and in Validate Showcase). The reachability
+ * rules it needs live in shell-docs and pull in shell-docs' own
+ * dependencies (`gray-matter`) and its `@/…` path alias. Neither survives
+ * being imported from another directory: tsx fixes path-alias resolution
+ * from the tsconfig it finds at startup, and Node resolves a dependency
+ * from the importing package's tree — so an import that works from
+ * shell-docs fails from `scripts` with a missing alias and from `shell`
+ * with a missing `gray-matter`.
+ *
+ * A subprocess sidesteps both. Run here, with shell-docs as the working
+ * directory, the alias resolves against shell-docs' tsconfig and the
+ * dependencies resolve against shell-docs' node_modules. The generator
+ * spawns this script and reads the JSON back, so the two packages share
+ * one source of truth without sharing a module graph.
+ *
+ * Usage: tsx scripts/emit-searchable-pages.ts <output-path>
+ */
+
+import fs from "fs";
+import path from "path";
+
+import {
+  buildCanonicalSlugMap,
+  getSearchablePages,
+} from "../src/lib/searchable-pages";
+
+const CONTENT_DIR = path.join(process.cwd(), "src/content/docs");
+
+function main() {
+  const outputPath = process.argv[2];
+  if (!outputPath) {
+    console.error(
+      "[emit-searchable-pages] missing output path argument\n" +
+        "Usage: tsx scripts/emit-searchable-pages.ts <output-path>",
+    );
+    process.exit(1);
+  }
+
+  const pages = getSearchablePages();
+
+  // Sets do not survive JSON, so every collection crosses the process
+  // boundary as a sorted array. Sorting keeps the payload stable between
+  // runs, which makes a diff of it meaningful when debugging a build.
+  const payload = {
+    slugs: [...pages.slugs].sort(),
+    navTitles: Object.fromEntries([...pages.navTitles.entries()].sort()),
+    fromNavigation: [...pages.fromNavigation].sort(),
+    fromLinks: [...pages.fromLinks].sort(),
+    forcedIn: [...pages.forcedIn].sort(),
+    forcedOut: [...pages.forcedOut].sort(),
+    // Canonicalization travels as data so the generator never has to import
+    // it across the package boundary.
+    canonicalBySlug: Object.fromEntries(
+      [...buildCanonicalSlugMap(CONTENT_DIR).entries()].sort(),
+    ),
+  };
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, JSON.stringify(payload) + "\n");
+
+  console.log(
+    `[emit-searchable-pages] ${payload.slugs.length} searchable slugs ` +
+      `(${payload.fromNavigation.length} from navigation, ` +
+      `${payload.fromLinks.length} from an inbound link, ` +
+      `${payload.forcedIn.length} forced in, ${payload.forcedOut.length} forced out)`,
+  );
+}
+
+main();

--- a/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
+++ b/showcase/shell-docs/src/app/ag-ui/[[...slug]]/page.tsx
@@ -159,11 +159,14 @@ const NAV_DEFINITION: NavTab[] = [
       },
       {
         section: "Development",
-        entries: [
-          "development/updates",
-          "development/roadmap",
-          "development/contributing",
-        ],
+        // "development/updates" ("What's New") is deliberately absent: it
+        // renders an <Update> component this app does not provide, so the
+        // page throws, and its newest entry is from April 2025. The MDX is
+        // vendored AG-UI content whose canonical home is docs.ag-ui.com, so
+        // it is unlinked here rather than edited. It is also excluded from
+        // the search index — see AGUI_PUBLISHED_SLUGS in
+        // showcase/scripts/generate-search-index.ts.
+        entries: ["development/roadmap", "development/contributing"],
       },
     ],
   },

--- a/showcase/shell-docs/src/components/__tests__/search-modal-intelligence-cta.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/search-modal-intelligence-cta.test.tsx
@@ -50,6 +50,8 @@ vi.mock("../framework-provider", () => ({
   }),
 }));
 
+import * as ctaMatching from "../../lib/intelligence-search-ctas";
+
 import { SearchModal } from "../search-modal";
 
 function resultRows(): HTMLElement[] {
@@ -93,7 +95,11 @@ async function search(query: string): Promise<void> {
   );
   fireEvent.change(screen.getByRole("combobox"), { target: { value: query } });
   await waitFor(() =>
-    expect(resultRows().length + (recommendation() ? 1 : 0)).toBeGreaterThan(0),
+    expect(
+      resultRows().length > 0 ||
+        recommendation() !== null ||
+        screen.queryByText(/No results for/) !== null,
+    ).toBe(true),
   );
 }
 
@@ -117,6 +123,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   delete window.__SHOWCASE_CONFIG__;
 });
 
@@ -144,7 +151,12 @@ describe("when the recommendation appears", () => {
   });
 
   it("stays away from unrelated queries", async () => {
-    for (const query of ["useCopilotAction", "angular quickstart", "css"]) {
+    for (const query of [
+      "useCopilotAction",
+      "angular quickstart",
+      "css",
+      "zzzznomatchingpage",
+    ]) {
       await search(query);
       expect(recommendation()).toBeNull();
       cleanup();
@@ -160,12 +172,36 @@ describe("when the recommendation appears", () => {
     expect(
       block.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    // ...and costs none of the twelve result slots.
-    expect(resultRows()).toHaveLength(12);
+    // ...and costs no organic result slots, regardless of index size.
+    const withRecommendation = resultRows().map((row) => row.textContent);
+    cleanup();
+    vi.spyOn(ctaMatching, "matchIntelligenceSearchCta").mockReturnValue(null);
+    await search("threads");
+    expect(recommendation()).toBeNull();
+    expect(resultRows().map((row) => row.textContent)).toEqual(
+      withRecommendation,
+    );
   });
 });
 
 describe("how the recommendation is announced", () => {
+  it.each(["threads", "threads zzzznomatchingpage", "zzzznomatchingpage"])(
+    "only controls rendered elements for %s",
+    async (query) => {
+      await search(query);
+      const input = screen.getByRole("combobox");
+      const controlled = input.getAttribute("aria-controls")?.split(" ") ?? [];
+      for (const id of controlled)
+        expect(document.getElementById(id)).not.toBeNull();
+      const list = screen.queryByRole("listbox", { name: "Search results" });
+      if (list) expect(controlled).toContain(list.id);
+      else
+        expect(controlled).toEqual(
+          recommendation() ? [recommendation()!.id] : [],
+        );
+    },
+  );
+
   it("is a labelled group, not another row in the results listbox", async () => {
     await search("threads");
 
@@ -191,17 +227,23 @@ describe("keyboard and pointer selection", () => {
     await search("threads");
 
     const input = screen.getByRole("combobox");
-    expect(input.getAttribute("aria-activedescendant")).toBe(primaryLink().id);
+    expect(input.getAttribute("aria-activedescendant")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain(
+      "Recommended: Threads",
+    );
     expect(resultRows()[0].getAttribute("aria-selected")).toBe("false");
 
     fireEvent.keyDown(input, { key: "ArrowDown" });
     expect(resultRows()[0].getAttribute("aria-selected")).toBe("true");
-    expect(input.getAttribute("aria-activedescendant")).not.toBe(
-      primaryLink().id,
-    );
+    const activeId = input.getAttribute("aria-activedescendant")!;
+    expect(document.getElementById(activeId)).toBe(resultRows()[0]);
+    expect(screen.getByRole("status").textContent).toBe("");
 
     fireEvent.keyDown(input, { key: "ArrowUp" });
-    expect(input.getAttribute("aria-activedescendant")).toBe(primaryLink().id);
+    expect(input.getAttribute("aria-activedescendant")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain(
+      "Recommended: Threads",
+    );
     expect(resultRows()[0].getAttribute("aria-selected")).toBe("false");
   });
 
@@ -229,7 +271,10 @@ describe("keyboard and pointer selection", () => {
 
     fireEvent.mouseEnter(recommendation()!);
     expect(resultRows()[2].getAttribute("aria-selected")).toBe("false");
-    expect(input.getAttribute("aria-activedescendant")).toBe(primaryLink().id);
+    expect(input.getAttribute("aria-activedescendant")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain(
+      "Recommended: Threads",
+    );
   });
 
   it("activates the block on Enter", async () => {

--- a/showcase/shell-docs/src/components/__tests__/search-modal-intelligence-cta.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/search-modal-intelligence-cta.test.tsx
@@ -1,0 +1,386 @@
+// @vitest-environment jsdom
+
+// Behavioural tests for the curated Intelligence recommendation in the
+// docs search modal. Everything is driven through the real modal — real
+// input, real keyboard events, real click handlers — so these stay true
+// across restyling and copy edits. Only the ambient wiring (router,
+// framework provider, runtime config, PostHog) is faked.
+//
+// The keyword table and matcher have their own tests in
+// lib/__tests__/intelligence-search-ctas.test.ts.
+
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const pushed: string[] = [];
+const captured: Array<{ event: string; props: Record<string, unknown> }> = [];
+let postHogThrows = false;
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: (event: string, props: Record<string, unknown>) => {
+      if (postHogThrows) throw new Error("blocked by an ad blocker");
+      captured.push({ event, props });
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/quickstart",
+  useRouter: () => ({
+    push: (href: string) => {
+      pushed.push(href);
+    },
+  }),
+}));
+
+vi.mock("../framework-provider", () => ({
+  DEFAULT_FRAMEWORK: "built-in-agent",
+  useFramework: () => ({
+    effectiveFramework: "built-in-agent",
+    knownFrameworks: [],
+    setStoredFramework: () => {},
+  }),
+}));
+
+import { SearchModal } from "../search-modal";
+
+function resultRows(): HTMLElement[] {
+  if (!screen.queryByRole("listbox", { name: "Search results" })) return [];
+  return screen.getAllByRole("option");
+}
+
+/**
+ * Indexes of the result rows whose trailing arrow is drawn in the accent
+ * colour — i.e. the rows the UI claims are selected.
+ */
+function accentedArrowRowIndexes(rows: HTMLElement[]): number[] {
+  return rows.flatMap((row, idx) => {
+    const arrow = row.querySelector("svg.lucide-arrow-right");
+    return arrow?.getAttribute("class")?.includes("text-[var(--accent)]")
+      ? [idx]
+      : [];
+  });
+}
+
+function recommendation(): HTMLElement | null {
+  return screen.queryByRole("group", { name: "Recommended guide" });
+}
+
+function recommendationLinks(): HTMLAnchorElement[] {
+  const block = recommendation();
+  if (!block) return [];
+  return Array.from(block.querySelectorAll("a[href]"));
+}
+
+function primaryLink(): HTMLElement {
+  return screen.getByRole("link", { name: /^Recommended:/ });
+}
+
+async function search(query: string): Promise<void> {
+  render(<SearchModal onClose={() => {}} />);
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: /Choose docs framework/ }).textContent,
+    ).not.toContain("Loading frameworks"),
+  );
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: query } });
+  await waitFor(() =>
+    expect(resultRows().length + (recommendation() ? 1 : 0)).toBeGreaterThan(0),
+  );
+}
+
+beforeEach(() => {
+  pushed.length = 0;
+  captured.length = 0;
+  postHogThrows = false;
+  window.__SHOWCASE_CONFIG__ = {
+    baseUrl: "https://docs.copilotkit.test/",
+    shellUrl: "https://showcase.copilotkit.test",
+    intelligenceSignupUrl: "https://ops.copilotkit.test/",
+    posthogKey: "",
+    posthogHost: "https://posthog.test/",
+    scarfPixelId: "",
+    googleAnalyticsTrackingId: "",
+    reb2bKey: "",
+    reoKey: "",
+    clerkPublishableKey: "",
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  delete window.__SHOWCASE_CONFIG__;
+});
+
+describe("when the recommendation appears", () => {
+  it("shows exactly one block for a keyword query", async () => {
+    await search("threads");
+
+    expect(
+      screen.getAllByRole("group", { name: "Recommended guide" }),
+    ).toHaveLength(1);
+    expect(recommendation()!.textContent).toContain(
+      "Threads that survive a reload",
+    );
+  });
+
+  it("shows the most specific block, never two", async () => {
+    await search("intelligence threads");
+
+    const blocks = screen.getAllByRole("group", { name: "Recommended guide" });
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].textContent).toContain("Threads that survive a reload");
+    expect(blocks[0].textContent).not.toContain(
+      "Persistent threads, analytics",
+    );
+  });
+
+  it("stays away from unrelated queries", async () => {
+    for (const query of ["useCopilotAction", "angular quickstart", "css"]) {
+      await search(query);
+      expect(recommendation()).toBeNull();
+      cleanup();
+    }
+  });
+
+  it("adds to the result list instead of replacing part of it", async () => {
+    await search("threads");
+
+    const block = recommendation()!;
+    const list = screen.getByRole("listbox", { name: "Search results" });
+    // The block renders above the organic results...
+    expect(
+      block.compareDocumentPosition(list) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // ...and costs none of the twelve result slots.
+    expect(resultRows()).toHaveLength(12);
+  });
+});
+
+describe("how the recommendation is announced", () => {
+  it("is a labelled group, not another row in the results listbox", async () => {
+    await search("threads");
+
+    const block = recommendation()!;
+    expect(block.getAttribute("role")).toBe("group");
+    expect(
+      screen.getAllByRole("option").every((option) => !block.contains(option)),
+    ).toBe(true);
+  });
+
+  it("names itself a recommendation on the link the keyboard lands on", async () => {
+    await search("threads");
+
+    expect(primaryLink().getAttribute("aria-label")).toContain("Recommended:");
+    expect(
+      screen.getByRole("combobox").getAttribute("aria-controls"),
+    ).toContain(recommendation()!.id);
+  });
+});
+
+describe("keyboard and pointer selection", () => {
+  it("puts the block first, ahead of the results", async () => {
+    await search("threads");
+
+    const input = screen.getByRole("combobox");
+    expect(input.getAttribute("aria-activedescendant")).toBe(primaryLink().id);
+    expect(resultRows()[0].getAttribute("aria-selected")).toBe("false");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(resultRows()[0].getAttribute("aria-selected")).toBe("true");
+    expect(input.getAttribute("aria-activedescendant")).not.toBe(
+      primaryLink().id,
+    );
+
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    expect(input.getAttribute("aria-activedescendant")).toBe(primaryLink().id);
+    expect(resultRows()[0].getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("lights the arrow on the selected row, not the one below it", async () => {
+    await search("threads");
+
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    const rows = resultRows();
+    expect(rows[1].getAttribute("aria-selected")).toBe("true");
+    // The accented arrow must sit on exactly the row that is selected.
+    // Before the fix the arrow compared the row index against a selection
+    // that counts the recommendation block, so it lit row 2 instead.
+    expect(accentedArrowRowIndexes(rows)).toEqual([1]);
+  });
+
+  it("keeps hover in sync exactly as result rows do", async () => {
+    await search("threads");
+
+    const input = screen.getByRole("combobox");
+    fireEvent.mouseEnter(resultRows()[2]);
+    expect(resultRows()[2].getAttribute("aria-selected")).toBe("true");
+
+    fireEvent.mouseEnter(recommendation()!);
+    expect(resultRows()[2].getAttribute("aria-selected")).toBe("false");
+    expect(input.getAttribute("aria-activedescendant")).toBe(primaryLink().id);
+  });
+
+  it("activates the block on Enter", async () => {
+    await search("threads");
+
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Enter" });
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].startsWith("/threads?")).toBe(true);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe("docs_conversion_clicked");
+    expect(captured[0].props.surface).toBe("docs-search:threads:threads");
+  });
+
+  it("activates a result on Enter once the selection has moved off the block", async () => {
+    await search("threads");
+
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).not.toContain("utm_source");
+    expect(captured).toHaveLength(0);
+  });
+});
+
+describe("the whole block is one clickable card", () => {
+  it("activates the primary destination from a click on the card body", async () => {
+    await search("self-hosting");
+
+    // The card-wide hit area belongs to the primary anchor's overlay, so a
+    // reader clicking the block's heading text lands on the primary page.
+    fireEvent.click(primaryLink());
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].startsWith("/intelligence/self-hosting?")).toBe(true);
+  });
+
+  it("sends a secondary link to its own destination, not the primary one", async () => {
+    await search("self-hosting");
+
+    const secondary = screen.getByRole("link", {
+      name: "Platform architecture",
+    });
+    fireEvent.click(secondary);
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].startsWith("/intelligence/intelligence-platform?")).toBe(
+      true,
+    );
+    expect(pushed[0]).not.toContain("/self-hosting");
+    // Stacked above the card overlay so its own click wins.
+    expect(secondary.closest("div")?.className).toContain("z-10");
+  });
+
+  it("keeps the primary action openable in a new tab", async () => {
+    await search("threads");
+
+    const primary = primaryLink() as HTMLAnchorElement;
+    // A real anchor with a real href: focusable, middle-clickable, and
+    // "open in new tab" lands on the same attributed URL a click would.
+    expect(primary.tagName).toBe("A");
+    expect(primary.getAttribute("href")).toContain("/threads?");
+    expect(primary.getAttribute("href")).toContain(
+      "utm_content=docs-search%3Athreads%3Athreads",
+    );
+
+    // A cmd-click is the browser's to handle — we must not swallow it.
+    fireEvent.click(primary, { metaKey: true });
+    expect(pushed).toHaveLength(0);
+    // ...but it is still reported.
+    expect(captured).toHaveLength(1);
+    expect(captured[0].props.surface).toBe("docs-search:threads:threads");
+  });
+
+  it("attributes every link with the surface and matched keyword", async () => {
+    await search("persistence");
+
+    for (const link of recommendationLinks()) {
+      expect(link.getAttribute("href")).toContain(
+        "utm_content=docs-search%3Athreads%3Apersistence",
+      );
+    }
+
+    fireEvent.click(recommendationLinks()[1]);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].props.surface).toBe("docs-search:threads:persistence");
+    expect(captured[0].props.matched_keyword).toBe("persistence");
+  });
+});
+
+describe("navigation and attribution", () => {
+  it("routes the primary link through the modal's own router", async () => {
+    await search("self-hosting");
+
+    fireEvent.click(primaryLink());
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].startsWith("/intelligence/self-hosting?")).toBe(true);
+  });
+
+  it("routes a secondary link the same way", async () => {
+    await search("self-hosting");
+
+    fireEvent.click(
+      screen.getByRole("link", { name: "Platform architecture" }),
+    );
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].startsWith("/intelligence/intelligence-platform?")).toBe(
+      true,
+    );
+  });
+
+  it("keeps every destination an internal docs route", async () => {
+    await search("intelligence");
+
+    const count = recommendationLinks().length;
+    expect(count).toBeGreaterThan(1);
+    for (let i = 0; i < count; i += 1) {
+      fireEvent.click(recommendationLinks()[i]);
+    }
+
+    expect(pushed).toHaveLength(count);
+    for (const href of pushed) {
+      expect(href.startsWith("/")).toBe(true);
+      expect(href).not.toMatch(/^(https?:)?\/\//);
+      // The placeholder origin used to run internal paths through the
+      // shared attribution helper must never leak into the href.
+      expect(href).not.toContain("invalid");
+    }
+  });
+
+  it("reports the keyword that fired rather than the raw query", async () => {
+    await search("persistence");
+
+    fireEvent.click(primaryLink());
+
+    expect(captured[0].props.matched_keyword).toBe("persistence");
+    expect(captured[0].props.cta_id).toBe("threads");
+    expect(captured[0].props.surface).toBe("docs-search:threads:persistence");
+  });
+
+  it("still navigates when analytics is blocked", async () => {
+    await search("threads");
+    postHogThrows = true;
+
+    fireEvent.click(primaryLink());
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].startsWith("/threads?")).toBe(true);
+  });
+});

--- a/showcase/shell-docs/src/components/__tests__/search-modal.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/search-modal.test.tsx
@@ -1,0 +1,388 @@
+// @vitest-environment jsdom
+
+// Behavioural tests for the docs search modal. They drive the real
+// component — type into the real input, read the real result rows,
+// navigate through the real click handler — so they stay true when
+// scoring constants are retuned. Only the ambient wiring (router,
+// framework provider, runtime config) is faked.
+
+import React from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const pushed: string[] = [];
+// The surface the reader is on. Mutable so a test can put the reader on a
+// frontend other than React and watch the ranking follow them.
+let currentPathname = "/quickstart";
+vi.mock("next/navigation", () => ({
+  usePathname: () => currentPathname,
+  useRouter: () => ({
+    push: (href: string) => {
+      pushed.push(href);
+    },
+  }),
+}));
+
+vi.mock("../framework-provider", () => ({
+  DEFAULT_FRAMEWORK: "built-in-agent",
+  useFramework: () => ({
+    effectiveFramework: "built-in-agent",
+    knownFrameworks: [],
+    setStoredFramework: () => {},
+  }),
+}));
+
+import { SearchModal } from "../search-modal";
+
+const SHELL_HOST = "https://showcase.copilotkit.test";
+
+function resultRows(): HTMLElement[] {
+  const list = screen.queryByRole("listbox", { name: "Search results" });
+  if (!list) return [];
+  // Scoped to the results listbox on purpose. The recommendation block is a
+  // separate one-option listbox of its own, so a page-wide option query
+  // would count it as a thirteenth result.
+  return within(list).queryAllByRole("option");
+}
+
+function resultTitles(): string[] {
+  return resultRows().map(
+    (row) =>
+      row.querySelector("[data-search-result-title]")?.textContent?.trim() ??
+      "",
+  );
+}
+
+/**
+ * Where each visible row leads, in the order the rows are shown. Read by
+ * clicking every row, which is the only way the destination is observable
+ * from outside the component.
+ */
+function resultHrefs(): string[] {
+  const before = pushed.length;
+  for (const row of resultRows()) fireEvent.click(row);
+  return pushed.slice(before);
+}
+
+/** Frontends whose pages a React reader should see demoted. */
+const FOREIGN_PREFIXES = [
+  "/angular/",
+  "/vue/",
+  "/react-native/",
+  "/slack/",
+  "/teams/",
+  "/reference/angular/",
+  "/reference/vue/",
+  "/reference/react-native/",
+];
+
+function belongsToAnotherFrontend(href: string): boolean {
+  return FOREIGN_PREFIXES.some((prefix) => href.startsWith(prefix));
+}
+
+async function search(query: string): Promise<void> {
+  render(<SearchModal onClose={() => {}} />);
+  // The framework picker and the docs-folder map come from a dynamically
+  // imported registry.json — wait for it before typing so results are
+  // built from the same inputs a real user's search sees.
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: /Choose docs framework/ }).textContent,
+    ).not.toContain("Loading frameworks"),
+  );
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: query } });
+  await waitFor(() => expect(resultRows().length).toBeGreaterThan(0));
+}
+
+beforeEach(() => {
+  pushed.length = 0;
+  window.__SHOWCASE_CONFIG__ = {
+    baseUrl: "https://docs.copilotkit.test/",
+    shellUrl: SHELL_HOST,
+    intelligenceSignupUrl: "https://ops.copilotkit.test/",
+    posthogKey: "",
+    posthogHost: "https://posthog.test/",
+    scarfPixelId: "",
+    googleAnalyticsTrackingId: "",
+    reb2bKey: "",
+    reoKey: "",
+    clerkPublishableKey: "",
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  delete window.__SHOWCASE_CONFIG__;
+  currentPathname = "/quickstart";
+});
+
+// "chat", "tools" and "state" are the queries that used to fan out into
+// feature-registry rows: many differently titled results that every one
+// of them navigated to the docs home page.
+const QUERIES = ["chat", "tools", "state", "threads", "intelligence"];
+
+describe("docs search results stay on the docs host", () => {
+  for (const query of QUERIES) {
+    it(`routes every "${query}" result to a real docs route`, async () => {
+      await search(query);
+
+      const rows = resultRows();
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) fireEvent.click(row);
+
+      expect(pushed.length).toBe(rows.length);
+      for (const href of pushed) {
+        // No showcase-host destination, no absolute URL of any kind.
+        expect(href).not.toContain(SHELL_HOST);
+        expect(href).not.toMatch(/^(https?:)?\/\//);
+        expect(href.startsWith("/")).toBe(true);
+        // The docs home page is never a stand-in destination.
+        expect(href).not.toBe("/");
+      }
+    });
+  }
+});
+
+describe("docs search ordering", () => {
+  it("ranks the canonical Threads guide above the threads drawer page", async () => {
+    await search("threads");
+
+    const titles = resultTitles();
+    expect(titles).toContain("Rich Threads");
+    expect(titles).toContain("Threads Drawer");
+    expect(titles.indexOf("Rich Threads")).toBeLessThan(
+      titles.indexOf("Threads Drawer"),
+    );
+  });
+
+  it("ranks the Intelligence landing page above pages that merely mention it", async () => {
+    await search("intelligence");
+
+    const titles = resultTitles();
+    expect(titles[0]).toBe("CopilotKit Intelligence");
+    expect(titles.indexOf("CopilotKit Intelligence")).toBeLessThan(
+      titles.indexOf("Self-host CopilotKit Intelligence"),
+    );
+  });
+
+  it("produces the same order for the same query twice", async () => {
+    await search("threads");
+    const first = resultTitles();
+    cleanup();
+    await search("threads");
+
+    expect(resultTitles()).toEqual(first);
+  });
+});
+
+describe("the reader's own frontend ranks above the others", () => {
+  it("keeps other frontends below agnostic rows for a React reader", async () => {
+    await search("chat");
+
+    const hrefs = resultHrefs();
+    const firstForeign = hrefs.findIndex(belongsToAnotherFrontend);
+    const lastOwn = hrefs.map(belongsToAnotherFrontend).lastIndexOf(false);
+
+    // Nothing is filtered out — a foreign row may still appear — but it
+    // can never sit above a row the reader can actually use.
+    expect(firstForeign === -1 || firstForeign > lastOwn).toBe(true);
+    expect(hrefs.slice(0, 3).every((h) => !belongsToAnotherFrontend(h))).toBe(
+      true,
+    );
+  });
+
+  // A reference symbol documented once per frontend is where the demotion
+  // is observable on its own: the copies share a type, a title and a title
+  // length, so nothing but the penalty separates them. Take the penalty
+  // away and the destination tie-break decides — "/reference/angular/…"
+  // sorts BEFORE "/reference/components/…" — so the foreign copies would
+  // take the visible slots instead of losing them.
+  it("keeps another frontend's copy of a component out of the visible rows", async () => {
+    await search("copilotchat");
+
+    const hrefs = resultHrefs();
+    expect(hrefs).toContain("/reference/components/CopilotChat");
+    expect(hrefs.filter(belongsToAnotherFrontend)).toEqual([]);
+  });
+
+  // The mirror image, and what it pins is the surface detection rather than
+  // the size of the penalty: on an Angular route Angular is the reader's own
+  // frontend, so its copy leads and React's agnostic copy follows. Ignore
+  // the reader's surface and the Angular rows become foreign and vanish, as
+  // they do in the test above.
+  it("follows the reader onto an Angular surface", async () => {
+    currentPathname = "/angular/quickstart";
+    await search("copilotchat");
+
+    const hrefs = resultHrefs();
+    expect(hrefs).toContain("/reference/angular/components/CopilotChat");
+    expect(
+      hrefs.indexOf("/reference/angular/components/CopilotChat"),
+    ).toBeLessThan(hrefs.indexOf("/reference/components/CopilotChat"));
+  });
+
+  // NOT tested, deliberately: the waiver that drops the penalty when the
+  // query names a frontend ("angular chat"). It is not observable through
+  // the result list, because every term must match for a row to appear at
+  // all — naming a frontend filters the agnostic rows out before ranking, so
+  // there is nothing left for a demoted row to lose to. Measured on the real
+  // index: "angular chat" matches 24 rows, 23 of them Angular's own, and a
+  // bare "angular" matches 78 with only 3 agnostic. The waiver stays in the
+  // code as a guard for a query where that ratio is different; a test
+  // asserting it here would pass with the waiver removed and would only look
+  // like coverage.
+});
+
+describe("the deprecated V1 reference", () => {
+  it("sorts last, below everything else", async () => {
+    await search("copilotruntime");
+
+    const hrefs = resultHrefs();
+    const v1 = hrefs.filter((href) => href.startsWith("/reference/v1/"));
+    // Demoted, never filtered: still reachable, just last.
+    expect(v1.length).toBeGreaterThan(0);
+    expect(hrefs.slice(-v1.length)).toEqual(v1);
+  });
+
+  it("is marked as deprecated in the row", async () => {
+    await search("copilotruntime");
+
+    const rows = resultRows();
+    const marked = rows.filter((row) =>
+      row.querySelector("[data-search-result-deprecated]"),
+    );
+    expect(marked.length).toBeGreaterThan(0);
+    expect(marked[0].textContent).toContain("Deprecated");
+    // Only the V1 rows carry it.
+    expect(marked.length).toBeLessThan(rows.length);
+  });
+});
+
+describe("punctuation and camelCase do not defeat the match", () => {
+  // The apostrophe sits on the READER's side of this comparison: the
+  // announcement pages live under a section spelled "Whats new", while a
+  // reader naturally types the phrase with an apostrophe. Without folding
+  // punctuation out of the query, "what's new" finds nothing at all.
+  it('finds the announcement pages from "what\'s new"', async () => {
+    await search("what's new");
+
+    expect(resultHrefs().some((href) => href.startsWith("/whats-new/"))).toBe(
+      true,
+    );
+  });
+
+  it('finds the same pages from "whats new"', async () => {
+    await search("whats new");
+
+    expect(resultHrefs().some((href) => href.startsWith("/whats-new/"))).toBe(
+      true,
+    );
+  });
+
+  it('ranks useCopilotKit near the top of "use Copilot kit"', async () => {
+    await search("use Copilot kit");
+
+    // Spelling the identifier out in words names it exactly, so it beats
+    // the pages that merely happen to contain all three words.
+    expect(resultHrefs().slice(0, 3)).toContain(
+      "/reference/hooks/useCopilotKit",
+    );
+  });
+
+  it('finds CopilotChat from "copilot chat"', async () => {
+    await search("copilot chat");
+
+    expect(resultTitles()[0]).toBe("CopilotChat");
+  });
+
+  it('finds "AG-UI" from "ag ui"', async () => {
+    await search("ag ui");
+
+    expect(resultTitles()[0]).toBe("AG-UI");
+    expect(resultHrefs()[0]).toBe("/agentic-protocols/ag-ui");
+  });
+
+  it("does not turn an unrelated query into a match", async () => {
+    render(<SearchModal onClose={() => {}} />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Choose docs framework/ })
+          .textContent,
+      ).not.toContain("Loading frameworks"),
+    );
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "kubernetes ingress" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/No results for/)).toBeTruthy(),
+    );
+    expect(resultRows()).toHaveLength(0);
+  });
+});
+
+describe("keyboard selection scrolls the list", () => {
+  let scrolled: Array<{ id: string; options: unknown }>;
+
+  beforeEach(() => {
+    scrolled = [];
+    // jsdom does not implement scrollIntoView, so the component's optional
+    // call is a no-op until one is provided here.
+    Element.prototype.scrollIntoView = function (
+      this: HTMLElement,
+      options?: unknown,
+    ) {
+      scrolled.push({ id: this.id, options });
+    } as typeof Element.prototype.scrollIntoView;
+  });
+
+  afterEach(() => {
+    // @ts-expect-error putting back jsdom's missing implementation
+    delete Element.prototype.scrollIntoView;
+  });
+
+  it("brings the keyboard-selected row into view with the smallest scroll", async () => {
+    await search("chat");
+
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    // No recommendation block for "chat", so two presses land on row 2.
+    const last = scrolled[scrolled.length - 1];
+    expect(last.id).toBe(resultRows()[2].id);
+    expect(last.options).toEqual({ block: "nearest" });
+  });
+
+  it("does not scroll when hover moves the selection", async () => {
+    await search("chat");
+
+    scrolled.length = 0;
+    fireEvent.mouseEnter(resultRows()[5]);
+
+    expect(resultRows()[5].getAttribute("aria-selected")).toBe("true");
+    expect(scrolled).toHaveLength(0);
+  });
+
+  it("stops on the last row rather than wrapping to the top", async () => {
+    await search("chat");
+
+    const input = screen.getByRole("combobox");
+    const rowCount = resultRows().length;
+    for (let i = 0; i < rowCount + 3; i += 1) {
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+    }
+
+    expect(resultRows()[rowCount - 1].getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(resultRows()[0].getAttribute("aria-selected")).toBe("false");
+  });
+});

--- a/showcase/shell-docs/src/components/intelligence-search-cta.tsx
+++ b/showcase/shell-docs/src/components/intelligence-search-cta.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+// The curated Intelligence recommendation that sits above the docs
+// search result list. See lib/intelligence-search-ctas.ts for the data
+// and the matching rules; this file is only presentation, selection and
+// attribution.
+//
+// Visual language is inherited from react/ops-platform-cta.tsx — the 2px
+// accent left-edge stripe, the CopilotKit kite as the authored stamp,
+// --bg-surface / --border / --accent, shell-docs-radius-surface, and an
+// accent text CTA with an arrow. It is deliberately NOT the marketing
+// slab: a search row has far tighter geometry, so the type scale is the
+// modal's own and the padding matches a result row rather than a
+// mid-article callout. What keeps it visibly distinct from an organic
+// result row is the border, the stripe, the kite and the "Recommended"
+// eyebrow; every colour comes from a theme token so it reads correctly
+// in light and dark.
+//
+// Accessibility: the block is a labelled `group`, NOT an option in the
+// search-results listbox, so assistive technology announces it as a
+// recommendation rather than as a fourteenth result. The primary link
+// carries the id the search input points aria-activedescendant at, and
+// its accessible name repeats the recommendation framing so a reader
+// arrowing onto it hears what kind of thing they landed on.
+//
+// The whole card activates the primary destination. Every link here is a
+// real anchor with a real, already-attributed href — so focus, middle-click
+// and open-in-new-tab all behave — and the primary one grows a pseudo-
+// element overlay across the card rather than wrapping the secondary links,
+// which would be invalid nested-anchor markup.
+
+import posthog from "posthog-js";
+import { useCallback } from "react";
+
+import { CopilotKitMark } from "@/components/copilotkit-mark";
+import {
+  buildTrackedInternalDocsHref,
+  intelligenceSearchCtaSurface,
+  matchedKeywordFor,
+} from "@/lib/intelligence-search-ctas";
+import type { IntelligenceSearchCta } from "@/lib/intelligence-search-ctas";
+
+function ArrowRight({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M5 12h14" />
+      <path d="m12 5 7 7-7 7" />
+    </svg>
+  );
+}
+
+export interface IntelligenceSearchCtaAttribution {
+  /** Frontend the docs route is scoped to. */
+  frontend?: string;
+  /** Agent backend the docs route is scoped to. */
+  backend?: string;
+}
+
+/**
+ * Records the click and hands the attributed, root-relative href back to
+ * the caller's navigation function.
+ *
+ * Shared by the block's own links and by the modal's Enter handler so
+ * both paths report identically — a keyboard activation must not be
+ * invisible in the funnel just because no mouse was involved.
+ */
+export function activateIntelligenceSearchCta({
+  cta,
+  query,
+  destination,
+  attribution,
+  navigate,
+}: {
+  cta: IntelligenceSearchCta;
+  query: string;
+  destination: string;
+  attribution: IntelligenceSearchCtaAttribution;
+  navigate: (href: string) => void;
+}): void {
+  const matchedKeyword = matchedKeywordFor(cta, query);
+  const surface = intelligenceSearchCtaSurface(cta.id, matchedKeyword);
+  const href = buildTrackedInternalDocsHref(destination, {
+    surface,
+    ...attribution,
+  });
+
+  try {
+    posthog.capture("docs_conversion_clicked", {
+      surface,
+      location: surface,
+      destination: href,
+      cta_id: cta.id,
+      // The matched KEYWORD, never the raw query — the reader's typed
+      // text is not ours to ship to analytics.
+      matched_keyword: matchedKeyword,
+    });
+  } catch {
+    // PostHog is routinely blocked by ad blockers; navigation must still
+    // work. Same guard as ops-platform-cta.tsx.
+  }
+
+  navigate(href);
+}
+
+export interface IntelligenceSearchCtaBlockProps {
+  cta: IntelligenceSearchCta;
+  /** The reader's raw query — used only to report which keyword fired. */
+  query: string;
+  /** DOM id of the block itself, so the search input can aria-control it. */
+  groupId: string;
+  /** DOM id the search input points aria-activedescendant at. */
+  optionId: string;
+  /** True while this block is the keyboard selection. */
+  selected: boolean;
+  /** Keeps hover and keyboard selection in sync, exactly as result rows do. */
+  onHover: () => void;
+  /**
+   * Internal navigation. Must be the modal's own navigateTo so
+   * client-side routing and modal-close behaviour match result rows.
+   */
+  onNavigate: (href: string) => void;
+  attribution: IntelligenceSearchCtaAttribution;
+}
+
+/**
+ * True for the clicks the browser must own: middle-click, cmd/ctrl-click,
+ * shift-click and alt-click. Intercepting those would break "open in a new
+ * tab", which is the reason the primary action is a real anchor with a real
+ * href rather than a button.
+ */
+function isBrowserOwnedClick(event: React.MouseEvent): boolean {
+  return (
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  );
+}
+
+export function IntelligenceSearchCtaBlock({
+  cta,
+  query,
+  groupId,
+  optionId,
+  selected,
+  onHover,
+  onNavigate,
+  attribution,
+}: IntelligenceSearchCtaBlockProps) {
+  const surface = intelligenceSearchCtaSurface(
+    cta.id,
+    matchedKeywordFor(cta, query),
+  );
+
+  const go = useCallback(
+    (destination: string) => {
+      activateIntelligenceSearchCta({
+        cta,
+        query,
+        destination,
+        attribution,
+        navigate: onNavigate,
+      });
+    },
+    [attribution, cta, onNavigate, query],
+  );
+
+  /**
+   * The attributed href an anchor carries. Identical to the destination
+   * `activateIntelligenceSearchCta` navigates to, so a reader who opens the
+   * link in a new tab lands on exactly the same attributed URL as one who
+   * clicks it normally.
+   */
+  const hrefFor = useCallback(
+    (destination: string) =>
+      buildTrackedInternalDocsHref(destination, { surface, ...attribution }),
+    [attribution, surface],
+  );
+
+  const clickHandlerFor = useCallback(
+    (destination: string) => (event: React.MouseEvent<HTMLAnchorElement>) => {
+      if (isBrowserOwnedClick(event)) {
+        // Still report the click, but let the browser follow the href —
+        // the no-op navigate keeps the funnel honest without stealing the
+        // new tab from the reader.
+        activateIntelligenceSearchCta({
+          cta,
+          query,
+          destination,
+          attribution,
+          navigate: () => {},
+        });
+        return;
+      }
+      event.preventDefault();
+      go(destination);
+    },
+    [attribution, cta, go, query],
+  );
+
+  return (
+    <div
+      id={groupId}
+      role="group"
+      aria-label="Recommended guide"
+      onMouseEnter={onHover}
+      data-cta-surface={surface}
+      className="border-b border-[var(--border)] p-2"
+    >
+      <div
+        className={`shell-docs-radius-surface relative overflow-hidden border bg-[var(--bg-surface)] px-3 py-3 pl-4 transition-colors ${
+          selected
+            ? "border-[var(--accent)] bg-[var(--bg-elevated)]"
+            : "border-[var(--border)]"
+        }`}
+      >
+        {/* 2px accent stripe — the structural brand signature shared with
+            the in-page Intelligence CTAs. */}
+        <span
+          aria-hidden="true"
+          className="shell-docs-cta-stripe pointer-events-none absolute left-0 top-0 h-full w-[2px]"
+        />
+        <div className="flex min-w-0 items-start gap-3">
+          <CopilotKitMark className="mt-0.5 h-[18px] w-4 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[10px] uppercase tracking-wide text-[var(--accent)]">
+              Recommended
+            </div>
+            <div className="mt-0.5 text-[13px] font-semibold leading-snug text-[var(--text)]">
+              {cta.title}
+            </div>
+            <div className="mt-1 text-[11px] leading-relaxed text-[var(--text-muted)]">
+              {cta.body}
+            </div>
+            {/* Card-link overlay: the `after:` pseudo-element stretches the
+                primary anchor's hit area across the whole card, so a click
+                anywhere on the block goes to the primary destination.
+                Nesting the secondary links inside this anchor would be
+                invalid HTML, so they stay siblings and are lifted above the
+                overlay below. The accepted cost is that text inside the
+                card is no longer selectable. */}
+            <a
+              id={optionId}
+              href={hrefFor(cta.primary.href)}
+              // Repeats the framing so a reader who arrows onto this from
+              // the search input hears "recommendation", not just a label.
+              aria-label={`Recommended: ${cta.title}. ${cta.primary.label}`}
+              onClick={clickHandlerFor(cta.primary.href)}
+              className="mt-2 inline-flex cursor-pointer items-center gap-1 text-[12px] font-semibold text-[var(--accent)] no-underline transition-opacity after:absolute after:inset-0 after:z-0 after:content-[''] hover:opacity-80"
+            >
+              {cta.primary.label}
+              <ArrowRight className="h-3.5 w-3.5" />
+            </a>
+            {/* Positioned and stacked above the overlay so each secondary
+                link's own click wins over the card-wide primary one. */}
+            <div className="relative z-10 mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+              {cta.secondary.map((link) => (
+                <a
+                  key={link.href}
+                  href={hrefFor(link.href)}
+                  onClick={clickHandlerFor(link.href)}
+                  className="cursor-pointer text-[11px] text-[var(--text-muted)] underline decoration-[var(--border)] underline-offset-2 transition-colors hover:text-[var(--text)] hover:decoration-[var(--accent)]"
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -789,13 +789,13 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
     results.length > 0 ||
     (hasQuery && results.length === 0 && !registryLoading);
 
-  // Announces the current selection to assistive technology whether it
-  // sits on the recommendation or on a result row.
+  // Only result options belong to the combobox listbox. The separate
+  // recommendation keeps its links and is announced by a live region.
   const activeDescendantId =
     selectableCount === 0
       ? undefined
       : intelligenceCta && selectedIndex === 0
-        ? CTA_OPTION_ID
+        ? undefined
         : `${RESULTS_LISTBOX_ID}-option-${selectedIndex - ctaOffset}`;
 
   return (
@@ -838,9 +838,12 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
               role="combobox"
               aria-expanded={selectableCount > 0}
               aria-controls={
-                intelligenceCta
-                  ? `${CTA_GROUP_ID} ${RESULTS_LISTBOX_ID}`
-                  : RESULTS_LISTBOX_ID
+                [
+                  intelligenceCta ? CTA_GROUP_ID : null,
+                  results.length > 0 ? RESULTS_LISTBOX_ID : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ") || undefined
               }
               aria-activedescendant={activeDescendantId}
               aria-autocomplete="list"
@@ -960,6 +963,17 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
               Loading integrations and framework docs...
             </div>
           )}
+
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="sr-only"
+          >
+            {intelligenceCta && selectedIndex === 0
+              ? `Recommended: ${intelligenceCta.title}. ${intelligenceCta.primary.label}. Press Enter to open.`
+              : ""}
+          </div>
 
           {intelligenceCta && (
             <IntelligenceSearchCtaBlock

--- a/showcase/shell-docs/src/components/search-modal.tsx
+++ b/showcase/shell-docs/src/components/search-modal.tsx
@@ -5,7 +5,8 @@ import { usePathname, useRouter } from "next/navigation";
 import { ArrowRight, Check, ChevronDown, Search, X } from "lucide-react";
 import searchIndex from "@/data/search-index.json";
 import { DEFAULT_FRAMEWORK, useFramework } from "./framework-provider";
-import { frontendFromPathname } from "@/lib/frontend-options";
+import { frontendFromPathname, isFrontendId } from "@/lib/frontend-options";
+import type { FrontendId } from "@/lib/frontend-options";
 import { FrameworkLogo } from "./icons/framework-icons";
 import { compareByDisplayOrder } from "@/lib/framework-order";
 import type { Registry } from "@/lib/registry";
@@ -22,21 +23,30 @@ import {
   resolveChannelSearchResults,
 } from "@/lib/search-hrefs";
 import type { FrameworkSearchOption } from "@/lib/search-hrefs";
+import { matchIntelligenceSearchCta } from "@/lib/intelligence-search-ctas";
+import {
+  activateIntelligenceSearchCta,
+  IntelligenceSearchCtaBlock,
+} from "./intelligence-search-cta";
 
-// Integrations explorer + per-integration demo pages live on the shell
-// host (showcase.copilotkit.ai), not on shell-docs. Search results that
-// surface an integration or one of its demos route there directly. The
-// shell host is now read at runtime from window.__SHOWCASE_CONFIG__
-// (set by the root layout) so a single built artifact can serve
-// staging vs prod without rebuilding — see lib/runtime-config.client.
+// This modal searches DOCS ONLY. The integrations explorer and the
+// feature matrix live on the shell host (showcase.copilotkit.ai) and are
+// deliberately not searchable from here: readers asking a docs question
+// were getting showcase destinations mixed into their results, and the
+// feature rows had no docs page to point at at all.
+//
+// The registry is still loaded, for two reasons that have nothing to do
+// with producing results: the framework scope picker is built from it,
+// and the integration-docs branch below needs its docs-folder map.
+//
+// `/integrations` and `/matrix` can still reach the result list from a
+// stale cached search index, so normalizeHref() keeps rewriting those two
+// onto the shell host rather than letting them 404 here. The host is read
+// at runtime from window.__SHOWCASE_CONFIG__ (set by the root layout) so a
+// single built artifact serves staging and prod — see
+// lib/runtime-config.client.
 
-type SearchResultType =
-  | "integration"
-  | "feature"
-  | "page"
-  | "reference"
-  | "ag-ui"
-  | "docs";
+type SearchResultType = "page" | "reference" | "ag-ui" | "docs";
 
 interface SearchIndexEntry {
   type: "page" | "reference" | "ag-ui";
@@ -56,6 +66,13 @@ interface SearchResult {
   frameworkName?: string;
   frameworkCount?: number;
 }
+
+// Ties the search input to the result list for assistive technology:
+// the input is the combobox, the list is its popup, and the selected row
+// is announced through aria-activedescendant as arrow keys move.
+const RESULTS_LISTBOX_ID = "docs-search-results";
+const CTA_GROUP_ID = "docs-search-recommendation";
+const CTA_OPTION_ID = `${CTA_GROUP_ID}-primary`;
 
 function isExternalHref(href: string): boolean {
   // Protocol-relative or http(s) URLs, plus non-navigable schemes that
@@ -115,12 +132,66 @@ function buildDocsFolderMap(
   return map;
 }
 
+// Punctuation a reader routinely leaves out when typing a title they half
+// remember: apostrophes (straight and curly), hyphens, dots and slashes.
+// It is DELETED rather than turned into a space, and on both sides, so
+// "whats new" reaches "What's New" and "self hosting" reaches
+// "Self-hosting" — replacing with a space would leave "what s new", which
+// the query "whats" still could not find.
+const IGNORED_PUNCTUATION = /['’./-]+/g;
+
+// The boundary inside a camelCase or PascalCase identifier: a lower-case
+// letter or digit immediately followed by a capital. Split on the HAYSTACK
+// side only — the reader types words, the docs are full of identifiers —
+// so "use Copilot kit" reaches `useCopilotKit` and "copilot chat" reaches
+// `CopilotChat`.
+const CAMEL_CASE_BOUNDARY = /([a-z0-9])([A-Z])/g;
+
+/**
+ * The searchable form of an entry's text: the plain form AND, when the text
+ * holds an identifier, the camel-split form appended after it.
+ *
+ * Both are needed. Splitting alone would break the reader who types the
+ * identifier as one word — `useCopilotKit` split to "use copilot kit" no
+ * longer contains "usecopilotkit" — and not splitting is what made
+ * "use Copilot kit" miss in the first place.
+ *
+ * This runs over every entry on every keystroke, so it stays two regex
+ * passes over one already-joined string rather than a tokenizer, and skips
+ * the concatenation entirely for text with no identifier in it.
+ */
+function normalizeHaystack(text: string): string {
+  const plain = text.replace(IGNORED_PUNCTUATION, "").toLowerCase();
+  const split = text
+    .replace(CAMEL_CASE_BOUNDARY, "$1 $2")
+    .replace(IGNORED_PUNCTUATION, "")
+    .toLowerCase();
+  return split === plain ? plain : `${plain} ${split}`;
+}
+
+/** The query with the same punctuation removed, still split into words. */
+function normalizeQuery(query: string): string {
+  return query.replace(IGNORED_PUNCTUATION, "").toLowerCase();
+}
+
+/**
+ * Punctuation, camelCase boundaries and spacing all removed. Used only to
+ * recognise a title the reader spelled out in words — "ag ui" for "AG-UI",
+ * "whats new" for "What's New", "use Copilot kit" for `useCopilotKit`.
+ */
+function condense(text: string): string {
+  return text
+    .replace(IGNORED_PUNCTUATION, "")
+    .replace(/\s+/g, "")
+    .toLowerCase();
+}
+
 function matchesQuery(
   fields: Array<string | undefined>,
   query: string,
 ): boolean {
-  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
-  const haystack = fields.filter(Boolean).join(" ").toLowerCase();
+  const terms = normalizeQuery(query).split(/\s+/).filter(Boolean);
+  const haystack = normalizeHaystack(fields.filter(Boolean).join(" "));
   return terms.every((term) => haystack.includes(term));
 }
 
@@ -130,25 +201,207 @@ function formatType(type: SearchResultType): string {
   return type;
 }
 
-function scoreResult(result: SearchResult, query: string): number {
-  const q = query.toLowerCase();
-  const title = result.title.toLowerCase();
+const WORD_CHARACTER = /[a-z0-9]/;
+
+/**
+ * True when `needle` appears in `haystack` standing on its own rather than
+ * buried inside a longer word. Both arguments must already be lowercased.
+ *
+ * Used instead of a `\b` regex so the query needs no escaping and so a
+ * query with leading or trailing punctuation still behaves sensibly.
+ */
+function matchesWholeWord(haystack: string, needle: string): boolean {
+  if (!needle) return false;
+  for (let from = 0; ; from += 1) {
+    const at = haystack.indexOf(needle, from);
+    if (at === -1) return false;
+    const before = at === 0 ? "" : haystack[at - 1];
+    const after = haystack[at + needle.length] ?? "";
+    if (!WORD_CHARACTER.test(before) && !WORD_CHARACTER.test(after)) {
+      return true;
+    }
+    from = at;
+  }
+}
+
+// ---------------------------------------------------------------------
+// Frontend affinity
+//
+// The index is one flat list across every frontend, so a React reader
+// searching "chat" got a screen of Angular: of 78 matches, roughly 38
+// belonged to a frontend they are not using. Those rows are DEMOTED,
+// never filtered — a React reader who wants the Angular page must still
+// find it by typing "angular chat", and because both words then match,
+// those rows climb back to the top on their own merits.
+// ---------------------------------------------------------------------
+
+/**
+ * The frontend a destination belongs to, or null when it is
+ * frontend-agnostic. Agnostic destinations are never penalized.
+ *
+ * Two shapes name a frontend: a leading `/vue/…`, `/angular/…`,
+ * `/react-native/…`, `/slack/…`, `/teams/…` segment, and the same names
+ * one segment into the API reference (`/reference/angular/…`). Reference
+ * sub-trees that are not frontends — `/reference/hooks`, `/reference/core`,
+ * `/reference/channels`, `/reference/v1` — fall through to null.
+ */
+function frontendFromHref(href: string): FrontendId | null {
+  const segments = href.split(/[?#]/)[0].split("/").filter(Boolean);
+  if (segments.length === 0) return null;
+  const candidate = segments[0] === "reference" ? segments[1] : segments[0];
+  return isFrontendId(candidate) ? candidate : null;
+}
+
+/** Words that count as the reader naming a frontend in their query. */
+const FRONTEND_QUERY_PHRASES: Record<FrontendId, readonly string[]> = {
+  react: ["react"],
+  "react-spa": ["react spa"],
+  vue: ["vue"],
+  "react-native": ["react native"],
+  angular: ["angular"],
+  slack: ["slack"],
+  teams: ["teams"],
+};
+
+/**
+ * Frontends the query names outright. Their pages keep their natural rank,
+ * so "angular chat" puts Angular back on top from any surface.
+ */
+function frontendsNamedInQuery(query: string): Set<FrontendId> {
+  // Padded with spaces and matched as whole phrases so "react" does not
+  // count as naming React Native, and so a typed "react-native" — where
+  // the hyphen is a word separator, not noise — still counts.
+  const padded = ` ${query
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()} `;
+  const named = new Set<FrontendId>();
+  for (const [frontend, phrases] of Object.entries(FRONTEND_QUERY_PHRASES)) {
+    if (phrases.some((phrase) => padded.includes(` ${phrase} `))) {
+      named.add(frontend as FrontendId);
+    }
+  }
+  return named;
+}
+
+interface RankingContext {
+  /**
+   * The frontend the reader is on. `frontendFromPathname` returns null both
+   * on the root surface and under `/react/…`, and React is the effective
+   * default there — so a React reader sees agnostic and React pages ahead
+   * of Angular and Vue rather than the other way round.
+   */
+  readerFrontend: FrontendId;
+  namedFrontends: ReadonlySet<FrontendId>;
+}
+
+/**
+ * Added to the score of a row belonging to a frontend the reader is not
+ * using and did not ask for.
+ *
+ * 40 is the smallest round number that makes the demotion reliable. The
+ * widest swing the title bonuses can produce inside one result type is 36
+ * — an exact title match (-30) on a framework-scoped docs row (-6) — so
+ * anything above that guarantees a foreign-frontend row sits below every
+ * same-type row that is agnostic or matches the reader. It is deliberately
+ * not larger: the whole type ladder spans 0 to 40, so a demoted row falls
+ * by about one ladder height and may mix with the next type down, but the
+ * types keep their relative order among demoted rows and nothing is
+ * dropped from the list.
+ */
+const FOREIGN_FRONTEND_PENALTY = 40;
+
+/**
+ * The V1 reference is deprecated and answers with an API that no longer
+ * exists. Its 35-odd entries sort below everything else — handled as its
+ * own comparator tier rather than a score, because "always last" is a
+ * rule, not a weighting that another bonus could out-argue.
+ */
+function isDeprecatedV1Href(href: string): boolean {
+  return href === "/reference/v1" || href.startsWith("/reference/v1/");
+}
+
+function scoreResult(
+  result: SearchResult,
+  query: string,
+  context: RankingContext,
+): number {
+  // The title tiers below compare the same normalized forms the filter
+  // uses. Without that, a query the filter now accepts could still score
+  // zero against the very page it was typed for: "ag ui" matched "AG-UI"
+  // but was ranked as if it had matched nothing, and so never surfaced.
+  const q = normalizeQuery(query);
+  const title = normalizeHaystack(result.title);
   const typePriority: Record<SearchResultType, number> = {
     docs: 0,
     page: 1,
-    integration: 2,
     reference: 3,
     "ag-ui": 4,
-    feature: 6,
   };
 
   let score = typePriority[result.type] * 10;
+
+  const frontend = frontendFromHref(result.href);
+  if (
+    frontend !== null &&
+    frontend !== context.readerFrontend &&
+    !context.namedFrontends.has(frontend)
+  ) {
+    score += FOREIGN_FRONTEND_PENALTY;
+  }
+
   if (result.frameworkName) score -= 6;
-  if (title === q) score -= 30;
-  else if (title.startsWith(q)) score -= 18;
+  // Spelling the title out in words is still naming it exactly: "ag ui"
+  // for "AG-UI", "use Copilot kit" for `useCopilotKit`.
+  if (condense(result.title) === condense(query)) score -= 30;
+  // A whole-word hit anywhere in the title beats one buried inside a
+  // longer word. This slot used to be `title.startsWith(q)`, which was a
+  // crude stand-in for the same idea: it rewarded the query only when it
+  // was the FIRST word, so searching "threads" put "Threads Drawer" above
+  // the canonical "Rich Threads" guide, and left "useThreads" — where
+  // "threads" is not a word at all — tied with it.
+  else if (matchesWholeWord(title, q)) score -= 18;
   else if (title.includes(q)) score -= 8;
 
   return score;
+}
+
+/**
+ * Total order over results for one query. Everything the score leaves tied
+ * is settled here, so the result order can never fall back on the order the
+ * search index happened to be generated in.
+ */
+function compareResults(
+  a: SearchResult,
+  b: SearchResult,
+  query: string,
+  context: RankingContext,
+): number {
+  // Deprecated V1 reference pages sink below every other result, whatever
+  // their frontend and however well their title matches.
+  const byDeprecation =
+    Number(isDeprecatedV1Href(a.href)) - Number(isDeprecatedV1Href(b.href));
+  if (byDeprecation !== 0) return byDeprecation;
+
+  const byScore =
+    scoreResult(a, query, context) - scoreResult(b, query, context);
+  if (byScore !== 0) return byScore;
+
+  // A shorter title is nearly always the more general, canonical page for
+  // a topic: "Rich Threads" is the Threads guide, "Threads Drawer" is one
+  // component within it.
+  if (a.title.length !== b.title.length) {
+    return a.title.length - b.title.length;
+  }
+
+  const byTitle = a.title.localeCompare(b.title);
+  if (byTitle !== 0) return byTitle;
+
+  // Two rows can share a title — the same reference symbol documented for
+  // several frontends, say. Destination is the last discriminator and makes
+  // the order total, so it never falls through to the order the index
+  // happened to be generated in.
+  return a.href.localeCompare(b.href);
 }
 
 export function SearchModal({ onClose }: { onClose: () => void }) {
@@ -164,6 +417,10 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
   const [registryError, setRegistryError] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const selectedIndexRef = useRef(0);
+  // What moved the selection last. The result list scrolls to follow the
+  // selection only for "keyboard": hover moves the selection too, and
+  // scrolling on hover would slide the list out from under the pointer.
+  const selectionSourceRef = useRef<"keyboard" | "pointer">("pointer");
   const router = useRouter();
   const pathname = usePathname() ?? "";
   const activeFrontend = frontendFromPathname(pathname);
@@ -396,43 +653,13 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
       });
     }
 
-    if (registryData) {
-      for (const i of registryData.integrations || []) {
-        if (
-          process.env.NODE_ENV !== "production" &&
-          (!i.description || i.description.trim() === "")
-        ) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[search-modal] integration "${i.slug}" has no description — fix upstream in registry`,
-          );
-        }
-        if (matchesQuery([i.name, i.description], q)) {
-          items.push({
-            id: `integration:${i.slug}`,
-            type: "integration",
-            title: i.name,
-            subtitle: (i.description || "").slice(0, 80),
-            href: `${shellHost}/integrations/${i.slug}`,
-          });
-        }
-      }
-
-      for (const f of registryData.feature_registry?.features || []) {
-        if (matchesQuery([f.name, f.description], q)) {
-          items.push({
-            id: `feature:${f.id}`,
-            type: "feature",
-            title: f.name,
-            subtitle: f.description,
-            href: "/",
-          });
-        }
-      }
-    }
+    const ranking: RankingContext = {
+      readerFrontend: activeFrontend ?? "react",
+      namedFrontends: frontendsNamedInQuery(q),
+    };
 
     return dedupeResults(items)
-      .sort((a, b) => scoreResult(a, q) - scoreResult(b, q))
+      .sort((a, b) => compareResults(a, b, q, ranking))
       .slice(0, 12);
   }, [
     query,
@@ -443,11 +670,47 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
     activeFrontend,
   ]);
 
+  // The curated Intelligence recommendation, when the query asks for a
+  // topic Intelligence answers directly. It is an ADDITION above the
+  // result list, never a replacement: it takes no result slot and the
+  // twelve organic results below it are untouched.
+  const intelligenceCta = useMemo(
+    () => matchIntelligenceSearchCta(query),
+    [query],
+  );
+
+  // One selection model for the whole modal. When the recommendation is
+  // showing it occupies index 0 and results shift down by one, so
+  // arrow-down out of the block lands on the first result and Enter
+  // activates whatever is selected.
+  const ctaOffset = intelligenceCta ? 1 : 0;
+  const selectableCount = ctaOffset + results.length;
+
   useEffect(() => {
     setSelectedIndex((idx) =>
-      results.length === 0 ? 0 : Math.min(idx, results.length - 1),
+      selectableCount === 0 ? 0 : Math.min(idx, selectableCount - 1),
     );
-  }, [results.length]);
+  }, [selectableCount]);
+
+  // The result list is a fixed-height scroller, so arrowing past the fifth
+  // or sixth row used to move the selection out of sight. Rows carry a
+  // stable DOM id, so the selected one is found by id rather than through
+  // a ref array. `block: "nearest"` is the minimal scroll: the list moves
+  // only when the row would otherwise be off-screen, instead of recentring
+  // on every keystroke. The recommendation block sits outside the scroller
+  // and stays visible, so there is nothing to scroll to while the
+  // selection is on it.
+  useEffect(() => {
+    if (selectionSourceRef.current !== "keyboard") return;
+    const rowIndex = selectedIndex - ctaOffset;
+    if (rowIndex < 0) return;
+    const row = document.getElementById(
+      `${RESULTS_LISTBOX_ID}-option-${rowIndex}`,
+    );
+    // Optional call: jsdom and older engines do not implement it, and a
+    // missing scroll must never break navigation.
+    row?.scrollIntoView?.({ block: "nearest" });
+  }, [selectedIndex, ctaOffset]);
 
   const navigateTo = useCallback(
     (href: string) => {
@@ -469,23 +732,50 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
       if (e.nativeEvent.isComposing) return;
 
       if (e.key === "ArrowDown") {
-        if (results.length === 0) return;
+        if (selectableCount === 0) return;
         e.preventDefault();
-        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+        selectionSourceRef.current = "keyboard";
+        // Clamped, never wrapped: at the end of the list the selection
+        // stays on the last row rather than jumping back to the top.
+        setSelectedIndex((i) => Math.min(i + 1, selectableCount - 1));
       } else if (e.key === "ArrowUp") {
-        if (results.length === 0) return;
+        if (selectableCount === 0) return;
         e.preventDefault();
+        selectionSourceRef.current = "keyboard";
         setSelectedIndex((i) => Math.max(i - 1, 0));
       } else if (e.key === "Enter") {
         const idx = selectedIndexRef.current;
-        const chosen = results[idx];
+        if (intelligenceCta && idx === 0) {
+          e.preventDefault();
+          activateIntelligenceSearchCta({
+            cta: intelligenceCta,
+            query,
+            destination: intelligenceCta.primary.href,
+            attribution: {
+              frontend: activeFrontend ?? undefined,
+              backend: selectedFramework,
+            },
+            navigate: navigateTo,
+          });
+          return;
+        }
+        const chosen = results[idx - ctaOffset];
         if (chosen) {
           e.preventDefault();
           navigateTo(chosen.href);
         }
       }
     },
-    [results, navigateTo],
+    [
+      activeFrontend,
+      ctaOffset,
+      intelligenceCta,
+      navigateTo,
+      query,
+      results,
+      selectableCount,
+      selectedFramework,
+    ],
   );
 
   const registryLoading = !registryData && !registryError;
@@ -495,8 +785,18 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
   const hasContentBelowScope =
     registryError ||
     (hasQuery && registryLoading) ||
+    intelligenceCta !== null ||
     results.length > 0 ||
     (hasQuery && results.length === 0 && !registryLoading);
+
+  // Announces the current selection to assistive technology whether it
+  // sits on the recommendation or on a result row.
+  const activeDescendantId =
+    selectableCount === 0
+      ? undefined
+      : intelligenceCta && selectedIndex === 0
+        ? CTA_OPTION_ID
+        : `${RESULTS_LISTBOX_ID}-option-${selectedIndex - ctaOffset}`;
 
   return (
     <>
@@ -531,10 +831,20 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
               value={query}
               onChange={(e) => {
                 setQuery(e.target.value);
+                selectionSourceRef.current = "keyboard";
                 setSelectedIndex(0);
               }}
               onKeyDown={onInputKeyDown}
-              placeholder="Search docs, API reference, integrations..."
+              role="combobox"
+              aria-expanded={selectableCount > 0}
+              aria-controls={
+                intelligenceCta
+                  ? `${CTA_GROUP_ID} ${RESULTS_LISTBOX_ID}`
+                  : RESULTS_LISTBOX_ID
+              }
+              aria-activedescendant={activeDescendantId}
+              aria-autocomplete="list"
+              placeholder="Search docs, guides, API reference..."
               className="min-w-0 flex-1 bg-transparent text-[15px] text-[var(--text)] outline-none placeholder:text-[var(--text-faint)]"
             />
             <button
@@ -549,7 +859,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                 e.stopPropagation();
                 onClose();
               }}
-              className="shell-docs-radius-control inline-flex h-7 w-7 items-center justify-center text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
+              className="shell-docs-radius-control inline-flex h-7 w-7 cursor-pointer items-center justify-center text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text)]"
               aria-label="Close search"
             >
               <X className="h-4 w-4" />
@@ -569,7 +879,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                 type="button"
                 disabled={!hasFrameworkPicker}
                 onClick={() => setFrameworkPickerOpen((open) => !open)}
-                className="shell-docs-radius-control inline-flex h-8 max-w-[min(56vw,220px)] items-center justify-between gap-2 border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-left text-xs font-semibold text-[var(--text)] outline-none transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-hover)] focus-visible:border-[var(--accent)] disabled:opacity-60"
+                className="shell-docs-radius-control inline-flex h-8 max-w-[min(56vw,220px)] cursor-pointer items-center justify-between gap-2 border border-[var(--border)] bg-[var(--bg-surface)] px-2.5 text-left text-xs font-semibold text-[var(--text)] outline-none transition-colors hover:border-[var(--accent)] hover:bg-[var(--bg-hover)] focus-visible:border-[var(--accent)] disabled:cursor-default disabled:opacity-60"
                 aria-haspopup="listbox"
                 aria-expanded={frameworkPickerOpen}
                 aria-label={`Choose docs framework. Currently ${
@@ -606,7 +916,7 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                         role="option"
                         aria-selected={selected}
                         onClick={() => chooseFramework(option.slug)}
-                        className={`shell-docs-radius-control flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
+                        className={`shell-docs-radius-control flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors ${
                           selected
                             ? "bg-[var(--accent)]/10 text-[var(--text)]"
                             : "text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text)]"
@@ -651,31 +961,72 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
             </div>
           )}
 
+          {intelligenceCta && (
+            <IntelligenceSearchCtaBlock
+              cta={intelligenceCta}
+              query={query}
+              groupId={CTA_GROUP_ID}
+              optionId={CTA_OPTION_ID}
+              selected={selectedIndex === 0}
+              onHover={() => {
+                selectionSourceRef.current = "pointer";
+                setSelectedIndex(0);
+              }}
+              onNavigate={navigateTo}
+              attribution={{
+                frontend: activeFrontend ?? undefined,
+                backend: selectedFramework,
+              }}
+            />
+          )}
+
           {results.length > 0 && (
-            <div className="max-h-[390px] overflow-y-auto p-2">
+            <div
+              id={RESULTS_LISTBOX_ID}
+              role="listbox"
+              aria-label="Search results"
+              className="max-h-[390px] overflow-y-auto p-2"
+            >
               {results.map((r, idx) => (
                 <button
                   key={r.id}
+                  id={`${RESULTS_LISTBOX_ID}-option-${idx}`}
                   type="button"
-                  className={`shell-docs-radius-control flex w-full items-center gap-3 px-3 py-3 text-left transition-colors ${
-                    idx === selectedIndex
+                  role="option"
+                  aria-selected={idx + ctaOffset === selectedIndex}
+                  className={`shell-docs-radius-control flex w-full cursor-pointer items-center gap-3 px-3 py-3 text-left transition-colors ${
+                    idx + ctaOffset === selectedIndex
                       ? "bg-[var(--bg-elevated)]"
                       : "hover:bg-[var(--bg-hover)]"
                   }`}
                   onClick={() => navigateTo(r.href)}
-                  onMouseEnter={() => setSelectedIndex(idx)}
+                  onMouseEnter={() => {
+                    selectionSourceRef.current = "pointer";
+                    setSelectedIndex(idx + ctaOffset);
+                  }}
                 >
                   <span className="text-[10px] font-mono text-[var(--text-faint)] uppercase w-16 shrink-0">
                     {formatType(r.type)}
                   </span>
                   <div className="min-w-0 flex-1">
                     <div className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-[13px] font-semibold text-[var(--text)]">
+                      <span
+                        data-search-result-title
+                        className="truncate text-[13px] font-semibold text-[var(--text)]"
+                      >
                         {r.title}
                       </span>
                       {r.section && (
                         <span className="hidden shrink-0 text-[11px] font-normal text-[var(--text-faint)] sm:inline">
                           {r.section}
+                        </span>
+                      )}
+                      {isDeprecatedV1Href(r.href) && (
+                        <span
+                          data-search-result-deprecated
+                          className="shell-docs-radius-icon shrink-0 border border-[var(--border)] px-1.5 py-px font-mono text-[9px] uppercase tracking-wide text-[var(--text-faint)]"
+                        >
+                          Deprecated
                         </span>
                       )}
                     </div>
@@ -692,8 +1043,12 @@ export function SearchModal({ onClose }: { onClose: () => void }) {
                     )}
                   </div>
                   <ArrowRight
+                    // Must use the same offset selection test as the row's
+                    // own background and aria-selected: comparing the bare
+                    // `idx` lit the arrow one row BELOW the selected one
+                    // whenever the recommendation block took index 0.
                     className={`h-4 w-4 shrink-0 transition-colors ${
-                      idx === selectedIndex
+                      idx + ctaOffset === selectedIndex
                         ? "text-[var(--accent)]"
                         : "text-[var(--text-faint)]"
                     }`}

--- a/showcase/shell-docs/src/lib/__tests__/ag-ui-search-index.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/ag-ui-search-index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import searchIndex from "@/data/search-index.json";
+
+interface SearchEntry {
+  type: string;
+  title: string;
+  subtitle: string;
+  section: string;
+  href: string;
+}
+
+const entries = searchIndex as SearchEntry[];
+const hrefs = new Set(entries.map((entry) => entry.href));
+
+describe("AG-UI entries in the docs search index", () => {
+  // /ag-ui/development/updates is titled "What's New", holds a single entry
+  // from April 2025, and throws on render because it uses an <Update>
+  // component this app does not provide. It is vendored AG-UI content whose
+  // canonical home is docs.ag-ui.com, so it is unlinked rather than edited.
+  it("does not offer the broken AG-UI What's New page", () => {
+    expect(hrefs.has("/ag-ui/development/updates")).toBe(false);
+  });
+
+  it("still offers the AG-UI pages next to it in the sidebar", () => {
+    expect(hrefs.has("/ag-ui/development/roadmap")).toBe(true);
+    expect(hrefs.has("/ag-ui/development/contributing")).toBe(true);
+  });
+
+  it("keeps the rest of the AG-UI section searchable", () => {
+    const aguiEntries = entries.filter((entry) =>
+      entry.href.startsWith("/ag-ui"),
+    );
+    // A guard against silently emptying the AG-UI portion: the published
+    // slug list is hand-maintained, and a typo there should fail loudly.
+    expect(aguiEntries.length).toBeGreaterThan(30);
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/channels-guide-search.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-guide-search.test.ts
@@ -98,9 +98,20 @@ describe("generated Channels search index", () => {
     }
   });
 
-  it("emits byte-identical indexes for shell-docs and shell", () => {
-    expect(fs.readFileSync(docsIndexPath)).toEqual(
-      fs.readFileSync(shellIndexPath),
+  it("emits the same docs rows to shell-docs and shell", () => {
+    // The two indexes were byte-identical until the docs target stopped
+    // carrying the showcase-host rows (the showcase front door, the
+    // integrations explorer, the feature matrix) — clicking one of those
+    // from the docs leaves the documentation. Everything else must still
+    // match, so the dual emit cannot drift.
+    const showcaseHostDestinations = new Set(["/", "/integrations", "/matrix"]);
+    const docsIndex = JSON.parse(fs.readFileSync(docsIndexPath, "utf8"));
+    const shellIndex = JSON.parse(fs.readFileSync(shellIndexPath, "utf8"));
+
+    expect(docsIndex).toEqual(
+      shellIndex.filter(
+        (entry: { href: string }) => !showcaseHostDestinations.has(entry.href),
+      ),
     );
   });
 

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-search-ctas.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-search-ctas.test.ts
@@ -1,0 +1,189 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  INTELLIGENCE_SEARCH_CTAS,
+  buildTrackedInternalDocsHref,
+  matchIntelligenceSearchCta,
+  matchedKeywordFor,
+} from "@/lib/intelligence-search-ctas";
+import type { IntelligenceSearchCta } from "@/lib/intelligence-search-ctas";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const contentRoot = resolve(here, "../../content/docs");
+
+function everyDestination(cta: IntelligenceSearchCta): string[] {
+  return [cta.primary.href, ...cta.secondary.map((link) => link.href)];
+}
+
+const ALL_ENTRIES = [...INTELLIGENCE_SEARCH_CTAS];
+const ALL_LINKS = ALL_ENTRIES.flatMap((cta) =>
+  [cta.primary, ...cta.secondary].map((link) => ({ cta, link })),
+);
+
+describe("Intelligence search CTA destinations", () => {
+  it.each(ALL_LINKS)(
+    "$cta.id → $link.href is an internal docs route",
+    ({ link }) => {
+      // An absolute URL would break the modal's client-side navigation and
+      // drop the reader out of the docs entirely.
+      expect(link.href.startsWith("/")).toBe(true);
+      expect(link.href).not.toMatch(/^(https?:)?\/\//);
+      expect(link.href.toLowerCase()).not.toContain("http");
+    },
+  );
+
+  it.each(ALL_LINKS)(
+    "$cta.id → $link.href resolves to a page in the content tree",
+    ({ link }) => {
+      expect(existsSync(resolve(contentRoot, `.${link.href}.mdx`))).toBe(true);
+    },
+  );
+
+  it("gives every link a label and never repeats a destination inside one entry", () => {
+    for (const cta of ALL_ENTRIES) {
+      const destinations = everyDestination(cta);
+      expect(new Set(destinations).size).toBe(destinations.length);
+      expect(cta.secondary.length).toBeGreaterThanOrEqual(2);
+      expect(cta.secondary.length).toBeLessThanOrEqual(3);
+      for (const link of [cta.primary, ...cta.secondary]) {
+        expect(link.label.trim().length).toBeGreaterThan(0);
+      }
+      expect(cta.title.trim().length).toBeGreaterThan(0);
+      expect(cta.body.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the threads copy honest about what is paid", () => {
+    const threads = matchIntelligenceSearchCta("threads");
+    const copy = `${threads?.title} ${threads?.body}`.toLowerCase();
+
+    // Threads themselves are open source and free; Intelligence adds the
+    // durable storage behind them. The copy must not imply otherwise.
+    expect(copy).toContain("built into copilotkit");
+    expect(copy).toMatch(/resume|resumable/);
+    expect(copy).not.toMatch(/upgrade to|paid|pro plan|premium/);
+  });
+});
+
+describe("Intelligence search CTA matching", () => {
+  it("fires the expected entry for a whole-word query", () => {
+    expect(matchIntelligenceSearchCta("threads")?.id).toBe("threads");
+    expect(matchIntelligenceSearchCta("thread")?.id).toBe("threads");
+    expect(matchIntelligenceSearchCta("persistence")?.id).toBe("threads");
+    expect(matchIntelligenceSearchCta("persistent")?.id).toBe("threads");
+    expect(matchIntelligenceSearchCta("self-hosting")?.id).toBe("self-hosting");
+    expect(matchIntelligenceSearchCta("self-host")?.id).toBe("self-hosting");
+    expect(matchIntelligenceSearchCta("selfhosted")?.id).toBe("self-hosting");
+    expect(matchIntelligenceSearchCta("self-hosted")?.id).toBe("self-hosting");
+    expect(matchIntelligenceSearchCta("learning")?.id).toBe("learning");
+    expect(matchIntelligenceSearchCta("analytics")?.id).toBe("analytics");
+    expect(matchIntelligenceSearchCta("intelligence")?.id).toBe("intelligence");
+  });
+
+  it("does not fire on a word that merely contains a keyword", () => {
+    // The reason plain substring matching is forbidden: "spreadsheets"
+    // contains "threads".
+    expect(matchIntelligenceSearchCta("spreadsheets")).toBeNull();
+    expect(matchIntelligenceSearchCta("export spreadsheets")).toBeNull();
+  });
+
+  it("fires on a four-character prefix but not on a two-character one", () => {
+    expect(matchIntelligenceSearchCta("intell")?.id).toBe("intelligence");
+    expect(matchIntelligenceSearchCta("inte")?.id).toBe("intelligence");
+    expect(matchIntelligenceSearchCta("int")).toBeNull();
+    expect(matchIntelligenceSearchCta("in")).toBeNull();
+    expect(matchIntelligenceSearchCta("thre")?.id).toBe("threads");
+    expect(matchIntelligenceSearchCta("th")).toBeNull();
+  });
+
+  it("returns the most specific entry when several match, and only one", () => {
+    expect(matchIntelligenceSearchCta("intelligence threads")?.id).toBe(
+      "threads",
+    );
+    expect(matchIntelligenceSearchCta("threads intelligence")?.id).toBe(
+      "threads",
+    );
+    expect(
+      matchIntelligenceSearchCta("intelligence analytics learning")?.id,
+    ).not.toBe("intelligence");
+
+    // The API is single-valued by construction: there is no shape in
+    // which two blocks could render.
+    const match = matchIntelligenceSearchCta("intelligence threads");
+    expect(Array.isArray(match)).toBe(false);
+    expect(match).not.toBeNull();
+  });
+
+  it("declares specificity as data rather than inferring it", () => {
+    const byId = new Map(ALL_ENTRIES.map((cta) => [cta.id, cta.specificity]));
+    expect(byId.get("threads")).toBeGreaterThan(byId.get("self-hosting")!);
+    expect(byId.get("self-hosting")).toBeGreaterThan(byId.get("learning")!);
+    expect(byId.get("learning")).toBeGreaterThan(byId.get("intelligence")!);
+  });
+
+  it("ignores case and extra whitespace", () => {
+    expect(matchIntelligenceSearchCta("  THREADS  ")?.id).toBe("threads");
+    expect(matchIntelligenceSearchCta("Self-Hosting")?.id).toBe("self-hosting");
+    expect(matchIntelligenceSearchCta("  intelligence   threads ")?.id).toBe(
+      "threads",
+    );
+  });
+
+  it("stays out of the way of unrelated docs queries", () => {
+    for (const query of [
+      "useCopilotAction",
+      "angular quickstart",
+      "css",
+      "",
+      "   ",
+      "generative ui",
+      "mastra",
+      "tool calls",
+    ]) {
+      expect(matchIntelligenceSearchCta(query)).toBeNull();
+    }
+  });
+
+  it("reports which keyword fired", () => {
+    const threads = matchIntelligenceSearchCta("persistence")!;
+    expect(matchedKeywordFor(threads, "persistence")).toBe("persistence");
+    expect(matchedKeywordFor(threads, "threads")).toBe("threads");
+  });
+});
+
+describe("Intelligence search CTA attribution", () => {
+  it("keeps the destination internal while carrying docs CTA attribution", () => {
+    const href = buildTrackedInternalDocsHref("/intelligence/overview", {
+      surface: "docs-search:intelligence:intelligence",
+      frontend: "angular",
+      backend: "langgraph-python",
+    });
+
+    expect(href.startsWith("/intelligence/overview?")).toBe(true);
+    expect(href).not.toMatch(/^(https?:)?\/\//);
+    expect(href).not.toContain("invalid");
+
+    const params = new URLSearchParams(href.slice(href.indexOf("?")));
+    expect(params.get("utm_source")).toBe("docs");
+    expect(params.get("utm_medium")).toBe("cta");
+    expect(params.get("utm_campaign")).toBe("intelligence");
+    expect(params.get("utm_content")).toBe(
+      "docs-search:intelligence:intelligence",
+    );
+    expect(params.get("utm_frontend")).toBe("angular");
+    expect(params.get("utm_backend")).toBe("langgraph-python");
+  });
+
+  it("names search and the matched keyword in the surface", () => {
+    const href = buildTrackedInternalDocsHref("/threads", {
+      surface: "docs-search:threads:persistence",
+    });
+    const params = new URLSearchParams(href.slice(href.indexOf("?")));
+
+    expect(params.get("utm_content")).toBe("docs-search:threads:persistence");
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/search-index-build-contract.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/search-index-build-contract.test.ts
@@ -1,0 +1,96 @@
+import fs from "fs";
+import path from "path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the build contract behind the docs-search reachability filter.
+ *
+ * `generate-search-index.ts` lives in `showcase/scripts` but delegates the
+ * "can a reader reach this page?" decision to shell-docs, which it runs as a
+ * subprocess. Any app whose build stages the shell-docs CONTENT tree also
+ * consumes docs rows, so it must stage what that subprocess needs — or its
+ * search loses every docs row.
+ *
+ * That is not hypothetical. `showcase/shell/Dockerfile` staged the content
+ * tree and nothing else, so the showcase app's index went from 678 docs rows
+ * to zero while the build stayed green on a warning. The generator now fails
+ * loudly instead, and this test states the contract where a future Dockerfile
+ * edit will trip over it rather than discovering it in a deployed image.
+ */
+
+const SHOWCASE_ROOT = path.resolve(process.cwd(), "..");
+const CONTENT_COPY = "showcase/shell-docs/src/content/";
+
+/** Every `showcase/*\/Dockerfile` in the repo. */
+function dockerfiles(): { app: string; path: string; source: string }[] {
+  return fs
+    .readdirSync(SHOWCASE_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      app: entry.name,
+      path: path.join(SHOWCASE_ROOT, entry.name, "Dockerfile"),
+    }))
+    .filter((candidate) => fs.existsSync(candidate.path))
+    .map((candidate) => ({
+      ...candidate,
+      source: fs.readFileSync(candidate.path, "utf-8"),
+    }));
+}
+
+describe("docs-search build contract", () => {
+  const files = dockerfiles();
+
+  it("finds Dockerfiles to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files.map((file) => [file.app, file] as const))(
+    "%s: staging docs content also stages the reachability toolchain",
+    (_app, file) => {
+      // Only builds that stage the docs content AND generate the search
+      // index are bound by this. shell-docs' own image copies its whole
+      // tree, so the content marker is absent there; shell-dashboard stages
+      // the content for `probe-docs.ts` alone and never builds an index.
+      if (!file.source.includes(CONTENT_COPY)) return;
+      if (!file.source.includes("generate-search-index")) return;
+
+      // The emit script, the library it imports, and the tsconfig that
+      // resolves shell-docs' `@/…` alias.
+      expect(file.source).toContain("showcase/shell-docs/src/lib/");
+      expect(file.source).toContain("showcase/shell-docs/scripts/");
+      expect(file.source).toContain("showcase/shell-docs/tsconfig.json");
+
+      // No shell-docs install is required: the generator puts its own
+      // node_modules on the child's NODE_PATH. What the image must carry is
+      // the scripts install itself, which every such build already has
+      // because the generator runs from there.
+      expect(file.source).toMatch(/COPY showcase\/scripts\//);
+    },
+  );
+
+  it("the emit script and its entry point exist where the contract says", () => {
+    expect(
+      fs.existsSync(
+        path.join(process.cwd(), "scripts/emit-searchable-pages.ts"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(process.cwd(), "src/lib/searchable-pages.ts")),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(process.cwd(), "tsconfig.json"))).toBe(true);
+  });
+
+  it("declares gray-matter where the subprocess can resolve it", () => {
+    // The shell image symlinks shell-docs/node_modules at the scripts
+    // install, so `gray-matter` has to be a scripts dependency too — not
+    // only a shell-docs one.
+    const scriptsPkg = JSON.parse(
+      fs.readFileSync(
+        path.join(SHOWCASE_ROOT, "scripts/package.json"),
+        "utf-8",
+      ),
+    ) as { dependencies?: Record<string, string> };
+    expect(scriptsPkg.dependencies?.["gray-matter"]).toBeTruthy();
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/search-index-build-contract.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/search-index-build-contract.test.ts
@@ -1,5 +1,7 @@
 import fs from "fs";
 import path from "path";
+import os from "os";
+import { spawnSync } from "child_process";
 
 import { describe, expect, it } from "vitest";
 
@@ -93,4 +95,75 @@ describe("docs-search build contract", () => {
     ) as { dependencies?: Record<string, string> };
     expect(scriptsPkg.dependencies?.["gray-matter"]).toBeTruthy();
   });
+});
+
+describe("partially staged content", () => {
+  it.each([
+    ["reference"],
+    ["ag-ui"],
+    ["docs"],
+    ["reference", "ag-ui"],
+    ["docs", "reference"],
+    ["docs", "ag-ui"],
+  ])(
+    "rejects a build containing only %j before writing either index",
+    (...roots) => {
+      const staged = fs.mkdtempSync(
+        path.join(os.tmpdir(), "search-index-staging-"),
+      );
+      try {
+        const scripts = path.join(staged, "scripts");
+        fs.mkdirSync(scripts);
+        for (const file of ["generate-search-index.ts", "package.json"]) {
+          fs.copyFileSync(
+            path.join(SHOWCASE_ROOT, "scripts", file),
+            path.join(scripts, file),
+          );
+        }
+        fs.cpSync(
+          path.join(SHOWCASE_ROOT, "scripts/lib"),
+          path.join(scripts, "lib"),
+          { recursive: true },
+        );
+        fs.symlinkSync(
+          path.join(SHOWCASE_ROOT, "scripts/node_modules"),
+          path.join(scripts, "node_modules"),
+        );
+        for (const root of roots) {
+          fs.mkdirSync(path.join(staged, "shell-docs/src/content", root), {
+            recursive: true,
+          });
+        }
+        for (const app of ["shell-docs", "shell"]) {
+          const data = path.join(staged, app, "src/data");
+          fs.mkdirSync(data, { recursive: true });
+          fs.writeFileSync(
+            path.join(data, "search-index.json"),
+            "existing index",
+          );
+        }
+        const result = spawnSync(
+          process.execPath,
+          [
+            "--import",
+            path.join(scripts, "node_modules/tsx/dist/loader.mjs"),
+            path.join(scripts, "generate-search-index.ts"),
+          ],
+          { encoding: "utf8", timeout: 10000 },
+        );
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("incomplete content tree");
+        for (const app of ["shell-docs", "shell"]) {
+          expect(
+            fs.readFileSync(
+              path.join(staged, app, "src/data/search-index.json"),
+              "utf8",
+            ),
+          ).toBe("existing index");
+        }
+      } finally {
+        fs.rmSync(staged, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/showcase/shell-docs/src/lib/__tests__/search-index-navigability.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/search-index-navigability.test.ts
@@ -1,0 +1,181 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import docsSearchIndex from "../../data/search-index.json";
+import { isChannelDocsHref } from "../search-hrefs";
+import { isRouteGroupSegment } from "../route-groups";
+import { getSearchablePages, canonicalDocsSlug } from "../searchable-pages";
+
+interface SearchEntry {
+  type: string;
+  title: string;
+  href: string;
+}
+
+const docsEntries = docsSearchIndex as SearchEntry[];
+
+// The showcase app's copy of the index. Read from disk rather than
+// imported so this suite still runs in a checkout where only shell-docs
+// has been generated.
+const SHELL_INDEX_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "shell",
+  "src",
+  "data",
+  "search-index.json",
+);
+
+function readShellIndex(): SearchEntry[] | null {
+  if (!fs.existsSync(SHELL_INDEX_PATH)) return null;
+  return JSON.parse(fs.readFileSync(SHELL_INDEX_PATH, "utf-8"));
+}
+
+const SHOWCASE_HOST_DESTINATIONS = ["/", "/integrations", "/matrix"];
+
+function docsPageEntries(entries: SearchEntry[]): SearchEntry[] {
+  return entries.filter((entry) => entry.href.startsWith("/docs"));
+}
+
+describe("generated docs search index", () => {
+  it("offers no destination that would take a redirect hop", () => {
+    const withRouteGroup = docsEntries.filter((entry) =>
+      entry.href.split("/").some(isRouteGroupSegment),
+    );
+
+    expect(withRouteGroup.map((entry) => entry.href)).toEqual([]);
+  });
+
+  it("never sends two docs rows to the same place", () => {
+    const byHref = new Map<string, SearchEntry[]>();
+    for (const entry of docsPageEntries(docsEntries)) {
+      byHref.set(entry.href, [...(byHref.get(entry.href) ?? []), entry]);
+    }
+    const duplicated = [...byHref]
+      .filter(([, group]) => group.length > 1)
+      .map(([href]) => href);
+
+    expect(duplicated).toEqual([]);
+  });
+
+  it("never sends two rows of any kind to the same place", () => {
+    const seen = new Map<string, number>();
+    for (const entry of docsEntries) {
+      seen.set(entry.href, (seen.get(entry.href) ?? 0) + 1);
+    }
+
+    expect(
+      [...seen].filter(([, count]) => count > 1).map(([href]) => href),
+    ).toEqual([]);
+  });
+
+  it("leaves the docs for no showcase-host destination", () => {
+    const leaving = docsEntries.filter((entry) =>
+      SHOWCASE_HOST_DESTINATIONS.includes(entry.href),
+    );
+
+    expect(leaving.map((entry) => entry.href)).toEqual([]);
+  });
+
+  it("offers only docs pages a reader can reach from some sidebar", () => {
+    const searchable = getSearchablePages();
+    const unreachable = docsPageEntries(docsEntries)
+      .filter((entry) => !isChannelDocsHref(entry.href))
+      .filter((entry) => !entry.href.startsWith("/docs/frontends/"))
+      .filter((entry) => !searchable.slugs.has(canonicalDocsSlug(entry.href)));
+
+    expect(unreachable.map((entry) => entry.href)).toEqual([]);
+  });
+
+  it("drops the What's New roll-up page the maintained announcements replaced", () => {
+    expect(docsEntries.some((entry) => entry.href === "/docs/whats-new")).toBe(
+      false,
+    );
+  });
+
+  it("keeps an unlisted page whose only inbound link lives in a snippet", () => {
+    // `intelligence/headless-ui` is in no sidebar. It stays searchable
+    // because the Intelligence overview links to it — and that page's
+    // whole body is `<Overview />`, so the link is only visible once the
+    // snippet is inlined. This asserts the real resolution, which is why
+    // the page needs no `search: true` override.
+    const searchable = getSearchablePages();
+
+    expect(searchable.fromNavigation.has("intelligence/headless-ui")).toBe(
+      false,
+    );
+    expect(searchable.fromLinks.has("intelligence/headless-ui")).toBe(true);
+    expect(
+      docsEntries.some(
+        (entry) => entry.href === "/docs/intelligence/headless-ui",
+      ),
+    ).toBe(true);
+  });
+
+  it("needs no frontmatter override to reach its current coverage", () => {
+    // The escape hatch should stay rare: a mechanism proven by the rules
+    // beats one proven by a manual override. If a page legitimately needs
+    // `search: true` later, update this expectation deliberately.
+    expect([...getSearchablePages().forcedIn]).toEqual([]);
+  });
+
+  it("keeps the channel guides the modal re-routes at runtime", () => {
+    const channels = docsEntries.filter((entry) =>
+      isChannelDocsHref(entry.href),
+    );
+
+    // Filtering these against the docs navigation would wrongly delete
+    // them: `parseChannelDocsHref` turns each into a Slack and a Teams
+    // destination when the result list is built.
+    expect(channels.length).toBeGreaterThan(0);
+    expect(channels.map((entry) => entry.href)).toContain("/docs/channels");
+  });
+
+  it("keeps integration pages under the folder form the modal parses", () => {
+    const integrationEntries = docsPageEntries(docsEntries).filter((entry) =>
+      entry.href.startsWith("/docs/integrations/"),
+    );
+
+    expect(integrationEntries.length).toBeGreaterThan(0);
+    expect(integrationEntries.map((entry) => entry.href)).toContain(
+      "/docs/integrations/langgraph/threads",
+    );
+  });
+
+  it("holds enough docs pages that a broken navigation walk cannot pass", () => {
+    // Mirrors MIN_DOCS_ENTRIES in showcase/scripts/generate-search-index.ts.
+    expect(docsPageEntries(docsEntries).length).toBeGreaterThanOrEqual(495);
+  });
+});
+
+describe("generated showcase search index", () => {
+  it("keeps the integrations explorer and feature matrix the showcase owns", () => {
+    const shellIndex = readShellIndex();
+    if (shellIndex === null) return;
+
+    const hrefs = shellIndex.map((entry) => entry.href);
+    expect(hrefs).toContain("/integrations");
+    expect(hrefs).toContain("/matrix");
+    expect(hrefs).toContain("/");
+  });
+
+  it("agrees with the docs index on everything but the showcase rows", () => {
+    const shellIndex = readShellIndex();
+    if (shellIndex === null) return;
+
+    const onlyInShell = shellIndex
+      .filter(
+        (entry) =>
+          !docsEntries.some((docsEntry) => docsEntry.href === entry.href),
+      )
+      .map((entry) => entry.href)
+      .sort();
+
+    expect(onlyInShell).toEqual([...SHOWCASE_HOST_DESTINATIONS].sort());
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/searchable-pages.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/searchable-pages.test.ts
@@ -1,0 +1,342 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { canonicalDocsSlug, computeSearchablePages } from "../searchable-pages";
+import type { NavigationSurface } from "../searchable-pages";
+import type { NavNode } from "../docs-render";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Write a throwaway content tree: `{ "<slug>": "<mdx source>" }`. */
+function contentTree(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "searchable-pages-"));
+  tempDirs.push(dir);
+  for (const [slug, source] of Object.entries(files)) {
+    const file = path.join(dir, `${slug}.mdx`);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, source);
+  }
+  return dir;
+}
+
+function page(slug: string, title = slug): NavNode {
+  return { type: "page", title, slug };
+}
+
+function surface(nodes: NavNode[], extra: Partial<NavigationSurface> = {}) {
+  return [{ id: "test", nodes, ...extra }];
+}
+
+describe("searchable pages", () => {
+  it("leaves out a page that no sidebar lists and nobody links to", () => {
+    const contentDir = contentTree({
+      quickstart: "# Quickstart\n",
+      "whats-new": "# What's new\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("quickstart")]),
+    });
+
+    expect(slugs.has("quickstart")).toBe(true);
+    expect(slugs.has("whats-new")).toBe(false);
+  });
+
+  it("keeps a page that is absent from every sidebar but linked from prose", () => {
+    const contentDir = contentTree({
+      "intelligence/overview":
+        "See [fully headless UI](/intelligence/headless-ui) for details.\n",
+      "intelligence/headless-ui": "# Fully headless UI\n",
+    });
+
+    const { slugs, fromNavigation, fromLinks } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("intelligence/overview")]),
+    });
+
+    expect(fromNavigation.has("intelligence/headless-ui")).toBe(false);
+    expect(fromLinks.has("intelligence/headless-ui")).toBe(true);
+    expect(slugs.has("intelligence/headless-ui")).toBe(true);
+  });
+
+  it("counts links from the content a page inlines, not just its own file", () => {
+    // Most CopilotKit pages are a frontmatter block and one component
+    // reference; the prose that carries the links lives in the snippet.
+    const contentDir = contentTree({
+      "intelligence/overview": "<Overview components={props.components} />\n",
+      "intelligence/headless-ui": "# Fully headless UI\n",
+    });
+    const surfaces = surface([page("intelligence/overview")]);
+
+    // Reading only the page file sees no link at all.
+    expect(
+      computeSearchablePages({ contentDir, surfaces }).slugs.has(
+        "intelligence/headless-ui",
+      ),
+    ).toBe(false);
+
+    // Reading the page as the reader receives it does.
+    const withSnippets = computeSearchablePages({
+      contentDir,
+      surfaces,
+      readPageSource: (filePath, slug) =>
+        slug === "intelligence/overview"
+          ? "See [fully headless UI](/intelligence/headless-ui).\n"
+          : fs.readFileSync(filePath, "utf-8"),
+    });
+
+    expect(withSnippets.fromLinks.has("intelligence/headless-ui")).toBe(true);
+  });
+
+  it("finds link targets in JSX hrefs as well as markdown links", () => {
+    const contentDir = contentTree({
+      index: '<a href="/deep-dive">Deep dive</a>\n',
+      "deep-dive": "# Deep dive\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("")]),
+    });
+
+    expect(slugs.has("deep-dive")).toBe(true);
+  });
+
+  it("does not follow links out of a page that is itself unreachable", () => {
+    const contentDir = contentTree({
+      quickstart: "# Quickstart\n",
+      orphan: "Read [the leftover](/leftover).\n",
+      leftover: "# Leftover\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("quickstart")]),
+    });
+
+    expect(slugs.has("orphan")).toBe(false);
+    expect(slugs.has("leftover")).toBe(false);
+  });
+
+  it("resolves a framework-scoped link onto the page it actually serves", () => {
+    const contentDir = contentTree({
+      quickstart: "See [emitting messages](/langgraph-python/advanced/emit).\n",
+      "integrations/langgraph/advanced/emit": "# Emitting messages\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("quickstart")], {
+        id: "integration:langgraph-python",
+        integrationFolder: "langgraph",
+        routeScope: "langgraph-python",
+      }),
+    });
+
+    expect(slugs.has("integrations/langgraph/advanced/emit")).toBe(true);
+  });
+
+  it("lets `search: false` force a listed page out of the index", () => {
+    const contentDir = contentTree({
+      quickstart: "---\ntitle: Quickstart\nsearch: false\n---\n",
+    });
+
+    const { slugs, fromNavigation, forcedOut } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("quickstart")]),
+    });
+
+    expect(fromNavigation.has("quickstart")).toBe(true);
+    expect(forcedOut.has("quickstart")).toBe(true);
+    expect(slugs.has("quickstart")).toBe(false);
+  });
+
+  it("lets `search: true` force an unreachable page into the index", () => {
+    const contentDir = contentTree({
+      quickstart: "# Quickstart\n",
+      "intelligence/headless-ui":
+        "---\ntitle: Fully Headless UI\nsearch: true\n---\n",
+    });
+
+    const { slugs, fromNavigation, forcedIn } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("quickstart")]),
+    });
+
+    expect(fromNavigation.has("intelligence/headless-ui")).toBe(false);
+    expect(forcedIn.has("intelligence/headless-ui")).toBe(true);
+    expect(slugs.has("intelligence/headless-ui")).toBe(true);
+  });
+
+  it("indexes no page for a navigation entry that points off-site", () => {
+    const contentDir = contentTree({
+      quickstart: "# Quickstart\n",
+      "automatic-learning": "# Automatic learning\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([
+        page("quickstart"),
+        {
+          type: "page",
+          title: "Automatic learning",
+          slug: "automatic-learning",
+          href: "https://copilotkit.ai/intelligence#learning",
+        },
+      ]),
+    });
+
+    expect(slugs.has("automatic-learning")).toBe(false);
+  });
+
+  it("keeps a folder page that the sidebar renders as an expandable group", () => {
+    const contentDir = contentTree({
+      "human-in-the-loop/index": "# Human in the loop\n",
+      "human-in-the-loop/interrupt": "# Interrupts\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([
+        {
+          type: "group",
+          title: "Human-in-the-Loop",
+          slug: "human-in-the-loop",
+          children: [page("human-in-the-loop/interrupt")],
+        },
+      ]),
+    });
+
+    expect(slugs.has("human-in-the-loop")).toBe(true);
+    expect(slugs.has("human-in-the-loop/interrupt")).toBe(true);
+  });
+
+  it("ignores the synthetic slug an inline sidebar folder uses as a React key", () => {
+    const contentDir = contentTree({ threads: "# Threads\n" });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([
+        {
+          type: "group",
+          title: "Rich threads",
+          slug: "sidebar#rich-threads",
+          children: [page("threads")],
+        },
+      ]),
+    });
+
+    expect([...slugs]).toEqual(["threads"]);
+  });
+
+  it("keeps integration pages under the folder form the search modal expects", () => {
+    const contentDir = contentTree({
+      "integrations/adk/quickstart": "# ADK quickstart\n",
+    });
+
+    // A framework sidebar rewrites `integrations/adk/quickstart` down to a
+    // bare `quickstart`; the index generator still sees the folder form.
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("quickstart")], {
+        id: "integration:google-adk",
+        integrationFolder: "adk",
+        routeScope: "google-adk",
+      }),
+    });
+
+    expect(slugs.has("integrations/adk/quickstart")).toBe(true);
+  });
+
+  it("does not invent a folder-form slug with no file behind it", () => {
+    const contentDir = contentTree({ threads: "# Threads\n" });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("threads")], {
+        id: "integration:google-adk",
+        integrationFolder: "adk",
+        routeScope: "google-adk",
+      }),
+    });
+
+    expect(slugs.has("integrations/adk/threads")).toBe(false);
+  });
+
+  it("takes the union over surfaces rather than any single sidebar", () => {
+    const contentDir = contentTree({
+      threads: "# Threads\n",
+      "integrations/mastra/guardrails": "# Guardrails\n",
+    });
+
+    const { slugs } = computeSearchablePages({
+      contentDir,
+      surfaces: [
+        { id: "root", nodes: [page("threads")] },
+        {
+          id: "root-meta:integrations/mastra",
+          nodes: [page("integrations/mastra/guardrails")],
+        },
+      ],
+    });
+
+    expect(slugs.has("threads")).toBe(true);
+    expect(slugs.has("integrations/mastra/guardrails")).toBe(true);
+  });
+
+  it("names a page the way the sidebar names it", () => {
+    const contentDir = contentTree({ threads: "---\ntitle: Threads\n---\n" });
+
+    const { navTitles } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("threads", "Rich threads")]),
+    });
+
+    expect(navTitles.get("threads")).toBe("Rich threads");
+  });
+
+  it("ignores a sidebar title that only makes sense next to its parent", () => {
+    const contentDir = contentTree({
+      threads: "---\ntitle: Rich Threads\n---\n",
+    });
+
+    // `nav_title: Overview` reads fine under a "Rich Threads" group and
+    // identifies nothing in a flat list of search results.
+    const { navTitles } = computeSearchablePages({
+      contentDir,
+      surfaces: surface([page("threads", "Overview")]),
+    });
+
+    expect(navTitles.has("threads")).toBe(false);
+  });
+});
+
+describe("canonicalDocsSlug", () => {
+  it("strips the docs prefix, route groups and a trailing index", () => {
+    expect(canonicalDocsSlug("/docs/(other)/telemetry")).toBe("telemetry");
+    expect(canonicalDocsSlug("/docs/threads")).toBe("threads");
+    expect(canonicalDocsSlug("docs")).toBe("");
+    expect(canonicalDocsSlug("/docs")).toBe("");
+    expect(canonicalDocsSlug("human-in-the-loop/index")).toBe(
+      "human-in-the-loop",
+    );
+    expect(
+      canonicalDocsSlug("/docs/integrations/agno/(other)/contributing"),
+    ).toBe("integrations/agno/contributing");
+  });
+
+  it("does not mistake a slug segment that merely starts with docs", () => {
+    expect(canonicalDocsSlug("/docs/docs-status")).toBe("docs-status");
+  });
+});

--- a/showcase/shell-docs/src/lib/__tests__/searchable-pages.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/searchable-pages.test.ts
@@ -2,15 +2,21 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { canonicalDocsSlug, computeSearchablePages } from "../searchable-pages";
+import {
+  canonicalDocsSlug,
+  computeSearchablePages,
+  readPageSourceWithSnippets,
+} from "../searchable-pages";
 import type { NavigationSurface } from "../searchable-pages";
+import * as docsRender from "../docs-render";
 import type { NavNode } from "../docs-render";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -338,5 +344,26 @@ describe("canonicalDocsSlug", () => {
 
   it("does not mistake a slug segment that merely starts with docs", () => {
     expect(canonicalDocsSlug("/docs/docs-status")).toBe("docs-status");
+  });
+});
+
+describe("snippet failure diagnostics", () => {
+  it("reports the source and error, preserves raw links, and restores the logger", () => {
+    const raw = "See [guide](/guide).";
+    const dir = contentTree({ source: raw });
+    const error = new Error("snippet read failed");
+    vi.spyOn(docsRender, "inlineSnippets").mockImplementation(() => {
+      throw error;
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(
+      readPageSourceWithSnippets(path.join(dir, "source.mdx"), "source"),
+    ).toBe(raw);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('"source"'),
+      error,
+    );
+    expect(console.warn).toBe(warn);
   });
 });

--- a/showcase/shell-docs/src/lib/intelligence-search-ctas.ts
+++ b/showcase/shell-docs/src/lib/intelligence-search-ctas.ts
@@ -1,0 +1,249 @@
+// Curated Intelligence recommendations for the docs search modal.
+//
+// A reader who types "threads" or "self-hosting" into docs search is
+// asking a question CopilotKit Intelligence answers directly, but the
+// organic result list can only rank pages by title — it has no way to
+// say "here is the guide that actually addresses this". This module is
+// that editorial layer: a small keyword-to-recommendation table plus a
+// matcher, kept deliberately free of React, network calls and side
+// effects so it can be read, reviewed and tested as plain data.
+//
+// Rules the data must keep (all enforced by
+// lib/__tests__/intelligence-search-ctas.test.ts):
+//
+//  - Every destination is an INTERNAL docs route. Never an absolute URL:
+//    the modal navigates through next/router and an external href would
+//    both break client-side routing and drop the reader out of the docs.
+//  - Specificity is DECLARED, never inferred from keyword counts or
+//    string lengths, so "intelligence threads" resolving to the threads
+//    entry is a fact you can read off the table.
+//  - Exactly one entry ever renders.
+
+import type { DocsCtaAttribution } from "@/lib/docs-cta-href";
+import { buildTrackedDocsHref } from "@/lib/docs-cta-href";
+
+export interface IntelligenceSearchCtaLink {
+  label: string;
+  /** Internal docs route, e.g. "/intelligence/quickstart". */
+  href: string;
+}
+
+export interface IntelligenceSearchCta {
+  /** Stable identifier — flows into the PostHog event and the utm_content. */
+  id: string;
+  /**
+   * Words that trigger this entry. Matched as whole typed words, or as a
+   * typed prefix of at least four characters.
+   */
+  keywords: readonly string[];
+  /**
+   * Higher wins when several entries match. Declared, not inferred: the
+   * catch-all "intelligence" entry must never beat a topic entry.
+   */
+  specificity: number;
+  title: string;
+  body: string;
+  primary: IntelligenceSearchCtaLink;
+  secondary: readonly IntelligenceSearchCtaLink[];
+}
+
+/**
+ * Shortest typed prefix that may fire an entry. "intell" should find the
+ * Intelligence block; "in" should not turn every search into an advert.
+ */
+const MIN_PREFIX_LENGTH = 4;
+
+export const INTELLIGENCE_SEARCH_CTAS: readonly IntelligenceSearchCta[] = [
+  {
+    id: "threads",
+    keywords: ["threads", "thread", "persistence", "persistent"],
+    specificity: 30,
+    title: "Threads that survive a reload",
+    // Deliberate wording: CopilotKit's own threads are open source and
+    // free. What Intelligence adds is the durable, resumable storage
+    // behind them, so this must not read as "threads are a paid feature".
+    body: "Threads are built into CopilotKit. Intelligence stores them for you, so conversations resume across reloads, sessions and devices without you running a database.",
+    primary: { label: "Read the Threads guide", href: "/threads" },
+    secondary: [
+      {
+        label: "How thread persistence works",
+        href: "/intelligence/threads-explained",
+      },
+      { label: "Connect Intelligence", href: "/intelligence/quickstart" },
+      { label: "What Intelligence adds", href: "/intelligence/overview" },
+    ],
+  },
+  {
+    id: "self-hosting",
+    keywords: ["self-hosting", "self-host", "selfhosted", "self-hosted"],
+    specificity: 20,
+    title: "Run Intelligence on your own infrastructure",
+    body: "Intelligence self-hosts on your own cloud, in your own network, with your data staying inside your perimeter.",
+    primary: {
+      label: "Read the self-hosting guide",
+      href: "/intelligence/self-hosting",
+    },
+    secondary: [
+      { label: "What Intelligence adds", href: "/intelligence/overview" },
+      {
+        label: "Platform architecture",
+        href: "/intelligence/intelligence-platform",
+      },
+    ],
+  },
+  {
+    // No docs page describes learning on its own yet — it is a capability
+    // row on the Intelligence overview, which links out to the detail.
+    // The overview is also the right landing for a reader already running
+    // Intelligence, for whom a connect-in-five-minutes quickstart would
+    // be useless. Retargeting when a dedicated page ships is a one-line
+    // edit here.
+    id: "learning",
+    keywords: ["learning"],
+    specificity: 10,
+    title: "Agents that learn from real conversations",
+    body: "Intelligence turns the conversations your agent already has into evaluations and improvements, instead of leaving that signal on the floor.",
+    primary: {
+      label: "See what Intelligence adds",
+      href: "/intelligence/overview",
+    },
+    secondary: [
+      { label: "Connect Intelligence", href: "/intelligence/quickstart" },
+      { label: "Threads guide", href: "/threads" },
+    ],
+  },
+  {
+    // Same reasoning as "learning" above: analytics has no dedicated
+    // docs page yet.
+    id: "analytics",
+    keywords: ["analytics"],
+    specificity: 10,
+    title: "See what your agent actually does",
+    body: "Intelligence reports on the runs, tool calls and conversations behind your agent, so you can tell what is working in production.",
+    primary: {
+      label: "See what Intelligence adds",
+      href: "/intelligence/overview",
+    },
+    secondary: [
+      { label: "Connect Intelligence", href: "/intelligence/quickstart" },
+      { label: "Threads guide", href: "/threads" },
+    ],
+  },
+  {
+    id: "intelligence",
+    keywords: ["intelligence"],
+    // Lowest: the catch-all. Any topic entry above outranks it, which is
+    // why "intelligence threads" resolves to the threads entry.
+    specificity: 1,
+    title: "CopilotKit Intelligence",
+    body: "Persistent threads, analytics, automatic learning and production operations on top of the runtime you already run.",
+    primary: {
+      label: "See what Intelligence adds",
+      href: "/intelligence/overview",
+    },
+    secondary: [
+      { label: "Connect in 5 minutes", href: "/intelligence/quickstart" },
+      { label: "Threads guide", href: "/threads" },
+      { label: "Self-hosting", href: "/intelligence/self-hosting" },
+    ],
+  },
+];
+
+/** Splits a query into the words a reader actually typed. */
+function typedWords(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/[^a-z0-9-]+/)
+    .filter(Boolean);
+}
+
+/**
+ * A typed word triggers a keyword when it IS that keyword, or when it is
+ * a long-enough prefix of it.
+ *
+ * Never a plain substring test in either direction: substring matching
+ * makes "spreadsheets" fire the threads block, which is how a curated
+ * recommendation turns into noise.
+ */
+function wordTriggersKeyword(word: string, keyword: string): boolean {
+  if (word === keyword) return true;
+  return word.length >= MIN_PREFIX_LENGTH && keyword.startsWith(word);
+}
+
+/**
+ * The single recommendation to show for `query`, or null when the query
+ * is about something else. When several entries match, the highest
+ * declared specificity wins.
+ */
+export function matchIntelligenceSearchCta(
+  query: string,
+): IntelligenceSearchCta | null {
+  const words = typedWords(query);
+  if (words.length === 0) return null;
+
+  let best: IntelligenceSearchCta | null = null;
+  for (const cta of INTELLIGENCE_SEARCH_CTAS) {
+    const matches = cta.keywords.some((keyword) =>
+      words.some((word) => wordTriggersKeyword(word, keyword)),
+    );
+    if (!matches) continue;
+    if (!best || cta.specificity > best.specificity) best = cta;
+  }
+
+  return best;
+}
+
+/**
+ * Placeholder origin used only to run an internal path through the
+ * shared attribution helper. `buildTrackedDocsHref` takes an absolute
+ * URL (it is built for outbound CTAs), so a relative docs route has to
+ * be resolved against SOME origin before it can carry query params, and
+ * stripped back afterwards. The origin never reaches the returned href,
+ * and `.invalid` is reserved by RFC 2606 so it cannot resolve if it
+ * somehow leaked.
+ */
+const INTERNAL_HREF_BASE = "https://internal.invalid";
+
+/**
+ * Attribution-tagged version of an internal docs route.
+ *
+ * Returns a root-relative href so the modal can hand it straight to
+ * next/router: client-side routing and the modal's close behaviour stay
+ * exactly as they are for organic results, while the destination page
+ * still sees the same utm_* attribution every other docs CTA sends.
+ */
+export function buildTrackedInternalDocsHref(
+  destination: string,
+  attribution: DocsCtaAttribution,
+): string {
+  const absolute = new URL(destination, INTERNAL_HREF_BASE).toString();
+  const tracked = new URL(buildTrackedDocsHref(absolute, attribution));
+  return `${tracked.pathname}${tracked.search}${tracked.hash}`;
+}
+
+/** PostHog `location` / `utm_content` value for one search recommendation. */
+export function intelligenceSearchCtaSurface(
+  ctaId: string,
+  matchedKeyword: string,
+): string {
+  return `docs-search:${ctaId}:${matchedKeyword}`;
+}
+
+/**
+ * The keyword that actually fired the entry — reported alongside the
+ * click so the funnel can tell "threads" traffic from "persistence"
+ * traffic. Falls back to the entry's first keyword, which cannot happen
+ * for an entry that matched but keeps the return type honest.
+ */
+export function matchedKeywordFor(
+  cta: IntelligenceSearchCta,
+  query: string,
+): string {
+  const words = typedWords(query);
+  for (const keyword of cta.keywords) {
+    if (words.some((word) => wordTriggersKeyword(word, keyword))) {
+      return keyword;
+    }
+  }
+  return cta.keywords[0];
+}

--- a/showcase/shell-docs/src/lib/searchable-pages.ts
+++ b/showcase/shell-docs/src/lib/searchable-pages.ts
@@ -540,9 +540,13 @@ export function readPageSourceWithSnippets(
   console.warn = () => {};
   try {
     return inlineSnippets(raw, slug);
-  } catch {
+  } catch (error) {
     // Never let one unresolvable snippet reference cost us the links that
     // are in the page file itself.
+    warn(
+      `[searchable-pages] Failed to inline snippets for "${slug}"; link discovery will use only the page source.`,
+      error,
+    );
     return raw;
   } finally {
     console.warn = warn;

--- a/showcase/shell-docs/src/lib/searchable-pages.ts
+++ b/showcase/shell-docs/src/lib/searchable-pages.ts
@@ -1,0 +1,561 @@
+/**
+ * Which docs pages are allowed into the Cmd-K search index.
+ *
+ * Search used to be built by walking every `.mdx` file under
+ * `src/content/docs`. The sidebar is built from curated `meta.json`
+ * navigation plus the programmatic reorganization layer in
+ * `docs-render.tsx`. The two drifted: search offered pages that appear in
+ * no sidebar — leftovers from past reorganizations, with stale content and
+ * no surrounding context.
+ *
+ * A slug is searchable when EITHER of these holds:
+ *
+ *   (a) It appears in a navigation surface. Navigation is not one tree, so
+ *       this is the union over the root tree, every non-hidden
+ *       integration's sidebar, and every `"root": true` sub-tree (which the
+ *       root walk deliberately skips).
+ *
+ *   (b) A navigable page links to it, counting the snippets that page
+ *       inlines as part of it — most CopilotKit pages are thin wrappers
+ *       around shared snippets, and that is where the prose links live
+ *       (`intelligence/overview.mdx` is nothing but `<Overview />`, whose
+ *       snippet links to `intelligence/headless-ui`). One hop only, no
+ *       transitive closure. A page kept out of the sidebar but linked from
+ *       prose is intentional content, not a leftover.
+ *
+ * Frontmatter `search` is an explicit per-page override that wins over
+ * both rules: `search: false` forces a page out even when it qualifies,
+ * `search: true` forces a page in even when it does not. No page needs it
+ * today — it is the escape hatch for a page that is deliberately in no
+ * sidebar and that nothing links to either.
+ *
+ * Slugs are canonical: no leading slash, no `/docs` prefix, route-group
+ * segments (`(other)`) stripped, and no trailing `/index`. Route groups
+ * are stripped because the sidebar strips them too (`normalizeSidebarNav`)
+ * and the middleware 301-redirects any URL that still carries one.
+ *
+ * This module has no side effects and no Next.js imports, so it is
+ * directly unit-testable and importable from a `tsx` build script.
+ */
+
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import {
+  CONTENT_DIR,
+  buildFrameworkNav,
+  buildFrameworkOnlyNav,
+  buildNavTree,
+  inlineSnippets,
+  readMeta,
+} from "./docs-render";
+import type { NavNode } from "./docs-render";
+import { getDocsFolder, getDocsMode, getIntegrations } from "./registry";
+import { isRouteGroupSegment } from "./route-groups";
+
+/**
+ * One sidebar the docs app can actually render. `integrationFolder` is set
+ * when the surface rewrote `integrations/<folder>/<topic>` slugs down to
+ * bare `<topic>` — the folder form has to be recovered so entries stay
+ * matchable against the on-disk slug the index generator produces.
+ */
+export interface NavigationSurface {
+  /** Human-readable label, used only in diagnostics. */
+  id: string;
+  nodes: NavNode[];
+  integrationFolder?: string;
+  /**
+   * The public first path segment this surface is served under
+   * (`/langgraph-python/…`). Link targets in prose use this form, so it is
+   * how a link is mapped back onto `integrationFolder`.
+   */
+  routeScope?: string;
+}
+
+export interface SearchablePagesInput {
+  contentDir: string;
+  surfaces: NavigationSurface[];
+  /**
+   * Read the source of one page as the reader sees it. Defaults to a plain
+   * file read; `getSearchablePages` supplies a reader that also inlines the
+   * page's snippets, because most of the prose that carries links lives in
+   * shared snippets rather than in the page file itself.
+   */
+  readPageSource?: (filePath: string, slug: string) => string;
+}
+
+export interface SearchablePages {
+  /** Canonical slugs allowed into the docs portion of the search index. */
+  slugs: ReadonlySet<string>;
+  /** Canonical slug → the title the sidebar shows for it. */
+  navTitles: ReadonlyMap<string, string>;
+  /** Diagnostics: which rule admitted each slug. */
+  fromNavigation: ReadonlySet<string>;
+  fromLinks: ReadonlySet<string>;
+  forcedIn: ReadonlySet<string>;
+  forcedOut: ReadonlySet<string>;
+}
+
+/** First path segments on the docs host that are never a docs page. */
+const NON_DOCS_ROOT_SEGMENTS = new Set([
+  "reference",
+  "ag-ui",
+  // The integrations explorer and feature matrix live on the showcase host.
+  "integrations",
+  "matrix",
+  "api",
+  "_next",
+]);
+
+/** Frontend surfaces are routed at `/<frontend>/<topic>`, like frameworks. */
+const FRONTEND_SEGMENTS = ["vue", "react-native", "angular", "slack", "teams"];
+
+/**
+ * Sidebar titles that identify nothing once the surrounding group is gone.
+ *
+ * A page can set `nav_title: Overview` so the sidebar reads
+ * "Rich Threads › Overview" while the page itself is titled "Rich Threads".
+ * Search results are a flat list with no parent to lean on, so a bare
+ * "Overview" row is useless — the page's own title is kept instead.
+ */
+const CONTEXT_ONLY_NAV_TITLES = new Set(["overview", "introduction", "index"]);
+
+/** Whether a sidebar title is specific enough to name a search result. */
+export function isUsableSearchTitle(title: string): boolean {
+  return !CONTEXT_ONLY_NAV_TITLES.has(title.trim().toLowerCase());
+}
+
+/**
+ * Canonicalize a docs slug: drop a leading `/docs` or `/`, strip
+ * route-group segments, and collapse a trailing `/index` onto the folder.
+ */
+export function canonicalDocsSlug(slug: string): string {
+  const withoutPrefix = slug
+    .replace(/^\/?docs(?=\/|$)/, "")
+    .replace(/^\/+/, "");
+  const segments = withoutPrefix
+    .split("/")
+    .filter((segment) => segment.length > 0 && !isRouteGroupSegment(segment));
+  if (segments[segments.length - 1] === "index") segments.pop();
+  return segments.join("/");
+}
+
+/**
+ * Map every slug spelling a caller might hold for an `.mdx` file onto that
+ * file's canonical slug.
+ *
+ * The search-index generator lives in another package and cannot import
+ * `canonicalDocsSlug` — see `scripts/emit-searchable-pages.ts` for why — so
+ * it receives this mapping as data instead, and canonicalization stays
+ * defined exactly once.
+ *
+ * Two keys per file, because callers name the same page either way: the
+ * disk slug (`foo/index`) and the index-collapsed form (`foo`). Both point
+ * at the same canonical value, so a lookup succeeds whichever the caller
+ * happens to hold.
+ */
+export function buildCanonicalSlugMap(contentDir: string): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!fs.existsSync(contentDir)) return map;
+
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(child, prefix ? `${prefix}/${entry.name}` : entry.name);
+        continue;
+      }
+      if (!entry.name.endsWith(".mdx")) continue;
+
+      const base = entry.name.slice(0, -".mdx".length);
+      const diskSlug = prefix ? `${prefix}/${base}` : base;
+      const canonical = canonicalDocsSlug(diskSlug);
+      if (!map.has(diskSlug)) map.set(diskSlug, canonical);
+
+      if (base === "index") {
+        // `foo/index.mdx` is served at `/foo`, and that is the spelling the
+        // generator's own scan produces for it.
+        const collapsed = prefix;
+        if (collapsed && !map.has(collapsed)) map.set(collapsed, canonical);
+      }
+    }
+  };
+
+  walk(contentDir, "");
+  return map;
+}
+
+/**
+ * Map every `.mdx` file under `contentDir` to its canonical slug. Two disk
+ * paths can canonicalize to the same slug only if the content tree is
+ * broken (e.g. `(a)/x.mdx` and `x.mdx`); first walk order wins and the
+ * duplicate is ignored, because the router would resolve only one anyway.
+ */
+export function buildDocsFileIndex(contentDir: string): Map<string, string> {
+  const files = new Map<string, string>();
+  if (!fs.existsSync(contentDir)) return files;
+
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(child, prefix ? `${prefix}/${entry.name}` : entry.name);
+      } else if (entry.name.endsWith(".mdx")) {
+        const base = entry.name.slice(0, -".mdx".length);
+        const diskSlug = prefix ? `${prefix}/${base}` : base;
+        const slug = canonicalDocsSlug(diskSlug);
+        if (!files.has(slug)) files.set(slug, child);
+      }
+    }
+  };
+
+  walk(contentDir, "");
+  return files;
+}
+
+/**
+ * Collect the slugs and sidebar titles a single navigation surface
+ * contributes.
+ *
+ * Group nodes carry their own slug, which is frequently a real page (a
+ * folder with an `index.mdx` rendered as an expandable parent), so they are
+ * collected too — except synthetic ones, which use `<prefix>#<title>` as a
+ * React reconciliation key rather than a URL.
+ *
+ * Page nodes that carry an `href` point off-site (for example the
+ * Intelligence sidebar's marketing anchor) and contribute nothing: search
+ * must never promise a docs page that does not exist.
+ */
+export function collectNavigationSlugs(
+  surface: NavigationSurface,
+  fileIndex: ReadonlyMap<string, string>,
+): {
+  slugs: Set<string>;
+  /** Titles from `type: "page"` nodes — the page's own sidebar name. */
+  pageTitles: Map<string, string>;
+  /**
+   * Titles from `type: "group"` nodes. A group title is structural
+   * scaffolding and is often auto-derived from the folder name
+   * ("Frontend-tools"), so it is only a fallback.
+   */
+  groupTitles: Map<string, string>;
+} {
+  const slugs = new Set<string>();
+  const pageTitles = new Map<string, string>();
+  const groupTitles = new Map<string, string>();
+
+  const add = (rawSlug: string, title: string, kind: "page" | "group") => {
+    if (rawSlug.includes("#")) return;
+    const slug = canonicalDocsSlug(rawSlug);
+    slugs.add(slug);
+    const titles = kind === "page" ? pageTitles : groupTitles;
+    if (!titles.has(slug) && title && isUsableSearchTitle(title)) {
+      titles.set(slug, title);
+    }
+
+    // Framework surfaces rewrite `integrations/<folder>/<topic>` down to a
+    // bare `<topic>`. Recover the folder form so the entry still matches
+    // the on-disk slug, but only when that file actually exists — the bare
+    // slug usually comes from the shared root tree instead.
+    //
+    // Reachability only: no title is recorded for the folder form. The bare
+    // entry's title belongs to whichever file the framework actually
+    // resolved, which for a generated framework is the shared root page,
+    // not `integrations/<folder>/<topic>`. Titles for the folder form come
+    // from that integration's own `"root": true` surface, which walks the
+    // folder under its real prefix.
+    const folder = surface.integrationFolder;
+    if (!folder) return;
+    const folderSlug = canonicalDocsSlug(
+      slug ? `integrations/${folder}/${slug}` : `integrations/${folder}`,
+    );
+    if (fileIndex.has(folderSlug)) slugs.add(folderSlug);
+  };
+
+  const visit = (nodes: NavNode[]) => {
+    for (const node of nodes) {
+      if (node.type === "section") continue;
+      if (node.type === "page") {
+        if (node.href) continue;
+        add(node.slug, node.title, "page");
+        continue;
+      }
+      add(node.slug, node.title, "group");
+      visit(node.children);
+    }
+  };
+
+  visit(surface.nodes);
+  return { slugs, pageTitles, groupTitles };
+}
+
+/**
+ * Resolve an internal link target to every canonical docs slug it could
+ * point at. Empty when the target is not a docs page.
+ *
+ * Docs pages are served bare (`/threads`) and framework- or
+ * frontend-scoped (`/langgraph-python/threads`), so a leading scope
+ * segment is stripped. A framework-scoped topic can be backed by either
+ * the shared root page (`threads`) or that framework's own override
+ * (`integrations/langgraph/threads`), and the URL does not say which — so
+ * both candidates come back and the caller keeps whichever exists on disk.
+ */
+export function docsSlugCandidatesFromLinkTarget(
+  target: string,
+  folderForScope: (segment: string) => string | null,
+): string[] {
+  if (!target.startsWith("/")) return [];
+  const withoutFragment = target.split("#")[0].split("?")[0];
+  const segments = withoutFragment.split("/").filter(Boolean);
+  if (segments.length === 0) return [];
+
+  if (segments[0] === "docs") {
+    return [canonicalDocsSlug(segments.slice(1).join("/"))];
+  }
+
+  const folder = folderForScope(segments[0]);
+  if (folder !== null) {
+    const topic = canonicalDocsSlug(segments.slice(1).join("/"));
+    // A frontend scope (`/vue/…`) has no `integrations/` folder behind it.
+    if (folder === "") return [topic];
+    const scoped = canonicalDocsSlug(
+      topic ? `integrations/${folder}/${topic}` : `integrations/${folder}`,
+    );
+    return [topic, scoped];
+  }
+
+  if (NON_DOCS_ROOT_SEGMENTS.has(segments[0])) return [];
+  return [canonicalDocsSlug(segments.join("/"))];
+}
+
+// Stops at whitespace as well as `)` so a link that carries a title —
+// `](/threads "Rich threads")` — still yields `/threads`.
+const MARKDOWN_LINK = /\]\(\s*(\/[^)\s]*)/g;
+const JSX_HREF = /href=["'](\/[^"']*)["']/g;
+
+/** Every internal `/`-rooted link target in one MDX source. */
+export function extractInternalLinkTargets(source: string): string[] {
+  const targets: string[] = [];
+  for (const pattern of [MARKDOWN_LINK, JSX_HREF]) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) targets.push(match[1]);
+  }
+  return targets;
+}
+
+function readSearchOverride(filePath: string): boolean | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  let data: Record<string, unknown>;
+  try {
+    data = matter(raw).data as Record<string, unknown>;
+  } catch {
+    // A malformed frontmatter block is the content author's problem, not a
+    // reason to crash the whole index build. Fall back to the default rules.
+    return null;
+  }
+  const value = data.search;
+  return typeof value === "boolean" ? value : null;
+}
+
+/**
+ * The pure core: given a content tree and the navigation surfaces the app
+ * can render, decide which slugs search is allowed to offer.
+ */
+export function computeSearchablePages(
+  input: SearchablePagesInput,
+): SearchablePages {
+  const { contentDir, surfaces } = input;
+  const readPageSource =
+    input.readPageSource ?? ((filePath) => fs.readFileSync(filePath, "utf-8"));
+  const fileIndex = buildDocsFileIndex(contentDir);
+
+  // Rule (a): union over every navigation surface. Surfaces are consulted
+  // in order and the first title wins, so the naming stays stable and does
+  // not depend on which integration happens to be walked first.
+  const fromNavigation = new Set<string>();
+  const navPageTitles = new Map<string, string>();
+  const navGroupTitles = new Map<string, string>();
+  for (const surface of surfaces) {
+    const { slugs, pageTitles, groupTitles } = collectNavigationSlugs(
+      surface,
+      fileIndex,
+    );
+    for (const slug of slugs) fromNavigation.add(slug);
+    for (const [slug, title] of pageTitles) {
+      if (!navPageTitles.has(slug)) navPageTitles.set(slug, title);
+    }
+    for (const [slug, title] of groupTitles) {
+      if (!navGroupTitles.has(slug)) navGroupTitles.set(slug, title);
+    }
+  }
+  const navTitles = new Map(navGroupTitles);
+  for (const [slug, title] of navPageTitles) navTitles.set(slug, title);
+
+  // Rule (b): one hop out from any navigable page.
+  const scopeFolders = new Map<string, string>();
+  for (const segment of FRONTEND_SEGMENTS) scopeFolders.set(segment, "");
+  for (const surface of surfaces) {
+    if (!surface.routeScope) continue;
+    scopeFolders.set(surface.routeScope, surface.integrationFolder ?? "");
+  }
+  const folderForScope = (segment: string): string | null =>
+    scopeFolders.get(segment) ?? null;
+
+  const fromLinks = new Set<string>();
+  for (const slug of fromNavigation) {
+    const filePath = fileIndex.get(slug);
+    if (!filePath) continue;
+    let source: string;
+    try {
+      source = readPageSource(filePath, slug);
+    } catch {
+      continue;
+    }
+    for (const target of extractInternalLinkTargets(source)) {
+      for (const linked of docsSlugCandidatesFromLinkTarget(
+        target,
+        folderForScope,
+      )) {
+        if (linked === "") continue;
+        if (fromNavigation.has(linked)) continue;
+        if (!fileIndex.has(linked)) continue;
+        fromLinks.add(linked);
+      }
+    }
+  }
+
+  // Explicit per-page overrides win over both rules.
+  const forcedIn = new Set<string>();
+  const forcedOut = new Set<string>();
+  for (const [slug, filePath] of fileIndex) {
+    const override = readSearchOverride(filePath);
+    if (override === true) forcedIn.add(slug);
+    else if (override === false) forcedOut.add(slug);
+  }
+
+  const slugs = new Set<string>([...fromNavigation, ...fromLinks, ...forcedIn]);
+  for (const slug of forcedOut) slugs.delete(slug);
+
+  return { slugs, navTitles, fromNavigation, fromLinks, forcedIn, forcedOut };
+}
+
+/**
+ * Build the navigation surfaces the docs app can actually render.
+ *
+ * Three kinds, and all three are needed — dropping any one of them removes
+ * pages that a reader can reach from a real sidebar:
+ *
+ *   1. the root tree;
+ *   2. every non-hidden integration, using the builder the app itself picks
+ *      for that integration's `docs_mode`;
+ *   3. every `"root": true` sub-tree, which the root walk skips by design
+ *      (`if (subMeta?.root) continue`) because each is its own surface.
+ */
+export function defaultNavigationSurfaces(
+  contentDir: string = CONTENT_DIR,
+): NavigationSurface[] {
+  const surfaces: NavigationSurface[] = [
+    { id: "root", nodes: buildNavTree(contentDir) },
+  ];
+
+  for (const integration of getIntegrations()) {
+    const mode = getDocsMode(integration.slug);
+    if (mode === "hidden") continue;
+    const folder = getDocsFolder(integration.slug);
+    const nodes =
+      mode === "authored"
+        ? buildFrameworkOnlyNav(folder)
+        : buildFrameworkNav(folder, integration.name, integration.slug);
+    surfaces.push({
+      id: `integration:${integration.slug}`,
+      nodes,
+      integrationFolder: folder,
+      routeScope: integration.slug,
+    });
+  }
+
+  for (const dir of findRootMetaDirs(contentDir)) {
+    surfaces.push({
+      id: `root-meta:${dir.slug}`,
+      nodes: buildNavTree(dir.absolute, dir.slug),
+    });
+  }
+
+  return surfaces;
+}
+
+/** Every directory below `contentDir` whose meta.json declares `root: true`. */
+export function findRootMetaDirs(
+  contentDir: string,
+): Array<{ slug: string; absolute: string }> {
+  const found: Array<{ slug: string; absolute: string }> = [];
+  if (!fs.existsSync(contentDir)) return found;
+
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const absolute = path.join(dir, entry.name);
+      const slug = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (readMeta(absolute)?.root) found.push({ slug, absolute });
+      walk(absolute, slug);
+    }
+  };
+
+  walk(contentDir, "");
+  return found.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+/**
+ * Read one page the way the reader receives it, with its snippets inlined.
+ *
+ * Most CopilotKit docs pages are thin wrappers around shared snippets —
+ * `intelligence/overview.mdx` is nothing but `<Overview />` from
+ * `@/snippets/shared/intelligence/overview.mdx` — and that snippet is
+ * where the prose links live. Scanning only the page file sees none of
+ * them, so rule (b) would miss links the reader can plainly click.
+ *
+ * `inlineSnippets` already owns this resolution: the `@/snippets/…` import
+ * form, the `SNIPPET_MAP` component names, the `<SharedContent />`
+ * indirection through `SUBPATH_TO_COMPONENT` (which needs the slug), and
+ * transitive snippet-inside-snippet expansion with a visited set so a
+ * cycle cannot hang the build.
+ */
+export function readPageSourceWithSnippets(
+  filePath: string,
+  slug: string,
+): string {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  // `inlineSnippets` warns when a `<Component />` maps to no snippet file.
+  // Those are real React components from the global MDX registry, and the
+  // docs build already reports them when it renders the page — repeating
+  // them once per page here would bury the index build's own output and
+  // train readers to ignore the warning. Link discovery does not care.
+  const warn = console.warn;
+  console.warn = () => {};
+  try {
+    return inlineSnippets(raw, slug);
+  } catch {
+    // Never let one unresolvable snippet reference cost us the links that
+    // are in the page file itself.
+    return raw;
+  } finally {
+    console.warn = warn;
+  }
+}
+
+/** Convenience wrapper over the real content tree and the real registry. */
+export function getSearchablePages(
+  contentDir: string = CONTENT_DIR,
+): SearchablePages {
+  return computeSearchablePages({
+    contentDir,
+    surfaces: defaultNavigationSurfaces(contentDir),
+    readPageSource: readPageSourceWithSnippets,
+  });
+}

--- a/showcase/shell/Dockerfile
+++ b/showcase/shell/Dockerfile
@@ -18,6 +18,20 @@ COPY showcase/shell/ ./shell/
 COPY showcase/angular/src/ ./angular/src/
 COPY showcase/shell-docs/src/content/ ./shell-docs/src/content/
 
+# generate-search-index.ts only indexes docs pages a reader can reach from a
+# sidebar, and that decision is computed by shell-docs (see
+# shell-docs/scripts/emit-searchable-pages.ts). This app consumes the docs rows
+# too — its header search links across to the docs host — so it needs the same
+# decision, or its search silently loses every docs row.
+#
+# Stage the two trees the emit script needs plus the tsconfig that resolves
+# shell-docs' `@/…` alias. No shell-docs install is needed: the generator
+# runs the emit script with this image's scripts node_modules on NODE_PATH,
+# and `scripts/package.json` declares tsx and gray-matter for exactly that.
+COPY showcase/shell-docs/src/lib/ ./shell-docs/src/lib/
+COPY showcase/shell-docs/scripts/ ./shell-docs/scripts/
+COPY showcase/shell-docs/tsconfig.json ./shell-docs/tsconfig.json
+
 # Bake commit info into Next.js build
 ENV NEXT_PUBLIC_COMMIT_SHA=${COMMIT_SHA}
 ENV NEXT_PUBLIC_BRANCH=${BRANCH}


### PR DESCRIPTION
Closes OSS-1079.

Docs search was not trustworthy. Showcase rows competed with docs rows and some of them were dead links, abandoned pages answered as confidently as maintained ones, and the result order fell back on whatever order the index happened to be built in. On top of that, a reader who types the word for a capability — "analytics", "learning", "persistence" — had no way to learn that the capability is called Intelligence.

Three changes, plus a PRD at `prds/oss-1079-docs-search-and-intelligence-ctas.md` that records the decisions and the measurements behind them.

## Showcase rows leave the docs search

The modal loaded the showcase registry and pushed integration and feature rows into the result list. Every feature row was emitted with `href: "/"`, so a query like "chat" produced fifteen differently-titled rows that all navigated to the docs home page ("tools" six, "state" five). Both loops are gone. The registry is still loaded — the framework scope picker is built from it.

The generator now writes a different payload per target: the showcase home, the integrations explorer and the feature matrix stay in the index the showcase app consumes and leave the one the docs app consumes. Two hand-written entries that duplicated real pages ("Home", "API Reference") are removed outright.

## The index follows what a reader can actually reach

The docs portion of the index was a walk over every `.mdx` file on disk. It now derives from navigation: a page is indexed when it appears in a navigation surface, or when a page that appears in one links to it.

Navigation is not one tree. The union covers the root tree, one surface per non-hidden integration — using the same builder the app picks for that integration's `docs_mode` — and the sixteen `"root": true` sub-trees the root walk deliberately skips. Group nodes contribute their own slug, because a folder with an index page renders as an expandable parent. Entries whose destination is off-site contribute nothing, so no result promises a docs page that does not exist. Channel pages bypass the filter entirely; they are re-routed onto the Slack and Teams surfaces at runtime and filtering them against the docs navigation would delete live, linked pages.

A page's inlined snippets count as part of that page. Many pages here are thin wrappers around shared snippets — the Intelligence overview's whole body is one include — so a scan that reads only the page file sees almost nothing: 868 link targets before resolving includes, 1964 after. Resolution reuses the docs renderer's own inlining rather than a second resolver.

`search: false` forces a reachable page out and `search: true` forces an unreachable one in. As shipped no page needs either, and a test asserts the forced-in set is empty so reaching for the override stays a deliberate act.

Route-group segments are stripped from destinations, so results no longer take a redirect hop. Titles come from navigation where the two disagree, with guards so auto-derived group titles and `nav_title: Overview` do not leak into a flat result list. A coverage floor fails the build if the docs portion collapses.

## Order is deterministic, and Intelligence keywords get one recommendation

The old scoring rewarded a query that matched the *start* of a title, which is why "threads" put the threads-drawer component above the canonical Threads guide. That slot is now a whole-word test at the same weight, and everything still tied is settled by shorter-title-first and then alphabetically. Nothing depends on index construction order any more. No content family gets a bonus — deliberately, including Intelligence.

A curated keyword table drives a single recommendation block above the result list. Five entries today: threads, self-hosting, learning, analytics, and intelligence as the catch-all. Triggering is whole-word, or a typed prefix of at least four characters, never a plain substring. Specificity is declared, so "intelligence threads" resolves to the threads entry, and exactly one block ever renders. Every destination is an internal docs route.

`learning` and `analytics` point at the Intelligence overview because no docs page describes either capability yet — they are rows on that overview which link out for the detail. The overview is also the right landing for someone already running Intelligence, for whom a connect-in-five-minutes quickstart would be useless. Retargeting when those pages ship is a one-line edit.

The block reuses the in-page Intelligence CTA visual language (accent stripe, kite, theme tokens), is a labelled group rather than a fourteenth listbox option, participates in the existing arrow-key selection, and reports its surface and matched keyword through the same attribution helpers the other docs CTAs use.

## Numbers

| | before | after |
|---|---|---|
| docs-search index entries | 950 | 851 |
| of which docs pages | 678 | 583 |
| destinations with more than one entry | 2 | 0 |
| destinations taking a redirect hop | 36 | 0 |

Of the 583 docs entries, 637 slugs come from navigation, 9 more from an inbound prose link, and 94 entries left search as unreachable.

## Follow-ups this PR deliberately does not take

Two groups inside those 94 are substantive content, not leftovers, and both want a content decision rather than a search fix. The two step-by-step tutorial series (24 entries) form a closed link island: no navigation lists them and nothing reachable links in, so even unlimited transitive reachability would not find them. And 28 LangGraph pages under `advanced`, `troubleshooting` and `your-components` have zero inbound links anywhere, because the LangGraph navigation file references neither subtree. Adopt, redirect or delete — each is its own call.

Also untouched: content work on the What's New pages (the roll-up page leaves search and stays on disk), the near-duplicate search modal in the showcase app, the sitemap, and the matching engine itself.

## Verification

`npm test` 783 passing in `showcase/shell-docs`. Six failures remain and are pre-existing — verified by running the same files against a clean checkout of `origin/main`, where they fail identically: three `public-assets` PNG checks against unmaterialized LFS pointers, two `angular-docs-content` content checks, one `llm-text` mastra example. Typecheck clean, lint clean, production build green.

Checked in the browser against a local dev server: "threads" now leads with the Threads guide, "intelligence" leads with the Intelligence landing page, "chat" returns only real docs destinations, "learning" shows the recommendation, and the console is clean.

---

# Follow-up round, from testing the branch in a browser

Seven further changes after the first pass was tried by hand.

## The AG-UI "What's New" page is unlinked from search and nav

`/ag-ui/development/updates` is titled "What's New", holds a single entry dated April 2025, and throws on render because it uses an `<Update>` component this app does not provide — a Mintlify component from the upstream AG-UI docs. It is almost certainly the page the ticket's second complaint is about.

Our reachability rule did not catch it: the AG-UI section keeps its own hand-maintained published-slug list, which this PR deliberately does not reinterpret, and the page is listed in the AG-UI sidebar. So it is removed from both by hand, with a test and a floor assertion so a typo in that hand-maintained list cannot silently empty the AG-UI portion of the index.

The MDX itself is untouched. AG-UI docs are canonical upstream in `ag-ui-protocol/ag-ui` and this tree is a downstream mirror, so the page is unlinked here rather than edited.

### Open question for reviewers: should the AG-UI mirror be in these docs at all?

While tracking that page down, the mirror turned out to be an orphaned island:

- The site chrome has Docs, Reference and Cookbook. There is no AG-UI entry, in the desktop nav, the mobile nav or the footer.
- Nothing outside `/ag-ui/*` links into it. The only inbound links come from the section's own pages.
- Where our prose does reference AG-UI it uses `/ag-ui-protocol`, which redirects to `/agentic-protocols/ag-ui` in the main docs — not into the mirror. Ten other places link straight out to `docs.ag-ui.com`.
- `docs.ag-ui.com` is live and canonical, and the mirror is still being synced (last touched three days ago).

So 96 pages are maintained, served, and unreachable by anyone reading the docs, while search offers 42 of them. By the rule this PR introduces, the whole island fails the reachability test; it survives only because AG-UI is exempted.

Three ways forward, none taken here: keep it and give it a nav entry, which makes it legitimate in one move; drop the whole mirror from search while leaving the pages served; or retire the mirror and redirect `/ag-ui/*` to `docs.ag-ui.com`. The last is the real cleanup but has SEO consequences and spans two repos. Deliberately left as a product decision rather than folded into a search PR.

## Ranking: the reader's own frontend first, V1 last

Searching "chat" returned 78 matches, roughly 38 of them belonging to frontends the reader is not using — 13 Angular feature pages, 10 Vue, 9 Angular reference, 6 React Native — plus 5 from the deprecated V1 reference. A React reader got a screen of Angular.

Entries carrying another frontend are now demoted, never filtered: someone who wants Angular from a React page still finds it by typing "angular chat", and because both words then match, those rows come straight back to the top. Filtering would have hidden them outright, which is the failure this deliberately avoids. The penalty is waived as soon as the query names the frontend.

The deprecated V1 reference always sorts last, as a separate tier rather than a weight another bonus could out-argue, and those rows now carry a muted "Deprecated" tag.

## Matching survives punctuation and camelCase

`whats new` found nothing though the announcement pages exist, and `use Copilot kit` found nothing though `useCopilotKit` does. Punctuation — apostrophes, hyphens, dots, slashes — is now ignored on both sides of the comparison, and camelCase identifiers are split into words on the index side, so `use Copilot kit` reaches `useCopilotKit` and `ag ui` reaches `AG-UI`. Both forms feed the title tiers of the score as well, otherwise the page matches but never ranks. The haystack keeps the unsplit form too, so `copilotruntime` still finds `CopilotRuntime`.

The CTA keyword matcher is untouched: it stays whole-word-or-four-character-prefix, so loosening the result matching cannot make the recommendation block fire on unrelated queries.

## Keyboard, mouse and the recommendation block

- Arrowing past the sixth result used to move the selection out of sight — the list has a fixed height and nothing ever scrolled it. It now follows the keyboard, minimally, and only for keyboard moves: hover still selects but must not slide the list out from under the pointer. The selection stays on the last item rather than wrapping.
- The arrow icon at the end of a row lit up one row too low whenever the recommendation block was visible; the row background accounted for the block's selection slot and the icon did not.
- The whole recommendation block is clickable now, not just its primary link, via a card-link overlay so the two or three secondary links keep their own destinations. Nested anchors would have been invalid markup; the cost is that text inside the block is no longer selectable.
- Buttons in the modal — result rows, framework picker, close, CTA links — get a pointer cursor back, which Tailwind 4 dropped.

## Verification of this round

Browser-checked on a local dev server: keyboard scrolling follows selection while hover does not scroll, selection clamps at the last row, the arrow accent tracks the selected row, a click on the block's body lands on the Threads guide while a click on "Connect Intelligence" lands on the Intelligence quickstart, the V1 row sorts last with its tag, `what's new` and `whats new` both return the announcement pages, `use Copilot kit` surfaces `useCopilotKit`, "chat" is free of foreign-frontend rows and "angular chat" brings them back.

`npm test` 806 passing with the same 6 pre-existing failures. Lint and typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved documentation search relevance with predictable ranking, frontend-aware results, and better keyboard navigation.
  * Added curated Intelligence recommendations with accessible links and conversion tracking.
* **Bug Fixes**
  * Excluded broken, outdated, duplicate, and incorrect documentation links from results.
  * Improved handling of punctuation, camelCase terms, redirects, and canonical URLs.
  * Removed showcase destinations and the unlinked AG-UI “What’s New” page from docs search.
* **Documentation**
  * Updated navigation and search coverage for AG-UI documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->