### PR TITLE
fix(react-core): name the agent on CopilotKitProvider, warn when threads meet single-route

### DIFF
--- a/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
+++ b/packages/react-core/src/__tests__/threadid-propagation.contract.test.tsx
@@ -12,6 +12,7 @@ import {
 
 vi.mock("../v2/context", () => ({
   useCopilotKit: vi.fn(),
+  useDefaultAgentId: vi.fn(() => undefined),
 }));
 
 const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;

--- a/packages/react-core/src/v2/components/chat/CopilotChat.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChat.tsx
@@ -30,7 +30,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useCopilotKit, useLicenseContext } from "../../context";
+import {
+  useCopilotKit,
+  useDefaultAgentId,
+  useLicenseContext,
+} from "../../context";
 import { InlineFeatureWarning } from "../../components/license-warning-banner";
 import type { AbstractAgent } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
@@ -105,8 +109,9 @@ export function CopilotChat({
   const existingConfig = useCopilotChatConfiguration();
 
   // Apply priority: props > existing config > defaults
+  const providerAgentId = useDefaultAgentId();
   const resolvedAgentId =
-    agentId ?? existingConfig?.agentId ?? DEFAULT_AGENT_ID;
+    agentId ?? existingConfig?.agentId ?? providerAgentId ?? DEFAULT_AGENT_ID;
   const providedThreadId = threadId ?? existingConfig?.threadId;
   const baseThreadId = useMemo(
     () => providedThreadId ?? randomUUID(),

--- a/packages/react-core/src/v2/components/chat/CopilotThreadsDrawer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotThreadsDrawer.tsx
@@ -31,6 +31,7 @@ import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 import { useThreads } from "../../hooks/use-threads";
 import type { Thread } from "../../hooks/use-threads";
 import { useLicenseContext } from "../../providers/CopilotKitProvider";
+import { useDefaultAgentId } from "../../context";
 import { useCopilotChatConfiguration } from "../../providers/CopilotChatConfigurationProvider";
 
 /**
@@ -264,7 +265,9 @@ export function CopilotThreadsDrawer({
   // `threads` feature) surfaces the locked view.
   const licensePending = status === null;
 
-  const resolvedAgentId = agentId ?? configuration?.agentId ?? DEFAULT_AGENT_ID;
+  const providerAgentId = useDefaultAgentId();
+  const resolvedAgentId =
+    agentId ?? configuration?.agentId ?? providerAgentId ?? DEFAULT_AGENT_ID;
   const activeThreadId = configuration?.threadId ?? null;
 
   // While unlicensed, skip the thread fetch entirely: the element shows only

--- a/packages/react-core/src/v2/components/chat/__tests__/copilot-chat-throttle.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/copilot-chat-throttle.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../../hooks/use-agent", () => ({
 
 vi.mock("../../../context", () => ({
   useCopilotKit: vi.fn(),
+  useDefaultAgentId: vi.fn(() => undefined),
   useLicenseContext: vi.fn(() => ({
     checkFeature: () => true,
   })),

--- a/packages/react-core/src/v2/context.ts
+++ b/packages/react-core/src/v2/context.ts
@@ -63,3 +63,23 @@ export const LicenseContext = createContext<LicenseContextValue>({
 
 export const useLicenseContext = (): LicenseContextValue =>
   useContext(LicenseContext);
+
+// Provider-level default agent id, published by `<CopilotKitProvider agentId>`.
+//
+// This is a context of its own rather than a `CopilotChatConfigurationProvider`
+// rendered at the root, because that provider also owns a thread: it resolves a
+// threadId (minting a UUID when none is given) and the top-most one owns the
+// imperative active-thread override. Rendering it around the whole application
+// would hand every `<CopilotChat>` the same inherited threadId, so two sibling
+// chats would share one transcript. A bare string context carries the agent
+// default and nothing else.
+//
+// It is the LAST fallback before `DEFAULT_AGENT_ID`, so an explicit `agentId`
+// argument, a `<CopilotChat agentId>`, and a `<CopilotChatConfigurationProvider
+// agentId>` all still win.
+export const CopilotKitAgentIdContext = createContext<string | undefined>(
+  undefined,
+);
+
+export const useDefaultAgentId = (): string | undefined =>
+  useContext(CopilotKitAgentIdContext);

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-stability.test.tsx
@@ -13,6 +13,7 @@ import {
 // Mock the CopilotKit context to control copilotkit state directly
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
+  useDefaultAgentId: vi.fn(() => undefined),
 }));
 
 const mockUseCopilotKit = useCopilotKit as ReturnType<typeof vi.fn>;

--- a/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-agent-throttle.test.tsx
@@ -13,6 +13,7 @@ import type { RunAgentInput } from "@ag-ui/client";
 
 vi.mock("../../context", () => ({
   useCopilotKit: vi.fn(),
+  useDefaultAgentId: vi.fn(() => undefined),
 }));
 
 vi.mock("../../providers/CopilotChatConfigurationProvider", () => ({

--- a/packages/react-core/src/v2/hooks/use-agent.tsx
+++ b/packages/react-core/src/v2/hooks/use-agent.tsx
@@ -1,4 +1,4 @@
-import { useCopilotKit } from "../context";
+import { useCopilotKit, useDefaultAgentId } from "../context";
 import { useMemo, useEffect, useReducer, useRef, useState } from "react";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 import type { AbstractAgent } from "@ag-ui/client";
@@ -203,7 +203,9 @@ export function useAgent({
   // <CopilotChat agentId="..."> subtree resolves to 'default' and throws once
   // the runtime has synced only a non-default agent (#5533).
   const chatConfig = useCopilotChatConfiguration();
-  const resolvedAgentId = agentId ?? chatConfig?.agentId ?? DEFAULT_AGENT_ID;
+  const providerAgentId = useDefaultAgentId();
+  const resolvedAgentId =
+    agentId ?? chatConfig?.agentId ?? providerAgentId ?? DEFAULT_AGENT_ID;
 
   const { copilotkit } = useCopilotKit();
   // Read the provider-level default so it appears in the effect's dep array.

--- a/packages/react-core/src/v2/hooks/use-suggestions.tsx
+++ b/packages/react-core/src/v2/hooks/use-suggestions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Suggestion } from "@copilotkit/core";
-import { useCopilotKit } from "../context";
+import type { Suggestion } from "@copilotkit/core";
+import { useCopilotKit, useDefaultAgentId } from "../context";
 import { useCopilotChatConfiguration } from "../providers/CopilotChatConfigurationProvider";
 import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 
@@ -20,9 +20,10 @@ export function useSuggestions({
 }: UseSuggestionsOptions = {}): UseSuggestionsResult {
   const { copilotkit } = useCopilotKit();
   const config = useCopilotChatConfiguration();
+  const providerAgentId = useDefaultAgentId();
   const resolvedAgentId = useMemo(
-    () => agentId ?? config?.agentId ?? DEFAULT_AGENT_ID,
-    [agentId, config?.agentId],
+    () => agentId ?? config?.agentId ?? providerAgentId ?? DEFAULT_AGENT_ID,
+    [agentId, config?.agentId, providerAgentId],
   );
 
   const [suggestions, setSuggestions] = useState<Suggestion[]>(() => {

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
 } from "react";
 import { DEFAULT_AGENT_ID, randomUUID } from "@copilotkit/shared";
+import { useDefaultAgentId } from "../context";
 // Import from the tailwind-free leaf module (not ../lib/slots, which pulls
 // tailwind-merge) so this provider stays lean in the headless entry (issue #4893).
 import { useShallowStableRef } from "../lib/shallow-stable-ref";
@@ -196,7 +197,12 @@ export const CopilotChatConfigurationProvider: React.FC<
     [stableLabels, parentConfig?.labels],
   );
 
-  const resolvedAgentId = agentId ?? parentConfig?.agentId ?? DEFAULT_AGENT_ID;
+  // `<CopilotKitProvider agentId>` is the last fallback before the global
+  // default, so a provider-level agent reaches every chat that does not name
+  // one of its own.
+  const providerAgentId = useDefaultAgentId();
+  const resolvedAgentId =
+    agentId ?? parentConfig?.agentId ?? providerAgentId ?? DEFAULT_AGENT_ID;
 
   // A threadId prop is "authoritative" (caller-chosen) only when it is present
   // AND not explicitly flagged non-explicit. The v1 `<CopilotKit>` bridge pipes

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -16,7 +16,11 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 // Context extracted to ../context.ts for cross-platform reuse (React Native)
-import { CopilotKitContext, LicenseContext } from "../context";
+import {
+  CopilotKitAgentIdContext,
+  CopilotKitContext,
+  LicenseContext,
+} from "../context";
 import type { CopilotKitContextValue } from "../context";
 export type { CopilotKitContextValue } from "../context";
 export { CopilotKitContext, useLicenseContext } from "../context";
@@ -139,6 +143,15 @@ export interface CopilotKitProviderProps {
    */
   licenseToken?: string;
   properties?: Record<string, unknown>;
+  /**
+   * The id of the agent every `<CopilotChat>` under this provider talks to,
+   * unless a chat names its own with the `agentId` prop.
+   *
+   * This is the v2 replacement for the v1 `<CopilotKit agent="...">` prop. Set
+   * it here and you never need the v1 compatibility provider just to name an
+   * agent. Defaults to `"default"`.
+   */
+  agentId?: string;
   useSingleEndpoint?: boolean;
   agents__unsafe_dev_only?: Record<string, AbstractAgent>;
   selfManagedAgents?: Record<string, AbstractAgent>;
@@ -300,6 +313,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   humanInTheLoop,
   openGenerativeUI,
   enableInspector,
+  agentId,
   useSingleEndpoint,
   onError,
   a2ui,
@@ -1046,7 +1060,16 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
             />
           )}
           <CopilotKitInspectorContextProvider value={inspectorContextValue}>
-            {children}
+            {/*
+              Publish the provider-level agent default. This is a bare string
+              context, NOT a `CopilotChatConfigurationProvider`: that provider
+              also owns a thread, so wrapping the application in one would give
+              every descendant chat the same inherited threadId. See the
+              `CopilotKitAgentIdContext` comment in `../context`.
+            */}
+            <CopilotKitAgentIdContext.Provider value={agentId}>
+              {children}
+            </CopilotKitAgentIdContext.Provider>
             {shouldRenderInspector ? (
               <CopilotKitInspector
                 core={copilotkit}

--- a/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
+++ b/packages/react-core/src/v2/providers/__tests__/CopilotKitProvider.test.tsx
@@ -7,9 +7,14 @@ import { z } from "zod";
 import { ToolCallStatus } from "@copilotkit/core";
 import type { ReactFrontendTool } from "../../types/frontend-tool";
 import type { ReactHumanInTheLoop } from "../../types/human-in-the-loop";
+import { DEFAULT_AGENT_ID } from "@copilotkit/shared";
 import { HttpAgent } from "@ag-ui/client";
 import { defineWebInspector } from "@copilotkit/web-inspector";
 import { CopilotKitProvider, useCopilotKit } from "../CopilotKitProvider";
+import {
+  CopilotChatConfigurationProvider,
+  useCopilotChatConfiguration,
+} from "../CopilotChatConfigurationProvider";
 import { stubWindowLocation } from "../../../v1-deprecated/test-helpers/stub-window-location";
 
 // Mock console methods
@@ -927,6 +932,147 @@ describe("CopilotKitProvider", () => {
       );
 
       expect(capturedCopilotkit!.runtimeTransport).toBe("auto");
+    });
+  });
+
+  // OSS-1133: naming the agent used to require the v1 `<CopilotKit agent>`
+  // wrapper, because the v2 provider carried no agent prop at all.
+  describe("agentId", () => {
+    it("becomes the default agent for a chat that does not name one", () => {
+      const { result } = renderHook(() => useCopilotChatConfiguration(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider agentId="my_agent">
+            <CopilotChatConfigurationProvider>
+              {children}
+            </CopilotChatConfigurationProvider>
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current?.agentId).toBe("my_agent");
+    });
+
+    it("lets a nested chat configuration override it", () => {
+      const { result } = renderHook(() => useCopilotChatConfiguration(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider agentId="provider_agent">
+            <CopilotChatConfigurationProvider agentId="chat_agent">
+              {children}
+            </CopilotChatConfigurationProvider>
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current?.agentId).toBe("chat_agent");
+    });
+
+    it("leaves the global default in place when the prop is omitted", () => {
+      const { result } = renderHook(() => useCopilotChatConfiguration(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider>
+            <CopilotChatConfigurationProvider>
+              {children}
+            </CopilotChatConfigurationProvider>
+          </CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current?.agentId).toBe(DEFAULT_AGENT_ID);
+    });
+
+    it("publishes no chat configuration of its own", () => {
+      const { result } = renderHook(() => useCopilotChatConfiguration(), {
+        wrapper: ({ children }) => (
+          <CopilotKitProvider agentId="my_agent">{children}</CopilotKitProvider>
+        ),
+      });
+
+      expect(result.current).toBeNull();
+    });
+
+    it("follows a changed agentId", () => {
+      let captured: string | undefined;
+
+      function Collector() {
+        captured = useCopilotChatConfiguration()?.agentId;
+        return null;
+      }
+
+      const { rerender } = render(
+        <CopilotKitProvider agentId="first_agent">
+          <CopilotChatConfigurationProvider>
+            <Collector />
+          </CopilotChatConfigurationProvider>
+        </CopilotKitProvider>,
+      );
+      expect(captured).toBe("first_agent");
+
+      rerender(
+        <CopilotKitProvider agentId="second_agent">
+          <CopilotChatConfigurationProvider>
+            <Collector />
+          </CopilotChatConfigurationProvider>
+        </CopilotKitProvider>,
+      );
+      expect(captured).toBe("second_agent");
+    });
+
+    // The agent default must NOT arrive through a root
+    // `CopilotChatConfigurationProvider`: that provider also resolves a
+    // threadId, so every chat under it would inherit one thread and two
+    // sibling chats would share a transcript.
+    describe("thread isolation", () => {
+      beforeEach(async () => {
+        const { randomUUID } = await import("@copilotkit/shared");
+        let n = 0;
+        vi.mocked(randomUUID).mockImplementation(() => `thread-uuid-${++n}`);
+      });
+
+      afterEach(async () => {
+        const { randomUUID } = await import("@copilotkit/shared");
+        vi.mocked(randomUUID).mockImplementation(() => "mock-thread-id");
+      });
+
+      function renderSiblingChats(agentId?: string) {
+        const threadIds: (string | undefined)[] = [];
+
+        function Collector() {
+          threadIds.push(useCopilotChatConfiguration()?.threadId);
+          return null;
+        }
+
+        // Stands in for what `<CopilotChat>` renders: its own configuration
+        // provider with no threadId prop.
+        function Chat() {
+          return (
+            <CopilotChatConfigurationProvider>
+              <Collector />
+            </CopilotChatConfigurationProvider>
+          );
+        }
+
+        render(
+          <CopilotKitProvider agentId={agentId}>
+            <Chat />
+            <Chat />
+          </CopilotKitProvider>,
+        );
+
+        return threadIds;
+      }
+
+      it("gives sibling chats their own thread when agentId is set", () => {
+        const threadIds = renderSiblingChats("my_agent");
+
+        expect(threadIds).toHaveLength(2);
+        expect(new Set(threadIds).size).toBe(2);
+      });
+
+      it("matches the no-agentId tree", () => {
+        const threadIds = renderSiblingChats();
+
+        expect(new Set(threadIds).size).toBe(2);
+      });
     });
   });
 

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -23,40 +23,44 @@ mapping:
 
 <FrontendOnly frontend="react">
 
-| Provider                                 | `useSingleEndpoint` | Transport                                 | Needs handler | Route file                      |
-| ---------------------------------------- | ------------------- | ----------------------------------------- | ------------- | ------------------------------- |
-| `<CopilotKitProvider>`                   | omitted             | `auto` — detected from `/info`            | either        | matches the handler             |
-| `<CopilotKit>`                           | omitted             | `single` in released versions — see below | single-route  | `route.ts`, `POST`              |
-| `<CopilotKit>` or `<CopilotKitProvider>` | `{true}`            | `single`                                  | single-route  | `route.ts`, `POST`              |
-| `<CopilotKit>` or `<CopilotKitProvider>` | `{false}`           | `rest`                                    | multi-route   | `[[...slug]]/route.ts`, 4 verbs |
+| Provider                                 | `useSingleEndpoint` | Transport                          | Needs handler | Route file                      |
+| ---------------------------------------- | ------------------- | ---------------------------------- | ------------- | ------------------------------- |
+| `<CopilotKit>` or `<CopilotKitProvider>` | omitted             | `auto` — detected from the Runtime | either        | matches the handler             |
+| `<CopilotKit>` or `<CopilotKitProvider>` | `{true}`            | `single`                           | single-route  | `route.ts`, `POST`              |
+| `<CopilotKit>` or `<CopilotKitProvider>` | `{false}`           | `rest`                             | multi-route   | `[[...slug]]/route.ts`, 4 verbs |
 
 `<CopilotKit>` is a backward-compatible wrapper that renders
 `<CopilotKitProvider>` internally. Both are exported from
-`@copilotkit/react-core/v2`, but they do not treat an omitted
-`useSingleEndpoint` the same way, and that difference is what decides whether
-your app connects:
-
-- On `<CopilotKitProvider>`, omitting the prop gives `auto`: the client probes
-  `GET /info` and matches whichever mode your Runtime serves.
-- On `<CopilotKit>`, every released version still pins the flag to `true`
-  internally, so omitting it selects the **single-route** transport regardless
-  of what your Runtime serves. Against a multi-route handler that 404s.
-
-**So: with `<CopilotKit>` and a multi-route handler, pass
-`useSingleEndpoint={false}` explicitly.** The pin is removed on `main` and will
-ship in a future release, at which point the prop stays correct but stops being
-required — passing it is the forward-compatible choice either way.
+`@copilotkit/react-core/v2`, and since 1.70.2 both treat an omitted
+`useSingleEndpoint` the same way: the transport is `auto`, so the client probes
+the Runtime and matches whichever mode it serves.
 
 <Callout type="warn" title="Pinning the wrong mode 404s silently">
   Passing `useSingleEndpoint={true}` to a multi-route Runtime sends an envelope
   that matches no route, so the Runtime 404s while `GET /info` still returns 200
-  and the app looks connected. The same thing happens when you *omit* the prop
-  on `<CopilotKit>` in a released version, because that is what the pin above
-  does — the Runtime's error body names the fix in both cases.
+  and the app looks connected. The Runtime's error body names the fix.
+
+Before 1.70.2, `<CopilotKit>` pinned the flag to `true` internally, so omitting
+it selected the single-route transport and 404'd against a multi-route handler.
+On those versions, pass `useSingleEndpoint={false}` explicitly.
+
 </Callout>
 
 Both ship from the same package entry point, so moving between them is an import
-change, not a migration.
+change, not a migration. One prop does get renamed: `<CopilotKit>` names the
+agent with `agent`, and `<CopilotKitProvider>` names it with `agentId`.
+
+```tsx
+// v1 wrapper
+<CopilotKit runtimeUrl="/api/copilotkit" agent="my_agent" useSingleEndpoint={false}>
+
+// v2 provider
+<CopilotKitProvider runtimeUrl="/api/copilotkit" agentId="my_agent">
+```
+
+You can also name the agent per chat with `<CopilotChat agentId="my_agent">`, or
+for a subtree with `<CopilotChatConfigurationProvider agentId="my_agent">`. A
+provider-level `agentId` is the default that those two override.
 
 </FrontendOnly>
 

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/doctest.json
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/doctest.json
@@ -4,7 +4,7 @@
       "@copilotkit/runtime@1.68.3",
       "@ag-ui/client@0.0.57",
       "@ag-ui/core@0.0.57",
-      "@ag-ui/mastra",
+      "@ag-ui/mastra@1.1.2",
       "@mastra/client-js",
       "next"
     ]

--- a/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
@@ -3,10 +3,27 @@ title: "CopilotKit"
 description: "The CopilotKit provider component, wrapping your application."
 ---
 
-<Callout type="info">
-  This provider is shared across v1 and v2 APIs. In v2 docs, import it from
-  `@copilotkit/react-core/v2`.
+<Callout type="info" title="This is the v1 provider, re-exported for back-compat">
+  `<CopilotKit>` is the v1 provider. It is re-exported from
+  `@copilotkit/react-core/v2` so that a v1 application keeps working after the
+  import path changes, and it renders `<CopilotKitProvider>` internally. **The
+  v2 provider is `<CopilotKitProvider>`** — reach for that one in new v2 code.
 </Callout>
+
+The two are not aliases: they name the agent with different props.
+
+|                | v1 `<CopilotKit>`  | v2 `<CopilotKitProvider>` |
+| -------------- | ------------------ | ------------------------- |
+| Name the agent | `agent="my_agent"` | `agentId="my_agent"`      |
+
+You can also name the agent per chat with `<CopilotChat agentId="my_agent">`, or
+for a subtree with `<CopilotChatConfigurationProvider agentId="my_agent">`. Both
+of those override the provider-level default. See [Provider and handler
+pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
+
+Both providers treat an omitted `useSingleEndpoint` the same way: the transport
+is negotiated from the Runtime info response. Versions before 1.70.2 pinned
+`<CopilotKit>` to the single-route transport.
 
 This component will typically wrap your entire application (or a sub-tree of your application where you want to have a copilot). It provides the copilot context to all other components and hooks.
 


### PR DESCRIPTION
Fixes OSS-1133

Rebased onto `main`. The branch was 205 commits behind, and two of its three changes did not survive contact with current `main`. Both are corrected here, so this description replaces the original one rather than adding to it.

## What changed on `main` under this branch

**The single-route warning is gone.** The branch added a `useThreads` development warning on the premise that "the thread routes live outside the single-route envelope, so the list stays empty". That premise is no longer true. `main` now carries thread, memory, and annotation operations through the single-route endpoint with a `resource/request` envelope (`fetch-handler.ts:405`), advertises it as `singleRoute.resourceOperations` (`get-runtime-info.ts:177`), and the client reads the thread endpoints from there (`agent-registry.ts:1367`). A current single-route runtime serves threads, so the warning fired on a working configuration.

Narrowing it does not rescue it either: when the transport is `single` and the endpoints are still unavailable, the cause is a missing Intelligence or thread backend, not the transport — the client cannot tell those apart. The hook already surfaces the knowable fact through `threadEndpointsError`. The warning, its three tests, and the `useThreads.mdx` callout are dropped; `use-threads.tsx` and its test file are now byte-identical to `main`.

**The docs' `useSingleEndpoint` claim is stale.** Both pages said released versions of `<CopilotKit>` pin the flag to `true`. `dc73af1dc4` removed that pin and is an ancestor of the `v1.70.2` release, which is what `npm` serves today. Corrected on both pages.

## What this PR does

### `agentId` on `CopilotKitProvider`

```tsx
<CopilotKitProvider runtimeUrl="/api/copilotkit" agentId="my_agent">
```

`CopilotKitProvider` carries no agent prop at all, so the only way to name an agent at the provider level is the v1 compatibility component. The reporter had to read the installed type definitions to find that `agentId` lives on `<CopilotChat>` instead.

The prop publishes a bare string context (`CopilotKitAgentIdContext` in `src/v2/context.ts`) that is the **last** fallback before `DEFAULT_AGENT_ID`. Five resolution sites consult it: `CopilotChatConfigurationProvider` (which covers everything nested inside a chat), `CopilotChat`, `CopilotThreadsDrawer`, `useAgent`, and `useSuggestions`. An explicit `agentId` still wins at every one of them.

### Why not a root `CopilotChatConfigurationProvider`

The original branch published the default by rendering a `CopilotChatConfigurationProvider` at the root. That provider also owns a thread: it resolves a `threadId` (minting a UUID when none is given), and the top-most one owns the imperative active-thread override. Wrapping the application in one hands every descendant chat the same inherited `threadId`, so two sibling chats share a transcript.

Measured on the original branch with `randomUUID` mocked to increment:

| | sibling chat 1 | sibling chat 2 |
| -- | -- | -- |
| `<CopilotKitProvider>` | `uuid-1` | `uuid-2` |
| `<CopilotKitProvider agentId="my_agent">` | `uuid-1` | `uuid-1` |

A bare string context carries the agent default and nothing else, so the second row now matches the first.

### Docs

- `reference/components/CopilotKit.mdx`: the callout now says it is the v1 provider and points at `CopilotKitProvider`, followed by the agent-prop table. The `useSingleEndpoint` row is replaced by a sentence saying both providers negotiate the transport, with the pre-1.70.2 behavior named as history.
- `docs/backend/runtime-endpoints.mdx`: the prop rename (`agent` → `agentId`), and the transport table and its surrounding prose corrected for the removed pin.
- `reference/hooks/useThreads.mdx`: back to `main` (see above).

I did not rewrite the integration quickstarts that show `<CopilotKit agent=...>`. They already carry a "Which provider goes with which handler?" callout and pass `useSingleEndpoint={false}` explicitly, so they are correct as written; swapping the provider in all of them is a docs sweep of its own.

## Testing

This worktree has its own full `pnpm install` and a rebuilt workspace `dist`, so these numbers come from a clean environment on the rebased tree.

### Whole-package suite

Both rows are real runs in this worktree on the same rebase base, taken by checking `main`'s `packages/react-core/src` in and out around the run:

| | Test files | Tests | Failed |
| -- | -- | -- | -- |
| `origin/main` (31d0cda168) | 146 passed | 1639 | 0 |
| This branch | 146 passed | **1646** | 0 |

Exactly +7. Comparing the two runs' JSON reports file by file, `CopilotKitProvider.test.tsx` (39 → 46) is the only file whose count moved.

### The 7 new tests

```
✓ CopilotKitProvider > agentId > becomes the default agent for a chat that does not name one
✓ CopilotKitProvider > agentId > lets a nested chat configuration override it
✓ CopilotKitProvider > agentId > leaves the global default in place when the prop is omitted
✓ CopilotKitProvider > agentId > publishes no chat configuration of its own
✓ CopilotKitProvider > agentId > follows a changed agentId
✓ CopilotKitProvider > agentId > thread isolation > gives sibling chats their own thread when agentId is set
✓ CopilotKitProvider > agentId > thread isolation > matches the no-agentId tree
```

### Mutation checks

| Mutation | Result |
| -- | -- |
| drop the `providerAgentId` fallback in `CopilotChatConfigurationProvider` | `becomes the default agent for a chat that does not name one` and `follows a changed agentId` fail (2 failed / 44 passed) |
| publish the default through a root `CopilotChatConfigurationProvider` instead of the bare context | `publishes no chat configuration of its own` and both `thread isolation` tests fail (3 failed / 43 passed) |

The second mutation is the original branch's implementation, so the thread-isolation tests fail against the code they were written to catch.

### Build, typecheck, lint, format, MDX

- `nx build @copilotkit/react-core --skip-nx-cache`: succeeds. `context-singleton-preflight: OK — src/v2/context.ts bundled only into 4 allowed target(s)` — the new `CopilotChatConfigurationProvider` → `../context` import does not add a bundle target.
- `tsc --noEmit -p packages/react-core/tsconfig.json`: 0 errors.
- `oxlint` on the 7 changed source files: 0 errors, and the same 9 warnings before and after (measured by checking `main`'s copies into the same tree).
- Formatted with `oxfmt`.
- Both changed `.mdx` files compile through `@mdx-js/mdx` with `remark-gfm`, and all 9 string assertions in `docs-render.test.ts` against `runtime-endpoints.mdx` still hold.
- `nx test @copilotkit/react-native --skip-nx-cache`: 26 passed, 0 failed (it consumes `react-core`).

## Unrelated CI fix carried here

`doc-tests` went red on this branch for a reason that has nothing to do with it. `@ag-ui/mastra@1.1.3` was published on 2026-09-08 at 23:19:48Z and raised its peer range for `@ag-ui/client`/`@ag-ui/core` to `>=0.0.58`. The Mastra doctest pins both at `0.0.57` and left the adapter floating, so npm takes 1.1.3 and the install fails with `ERESOLVE`. Every other open PR's `doc-tests` run that passed completed before that timestamp — the latest at 23:13:15Z — and this branch's run at 23:45:20Z is the first one after it, so the break lands on every PR from here.

The second commit pins the adapter at `1.1.2`, whose peer range (`>=0.0.44`) the existing pins already satisfy. Bumping the client and core instead does not work: `@copilotkit/runtime@1.68.3` hard-depends on `@ag-ui/client@0.0.57`, so raising the snippet to `0.0.59` puts two copies of `AbstractAgent` in the tree and the snippet fails `tsc --noEmit` with `TS2769`. Measured locally both ways — version bump 21/22, adapter pin **22/22**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provider-level default agent selection through the `agentId` prop on `<CopilotKitProvider>`.
  - Descendant chats, threads, suggestions, and agent hooks now inherit the provider’s agent unless overridden locally.
  - Preserved separate thread identities for sibling chats.

- **Documentation**
  - Updated provider migration guidance, agent naming, and automatic endpoint detection behavior.
  - Added examples for provider, subtree, and per-chat agent configuration.

- **Chores**
  - Pinned the Mastra integration example dependency to version 1.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->