### PR TITLE
fix(react-core,vue,angular): recover a pending interrupt after a lost event or a reconnect

### DIFF
--- a/packages/angular/src/lib/inject-interrupt.spec.ts
+++ b/packages/angular/src/lib/inject-interrupt.spec.ts
@@ -39,6 +39,7 @@ class FakeAgent {
       outcome: "interrupt",
       interrupts,
       input: { runId },
+      event: { runId },
     } as never);
     this.subscriber?.onRunFinalized?.({ input: { runId } } as never);
   }

--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -342,4 +342,61 @@ describe("InterruptController", () => {
     expect(controller.hasInterrupt()).toBe(false);
     expect(controller.error()).toEqual(new Error("run failed"));
   });
+  // OSS-1131: committing only at `onRunFinalized` meant the connect path —
+  // where finalize fires at socket teardown, not once per replayed run —
+  // surfaced nothing, and a legacy gate had no durable record to recover from.
+  describe("recovery after a lost event or a reconnect", () => {
+    it("shows a standard gate from RUN_FINISHED on a stream that never finalizes", () => {
+      const { agent, controller } = setup();
+
+      agent.subscriber?.onRunFinishedEvent?.({
+        outcome: "interrupt",
+        interrupts: [makeInterrupt("replayed")],
+        input: { runId: "run-id" },
+      } as never);
+
+      expect(controller.interrupt()?.id).toBe("replayed");
+    });
+
+    it("shows a legacy gate from RUN_FINISHED on a stream that never finalizes", () => {
+      const { agent, controller } = setup();
+
+      agent.subscriber?.onCustomEvent?.({
+        event: { name: "on_interrupt", value: "approve?" },
+      } as never);
+      agent.subscriber?.onRunFinishedEvent?.({
+        outcome: "success",
+        input: { runId: "run-id" },
+      } as never);
+
+      expect(controller.event()).toEqual({
+        name: "on_interrupt",
+        value: "approve?",
+      });
+    });
+
+    it("restores an unresolved legacy interrupt when reconnecting", () => {
+      const { agent } = setup();
+      finalizeLegacy(agent, "approve?");
+
+      const next = new InterruptController(vi.fn());
+      next.connect(agent as unknown as AbstractAgent);
+
+      expect(next.event()).toEqual({
+        name: "on_interrupt",
+        value: "approve?",
+      });
+    });
+
+    it("forgets a legacy interrupt once a new run starts", () => {
+      const { agent } = setup();
+      finalizeLegacy(agent, "approve?");
+      agent.subscriber?.onRunStartedEvent?.({} as never);
+
+      const next = new InterruptController(vi.fn());
+      next.connect(agent as unknown as AbstractAgent);
+
+      expect(next.hasInterrupt()).toBe(false);
+    });
+  });
 });

--- a/packages/angular/src/lib/interrupt.spec.ts
+++ b/packages/angular/src/lib/interrupt.spec.ts
@@ -64,20 +64,28 @@ function finalizeStandard(
   agent: FakeAgent,
   interrupts: Interrupt[],
   runId = "run-id",
+  // The run the event names. On the connect path this differs from the run id
+  // of the request that opened the stream.
+  eventRunId = runId,
 ): void {
   agent.subscriber?.onRunFinishedEvent?.({
     outcome: "interrupt",
     interrupts,
     input: { runId },
+    event: { runId: eventRunId },
   } as never);
   agent.subscriber?.onRunFinalized?.({ input: { runId } } as never);
 }
 
