### PR TITLE
fix(core): send the whole RunAgentInput in the Intelligence run body

### DIFF
--- a/packages/core/src/__tests__/intelligence-agent.test.ts
+++ b/packages/core/src/__tests__/intelligence-agent.test.ts
@@ -269,6 +269,41 @@ describe("IntelligenceAgent", () => {
       });
     });
 
+    it("carries the AG-UI resume array in the run body", async () => {
+      const resume = [
+        {
+          interruptId: "int-1",
+          status: "resolved" as const,
+          payload: { ok: true },
+        },
+      ];
+      const agent = createAgent();
+      agent
+        .run({ ...defaultInput, resume })
+        .subscribe({ next: () => {}, error: () => {} });
+      await flushAsyncWork();
+
+      const [, options] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(options.body).resume).toEqual(resume);
+    });
+
+    it("posts every RunAgentInput field, so no protocol field is dropped", async () => {
+      const input: RunAgentInput = {
+        ...defaultInput,
+        forwardedProps: { command: { resume: "yes" } },
+        resume: [{ interruptId: "int-1", status: "cancelled" }],
+        state: { step: 2 },
+      };
+      const agent = createAgent();
+      agent.run(input).subscribe({ next: () => {}, error: () => {} });
+      await flushAsyncWork();
+
+      const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
+      for (const key of Object.keys(input) as (keyof RunAgentInput)[]) {
+        expect(body[key]).toEqual(input[key]);
+      }
+    });
+
     it("does not push any events to the channel during join", async () => {
       const agent = createAgent();
       agent.run(defaultInput).subscribe({ next: () => {}, error: () => {} });

--- a/packages/core/src/intelligence-agent.ts
+++ b/packages/core/src/intelligence-agent.ts
@@ -462,14 +462,10 @@ export class IntelligenceAgent extends AbstractAgent {
             "Content-Type": "application/json",
             ...this.headers,
           },
+          // Post the whole RunAgentInput rather than naming each field, so a
+          // protocol field such as `resume` cannot be dropped here again.
           body: JSON.stringify({
-            threadId: input.threadId,
-            runId: input.runId,
-            messages: input.messages,
-            tools: input.tools,
-            context: input.context,
-            state: input.state,
-            forwardedProps: input.forwardedProps,
+            ...input,
             ...(mode === "connect"
               ? {
                   lastSeenEventId:


### PR DESCRIPTION
Fixes OSS-1132

## Problem

`IntelligenceAgent` hand-built its REST run body by naming fields, and `resume` was not one of them:

```ts
body: JSON.stringify({ threadId, runId, messages, tools, context, state, forwardedProps })
```

`HttpAgent` posts the whole `RunAgentInput`, so the self-hosted and SSE paths carry `resume` correctly. Only the Intelligence transport dropped it.

The two interrupt paths carry their resume payload in different fields:

| Path | Trigger | Resume travels as | Survived the Intelligence body |
| -- | -- | -- | -- |
| Legacy | `on_interrupt` CUSTOM event | `forwardedProps.command.resume` | Yes |
| Standard | `RUN_FINISHED` with `outcome: "interrupt"` | top-level `resume[]` | **No** |

So resuming a standard interrupt against an Intelligence runtime failed silently: no error, no console output, and the graph simply re-entered its gate. The server side was already correct — `RunAgentInputSchema` declares `resume` and `parseRunRequest` parses with that schema.

Nothing the CLI scaffolds hits this combination today (it needs the built-in agent plus Intelligence mode plus HITL), which is why it stayed quiet.

## Change

Spread the input instead of naming fields, so a future protocol field cannot be lost the same way:

```ts
body: JSON.stringify({ ...input, ...(mode === "connect" ? { lastSeenEventId } : {}) })
```

## Testing

Verified in a worktree with its own full `pnpm install` and freshly built workspace `dist` output. The baseline is the same command with the two changed files checked out from `origin/main`.

### Two new tests in `packages/core/src/__tests__/intelligence-agent.test.ts`

- `carries the AG-UI resume array in the run body`
- `posts every RunAgentInput field, so no protocol field is dropped` — iterates the input's own keys, so it fails on any future omission

### Whole-package suite

| | Test files | Tests |
| -- | -- | -- |
| Baseline (`origin/main`) | 69 passed | 830 passed |
| With this change | 69 passed | **832 passed** |

+2, exactly the new tests. No failures either side.

### Mutation check

Reverted the source fix to the hand-built field list and re-ran the file:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
      Tests  2 failed | 59 passed (61)
```

Both new tests fail without the fix, so neither is self-fulfilling.

### Typecheck, lint, format

- `tsc --noEmit -p packages/core/tsconfig.json`: **0 errors**.
- `oxlint` on both files: 0 errors (2 pre-existing `consistent-function-scoping` warnings in the test file, unchanged).
- Formatted with `oxfmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent run requests so all provided run input fields are transmitted correctly.
  * Preserved resume information when starting an agent run.
  * Ensured no supported protocol fields are omitted from requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->