-function finalizeLegacy(agent: FakeAgent, value: unknown): void {
+function finalizeLegacy(
+  agent: FakeAgent,
+  value: unknown,
+  runId = "run-id",
+): void {
   agent.subscriber?.onCustomEvent?.({
     event: { name: "on_interrupt", value },
   } as never);
-  agent.subscriber?.onRunFinalized?.({} as never);
+  agent.subscriber?.onRunFinalized?.({ input: { runId } } as never);
 }
 
 describe("InterruptController", () => {
@@ -90,6 +98,7 @@ describe("InterruptController", () => {
       outcome: "interrupt",
       interrupts: [makeInterrupt("one"), makeInterrupt("two")],
       input: { runId: "run-id" },
+      event: { runId: "run-id" },
     } as never);
     agent.subscriber?.onRunFinalized?.({
       input: { runId: "run-id" },
@@ -165,6 +174,7 @@ describe("InterruptController", () => {
       outcome: "interrupt",
       interrupts: [makeInterrupt("approve-refund")],
       input: { runId: interruptedRunId },
+      event: { runId: interruptedRunId },
     } as never);
     interruptControllerSubscriber.onRunFinalized?.({
       input: { runId: interruptedRunId },
@@ -210,6 +220,7 @@ describe("InterruptController", () => {
 
     const resumePromise = controller.resolve({ approved: true });
     expect(run).toHaveBeenCalledWith(agent, {
+      runId: "run-id",
       forwardedProps: {
         command: {
           resume: { approved: true },
@@ -353,6 +364,7 @@ describe("InterruptController", () => {
         outcome: "interrupt",
         interrupts: [makeInterrupt("replayed")],
         input: { runId: "run-id" },
+        event: { runId: "run-id" },
       } as never);
 
       expect(controller.interrupt()?.id).toBe("replayed");
@@ -367,6 +379,7 @@ describe("InterruptController", () => {
       agent.subscriber?.onRunFinishedEvent?.({
         outcome: "success",
         input: { runId: "run-id" },
+        event: { runId: "run-id" },
       } as never);
 
       expect(controller.event()).toEqual({
@@ -397,6 +410,72 @@ describe("InterruptController", () => {
       next.connect(agent as unknown as AbstractAgent);
 
       expect(next.hasInterrupt()).toBe(false);
+    });
+    it("resumes the replayed run, not the connection that replayed it", async () => {
+      // A reconnect opens one long-lived request and replays the run that
+      // paused. `input.runId` names the connection; only the event names the
+      // run the backend is waiting on.
+      const { agent, controller, run, startResume } = setup();
+      finalizeStandard(
+        agent,
+        [makeInterrupt("approve-refund")],
+        "connection-123",
+        "original-run",
+      );
+
+      const resumePromise = controller.resolve({ approved: true });
+      expect(run).toHaveBeenCalledWith(
+        agent,
+        expect.objectContaining({ runId: "original-run" }),
+      );
+      startResume();
+      await resumePromise;
+    });
+
+    it("resumes a legacy gate with the run that raised it", async () => {
+      const { agent, controller, run, startResume } = setup();
+      finalizeLegacy(agent, "approve?", "gated-run");
+
+      const resumePromise = controller.resolve({ approved: true });
+      expect(run).toHaveBeenCalledWith(
+        agent,
+        expect.objectContaining({ runId: "gated-run" }),
+      );
+      startResume();
+      await resumePromise;
+    });
+
+    it("does not restore thread A's legacy gate inside thread B", () => {
+      // One agent instance serves every conversation. A's approval prompt must
+      // not surface while the app shows B, because answering it there would
+      // resume A.
+      const { agent } = setup();
+      finalizeLegacy(agent, "approve A?");
+
+      agent.threadId = "thread-b";
+      const next = new InterruptController(vi.fn());
+      next.connect(agent as unknown as AbstractAgent);
+
+      expect(next.hasInterrupt()).toBe(false);
+    });
+
+    it("restores thread A's legacy gate when the app returns to thread A", () => {
+      const { agent } = setup();
+      finalizeLegacy(agent, "approve A?");
+
+      agent.threadId = "thread-b";
+      const inOther = new InterruptController(vi.fn());
+      inOther.connect(agent as unknown as AbstractAgent);
+      expect(inOther.hasInterrupt()).toBe(false);
+
+      agent.threadId = "thread-a";
+      const back = new InterruptController(vi.fn());
+      back.connect(agent as unknown as AbstractAgent);
+
+      expect(back.event()).toEqual({
+        name: "on_interrupt",
+        value: "approve A?",
+      });
     });
   });
 });

--- a/packages/angular/src/lib/interrupt.ts
+++ b/packages/angular/src/lib/interrupt.ts
@@ -9,7 +9,10 @@ import type {
   RunAgentResult,
 } from "@ag-ui/client";
 import {
+  ɵclearLegacyInterrupt,
   ɵInterruptState,
+  ɵreadLegacyInterrupt,
+  ɵrecordLegacyInterrupt,
   type ɵInterruptDecision,
   type ɵPendingInterrupt,
 } from "@copilotkit/core";
@@ -168,6 +171,23 @@ export class InterruptController<TValue = unknown, TResult = never> {
 
     let legacy: InterruptEvent<TValue> | null = null;
     let standard: Interrupt[] | null = null;
+
+    // Publish whatever this run collected. Standard wins if both somehow
+    // appear for one run.
+    const commit = () => {
+      if (standard && standard.length > 0) {
+        this.#setPending({ kind: "standard", interrupts: standard });
+      } else if (legacy) {
+        // Record the legacy interrupt on the agent too. Standard interrupts
+        // get this for free from `agent.pendingInterrupts`; without it the
+        // legacy path cannot recover a gate whose event was already delivered.
+        ɵrecordLegacyInterrupt(agent, { event: legacy });
+        this.#setPending({ kind: "legacy", event: legacy });
+      }
+      legacy = null;
+      standard = null;
+    };
+
     const subscription = agent.subscribe({
       onCustomEvent: ({ event }) => {
         if (event.name === INTERRUPT_EVENT_NAME) {
@@ -184,39 +204,48 @@ export class InterruptController<TValue = unknown, TResult = never> {
           }
           standard = params.interrupts;
         }
+        // Commit here rather than only at `onRunFinalized`. On the connect
+        // path `onRunFinalized` fires when the long-lived socket stream tears
+        // down, not once per replayed run, so a reconnect that replays an
+        // interrupt would otherwise surface nothing.
+        commit();
       },
       onRunStartedEvent: () => {
         legacy = null;
         standard = null;
         this.#threadId = agent.threadId;
+        ɵclearLegacyInterrupt(agent);
         this.#clear();
       },
-      onRunFinalized: () => {
-        if (standard && standard.length > 0) {
-          this.#setPending({ kind: "standard", interrupts: standard });
-        } else if (legacy) {
-          this.#setPending({ kind: "legacy", event: legacy });
-        }
-        legacy = null;
-        standard = null;
-      },
+      // Fallback for a stream that ends without a RUN_FINISHED event. When
+      // RUN_FINISHED did arrive, `commit` already ran and left nothing to do.
+      onRunFinalized: commit,
       onRunFailed: ({ error }) => {
         legacy = null;
         standard = null;
+        ɵclearLegacyInterrupt(agent);
         this.#clear(error);
       },
       onRunErrorEvent: ({ event }) => {
         legacy = null;
         standard = null;
+        ɵclearLegacyInterrupt(agent);
         this.#clear(new Error(event.message));
       },
     });
     this.#unsubscribe = () => subscription.unsubscribe();
+
+    // Seed from what the client already knows this thread is waiting on, so a
+    // fresh controller or a reconnect surfaces a gate whose event arrived
+    // before this subscription existed.
+    const recordedLegacy = ɵreadLegacyInterrupt<TValue>(agent);
     if (agent.pendingInterrupts.length > 0) {
       this.#setPending({
         kind: "standard",
         interrupts: [...agent.pendingInterrupts],
       });
+    } else if (recordedLegacy) {
+      this.#setPending({ kind: "legacy", event: recordedLegacy.event });
     }
   }
 
@@ -281,6 +310,8 @@ export class InterruptController<TValue = unknown, TResult = never> {
       console.warn(
         "[CopilotKit] injectInterrupt: legacy on_interrupt events cannot be cancelled; dismissing.",
       );
+      // A dismissal ends the gate, so drop the recovery record with it.
+      ɵclearLegacyInterrupt(agent);
       this.#clear();
       return;
     }

--- a/packages/angular/src/lib/interrupt.ts
+++ b/packages/angular/src/lib/interrupt.ts
@@ -111,6 +111,8 @@ export class InterruptController<TValue = unknown, TResult = never> {
   readonly #error = signal<unknown | null>(null);
   readonly #interruptState = new ɵInterruptState<TValue>();
   readonly #interruptRunIds = new Map<string, string>();
+  /** The run a legacy `on_interrupt` gate paused, so a resume addresses it. */
+  #legacyRunId?: string;
   readonly #runner: InterruptRunner;
   readonly #options: InjectInterruptOptions<TValue, TResult>;
   #agent?: AbstractAgent;
@@ -171,17 +173,23 @@ export class InterruptController<TValue = unknown, TResult = never> {
 
     let legacy: InterruptEvent<TValue> | null = null;
     let standard: Interrupt[] | null = null;
+    let lastFinishedRunId: string | undefined;
 
     // Publish whatever this run collected. Standard wins if both somehow
     // appear for one run.
-    const commit = () => {
+    const commit = (runId: string | undefined) => {
       if (standard && standard.length > 0) {
         this.#setPending({ kind: "standard", interrupts: standard });
       } else if (legacy) {
+        this.#legacyRunId = runId;
         // Record the legacy interrupt on the agent too. Standard interrupts
         // get this for free from `agent.pendingInterrupts`; without it the
         // legacy path cannot recover a gate whose event was already delivered.
-        ɵrecordLegacyInterrupt(agent, { event: legacy });
+        ɵrecordLegacyInterrupt(agent, {
+          event: legacy,
+          threadId: agent.threadId,
+          ...(runId === undefined ? {} : { runId }),
+        });
         this.#setPending({ kind: "legacy", event: legacy });
       }
       legacy = null;
@@ -198,9 +206,15 @@ export class InterruptController<TValue = unknown, TResult = never> {
         }
       },
       onRunFinishedEvent: (params) => {
+        // `params.event.runId` names the run that paused. `params.input.runId`
+        // names the request that opened the stream, and on the connect path
+        // that is the long-lived connection, not the replayed run. Resuming
+        // under the connection id addresses a run the backend never paused.
+        const runId = params.event.runId;
+        lastFinishedRunId = runId;
         if (params.outcome === "interrupt") {
           for (const interrupt of params.interrupts) {
-            this.#interruptRunIds.set(interrupt.id, params.input.runId);
+            this.#interruptRunIds.set(interrupt.id, runId);
           }
           standard = params.interrupts;
         }
@@ -208,18 +222,22 @@ export class InterruptController<TValue = unknown, TResult = never> {
         // path `onRunFinalized` fires when the long-lived socket stream tears
         // down, not once per replayed run, so a reconnect that replays an
         // interrupt would otherwise surface nothing.
-        commit();
+        commit(runId);
       },
       onRunStartedEvent: () => {
         legacy = null;
         standard = null;
+        lastFinishedRunId = undefined;
         this.#threadId = agent.threadId;
         ɵclearLegacyInterrupt(agent);
         this.#clear();
       },
       // Fallback for a stream that ends without a RUN_FINISHED event. When
       // RUN_FINISHED did arrive, `commit` already ran and left nothing to do.
-      onRunFinalized: commit,
+      // `onRunFinalized` carries no event, so it falls back to the last run id
+      // RUN_FINISHED named and only then to the id of the opening request.
+      onRunFinalized: (params) =>
+        commit(lastFinishedRunId ?? params.input.runId),
       onRunFailed: ({ error }) => {
         legacy = null;
         standard = null;
@@ -238,13 +256,14 @@ export class InterruptController<TValue = unknown, TResult = never> {
     // Seed from what the client already knows this thread is waiting on, so a
     // fresh controller or a reconnect surfaces a gate whose event arrived
     // before this subscription existed.
-    const recordedLegacy = ɵreadLegacyInterrupt<TValue>(agent);
+    const recordedLegacy = ɵreadLegacyInterrupt<TValue>(agent, agent.threadId);
     if (agent.pendingInterrupts.length > 0) {
       this.#setPending({
         kind: "standard",
         interrupts: [...agent.pendingInterrupts],
       });
     } else if (recordedLegacy) {
+      this.#legacyRunId = recordedLegacy.runId;
       this.#setPending({ kind: "legacy", event: recordedLegacy.event });
     }
   }
@@ -275,7 +294,9 @@ export class InterruptController<TValue = unknown, TResult = never> {
     if (current.kind === "legacy") {
       const decision = this.#interruptState.resolve(payload, interruptId);
       if (decision.kind !== "legacy-resume") return;
+      const runId = this.#legacyRunId;
       return this.#startResume(agent, {
+        ...(runId === undefined ? {} : { runId }),
         forwardedProps: {
           command: {
             resume: decision.payload,
@@ -522,5 +543,6 @@ export class InterruptController<TValue = unknown, TResult = never> {
     this.#resumePromise = undefined;
     this.#interruptState.clear();
     this.#interruptRunIds.clear();
+    this.#legacyRunId = undefined;
   }
 }

--- a/packages/core/src/__tests__/interrupt-state.test.ts
+++ b/packages/core/src/__tests__/interrupt-state.test.ts
@@ -1,7 +1,12 @@
 import type { Interrupt } from "@ag-ui/client";
 import { describe, expect, it } from "vitest";
 
-import { ɵInterruptState } from "../interrupt-state";
+import {
+  ɵclearLegacyInterrupt,
+  ɵInterruptState,
+  ɵreadLegacyInterrupt,
+  ɵrecordLegacyInterrupt,
+} from "../interrupt-state";
 
 function interrupt(
   id: string,
@@ -69,5 +74,44 @@ describe("ɵInterruptState", () => {
       payload: "approved",
       interruptValue: { requestId: "request-1" },
     });
+  });
+});
+
+describe("legacy interrupt record", () => {
+  it("returns null for an agent that holds no legacy interrupt", () => {
+    expect(ɵreadLegacyInterrupt({})).toBeNull();
+  });
+
+  it("reads back what was recorded for one agent", () => {
+    const agent = {};
+    ɵrecordLegacyInterrupt(agent, {
+      event: { name: "on_interrupt", value: "approve?" },
+      runId: "run-1",
+    });
+
+    expect(ɵreadLegacyInterrupt(agent)).toEqual({
+      event: { name: "on_interrupt", value: "approve?" },
+      runId: "run-1",
+    });
+  });
+
+  it("keeps one agent's record out of another agent's", () => {
+    const first = {};
+    const second = {};
+    ɵrecordLegacyInterrupt(first, {
+      event: { name: "on_interrupt", value: "first" },
+    });
+
+    expect(ɵreadLegacyInterrupt(second)).toBeNull();
+  });
+
+  it("forgets a record on clear", () => {
+    const agent = {};
+    ɵrecordLegacyInterrupt(agent, {
+      event: { name: "on_interrupt", value: "approve?" },
+    });
+    ɵclearLegacyInterrupt(agent);
+
+    expect(ɵreadLegacyInterrupt(agent)).toBeNull();
   });
 });

--- a/packages/core/src/__tests__/interrupt-state.test.ts
+++ b/packages/core/src/__tests__/interrupt-state.test.ts
@@ -79,18 +79,20 @@ describe("ɵInterruptState", () => {
 
 describe("legacy interrupt record", () => {
   it("returns null for an agent that holds no legacy interrupt", () => {
-    expect(ɵreadLegacyInterrupt({})).toBeNull();
+    expect(ɵreadLegacyInterrupt({}, "thread-1")).toBeNull();
   });
 
   it("reads back what was recorded for one agent", () => {
     const agent = {};
     ɵrecordLegacyInterrupt(agent, {
       event: { name: "on_interrupt", value: "approve?" },
+      threadId: "thread-1",
       runId: "run-1",
     });
 
-    expect(ɵreadLegacyInterrupt(agent)).toEqual({
+    expect(ɵreadLegacyInterrupt(agent, "thread-1")).toEqual({
       event: { name: "on_interrupt", value: "approve?" },
+      threadId: "thread-1",
       runId: "run-1",
     });
   });
@@ -100,18 +102,51 @@ describe("legacy interrupt record", () => {
     const second = {};
     ɵrecordLegacyInterrupt(first, {
       event: { name: "on_interrupt", value: "first" },
+      threadId: "thread-1",
     });
 
-    expect(ɵreadLegacyInterrupt(second)).toBeNull();
+    expect(ɵreadLegacyInterrupt(second, "thread-1")).toBeNull();
+  });
+
+  it("hides a record raised in a different thread", () => {
+    // One agent instance serves every conversation. Thread A's approval
+    // prompt must not surface while the app shows thread B, because
+    // answering it there would resume A.
+    const agent = {};
+    ɵrecordLegacyInterrupt(agent, {
+      event: { name: "on_interrupt", value: "approve A?" },
+      threadId: "thread-a",
+      runId: "run-a",
+    });
+
+    expect(ɵreadLegacyInterrupt(agent, "thread-b")).toBeNull();
+  });
+
+  it("still recovers the record when the original thread comes back", () => {
+    const agent = {};
+    ɵrecordLegacyInterrupt(agent, {
+      event: { name: "on_interrupt", value: "approve A?" },
+      threadId: "thread-a",
+      runId: "run-a",
+    });
+
+    // Reading from thread B must not consume or drop the record.
+    expect(ɵreadLegacyInterrupt(agent, "thread-b")).toBeNull();
+    expect(ɵreadLegacyInterrupt(agent, "thread-a")).toEqual({
+      event: { name: "on_interrupt", value: "approve A?" },
+      threadId: "thread-a",
+      runId: "run-a",
+    });
   });
 
   it("forgets a record on clear", () => {
     const agent = {};
     ɵrecordLegacyInterrupt(agent, {
       event: { name: "on_interrupt", value: "approve?" },
+      threadId: "thread-1",
     });
     ɵclearLegacyInterrupt(agent);
 
-    expect(ɵreadLegacyInterrupt(agent)).toBeNull();
+    expect(ɵreadLegacyInterrupt(agent, "thread-1")).toBeNull();
   });
 });

--- a/packages/core/src/interrupt-state.ts
+++ b/packages/core/src/interrupt-state.ts
@@ -50,6 +50,61 @@ function toolResultContent(response: ResumeResponse): string {
 }
 
 /**
+ * @internal A legacy interrupt a thread is still waiting on, plus the run that
+ * raised it. Application authors must not depend on this contract.
+ */
+export interface ɵLegacyInterruptRecord<TValue = unknown> {
+  event: ɵInterruptEvent<TValue>;
+  runId?: string;
+}
+
+/**
+ * Legacy `on_interrupt` interrupts a thread is still waiting on, keyed by the
+ * agent that received them.
+ *
+ * `AbstractAgent.pendingInterrupts` records standard AG-UI interrupts, so a
+ * framework adapter can recover a standard gate after a remount or a
+ * reconnect. Legacy custom-event interrupts have no such record upstream,
+ * which left the path every CLI starter takes with no way to recover a gate
+ * whose event was already delivered. This map is that record.
+ */
+const legacyInterrupts = new WeakMap<object, ɵLegacyInterruptRecord>();
+
+/**
+ * @internal Record the legacy interrupt an agent is waiting on. Application
+ * authors must not depend on this API.
+ */
+export function ɵrecordLegacyInterrupt<TValue>(
+  agent: object,
+  record: ɵLegacyInterruptRecord<TValue>,
+): void {
+  legacyInterrupts.set(agent, record as ɵLegacyInterruptRecord);
+}
+
+/**
+ * @internal Read the legacy interrupt an agent is waiting on, if any.
+ * Application authors must not depend on this API.
+ */
+export function ɵreadLegacyInterrupt<TValue = unknown>(
+  agent: object,
+): ɵLegacyInterruptRecord<TValue> | null {
+  return (
+    (legacyInterrupts.get(agent) as
+      | ɵLegacyInterruptRecord<TValue>
+      | undefined) ?? null
+  );
+}
+
+/**
+ * @internal Forget the legacy interrupt an agent was waiting on. Call this
+ * when a new run starts, and when the interrupt is addressed or dismissed.
+ * Application authors must not depend on this API.
+ */
+export function ɵclearLegacyInterrupt(agent: object): void {
+  legacyInterrupts.delete(agent);
+}
+
+/**
  * @internal Framework-neutral interrupt response state shared by framework
  * adapters. Application authors must not depend on this API.
  */

--- a/packages/core/src/interrupt-state.ts
+++ b/packages/core/src/interrupt-state.ts
@@ -50,11 +50,17 @@ function toolResultContent(response: ResumeResponse): string {
 }
 
 /**
- * @internal A legacy interrupt a thread is still waiting on, plus the run that
- * raised it. Application authors must not depend on this contract.
+ * @internal A legacy interrupt a thread is still waiting on, plus the thread
+ * and the run that raised it. Application authors must not depend on this
+ * contract.
  */
 export interface ɵLegacyInterruptRecord<TValue = unknown> {
   event: ɵInterruptEvent<TValue>;
+  /**
+   * The conversation that raised the interrupt. One agent instance serves
+   * every conversation an app opens, so the record has to name its own.
+   */
+  threadId: string;
   runId?: string;
 }
 
@@ -82,17 +88,24 @@ export function ɵrecordLegacyInterrupt<TValue>(
 }
 
 /**
- * @internal Read the legacy interrupt an agent is waiting on, if any.
+ * @internal Read the legacy interrupt an agent is waiting on in one thread.
+ *
+ * A record raised in another thread stays stored but does not surface here.
+ * The agent survives a thread switch, so returning that record would show one
+ * conversation's approval prompt inside another, and answering it would resume
+ * the wrong conversation.
+ *
  * Application authors must not depend on this API.
  */
 export function ɵreadLegacyInterrupt<TValue = unknown>(
   agent: object,
+  threadId: string,
 ): ɵLegacyInterruptRecord<TValue> | null {
-  return (
-    (legacyInterrupts.get(agent) as
-      | ɵLegacyInterruptRecord<TValue>
-      | undefined) ?? null
-  );
+  const record = legacyInterrupts.get(agent) as
+    | ɵLegacyInterruptRecord<TValue>
+    | undefined;
+  if (!record) return null;
+  return record.threadId === threadId ? record : null;
 }
 
 /**

--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -1261,4 +1261,164 @@ describe("useInterrupt", () => {
       });
     });
   });
+  // OSS-1131: a gate must survive a stream that never finalizes, a remount and
+  // a reconnect. Committing only at `onRunFinalized` meant the connect path —
+  // where finalize fires at socket teardown, not once per run — surfaced
+  // nothing, and effect cleanup then discarded the gate for good.
+  describe("recovery after a lost event or a reconnect", () => {
+    const INTERRUPT: Interrupt = { id: "int-1", reason: "approval" };
+
+    function RecoveryHarness() {
+      const element = useInterrupt({
+        renderInChat: false,
+        render: ({ event, interrupt }) => (
+          <div data-testid="gate">{String(interrupt?.id ?? event.value)}</div>
+        ),
+      });
+      return <div data-testid="gate-container">{element}</div>;
+    }
+
+    it("shows a standard gate from RUN_FINISHED on a stream that never finalizes", () => {
+      render(<RecoveryHarness />);
+
+      act(() => {
+        handlers.onRunFinishedEvent?.({
+          outcome: "interrupt",
+          interrupts: [INTERRUPT],
+          input: { runId: "replayed-run" },
+        });
+      });
+
+      expect(screen.getByTestId("gate").textContent).toBe("int-1");
+    });
+
+    it("shows a legacy gate from RUN_FINISHED on a stream that never finalizes", () => {
+      render(<RecoveryHarness />);
+
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve?" },
+        });
+        handlers.onRunFinishedEvent?.({
+          outcome: "success",
+          input: { runId: "replayed-run" },
+        });
+      });
+
+      expect(screen.getByTestId("gate").textContent).toBe("approve?");
+    });
+
+    it("seeds a standard gate from agent.pendingInterrupts on mount", () => {
+      (mockAgent as { pendingInterrupts: Interrupt[] }).pendingInterrupts = [
+        INTERRUPT,
+      ];
+
+      render(<RecoveryHarness />);
+
+      expect(screen.getByTestId("gate").textContent).toBe("int-1");
+    });
+
+    it("recovers a legacy gate on remount", () => {
+      const first = render(<RecoveryHarness />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve?" },
+        });
+        finalizeRun();
+      });
+      expect(screen.getByTestId("gate").textContent).toBe("approve?");
+
+      first.unmount();
+      render(<RecoveryHarness />);
+
+      expect(screen.getByTestId("gate").textContent).toBe("approve?");
+    });
+
+    it("resumes a recovered legacy gate with the run that raised it", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const calls: Array<(payload?: unknown) => Promise<unknown>> = [];
+      function ResumeHarness() {
+        useInterrupt({
+          render: ({ resolve }) => {
+            calls.push(resolve);
+            return <></>;
+          },
+        });
+        return null;
+      }
+
+      const first = render(<ResumeHarness />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve?" },
+        });
+        finalizeRun("gated-run");
+      });
+      first.unmount();
+      calls.length = 0;
+
+      render(<ResumeHarness />);
+      await act(async () => {
+        await calls.at(-1)!({ approved: true });
+      });
+
+      expect(runAgentMock).toHaveBeenCalledWith({
+        agent: mockAgent,
+        runId: "gated-run",
+        forwardedProps: {
+          command: {
+            resume: { approved: true },
+            interruptEvent: "approve?",
+          },
+        },
+      });
+    });
+
+    it("forgets a legacy gate once a new run starts", () => {
+      const first = render(<RecoveryHarness />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve?" },
+        });
+        finalizeRun();
+      });
+      act(() => handlers.onRunStartedEvent?.());
+      first.unmount();
+
+      render(<RecoveryHarness />);
+
+      expect(screen.queryByTestId("gate")).toBeNull();
+    });
+
+    it("forgets a legacy gate once it is dismissed", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const cancels: Array<() => Promise<unknown>> = [];
+      function DismissHarness() {
+        useInterrupt({
+          render: ({ cancel }) => {
+            cancels.push(cancel);
+            return <></>;
+          },
+        });
+        return null;
+      }
+
+      const first = render(<DismissHarness />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve?" },
+        });
+        finalizeRun();
+      });
+      act(() => {
+        void cancels.at(-1)!();
+      });
+      first.unmount();
+
+      render(<RecoveryHarness />);
+
+      expect(screen.queryByTestId("gate")).toBeNull();
+      warn.mockRestore();
+    });
+  });
 });

--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -19,11 +19,16 @@ const mockUseAgent = useAgent as ReturnType<typeof vi.fn>;
 
 type TestRunInput = Pick<RunAgentInput, "runId">;
 
-type RunFinishedParams =
-  | ({ outcome: "success"; result?: unknown } & { input: TestRunInput })
-  | ({ outcome: "interrupt"; interrupts: Interrupt[] } & {
-      input: TestRunInput;
-    });
+/**
+ * The event names the run that finished. On the connect path that differs from
+ * `input.runId`, which names the long-lived request that opened the stream.
+ */
+type TestRunFinishedEvent = { runId: string };
+
+type RunFinishedParams = (
+  | { outcome: "success"; result?: unknown }
+  | { outcome: "interrupt"; interrupts: Interrupt[] }
+) & { input: TestRunInput; event: TestRunFinishedEvent };
 
 type SubscriptionHandlers = {
   onCustomEvent?: (payload: {
@@ -57,6 +62,7 @@ describe("useInterrupt", () => {
     mockAgent = {
       subscribe: subscribeMock,
       id: "test-agent",
+      threadId: "thread-1",
       pendingInterrupts: [] as Interrupt[],
       addMessage: vi.fn(),
     };
@@ -826,6 +832,7 @@ describe("useInterrupt", () => {
           outcome: "interrupt",
           interrupts,
           input: { runId },
+          event: { runId },
         });
       });
     }
@@ -1286,6 +1293,7 @@ describe("useInterrupt", () => {
           outcome: "interrupt",
           interrupts: [INTERRUPT],
           input: { runId: "replayed-run" },
+          event: { runId: "replayed-run" },
         });
       });
 
@@ -1302,6 +1310,7 @@ describe("useInterrupt", () => {
         handlers.onRunFinishedEvent?.({
           outcome: "success",
           input: { runId: "replayed-run" },
+          event: { runId: "replayed-run" },
         });
       });
 
@@ -1419,6 +1428,187 @@ describe("useInterrupt", () => {
 
       expect(screen.queryByTestId("gate")).toBeNull();
       warn.mockRestore();
+    });
+  });
+  // Three ways an answer reached a run, a thread or an agent that never asked
+  // for it. Each is a submission the reader did not intend, so each test
+  // asserts on what `runAgent` received, not only on what the UI showed.
+  describe("a gate answers only the run, thread and agent that raised it", () => {
+    const INTERRUPT: Interrupt = { id: "int-1", reason: "approval" };
+
+    function GateHarness({
+      resolves,
+    }: {
+      resolves: Array<(payload?: unknown) => Promise<unknown>>;
+    }) {
+      const element = useInterrupt({
+        renderInChat: false,
+        render: ({ event, interrupt, resolve }) => {
+          resolves.push(resolve);
+          return (
+            <div data-testid="gate">{String(interrupt?.id ?? event.value)}</div>
+          );
+        },
+      });
+      return <div data-testid="gate-container">{element}</div>;
+    }
+
+    it("resumes the replayed run, not the connection that replayed it", async () => {
+      // A reconnect opens one long-lived request and replays the run that
+      // paused. `input.runId` names the connection; only `event.runId` names
+      // the run the backend is waiting on.
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const resolves: Array<(payload?: unknown) => Promise<unknown>> = [];
+      render(<GateHarness resolves={resolves} />);
+
+      (mockAgent as { pendingInterrupts: Interrupt[] }).pendingInterrupts = [
+        INTERRUPT,
+      ];
+      act(() => {
+        handlers.onRunFinishedEvent?.({
+          outcome: "interrupt",
+          interrupts: [INTERRUPT],
+          input: { runId: "connection-123" },
+          event: { runId: "original-run" },
+        });
+      });
+
+      await act(async () => {
+        await resolves.at(-1)!({ approved: true });
+      });
+
+      expect(runAgentMock).toHaveBeenCalledTimes(1);
+      expect(runAgentMock.mock.calls[0][0].runId).toBe("original-run");
+    });
+
+    it("resumes the replayed legacy run, not the connection that replayed it", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const resolves: Array<(payload?: unknown) => Promise<unknown>> = [];
+      render(<GateHarness resolves={resolves} />);
+
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve?" },
+        });
+        handlers.onRunFinishedEvent?.({
+          outcome: "success",
+          input: { runId: "connection-123" },
+          event: { runId: "original-run" },
+        });
+      });
+
+      await act(async () => {
+        await resolves.at(-1)!({ approved: true });
+      });
+
+      expect(runAgentMock).toHaveBeenCalledTimes(1);
+      expect(runAgentMock.mock.calls[0][0].runId).toBe("original-run");
+    });
+
+    it("does not surface thread A's gate after the app switches to thread B", () => {
+      const resolves: Array<(payload?: unknown) => Promise<unknown>> = [];
+      const first = render(<GateHarness resolves={resolves} />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve A?" },
+        });
+        finalizeRun("run-a");
+      });
+      expect(screen.getByTestId("gate").textContent).toBe("approve A?");
+
+      // The app switches conversation. `useAgent` mutates the thread on the
+      // same agent instance, so the gate's own record is the only thing that
+      // still knows which conversation raised it.
+      first.unmount();
+      (mockAgent as { threadId: string }).threadId = "thread-2";
+      render(<GateHarness resolves={resolves} />);
+
+      expect(screen.queryByTestId("gate")).toBeNull();
+    });
+
+    it("recovers thread A's gate when the app returns to thread A", () => {
+      const resolves: Array<(payload?: unknown) => Promise<unknown>> = [];
+      const first = render(<GateHarness resolves={resolves} />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve A?" },
+        });
+        finalizeRun("run-a");
+      });
+      first.unmount();
+
+      (mockAgent as { threadId: string }).threadId = "thread-2";
+      const second = render(<GateHarness resolves={resolves} />);
+      expect(screen.queryByTestId("gate")).toBeNull();
+      second.unmount();
+
+      (mockAgent as { threadId: string }).threadId = "thread-1";
+      render(<GateHarness resolves={resolves} />);
+
+      expect(screen.getByTestId("gate").textContent).toBe("approve A?");
+    });
+
+    it("does not submit thread A's answer after a thread switch without a remount", async () => {
+      // The thread can change on a mounted hook, because `useAgent` writes it
+      // onto the agent instance in an effect of its own.
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const resolves: Array<(payload?: unknown) => Promise<unknown>> = [];
+      render(<GateHarness resolves={resolves} />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve A?" },
+        });
+        finalizeRun("run-a");
+      });
+
+      (mockAgent as { threadId: string }).threadId = "thread-2";
+      await act(async () => {
+        await resolves.at(-1)!({ approved: true });
+      });
+
+      expect(runAgentMock).not.toHaveBeenCalled();
+      await waitFor(() => expect(screen.queryByTestId("gate")).toBeNull());
+    });
+
+    it("drops the old agent's gate when the same hook switches to an agent with no gate", async () => {
+      // The hook stays mounted and `useAgent` hands it a different agent. The
+      // effect re-runs, so `resolve` now closes over the second agent while
+      // the first agent's prompt is what the reader sees.
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const resolves: Array<(payload?: unknown) => Promise<unknown>> = [];
+      const { rerender } = render(<GateHarness resolves={resolves} />);
+      act(() => {
+        handlers.onCustomEvent?.({
+          event: { name: "on_interrupt", value: "approve on agent one?" },
+        });
+        finalizeRun("run-a");
+      });
+      expect(screen.getByTestId("gate").textContent).toBe(
+        "approve on agent one?",
+      );
+
+      // A second agent, waiting on nothing. The first agent keeps its own
+      // record, so switching must not carry its prompt across.
+      const secondAgent = {
+        subscribe: subscribeMock,
+        id: "other-agent",
+        threadId: "thread-1",
+        pendingInterrupts: [] as Interrupt[],
+        addMessage: vi.fn(),
+      };
+      mockUseAgent.mockReturnValue({ agent: secondAgent });
+      act(() => {
+        rerender(<GateHarness resolves={resolves} />);
+      });
+
+      expect(screen.queryByTestId("gate")).toBeNull();
+
+      // The prompt the first agent rendered is still callable from a retained
+      // reference. It must refuse rather than resume through the second agent.
+      await act(async () => {
+        await resolves.at(-1)!({ approved: true });
+      });
+      expect(runAgentMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -7,7 +7,12 @@ import React, {
 } from "react";
 import { randomUUID } from "@ag-ui/client";
 import type { Interrupt, Message } from "@ag-ui/client";
-import { ɵInterruptState } from "@copilotkit/core";
+import {
+  ɵclearLegacyInterrupt,
+  ɵInterruptState,
+  ɵreadLegacyInterrupt,
+  ɵrecordLegacyInterrupt,
+} from "@copilotkit/core";
 import type { ɵPendingInterrupt } from "@copilotkit/core";
 import { useCopilotKit } from "../context";
 import { useAgent } from "./use-agent";
@@ -189,6 +194,39 @@ export function useInterrupt<
     let localLegacy: InterruptEvent | null = null;
     let localStandard: Interrupt[] | null = null;
 
+    // Publish whatever this run collected. Standard wins if both somehow
+    // appear for one run.
+    const commit = (runId: string | undefined) => {
+      if (localStandard && localStandard.length > 0) {
+        interruptState.setStandard(localStandard);
+        setPending(interruptState.pending);
+      } else if (localLegacy) {
+        legacyRunIdRef.current = runId;
+        // Record the legacy interrupt on the agent too. Standard interrupts
+        // get this for free from `agent.pendingInterrupts`; without it the
+        // legacy path — the one every CLI starter takes — cannot recover a
+        // gate whose event was already delivered.
+        ɵrecordLegacyInterrupt(agent, {
+          event: localLegacy,
+          ...(runId === undefined ? {} : { runId }),
+        });
+        interruptState.setLegacy(localLegacy);
+        setPending(interruptState.pending);
+      }
+      localLegacy = null;
+      localStandard = null;
+    };
+
+    const forget = () => {
+      localLegacy = null;
+      localStandard = null;
+      interruptRunIdsRef.current.clear();
+      legacyRunIdRef.current = undefined;
+      ɵclearLegacyInterrupt(agent);
+      interruptState.clear();
+      setPending(null);
+    };
+
     const subscription = agent.subscribe({
       onCustomEvent: ({ event }) => {
         if (event.name === INTERRUPT_EVENT_NAME) {
@@ -203,41 +241,43 @@ export function useInterrupt<
           }
           localStandard = params.interrupts;
         }
+        // Commit here rather than only at `onRunFinalized`. On the connect
+        // path `onRunFinalized` fires when the long-lived socket stream tears
+        // down, not once per replayed run, so a reconnect that replays an
+        // interrupt would otherwise surface nothing.
+        commit(params.input.runId);
       },
-      onRunStartedEvent: () => {
-        localLegacy = null;
-        localStandard = null;
-        interruptRunIdsRef.current.clear();
-        legacyRunIdRef.current = undefined;
-        interruptState.clear();
-        setPending(null);
-      },
-      onRunFinalized: (params) => {
-        // Standard wins if both somehow appear for one run.
-        if (localStandard && localStandard.length > 0) {
-          interruptState.setStandard(localStandard);
-          setPending(interruptState.pending);
-        } else if (localLegacy) {
-          legacyRunIdRef.current = params.input.runId;
-          interruptState.setLegacy(localLegacy);
-          setPending(interruptState.pending);
-        }
-        localLegacy = null;
-        localStandard = null;
-      },
-      onRunFailed: () => {
-        localLegacy = null;
-        localStandard = null;
-        interruptRunIdsRef.current.clear();
-        legacyRunIdRef.current = undefined;
-        interruptState.clear();
-        setPending(null);
-      },
+      onRunStartedEvent: forget,
+      // Fallback for a stream that ends without a RUN_FINISHED event. When
+      // RUN_FINISHED did arrive, `commit` already ran and left nothing to do.
+      onRunFinalized: (params) => commit(params.input.runId),
+      onRunFailed: forget,
     });
+
+    // Seed from what the client already knows this thread is waiting on, so a
+    // mount, a remount or a reconnect surfaces a gate whose event arrived
+    // before this subscription existed.
+    const recordedLegacy = ɵreadLegacyInterrupt(agent);
+    if (agent.pendingInterrupts.length > 0) {
+      interruptState.setStandard(agent.pendingInterrupts);
+      setPending(interruptState.pending);
+    } else if (recordedLegacy) {
+      legacyRunIdRef.current = recordedLegacy.runId;
+      interruptState.setLegacy(recordedLegacy.event);
+      setPending(interruptState.pending);
+    }
 
     return () => {
       subscription.unsubscribe();
-      interruptState.clear();
+      // Keep the accumulated state when the agent still records a gate, so a
+      // remount can pick it back up. Discarding it here is what made an
+      // interrupted thread unrecoverable.
+      if (
+        agent.pendingInterrupts.length === 0 &&
+        !ɵreadLegacyInterrupt(agent)
+      ) {
+        interruptState.clear();
+      }
     };
   }, [agent]);
 
@@ -282,6 +322,7 @@ export function useInterrupt<
         console.error(
           `[CopilotKit] useInterrupt: interrupt ${decision.interrupt.id} expired at ${decision.interrupt.expiresAt}; not resuming.`,
         );
+        ɵclearLegacyInterrupt(agent);
         interruptStateRef.current.clear();
         setPending(null);
         return;
@@ -337,6 +378,8 @@ export function useInterrupt<
         console.warn(
           "[CopilotKit] useInterrupt: cancel() is not supported for legacy on_interrupt interrupts; dismissing.",
         );
+        // A dismissal ends the gate, so drop the recovery record with it.
+        ɵclearLegacyInterrupt(agent);
         interruptStateRef.current.clear();
         setPending(null);
         return;
@@ -345,6 +388,7 @@ export function useInterrupt<
         console.error(
           `[CopilotKit] useInterrupt: interrupt ${decision.interrupt.id} expired at ${decision.interrupt.expiresAt}; not resuming.`,
         );
+        ɵclearLegacyInterrupt(agent);
         interruptStateRef.current.clear();
         setPending(null);
         return;

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -188,19 +188,28 @@ export function useInterrupt<
   const interruptStateRef = useRef(new ɵInterruptState());
   const interruptRunIdsRef = useRef(new Map<string, string>());
   const legacyRunIdRef = useRef<string | undefined>(undefined);
+  /**
+   * The thread the pending gate belongs to. The app can switch threads on the
+   * same agent instance without remounting this hook, so a submit has to prove
+   * the gate still belongs to the conversation on screen.
+   */
+  const pendingThreadIdRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     const interruptState = interruptStateRef.current;
     let localLegacy: InterruptEvent | null = null;
     let localStandard: Interrupt[] | null = null;
+    let lastFinishedRunId: string | undefined;
 
     // Publish whatever this run collected. Standard wins if both somehow
     // appear for one run.
     const commit = (runId: string | undefined) => {
       if (localStandard && localStandard.length > 0) {
+        pendingThreadIdRef.current = agent.threadId;
         interruptState.setStandard(localStandard);
         setPending(interruptState.pending);
       } else if (localLegacy) {
+        pendingThreadIdRef.current = agent.threadId;
         legacyRunIdRef.current = runId;
         // Record the legacy interrupt on the agent too. Standard interrupts
         // get this for free from `agent.pendingInterrupts`; without it the
@@ -208,6 +217,7 @@ export function useInterrupt<
         // gate whose event was already delivered.
         ɵrecordLegacyInterrupt(agent, {
           event: localLegacy,
+          threadId: agent.threadId,
           ...(runId === undefined ? {} : { runId }),
         });
         interruptState.setLegacy(localLegacy);
@@ -220,8 +230,10 @@ export function useInterrupt<
     const forget = () => {
       localLegacy = null;
       localStandard = null;
+      lastFinishedRunId = undefined;
       interruptRunIdsRef.current.clear();
       legacyRunIdRef.current = undefined;
+      pendingThreadIdRef.current = undefined;
       ɵclearLegacyInterrupt(agent);
       interruptState.clear();
       setPending(null);
@@ -234,8 +246,13 @@ export function useInterrupt<
         }
       },
       onRunFinishedEvent: (params) => {
+        // `params.event.runId` names the run that paused. `params.input.runId`
+        // names the request that opened the stream, and on the connect path
+        // that is the long-lived connection, not the replayed run. Resuming
+        // under the connection id addresses a run the backend never paused.
+        const runId = params.event.runId;
+        lastFinishedRunId = runId;
         if (params.outcome === "interrupt") {
-          const runId = params.input.runId;
           for (const interrupt of params.interrupts) {
             interruptRunIdsRef.current.set(interrupt.id, runId);
           }
@@ -245,26 +262,40 @@ export function useInterrupt<
         // path `onRunFinalized` fires when the long-lived socket stream tears
         // down, not once per replayed run, so a reconnect that replays an
         // interrupt would otherwise surface nothing.
-        commit(params.input.runId);
+        commit(runId);
       },
       onRunStartedEvent: forget,
       // Fallback for a stream that ends without a RUN_FINISHED event. When
       // RUN_FINISHED did arrive, `commit` already ran and left nothing to do.
-      onRunFinalized: (params) => commit(params.input.runId),
+      // `onRunFinalized` carries no event, so it falls back to the last run id
+      // RUN_FINISHED named and only then to the id of the opening request.
+      onRunFinalized: (params) =>
+        commit(lastFinishedRunId ?? params.input.runId),
       onRunFailed: forget,
     });
 
     // Seed from what the client already knows this thread is waiting on, so a
     // mount, a remount or a reconnect surfaces a gate whose event arrived
     // before this subscription existed.
-    const recordedLegacy = ɵreadLegacyInterrupt(agent);
+    const recordedLegacy = ɵreadLegacyInterrupt(agent, agent.threadId);
     if (agent.pendingInterrupts.length > 0) {
+      pendingThreadIdRef.current = agent.threadId;
       interruptState.setStandard(agent.pendingInterrupts);
       setPending(interruptState.pending);
     } else if (recordedLegacy) {
+      pendingThreadIdRef.current = recordedLegacy.threadId;
       legacyRunIdRef.current = recordedLegacy.runId;
       interruptState.setLegacy(recordedLegacy.event);
       setPending(interruptState.pending);
+    } else {
+      // This agent waits on nothing. State left over from the agent this hook
+      // watched before must not survive the switch: the prompt would stay on
+      // screen and send its answer to an agent that never asked.
+      interruptRunIdsRef.current.clear();
+      legacyRunIdRef.current = undefined;
+      pendingThreadIdRef.current = undefined;
+      interruptState.clear();
+      setPending(null);
     }
 
     return () => {
@@ -274,17 +305,36 @@ export function useInterrupt<
       // interrupted thread unrecoverable.
       if (
         agent.pendingInterrupts.length === 0 &&
-        !ɵreadLegacyInterrupt(agent)
+        !ɵreadLegacyInterrupt(agent, agent.threadId)
       ) {
         interruptState.clear();
       }
     };
   }, [agent]);
 
+  /**
+   * Drop a gate the conversation on screen no longer owns.
+   *
+   * One agent instance serves every thread an app opens, and a thread switch
+   * mutates `agent.threadId` in place without remounting this hook. Submitting
+   * then resumes a conversation the reader is not looking at.
+   */
+  const abandonIfThreadChanged = useCallback((): boolean => {
+    const owner = pendingThreadIdRef.current;
+    if (owner === undefined || owner === agent.threadId) return false;
+    interruptRunIdsRef.current.clear();
+    legacyRunIdRef.current = undefined;
+    pendingThreadIdRef.current = undefined;
+    interruptStateRef.current.clear();
+    setPending(null);
+    return true;
+  }, [agent]);
+
   const resolve: InterruptResolveFn = useCallback(
     async (payload, interruptId) => {
       const current = pendingRef.current;
       if (!current) return;
+      if (abandonIfThreadChanged()) return;
 
       if (
         current.kind === "standard" &&
@@ -355,13 +405,14 @@ export function useInterrupt<
         throw err;
       }
     },
-    [agent, copilotkit],
+    [agent, copilotkit, abandonIfThreadChanged],
   );
 
   const cancel: InterruptCancelFn = useCallback(
     async (interruptId) => {
       const current = pendingRef.current;
       if (!current) return;
+      if (abandonIfThreadChanged()) return;
 
       if (
         current.kind === "standard" &&
@@ -421,7 +472,7 @@ export function useInterrupt<
         throw err;
       }
     },
-    [agent, copilotkit],
+    [agent, copilotkit, abandonIfThreadChanged],
   );
 
   // Stabilize consumer-supplied callbacks behind refs so inline lambdas do not

--- a/packages/vue/src/v2/hooks/__tests__/use-interrupt.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-interrupt.test.ts
@@ -527,4 +527,79 @@ describe("useInterrupt", () => {
       });
     });
   });
+  // OSS-1131: a gate must survive a stream that never finalizes, a remount and
+  // a reconnect. Committing only at `onRunFinalized` meant the connect path —
+  // where finalize fires at socket teardown, not once per run — surfaced
+  // nothing.
+  describe("recovery after a lost event or a reconnect", () => {
+    const INTERRUPT: Interrupt = { id: "int-1", reason: "approval" };
+
+    it("shows a standard gate from RUN_FINISHED on a stream that never finalizes", async () => {
+      const wrapper = mountHarness({ renderInChat: false });
+
+      handlers.onRunFinishedEvent?.({
+        outcome: "interrupt",
+        interrupts: [INTERRUPT],
+      });
+      await nextTick();
+
+      expect(wrapper.get("[data-testid=interrupt-state]").text()).not.toBe(
+        "idle",
+      );
+    });
+
+    it("shows a legacy gate from RUN_FINISHED on a stream that never finalizes", async () => {
+      const wrapper = mountHarness({ renderInChat: false });
+
+      handlers.onCustomEvent?.({
+        event: { name: "on_interrupt", value: "approve?" },
+      });
+      handlers.onRunFinishedEvent?.({ outcome: "success" });
+      await nextTick();
+
+      expect(wrapper.get("[data-testid=interrupt-state]").text()).toContain(
+        "approve?",
+      );
+    });
+
+    it("seeds a standard gate from agent.pendingInterrupts on mount", async () => {
+      (mockAgent as { pendingInterrupts: Interrupt[] }).pendingInterrupts = [
+        INTERRUPT,
+      ];
+
+      const wrapper = mountHarness({ renderInChat: false });
+      await nextTick();
+
+      expect(wrapper.get("[data-testid=interrupt-state]").text()).not.toBe(
+        "idle",
+      );
+    });
+
+    it("recovers a legacy gate on remount", async () => {
+      const first = mountHarness({ renderInChat: false });
+      emitInterrupt("approve?");
+      await nextTick();
+      first.unmount();
+
+      const second = mountHarness({ renderInChat: false });
+      await nextTick();
+
+      expect(second.get("[data-testid=interrupt-state]").text()).toContain(
+        "approve?",
+      );
+    });
+
+    it("forgets a legacy gate once a new run starts", async () => {
+      const first = mountHarness({ renderInChat: false });
+      emitInterrupt("approve?");
+      await nextTick();
+      handlers.onRunStartedEvent?.();
+      first.unmount();
+
+      const second = mountHarness({ renderInChat: false });
+      await nextTick();
+
+      expect(second.get("[data-testid=interrupt-state]").text()).toBe("idle");
+    });
+  });
 });

--- a/packages/vue/src/v2/hooks/__tests__/use-interrupt.test.ts
+++ b/packages/vue/src/v2/hooks/__tests__/use-interrupt.test.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { computed, defineComponent, h, nextTick } from "vue";
+import { computed, defineComponent, h, nextTick, shallowRef } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Interrupt } from "@ag-ui/client";
 import { useCopilotKit } from "../../providers/useCopilotKit";
@@ -17,9 +17,18 @@ vi.mock("../use-agent", () => ({
 const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;
 const mockUseAgent = useAgent as ReturnType<typeof vi.fn>;
 
-type RunFinishedParams =
+type TestRunInput = { runId: string };
+
+/**
+ * The event names the run that finished. On the connect path that differs from
+ * `input.runId`, which names the long-lived request that opened the stream.
+ */
+type TestRunFinishedEvent = { runId: string };
+
+type RunFinishedParams = (
   | { outcome: "success"; result?: unknown }
-  | { outcome: "interrupt"; interrupts: Interrupt[] };
+  | { outcome: "interrupt"; interrupts: Interrupt[] }
+) & { input: TestRunInput; event: TestRunFinishedEvent };
 
 type SubscriptionHandlers = {
   onCustomEvent?: (payload: {
@@ -27,7 +36,7 @@ type SubscriptionHandlers = {
   }) => void;
   onRunStartedEvent?: () => void;
   onRunFinishedEvent?: (params: RunFinishedParams) => void;
-  onRunFinalized?: () => void;
+  onRunFinalized?: (params: { input: TestRunInput }) => void;
   onRunFailed?: () => void;
 };
 
@@ -57,6 +66,7 @@ describe("useInterrupt", () => {
     mockAgent = {
       subscribe: subscribeMock,
       id: "test-agent",
+      threadId: "thread-1",
       pendingInterrupts: [] as Interrupt[],
     };
 
@@ -123,11 +133,11 @@ describe("useInterrupt", () => {
     return mount(Harness);
   }
 
-  function emitInterrupt(value: unknown) {
+  function emitInterrupt(value: unknown, runId = "legacy-run") {
     handlers.onCustomEvent?.({
       event: { name: "on_interrupt", value },
     });
-    handlers.onRunFinalized?.();
+    handlers.onRunFinalized?.({ input: { runId } });
   }
 
   it("subscribes on mount and unsubscribes on unmount", () => {
@@ -149,7 +159,7 @@ describe("useInterrupt", () => {
     handlers.onCustomEvent?.({
       event: { name: "not_interrupt", value: "x" },
     });
-    handlers.onRunFinalized?.();
+    handlers.onRunFinalized?.({ input: { runId: "legacy-run" } });
 
     expect(wrapper.get("[data-testid=interrupt-state]").text()).toBe("idle");
   });
@@ -163,7 +173,7 @@ describe("useInterrupt", () => {
     await nextTick();
     expect(wrapper.get("[data-testid=interrupt-state]").text()).toBe("idle");
 
-    handlers.onRunFinalized?.();
+    handlers.onRunFinalized?.({ input: { runId: "legacy-run" } });
     await nextTick();
     expect(wrapper.get("[data-testid=interrupt-state]").text()).toContain(
       "pending",
@@ -204,6 +214,7 @@ describe("useInterrupt", () => {
     );
     expect(runAgentMock).toHaveBeenCalledWith({
       agent: mockAgent,
+      runId: "legacy-run",
       forwardedProps: {
         command: {
           resume: { approved: true, value: "approve-me" },
@@ -341,7 +352,7 @@ describe("useInterrupt", () => {
       event: { name: "on_interrupt", value: "lost" },
     });
     handlers.onRunFailed?.();
-    handlers.onRunFinalized?.();
+    handlers.onRunFinalized?.({ input: { runId: "legacy-run" } });
     await nextTick();
 
     expect(wrapper.get("[data-testid=interrupt-state]").text()).toBe("idle");
@@ -356,7 +367,7 @@ describe("useInterrupt", () => {
     handlers.onCustomEvent?.({
       event: { name: "on_interrupt", value: "second" },
     });
-    handlers.onRunFinalized?.();
+    handlers.onRunFinalized?.({ input: { runId: "legacy-run" } });
     await nextTick();
 
     expect(wrapper.get("[data-testid=interrupt-state]").text()).toContain(
@@ -408,8 +419,13 @@ describe("useInterrupt", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (mockAgent as any).pendingInterrupts = interrupts;
       handlers.onRunStartedEvent?.();
-      handlers.onRunFinishedEvent?.({ outcome: "interrupt", interrupts });
-      handlers.onRunFinalized?.();
+      handlers.onRunFinishedEvent?.({
+        outcome: "interrupt",
+        interrupts,
+        input: { runId: "run-1" },
+        event: { runId: "run-1" },
+      });
+      handlers.onRunFinalized?.({ input: { runId: "legacy-run" } });
     }
 
     it("resolveInterrupt resumes with a resolved ResumeEntry", async () => {
@@ -427,6 +443,7 @@ describe("useInterrupt", () => {
 
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "run-1",
         resume: [
           { interruptId: "int-1", status: "resolved", payload: { ok: true } },
         ],
@@ -448,6 +465,7 @@ describe("useInterrupt", () => {
 
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "run-1",
         resume: [{ interruptId: "int-1", status: "cancelled" }],
       });
     });
@@ -511,7 +529,7 @@ describe("useInterrupt", () => {
       handlers.onCustomEvent?.({
         event: { name: "on_interrupt", value: "q?" },
       });
-      handlers.onRunFinalized?.();
+      handlers.onRunFinalized?.({ input: { runId: "legacy-run" } });
       await nextTick();
 
       // Call resolve with legacy payload
@@ -521,6 +539,7 @@ describe("useInterrupt", () => {
 
       expect(runAgentMock).toHaveBeenCalledWith({
         agent: mockAgent,
+        runId: "legacy-run",
         forwardedProps: {
           command: { resume: { approved: true }, interruptEvent: "q?" },
         },
@@ -540,6 +559,8 @@ describe("useInterrupt", () => {
       handlers.onRunFinishedEvent?.({
         outcome: "interrupt",
         interrupts: [INTERRUPT],
+        input: { runId: "replayed-run" },
+        event: { runId: "replayed-run" },
       });
       await nextTick();
 
@@ -554,7 +575,11 @@ describe("useInterrupt", () => {
       handlers.onCustomEvent?.({
         event: { name: "on_interrupt", value: "approve?" },
       });
-      handlers.onRunFinishedEvent?.({ outcome: "success" });
+      handlers.onRunFinishedEvent?.({
+        outcome: "success",
+        input: { runId: "replayed-run" },
+        event: { runId: "replayed-run" },
+      });
       await nextTick();
 
       expect(wrapper.get("[data-testid=interrupt-state]").text()).toContain(
@@ -600,6 +625,143 @@ describe("useInterrupt", () => {
       await nextTick();
 
       expect(second.get("[data-testid=interrupt-state]").text()).toBe("idle");
+    });
+  });
+  // Parity with the React hook: a gate answers only the run, the thread and
+  // the agent that raised it.
+  describe("a gate answers only the run, thread and agent that raised it", () => {
+    const INTERRUPT: Interrupt = { id: "int-1", reason: "approval" };
+
+    function mountGateHarness() {
+      const Harness = defineComponent({
+        setup() {
+          const { slotProps } = useInterrupt({ renderInChat: false });
+          return () => {
+            const props = slotProps.value;
+            if (!props) return h("div", { "data-testid": "gate" }, "idle");
+            return h(
+              "button",
+              {
+                "data-testid": "gate",
+                onClick: () => void props.resolve({ approved: true }),
+              },
+              String(props.event.value ?? "gate"),
+            );
+          };
+        },
+      });
+      return mount(Harness);
+    }
+
+    it("resumes the replayed legacy run, not the connection that replayed it", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const wrapper = mountGateHarness();
+
+      handlers.onCustomEvent?.({
+        event: { name: "on_interrupt", value: "approve?" },
+      });
+      handlers.onRunFinishedEvent?.({
+        outcome: "success",
+        input: { runId: "connection-123" },
+        event: { runId: "original-run" },
+      });
+      await nextTick();
+      await wrapper.get("[data-testid=gate]").trigger("click");
+      await nextTick();
+
+      expect(runAgentMock).toHaveBeenCalledTimes(1);
+      expect(runAgentMock.mock.calls[0][0].runId).toBe("original-run");
+    });
+
+    it("resumes the replayed standard run, not the connection that replayed it", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const wrapper = mountGateHarness();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockAgent as any).pendingInterrupts = [INTERRUPT];
+      handlers.onRunFinishedEvent?.({
+        outcome: "interrupt",
+        interrupts: [INTERRUPT],
+        input: { runId: "connection-123" },
+        event: { runId: "original-run" },
+      });
+      await nextTick();
+      await wrapper.get("[data-testid=gate]").trigger("click");
+      await nextTick();
+
+      expect(runAgentMock).toHaveBeenCalledTimes(1);
+      expect(runAgentMock.mock.calls[0][0].runId).toBe("original-run");
+    });
+
+    it("does not surface thread A's gate after the app switches to thread B", async () => {
+      const first = mountGateHarness();
+      emitInterrupt("approve A?", "run-a");
+      await nextTick();
+      expect(first.get("[data-testid=gate]").text()).toBe("approve A?");
+      first.unmount();
+
+      (mockAgent as { threadId: string }).threadId = "thread-2";
+      const second = mountGateHarness();
+      await nextTick();
+
+      expect(second.get("[data-testid=gate]").text()).toBe("idle");
+    });
+
+    it("recovers thread A's gate when the app returns to thread A", async () => {
+      const first = mountGateHarness();
+      emitInterrupt("approve A?", "run-a");
+      await nextTick();
+      first.unmount();
+
+      (mockAgent as { threadId: string }).threadId = "thread-2";
+      const second = mountGateHarness();
+      await nextTick();
+      expect(second.get("[data-testid=gate]").text()).toBe("idle");
+      second.unmount();
+
+      (mockAgent as { threadId: string }).threadId = "thread-1";
+      const third = mountGateHarness();
+      await nextTick();
+
+      expect(third.get("[data-testid=gate]").text()).toBe("approve A?");
+    });
+
+    it("does not submit thread A's answer after a thread switch without a remount", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const wrapper = mountGateHarness();
+      emitInterrupt("approve A?", "run-a");
+      await nextTick();
+
+      (mockAgent as { threadId: string }).threadId = "thread-2";
+      await wrapper.get("[data-testid=gate]").trigger("click");
+      await nextTick();
+
+      expect(runAgentMock).not.toHaveBeenCalled();
+      expect(wrapper.get("[data-testid=gate]").text()).toBe("idle");
+    });
+
+    it("drops the old agent's gate when the watcher switches to an agent with no gate", async () => {
+      runAgentMock.mockResolvedValue({ result: undefined, newMessages: [] });
+      const agentRef = shallowRef(mockAgent);
+      mockUseAgent.mockReturnValue({ agent: agentRef });
+
+      const wrapper = mountGateHarness();
+      emitInterrupt("approve on agent one?", "run-a");
+      await nextTick();
+      expect(wrapper.get("[data-testid=gate]").text()).toBe(
+        "approve on agent one?",
+      );
+
+      agentRef.value = {
+        subscribe: subscribeMock,
+        id: "other-agent",
+        threadId: "thread-1",
+        pendingInterrupts: [] as Interrupt[],
+      };
+      await nextTick();
+
+      expect(wrapper.get("[data-testid=gate]").text()).toBe("idle");
+      expect(runAgentMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/vue/src/v2/hooks/use-interrupt.ts
+++ b/packages/vue/src/v2/hooks/use-interrupt.ts
@@ -2,6 +2,11 @@ import { computed, onScopeDispose, shallowRef, watch } from "vue";
 import type { ComputedRef, Ref } from "vue";
 import { buildResumeArray, isInterruptExpired } from "@ag-ui/client";
 import type { Interrupt, RunAgentResult } from "@ag-ui/client";
+import {
+  ɵclearLegacyInterrupt,
+  ɵreadLegacyInterrupt,
+  ɵrecordLegacyInterrupt,
+} from "@copilotkit/core";
 import { useCopilotKit } from "../providers/useCopilotKit";
 import { useAgent } from "./use-agent";
 import type {
@@ -149,6 +154,34 @@ export function useInterrupt<TValue = unknown, TResult = never>(
       let localLegacy: InterruptEvent<TValue> | null = null;
       let localStandard: Interrupt[] | null = null;
 
+      // Publish whatever this run collected. Standard wins if both somehow
+      // appear for one run.
+      const commit = () => {
+        if (localStandard && localStandard.length > 0) {
+          pending.value = { kind: "standard", interrupts: localStandard };
+        } else if (localLegacy) {
+          // Record the legacy interrupt on the agent too. Standard interrupts
+          // get this for free from `agent.pendingInterrupts`; without it the
+          // legacy path cannot recover a gate whose event was already
+          // delivered.
+          ɵrecordLegacyInterrupt(resolvedAgent, { event: localLegacy });
+          pending.value = { kind: "legacy", event: localLegacy };
+        }
+        localLegacy = null;
+        localStandard = null;
+      };
+
+      const forget = () => {
+        localLegacy = null;
+        localStandard = null;
+        ɵclearLegacyInterrupt(resolvedAgent);
+        // Reset accumulated responses for the new run.
+        for (const k of Object.keys(responses)) {
+          delete responses[k];
+        }
+        pending.value = null;
+      };
+
       const subscription = resolvedAgent.subscribe({
         onCustomEvent: ({ event }) => {
           if (event.name === INTERRUPT_EVENT_NAME) {
@@ -162,35 +195,31 @@ export function useInterrupt<TValue = unknown, TResult = never>(
           if (params.outcome === "interrupt") {
             localStandard = params.interrupts;
           }
+          // Commit here rather than only at `onRunFinalized`. On the connect
+          // path `onRunFinalized` fires when the long-lived socket stream tears
+          // down, not once per replayed run, so a reconnect that replays an
+          // interrupt would otherwise surface nothing.
+          commit();
         },
-        onRunStartedEvent: () => {
-          localLegacy = null;
-          localStandard = null;
-          // Reset accumulated responses for the new run.
-          for (const k of Object.keys(responses)) {
-            delete responses[k];
-          }
-          pending.value = null;
-        },
-        onRunFinalized: () => {
-          // Standard wins if both somehow appear for one run.
-          if (localStandard && localStandard.length > 0) {
-            pending.value = { kind: "standard", interrupts: localStandard };
-          } else if (localLegacy) {
-            pending.value = { kind: "legacy", event: localLegacy };
-          }
-          localLegacy = null;
-          localStandard = null;
-        },
-        onRunFailed: () => {
-          localLegacy = null;
-          localStandard = null;
-          for (const k of Object.keys(responses)) {
-            delete responses[k];
-          }
-          pending.value = null;
-        },
+        onRunStartedEvent: forget,
+        // Fallback for a stream that ends without a RUN_FINISHED event. When
+        // RUN_FINISHED did arrive, `commit` already ran and left nothing to do.
+        onRunFinalized: commit,
+        onRunFailed: forget,
       });
+
+      // Seed from what the client already knows this thread is waiting on, so
+      // a mount or a reconnect surfaces a gate whose event arrived before this
+      // subscription existed.
+      const recordedLegacy = ɵreadLegacyInterrupt<TValue>(resolvedAgent);
+      if (resolvedAgent.pendingInterrupts.length > 0) {
+        pending.value = {
+          kind: "standard",
+          interrupts: [...resolvedAgent.pendingInterrupts],
+        };
+      } else if (recordedLegacy) {
+        pending.value = { kind: "legacy", event: recordedLegacy.event };
+      }
 
       onCleanup(() => subscription.unsubscribe());
     },
@@ -283,6 +312,9 @@ export function useInterrupt<TValue = unknown, TResult = never>(
       console.warn(
         "[CopilotKit] useInterrupt: cancel() is not supported for legacy on_interrupt interrupts; dismissing.",
       );
+      // A dismissal ends the gate, so drop the recovery record with it.
+      const dismissedAgent = agent.value;
+      if (dismissedAgent) ɵclearLegacyInterrupt(dismissedAgent);
       pending.value = null;
       return;
     }

--- a/packages/vue/src/v2/hooks/use-interrupt.ts
+++ b/packages/vue/src/v2/hooks/use-interrupt.ts
@@ -141,6 +141,37 @@ export function useInterrupt<TValue = unknown, TResult = never>(
 
   // Accumulated per-interrupt responses for the current standard interrupt set.
   const responses: Record<string, ResumeResponse> = {};
+  // The run each open interrupt paused, so a resume addresses that run rather
+  // than whichever request happened to open the stream.
+  const interruptRunIds = new Map<string, string>();
+  let legacyRunId: string | undefined;
+  /**
+   * The thread the pending gate belongs to. The app can switch threads on the
+   * same agent instance without re-running the watcher, so a submit has to
+   * prove the gate still belongs to the conversation on screen.
+   */
+  let pendingThreadId: string | undefined;
+
+  /** Forget a gate the conversation on screen no longer owns. */
+  const abandonIfThreadChanged = (resolvedAgent: {
+    threadId: string;
+  }): boolean => {
+    if (
+      pendingThreadId === undefined ||
+      pendingThreadId === resolvedAgent.threadId
+    ) {
+      return false;
+    }
+    pendingThreadId = undefined;
+    legacyRunId = undefined;
+    interruptRunIds.clear();
+    for (const k of Object.keys(responses)) {
+      delete responses[k];
+    }
+    pending.value = null;
+    result.value = null;
+    return true;
+  };
 
   watch(
     agent,
@@ -153,18 +184,26 @@ export function useInterrupt<TValue = unknown, TResult = never>(
 
       let localLegacy: InterruptEvent<TValue> | null = null;
       let localStandard: Interrupt[] | null = null;
+      let lastFinishedRunId: string | undefined;
 
       // Publish whatever this run collected. Standard wins if both somehow
       // appear for one run.
-      const commit = () => {
+      const commit = (runId: string | undefined) => {
         if (localStandard && localStandard.length > 0) {
+          pendingThreadId = resolvedAgent.threadId;
           pending.value = { kind: "standard", interrupts: localStandard };
         } else if (localLegacy) {
+          pendingThreadId = resolvedAgent.threadId;
+          legacyRunId = runId;
           // Record the legacy interrupt on the agent too. Standard interrupts
           // get this for free from `agent.pendingInterrupts`; without it the
           // legacy path cannot recover a gate whose event was already
           // delivered.
-          ɵrecordLegacyInterrupt(resolvedAgent, { event: localLegacy });
+          ɵrecordLegacyInterrupt(resolvedAgent, {
+            event: localLegacy,
+            threadId: resolvedAgent.threadId,
+            ...(runId === undefined ? {} : { runId }),
+          });
           pending.value = { kind: "legacy", event: localLegacy };
         }
         localLegacy = null;
@@ -174,6 +213,10 @@ export function useInterrupt<TValue = unknown, TResult = never>(
       const forget = () => {
         localLegacy = null;
         localStandard = null;
+        lastFinishedRunId = undefined;
+        legacyRunId = undefined;
+        pendingThreadId = undefined;
+        interruptRunIds.clear();
         ɵclearLegacyInterrupt(resolvedAgent);
         // Reset accumulated responses for the new run.
         for (const k of Object.keys(responses)) {
@@ -192,33 +235,62 @@ export function useInterrupt<TValue = unknown, TResult = never>(
           }
         },
         onRunFinishedEvent: (params) => {
+          // `params.event.runId` names the run that paused. `params.input.runId`
+          // names the request that opened the stream, and on the connect path
+          // that is the long-lived connection, not the replayed run.
+          const runId = params.event.runId;
+          lastFinishedRunId = runId;
           if (params.outcome === "interrupt") {
+            for (const interrupt of params.interrupts) {
+              interruptRunIds.set(interrupt.id, runId);
+            }
             localStandard = params.interrupts;
           }
           // Commit here rather than only at `onRunFinalized`. On the connect
           // path `onRunFinalized` fires when the long-lived socket stream tears
           // down, not once per replayed run, so a reconnect that replays an
           // interrupt would otherwise surface nothing.
-          commit();
+          commit(runId);
         },
         onRunStartedEvent: forget,
         // Fallback for a stream that ends without a RUN_FINISHED event. When
         // RUN_FINISHED did arrive, `commit` already ran and left nothing to do.
-        onRunFinalized: commit,
+        // `onRunFinalized` carries no event, so it falls back to the last run
+        // id RUN_FINISHED named and only then to the opening request.
+        onRunFinalized: (params) =>
+          commit(lastFinishedRunId ?? params.input.runId),
         onRunFailed: forget,
       });
 
       // Seed from what the client already knows this thread is waiting on, so
       // a mount or a reconnect surfaces a gate whose event arrived before this
       // subscription existed.
-      const recordedLegacy = ɵreadLegacyInterrupt<TValue>(resolvedAgent);
+      const recordedLegacy = ɵreadLegacyInterrupt<TValue>(
+        resolvedAgent,
+        resolvedAgent.threadId,
+      );
       if (resolvedAgent.pendingInterrupts.length > 0) {
+        pendingThreadId = resolvedAgent.threadId;
         pending.value = {
           kind: "standard",
           interrupts: [...resolvedAgent.pendingInterrupts],
         };
       } else if (recordedLegacy) {
+        pendingThreadId = recordedLegacy.threadId;
+        legacyRunId = recordedLegacy.runId;
         pending.value = { kind: "legacy", event: recordedLegacy.event };
+      } else {
+        // This agent waits on nothing. State left over from the agent this
+        // hook watched before must not survive the switch: the prompt would
+        // stay on screen and send its answer to an agent that never asked.
+        legacyRunId = undefined;
+        pendingThreadId = undefined;
+        interruptRunIds.clear();
+        for (const k of Object.keys(responses)) {
+          delete responses[k];
+        }
+        pending.value = null;
+        result.value = null;
       }
 
       onCleanup(() => subscription.unsubscribe());
@@ -249,10 +321,17 @@ export function useInterrupt<TValue = unknown, TResult = never>(
     for (const k of Object.keys(responses)) {
       delete responses[k];
     }
+    const runId = resume
+      .map((entry) => interruptRunIds.get(entry.interruptId))
+      .find((candidate): candidate is string => candidate !== undefined);
     const resolvedAgent = agent.value;
     if (!resolvedAgent) return;
     try {
-      return await copilotkit.value.runAgent({ agent: resolvedAgent, resume });
+      return await copilotkit.value.runAgent({
+        agent: resolvedAgent,
+        resume,
+        ...(runId === undefined ? {} : { runId }),
+      });
     } catch (err) {
       console.error(
         "[CopilotKit] useInterrupt resolve: runAgent rejected; clearing pending + rethrowing",
@@ -269,12 +348,15 @@ export function useInterrupt<TValue = unknown, TResult = never>(
 
     const resolvedAgent = agent.value;
     if (!resolvedAgent) return;
+    if (abandonIfThreadChanged(resolvedAgent)) return;
 
     if (current.kind === "legacy") {
       const interruptEventValue = current.event.value;
+      const runId = legacyRunId;
       try {
         return await copilotkit.value.runAgent({
           agent: resolvedAgent,
+          ...(runId === undefined ? {} : { runId }),
           forwardedProps: {
             command: {
               resume: payload,
@@ -306,6 +388,9 @@ export function useInterrupt<TValue = unknown, TResult = never>(
   const cancel: InterruptCancelFn = async (interruptId?) => {
     const current = pending.value;
     if (!current) return;
+
+    const currentAgent = agent.value;
+    if (currentAgent && abandonIfThreadChanged(currentAgent)) return;
 
     if (current.kind === "legacy") {
       // Legacy interrupts have no cancel semantics; dismiss without resuming.


### PR DESCRIPTION
Fixes OSS-1131

## Problem

An interrupted thread could become permanently unusable, with no error surface at all.

The interrupt hooks captured an interrupt into a closure variable — on `onCustomEvent` for the legacy `on_interrupt` path, on `onRunFinishedEvent` for the standard path — and committed it to state only inside `onRunFinalized`. On the `connect` path that callback runs in the rxjs `finalize()` of a long-lived socket stream, so it fires at socket teardown rather than once per replayed run. A reconnect therefore delivered the replayed interrupt and surfaced nothing, and effect cleanup then called `interruptState.clear()`.

The Intelligence gateway does replay: `connect` passes `last_seen_event_id`, and `RunHandler.connectAgent` clears the cursor on a fresh thread restore to request a full history. The event arrived. The hook dropped it.

There was nothing to fall back to:

- `AbstractAgent` records `agent.pendingInterrupts` on every `RUN_FINISHED`, on both the run and connect pipelines. `useInterrupt` never read it.
- That record exists only for **standard** interrupts. A legacy `on_interrupt` interrupt was stored nowhere durable, so the legacy path — the one every CLI starter takes — had no recovery path at all.
- `AbstractAgent.onInitialize` throws `Thread has N pending interrupt(s) not addressed by resume` when that array is stale, so the thread then rejects every later run.

## Change

1. **Commit on `onRunFinishedEvent`**, so the connect stream's lifecycle no longer gates the UI. `onRunFinalized` stays as the fallback for a stream that ends without a `RUN_FINISHED` event; when `RUN_FINISHED` did arrive, the commit already ran and the fallback finds nothing.
2. **Seed on subscribe** from what the client already knows the thread is waiting on, so a mount, a remount or a reconnect surfaces a gate whose event arrived before the subscription existed.
3. **Record legacy interrupts durably** — new internal `ɵrecordLegacyInterrupt` / `ɵreadLegacyInterrupt` / `ɵclearLegacyInterrupt` in `@copilotkit/core`, a `WeakMap` keyed by agent that mirrors what `pendingInterrupts` gives the standard path. It carries the raising run's id too, so a recovered legacy gate resumes against the right run. The record is dropped when a new run starts, when a run fails, and when a legacy gate is dismissed or expires.
4. **Stop discarding state in cleanup** while the agent still records a gate.

Applied across React, Vue and Angular — the mechanism was identical in all three. Angular already seeded standard interrupts from `agent.pendingInterrupts` but still committed at finalize, so it had the connect-path half of the bug and none of the legacy half.

## Testing

Verified in a worktree with its own full `pnpm install` and freshly built workspace `dist` output, so these are clean numbers rather than shared-checkout noise. Baselines are the same commands with the eight changed files checked out from `origin/main`.

### Whole-package suites

| Package | Baseline (`origin/main`) | With this change | Delta |
| -- | -- | -- | -- |
| `@copilotkit/core` | 69 files, 830 passed | 69 files, **834 passed** | +4 |
| `@copilotkit/react-core` | 138 files passed / 2 failed, 1583 passed / 7 failed | same files, **1590 passed** / 7 failed | +7 |
| `@copilotkit/vue` | 104 files, 1103 passed | 104 files, **1108 passed** | +5 |
| `@copilotkit/angular` | 51 files, 328 passed / 1 skipped | 51 files, **332 passed** / 1 skipped | +4 |

+20 tests, all passing, no test moved from pass to fail. react-core's 7 failures are the pre-existing `pinToSend` jsdom layout tests, identical before and after.

### The new tests

`@copilotkit/core` — `src/__tests__/interrupt-state.test.ts`: no record for a fresh agent, read-back of a record, per-agent isolation, clearing.

`@copilotkit/react-core` — `src/v2/hooks/__tests__/use-interrupt.test.tsx`:

```
 ✓ recovery after a lost event or a reconnect > shows a standard gate from RUN_FINISHED on a stream that never finalizes
 ✓ recovery after a lost event or a reconnect > shows a legacy gate from RUN_FINISHED on a stream that never finalizes
 ✓ recovery after a lost event or a reconnect > seeds a standard gate from agent.pendingInterrupts on mount
 ✓ recovery after a lost event or a reconnect > recovers a legacy gate on remount
 ✓ recovery after a lost event or a reconnect > resumes a recovered legacy gate with the run that raised it
 ✓ recovery after a lost event or a reconnect > forgets a legacy gate once a new run starts
 ✓ recovery after a lost event or a reconnect > forgets a legacy gate once it is dismissed
```

The connect-path requirement is covered specifically: the two "never finalizes" tests fire `onRunFinishedEvent` and never fire `onRunFinalized`.

`@copilotkit/vue` — 5 equivalents. `@copilotkit/angular` — 4 equivalents in `src/lib/interrupt.spec.ts`.

### Mutation checks

Every new test was proved to fail without the fix it covers. Each mutation was applied to a pristine copy of the file, so no two mutations mask each other.

| Package | Mutation | Result |
| -- | -- | -- |
| react-core | stop committing at `onRunFinishedEvent` | the 2 "never finalizes" tests fail (2 failed / 40 passed) |
| react-core | remove the seeding block | the 3 recovery tests fail (3 failed / 39 passed) |
| react-core | remove every `ɵclearLegacyInterrupt` call | the 2 "forgets" tests fail (2 failed / 40 passed) |
| vue | drop the `commit()` call | the 2 "never finalizes" tests fail |
| vue | drop the seeding | the 2 recovery tests fail |
| vue | drop `ɵclearLegacyInterrupt` | "forgets a legacy gate once a new run starts" fails |
| angular | drop the `commit()` call | the 2 "never finalizes" tests fail |
| angular | drop the legacy seed | "restores an unresolved legacy interrupt when reconnecting" fails |
| angular | drop `ɵclearLegacyInterrupt` | "forgets a legacy interrupt once a new run starts" fails |

### Typecheck, lint, format

- `tsc --noEmit`: **0 errors** for `core`, `react-core` and `angular`. `vue` needs `vue-tsc` (raw `tsc` cannot resolve `.vue` SFCs): `vue-tsc --noEmit` reports **0 errors**.
- `oxlint` on all eight changed files: **0 warnings, 0 errors**.
- Formatted with `oxfmt`.

## Residual gap, not addressed here

`agent.pendingInterrupts` is only ever corrected by an event that arrives. Nothing can ask the server what a thread is waiting on: `handle-connect.ts` attaches a live stream and carries no snapshot, and `packages/core/src/threads.ts` has no reference to interrupts. Separately, `run` mode joins the channel with no cursor while only `connect` mode sends `last_seen_event_id`, so a graph that interrupts before the browser finishes joining has no client-side way to request a replay. That needs its own issue if these fixes prove insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interrupt recovery when runs finish without finalization events or events are replayed.
  * Restored pending interrupts after reconnecting, remounting, or missed events.
  * Resumed interruptions against the originating run rather than the connection’s run.
  * Scoped interrupt prompts and cleanup to the correct thread and agent, preventing stale prompts or responses after switching.
  * Ensured legacy interrupt prompts clear after new runs, dismissal, resolution, or expiration.
* **Tests**
  * Added recovery and isolation coverage across Angular, React, and Vue integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->