### PR TITLE
feat(web-inspector): the launcher's two overlays become one island

### DIFF
--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -78,8 +78,9 @@ const EDGE_MARGIN = 16;
  * The capsule is pinned to `--cpk-launcher-island` rather than sized by its
  * content, so this constant mirrors that token's value rather than a
  * measured text width. It no longer depends on the label, the padding, or
- * the launcher size — it is the same 272 at every point of the size clamp,
- * which is what the two tests either side of `TIGHTEST_FIT` pin down.
+ * the launcher size. The threshold at which neither side has room moves
+ * with the token, which is what the two tests either side of
+ * `TIGHTEST_FIT` pin down.
  */
 const ISLAND_WIDTH = 272;
 
@@ -1660,11 +1661,11 @@ test("with no room the failure is still spoken", async () => {
 });
 
 // The narrowest window a rightward pill fits in: the launcher's own left
-// offset, the mark, its overhang, and the margin the pill keeps from the edge.
-// Widening the pill — as the padding and the second line did — moves this,
-// which is the whole reason ISLAND_WIDTH is a named number.
-const TIGHTEST_FIT =
-  EDGE_MARGIN + LAUNCHER_SIZE + (ISLAND_WIDTH - LAUNCHER_SIZE) + EDGE_MARGIN;
+// offset, the island's own width, and the margin the pill keeps from the
+// edge on the other side. LAUNCHER_SIZE cancels out now that the width is
+// a token rather than content-derived, which is the whole reason
+// ISLAND_WIDTH is a named number.
+const TIGHTEST_FIT = EDGE_MARGIN + ISLAND_WIDTH + EDGE_MARGIN;
 
 test("a window exactly wide enough still opens the pill", async () => {
   const context = await setup();

--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -372,12 +372,14 @@ const pulsing = (inspector: WebInspectorElement): boolean =>
 
 /** The pill on the closed launcher, or null when the launcher is not talking. */
 function pill(inspector: WebInspectorElement): HTMLElement | null {
-  return root(inspector).querySelector<HTMLElement>("[data-cpk-launcher-pill]");
+  return root(inspector).querySelector<HTMLElement>(
+    "[data-cpk-launcher-capsule]",
+  );
 }
 
 /** Which subject the pill names, or null when there is no pill. */
 function pillSubject(inspector: WebInspectorElement): string | null {
-  return pill(inspector)?.getAttribute("data-cpk-launcher-pill") ?? null;
+  return pill(inspector)?.getAttribute("data-cpk-launcher-capsule") ?? null;
 }
 
 /** The pill's first line — the failure class — or null when there is no pill. */
@@ -395,14 +397,14 @@ function lineText(
   line: "heading" | "subline",
 ): string | null {
   const text = pill(inspector)
-    ?.querySelector(`[data-cpk-pill-${line}]`)
+    ?.querySelector(`[data-cpk-capsule-${line}]`)
     ?.textContent?.trim();
   return text === undefined || text === "" ? null : text;
 }
 
 /** Which side the pill grew from, or null when there is no pill. */
 function pillDirection(inspector: WebInspectorElement): string | null {
-  return pill(inspector)?.getAttribute("data-cpk-pill-direction") ?? null;
+  return pill(inspector)?.getAttribute("data-cpk-capsule-direction") ?? null;
 }
 
 /**
@@ -411,7 +413,7 @@ function pillDirection(inspector: WebInspectorElement): string | null {
  * is shown.
  */
 function pillPhase(inspector: WebInspectorElement): string | null {
-  return pill(inspector)?.getAttribute("data-cpk-pill-phase") ?? null;
+  return pill(inspector)?.getAttribute("data-cpk-capsule-phase") ?? null;
 }
 
 /** Whether the pill is actually showing its words. */
@@ -491,7 +493,7 @@ function stubGeometry(options: {
       if (this.classList.contains("console-button")) {
         return box(options.launcherLeft, LAUNCHER_SIZE);
       }
-      if (this.hasAttribute("data-cpk-launcher-pill")) {
+      if (this.hasAttribute("data-cpk-launcher-capsule")) {
         // A clip never changes the layout box, so this is the full width
         // whichever phase the pill is in.
         return box(options.launcherLeft, options.pillWidth);
@@ -1368,7 +1370,8 @@ test("every subject's pill carries the same subline", async () => {
 test("the second line does not make the pill taller than the launcher", async () => {
   const context = await setup();
   const css = stylesheetText(context.inspector);
-  const pillRule = /\.cpk-launcher-pill\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  const pillRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
 
   // Two lines inside an unchanged height: a column, centred, with the pill's
   // height still pinned to the launcher's own diameter. Growing the pill
@@ -1381,9 +1384,9 @@ test("the second line does not make the pill taller than the launcher", async ()
 
   // The two lines are typographically distinct, and the subline recedes.
   const heading =
-    /\.cpk-launcher-pill__heading\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+    /\.cpk-launcher-capsule__heading\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
   const subline =
-    /\.cpk-launcher-pill__subline\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+    /\.cpk-launcher-capsule__subline\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
   expect(heading).toContain("font-size: 12px");
   expect(heading).toContain("line-height: 1.2");
   expect(subline).toContain("font-size: 10.5px");
@@ -1409,7 +1412,7 @@ test("the pill's text is held off its own border and clear of the mark", async (
   for (const direction of ["left", "right"]) {
     const rule =
       new RegExp(
-        `\\.cpk-launcher-pill\\[data-cpk-pill-direction="${direction}"\\]\\s*\\{([\\s\\S]*?)\\}`,
+        `\\.cpk-launcher-capsule\\[data-cpk-capsule-direction="${direction}"\\]\\s*\\{([\\s\\S]*?)\\}`,
       ).exec(css)?.[1] ?? "";
     expect(rule).toContain("calc(var(--cpk-launcher-size) / 2)");
     expect(rule).toContain("calc(var(--cpk-launcher-size) + 12px)");
@@ -1440,7 +1443,7 @@ test("the pill and the launcher share one surface and one edge", async () => {
   expect(buttonRules).toContain("var(--cpk-launcher-face)");
   expect(buttonRules).toContain("var(--cpk-launcher-edge)");
 
-  const pillRules = allBlocks(/\.cpk-launcher-pill\s*\{([\s\S]*?)\}/g);
+  const pillRules = allBlocks(/\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/g);
   expect(pillRules).toContain("var(--cpk-launcher-face)");
   expect(pillRules).toContain("var(--cpk-launcher-edge)");
   expect(pillRules).not.toContain("color-mix");
@@ -1713,7 +1716,7 @@ test("reduced motion shows the pill with no clip animation and the same hold", a
   );
   // Shown by opacity alone, with the clip held open rather than animated.
   expect(reduced).toContain(
-    '.cpk-launcher-pill[data-cpk-pill-phase="holding"]',
+    '.cpk-launcher-capsule[data-cpk-capsule-phase="holding"]',
   );
   expect(reduced).toContain("animation: none");
   expect(reduced).toContain("clip-path: inset(0 0 0 0)");
@@ -1728,7 +1731,7 @@ test("the reveal animates a rectangular clip, never a width or a scale", async (
   for (const direction of ["left", "right"]) {
     const frames =
       new RegExp(
-        `@keyframes\\s+cpk-launcher-pill-${direction}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`,
+        `@keyframes\\s+cpk-launcher-capsule-${direction}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`,
       ).exec(css)?.[1] ?? "";
     expect(frames).toContain("clip-path: inset(");
     expect(frames).toContain("opacity");
@@ -1740,8 +1743,13 @@ test("the reveal animates a rectangular clip, never a width or a scale", async (
   }
 
   // Laid out at full width from the start, so only the visible region moves.
-  const pillRule = /\.cpk-launcher-pill\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
-  expect(pillRule).not.toMatch(/(^|[^-])width\s*:/);
+  // The layout guarantee is that no *keyframe* animates width — the two
+  // `expect(frames).not.toContain("width")` assertions above are the real
+  // guard. A static declared width is what makes the capsule and the drawer
+  // flush by construction.
+  const pillRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  expect(pillRule).toContain("width: var(--cpk-launcher-island)");
   expect(pillRule).not.toContain("transform: scale");
 });
 
@@ -1756,7 +1764,7 @@ test("the revealing edge is the capsule's own rounded end, not a straight wipe",
   for (const direction of ["left", "right"]) {
     const frames =
       new RegExp(
-        `@keyframes\\s+cpk-launcher-pill-${direction}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`,
+        `@keyframes\\s+cpk-launcher-capsule-${direction}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`,
       ).exec(css)?.[1] ?? "";
     const stops = frames.match(/clip-path:[\s\S]*?;/g) ?? [];
     expect(stops).toHaveLength(2);
@@ -1840,7 +1848,8 @@ test("the pill is clickable only while it is on screen", async () => {
   const context = await setup();
   await armConnectionFailure(context);
   const css = stylesheetText(context.inspector);
-  const pillRule = /\.cpk-launcher-pill\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  const pillRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
 
   // During the beat the clip covers the mark alone, and a click target nobody
   // can see over someone else's page is not something to ship. The base rule
@@ -1848,7 +1857,7 @@ test("the pill is clickable only while it is on screen", async () => {
   // back.
   expect(pillRule).toContain("pointer-events: none");
   const visible =
-    /\.cpk-launcher-pill\[data-cpk-pill-phase="opening"\],\s*\.cpk-launcher-pill\[data-cpk-pill-phase="holding"\],\s*\.cpk-launcher-pill\[data-cpk-pill-phase="closing"\]\s*\{([\s\S]*?)\}/.exec(
+    /\.cpk-launcher-capsule\[data-cpk-capsule-phase="opening"\],\s*\.cpk-launcher-capsule\[data-cpk-capsule-phase="holding"\],\s*\.cpk-launcher-capsule\[data-cpk-capsule-phase="closing"\]\s*\{([\s\S]*?)\}/.exec(
       css,
     )?.[1] ?? "";
   expect(visible).toContain("pointer-events: auto");

--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -62,7 +62,7 @@ const THREADS_ERROR_WORDS = "Failed to load threads";
  * The pill's second line: the one string in this feature that appears nowhere
  * else in the product, and the only one that is shown without being spoken.
  */
-const PILL_SUBLINE_WORDS = "Open Inspector for details";
+const PILL_SUBLINE_WORDS = "Click to open Inspector";
 
 /** The launcher's rendered diameter at the suite's viewport. */
 const LAUNCHER_SIZE = 52;
@@ -1717,24 +1717,32 @@ test("the reveal animates a rectangular clip, never a width or a scale", async (
   const context = await setup();
   const css = stylesheetText(context.inspector);
 
-  // The two directions are the same animation with the inset on the other
-  // side, which is what makes choosing a side nearly free.
+  // Four keyframes now, not two: opening and closing are written out
+  // separately per direction rather than one reversed, so the layout
+  // guarantee has to hold for the close as much as for the open — a closing
+  // keyframe that snuck a width or a scale back in would be just as much of
+  // a regression as an opening one.
   for (const direction of ["left", "right"]) {
-    const frames =
-      new RegExp(
-        `@keyframes\\s+cpk-launcher-capsule-${direction}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`,
-      ).exec(css)?.[1] ?? "";
-    expect(frames).toContain("clip-path: inset(");
-    expect(frames).toContain("opacity");
-    // Animating either of these gives up the layout guarantee — `width` forces
-    // a layout on every frame on someone else's page, and a horizontal scale
-    // squashes the mark itself, so the dot and halo would become ellipses.
-    expect(frames).not.toContain("width");
-    expect(frames).not.toContain("scale");
+    for (const name of [
+      `cpk-launcher-island-${direction}`,
+      `cpk-launcher-island-close-${direction}`,
+    ]) {
+      const frames =
+        new RegExp(`@keyframes\\s+${name}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`).exec(
+          css,
+        )?.[1] ?? "";
+      expect(frames).toContain("clip-path: inset(");
+      expect(frames).toContain("opacity");
+      // Animating either of these gives up the layout guarantee — `width` forces
+      // a layout on every frame on someone else's page, and a horizontal scale
+      // squashes the mark itself, so the dot and halo would become ellipses.
+      expect(frames).not.toContain("width");
+      expect(frames).not.toContain("scale");
+    }
   }
 
   // Laid out at full width from the start, so only the visible region moves.
-  // The layout guarantee is that no *keyframe* animates width — the two
+  // The layout guarantee is that no *keyframe* animates width — the four
   // `expect(frames).not.toContain("width")` assertions above are the real
   // guard. A static declared width is what makes the capsule and the drawer
   // flush by construction.
@@ -1749,19 +1757,38 @@ test("the revealing edge is the capsule's own rounded end, not a straight wipe",
   const css = stylesheetText(context.inspector);
 
   // An unrounded inset sweeps a straight vertical line sideways and reads as a
-  // wipe. Rounding BOTH stops of BOTH directions makes it read as an opening —
-  // and a clip-path only interpolates between shapes of the same kind, so a
-  // `round` on one stop alone would stop the reveal animating at all.
+  // wipe. Rounding BOTH stops of BOTH directions — and now of the closing
+  // keyframe as well as the opening one — makes it read as an opening
+  // whichever way it is travelling: a straight-edged close would be exactly
+  // as wrong as a straight-edged open. A clip-path only interpolates between
+  // shapes of the same kind, so a `round` on one stop alone would stop the
+  // reveal animating at all.
+  //
+  // The radius is the island's own token rather than a bare pixel figure,
+  // because this one pair of keyframes now also drives the taller drawer:
+  // a literal that happened to clamp to a circle at the capsule's height
+  // would round the drawer by the wrong amount.
   for (const direction of ["left", "right"]) {
-    const frames =
-      new RegExp(
-        `@keyframes\\s+cpk-launcher-capsule-${direction}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`,
-      ).exec(css)?.[1] ?? "";
-    const stops = frames.match(/clip-path:[\s\S]*?;/g) ?? [];
-    expect(stops).toHaveLength(2);
-    for (const stop of stops) {
-      expect(stop).toContain("inset(");
-      expect(stop).toContain("round 999px");
+    for (const name of [
+      `cpk-launcher-island-${direction}`,
+      `cpk-launcher-island-close-${direction}`,
+    ]) {
+      const frames =
+        new RegExp(`@keyframes\\s+${name}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`).exec(
+          css,
+        )?.[1] ?? "";
+      const stops = frames.match(/clip-path:[\s\S]*?;/g) ?? [];
+      expect(stops).toHaveLength(2);
+      for (const stop of stops) {
+        // Whitespace collapsed: the declaration wraps "round" onto its own
+        // line from the radius that follows it, which a literal substring
+        // check would otherwise trip over.
+        const normalized = stop.replace(/\s+/g, " ");
+        expect(normalized).toContain("inset(");
+        expect(normalized).toContain(
+          "round calc(var(--cpk-launcher-size) / 2)",
+        );
+      }
     }
   }
 });

--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -1717,35 +1717,58 @@ test("the reveal animates a rectangular clip, never a width or a scale", async (
   const context = await setup();
   const css = stylesheetText(context.inspector);
 
-  // Four keyframes now, not two: opening and closing are written out
-  // separately per direction rather than one reversed, so the layout
-  // guarantee has to hold for the close as much as for the open — a closing
-  // keyframe that snuck a width or a scale back in would be just as much of
-  // a regression as an opening one.
-  for (const direction of ["left", "right"]) {
-    for (const name of [
-      `cpk-launcher-island-${direction}`,
-      `cpk-launcher-island-close-${direction}`,
-    ]) {
-      const frames =
-        new RegExp(`@keyframes\\s+${name}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`).exec(
-          css,
-        )?.[1] ?? "";
-      expect(frames).toContain("clip-path: inset(");
-      expect(frames).toContain("opacity");
-      // Animating either of these gives up the layout guarantee — `width` forces
-      // a layout on every frame on someone else's page, and a horizontal scale
-      // squashes the mark itself, so the dot and halo would become ellipses.
-      expect(frames).not.toContain("width");
-      expect(frames).not.toContain("scale");
-    }
+  // Two keyframes now, not four: `cpk-launcher-island-open` and
+  // `cpk-launcher-island-close` are shared by all four corners, because the
+  // closed stop's shape moved out of the keyframe and into
+  // `--cpk-island-closed`, a custom property composed on
+  // `.cpk-launcher-capsule, .cpk-launcher-drawer` from the
+  // `--cpk-island-clip-*` properties each corner overrides. A direction no
+  // longer picks a keyframe name — it only ever picks those four properties
+  // — so the old `for (const direction of ["left", "right"])` loop has
+  // nothing left to vary here and is gone.
+  for (const name of [
+    "cpk-launcher-island-open",
+    "cpk-launcher-island-close",
+  ]) {
+    const frames =
+      new RegExp(`@keyframes\\s+${name}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`).exec(
+        css,
+      )?.[1] ?? "";
+    // The open stop is still written as a literal `inset(...)` inside the
+    // keyframe; the closed stop now reads `var(--cpk-island-closed)`
+    // instead (its own shape is checked below, where it now lives), so this
+    // covers only the half of the guarantee the keyframe still states
+    // directly.
+    expect(frames).toContain("clip-path: inset(");
+    expect(frames).toContain("opacity");
+    // Animating either of these gives up the layout guarantee — `width` forces
+    // a layout on every frame on someone else's page, and a horizontal scale
+    // squashes the mark itself, so the dot and halo would become ellipses.
+    expect(frames).not.toContain("width");
+    expect(frames).not.toContain("scale");
   }
 
+  // The closed stop's shape lives in `--cpk-island-closed` now, so the
+  // "rectangular clip, never a width or a scale" guarantee has to be
+  // re-checked there too: a regression could swap the keyframe's literal
+  // `inset()` for this property's value and still pass the loop above.
+  const islandRule =
+    /\.cpk-launcher-capsule,\s*\.cpk-launcher-drawer\s*\{([\s\S]*?)\}/.exec(
+      css,
+    )?.[1] ?? "";
+  const closedValue =
+    /--cpk-island-closed:\s*([\s\S]*?);/
+      .exec(islandRule)?.[1]
+      ?.replace(/\s+/g, " ") ?? "";
+  expect(closedValue).toContain("inset(");
+  expect(closedValue).not.toContain("width");
+  expect(closedValue).not.toContain("scale");
+
   // Laid out at full width from the start, so only the visible region moves.
-  // The layout guarantee is that no *keyframe* animates width — the four
-  // `expect(frames).not.toContain("width")` assertions above are the real
-  // guard. A static declared width is what makes the capsule and the drawer
-  // flush by construction.
+  // The layout guarantee is that no *keyframe* animates width — the
+  // `not.toContain("width")` assertions above are the real guard. A static
+  // declared width is what makes the capsule and the drawer flush by
+  // construction.
   const pillRule =
     /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
   expect(pillRule).toContain("width: var(--cpk-launcher-island)");
@@ -1757,40 +1780,62 @@ test("the revealing edge is the capsule's own rounded end, not a straight wipe",
   const css = stylesheetText(context.inspector);
 
   // An unrounded inset sweeps a straight vertical line sideways and reads as a
-  // wipe. Rounding BOTH stops of BOTH directions — and now of the closing
-  // keyframe as well as the opening one — makes it read as an opening
-  // whichever way it is travelling: a straight-edged close would be exactly
-  // as wrong as a straight-edged open. A clip-path only interpolates between
-  // shapes of the same kind, so a `round` on one stop alone would stop the
-  // reveal animating at all.
+  // wipe. Rounding BOTH stops of BOTH the open and the close keyframe makes it
+  // read as an opening whichever way it is travelling: a straight-edged close
+  // would be exactly as wrong as a straight-edged open. A clip-path only
+  // interpolates between shapes of the same kind, so a `round` on one stop
+  // alone would stop the reveal animating at all.
+  //
+  // Only one of the two stops is still written out inside the keyframe now —
+  // the other reads `var(--cpk-island-closed)`, because the closed shape is
+  // composed once on `.cpk-launcher-capsule, .cpk-launcher-drawer` from
+  // `--cpk-island-clip-*` and shared across all four corners instead of being
+  // copied into a `close-left`/`close-right` pair. So "both stops rounded" is
+  // now checked in two places: the literal stop right here, and the
+  // `--cpk-island-closed` declaration itself, followed to below. A direction
+  // no longer selects a keyframe name, so the old `["left", "right"]` loop is
+  // gone — the keyframes are the same regardless of which corner is opening.
   //
   // The radius is the island's own token rather than a bare pixel figure,
   // because this one pair of keyframes now also drives the taller drawer:
   // a literal that happened to clamp to a circle at the capsule's height
   // would round the drawer by the wrong amount.
-  for (const direction of ["left", "right"]) {
-    for (const name of [
-      `cpk-launcher-island-${direction}`,
-      `cpk-launcher-island-close-${direction}`,
-    ]) {
-      const frames =
-        new RegExp(`@keyframes\\s+${name}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`).exec(
-          css,
-        )?.[1] ?? "";
-      const stops = frames.match(/clip-path:[\s\S]*?;/g) ?? [];
-      expect(stops).toHaveLength(2);
-      for (const stop of stops) {
-        // Whitespace collapsed: the declaration wraps "round" onto its own
-        // line from the radius that follows it, which a literal substring
-        // check would otherwise trip over.
-        const normalized = stop.replace(/\s+/g, " ");
-        expect(normalized).toContain("inset(");
-        expect(normalized).toContain(
-          "round calc(var(--cpk-launcher-size) / 2)",
-        );
-      }
-    }
+  for (const name of [
+    "cpk-launcher-island-open",
+    "cpk-launcher-island-close",
+  ]) {
+    const frames =
+      new RegExp(`@keyframes\\s+${name}\\s*\\{([\\s\\S]*?\\}\\s*)\\}`).exec(
+        css,
+      )?.[1] ?? "";
+    const stops = frames.match(/clip-path:[\s\S]*?;/g) ?? [];
+    expect(stops).toHaveLength(2);
+    const literalStop = stops.find((stop) => stop.includes("inset("));
+    const closedStop = stops.find((stop) =>
+      stop.includes("var(--cpk-island-closed)"),
+    );
+    expect(closedStop).toBeTruthy();
+    // Whitespace collapsed: the declaration wraps "round" onto its own
+    // line from the radius that follows it, which a literal substring
+    // check would otherwise trip over.
+    const normalized = (literalStop ?? "").replace(/\s+/g, " ");
+    expect(normalized).toContain("inset(");
+    expect(normalized).toContain("round calc(var(--cpk-launcher-size) / 2)");
   }
+
+  // Follow the closed stop to where its shape is actually declared, and
+  // check the rounding survived the move: a `--cpk-island-closed` that
+  // dropped its `round` would square off every corner the reveal closes
+  // into, even though the keyframe text above never mentions it.
+  const islandRule =
+    /\.cpk-launcher-capsule,\s*\.cpk-launcher-drawer\s*\{([\s\S]*?)\}/.exec(
+      css,
+    )?.[1] ?? "";
+  const closedValue =
+    /--cpk-island-closed:\s*([\s\S]*?);/
+      .exec(islandRule)?.[1]
+      ?.replace(/\s+/g, " ") ?? "";
+  expect(closedValue).toContain("round calc(var(--cpk-launcher-size) / 2)");
 });
 
 // ── Clicking the pill ─────────────────────────────────────────────────────

--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -71,24 +71,17 @@ const LAUNCHER_SIZE = 52;
 const EDGE_MARGIN = 16;
 
 /**
- * The pill's natural width at its widest label, as the direction logic would
- * measure it. jsdom lays nothing out — every rect is zero — so this is stubbed
- * rather than measured; see `stubGeometry`.
+ * The capsule's rendered width, as the direction logic would measure it via
+ * `getBoundingClientRect().width`. jsdom lays nothing out — every rect is
+ * zero — so this is stubbed rather than measured; see `stubGeometry`.
  *
- * It grew when the pill did: the mark-side padding went from `+2px` to `+12px`,
- * and the subline is now the widest line in it rather than the failure class.
- * It moved again when the text-side padding stopped being a literal and the two
- * lines grew a point: padding is measured from the bounding box, but the first
- * half-height of that side is the rounded cap, so a bare 14px left the text
- * sitting inside the curve. That side is now exactly `size / 2` — the radius —
- * which lands the text where the cap ends, i.e. 26 at this harness's launcher
- * size of 52.
- * Checked against a real browser at 12px/10.5px: 26 text-side padding +
- * 130 subline + 64 mark-side padding + 2 border. The threshold at which neither
- * side has room moved with it, which is what the two tests either side of
- * `TIGHTEST_FIT` pin down.
+ * The capsule is pinned to `--cpk-launcher-island` rather than sized by its
+ * content, so this constant mirrors that token's value rather than a
+ * measured text width. It no longer depends on the label, the padding, or
+ * the launcher size — it is the same 272 at every point of the size clamp,
+ * which is what the two tests either side of `TIGHTEST_FIT` pin down.
  */
-const PILL_WIDTH = 222;
+const ISLAND_WIDTH = 272;
 
 const ENABLED_ENDPOINTS = {
   list: true,
@@ -1402,7 +1395,7 @@ test("the pill's text is held off its own border and clear of the mark", async (
   // Both directions, because the mark is on the other end in each: the text
   // side gets room so the words do not sit against the border, and the mark
   // side clears the circle with room to spare. Widening the pill moves the
-  // threshold at which neither side has room — see PILL_WIDTH.
+  // threshold at which neither side has room — see ISLAND_WIDTH.
   //
   // The text side must stay derived from the capsule's radius rather than a
   // literal. Padding is measured from the bounding box, but the first
@@ -1604,7 +1597,7 @@ test("the pill opens left when there is room to the left", async () => {
   // Anchored top-right with the whole window to its left.
   stubGeometry({
     launcherLeft: 1200,
-    pillWidth: PILL_WIDTH,
+    pillWidth: ISLAND_WIDTH,
     viewportWidth: 1280,
   });
   await armConnectionFailure(context);
@@ -1621,7 +1614,7 @@ test("the pill opens right when the launcher sits too close to the left edge", a
   // exists — permanently, because the position persists.
   stubGeometry({
     launcherLeft: 16,
-    pillWidth: PILL_WIDTH,
+    pillWidth: ISLAND_WIDTH,
     viewportWidth: 1280,
   });
   await armConnectionFailure(context);
@@ -1635,7 +1628,11 @@ test("the pill opens right when the launcher sits too close to the left edge", a
 test("neither side having room leaves the dot and the beat untouched, and no pill", async () => {
   const context = await setup();
   // A window too narrow for the label on either side.
-  stubGeometry({ launcherLeft: 16, pillWidth: PILL_WIDTH, viewportWidth: 130 });
+  stubGeometry({
+    launcherLeft: 16,
+    pillWidth: ISLAND_WIDTH,
+    viewportWidth: 130,
+  });
   await armConnectionFailure(context);
 
   // The signal is intact and only the label is lost: degrading honestly beats
@@ -1651,7 +1648,11 @@ test("neither side having room leaves the dot and the beat untouched, and no pil
 
 test("with no room the failure is still spoken", async () => {
   const context = await setup();
-  stubGeometry({ launcherLeft: 16, pillWidth: PILL_WIDTH, viewportWidth: 130 });
+  stubGeometry({
+    launcherLeft: 16,
+    pillWidth: ISLAND_WIDTH,
+    viewportWidth: 130,
+  });
   await armConnectionFailure(context);
 
   // The same words still arrive; they simply arrive without the movement.
@@ -1661,15 +1662,15 @@ test("with no room the failure is still spoken", async () => {
 // The narrowest window a rightward pill fits in: the launcher's own left
 // offset, the mark, its overhang, and the margin the pill keeps from the edge.
 // Widening the pill — as the padding and the second line did — moves this,
-// which is the whole reason PILL_WIDTH is a named number.
+// which is the whole reason ISLAND_WIDTH is a named number.
 const TIGHTEST_FIT =
-  EDGE_MARGIN + LAUNCHER_SIZE + (PILL_WIDTH - LAUNCHER_SIZE) + EDGE_MARGIN;
+  EDGE_MARGIN + LAUNCHER_SIZE + (ISLAND_WIDTH - LAUNCHER_SIZE) + EDGE_MARGIN;
 
 test("a window exactly wide enough still opens the pill", async () => {
   const context = await setup();
   stubGeometry({
     launcherLeft: EDGE_MARGIN,
-    pillWidth: PILL_WIDTH,
+    pillWidth: ISLAND_WIDTH,
     viewportWidth: TIGHTEST_FIT,
   });
   await armConnectionFailure(context);
@@ -1681,7 +1682,7 @@ test("one pixel narrower than that degrades to no pill at all", async () => {
   const context = await setup();
   stubGeometry({
     launcherLeft: EDGE_MARGIN,
-    pillWidth: PILL_WIDTH,
+    pillWidth: ISLAND_WIDTH,
     viewportWidth: TIGHTEST_FIT - 1,
   });
   await armConnectionFailure(context);
@@ -2059,7 +2060,7 @@ test("the visibility event reports whether the pill was shown or suppressed", as
   const context = await setup();
   stubGeometry({
     launcherLeft: 1200,
-    pillWidth: PILL_WIDTH,
+    pillWidth: ISLAND_WIDTH,
     viewportWidth: 1280,
   });
   await armConnectionFailure(context);
@@ -2072,7 +2073,11 @@ test("the visibility event reports the no-room fallback as suppressed", async ()
   // A degradation whose frequency is unknown is a degradation that gets argued
   // about later, so the silent case is the one this property exists to count.
   const context = await setup();
-  stubGeometry({ launcherLeft: 16, pillWidth: PILL_WIDTH, viewportWidth: 130 });
+  stubGeometry({
+    launcherLeft: 16,
+    pillWidth: ISLAND_WIDTH,
+    viewportWidth: 130,
+  });
   await armConnectionFailure(context);
 
   expect(pill(context.inspector)).toBeNull();

--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -71,9 +71,10 @@ const LAUNCHER_SIZE = 52;
 const EDGE_MARGIN = 16;
 
 /**
- * The capsule's rendered width, as the direction logic would measure it via
- * `getBoundingClientRect().width`. jsdom lays nothing out — every rect is
- * zero — so this is stubbed rather than measured; see `stubGeometry`.
+ * The island's pinned width, mirroring `LAUNCHER_ISLAND_WIDTH` in the
+ * implementation. The direction rule never measures the capsule — jsdom lays
+ * nothing out, so every rect is zero regardless — it takes only the
+ * launcher mark's rect (stubbed by `stubGeometry`) and this constant.
  *
  * The capsule is pinned to `--cpk-launcher-island` rather than sized by its
  * content, so this constant mirrors that token's value rather than a
@@ -442,19 +443,18 @@ function renderedText(inspector: WebInspectorElement): string {
 }
 
 /**
- * Gives the launcher and the pill real dimensions, because jsdom lays nothing
- * out: every rect is zero, so the pill would trivially fit on either side and
- * the direction decision would never be exercised.
+ * Gives the launcher mark real dimensions, because jsdom lays nothing out:
+ * every rect is zero, so the direction rule would always see a mark with no
+ * width and the decision would never be exercised.
  *
  * `launcherLeft` is where the launcher's left edge sits, which is what a
- * reader changes by dragging it, and `pillWidth` is the pill's natural width
- * at its full label.
+ * reader changes by dragging it. The rule reads only that rect and the
+ * island's constant width, never the capsule's own dimensions.
  */
 let restoreViewportWidth: (() => void) | null = null;
 
 function stubGeometry(options: {
   launcherLeft: number;
-  pillWidth: number;
   viewportWidth: number;
 }): void {
   const previousWidth = window.innerWidth;
@@ -486,11 +486,6 @@ function stubGeometry(options: {
         }) as DOMRect;
       if (this.classList.contains("console-button")) {
         return box(options.launcherLeft, LAUNCHER_SIZE);
-      }
-      if (this.hasAttribute("data-cpk-launcher-capsule")) {
-        // A clip never changes the layout box, so this is the full width
-        // whichever phase the pill is in.
-        return box(options.launcherLeft, options.pillWidth);
       }
       return box(0, 0);
     },
@@ -1598,7 +1593,6 @@ test("the pill opens left when there is room to the left", async () => {
   // Anchored top-right with the whole window to its left.
   stubGeometry({
     launcherLeft: 1200,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: 1280,
   });
   await armConnectionFailure(context);
@@ -1615,7 +1609,6 @@ test("the pill opens right when the launcher sits too close to the left edge", a
   // exists — permanently, because the position persists.
   stubGeometry({
     launcherLeft: 16,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: 1280,
   });
   await armConnectionFailure(context);
@@ -1631,7 +1624,6 @@ test("neither side having room leaves the dot and the beat untouched, and no pil
   // A window too narrow for the label on either side.
   stubGeometry({
     launcherLeft: 16,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: 130,
   });
   await armConnectionFailure(context);
@@ -1651,7 +1643,6 @@ test("with no room the failure is still spoken", async () => {
   const context = await setup();
   stubGeometry({
     launcherLeft: 16,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: 130,
   });
   await armConnectionFailure(context);
@@ -1671,7 +1662,6 @@ test("a window exactly wide enough still opens the pill", async () => {
   const context = await setup();
   stubGeometry({
     launcherLeft: EDGE_MARGIN,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: TIGHTEST_FIT,
   });
   await armConnectionFailure(context);
@@ -1683,7 +1673,6 @@ test("one pixel narrower than that degrades to no pill at all", async () => {
   const context = await setup();
   stubGeometry({
     launcherLeft: EDGE_MARGIN,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: TIGHTEST_FIT - 1,
   });
   await armConnectionFailure(context);
@@ -2061,7 +2050,6 @@ test("the visibility event reports whether the pill was shown or suppressed", as
   const context = await setup();
   stubGeometry({
     launcherLeft: 1200,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: 1280,
   });
   await armConnectionFailure(context);
@@ -2076,7 +2064,6 @@ test("the visibility event reports the no-room fallback as suppressed", async ()
   const context = await setup();
   stubGeometry({
     launcherLeft: 16,
-    pillWidth: ISLAND_WIDTH,
     viewportWidth: 130,
   });
   await armConnectionFailure(context);

--- a/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-error-signal.spec.ts
@@ -1662,9 +1662,9 @@ test("with no room the failure is still spoken", async () => {
 
 // The narrowest window a rightward pill fits in: the launcher's own left
 // offset, the island's own width, and the margin the pill keeps from the
-// edge on the other side. LAUNCHER_SIZE cancels out now that the width is
-// a token rather than content-derived, which is the whole reason
-// ISLAND_WIDTH is a named number.
+// edge on the other side. LAUNCHER_SIZE has always cancelled here — the
+// mark's width is inside the island's. The threshold moves with the token,
+// which is the whole reason ISLAND_WIDTH is a named number.
 const TIGHTEST_FIT = EDGE_MARGIN + ISLAND_WIDTH + EDGE_MARGIN;
 
 test("a window exactly wide enough still opens the pill", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
@@ -116,6 +116,15 @@ function hudRowLabels(inspector: WebInspectorElement): string[] {
   });
 }
 
+function capsuleHeading(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-capsule-heading]")
+      ?.textContent?.replace(/\s+/g, " ")
+      .trim() ?? null
+  );
+}
+
 function currentMenu(inspector: WebInspectorElement): string | null {
   return (
     root(inspector)
@@ -143,6 +152,7 @@ async function setup(options: Options = {}): Promise<{
   inspector: WebInspectorElement;
   openHud: () => Promise<void>;
   clickHud: (row: string) => Promise<void>;
+  clickCapsule: () => Promise<void>;
   pressLauncher: () => Promise<void>;
 }> {
   document.body.replaceChildren();
@@ -202,6 +212,14 @@ async function setup(options: Options = {}): Promise<{
     await settle(inspector);
   };
 
+  const clickCapsule = async (): Promise<void> => {
+    const capsule = requireElement(
+      root(inspector).querySelector<HTMLElement>("[data-cpk-launcher-capsule]"),
+    );
+    capsule.click();
+    await settle(inspector);
+  };
+
   const pressLauncher = async (): Promise<void> => {
     const button = launcherButton(inspector);
     const init = { bubbles: true, composed: true, pointerId: 1, button: 0 };
@@ -211,7 +229,7 @@ async function setup(options: Options = {}): Promise<{
     await settle(inspector);
   };
 
-  return { inspector, openHud, clickHud, pressLauncher };
+  return { inspector, openHud, clickHud, clickCapsule, pressLauncher };
 }
 
 test("the HUD stays closed during the initial page-settle delay", async () => {
@@ -232,16 +250,22 @@ test("the HUD previews every feature in sequence on page load, then leaves", asy
 
   const introHud = requireElement(hud(inspector));
   expect(introHud.getAttribute("data-cpk-hud-intro")).toBe("true");
+  // Intelligence previews too, but as the capsule's title rather than a
+  // staggered row — it is the connection the two rows below are carried
+  // over, not a third feature beside them.
+  expect(capsuleHeading(inspector)).toBe("Intelligence connected");
   expect(hudRowLabels(inspector)).toEqual([
-    "Threads on",
-    "Intelligence connected",
-    "Learning on",
+    "Threads enabled",
+    "Learning enabled",
   ]);
+  // Two rows now, so two staggered delays: rowStart (180ms) then
+  // rowStart + rowStagger (180ms + 170ms = 350ms). See
+  // LAUNCHER_HUD_INTRO_MS in src/index.ts.
   expect(
     Array.from(
       root(inspector).querySelectorAll<HTMLElement>("[data-cpk-hud-row]"),
     ).map((row) => row.style.getPropertyValue("--cpk-hud-row-delay")),
-  ).toEqual(["180ms", "350ms", "520ms"]);
+  ).toEqual(["180ms", "350ms"]);
 
   await vi.advanceTimersByTimeAsync(3400);
   await settle(inspector);
@@ -263,36 +287,32 @@ test("hovering during the page-load preview keeps the HUD open", async () => {
   expect(hud(inspector)?.hasAttribute("data-cpk-hud-intro")).toBe(false);
 });
 
-test("hovering the launcher shows Threads, Intelligence, and Learning", async () => {
+test("hovering the launcher shows Threads and Learning, disabled", async () => {
   const { inspector, openHud } = await setup();
   await openHud();
   expect(hudOpen(inspector)).toBe(true);
   expect(hudRowLabels(inspector)).toEqual([
-    "Turn on Threads",
-    "Turn on Intelligence",
-    "Turn on Learning",
+    "Threads disabled",
+    "Learning disabled",
   ]);
+  // Intelligence is not a row any more; it is the capsule's title.
+  expect(capsuleHeading(inspector)).toBe("Intelligence not connected");
 });
 
-test("connected Intelligence and Threads keep their slots and show a check", async () => {
+test("connected Threads and Learning show a check, and Intelligence titles the capsule", async () => {
   const { inspector, openHud } = await setup({
     intelligence: true,
     endpoints: ENABLED_ENDPOINTS,
   });
   await openHud();
   expect(hudRowLabels(inspector)).toEqual([
-    "Threads on",
-    "Intelligence connected",
-    "Learning on",
+    "Threads enabled",
+    "Learning enabled",
   ]);
+  expect(capsuleHeading(inspector)).toBe("Intelligence connected");
   expect(
     root(inspector).querySelector(
       '[data-cpk-hud-row="threads"] [data-cpk-hud-check]',
-    ),
-  ).not.toBeNull();
-  expect(
-    root(inspector).querySelector(
-      '[data-cpk-hud-row="intelligence"] [data-cpk-hud-check]',
     ),
   ).not.toBeNull();
   expect(
@@ -311,17 +331,24 @@ test("the HUD respects a runtime that is not entitled to Intelligence", async ()
 
   await openHud();
 
+  // The transport flags (intelligence + endpoints) are present, but the
+  // license is not entitled: the title must say so, not just the rows.
+  expect(capsuleHeading(inspector)).toBe("Intelligence not connected");
   expect(hudRowLabels(inspector)).toEqual([
-    "Turn on Threads",
-    "Turn on Intelligence",
-    "Turn on Learning",
+    "Threads disabled",
+    "Learning disabled",
   ]);
-  for (const row of ["threads", "intelligence", "learning"] as const) {
+  for (const row of ["threads", "learning"] as const) {
     expect(
       root(inspector).querySelector(
         `[data-cpk-hud-row="${row}"] [data-cpk-hud-check]`,
       ),
     ).toBeNull();
+    expect(
+      root(inspector).querySelector(
+        `[data-cpk-hud-row="${row}"] [data-cpk-hud-cross]`,
+      ),
+    ).not.toBeNull();
   }
 });
 
@@ -368,18 +395,31 @@ test("Threads on still lands on the Threads view", async () => {
   expect(currentMenu(inspector)).toBe("threads");
 });
 
-test("Turn on Intelligence lands on Home", async () => {
-  const { inspector, openHud, clickHud } = await setup();
+// There is no longer an Intelligence row to click: Intelligence is the
+// capsule's title now, and the capsule itself is clickable — it opens the
+// Inspector exactly as pressing the launcher mark does (see
+// `handlePillClick` in src/index.ts), reusing the same plain-open path
+// rather than a HUD row's `hudLandingMenu` override. A plain open lands on
+// whichever menu was last selected, which for a fresh Inspector is "home".
+// That is the equivalent guarantee to what these two tests checked before:
+// interacting with the Intelligence surface opens the Inspector on Home, in
+// both the connected and not-connected states.
+test("clicking the capsule opens Inspector on Home when Intelligence is not connected", async () => {
+  const { inspector, openHud, clickCapsule } = await setup();
   await openHud();
-  await clickHud("intelligence");
+  await clickCapsule();
   expect(currentMenu(inspector)).toBe("home");
+  expect(hud(inspector)).toBeNull();
 });
 
-test("Intelligence connected lands on Home", async () => {
-  const { inspector, openHud, clickHud } = await setup({ intelligence: true });
+test("clicking the capsule opens Inspector on Home when Intelligence is connected", async () => {
+  const { inspector, openHud, clickCapsule } = await setup({
+    intelligence: true,
+  });
   await openHud();
-  await clickHud("intelligence");
+  await clickCapsule();
   expect(currentMenu(inspector)).toBe("home");
+  expect(hud(inspector)).toBeNull();
 });
 
 test("Turn on Learning lands on the Learning view", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
@@ -98,7 +98,9 @@ function launcherButton(inspector: WebInspectorElement): HTMLButtonElement {
 }
 
 function hud(inspector: WebInspectorElement): HTMLElement | null {
-  return root(inspector).querySelector<HTMLElement>("[data-cpk-launcher-hud]");
+  return root(inspector).querySelector<HTMLElement>(
+    "[data-cpk-launcher-drawer]",
+  );
 }
 
 function hudOpen(inspector: WebInspectorElement): boolean {
@@ -231,7 +233,6 @@ test("the HUD previews every feature in sequence on page load, then leaves", asy
   const introHud = requireElement(hud(inspector));
   expect(introHud.getAttribute("data-cpk-hud-intro")).toBe("true");
   expect(hudRowLabels(inspector)).toEqual([
-    "Open Inspector",
     "Threads on",
     "Intelligence connected",
     "Learning on",
@@ -240,7 +241,7 @@ test("the HUD previews every feature in sequence on page load, then leaves", asy
     Array.from(
       root(inspector).querySelectorAll<HTMLElement>("[data-cpk-hud-row]"),
     ).map((row) => row.style.getPropertyValue("--cpk-hud-row-delay")),
-  ).toEqual(["180ms", "350ms", "520ms", "690ms"]);
+  ).toEqual(["180ms", "350ms", "520ms"]);
 
   await vi.advanceTimersByTimeAsync(3400);
   await settle(inspector);
@@ -262,12 +263,11 @@ test("hovering during the page-load preview keeps the HUD open", async () => {
   expect(hud(inspector)?.hasAttribute("data-cpk-hud-intro")).toBe(false);
 });
 
-test("hovering the launcher shows Open Inspector, Threads, Intelligence, and Learning", async () => {
+test("hovering the launcher shows Threads, Intelligence, and Learning", async () => {
   const { inspector, openHud } = await setup();
   await openHud();
   expect(hudOpen(inspector)).toBe(true);
   expect(hudRowLabels(inspector)).toEqual([
-    "Open Inspector",
     "Turn on Threads",
     "Turn on Intelligence",
     "Turn on Learning",
@@ -281,7 +281,6 @@ test("connected Intelligence and Threads keep their slots and show a check", asy
   });
   await openHud();
   expect(hudRowLabels(inspector)).toEqual([
-    "Open Inspector",
     "Threads on",
     "Intelligence connected",
     "Learning on",
@@ -313,7 +312,6 @@ test("the HUD respects a runtime that is not entitled to Intelligence", async ()
   await openHud();
 
   expect(hudRowLabels(inspector)).toEqual([
-    "Open Inspector",
     "Turn on Threads",
     "Turn on Intelligence",
     "Turn on Learning",
@@ -343,14 +341,6 @@ test("the floating window does not cover the sidebar toggle with a SW handle", a
   expect(tree.querySelector("[data-inspector-sidebar-toggle]")).not.toBeNull();
 });
 
-test("Open Inspector in the HUD opens the panel", async () => {
-  const { inspector, openHud, clickHud } = await setup();
-  await openHud();
-  await clickHud("inspector");
-  expect(root(inspector).querySelector(".inspector-window")).not.toBeNull();
-  expect(currentMenu(inspector)).toBe("home");
-});
-
 test("Turn on Threads lands on the Threads view", async () => {
   const { inspector, openHud, clickHud } = await setup();
   await openHud();
@@ -361,12 +351,10 @@ test("Turn on Threads lands on the Threads view", async () => {
 test("a press on the row body lands, not only the title", async () => {
   const { inspector, openHud } = await setup();
   await openHud();
-  const detail = requireElement(
-    root(inspector).querySelector<HTMLElement>(
-      '[data-cpk-hud-row="threads"] .cpk-launcher-hud__detail',
-    ),
+  const rowBody = requireElement(
+    root(inspector).querySelector<HTMLElement>('[data-cpk-hud-row="threads"]'),
   );
-  detail.click();
+  rowBody.click();
   await settle(inspector);
   expect(currentMenu(inspector)).toBe("threads");
 });
@@ -378,25 +366,6 @@ test("Threads on still lands on the Threads view", async () => {
   await openHud();
   await clickHud("threads");
   expect(currentMenu(inspector)).toBe("threads");
-});
-
-test("the help mark keeps a row's detail open without hover", async () => {
-  const { inspector, openHud } = await setup();
-  await openHud();
-  const help = requireElement(
-    root(inspector).querySelector<HTMLButtonElement>(
-      '[data-cpk-hud-row="threads"] [aria-expanded]',
-    ),
-  );
-  help.click();
-  await settle(inspector);
-  expect(
-    root(inspector)
-      .querySelector('[data-cpk-hud-row="threads"]')
-      ?.getAttribute("data-cpk-hud-help"),
-  ).toBe("open");
-  expect(help.getAttribute("aria-expanded")).toBe("true");
-  expect(root(inspector).querySelector(".inspector-window")).toBeNull();
 });
 
 test("Turn on Intelligence lands on Home", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-island-direction.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island-direction.spec.ts
@@ -1,5 +1,5 @@
 // Launcher island direction — the one spec that drives both surfaces at one
-// stubbed geometry.
+// stubbed geometry, on both of the axes the island can open along.
 //
 // The capsule and the drawer used to decide which side of the mark to open
 // on through two different rules. The drawer measured itself as a card
@@ -22,9 +22,20 @@
 // the only thing that can catch the two rules drifting apart again, so it
 // lives here, in its own file, rather than folded into either suite above.
 //
+// The vertical axis arrived later, and arrived with the same shape of hole:
+// the rule read `viewportWidth` and nothing else, so an island dragged to the
+// foot of the window opened on the correct SIDE and then ran off the bottom
+// of the screen — rows unreachable, and nothing left on screen to say they
+// were there. It is the same defect one axis over, so it is guarded here, in
+// the same file, by the same join: one geometry, both surfaces, compare what
+// each one chose.
+//
 // Same `stubGeometry` idiom as the other launcher suites: jsdom lays nothing
 // out, so `getBoundingClientRect` is mocked to give the mark and the capsule
-// real boxes rather than the all-zero rect jsdom would otherwise return.
+// real boxes rather than the all-zero rect jsdom would otherwise return. The
+// vertical cases stub `window.innerHeight` alongside `innerWidth` for the
+// same reason: jsdom's default 768 is plenty of room, so a rule that never
+// looked down would pass every one of them.
 
 import {
   CopilotKitCore,
@@ -55,6 +66,36 @@ const OVERHANG = ISLAND_WIDTH - LAUNCHER_SIZE; // 220
  * 264. Anything in [236, 264) used to give capsule=left, drawer=right.
  */
 const DIVERGENT_LEFT = 240;
+
+/**
+ * The island's height at this suite's launcher size, and the part of it that
+ * hangs past the mark.
+ *
+ * Written out here as the arithmetic the rule performs rather than as the
+ * number it comes to, so this file states the same relationship
+ * `launcherIslandHeight` does: the capsule's band is the mark itself, and
+ * everything past it is the drawer's chrome plus its rows. If a third row is
+ * ever added, `ISLAND_ROWS` is the one figure here that has to follow it.
+ */
+const ISLAND_CHROME = 16; // two hairlines + the band gap + the room past the last row
+const ISLAND_ROW_HEIGHT = 32;
+const ISLAND_ROWS = 2;
+const ISLAND_HEIGHT =
+  LAUNCHER_SIZE + ISLAND_CHROME + ISLAND_ROWS * ISLAND_ROW_HEIGHT; // 132
+/** What the vertical axis actually has to find room for. */
+const DROP_OVERHANG = ISLAND_HEIGHT - LAUNCHER_SIZE; // 80
+
+/**
+ * A viewport and a `mark.top` that leave the island no room below the mark
+ * and plenty above it.
+ *
+ * `mark.bottom` is 172, so the room below is 200 - 16 - 172 = 12, well short
+ * of the 80 the rows need; the room above is 120 - 16 = 104, comfortably past
+ * it. Downward is the preferred answer, so a rule that reached "up" here can
+ * only have got there by looking.
+ */
+const SHORT_VIEWPORT_HEIGHT = 200;
+const LOW_LAUNCHER_TOP = 120;
 
 // The gesture's four phases, stated once for this suite. Matches
 // launcher-error-signal.spec.ts's own constants; the drawer is only reached
@@ -108,35 +149,52 @@ class DirectionTestCore extends CopilotKitCore {
   }
 }
 
-let restoreViewportWidth: (() => void) | null = null;
+let restoreViewport: (() => void) | null = null;
 
+/** Both viewport dimensions together — the rule reads them as a pair. */
+function setViewport(width: number, height: number): void {
+  for (const [key, value] of [
+    ["innerWidth", width],
+    ["innerHeight", height],
+  ] as const) {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+}
+
+/**
+ * The stubbed geometry.
+ *
+ * `launcherTop` and `viewportHeight` default to the values every test in this
+ * file used before the vertical axis existed: the mark at the top of the
+ * window, and jsdom's own 768px viewport. A horizontal test therefore reads
+ * exactly as it did, and any test that says nothing about the vertical axis is
+ * asking for the case with room to spare below.
+ */
 function stubGeometry(options: {
   launcherLeft: number;
   viewportWidth: number;
+  launcherTop?: number;
+  viewportHeight?: number;
 }): void {
+  const launcherTop = options.launcherTop ?? 0;
   const previousWidth = window.innerWidth;
-  Object.defineProperty(window, "innerWidth", {
-    configurable: true,
-    writable: true,
-    value: options.viewportWidth,
-  });
-  restoreViewportWidth = () => {
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      writable: true,
-      value: previousWidth,
-    });
-  };
+  const previousHeight = window.innerHeight;
+  setViewport(options.viewportWidth, options.viewportHeight ?? previousHeight);
+  restoreViewport = () => setViewport(previousWidth, previousHeight);
   vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
     function (this: HTMLElement): DOMRect {
       const box = (left: number, width: number): DOMRect =>
         ({
           x: left,
-          y: 0,
+          y: launcherTop,
           left,
           right: left + width,
-          top: 0,
-          bottom: LAUNCHER_SIZE,
+          top: launcherTop,
+          bottom: launcherTop + LAUNCHER_SIZE,
           width,
           height: LAUNCHER_SIZE,
           toJSON: () => ({}),
@@ -157,8 +215,8 @@ let cleanup: (() => void) | null = null;
 afterEach(() => {
   cleanup?.();
   cleanup = null;
-  restoreViewportWidth?.();
-  restoreViewportWidth = null;
+  restoreViewport?.();
+  restoreViewport = null;
   vi.useRealTimers();
 });
 
@@ -184,9 +242,36 @@ function drawerSide(inspector: WebInspectorElement): string | null {
   );
 }
 
+/**
+ * The vertical half of each surface's answer.
+ *
+ * One attribute name for both, unlike the side — which the capsule and the
+ * drawer each spell their own way for historical reasons. Read off each
+ * element separately all the same: the point of this file is to compare what
+ * the two of them are actually carrying, and reading one and assuming the
+ * other would prove nothing.
+ */
+function capsuleDrop(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-launcher-capsule]")
+      ?.getAttribute("data-cpk-island-drop") ?? null
+  );
+}
+
+function drawerDrop(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-launcher-drawer]")
+      ?.getAttribute("data-cpk-island-drop") ?? null
+  );
+}
+
 async function setup(geometry: {
   launcherLeft: number;
   viewportWidth: number;
+  launcherTop?: number;
+  viewportHeight?: number;
 }): Promise<{
   inspector: WebInspectorElement;
   advance: (ms: number) => Promise<void>;
@@ -305,6 +390,143 @@ test("with no room on either side, neither half opens", async () => {
   } drawer=${drawerPresent ? "shown" : "stood down"} dot=${
     dotPresent ? "present" : "gone"
   }`;
+
+  expect(capsulePresent, observed).toBe(false);
+  expect(drawerPresent, observed).toBe(false);
+  expect(dotPresent, observed).toBe(true);
+});
+
+// ── The vertical axis ─────────────────────────────────────────────────────
+//
+// Same three shapes as above, one axis over: the two surfaces agree where
+// the flip is needed, they agree where it is not, and where neither way up
+// fits they both stand down and leave the dot.
+
+test("the capsule and the drawer flip up together when the rows will not fit below", async () => {
+  const context = await setup({
+    launcherLeft: DIVERGENT_LEFT,
+    viewportWidth: 1280,
+    launcherTop: LOW_LAUNCHER_TOP,
+    viewportHeight: SHORT_VIEWPORT_HEIGHT,
+  });
+
+  await context.breakConnection();
+  const capsule = capsuleDrop(context.inspector);
+
+  await context.advance(GESTURE_MS);
+  await context.dwell();
+  const drawer = drawerDrop(context.inspector);
+
+  const roomBelow =
+    SHORT_VIEWPORT_HEIGHT - EDGE_MARGIN - (LOW_LAUNCHER_TOP + LAUNCHER_SIZE);
+  const observed =
+    `mark.top=${LOW_LAUNCHER_TOP} viewportHeight=${SHORT_VIEWPORT_HEIGHT} ` +
+    `roomBelow=${roomBelow} needs=${DROP_OVERHANG} ` +
+    `capsule=${capsule} drawer=${drawer}`;
+  expect(capsule, observed).not.toBeNull();
+  expect(drawer, observed).not.toBeNull();
+  expect(drawer, observed).toBe(capsule);
+  // The drawer's rows hang 80px past the mark and only 12px of window is left
+  // below it, so the island has to hang from the mark's bottom edge instead.
+  expect(capsule, observed).toBe("up");
+});
+
+// The next two tests are one test in two halves, and they are the only thing
+// in this suite that can see the island's HEIGHT.
+//
+// The flip test above passes on any height between 13px and 105px of
+// overhang, so it says the rule looks down but not what it looks for. These
+// two put the window one pixel either side of the exact figure
+// `launcherIslandHeight` computes, so the arithmetic behind that figure — two
+// hairlines, the band that clears the mark, the room past the last row, and
+// the rows themselves — is load-bearing here. Get any term of it wrong, or
+// add a row without the height following, and one of the two fails.
+//
+// Downward is also the island's natural direction, so the first of them is
+// the case that must not change at all.
+
+test("with exactly the room the rows need below it, the island still opens downward", async () => {
+  const viewportHeight =
+    EDGE_MARGIN + LOW_LAUNCHER_TOP + LAUNCHER_SIZE + DROP_OVERHANG;
+  const context = await setup({
+    launcherLeft: DIVERGENT_LEFT,
+    viewportWidth: 1280,
+    launcherTop: LOW_LAUNCHER_TOP,
+    viewportHeight,
+  });
+
+  await context.breakConnection();
+  const capsule = capsuleDrop(context.inspector);
+
+  await context.advance(GESTURE_MS);
+  await context.dwell();
+  const drawer = drawerDrop(context.inspector);
+
+  const observed =
+    `viewportHeight=${viewportHeight} roomBelow=${DROP_OVERHANG} ` +
+    `needs=${DROP_OVERHANG} capsule=${capsule} drawer=${drawer}`;
+  expect(drawer, observed).toBe(capsule);
+  expect(capsule, observed).toBe("down");
+});
+
+test("one pixel short of it, the island flips up", async () => {
+  const viewportHeight =
+    EDGE_MARGIN + LOW_LAUNCHER_TOP + LAUNCHER_SIZE + DROP_OVERHANG - 1;
+  const context = await setup({
+    launcherLeft: DIVERGENT_LEFT,
+    viewportWidth: 1280,
+    launcherTop: LOW_LAUNCHER_TOP,
+    viewportHeight,
+  });
+
+  await context.breakConnection();
+  const capsule = capsuleDrop(context.inspector);
+
+  await context.advance(GESTURE_MS);
+  await context.dwell();
+  const drawer = drawerDrop(context.inspector);
+
+  const observed =
+    `viewportHeight=${viewportHeight} roomBelow=${DROP_OVERHANG - 1} ` +
+    `needs=${DROP_OVERHANG} capsule=${capsule} drawer=${drawer}`;
+  expect(drawer, observed).toBe(capsule);
+  expect(capsule, observed).toBe("up");
+});
+
+test("with no room above or below, neither half opens", async () => {
+  // The vertical mirror of the no-room test above: a window exactly one mark
+  // plus its two margins tall, so the rows have nowhere to go either way.
+  // Horizontally there is room to spare, which is the point — the island is
+  // dropped on the strength of the axis that fails, not because both did.
+  const viewportHeight = EDGE_MARGIN + LAUNCHER_SIZE + EDGE_MARGIN;
+  const context = await setup({
+    launcherLeft: DIVERGENT_LEFT,
+    viewportWidth: 1280,
+    launcherTop: EDGE_MARGIN,
+    viewportHeight,
+  });
+
+  await context.breakConnection();
+  const capsulePresent =
+    root(context.inspector).querySelector("[data-cpk-launcher-capsule]") !==
+    null;
+
+  await context.advance(GESTURE_MS);
+  await context.dwell();
+  const drawerPresent =
+    root(context.inspector).querySelector("[data-cpk-launcher-drawer]") !==
+    null;
+
+  // The signal itself is intact, exactly as it is when the horizontal axis
+  // is the one with no room: the dot survives, only the labels are lost.
+  const dotPresent =
+    root(context.inspector).querySelector("[data-cpk-signal-dot]") !== null;
+
+  const observed =
+    `viewportHeight=${viewportHeight} needs=${DROP_OVERHANG} ` +
+    `capsule=${capsulePresent ? "shown" : "stood down"} ` +
+    `drawer=${drawerPresent ? "shown" : "stood down"} ` +
+    `dot=${dotPresent ? "present" : "gone"}`;
 
   expect(capsulePresent, observed).toBe(false);
   expect(drawerPresent, observed).toBe(false);

--- a/packages/web-inspector/src/__tests__/launcher-island-direction.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island-direction.spec.ts
@@ -1,0 +1,312 @@
+// Launcher island direction — the one spec that drives both surfaces at one
+// stubbed geometry.
+//
+// The capsule and the drawer used to decide which side of the mark to open
+// on through two different rules. The drawer measured itself as a card
+// standing beside the launcher and used a stale width; the capsule measured
+// the overhang of an island drawn over the mark. For any `mark.left` in
+// [236, 264) at LAUNCHER_SIZE = 52 the two rules disagreed outright — the
+// capsule opened left, the drawer opened right, two halves of one object
+// pointing away from each other. A second divergence let the drawer fall
+// back to a side and clip off the viewport in exactly the position where the
+// capsule correctly declined to open at all.
+//
+// The entire shipped suite — 615 tests — stayed green against a deliberate
+// reintroduction of that bug. That is not a gap in effort: it is a gap in
+// shape. launcher-error-signal.spec.ts stubs geometry and asserts the
+// capsule's own direction (see its `stubGeometry` and the tests around
+// `pillDirection`); launcher-island.spec.ts asserts the drawer's markup and
+// stylesheet with no geometry stub at all. Both are thorough about the
+// surface they cover, and neither ever puts the capsule and the drawer at
+// the same `mark.left` and compares what each one chose. That comparison is
+// the only thing that can catch the two rules drifting apart again, so it
+// lives here, in its own file, rather than folded into either suite above.
+//
+// Same `stubGeometry` idiom as the other launcher suites: jsdom lays nothing
+// out, so `getBoundingClientRect` is mocked to give the mark and the capsule
+// real boxes rather than the all-zero rect jsdom would otherwise return.
+
+import {
+  CopilotKitCore,
+  CopilotKitCoreRuntimeConnectionStatus,
+} from "@copilotkit/core";
+import type {
+  IntelligenceRuntimeInfo,
+  ThreadEndpointRuntimeInfo,
+} from "@copilotkit/shared";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { WebInspectorElement } from "../index.js";
+
+const RUNTIME_URL = "https://runtime.launcher-island-direction.test";
+
+/** The launcher's rendered diameter at this suite's viewport. */
+const LAUNCHER_SIZE = 52;
+const EDGE_MARGIN = 16;
+const ISLAND_WIDTH = 272;
+/** The island's overhang past the mark — the part that actually needs room. */
+const OVERHANG = ISLAND_WIDTH - LAUNCHER_SIZE; // 220
+
+/**
+ * A `mark.left` inside the range the two rules used to disagree over.
+ *
+ * The capsule's (correct) rule opens left from `EDGE_MARGIN + OVERHANG` =
+ * 236. The drawer's stale rule opened left only from `EDGE_MARGIN + 248` =
+ * 264. Anything in [236, 264) used to give capsule=left, drawer=right.
+ */
+const DIVERGENT_LEFT = 240;
+
+// The gesture's four phases, stated once for this suite. Matches
+// launcher-error-signal.spec.ts's own constants; the drawer is only reached
+// once the capsule's gesture has fully closed, so both tests here have to
+// wait out all four before opening the drawer on top of it.
+const ERROR_BEAT_MS = 400;
+const PILL_OPEN_MS = 250;
+const PILL_HOLD_MS = 2500;
+const PILL_CLOSE_MS = 250;
+const GESTURE_MS = ERROR_BEAT_MS + PILL_OPEN_MS + PILL_HOLD_MS + PILL_CLOSE_MS;
+
+const ENABLED_ENDPOINTS = {
+  list: true,
+  inspect: true,
+  mutations: false,
+  realtimeMetadata: false,
+} satisfies ThreadEndpointRuntimeInfo;
+
+class DirectionTestCore extends CopilotKitCore {
+  constructor() {
+    super({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+  }
+
+  override get threadEndpoints(): ThreadEndpointRuntimeInfo | undefined {
+    return ENABLED_ENDPOINTS;
+  }
+
+  override get intelligence(): IntelligenceRuntimeInfo | undefined {
+    return undefined;
+  }
+
+  override get telemetryDisabled(): boolean {
+    return true;
+  }
+
+  async emitStatus(
+    status: CopilotKitCoreRuntimeConnectionStatus,
+  ): Promise<void> {
+    await this.notifySubscribers(
+      (subscriber) =>
+        subscriber.onRuntimeConnectionStatusChanged?.({
+          copilotkit: this,
+          status,
+        }),
+      "direction test runtime subscriber failed",
+    );
+  }
+}
+
+let restoreViewportWidth: (() => void) | null = null;
+
+function stubGeometry(options: {
+  launcherLeft: number;
+  viewportWidth: number;
+}): void {
+  const previousWidth = window.innerWidth;
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: options.viewportWidth,
+  });
+  restoreViewportWidth = () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: previousWidth,
+    });
+  };
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement): DOMRect {
+      const box = (left: number, width: number): DOMRect =>
+        ({
+          x: left,
+          y: 0,
+          left,
+          right: left + width,
+          top: 0,
+          bottom: LAUNCHER_SIZE,
+          width,
+          height: LAUNCHER_SIZE,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      if (this.classList.contains("console-button")) {
+        return box(options.launcherLeft, LAUNCHER_SIZE);
+      }
+      if (this.hasAttribute("data-cpk-launcher-capsule")) {
+        return box(options.launcherLeft, ISLAND_WIDTH);
+      }
+      return box(0, 0);
+    },
+  );
+}
+
+let cleanup: (() => void) | null = null;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+  restoreViewportWidth?.();
+  restoreViewportWidth = null;
+  vi.useRealTimers();
+});
+
+function root(inspector: WebInspectorElement): ShadowRoot {
+  const shadow = inspector.shadowRoot;
+  if (!shadow) throw new Error("no shadow root");
+  return shadow;
+}
+
+function capsuleSide(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-launcher-capsule]")
+      ?.getAttribute("data-cpk-capsule-direction") ?? null
+  );
+}
+
+function drawerSide(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-launcher-drawer]")
+      ?.getAttribute("data-cpk-drawer-side") ?? null
+  );
+}
+
+async function setup(geometry: {
+  launcherLeft: number;
+  viewportWidth: number;
+}): Promise<{
+  inspector: WebInspectorElement;
+  advance: (ms: number) => Promise<void>;
+  breakConnection: () => Promise<void>;
+  dwell: () => Promise<void>;
+}> {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    Object.assign(
+      vi.fn(async () => new Response(null, { status: 404 })),
+      globalThis.fetch,
+    ),
+  );
+
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+  const inspector = new WebInspectorElement();
+  const core = new DirectionTestCore();
+  document.body.append(inspector);
+  inspector.core = core;
+  await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Connected);
+
+  const flush = async (): Promise<void> => {
+    for (let turn = 0; turn < 6; turn += 1) {
+      await vi.advanceTimersByTimeAsync(0);
+      await inspector.updateComplete;
+    }
+  };
+  await flush();
+
+  // Stubbed after mount, exactly as the shipped suite does it.
+  stubGeometry(geometry);
+
+  cleanup = () => {
+    inspector.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    document.body.replaceChildren();
+  };
+
+  return {
+    inspector,
+    advance: async (ms: number) => {
+      await vi.advanceTimersByTimeAsync(ms);
+      await flush();
+    },
+    breakConnection: async () => {
+      await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Error);
+      await flush();
+    },
+    dwell: async () => {
+      const wrapper = root(inspector).querySelector<HTMLElement>(
+        ".console-button-wrapper",
+      );
+      if (!wrapper) throw new Error("no launcher wrapper");
+      wrapper.dispatchEvent(
+        new PointerEvent("pointerenter", { bubbles: true, composed: true }),
+      );
+      await flush();
+    },
+  };
+}
+
+test("the capsule and the drawer open on the same side", async () => {
+  const context = await setup({
+    launcherLeft: DIVERGENT_LEFT,
+    viewportWidth: 1280,
+  });
+
+  await context.breakConnection();
+  const capsule = capsuleSide(context.inspector);
+
+  // Let the whole gesture finish so the drawer is no longer blocked by it.
+  await context.advance(GESTURE_MS);
+  await context.dwell();
+  const drawer = drawerSide(context.inspector);
+
+  const observed = `mark.left=${DIVERGENT_LEFT} capsule=${capsule} drawer=${drawer}`;
+  expect(capsule, observed).not.toBeNull();
+  expect(drawer, observed).not.toBeNull();
+  expect(drawer, observed).toBe(capsule);
+  // And the side is the one the correct rule gives: 240 - 220 = 20 >= 16.
+  expect(capsule, observed).toBe("left");
+});
+
+test("with no room on either side, neither half opens", async () => {
+  // Narrow enough that neither side clears EDGE_MARGIN with the overhang.
+  const viewportWidth = EDGE_MARGIN + LAUNCHER_SIZE + EDGE_MARGIN;
+  const context = await setup({
+    launcherLeft: EDGE_MARGIN,
+    viewportWidth,
+  });
+
+  await context.breakConnection();
+  const capsulePresent =
+    root(context.inspector).querySelector("[data-cpk-launcher-capsule]") !==
+    null;
+
+  await context.advance(GESTURE_MS);
+  await context.dwell();
+  const drawerPresent =
+    root(context.inspector).querySelector("[data-cpk-launcher-drawer]") !==
+    null;
+
+  // The signal itself is intact: the dot survives, only the labels are lost.
+  const dotPresent =
+    root(context.inspector).querySelector("[data-cpk-signal-dot]") !== null;
+
+  const observed = `viewport=${viewportWidth} capsule=${
+    capsulePresent ? "shown" : "stood down"
+  } drawer=${drawerPresent ? "shown" : "stood down"} dot=${
+    dotPresent ? "present" : "gone"
+  }`;
+
+  expect(capsulePresent, observed).toBe(false);
+  expect(drawerPresent, observed).toBe(false);
+  expect(dotPresent, observed).toBe(true);
+});

--- a/packages/web-inspector/src/__tests__/launcher-island-direction.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island-direction.spec.ts
@@ -55,9 +55,6 @@ const RUNTIME_URL = "https://runtime.launcher-island-direction.test";
 const LAUNCHER_SIZE = 52;
 const EDGE_MARGIN = 16;
 const ISLAND_WIDTH = 272;
-/** The island's overhang past the mark — the part that actually needs room. */
-const OVERHANG = ISLAND_WIDTH - LAUNCHER_SIZE; // 220
-
 /**
  * A `mark.left` inside the range the two rules used to disagree over.
  *

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -16,6 +16,7 @@
 
 import {
   CopilotKitCore,
+  CopilotKitCoreErrorCode,
   CopilotKitCoreRuntimeConnectionStatus,
 } from "@copilotkit/core";
 import type {
@@ -26,9 +27,32 @@ import type {
 import { afterEach, expect, test, vi } from "vitest";
 
 import { WebInspectorElement } from "../index.js";
+import { TELEMETRY_EVENTS, TELEMETRY_INGEST_URL } from "../lib/telemetry.js";
 
 const RUNTIME_URL = "https://runtime.launcher-hud.test";
 const ANNOUNCEMENT_URL = "https://cdn.copilotkit.ai/announcements.json";
+const ANNOUNCEMENT_TIMESTAMP = "2026-08-01T09:00:00.000Z";
+/** The announcement's own cadence, which is slower than an error's. */
+const NEWS_BEAT_MS = 2100;
+
+/**
+ * The gesture, stated once, mirroring `ERROR_GESTURE_MS` in the
+ * implementation — 3400ms end to end, not the 4500 a stale note once claimed.
+ */
+const ERROR_BEAT_MS = 400;
+const PILL_OPEN_MS = 250;
+const PILL_HOLD_MS = 2500;
+const PILL_CLOSE_MS = 250;
+const GESTURE_MS = ERROR_BEAT_MS + PILL_OPEN_MS + PILL_HOLD_MS + PILL_CLOSE_MS;
+
+/** The dwell reveal's own durations, mirroring `LAUNCHER_ISLAND_MS`. */
+const ISLAND_CLOSE_MS = 220;
+
+/** Words the capsule can carry, each owned by the panel it comes from. */
+const RUNTIME_ERROR_WORDS = "Runtime error";
+const RUN_ERROR_WORDS = "Agent run failed";
+const INTELLIGENCE_OFF_WORDS = "Intelligence not connected";
+const INTELLIGENCE_ON_WORDS = "Intelligence connected";
 
 const ENABLED_ENDPOINTS = {
   list: true,
@@ -41,6 +65,23 @@ type Options = Readonly<{
   endpoints?: ThreadEndpointRuntimeInfo;
   intelligence?: boolean;
   licenseStatus?: RuntimeLicenseStatus;
+  /**
+   * Install the fake clock before the element mounts, for the arbitration
+   * suite at the foot of this file. A timer started during mount would
+   * otherwise stay on the real one and never be reached.
+   */
+  fakeTimers?: boolean;
+  /**
+   * Hold the announcement feed until `releaseAnnouncement()` is called, so
+   * the news signal can be armed at a chosen moment mid-test rather than
+   * during mount.
+   */
+  announcementPending?: boolean;
+}>;
+
+type TelemetryBody = Readonly<{
+  event: string;
+  properties: Readonly<Record<string, unknown>>;
 }>;
 
 class IslandTestCore extends CopilotKitCore {
@@ -86,6 +127,24 @@ class IslandTestCore extends CopilotKitCore {
       "HUD test runtime subscriber failed",
     );
   }
+
+  /**
+   * Arms one of the event-error signals — the second armed subject the
+   * priority row of the case table needs, reached without standing up a
+   * thread store. Same idiom as launcher-error-signal.spec.ts.
+   */
+  async emitAppError(code: CopilotKitCoreErrorCode): Promise<void> {
+    await this.notifySubscribers(
+      (subscriber) =>
+        subscriber.onError?.({
+          copilotkit: this,
+          error: new Error("island lab failure"),
+          code,
+          context: {},
+        }),
+      "HUD test onError subscriber failed",
+    );
+  }
 }
 
 function requireElement<T extends Node>(element: T | null | undefined): T {
@@ -108,9 +167,12 @@ function launcherButton(inspector: WebInspectorElement): HTMLButtonElement {
 }
 
 function hud(inspector: WebInspectorElement): HTMLElement | null {
-  return root(inspector).querySelector<HTMLElement>("[data-cpk-launcher-hud]");
+  return root(inspector).querySelector<HTMLElement>(
+    "[data-cpk-launcher-drawer]",
+  );
 }
 
+/** Whether the drawer — the island's list half — is on the page. */
 function hudOpen(inspector: WebInspectorElement): boolean {
   return hud(inspector) !== null;
 }
@@ -140,11 +202,34 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+/**
+ * Let renders and resolved fetches land without moving the clock.
+ *
+ * Both branches drain microtasks and zero-delay timers, so which clock is
+ * installed does not change what a caller has to write.
+ */
 async function settle(inspector: WebInspectorElement): Promise<void> {
   for (let turn = 0; turn < 6; turn += 1) {
+    if (vi.isFakeTimers()) await vi.advanceTimersByTimeAsync(0);
     await inspector.updateComplete;
     await Promise.resolve();
   }
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseTelemetryBody(raw: string): TelemetryBody {
+  const parsed: unknown = JSON.parse(raw);
+  if (
+    !isRecord(parsed) ||
+    typeof parsed.event !== "string" ||
+    !isRecord(parsed.properties)
+  ) {
+    throw new Error("Telemetry request body had an unexpected shape");
+  }
+  return { event: parsed.event, properties: parsed.properties };
 }
 
 async function setup(options: Options = {}): Promise<{
@@ -155,26 +240,67 @@ async function setup(options: Options = {}): Promise<{
   clickCapsule: () => Promise<void>;
   pressLauncher: () => Promise<void>;
   closeInspector: () => Promise<void>;
+  /** Move the clock and settle. Requires `fakeTimers`. */
+  advance: (ms: number) => Promise<void>;
+  /** The pointer leaves the launcher. The island plays its exit. */
+  leaveHud: () => Promise<void>;
+  /** Keyboard dwell: focus arrives on, then departs, the launcher. */
+  focusHud: () => Promise<void>;
+  blurHud: () => Promise<void>;
+  breakConnection: () => Promise<void>;
+  healConnection: () => Promise<void>;
+  fireRunError: () => Promise<void>;
+  /** Publish the held announcement feed, arming the news signal mid-test. */
+  releaseAnnouncement: () => Promise<void>;
+  /** Every telemetry payload this component has posted, in order. */
+  telemetryBodies: TelemetryBody[];
 }> {
   document.body.replaceChildren();
   window.localStorage.clear();
   window.sessionStorage.clear();
+  const telemetryBodies: TelemetryBody[] = [];
+  let releaseAnnouncementFeed: (() => void) | null = null;
   vi.stubGlobal(
     "fetch",
     Object.assign(
-      vi.fn(async (input: RequestInfo | URL) => {
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const href = new URL(
           input instanceof Request ? input.url : String(input),
           window.location.href,
         ).href;
+        if (href === TELEMETRY_INGEST_URL) {
+          if (typeof init?.body === "string") {
+            telemetryBodies.push(parseTelemetryBody(init.body));
+          }
+          return new Response(null, { status: 204 });
+        }
         if (href === ANNOUNCEMENT_URL) {
-          return new Response(null, { status: 404 });
+          if (!options.announcementPending) {
+            return new Response(null, { status: 404 });
+          }
+          await new Promise<void>((resolve) => {
+            releaseAnnouncementFeed = resolve;
+          });
+          return new Response(
+            JSON.stringify({
+              timestamp: ANNOUNCEMENT_TIMESTAMP,
+              previewText: "Channels are here",
+              announcement: "## Channels\n\nRead the release notes.",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
         }
         return new Response(null, { status: 404 });
       }),
       globalThis.fetch,
     ),
   );
+
+  if (options.fakeTimers) {
+    // Limited to the two timer functions the launcher uses, so the
+    // announcement's date handling is untouched.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  }
 
   const inspector = new WebInspectorElement();
   const core = new IslandTestCore(options);
@@ -184,6 +310,7 @@ async function setup(options: Options = {}): Promise<{
   await settle(inspector);
 
   const teardown = (): void => {
+    vi.useRealTimers();
     inspector.remove();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -193,13 +320,41 @@ async function setup(options: Options = {}): Promise<{
   };
   cleanup = teardown;
 
-  const openHud = async (): Promise<void> => {
-    const wrapper = requireElement(
+  const wrapper = (): HTMLElement =>
+    requireElement(
       root(inspector).querySelector<HTMLElement>(".console-button-wrapper"),
     );
-    wrapper.dispatchEvent(
+
+  const openHud = async (): Promise<void> => {
+    wrapper().dispatchEvent(
       new PointerEvent("pointerenter", { bubbles: true, composed: true }),
     );
+    await settle(inspector);
+  };
+
+  const leaveHud = async (): Promise<void> => {
+    wrapper().dispatchEvent(
+      new PointerEvent("pointerleave", { bubbles: true, composed: true }),
+    );
+    await settle(inspector);
+  };
+
+  const focusHud = async (): Promise<void> => {
+    wrapper().dispatchEvent(
+      new FocusEvent("focusin", { bubbles: true, composed: true }),
+    );
+    await settle(inspector);
+  };
+
+  const blurHud = async (): Promise<void> => {
+    wrapper().dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, composed: true }),
+    );
+    await settle(inspector);
+  };
+
+  const advance = async (ms: number): Promise<void> => {
+    await vi.advanceTimersByTimeAsync(ms);
     await settle(inspector);
   };
 
@@ -248,6 +403,30 @@ async function setup(options: Options = {}): Promise<{
     clickCapsule,
     pressLauncher,
     closeInspector,
+    advance,
+    leaveHud,
+    focusHud,
+    blurHud,
+    telemetryBodies,
+    breakConnection: async () => {
+      await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Error);
+      await settle(inspector);
+    },
+    healConnection: async () => {
+      await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Connected);
+      await settle(inspector);
+    },
+    fireRunError: async () => {
+      await core.emitAppError(CopilotKitCoreErrorCode.AGENT_RUN_FAILED);
+      await settle(inspector);
+    },
+    releaseAnnouncement: async () => {
+      if (releaseAnnouncementFeed === null) {
+        throw new Error("This scenario has no held announcement feed");
+      }
+      releaseAnnouncementFeed();
+      await settle(inspector);
+    },
   };
 }
 
@@ -597,7 +776,8 @@ test("every launcher rule reaches an element, and every launcher element has a r
   //   about a bare hover does. It needs an armed runtime error.
   // - The drawer is a dwell surface: `renderLauncherDrawer` only returns
   //   markup while `launcherHudOpen` is true, which a pointerenter dwell sets
-  //   but an armed error does not (arming a signal closes the hud).
+  //   but a timed gesture never does — the drawer opens on dwell and on
+  //   nothing else, which is arbitration rule 2.
   //
   // A guard that checked only one of these would quietly stop covering
   // whichever surface that state does not render — which is exactly how
@@ -1086,4 +1266,470 @@ test("the connected dwell capsule opens without forcing Home, leaving the reader
   // Not Home: the capsule stayed neutral and reopened wherever the reader
   // already was, exactly as the plain launcher mark does.
   expect(currentMenu(inspector)).toBe("threads");
+});
+
+// ── Arbitration: two drivers, one island ──────────────────────────────────
+//
+// One test per row of the spec's case table, plus the two silences the dwell
+// driver owes.
+//
+// The split under test: a SIGNAL is event-shaped (it has a moment, so it beats,
+// speaks and self-closes) and a DWELL is state-shaped (it has no moment, so it
+// announces nothing, counts nothing, and ends only when the reader leaves).
+// Capsule and drawer are two slots arbitrated apart — the driver decides how
+// the island opens, the armed signal decides what the capsule says.
+//
+// Every assertion below reads rendered attributes and text, never a private
+// field, so the shape of the state machine behind them stays free to change.
+
+/** Which subject the capsule names, or null when there is no capsule. */
+function capsuleSubject(inspector: WebInspectorElement): string | null {
+  return capsule(inspector)?.getAttribute("data-cpk-launcher-capsule") ?? null;
+}
+
+/**
+ * The gesture's phase attribute, which drives the timed reveal and its static
+ * hold. Absent whenever the dwell is the one opening the capsule.
+ */
+function capsulePhase(inspector: WebInspectorElement): string | null {
+  return capsule(inspector)?.getAttribute("data-cpk-capsule-phase") ?? null;
+}
+
+/** The dwell reveal's phase, shared by both halves of the island. */
+function islandPhase(inspector: WebInspectorElement): string | null {
+  return capsule(inspector)?.getAttribute("data-cpk-island-phase") ?? null;
+}
+
+/** Whether a beat is in flight on the launcher right now. */
+function beating(inspector: WebInspectorElement): boolean {
+  return (
+    launcherButton(inspector).getAttribute("data-cpk-signal-pulsing") === "true"
+  );
+}
+
+/** Which subject owns the resting dot, or null when the launcher is quiet. */
+function dotSubject(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-signal-dot]")
+      ?.getAttribute("data-cpk-signal-dot") ?? null
+  );
+}
+
+/** What the launcher has put into its polite live region, if anything. */
+function spoken(inspector: WebInspectorElement): string {
+  return (
+    root(inspector)
+      .querySelector("[data-cpk-launcher-announcement]")
+      ?.textContent?.trim() ?? ""
+  );
+}
+
+function errorImpressions(bodies: TelemetryBody[]): TelemetryBody[] {
+  return bodies.filter(
+    (body) => body.event === TELEMETRY_EVENTS.errorSignalViewed,
+  );
+}
+
+/**
+ * Advances `total` in slices, asserting no beat is in flight after any of them.
+ *
+ * The slice is deliberately shorter than the 400ms error cadence: a single
+ * long advance runs a whole beat start-to-finish inside itself and comes back
+ * to a quiet launcher, so it cannot tell "never beat" from "beat while nobody
+ * was looking" — and "the launcher never twitched" is precisely the claim
+ * decisions 12 and 13 make.
+ */
+const BEAT_SAMPLE_MS = 200;
+
+async function advanceWithoutBeating(
+  context: {
+    inspector: WebInspectorElement;
+    advance: (ms: number) => Promise<void>;
+  },
+  total: number,
+): Promise<void> {
+  const steps = Math.ceil(total / BEAT_SAMPLE_MS);
+  for (let step = 0; step < steps; step += 1) {
+    await context.advance(BEAT_SAMPLE_MS);
+    expect(
+      beating(context.inspector),
+      `a beat ran ${(step + 1) * BEAT_SAMPLE_MS}ms into a window that must stay still`,
+    ).toBe(false);
+  }
+}
+
+// Row 1 — Nothing armed, no dwell: capsule —, drawer —, beat —.
+test("case table: with nothing armed and nobody hovering, the launcher shows neither half", async () => {
+  const { inspector } = await setup({ intelligence: true });
+
+  expect(capsule(inspector), "a capsule with nothing to say").toBeNull();
+  expect(hudOpen(inspector), "a drawer nobody asked for").toBe(false);
+  expect(beating(inspector)).toBe(false);
+  expect(dotSubject(inspector)).toBeNull();
+});
+
+// Row 2 — Signal fires, no dwell: capsule = the signal's pillLabel, drawer —,
+// beat yes, then the whole thing self-closes.
+test("case table: a signal firing with nobody hovering beats, shows its words alone, and closes itself", async () => {
+  const context = await setup({ fakeTimers: true });
+  await context.breakConnection();
+
+  // The beat says *here*.
+  expect(beating(context.inspector)).toBe(true);
+  expect(hudOpen(context.inspector), "a timed gesture opened the drawer").toBe(
+    false,
+  );
+
+  // Then the pill says *this*.
+  await context.advance(ERROR_BEAT_MS + PILL_OPEN_MS);
+  expect(capsuleHeading(context.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  expect(capsuleSubject(context.inspector)).toBe("connection");
+  expect(capsulePhase(context.inspector)).toBe("holding");
+  expect(
+    hudOpen(context.inspector),
+    "arbitration rule 2: the drawer opens only on dwell",
+  ).toBe(false);
+
+  // And it ends on its own clock, leaving the dot behind.
+  await context.advance(PILL_HOLD_MS + PILL_CLOSE_MS);
+  expect(capsule(context.inspector)).toBeNull();
+  expect(dotSubject(context.inspector)).toBe("connection");
+});
+
+// Row 3 — Dwell, nothing armed: capsule = the services summary, drawer = the
+// services, no beat.
+test("case table: a dwell with nothing armed opens the summary over the services", async () => {
+  const { inspector, openHud } = await setup({ intelligence: true });
+  await openHud();
+
+  expect(capsuleHeading(inspector)).toBe(INTELLIGENCE_ON_WORDS);
+  expect(capsuleSubject(inspector)).toBe("intelligence");
+  expect(islandPhase(inspector)).toBe("open");
+  expect(hudRowLabels(inspector)).toEqual([
+    "Threads disabled",
+    "Learning enabled",
+  ]);
+  expect(beating(inspector)).toBe(false);
+});
+
+// Row 4 — Dwell begins during a running gesture: capsule keeps the signal's
+// pillLabel, the drawer opens, and the clock stops.
+//
+// This is the first of the two defects. `openLauncherHud` used to refuse
+// outright while `gestureSignal` was set, so a hover during the 3.4 seconds
+// after a failure opened nothing at all — the reader looking where the
+// launcher just asked them to look, and getting silence.
+test("case table: hovering during a running gesture opens the drawer and keeps the signal's words", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  await context.breakConnection();
+  await context.advance(ERROR_BEAT_MS + PILL_OPEN_MS);
+  expect(capsulePhase(context.inspector), "setup: mid-gesture").toBe("holding");
+
+  await context.openHud();
+
+  expect(
+    hudOpen(context.inspector),
+    "the drawer stayed shut under a hover because a gesture was running",
+  ).toBe(true);
+  expect(hudRowLabels(context.inspector)).toEqual([
+    "Threads disabled",
+    "Learning enabled",
+  ]);
+  // The words are the failure's, not the summary's: the reader hovered
+  // *because* of the signal.
+  expect(capsuleHeading(context.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  expect(capsuleSubject(context.inspector)).toBe("connection");
+  // And the island is opening on the dwell's reveal, not holding on the
+  // gesture's — one surface, one animation.
+  expect(islandPhase(context.inspector)).toBe("open");
+  expect(capsulePhase(context.inspector)).toBeNull();
+});
+
+// Row 4, second half — the clock stops.
+//
+// WCAG 2.1 SC 1.4.13 requires hover-triggered content to stay until the
+// pointer leaves or the reader dismisses it. `beginGestureTail` used to end
+// with `closeLauncherHud()`, and the hold used to expire on its own timer, so
+// the island vanished from under the pointer either way.
+test("case table: nothing times out under a dwelling pointer, however long it stays", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  await context.breakConnection();
+  await context.advance(ERROR_BEAT_MS);
+  await context.openHud();
+
+  // Well past the whole 3400ms gesture, and past its hold several times over.
+  await advanceWithoutBeating(context, GESTURE_MS * 3);
+
+  expect(
+    capsuleHeading(context.inspector),
+    "the capsule timed out under the pointer",
+  ).toBe(RUNTIME_ERROR_WORDS);
+  expect(
+    hudOpen(context.inspector),
+    "the drawer timed out under the pointer",
+  ).toBe(true);
+  expect(islandPhase(context.inspector)).toBe("open");
+  // The sentence is the third thing on the gesture's clock, and it is the one
+  // that shows the clock really stopped rather than merely going unseen:
+  // the capsule's words survive a gesture that ends underneath them, because
+  // the dwell would go on supplying them from the armed signal. The live
+  // region would not. A screen-reader user who focused the launcher as the
+  // failure arrived must not have the announcement retracted while they are
+  // still standing on it.
+  expect(
+    spoken(context.inspector),
+    "the gesture ended under the pointer and took its sentence with it",
+  ).toBe(RUNTIME_ERROR_WORDS);
+
+  // And it ends when the reader does, not before.
+  await context.leaveHud();
+  await context.advance(ISLAND_CLOSE_MS);
+  expect(spoken(context.inspector)).toBe("");
+});
+
+// Row 5 — Signal fires during dwell: the capsule swaps to the pillLabel, the
+// drawer is unchanged, and there is NO beat (decision 12).
+test("case table: a signal arriving during a dwell swaps the words in without beating", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  await context.openHud();
+  expect(capsuleHeading(context.inspector)).toBe(INTELLIGENCE_ON_WORDS);
+  const rowsBefore = hudRowLabels(context.inspector);
+
+  await context.breakConnection();
+
+  expect(capsuleHeading(context.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  expect(capsuleSubject(context.inspector)).toBe("connection");
+  expect(
+    beating(context.inspector),
+    "decision 12: the launcher twitched under an aiming pointer",
+  ).toBe(false);
+  expect(
+    hudOpen(context.inspector),
+    "the drawer closed under the pointer when the signal arrived",
+  ).toBe(true);
+  expect(hudRowLabels(context.inspector), "the drawer's list changed").toEqual(
+    rowsBefore,
+  );
+  expect(islandPhase(context.inspector)).toBe("open");
+
+  // Not one beat, at any point in the window a gesture would have occupied.
+  await advanceWithoutBeating(context, GESTURE_MS);
+  expect(capsuleHeading(context.inspector)).toBe(RUNTIME_ERROR_WORDS);
+
+  // And the gesture it never ran does not run on the way out either.
+  await context.leaveHud();
+  await context.advance(ISLAND_CLOSE_MS);
+  expect(capsule(context.inspector)).toBeNull();
+  await advanceWithoutBeating(context, GESTURE_MS);
+  expect(capsule(context.inspector)).toBeNull();
+  expect(dotSubject(context.inspector)).toBe("connection");
+});
+
+// Row 6 — Signal resolves during dwell: the capsule falls back to the summary,
+// the drawer is unchanged, and no beat.
+test("case table: a signal healing during a dwell falls back to the summary in place", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  await context.openHud();
+  await context.breakConnection();
+  expect(capsuleHeading(context.inspector), "setup: showing the failure").toBe(
+    RUNTIME_ERROR_WORDS,
+  );
+  const rowsBefore = hudRowLabels(context.inspector);
+
+  await context.healConnection();
+
+  expect(capsuleHeading(context.inspector)).toBe(INTELLIGENCE_ON_WORDS);
+  expect(capsuleSubject(context.inspector)).toBe("intelligence");
+  expect(hudOpen(context.inspector)).toBe(true);
+  expect(hudRowLabels(context.inspector)).toEqual(rowsBefore);
+  // OSS-903 decision 5: a recovery is not announced, and it does not close
+  // the island the reader is still reading.
+  expect(beating(context.inspector)).toBe(false);
+  expect(spoken(context.inspector)).toBe("");
+  expect(dotSubject(context.inspector)).toBeNull();
+  await advanceWithoutBeating(context, GESTURE_MS);
+  expect(hudOpen(context.inspector)).toBe(true);
+});
+
+// Row 7 — Dwell ends after a signal was shown in it: capsule —, drawer —, and
+// NO beat at all (decision 13). The dot stays lit, because the signal is
+// still armed: what is lost is the announcement, not the information.
+test("case table: a dwell that showed a signal does not replay the gesture when the pointer leaves", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  // A real gesture, parked mid-flight by the pointer arriving on it. This is
+  // the case decision 13 is actually about: there IS a suspended sequence,
+  // and the temptation is to let it finish once the reader steps away.
+  await context.breakConnection();
+  await context.advance(ERROR_BEAT_MS);
+  await context.openHud();
+  expect(
+    capsuleHeading(context.inspector),
+    "setup: parked under the pointer",
+  ).toBe(RUNTIME_ERROR_WORDS);
+
+  await context.leaveHud();
+  await context.advance(ISLAND_CLOSE_MS);
+
+  // The island leaves once and stays gone. It does not hand back to the
+  // gesture it interrupted.
+  expect(
+    capsule(context.inspector),
+    "decision 13: the parked gesture resumed as the island left",
+  ).toBeNull();
+  expect(hudOpen(context.inspector)).toBe(false);
+  expect(spoken(context.inspector)).toBe("");
+  // The whole gesture's worth of clock, twice over, and nothing runs.
+  await advanceWithoutBeating(context, GESTURE_MS * 2);
+  expect(
+    capsule(context.inspector),
+    "decision 13: the timed gesture replayed after the pointer left",
+  ).toBeNull();
+  // The information did not go anywhere.
+  expect(dotSubject(context.inspector)).toBe("connection");
+});
+
+// The same row through the keyboard, because focus is the other half of the
+// dwell driver and SC 1.4.13 covers both.
+test("case table: focus dwells and blur ends it, on the same terms as the pointer", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  await context.breakConnection();
+  await context.advance(ERROR_BEAT_MS);
+
+  await context.focusHud();
+  expect(hudOpen(context.inspector)).toBe(true);
+  expect(capsuleHeading(context.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  await advanceWithoutBeating(context, GESTURE_MS * 2);
+  expect(hudOpen(context.inspector), "focus did not hold the clock").toBe(true);
+
+  await context.blurHud();
+  expect(hudOpen(context.inspector)).toBe(false);
+  expect(
+    capsule(context.inspector),
+    "decision 13: the parked gesture resumed the moment focus left",
+  ).toBeNull();
+  await advanceWithoutBeating(context, GESTURE_MS);
+  expect(capsule(context.inspector)).toBeNull();
+  expect(dotSubject(context.inspector)).toBe("connection");
+});
+
+// Row 8 — Two signals armed: the higher `priority` wins the capsule.
+test("case table: with two signals armed the higher priority owns the capsule, whichever armed first", async () => {
+  // `run` (priority 3) first, then `connection` (priority 5) over the top.
+  const rising = await setup({ intelligence: true, fakeTimers: true });
+  await rising.openHud();
+  await rising.fireRunError();
+  expect(capsuleHeading(rising.inspector), "setup: the lesser failure").toBe(
+    RUN_ERROR_WORDS,
+  );
+  await rising.breakConnection();
+  expect(capsuleHeading(rising.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  expect(capsuleSubject(rising.inspector)).toBe("connection");
+  rising.inspector.remove();
+
+  // And the other order: the worse failure keeps the capsule when a lesser one
+  // arms behind it.
+  const falling = await setup({ intelligence: true, fakeTimers: true });
+  await falling.openHud();
+  await falling.breakConnection();
+  await falling.fireRunError();
+  expect(capsuleHeading(falling.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  expect(capsuleSubject(falling.inspector)).toBe("connection");
+});
+
+// The registry, not the arbitration, is what keeps the announcement out of the
+// capsule: `whats-new` declares no `pillLabel`. Pinned here because the
+// arbitration would otherwise be free to acquire a special case for it.
+test("case table: a dwell never shows a signal that declares no capsule words", async () => {
+  const { inspector, openHud } = await setup({ intelligence: true });
+  await openHud();
+  expect(capsuleSubject(inspector)).toBe("intelligence");
+  expect(capsuleSubject(inspector)).not.toBe("whats-new");
+});
+
+// ── The two silences ──────────────────────────────────────────────────────
+
+test("the dwell driver puts nothing into the live region, because nothing changed", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  expect(spoken(context.inspector)).toBe("");
+
+  await context.openHud();
+  expect(
+    spoken(context.inspector),
+    "a hover spoke into the polite live region",
+  ).toBe("");
+
+  // Including the case where the dwell is carrying a signal's words: the
+  // signal arrived under the pointer, so it was shown rather than announced
+  // (decision 13). A screen-reader user who is focused here is reading the
+  // capsule, not waiting to be told about it.
+  await context.breakConnection();
+  expect(capsuleHeading(context.inspector)).toBe(RUNTIME_ERROR_WORDS);
+  expect(spoken(context.inspector)).toBe("");
+
+  await context.leaveHud();
+  await context.advance(ISLAND_CLOSE_MS);
+  expect(spoken(context.inspector)).toBe("");
+});
+
+test("the dwell driver counts no impression, because a state has no occurrences", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+
+  await context.openHud();
+  await context.advance(GESTURE_MS);
+  await context.leaveHud();
+  await context.advance(ISLAND_CLOSE_MS);
+  await context.openHud();
+  await context.advance(GESTURE_MS);
+
+  expect(
+    context.telemetryBodies.map((body) => body.event),
+    "hovering was counted, which would make the metric measure mouse movement",
+  ).toEqual([]);
+});
+
+// The mirror of the silence above, and the reason it is not a licence to drop
+// the signal driver's own impression: `maybeTrackErrorSignalViewed` holds the
+// event until this outage's pill question is answered, and a signal shown in
+// a dwelling capsule never runs a pill. Left unanswered, the impression for
+// every failure that arrives under the pointer is silently lost.
+test("a signal shown in a dwelling capsule still reports its one impression", async () => {
+  const context = await setup({ intelligence: true, fakeTimers: true });
+  await context.openHud();
+  await context.breakConnection();
+  await context.advance(GESTURE_MS);
+
+  const impressions = errorImpressions(context.telemetryBodies);
+  expect(impressions).toHaveLength(1);
+  expect(impressions[0]?.properties.source).toBe("connection");
+  expect(impressions[0]?.properties.label).toBe("shown");
+});
+
+// Decision 12 without decision 13: a signal that declares no `pillLabel` has
+// no words to swap in, so a dwell shows the reader nothing about it. Its beat
+// is therefore DEFERRED rather than spent — the launcher still must not twitch
+// under an aiming pointer, but the nudge is owed and gets paid when the reader
+// leaves. Spending it here would silently drop the announcement's one nudge.
+test("a beat with no words to show is held while the pointer is there, then runs", async () => {
+  const context = await setup({
+    intelligence: true,
+    fakeTimers: true,
+    announcementPending: true,
+  });
+
+  await context.openHud();
+  await context.releaseAnnouncement();
+
+  // Armed, dotted, and silent — the announcement never reaches the capsule.
+  expect(dotSubject(context.inspector)).toBe("whats-new");
+  expect(capsuleSubject(context.inspector)).toBe("intelligence");
+  await advanceWithoutBeating(context, NEWS_BEAT_MS * 2);
+
+  await context.leaveHud();
+  await context.advance(ISLAND_CLOSE_MS);
+
+  expect(
+    beating(context.inspector),
+    "the held beat was dropped rather than deferred",
+  ).toBe(true);
 });

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -242,6 +242,24 @@ function drawerRows(inspector: WebInspectorElement): HTMLElement[] {
   );
 }
 
+function capsuleHeading(inspector: WebInspectorElement): string | null {
+  return (
+    capsule(inspector)
+      ?.querySelector("[data-cpk-capsule-heading]")
+      ?.textContent?.replace(/\s+/g, " ")
+      .trim() ?? null
+  );
+}
+
+function capsuleSubline(inspector: WebInspectorElement): string | null {
+  return (
+    capsule(inspector)
+      ?.querySelector("[data-cpk-capsule-subline]")
+      ?.textContent?.replace(/\s+/g, " ")
+      .trim() ?? null
+  );
+}
+
 /**
  * The body of a rule whose selector is exactly `selector`, not one that merely
  * ends with it. `.cpk-launcher-drawer` also appears inside a descendant
@@ -272,6 +290,42 @@ function ruleBody(css: string, selector: string): string | null {
  */
 function drawerRuleBody(css: string): string {
   return ruleBody(css, ".cpk-launcher-drawer") ?? "";
+}
+
+/**
+ * The full body of a `@keyframes NAME { ... }` rule. Each stop inside it is
+ * itself a `{ ... }` block, so `ruleBody`'s "stop at the first `}`" pattern
+ * would return only the first stop's declarations rather than the whole
+ * rule. This balances braces instead, walking from the rule's own opening
+ * brace to its matching close.
+ */
+function keyframesBody(css: string, name: string): string {
+  const start = css.indexOf(`@keyframes ${name}`);
+  if (start === -1) return "";
+  const braceStart = css.indexOf("{", start);
+  if (braceStart === -1) return "";
+  let depth = 0;
+  for (let i = braceStart; i < css.length; i += 1) {
+    if (css[i] === "{") depth += 1;
+    else if (css[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(braceStart + 1, i);
+    }
+  }
+  return "";
+}
+
+/**
+ * The `clip-path` declared on one stop — `"0%"` or `"100%"` — of a keyframes
+ * body, whitespace collapsed to single spaces so a `calc()` expression
+ * wrapped across several source lines compares equal to the same expression
+ * written on one line.
+ */
+function clipPathAtStop(body: string, stop: "0%" | "100%"): string {
+  const match = new RegExp(
+    `${stop}\\s*\\{[\\s\\S]*?clip-path:\\s*([\\s\\S]*?);`,
+  ).exec(body);
+  return match?.[1]?.replace(/\s+/g, " ").trim() ?? "";
 }
 
 test("the capsule and the launcher share one surface and one edge", async () => {
@@ -393,14 +447,13 @@ test("the drawer and the capsule share a top edge and a width", async () => {
   }
 });
 
-test("the drawer names three services and nothing else", async () => {
+test("the drawer names two services and nothing else, Intelligence having left for the capsule's title", async () => {
   const { inspector, openHud } = await setup({ intelligence: true });
   await openHud();
   // A real DOM assertion, not a stylesheet one: jsdom matches selectors even
   // though it lays nothing out, so querySelectorAll and .dataset both work.
   expect(drawerRows(inspector).map((row) => row.dataset.cpkHudRow)).toEqual([
     "threads",
-    "intelligence",
     "learning",
   ]);
 });
@@ -600,6 +653,11 @@ test("every launcher rule reaches an element, and every launcher element has a r
     // Presence marker for the row's checkmark SVG, read by
     // launcher-hud.spec.ts.
     "data-cpk-hud-check",
+    // Presence marker for the row's cross SVG — the disabled-row mirror of
+    // the checkmark above. Styling comes from the `.cpk-launcher-drawer__cross`
+    // class (verified: four rules reference it), not from this attribute; it
+    // is a query hook exactly like its sibling, for the same reason.
+    "data-cpk-hud-cross",
     // Presence marker for the capsule's heading span. No selector — CSS or
     // test — currently addresses it by this attribute.
     "data-cpk-capsule-heading",
@@ -636,4 +694,112 @@ test("the drawer paints behind the capsule, which paints behind the mark", async
   const mark = z(".console-button", "the launcher");
   expect(drawer).toBeLessThan(capsule);
   expect(capsule).toBeLessThan(mark);
+});
+
+test("the capsule shows on dwell, titled with the Intelligence connection it is the parent of", async () => {
+  // Connected: `intelligence: true` makes `CopilotKitCore.intelligence`
+  // truthy, which is what the home briefing falls back to for
+  // `hero.connection` while no metadata has been fetched (licenseState
+  // stays "unknown" in this suite).
+  const connected = await setup({ intelligence: true });
+  await connected.openHud();
+  expect(
+    capsule(connected.inspector),
+    "the capsule does not render on a bare dwell",
+  ).not.toBeNull();
+  expect(capsuleHeading(connected.inspector)).toBe("Intelligence connected");
+  // The subline is the fixed invitation, unrelated to the connection state;
+  // pinned here too so a future edit cannot satisfy the heading assertion by
+  // swapping the two spans' content.
+  expect(capsuleSubline(connected.inspector)).toBe("Click to open Inspector");
+
+  // Not connected: no `intelligence` option at all.
+  const disconnected = await setup();
+  await disconnected.openHud();
+  expect(capsuleHeading(disconnected.inspector)).toBe(
+    "Intelligence not connected",
+  );
+  expect(capsuleSubline(disconnected.inspector)).toBe(
+    "Click to open Inspector",
+  );
+});
+
+test("a disabled row carries the cross, an enabled row carries the check, and the two are not the same colour", async () => {
+  // No `endpoints` option: `areThreadEndpointsAvailable()` reads
+  // `this._core?.threadEndpoints`, which is `undefined` here, so Threads is
+  // disabled. Learning is backed by the component's own
+  // `_memoriesAvailable`, which defaults to `true` and nothing here turns
+  // off — so one setup produces one row of each kind.
+  const { inspector, openHud } = await setup({ intelligence: true });
+  await openHud();
+
+  const rows = drawerRows(inspector);
+  const threadsRow = rows.find((row) => row.dataset.cpkHudRow === "threads");
+  const learningRow = rows.find((row) => row.dataset.cpkHudRow === "learning");
+  if (!threadsRow || !learningRow) {
+    throw new Error(
+      `expected a threads row and a learning row, got ${rows
+        .map((row) => row.dataset.cpkHudRow)
+        .join(", ")}`,
+    );
+  }
+
+  // Each row carries exactly one glyph, and it is the one that matches its
+  // own state.
+  expect(threadsRow.querySelector("[data-cpk-hud-cross]")).not.toBeNull();
+  expect(threadsRow.querySelector("[data-cpk-hud-check]")).toBeNull();
+  expect(learningRow.querySelector("[data-cpk-hud-check]")).not.toBeNull();
+  expect(learningRow.querySelector("[data-cpk-hud-cross]")).toBeNull();
+
+  // What is under test is the SHARING, not the value, same as the rest of
+  // this file: the two glyphs must resolve to different colours, whatever
+  // those colours are, so the on/off pair stays visually distinguishable to
+  // a reader who cannot rely on the row text alone. Asserting a literal hex
+  // would pass today and stay silent the day someone hardcodes the two
+  // glyphs onto the same colour.
+  const css = stylesheetText(inspector);
+  const checkColor = /color:\s*([^;]+);/
+    .exec(ruleBody(css, ".cpk-launcher-drawer__check") ?? "")?.[1]
+    ?.trim();
+  const crossColor = /color:\s*([^;]+);/
+    .exec(ruleBody(css, ".cpk-launcher-drawer__cross") ?? "")?.[1]
+    ?.trim();
+  expect(checkColor, "the check has no colour rule").toBeTruthy();
+  expect(crossColor, "the cross has no colour rule").toBeTruthy();
+  expect(crossColor).not.toBe(checkColor);
+});
+
+test("the closed island clips to exactly the mark's footprint, and the open island clips to none of it", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+
+  // The open end of both directions is the same shape: nothing held back at
+  // all, rounded by the launcher's own radius rather than a bare pixel that
+  // would agree with the circle only at one clamp width.
+  const openClip = "inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2))";
+
+  const left = keyframesBody(css, "cpk-launcher-island-left");
+  const right = keyframesBody(css, "cpk-launcher-island-right");
+  expect(left, "cpk-launcher-island-left is missing").not.toBe("");
+  expect(right, "cpk-launcher-island-right is missing").not.toBe("");
+
+  // -left opens toward the left, so the mark sits at the island's top-right
+  // corner: the closed (0%) frame must leave exactly that size-by-size
+  // corner visible — nothing taken off the top or the right, and everything
+  // but the mark's own size taken off the bottom and the left — expressed
+  // through `--cpk-launcher-size`, not a literal. An island whose closed
+  // frame left more than that visible would not be a circle opening out, it
+  // would be a second surface appearing outside the mark before the reveal
+  // even starts.
+  expect(clipPathAtStop(left, "0%")).toBe(
+    "inset( 0 0 calc(100% - var(--cpk-launcher-size)) calc(100% - var(--cpk-launcher-size)) round calc(var(--cpk-launcher-size) / 2) )",
+  );
+  expect(clipPathAtStop(left, "100%")).toBe(openClip);
+
+  // -right is the mirror: the mark sits at the top-left corner, so the pair
+  // of insets held at zero moves from (top, right) to (top, left).
+  expect(clipPathAtStop(right, "0%")).toBe(
+    "inset( 0 calc(100% - var(--cpk-launcher-size)) calc(100% - var(--cpk-launcher-size)) 0 round calc(var(--cpk-launcher-size) / 2) )",
+  );
+  expect(clipPathAtStop(right, "100%")).toBe(openClip);
 });

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -934,11 +934,13 @@ test("the drawer paints behind the capsule, which paints behind the mark", async
     expect(m, `${name} must declare an explicit z-index`).not.toBeNull();
     return Number(m![1]);
   };
-  const drawer = z(".cpk-launcher-drawer", "the drawer");
-  const capsule = z(".cpk-launcher-capsule", "the capsule");
-  const mark = z(".console-button", "the launcher");
-  expect(drawer).toBeLessThan(capsule);
-  expect(capsule).toBeLessThan(mark);
+  // Named with the axis, not after the elements: bare `capsule`/`drawer`
+  // shadow this file's own element helpers of the same name.
+  const drawerZ = z(".cpk-launcher-drawer", "the drawer");
+  const capsuleZ = z(".cpk-launcher-capsule", "the capsule");
+  const markZ = z(".console-button", "the launcher");
+  expect(drawerZ).toBeLessThan(capsuleZ);
+  expect(capsuleZ).toBeLessThan(markZ);
 });
 
 test("the launcher declares its own ring instead of trusting the Tailwind border utility", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -941,33 +941,36 @@ test("the drawer paints behind the capsule, which paints behind the mark", async
   expect(capsule).toBeLessThan(mark);
 });
 
-test("the launcher draws no ring, on every host alike", async () => {
+test("the launcher declares its own ring instead of trusting the Tailwind border utility", async () => {
   const { inspector } = await setup();
   const css = stylesheetText(inspector);
 
-  // The button's class list carries Tailwind's own border utility (it also
-  // supplies unrelated resets), and that utility is the reason the ring was
-  // never a decision. The generated rule is
-  // `.border { border-style: var(--tw-border-style); border-width: 1px }`,
+  // The button's class list carries Tailwind's own border utility, and a
+  // reader skimming the markup could reasonably assume that is what draws the
+  // launcher's hairline. It cannot be relied on for that: the generated rule
+  // is `.border { border-style: var(--tw-border-style); border-width: 1px }`,
   // and `--tw-border-style` is registered by a Tailwind `@property` rule.
   // `@property` inside a stylesheet ADOPTED into a shadow root does not
-  // register document-wide, so inside this component's shadow root the
-  // variable was unresolved: `border-style` fell back to `none`, and CSS then
-  // computed `border-width` to 0 regardless of the declared 1px.
+  // register document-wide, so inside this shadow root the variable was
+  // unresolved: `border-style` fell back to `none`, and CSS then computed
+  // `border-width` to 0 regardless of the declared 1px. The SAME stylesheet
+  // bytes therefore drew a ring on a host page that loads Tailwind v4 and no
+  // ring on one that does not.
   //
-  // So the SAME stylesheet bytes drew a hairline on a host page that loads
-  // Tailwind v4 and no hairline on one that does not. The launcher is meant
-  // to look the same on both, and ringless is the look that was chosen from
-  // seeing them side by side — so the sheet has to say so, or the utility
-  // decides again on the next Tailwind host.
+  // That is the whole point of declaring it, and the reason is not symmetry
+  // for its own sake. The ring exists to separate the launcher from a DARK
+  // page: the face is #181C1F, measured at 1.10:1 against GitHub dark, which
+  // is indistinguishable from the page on its own. So on precisely the hosts
+  // the ring is FOR, the inherited version was the one that vanished. The
+  // intent sat in the sheet while the pixels were up to the host.
   //
-  // This guards the zeroing declaration, not the absence of a border: an
-  // assertion that merely found no `border:` line would pass just as happily
-  // against the old bug, where nothing was declared and the host decided.
-  //
-  // A computed-style assertion cannot see any of this — jsdom resolves no CSS
-  // off a shadow-root stylesheet, so declared-nothing and declared-zero read
-  // back an identical 0px — which is why this suite reads stylesheet text.
+  // A computed-style assertion cannot see any of this: jsdom resolves no CSS
+  // off a shadow-root stylesheet, so the broken state (nothing declared) and
+  // the fixed state (1px solid) read back an identical computed 0px / "" —
+  // only the declaration text tells them apart, which is why this suite reads
+  // stylesheet text. And the assertion is for PRESENCE, not a value: the bug
+  // was a missing declaration, not a wrong one, exactly like the z-index
+  // guard above.
   //
   // The declaration lives on the SECOND `.console-button` rule in this sheet;
   // the first carries only layout (width/height/z-index/transition), so this
@@ -977,30 +980,29 @@ test("the launcher draws no ring, on every host alike", async () => {
     consoleButtonRules.length,
     "expected two .console-button rules (layout, then paint)",
   ).toBeGreaterThanOrEqual(2);
-
-  const zeroesTheRing = consoleButtonRules.some((rule) =>
-    /border:\s*0\s*;/.test(rule),
+  const declaresOwnRing = consoleButtonRules.some(
+    (rule) =>
+      /border-width:\s*1px/.test(rule) && /border-style:\s*solid/.test(rule),
   );
   expect(
-    zeroesTheRing,
-    "no .console-button rule zeroes the border; the ring is back to " +
-      "depending on whether the host page registers --tw-border-style for " +
-      "the Tailwind border utility, which is how it came to differ between " +
-      "two hosts running identical bytes",
+    declaresOwnRing,
+    "no .console-button rule declares border-width and border-style; the " +
+      "ring is back to depending on the host page registering " +
+      "--tw-border-style for the Tailwind border utility, which is exactly " +
+      "the dark-page case the ring exists for",
   ).toBe(true);
 
-  // And nothing may put one back on a state of the same element: a ring that
-  // appears only on hover or focus is the seam this shape exists to remove.
-  // :focus-visible is exempt and deliberately so — that outline is an
-  // accessibility affordance, not decoration, and it is an `outline`, which
-  // does not affect layout or the island's footprint.
-  const ringBack = consoleButtonRules.some((rule) =>
-    /border-(width|style)\s*:\s*(?!0)/.test(rule),
+  // And it must read the same token the island reads, or the circle and the
+  // thing it grows into are ringed differently on the one gesture where both
+  // are on screen at once.
+  const ringToken = consoleButtonRules.some((rule) =>
+    /border-color:\s*var\(--cpk-launcher-edge\)/.test(rule),
   );
   expect(
-    ringBack,
-    "a .console-button rule declares a non-zero border again",
-  ).toBe(false);
+    ringToken,
+    "the launcher's ring does not read var(--cpk-launcher-edge), so it can " +
+      "drift from the capsule and drawer hairlines",
+  ).toBe(true);
 });
 
 test("the circle and the island paint the same surface", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -574,7 +574,8 @@ function clipProps(body: string): Partial<Record<ClipSide, string>> {
     const match = new RegExp(`--cpk-island-clip-${side}:\\s*([^;]+);`).exec(
       body,
     );
-    if (match) props[side] = match[1].replace(/\s+/g, " ").trim();
+    const value = match?.[1];
+    if (value !== undefined) props[side] = value.replace(/\s+/g, " ").trim();
   }
   return props;
 }

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -1,0 +1,295 @@
+// Launcher island (the capsule the closed launcher opens into)
+//
+// Same discipline as the other launcher suites: assertions read the actual
+// adopted stylesheet text rather than computed style or layout geometry.
+// This suite runs under jsdom (see packages/web-inspector/vitest.config.ts),
+// which returns "" for every custom-property read off a shadow-root
+// stylesheet, rgba(0, 0, 0, 0) for backgroundColor, and an all-zero DOMRect
+// for every element — so getComputedStyle() and getBoundingClientRect()
+// cannot tell these cases apart. The stylesheet text can, so every test here
+// extracts a CSS rule by name and inspects its declarations directly.
+//
+// What is under test is the SHARING, not the value: the capsule and the
+// launcher resolve the same custom properties rather than each carrying its
+// own literal, so a later edit that changes a token moves both, and a later
+// edit that hardcodes either fails here.
+
+import {
+  CopilotKitCore,
+  CopilotKitCoreRuntimeConnectionStatus,
+} from "@copilotkit/core";
+import type {
+  IntelligenceRuntimeInfo,
+  RuntimeLicenseStatus,
+  ThreadEndpointRuntimeInfo,
+} from "@copilotkit/shared";
+import { afterEach, expect, test, vi } from "vitest";
+
+import { WebInspectorElement } from "../index.js";
+
+const RUNTIME_URL = "https://runtime.launcher-hud.test";
+const ANNOUNCEMENT_URL = "https://cdn.copilotkit.ai/announcements.json";
+
+const ENABLED_ENDPOINTS = {
+  list: true,
+  inspect: true,
+  mutations: false,
+  realtimeMetadata: false,
+} satisfies ThreadEndpointRuntimeInfo;
+
+type Options = Readonly<{
+  endpoints?: ThreadEndpointRuntimeInfo;
+  intelligence?: boolean;
+  licenseStatus?: RuntimeLicenseStatus;
+}>;
+
+class IslandTestCore extends CopilotKitCore {
+  private readonly endpointsValue: ThreadEndpointRuntimeInfo | undefined;
+  private readonly intelligenceValue: IntelligenceRuntimeInfo | undefined;
+  private readonly licenseStatusValue: RuntimeLicenseStatus | undefined;
+
+  constructor(options: Options) {
+    super({
+      runtimeUrl: RUNTIME_URL,
+      runtimeTransport: "rest",
+      deferInitialConnection: true,
+    });
+    this.endpointsValue = options.endpoints;
+    this.intelligenceValue =
+      options.intelligence === true
+        ? { wsUrl: "wss://intelligence.launcher-hud.test" }
+        : undefined;
+    this.licenseStatusValue = options.licenseStatus;
+  }
+
+  override get threadEndpoints(): ThreadEndpointRuntimeInfo | undefined {
+    return this.endpointsValue;
+  }
+
+  override get intelligence(): IntelligenceRuntimeInfo | undefined {
+    return this.intelligenceValue;
+  }
+
+  override get licenseStatus(): RuntimeLicenseStatus | undefined {
+    return this.licenseStatusValue;
+  }
+
+  async emitStatus(
+    status: CopilotKitCoreRuntimeConnectionStatus,
+  ): Promise<void> {
+    await this.notifySubscribers(
+      (subscriber) =>
+        subscriber.onRuntimeConnectionStatusChanged?.({
+          copilotkit: this,
+          status,
+        }),
+      "HUD test runtime subscriber failed",
+    );
+  }
+}
+
+function requireElement<T extends Node>(element: T | null | undefined): T {
+  if (!element) {
+    throw new Error("Expected an element");
+  }
+  return element;
+}
+
+function root(inspector: WebInspectorElement): ShadowRoot {
+  return requireElement(inspector.shadowRoot);
+}
+
+function launcherButton(inspector: WebInspectorElement): HTMLButtonElement {
+  return requireElement(
+    root(inspector).querySelector<HTMLButtonElement>(
+      'button[aria-label^="Web Inspector"]',
+    ),
+  );
+}
+
+function hud(inspector: WebInspectorElement): HTMLElement | null {
+  return root(inspector).querySelector<HTMLElement>("[data-cpk-launcher-hud]");
+}
+
+function hudOpen(inspector: WebInspectorElement): boolean {
+  return hud(inspector) !== null;
+}
+
+function hudRowLabels(inspector: WebInspectorElement): string[] {
+  return Array.from(
+    root(inspector).querySelectorAll<HTMLElement>("[data-cpk-hud-row]"),
+  ).map((row) => {
+    const action = row.querySelector("[data-cpk-hud-action]");
+    return action?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+  });
+}
+
+function currentMenu(inspector: WebInspectorElement): string | null {
+  return (
+    root(inspector)
+      .querySelector('button[data-inspector-menu-key][aria-current="page"]')
+      ?.getAttribute("data-inspector-menu-key") ?? null
+  );
+}
+
+let cleanup: (() => void) | null = null;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = null;
+  vi.useRealTimers();
+});
+
+async function settle(inspector: WebInspectorElement): Promise<void> {
+  for (let turn = 0; turn < 6; turn += 1) {
+    await inspector.updateComplete;
+    await Promise.resolve();
+  }
+}
+
+async function setup(options: Options = {}): Promise<{
+  inspector: WebInspectorElement;
+  openHud: () => Promise<void>;
+  clickHud: (row: string) => Promise<void>;
+  pressLauncher: () => Promise<void>;
+}> {
+  document.body.replaceChildren();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    Object.assign(
+      vi.fn(async (input: RequestInfo | URL) => {
+        const href = new URL(
+          input instanceof Request ? input.url : String(input),
+          window.location.href,
+        ).href;
+        if (href === ANNOUNCEMENT_URL) {
+          return new Response(null, { status: 404 });
+        }
+        return new Response(null, { status: 404 });
+      }),
+      globalThis.fetch,
+    ),
+  );
+
+  const inspector = new WebInspectorElement();
+  const core = new IslandTestCore(options);
+  document.body.append(inspector);
+  inspector.core = core;
+  await core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Connected);
+  await settle(inspector);
+
+  const teardown = (): void => {
+    inspector.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    document.body.replaceChildren();
+  };
+  cleanup = teardown;
+
+  const openHud = async (): Promise<void> => {
+    const wrapper = requireElement(
+      root(inspector).querySelector<HTMLElement>(".console-button-wrapper"),
+    );
+    wrapper.dispatchEvent(
+      new PointerEvent("pointerenter", { bubbles: true, composed: true }),
+    );
+    await settle(inspector);
+  };
+
+  const clickHud = async (row: string): Promise<void> => {
+    const control = requireElement(
+      root(inspector).querySelector<HTMLButtonElement>(
+        `[data-cpk-hud-row="${row}"] [data-cpk-hud-action]`,
+      ),
+    );
+    control.click();
+    await settle(inspector);
+  };
+
+  const pressLauncher = async (): Promise<void> => {
+    const button = launcherButton(inspector);
+    const init = { bubbles: true, composed: true, pointerId: 1, button: 0 };
+    button.dispatchEvent(new PointerEvent("pointerdown", init));
+    button.dispatchEvent(new PointerEvent("pointerup", init));
+    button.click();
+    await settle(inspector);
+  };
+
+  return { inspector, openHud, clickHud, pressLauncher };
+}
+
+/** Every stylesheet this component adopts, as one string. */
+function stylesheetText(inspector: WebInspectorElement): string {
+  return Array.from(root(inspector).querySelectorAll("style"))
+    .map((style) => style.textContent ?? "")
+    .join("\n");
+}
+
+function capsule(inspector: WebInspectorElement): HTMLElement | null {
+  return root(inspector).querySelector<HTMLElement>(
+    "[data-cpk-launcher-capsule]",
+  );
+}
+
+test("the capsule and the launcher share one surface and one edge", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+  const wrapperRule =
+    /\.console-button-wrapper\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  // The wrapper is the one place the tokens are declared. If a later edit
+  // moves the declaration elsewhere, both consumers below lose their source
+  // of truth silently — this pins the source, not just the consumers.
+  expect(wrapperRule).toContain("--cpk-launcher-face:");
+  expect(wrapperRule).toContain("--cpk-launcher-edge:");
+
+  const capsuleRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  // The capsule resolves the wrapper's own tokens rather than restating the
+  // colours. A future edit that changes a token moves both the launcher and
+  // the capsule at once; a future edit that hardcodes either drifts apart
+  // without this failing to catch it.
+  expect(capsuleRule).toContain("var(--cpk-launcher-face)");
+  expect(capsuleRule).toContain("var(--cpk-launcher-edge)");
+  // color-mix would be a second, independently-computed surface rather than
+  // the same one the launcher already carries.
+  expect(capsuleRule).not.toContain("color-mix");
+});
+
+test("the island width is a shared custom property, not a literal", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+
+  const wrapperRule =
+    /\.console-button-wrapper\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  // The width is declared once, as a length, on the wrapper. Asserted as a
+  // pattern rather than a specific number: the value is allowed to change,
+  // but it must still live on the shared token rather than move onto the
+  // capsule as its own literal.
+  expect(wrapperRule).toMatch(/--cpk-launcher-island:\s*\d+(\.\d+)?px/);
+
+  const capsuleRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  // The capsule reads that same token for its own width. If it instead
+  // carried a matching literal, the two would agree today and silently
+  // drift the next time either one is edited.
+  expect(capsuleRule).toContain("width: var(--cpk-launcher-island)");
+});
+
+test("one radius expression makes every island shape", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+
+  const capsuleRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  // The radius is derived from the launcher's own size rather than a bare
+  // pixel value, so the capsule's ends stay exactly as round as the circle
+  // it opens from at every size the clamp produces. A literal radius would
+  // agree with the circle only at one width and drift at every other.
+  expect(capsuleRule).toContain(
+    "border-radius: calc(var(--cpk-launcher-size) / 2)",
+  );
+});

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -149,6 +149,7 @@ async function settle(inspector: WebInspectorElement): Promise<void> {
 
 async function setup(options: Options = {}): Promise<{
   inspector: WebInspectorElement;
+  core: IslandTestCore;
   openHud: () => Promise<void>;
   clickHud: (row: string) => Promise<void>;
   pressLauncher: () => Promise<void>;
@@ -219,7 +220,7 @@ async function setup(options: Options = {}): Promise<{
     await settle(inspector);
   };
 
-  return { inspector, openHud, clickHud, pressLauncher };
+  return { inspector, core, openHud, clickHud, pressLauncher };
 }
 
 /** Every stylesheet this component adopts, as one string. */
@@ -233,6 +234,44 @@ function capsule(inspector: WebInspectorElement): HTMLElement | null {
   return root(inspector).querySelector<HTMLElement>(
     "[data-cpk-launcher-capsule]",
   );
+}
+
+function drawerRows(inspector: WebInspectorElement): HTMLElement[] {
+  return Array.from(
+    root(inspector).querySelectorAll<HTMLElement>("[data-cpk-hud-row]"),
+  );
+}
+
+/**
+ * The body of a rule whose selector is exactly `selector`, not one that merely
+ * ends with it. `.cpk-launcher-drawer` also appears inside a descendant
+ * selector earlier in the sheet, and a naive match returns that one.
+ *
+ * The gap between the rule boundary and the selector is `(whitespace |
+ * /* comment *\/)*`, not bare `\s*`: `.cpk-launcher-capsule` sits behind a
+ * multi-paragraph `/* ... *\/` doc comment, and a whitespace-only gap never
+ * reaches past it, so the anchored match silently fails closed (returns
+ * null) for that selector specifically.
+ */
+function ruleBody(css: string, selector: string): string | null {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const gap = "(?:\\s|/\\*[\\s\\S]*?\\*/)*";
+  const re = new RegExp(`(?:^|\\})${gap}${escaped}${gap}\\{([\\s\\S]*?)\\}`);
+  return re.exec(css)?.[1] ?? null;
+}
+
+/**
+ * The plain substring pattern `/\.cpk-launcher-drawer\s*\{.../` also matches
+ * inside `.console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-drawer`
+ * — a compound rule that toggles visibility and sits earlier in the
+ * stylesheet than the drawer's own geometry rule. Unanchored, `.exec` returns
+ * that compound rule's body (pointer-events/opacity/visibility) instead of
+ * the rule under test. `ruleBody` anchors the match on a rule boundary (start
+ * of string or a preceding `}`), which skips any selector where
+ * `.cpk-launcher-drawer` is a compound tail rather than the whole selector.
+ */
+function drawerRuleBody(css: string): string {
+  return ruleBody(css, ".cpk-launcher-drawer") ?? "";
 }
 
 test("the capsule and the launcher share one surface and one edge", async () => {
@@ -257,6 +296,15 @@ test("the capsule and the launcher share one surface and one edge", async () => 
   // color-mix would be a second, independently-computed surface rather than
   // the same one the launcher already carries.
   expect(capsuleRule).not.toContain("color-mix");
+
+  const drawerRule = drawerRuleBody(css);
+  // The drawer is the capsule's sibling surface, not a second one: it reads
+  // the same wrapper tokens rather than restating the colours, so spec
+  // decisions 1 and 5 (one surface, shared by every launcher-opened piece)
+  // hold for the drawer too, not just the capsule.
+  expect(drawerRule).toContain("var(--cpk-launcher-face)");
+  expect(drawerRule).toContain("var(--cpk-launcher-edge)");
+  expect(drawerRule).not.toContain("color-mix");
 });
 
 test("the island width is a shared custom property, not a literal", async () => {
@@ -277,6 +325,12 @@ test("the island width is a shared custom property, not a literal", async () => 
   // carried a matching literal, the two would agree today and silently
   // drift the next time either one is edited.
   expect(capsuleRule).toContain("width: var(--cpk-launcher-island)");
+
+  const drawerRule = drawerRuleBody(css);
+  // The drawer reads the same shared width token as the capsule, so the two
+  // stay flush by construction (spec decision 9) rather than by two literals
+  // that happen to agree today.
+  expect(drawerRule).toContain("width: var(--cpk-launcher-island)");
 });
 
 test("one radius expression makes every island shape", async () => {
@@ -292,4 +346,162 @@ test("one radius expression makes every island shape", async () => {
   expect(capsuleRule).toContain(
     "border-radius: calc(var(--cpk-launcher-size) / 2)",
   );
+
+  const drawerRule = drawerRuleBody(css);
+  // Same derived expression on the drawer: its corners stay exactly as round
+  // as the circle the launcher opens from, at every size the clamp produces.
+  expect(drawerRule).toContain(
+    "border-radius: calc(var(--cpk-launcher-size) / 2)",
+  );
+});
+
+test("the drawer reserves a band the launcher mark sits in", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+  const drawerRule = drawerRuleBody(css);
+  // Self-check on the helper: `border-radius` only appears on the drawer's
+  // own standalone rule, not on the earlier compound
+  // `.console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-drawer`
+  // visibility toggle. If `drawerRuleBody` ever regressed to matching that
+  // compound rule again, this would fail before the padding assertion below
+  // got a chance to fail on the same wrong body.
+  expect(drawerRule).toContain(
+    "border-radius: calc(var(--cpk-launcher-size) / 2)",
+  );
+  // On main the first HUD row's top was 39px against a mark bottom of 62px -
+  // 23px of overlap - and the mark's z-index swallowed the click, so a row
+  // that looked like a link was not one. The fix is a top padding band sized
+  // to clear the mark plus a margin, not a row that happens to sit lower.
+  //
+  // jsdom performs no layout: a getBoundingClientRect version of this test
+  // would read {0,0,0,0} for both the row and the mark, always report an
+  // overlap (0 <= 0), and never fail no matter what the CSS says. Reading
+  // the declaration itself is the only way this suite can see the band.
+  expect(drawerRule).toContain("padding: calc(var(--cpk-launcher-size) + 6px)");
+});
+
+test("the drawer and the capsule share a top edge and a width", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+  const drawerRule = drawerRuleBody(css);
+  const capsuleRule =
+    /\.cpk-launcher-capsule\s*\{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+  for (const rule of [drawerRule, capsuleRule]) {
+    expect(rule).toContain("top: 50%");
+    expect(rule).toContain("margin-top: calc(var(--cpk-launcher-size) / -2)");
+    expect(rule).toContain("width: var(--cpk-launcher-island)");
+  }
+});
+
+test("the drawer names three services and nothing else", async () => {
+  const { inspector, openHud } = await setup({ intelligence: true });
+  await openHud();
+  // A real DOM assertion, not a stylesheet one: jsdom matches selectors even
+  // though it lays nothing out, so querySelectorAll and .dataset both work.
+  expect(drawerRows(inspector).map((row) => row.dataset.cpkHudRow)).toEqual([
+    "threads",
+    "intelligence",
+    "learning",
+  ]);
+});
+
+test("rows carry no help button and no detail paragraph", async () => {
+  const { inspector, openHud } = await setup({ intelligence: true });
+  await openHud();
+  // The pre-drawer HUD had a per-row help affordance and an expandable
+  // detail paragraph; the drawer replaced both with a single click target.
+  // If either ever reappears in markup, it should be a deliberate decision,
+  // not a leftover from the old row template.
+  expect(root(inspector).querySelector(".cpk-launcher-hud__help")).toBeNull();
+  expect(root(inspector).querySelector(".cpk-launcher-hud__detail")).toBeNull();
+});
+
+/** Every `cpk-launcher-*` class actually carried by an element in `shadow`. */
+function launcherDomClasses(shadow: ShadowRoot): Set<string> {
+  return new Set(
+    Array.from(shadow.querySelectorAll<HTMLElement>('[class*="cpk-launcher-"]'))
+      .flatMap((el) => Array.from(el.classList))
+      .filter((c) => c.startsWith("cpk-launcher-")),
+  );
+}
+
+test("every launcher rule reaches an element, and every launcher element has a rule", async () => {
+  // No single state renders the whole island, so this guard has to look at
+  // the union of two states rather than one:
+  //
+  // - The capsule is a gesture surface: `renderLauncherCapsule` only returns
+  //   markup while `gestureSignal` and `pillPhase` are set, which nothing
+  //   about a bare hover does. It needs an armed runtime error.
+  // - The drawer is a dwell surface: `renderLauncherDrawer` only returns
+  //   markup while `launcherHudOpen` is true, which a pointerenter dwell sets
+  //   but an armed error does not (arming a signal closes the hud).
+  //
+  // A guard that checked only one of these would quietly stop covering
+  // whichever surface that state does not render — which is exactly how
+  // `.cpk-launcher-capsule` went unreachable under the dwell-only version of
+  // this test without the suite failing on it.
+
+  // Dwell: a pointerenter opens the drawer.
+  const dwell = await setup({ intelligence: true });
+  await dwell.openHud();
+  const css = stylesheetText(dwell.inspector);
+  const dwellClasses = launcherDomClasses(root(dwell.inspector));
+
+  // Gesture: an armed runtime error opens the capsule. Same idiom
+  // launcher-error-signal.spec.ts uses to arm the `connection` signal:
+  // `emitStatus(Error)` followed by a settle.
+  const gesture = await setup({ intelligence: true });
+  await gesture.core.emitStatus(CopilotKitCoreRuntimeConnectionStatus.Error);
+  await settle(gesture.inspector);
+  const gestureClasses = launcherDomClasses(root(gesture.inspector));
+
+  const domClasses = new Set([...dwellClasses, ...gestureClasses]);
+
+  // (a) No orphan rule. A selector that matches nothing is a rule that does
+  // nothing, and wave 2 shipped six of them green: the stylesheet had been
+  // renamed to .cpk-launcher-drawer* while the markup still said
+  // .cpk-launcher-hud*, so the launcher rendered with no styling at all and
+  // the suite could not see it.
+  //
+  // expect.soft: collect every failing class instead of stopping at the
+  // first one, and — critically — instead of stopping before direction (b)
+  // ever runs. The single-state version of this test threw on the first
+  // unreached class and never reached (b) at all.
+  const selectorClasses = new Set(
+    Array.from(css.matchAll(/\.(cpk-launcher-(?:capsule|drawer)[\w-]*)/g))
+      .map((m) => m[1])
+      .filter((cls): cls is string => cls !== undefined),
+  );
+  expect(selectorClasses.size).toBeGreaterThan(0);
+  for (const cls of selectorClasses) {
+    expect
+      .soft(domClasses.has(cls), `no element carries .${cls} in either state`)
+      .toBe(true);
+  }
+
+  // (b) The mirror error: markup renamed ahead of the sheet.
+  for (const cls of domClasses) {
+    expect
+      .soft(css, `.${cls} is rendered but has no rule`)
+      .toContain(`.${cls}`);
+  }
+});
+
+test("the drawer paints behind the capsule, which paints behind the mark", async () => {
+  const { inspector } = await setup({ intelligence: true });
+  const css = stylesheetText(inspector);
+  const z = (selector: string, name: string): number => {
+    const rule = ruleBody(css, selector) ?? "";
+    const m = /z-index:\s*(-?\d+)/.exec(rule);
+    // Absence is the failure mode, not a wrong number: an omitted z-index
+    // reads as "on top" for a positioned sibling later in the DOM, which is
+    // how the drawer came to paint over the mark it is supposed to sit under.
+    expect(m, `${name} must declare an explicit z-index`).not.toBeNull();
+    return Number(m![1]);
+  };
+  const drawer = z(".cpk-launcher-drawer", "the drawer");
+  const capsule = z(".cpk-launcher-capsule", "the capsule");
+  const mark = z(".console-button", "the launcher");
+  expect(drawer).toBeLessThan(capsule);
+  expect(capsule).toBeLessThan(mark);
 });

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -152,7 +152,9 @@ async function setup(options: Options = {}): Promise<{
   core: IslandTestCore;
   openHud: () => Promise<void>;
   clickHud: (row: string) => Promise<void>;
+  clickCapsule: () => Promise<void>;
   pressLauncher: () => Promise<void>;
+  closeInspector: () => Promise<void>;
 }> {
   document.body.replaceChildren();
   window.localStorage.clear();
@@ -211,6 +213,14 @@ async function setup(options: Options = {}): Promise<{
     await settle(inspector);
   };
 
+  const clickCapsule = async (): Promise<void> => {
+    const pill = requireElement(
+      root(inspector).querySelector<HTMLElement>("[data-cpk-launcher-capsule]"),
+    );
+    pill.click();
+    await settle(inspector);
+  };
+
   const pressLauncher = async (): Promise<void> => {
     const button = launcherButton(inspector);
     const init = { bubbles: true, composed: true, pointerId: 1, button: 0 };
@@ -220,7 +230,25 @@ async function setup(options: Options = {}): Promise<{
     await settle(inspector);
   };
 
-  return { inspector, core, openHud, clickHud, pressLauncher };
+  const closeInspector = async (): Promise<void> => {
+    const button = requireElement(
+      root(inspector).querySelector<HTMLButtonElement>(
+        'button[aria-label="Close Web Inspector"]',
+      ),
+    );
+    button.click();
+    await settle(inspector);
+  };
+
+  return {
+    inspector,
+    core,
+    openHud,
+    clickHud,
+    clickCapsule,
+    pressLauncher,
+    closeInspector,
+  };
 }
 
 /** Every stylesheet this component adopts, as one string. */
@@ -877,4 +905,59 @@ test("the closed island clips to exactly the mark's footprint, and the open isla
     "inset( 0 calc(100% - var(--cpk-launcher-size)) calc(100% - var(--cpk-launcher-size)) 0 round calc(var(--cpk-launcher-size) / 2) )",
   );
   expect(clipPathAtStop(right, "100%")).toBe(openClip);
+});
+
+// `handlePillClick` fires for the capsule in both of its states (see
+// `renderLauncherCapsule`), and the two states disagree about where a click
+// should land: a running gesture already carries its own `landingTarget` and
+// must keep it, while the dwell state — the one under test here — is the
+// capsule reading Intelligence's own connection back to the reader, and only
+// when that reading is "not connected" does the capsule steer the click to
+// Home, because Home is where Intelligence gets set up.
+//
+// A test that opens a fresh Inspector and checks for "home" proves nothing:
+// a brand-new instance defaults to Home regardless of what clicked it, so
+// both the routed and the unrouted outcome look identical. Each test below
+// first drives the reader to a menu that is NOT Home (Threads, via a HUD row
+// — a landing mechanism already covered elsewhere in this suite) and closes
+// the Inspector, leaving `selectedMenu` sitting on that other view exactly as
+// the plain launcher mark would leave it. Only then does it dwell-open the
+// HUD and click the capsule, so a pass can only mean the capsule actually
+// decided the destination one way or the other.
+test("the disconnected dwell capsule routes to Home even off a different starting view", async () => {
+  const { inspector, openHud, clickHud, closeInspector, clickCapsule } =
+    await setup(); // no `intelligence` option: disconnected.
+
+  await openHud();
+  await clickHud("threads");
+  expect(currentMenu(inspector), "setup: expected to land on Threads").toBe(
+    "threads",
+  );
+
+  await closeInspector();
+  await openHud();
+  expect(capsuleHeading(inspector)).toBe("Intelligence not connected");
+
+  await clickCapsule();
+  expect(currentMenu(inspector)).toBe("home");
+});
+
+test("the connected dwell capsule opens without forcing Home, leaving the reader's view alone", async () => {
+  const { inspector, openHud, clickHud, closeInspector, clickCapsule } =
+    await setup({ intelligence: true }); // connected.
+
+  await openHud();
+  await clickHud("threads");
+  expect(currentMenu(inspector), "setup: expected to land on Threads").toBe(
+    "threads",
+  );
+
+  await closeInspector();
+  await openHud();
+  expect(capsuleHeading(inspector)).toBe("Intelligence connected");
+
+  await clickCapsule();
+  // Not Home: the capsule stayed neutral and reopened wherever the reader
+  // already was, exactly as the plain launcher mark does.
+  expect(currentMenu(inspector)).toBe("threads");
 });

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -376,6 +376,30 @@ function clipPathAtStop(body: string, stop: "0%" | "100%"): string {
   return match?.[1]?.replace(/\s+/g, " ").trim() ?? "";
 }
 
+type ClipSide = "top" | "right" | "bottom" | "left";
+
+/**
+ * The `--cpk-island-clip-*` declarations actually present in one rule body,
+ * keyed by side. The island's closed shape is no longer stated once per
+ * direction inside a keyframe; it is composed from whichever of these
+ * declarations apply, on the very rules that pin the island to a corner (see
+ * the comment above the corner test below). A rule that only overrides one
+ * axis — the vertical drop, or the horizontal side — legitimately leaves the
+ * other two keys absent here rather than present-but-wrong, which is what
+ * lets the corner-composing test merge exactly the rules that apply, the
+ * same way the cascade does, instead of re-deriving the cascade itself.
+ */
+function clipProps(body: string): Partial<Record<ClipSide, string>> {
+  const props: Partial<Record<ClipSide, string>> = {};
+  for (const side of ["top", "right", "bottom", "left"] as const) {
+    const match = new RegExp(`--cpk-island-clip-${side}:\\s*([^;]+);`).exec(
+      body,
+    );
+    if (match) props[side] = match[1].replace(/\s+/g, " ").trim();
+  }
+  return props;
+}
+
 test("the capsule and the launcher share one surface and one edge", async () => {
   const { inspector } = await setup();
   const css = stylesheetText(inspector);
@@ -872,39 +896,141 @@ test("a disabled row carries the cross, an enabled row carries the check, and th
   expect(crossColor).not.toBe(checkColor);
 });
 
-test("the closed island clips to exactly the mark's footprint, and the open island clips to none of it", async () => {
+test("the closed island clips to exactly the mark's footprint at every corner, and the open island clips to none of it", async () => {
   const { inspector } = await setup();
   const css = stylesheetText(inspector);
 
-  // The open end of both directions is the same shape: nothing held back at
-  // all, rounded by the launcher's own radius rather than a bare pixel that
-  // would agree with the circle only at one clamp width.
+  // The mark can now be at any of four corners (the island flips up as well
+  // as sideways), and the naive way to spell that would be four closed
+  // shapes inside the keyframes — doubling the two this suite used to pin.
+  // Instead the shape moved OUT of the keyframes entirely: each rule that
+  // pins the island to an edge — the base rule (the resting corner), the
+  // vertical override for `drop="up"`, and the horizontal override for
+  // `side="right"` (once per surface, since the capsule reads its own
+  // direction attribute and the drawer its own side attribute for the one
+  // `placement.side` answer) — declares the `--cpk-island-clip-*` properties
+  // for the edge(s) it owns. A shared rule then composes all four into one
+  // property, `--cpk-island-closed`, which the resting `clip-path` and both
+  // keyframes read.
+  //
+  // That is why the shape lives on the corner rules rather than inside the
+  // keyframes: the corner a keyframe closes into is decided by the very same
+  // declaration block that pins the island to that corner, so the two
+  // cannot name different corners the way two independently-written
+  // literals could — and it is what lets four corners share two keyframes
+  // instead of eight.
+
+  const FULL = "calc(100% - var(--cpk-launcher-size))";
+
+  // The base rule: shared by the capsule and the drawer, and the only rule
+  // that gives all four properties an unconditional value — the resting
+  // corner, side="left"/drop="down", mark at the island's top-right. It also
+  // composes them into `--cpk-island-closed` and is what the resting
+  // `clip-path` reads, so this one rule is both a corner declaration and the
+  // shared composition site.
+  const baseRule =
+    /\.cpk-launcher-capsule,\s*\.cpk-launcher-drawer\s*\{([\s\S]*?)\}/.exec(
+      css,
+    )?.[1] ?? "";
+  const base = clipProps(baseRule);
+  expect(base.top, "base rule: --cpk-island-clip-top").toBe("0");
+  expect(base.right, "base rule: --cpk-island-clip-right").toBe("0");
+  expect(base.bottom, "base rule: --cpk-island-clip-bottom").toBe(FULL);
+  expect(base.left, "base rule: --cpk-island-clip-left").toBe(FULL);
+  expect(baseRule).toContain("clip-path: var(--cpk-island-closed)");
+
+  // The vertical override: shared by both surfaces, and the only rule that
+  // touches top/bottom for the "up" drop — one of the two NEW corners this
+  // suite never had to cover before. It knows nothing about which side the
+  // island opens toward, so it must leave left/right alone.
+  const dropUpRule =
+    /\.cpk-launcher-capsule\[data-cpk-island-drop="up"\],\s*\.cpk-launcher-drawer\[data-cpk-island-drop="up"\]\s*\{([\s\S]*?)\}/.exec(
+      css,
+    )?.[1] ?? "";
+  const dropUp = clipProps(dropUpRule);
+  expect(dropUp.top, "drop=up rule: --cpk-island-clip-top").toBe(FULL);
+  expect(dropUp.bottom, "drop=up rule: --cpk-island-clip-bottom").toBe("0");
+
+  // The horizontal override, once per surface — the capsule and the drawer
+  // read different attributes for the same one `placement.side` answer, so
+  // there are two rules, and the two must still agree: they draw the same
+  // corner of the same object.
+  const capsuleRight = clipProps(
+    ruleBody(
+      css,
+      '.cpk-launcher-capsule[data-cpk-capsule-direction="right"]',
+    ) ?? "",
+  );
+  const drawerRight = clipProps(
+    ruleBody(css, '.cpk-launcher-drawer[data-cpk-drawer-side="right"]') ?? "",
+  );
+  for (const [name, rule] of [
+    ["capsule", capsuleRight],
+    ["drawer", drawerRight],
+  ] as const) {
+    expect(rule.left, `${name} side=right rule: --cpk-island-clip-left`).toBe(
+      "0",
+    );
+    expect(rule.right, `${name} side=right rule: --cpk-island-clip-right`).toBe(
+      FULL,
+    );
+  }
+
+  // Compose the four corners exactly as the cascade does: the base supplies
+  // every property, and each override wins only the two it actually
+  // declares. Built from the values already asserted above, not from a
+  // second, independent set of literals — these are what the rules just
+  // checked actually produce together, the same as a reader's browser would
+  // compose them.
+  const corners = {
+    "top-right (side=left, drop=down, the default)": { ...base },
+    "top-left (side=right, drop=down)": { ...base, ...capsuleRight },
+    "bottom-right (side=left, drop=up)": { ...base, ...dropUp },
+    "bottom-left (side=right, drop=up)": {
+      ...base,
+      ...capsuleRight,
+      ...dropUp,
+    },
+  };
+
+  // The two "up" corners are exactly where a mistake would hide: they are
+  // new, and a copy-paste that carried the "down" rule's values into the
+  // "up" rule (or the reverse) would leave every individual assertion above
+  // satisfied — each declared value would still be "0" or the mark's own
+  // size — while two of these four supposedly different corners were
+  // secretly the same rectangle. Only comparing the composed results catches
+  // that; an island whose closed frame left more than the mark's own corner
+  // visible would not be a circle opening out, it would be a second surface
+  // appearing before the reveal even starts.
+  const shapes = Object.values(corners).map((clip) =>
+    [clip.top, clip.right, clip.bottom, clip.left].join("|"),
+  );
+  expect(
+    new Set(shapes).size,
+    `expected four distinct corners, got: ${Object.keys(corners)
+      .map((name, i) => `${name} = ${shapes[i]}`)
+      .join("; ")}`,
+  ).toBe(4);
+
+  // The composed property is what both the resting clip (asserted above) and
+  // both keyframes read — never a hardcoded corner of their own, which is
+  // the only thing that keeps the shape and the anchor from drifting apart.
+  const openKeyframes = keyframesBody(css, "cpk-launcher-island-open");
+  const closeKeyframes = keyframesBody(css, "cpk-launcher-island-close");
+  expect(openKeyframes, "cpk-launcher-island-open is missing").not.toBe("");
+  expect(closeKeyframes, "cpk-launcher-island-close is missing").not.toBe("");
+
+  expect(clipPathAtStop(openKeyframes, "0%")).toBe("var(--cpk-island-closed)");
+  expect(clipPathAtStop(closeKeyframes, "100%")).toBe(
+    "var(--cpk-island-closed)",
+  );
+
+  // The open end of the reveal is still the whole island, held back on no
+  // side at all, rounded by the launcher's own radius rather than a bare
+  // pixel that would agree with the circle only at one clamp width.
   const openClip = "inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2))";
-
-  const left = keyframesBody(css, "cpk-launcher-island-left");
-  const right = keyframesBody(css, "cpk-launcher-island-right");
-  expect(left, "cpk-launcher-island-left is missing").not.toBe("");
-  expect(right, "cpk-launcher-island-right is missing").not.toBe("");
-
-  // -left opens toward the left, so the mark sits at the island's top-right
-  // corner: the closed (0%) frame must leave exactly that size-by-size
-  // corner visible — nothing taken off the top or the right, and everything
-  // but the mark's own size taken off the bottom and the left — expressed
-  // through `--cpk-launcher-size`, not a literal. An island whose closed
-  // frame left more than that visible would not be a circle opening out, it
-  // would be a second surface appearing outside the mark before the reveal
-  // even starts.
-  expect(clipPathAtStop(left, "0%")).toBe(
-    "inset( 0 0 calc(100% - var(--cpk-launcher-size)) calc(100% - var(--cpk-launcher-size)) round calc(var(--cpk-launcher-size) / 2) )",
-  );
-  expect(clipPathAtStop(left, "100%")).toBe(openClip);
-
-  // -right is the mirror: the mark sits at the top-left corner, so the pair
-  // of insets held at zero moves from (top, right) to (top, left).
-  expect(clipPathAtStop(right, "0%")).toBe(
-    "inset( 0 calc(100% - var(--cpk-launcher-size)) calc(100% - var(--cpk-launcher-size)) 0 round calc(var(--cpk-launcher-size) / 2) )",
-  );
-  expect(clipPathAtStop(right, "100%")).toBe(openClip);
+  expect(clipPathAtStop(openKeyframes, "100%")).toBe(openClip);
+  expect(clipPathAtStop(closeKeyframes, "0%")).toBe(openClip);
 });
 
 // `handlePillClick` fires for the capsule in both of its states (see

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -279,6 +279,26 @@ function ruleBody(css: string, selector: string): string | null {
 }
 
 /**
+ * Every rule body whose selector is exactly `selector`, in source order —
+ * the `ruleBody` above returns only the first. `.console-button` itself is
+ * declared twice in this stylesheet: an early rule carries layout only
+ * (width/height/z-index/transition), and a second, later rule under the
+ * "Floating button" comment carries paint (background, border, box-shadow).
+ * A helper that stopped at the first occurrence would read the layout rule
+ * and never see the paint one at all — silently checking nothing about the
+ * declarations under test regardless of what they say.
+ */
+function allRuleBodies(css: string, selector: string): string[] {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const gap = "(?:\\s|/\\*[\\s\\S]*?\\*/)*";
+  const re = new RegExp(
+    `(?:^|\\})${gap}${escaped}${gap}\\{([\\s\\S]*?)\\}`,
+    "g",
+  );
+  return Array.from(css.matchAll(re)).map((m) => m[1] ?? "");
+}
+
+/**
  * The plain substring pattern `/\.cpk-launcher-drawer\s*\{.../` also matches
  * inside `.console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-drawer`
  * — a compound rule that toggles visibility and sits earlier in the
@@ -694,6 +714,61 @@ test("the drawer paints behind the capsule, which paints behind the mark", async
   const mark = z(".console-button", "the launcher");
   expect(drawer).toBeLessThan(capsule);
   expect(capsule).toBeLessThan(mark);
+});
+
+test("the launcher declares its own ring instead of trusting the Tailwind border utility", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+
+  // The button's class list still carries Tailwind's `border` utility (it
+  // also supplies unrelated resets), so a reader skimming the markup could
+  // reasonably assume that utility is what draws the launcher's 1px ring.
+  // It cannot be relied on for that: the generated utility is
+  // `.border { border-style: var(--tw-border-style); border-width: 1px }`,
+  // and `--tw-border-style` is registered by a Tailwind `@property` rule.
+  // `@property` inside a stylesheet ADOPTED into a shadow root does not
+  // register document-wide, so inside this component's shadow root the
+  // variable was unresolved: `border-style` fell back to `none`, and CSS
+  // then computes `border-width` to 0 regardless of the declared 1px. The
+  // ring therefore rendered only when the HOST page happened to load
+  // Tailwind v4 itself and register the property for us — on a plain host
+  // page it silently vanished, with the same stylesheet bytes either way.
+  // Measured live: the launcher's face against a dark host page is 1.10:1
+  // (GitHub dark), indistinguishable from the page on its own, so this
+  // hairline is not decoration — on that host it was the launcher's only
+  // contour.
+  //
+  // The fix is the hand-written `.console-button` rule declaring
+  // `border-width` and `border-style` itself, so the ring no longer
+  // depends on what the host page happens to have loaded. That declaration
+  // lives on the SECOND `.console-button` rule in this sheet — the first,
+  // earlier one only carries layout (width/height/z-index/transition) — so
+  // this reads every `.console-button` rule rather than just the first,
+  // the same trap `ruleBody`'s own doc comment above calls out for
+  // `.cpk-launcher-capsule`.
+  //
+  // A computed-style assertion cannot see any of this: jsdom resolves no
+  // CSS off a shadow-root stylesheet, so the broken state (no declaration)
+  // and the fixed state (1px solid) read back an identical computed 0px /
+  // "" — only the declaration text tells them apart, which is why this
+  // whole suite reads stylesheet text instead. And the assertion has to be
+  // for PRESENCE, not a value: the bug was a missing declaration, not a
+  // wrong one, exactly like the z-index guard just above.
+  const consoleButtonRules = allRuleBodies(css, ".console-button");
+  expect(
+    consoleButtonRules.length,
+    "expected two .console-button rules (layout, then paint)",
+  ).toBeGreaterThanOrEqual(2);
+  const declaresOwnRing = consoleButtonRules.some(
+    (rule) =>
+      /border-width:\s*1px/.test(rule) && /border-style:\s*solid/.test(rule),
+  );
+  expect(
+    declaresOwnRing,
+    "no .console-button rule declares border-width and border-style; the " +
+      "ring is back to depending on the host page registering " +
+      "--tw-border-style for the Tailwind `border` utility",
+  ).toBe(true);
 });
 
 test("the capsule shows on dwell, titled with the Intelligence connection it is the parent of", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -51,15 +51,7 @@ const ISLAND_CLOSE_MS = 220;
 /** Words the capsule can carry, each owned by the panel it comes from. */
 const RUNTIME_ERROR_WORDS = "Runtime error";
 const RUN_ERROR_WORDS = "Agent run failed";
-const INTELLIGENCE_OFF_WORDS = "Intelligence not connected";
 const INTELLIGENCE_ON_WORDS = "Intelligence connected";
-
-const ENABLED_ENDPOINTS = {
-  list: true,
-  inspect: true,
-  mutations: false,
-  realtimeMetadata: false,
-} satisfies ThreadEndpointRuntimeInfo;
 
 type Options = Readonly<{
   endpoints?: ThreadEndpointRuntimeInfo;
@@ -949,59 +941,102 @@ test("the drawer paints behind the capsule, which paints behind the mark", async
   expect(capsule).toBeLessThan(mark);
 });
 
-test("the launcher declares its own ring instead of trusting the Tailwind border utility", async () => {
+test("the launcher draws no ring, on every host alike", async () => {
   const { inspector } = await setup();
   const css = stylesheetText(inspector);
 
-  // The button's class list still carries Tailwind's `border` utility (it
-  // also supplies unrelated resets), so a reader skimming the markup could
-  // reasonably assume that utility is what draws the launcher's 1px ring.
-  // It cannot be relied on for that: the generated utility is
+  // The button's class list carries Tailwind's own border utility (it also
+  // supplies unrelated resets), and that utility is the reason the ring was
+  // never a decision. The generated rule is
   // `.border { border-style: var(--tw-border-style); border-width: 1px }`,
   // and `--tw-border-style` is registered by a Tailwind `@property` rule.
   // `@property` inside a stylesheet ADOPTED into a shadow root does not
   // register document-wide, so inside this component's shadow root the
-  // variable was unresolved: `border-style` fell back to `none`, and CSS
-  // then computes `border-width` to 0 regardless of the declared 1px. The
-  // ring therefore rendered only when the HOST page happened to load
-  // Tailwind v4 itself and register the property for us — on a plain host
-  // page it silently vanished, with the same stylesheet bytes either way.
-  // Measured live: the launcher's face against a dark host page is 1.10:1
-  // (GitHub dark), indistinguishable from the page on its own, so this
-  // hairline is not decoration — on that host it was the launcher's only
-  // contour.
+  // variable was unresolved: `border-style` fell back to `none`, and CSS then
+  // computed `border-width` to 0 regardless of the declared 1px.
   //
-  // The fix is the hand-written `.console-button` rule declaring
-  // `border-width` and `border-style` itself, so the ring no longer
-  // depends on what the host page happens to have loaded. That declaration
-  // lives on the SECOND `.console-button` rule in this sheet — the first,
-  // earlier one only carries layout (width/height/z-index/transition) — so
-  // this reads every `.console-button` rule rather than just the first,
-  // the same trap `ruleBody`'s own doc comment above calls out for
-  // `.cpk-launcher-capsule`.
+  // So the SAME stylesheet bytes drew a hairline on a host page that loads
+  // Tailwind v4 and no hairline on one that does not. The launcher is meant
+  // to look the same on both, and ringless is the look that was chosen from
+  // seeing them side by side — so the sheet has to say so, or the utility
+  // decides again on the next Tailwind host.
   //
-  // A computed-style assertion cannot see any of this: jsdom resolves no
-  // CSS off a shadow-root stylesheet, so the broken state (no declaration)
-  // and the fixed state (1px solid) read back an identical computed 0px /
-  // "" — only the declaration text tells them apart, which is why this
-  // whole suite reads stylesheet text instead. And the assertion has to be
-  // for PRESENCE, not a value: the bug was a missing declaration, not a
-  // wrong one, exactly like the z-index guard just above.
+  // This guards the zeroing declaration, not the absence of a border: an
+  // assertion that merely found no `border:` line would pass just as happily
+  // against the old bug, where nothing was declared and the host decided.
+  //
+  // A computed-style assertion cannot see any of this — jsdom resolves no CSS
+  // off a shadow-root stylesheet, so declared-nothing and declared-zero read
+  // back an identical 0px — which is why this suite reads stylesheet text.
+  //
+  // The declaration lives on the SECOND `.console-button` rule in this sheet;
+  // the first carries only layout (width/height/z-index/transition), so this
+  // reads every `.console-button` rule rather than just the first.
   const consoleButtonRules = allRuleBodies(css, ".console-button");
   expect(
     consoleButtonRules.length,
     "expected two .console-button rules (layout, then paint)",
   ).toBeGreaterThanOrEqual(2);
-  const declaresOwnRing = consoleButtonRules.some(
-    (rule) =>
-      /border-width:\s*1px/.test(rule) && /border-style:\s*solid/.test(rule),
+
+  const zeroesTheRing = consoleButtonRules.some((rule) =>
+    /border:\s*0\s*;/.test(rule),
   );
   expect(
-    declaresOwnRing,
-    "no .console-button rule declares border-width and border-style; the " +
-      "ring is back to depending on the host page registering " +
-      "--tw-border-style for the Tailwind `border` utility",
+    zeroesTheRing,
+    "no .console-button rule zeroes the border; the ring is back to " +
+      "depending on whether the host page registers --tw-border-style for " +
+      "the Tailwind border utility, which is how it came to differ between " +
+      "two hosts running identical bytes",
   ).toBe(true);
+
+  // And nothing may put one back on a state of the same element: a ring that
+  // appears only on hover or focus is the seam this shape exists to remove.
+  // :focus-visible is exempt and deliberately so — that outline is an
+  // accessibility affordance, not decoration, and it is an `outline`, which
+  // does not affect layout or the island's footprint.
+  const ringBack = consoleButtonRules.some((rule) =>
+    /border-(width|style)\s*:\s*(?!0)/.test(rule),
+  );
+  expect(
+    ringBack,
+    "a .console-button rule declares a non-zero border again",
+  ).toBe(false);
+});
+
+test("the circle and the island paint the same surface", async () => {
+  const { inspector } = await setup({ intelligence: true });
+  const css = stylesheetText(inspector);
+
+  // The capsule spans the whole island and reaches under the mark, so the two
+  // faces overlap. While both were translucent that overlap composited 0.95
+  // over 0.95 = 0.9975, and against a white page the circle came out at
+  // channel 24.6 against the pill's 35.6 — the circle read as a darker disc
+  // sitting ON the pill rather than as the same surface grown, which is the
+  // one thing this shape is for.
+  //
+  // Two halves, because either alone still lets them drift: they must name
+  // the SAME token, and that token must be opaque. A shared translucent token
+  // would stack again; two opaque literals would be one careless edit apart.
+  const faceValue = /--cpk-launcher-face:\s*([^;]+);/.exec(css)?.[1]?.trim();
+  expect(faceValue, "--cpk-launcher-face is not declared").toBeDefined();
+  expect(
+    faceValue,
+    "--cpk-launcher-face is translucent again; the capsule reaches under " +
+      "the mark, so two translucent faces stack there and the circle goes " +
+      "darker than the island it grew into",
+  ).toMatch(/^rgb\(|^#/);
+
+  for (const [selector, name] of [
+    [".console-button", "the launcher"],
+    [".cpk-launcher-capsule", "the capsule"],
+    [".cpk-launcher-drawer", "the drawer"],
+  ] as const) {
+    const rules = allRuleBodies(css, selector).join("\n");
+    expect(
+      /background(-color)?:\s*var\(--cpk-launcher-face\)/.test(rules),
+      `${name} does not paint with var(--cpk-launcher-face)`,
+    ).toBe(true);
+  }
 });
 
 test("the capsule shows on dwell, titled with the Intelligence connection it is the parent of", async () => {

--- a/packages/web-inspector/src/__tests__/launcher-island.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-island.spec.ts
@@ -425,6 +425,44 @@ function launcherDomClasses(shadow: ShadowRoot): Set<string> {
   );
 }
 
+/** Every `data-cpk-*` attribute name actually carried by an element in `shadow`. */
+function launcherDomAttributes(shadow: ShadowRoot): Set<string> {
+  return new Set(
+    Array.from(shadow.querySelectorAll<HTMLElement>("*")).flatMap((el) =>
+      Array.from(el.attributes)
+        .map((attr) => attr.name)
+        .filter((name) => /^data-cpk-[\w-]+$/.test(name)),
+    ),
+  );
+}
+
+test("the drawer has a rule for each side it can open on", async () => {
+  const { inspector } = await setup();
+  const css = stylesheetText(inspector);
+  // This is the hole the class scan below cannot see: its regex stops at
+  // `[`, so `.cpk-launcher-drawer[data-cpk-drawer-side="right"]` only ever
+  // contributes the reachable class `cpk-launcher-drawer`. Rename the
+  // attribute in the stylesheet alone and every one of this file's other
+  // tests — all 617 of them — stays green, while the renamed rule matches no
+  // element: the right-opening drawer falls through to the base rule's
+  // `right: 0` and renders roughly 210px off the left edge of the viewport,
+  // for exactly the reader the direction-by-room rule exists to protect.
+  // Pinning both rules' bodies directly closes that gap.
+  const rightRule = ruleBody(
+    css,
+    '.cpk-launcher-drawer[data-cpk-drawer-side="right"]',
+  );
+  expect(rightRule, "no rule for the right-opening drawer").not.toBeNull();
+  expect(rightRule).toContain("left: 0");
+  expect(rightRule).toContain("right: auto");
+
+  // The base rule is the left-opening default: no `data-cpk-drawer-side`
+  // attribute at all resolves here, and it must still anchor the drawer to
+  // the right edge for that default to mean anything.
+  const baseRule = drawerRuleBody(css);
+  expect(baseRule).toContain("right: 0");
+});
+
 test("every launcher rule reaches an element, and every launcher element has a rule", async () => {
   // No single state renders the whole island, so this guard has to look at
   // the union of two states rather than one:
@@ -484,6 +522,100 @@ test("every launcher rule reaches an element, and every launcher element has a r
     expect
       .soft(css, `.${cls} is rendered but has no rule`)
       .toContain(`.${cls}`);
+  }
+
+  // (c)/(d) The same join again, but over attribute NAMES rather than class
+  // names. This is the half (a)/(b) above cannot see: the class regex stops
+  // at `[`, so `.cpk-launcher-drawer[data-cpk-drawer-side="right"]` only
+  // ever contributes the reachable class `cpk-launcher-drawer` — a
+  // stylesheet-only rename of `data-cpk-drawer-side` leaves (a)/(b) green
+  // while the renamed rule matches no element. The capsule's equivalent,
+  // `data-cpk-capsule-direction`, is pinned directly in
+  // launcher-error-signal.spec.ts; nothing pinned the drawer's, which is the
+  // asymmetry this join closes.
+  const dwellAttributes = launcherDomAttributes(root(dwell.inspector));
+  const gestureAttributes = launcherDomAttributes(root(gesture.inspector));
+  const domAttributes = new Set([...dwellAttributes, ...gestureAttributes]);
+
+  const selectorAttributes = new Set(
+    Array.from(css.matchAll(/data-cpk-[\w-]+/g)).map((m) => m[0]),
+  );
+  expect(selectorAttributes.size).toBeGreaterThan(0);
+
+  // Two sheet-declared names are legitimately absent from both states here —
+  // verified by reading the one code path that sets each, not assumed. Both
+  // are correctly wired; this suite simply never visits the state that
+  // reaches them. Neither is a rename casualty, so excluding them is not
+  // silencing a hole — leaving them in would make this join flaky against
+  // working code instead of catching a real regression.
+  const attributesReachedByAThirdStateOnly = new Set([
+    // Set only by the one-shot page-load intro preview
+    // (`scheduleLauncherHudIntro`, guarded by its own start/end timers) —
+    // never by `openHud()`'s pointerenter dwell path, which opens the drawer
+    // without touching `launcherHudIntro`. A third, timer-gated state this
+    // suite does not drive into.
+    "data-cpk-hud-intro",
+    // Styles `.inspector-nav-signal-dot`, the OPEN panel's sidebar
+    // navigation marker (see the render call beside
+    // `class="inspector-nav-signal-dot"`) — a different surface from the
+    // closed launcher this file covers. Neither dwell nor gesture opens the
+    // panel.
+    "data-cpk-signal-tone",
+  ]);
+  for (const attr of selectorAttributes) {
+    if (attributesReachedByAThirdStateOnly.has(attr)) continue;
+    expect
+      .soft(
+        domAttributes.has(attr),
+        `no element carries [${attr}] in either state`,
+      )
+      .toBe(true);
+  }
+
+  // Nine DOM-only names are excluded from the mirror direction below — every
+  // one confirmed by grep to be a query hook other spec files (or this
+  // component's own click handler) address by attribute selector, never a
+  // CSS one, and confirmed absent from this component's stylesheet rather
+  // than merely unchecked. A name added here without that same verification
+  // would be silencing a real hole, not documenting one.
+  const domOnlyQueryHooks = new Set([
+    // Live-region marker (role="status"); the region itself carries no
+    // visual styling, so nothing selects it.
+    "data-cpk-launcher-announcement",
+    // Boolean identity marker on the drawer root; queried by
+    // launcher-hud.spec.ts and launcher-island-direction.spec.ts. The
+    // `cpk-launcher-drawer` class carries the styling, this attribute does
+    // not.
+    "data-cpk-launcher-drawer",
+    // Boolean/key identity marker on the capsule root; queried by
+    // launcher-island-direction.spec.ts and launcher-error-signal.spec.ts.
+    // Same split as the drawer's marker above.
+    "data-cpk-launcher-capsule",
+    // Row-id query hook, read by launcher-hud.spec.ts and by this
+    // component's own `handleHudRowClick` closest() check.
+    "data-cpk-hud-row",
+    // Click-target query hook, read by launcher-hud.spec.ts and by this
+    // component's own `handleHudRowClick` closest() check.
+    "data-cpk-hud-action",
+    // Presence marker for the row's checkmark SVG, read by
+    // launcher-hud.spec.ts.
+    "data-cpk-hud-check",
+    // Presence marker for the capsule's heading span. No selector — CSS or
+    // test — currently addresses it by this attribute.
+    "data-cpk-capsule-heading",
+    // Presence marker for the capsule's subline span. Same as the heading
+    // marker above.
+    "data-cpk-capsule-subline",
+    // Query hook for the decorative signal dot, read by
+    // launcher-island-direction.spec.ts, launcher-error-signal.spec.ts,
+    // launcher-signal.spec.ts and inspector-pop-out.spec.ts.
+    "data-cpk-signal-dot",
+  ]);
+  for (const attr of domAttributes) {
+    if (domOnlyQueryHooks.has(attr)) continue;
+    expect
+      .soft(css, `${attr} is rendered but no rule references it`)
+      .toContain(attr);
   }
 });
 

--- a/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
@@ -746,9 +746,11 @@ test("the launcher animates opacity, transform and a clip — nothing that force
     css.matchAll(/@keyframes\s+cpk-launcher-[\w-]+\s*\{([\s\S]*?\}\s*)\}/g),
   );
   const keyframes = keyframeMatches.map((match) => match[1] ?? "");
-  // Two for the halo, one per direction for both launcher reveals, and one
+  // Two for the halo, one per direction for the capsule reveal, one
+  // direction-agnostic HUD intro (it now only fades, so left and right
+  // share the same keyframe instead of needing a mirrored one), and one
   // each for the HUD row and connected check stagger.
-  expect(keyframes).toHaveLength(8);
+  expect(keyframes).toHaveLength(7);
 
   const animated = new Set(
     keyframes

--- a/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
@@ -746,11 +746,13 @@ test("the launcher animates opacity, transform and a clip — nothing that force
     css.matchAll(/@keyframes\s+cpk-launcher-[\w-]+\s*\{([\s\S]*?\}\s*)\}/g),
   );
   const keyframes = keyframeMatches.map((match) => match[1] ?? "");
-  // Two for the halo, one per direction for the capsule reveal, one
-  // direction-agnostic HUD intro (it now only fades, so left and right
-  // share the same keyframe instead of needing a mirrored one), and one
-  // each for the HUD row and connected check stagger.
-  expect(keyframes).toHaveLength(7);
+  // Two for the halo. Four for the island, which is two per direction:
+  // opening and closing need separate keyframes because the clip runs from
+  // the mark's own circle outward, and reversing that is not the same shape
+  // sequence played backwards. One direction-agnostic HUD intro (it only
+  // fades, so left and right share it). One each for the HUD row and the
+  // connected check stagger.
+  expect(keyframes).toHaveLength(9);
 
   const animated = new Set(
     keyframes

--- a/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-signal.spec.ts
@@ -746,13 +746,14 @@ test("the launcher animates opacity, transform and a clip — nothing that force
     css.matchAll(/@keyframes\s+cpk-launcher-[\w-]+\s*\{([\s\S]*?\}\s*)\}/g),
   );
   const keyframes = keyframeMatches.map((match) => match[1] ?? "");
-  // Two for the halo. Four for the island, which is two per direction:
-  // opening and closing need separate keyframes because the clip runs from
-  // the mark's own circle outward, and reversing that is not the same shape
-  // sequence played backwards. One direction-agnostic HUD intro (it only
-  // fades, so left and right share it). One each for the HUD row and the
-  // connected check stagger.
-  expect(keyframes).toHaveLength(9);
+  // Two for the halo. Two for the island: one open, one close, serving all
+  // four corners. The corner the clip closes into is not baked into the
+  // keyframe any more - it is composed per corner into --cpk-island-closed on
+  // the same rules that pin the island to that corner, so the shape it grows
+  // from cannot disagree with where it is anchored. That is what took this
+  // from four island keyframes to two while adding the up-flip. One
+  // direction-agnostic HUD intro, and one each for the row and check stagger.
+  expect(keyframes).toHaveLength(7);
 
   const animated = new Set(
     keyframes

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9759,241 +9759,96 @@ export class WebInspectorElement extends LitElement {
         }
       }
 
-      /* ── Launcher HUD: hover menu, quieter than the error island ── */
-      .console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-hud {
+      /*
+       * The drawer sits BEHIND the capsule and shares its top edge, so it can
+       * only ever be seen below it. The row/mark overlap is not fixed here,
+       * it is made impossible: the top of this box is covered by the capsule,
+       * which is covered in turn by the mark.
+       *
+       * Because it grows downward from behind a capsule that never moves,
+       * the only thing that changes between states is this element's height.
+       * Nothing morphs and no edge travels.
+       *
+       * No shadow, no second surface token, no blur. The capsule's own bottom
+       * border is the whole separator, measured at 1.82:1 against this
+       * surface on both light and dark host pages - the edge is internal, so
+       * the host page cannot reach it. See spec decision 6.
+       */
+      .console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-drawer {
         pointer-events: auto;
         opacity: 1;
-        transform: none;
         visibility: visible;
       }
 
-      .cpk-launcher-hud {
-        --hud-fill: var(--cpk-inspector-surface-dark);
-        --hud-line: rgb(190 194 255 / 0.5);
-        --hud-blur: blur(12px) saturate(1.2);
+      .cpk-launcher-drawer {
         position: absolute;
-        top: 0;
-        z-index: 4;
-        padding-right: 14px;
+        top: 50%;
+        margin-top: calc(var(--cpk-launcher-size) / -2);
+        right: 0;
+        z-index: 1;
+        width: var(--cpk-launcher-island);
+        box-sizing: border-box;
+        /* Top padding clears the capsule that covers this band. */
+        padding: calc(var(--cpk-launcher-size) + 6px) 8px 8px;
+        border-radius: calc(var(--cpk-launcher-size) / 2);
+        border: 1px solid var(--cpk-launcher-edge);
+        background: var(--cpk-launcher-face);
+        color: #fff;
         pointer-events: none;
         opacity: 0;
         visibility: hidden;
-        transform: translateX(8px);
-        transition:
-          opacity 160ms ease,
-          transform 200ms cubic-bezier(0.16, 1, 0.3, 1);
+        transition: opacity 160ms ease;
       }
 
-      .cpk-launcher-hud[data-cpk-hud-side="left"] {
-        right: 100%;
-        padding-right: 14px;
-        padding-left: 0;
-      }
-
-      .cpk-launcher-hud[data-cpk-hud-side="right"] {
-        left: 100%;
+      .cpk-launcher-drawer[data-cpk-drawer-side="right"] {
         right: auto;
-        padding-right: 0;
-        padding-left: 14px;
-        transform: translateX(-8px);
+        left: 0;
       }
 
-      .console-button-wrapper[data-cpk-hud="open"]
-        .cpk-launcher-hud[data-cpk-hud-side="right"] {
-        transform: none;
-      }
-
-      .cpk-launcher-hud__card {
-        position: relative;
-        width: 228px;
-        padding: 4px;
-        border: 1px dotted var(--hud-line);
-        border-radius: var(--cpk-inspector-shell-radius);
-        background: var(--hud-fill);
-        color: #fff;
-        backdrop-filter: var(--hud-blur);
-        -webkit-backdrop-filter: var(--hud-blur);
-        box-shadow: 0 8px 20px rgb(1 5 7 / 0.18);
-      }
-
-      .cpk-launcher-hud[data-color-scheme="light"] {
-        --hud-fill: #fff;
-        --hud-line: #d8d8e8;
-      }
-
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__card {
-        color: #010507;
-      }
-
-      .cpk-launcher-hud__arrow {
-        position: absolute;
-        top: calc(var(--cpk-launcher-size) / 2);
-        z-index: 1;
-        width: 10px;
-        height: 10px;
-        border: 0;
-        /* The card frosts the page behind it, so it reads lighter than the
-           raw fill. Mix a little white so the arrow matches the glass card
-           without going lighter than the HUD. */
-        background: color-mix(in srgb, var(--hud-fill) 88%, white 12%);
-        transform: translateY(-50%) rotate(45deg);
-      }
-
-      .cpk-launcher-hud[data-cpk-hud-side="left"] .cpk-launcher-hud__arrow {
-        right: 9px;
-      }
-
-      .cpk-launcher-hud[data-cpk-hud-side="right"] .cpk-launcher-hud__arrow {
-        left: 9px;
-      }
-
-      .cpk-launcher-hud__list {
+      .cpk-launcher-drawer__list {
         margin: 0;
         padding: 0;
         list-style: none;
       }
 
-      .cpk-launcher-hud__list + .cpk-launcher-hud__list {
-        margin-top: 4px;
-        padding-top: 4px;
-        border-top: 1px dotted var(--hud-line);
-      }
-
-      .cpk-launcher-hud__row {
-        position: relative;
-        display: grid;
-        grid-template-columns: 1fr 28px;
-        align-items: start;
-        border-radius: 7px;
-        cursor: pointer;
-      }
-
-      .cpk-launcher-hud__row + .cpk-launcher-hud__row {
-        margin-top: 1px;
-      }
-
-      .cpk-launcher-hud__row:hover,
-      .cpk-launcher-hud__row:focus-within,
-      .cpk-launcher-hud__row[data-cpk-hud-help="open"] {
-        background: rgb(255 255 255 / 0.06);
-      }
-
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__row:hover,
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__row:focus-within,
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__row[data-cpk-hud-help="open"] {
-        background: #f0f0f4;
-      }
-
-      .cpk-launcher-hud__action {
+      .cpk-launcher-drawer__row {
         display: flex;
-        gap: 8px;
-        min-height: 32px;
         align-items: center;
-        padding: 6px 8px;
-        border: 0;
-        border-radius: 7px;
-        background: transparent;
-        color: #fff;
-        font-family: inherit;
-        font-size: 12px;
-        font-weight: 600;
-        text-align: start;
-        cursor: pointer;
-      }
-
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__action {
-        color: #010507;
-      }
-
-      /* Stretch the row action over the whole tab, including the detail
-         copy. The help mark sits above this layer. */
-      .cpk-launcher-hud__action::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-      }
-
-      .cpk-launcher-hud__check {
-        flex: none;
-        width: 14px;
-        height: 14px;
-        color: #34d399;
-      }
-
-      .cpk-launcher-hud__help {
-        position: relative;
-        z-index: 1;
-        display: inline-flex;
-        width: 28px;
+        gap: 9px;
         height: 32px;
-        align-items: center;
-        justify-content: center;
-        padding: 0;
-        border: 0;
-        background: transparent;
-        color: rgb(255 255 255 / 0.78);
+        padding: 0 20px;
+        border-radius: 999px;
         font-size: 12px;
-        font-weight: 600;
+        font-weight: 500;
+      }
+
+      .cpk-launcher-drawer__row:hover,
+      .cpk-launcher-drawer__row:focus-within {
+        background: rgb(255 255 255 / 0.07);
+      }
+
+      .cpk-launcher-drawer__action {
+        all: unset;
+        flex: 1;
         cursor: pointer;
+        color: inherit;
+        font: inherit;
       }
 
-      .cpk-launcher-hud__help span {
-        display: inline-flex;
-        width: 16px;
-        height: 16px;
-        align-items: center;
-        justify-content: center;
-        border: 1px dotted rgb(190 194 255 / 0.55);
-        border-radius: 50%;
-        line-height: 1;
+      .cpk-launcher-drawer__action:focus-visible {
+        outline: 2px solid var(--cpk-launcher-edge);
+        outline-offset: 2px;
       }
 
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__help {
-        color: #68686e;
-      }
-
-      .cpk-launcher-hud__help:focus-visible,
-      .cpk-launcher-hud__action:focus-visible {
-        outline: 2px solid #bec2ff;
-        outline-offset: 1px;
-      }
-
-      .cpk-launcher-hud__detail {
-        grid-column: 1 / -1;
-        max-height: 0;
-        margin: 0;
-        padding: 0 8px;
-        overflow: hidden;
-        color: rgb(255 255 255 / 0.78);
-        font-size: 11px;
-        font-weight: 400;
-        line-height: 1.4;
-        opacity: 0;
-        pointer-events: none;
-        transform: translateY(-6px);
-        transition:
-          max-height 200ms cubic-bezier(0.16, 1, 0.3, 1),
-          opacity 150ms ease-out,
-          transform 200ms cubic-bezier(0.16, 1, 0.3, 1),
-          padding-bottom 200ms cubic-bezier(0.16, 1, 0.3, 1);
-      }
-
-      .cpk-launcher-hud[data-color-scheme="light"] .cpk-launcher-hud__detail {
-        color: #68686e;
-      }
-
-      .cpk-launcher-hud__row:hover .cpk-launcher-hud__detail,
-      .cpk-launcher-hud__row:focus-within .cpk-launcher-hud__detail,
-      .cpk-launcher-hud__row[data-cpk-hud-help="open"] .cpk-launcher-hud__detail {
-        max-height: 72px;
-        padding: 0 8px 7px;
-        opacity: 1;
-        transform: none;
+      .cpk-launcher-drawer__check {
+        flex: none;
+        width: 12px;
+        height: 12px;
+        color: #6ee7a8;
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .cpk-launcher-hud,
-        .cpk-launcher-hud__detail {
+        .cpk-launcher-drawer {
           transition: none;
         }
       }
@@ -10007,32 +9862,26 @@ export class WebInspectorElement extends LitElement {
       @keyframes cpk-launcher-hud-intro {
         0% {
           opacity: 0;
-          transform: translateX(8px);
         }
         8%,
         88% {
           opacity: 1;
-          transform: none;
         }
         100% {
           opacity: 0;
-          transform: translateX(4px);
         }
       }
 
       @keyframes cpk-launcher-hud-intro-right {
         0% {
           opacity: 0;
-          transform: translateX(-8px);
         }
         8%,
         88% {
           opacity: 1;
-          transform: none;
         }
         100% {
           opacity: 0;
-          transform: translateX(-4px);
         }
       }
 
@@ -10058,37 +9907,37 @@ export class WebInspectorElement extends LitElement {
         }
       }
 
-      .cpk-launcher-hud[data-cpk-hud-intro="true"] {
+      .cpk-launcher-drawer[data-cpk-hud-intro="true"] {
         animation: cpk-launcher-hud-intro
           var(--cpk-launcher-hud-intro-duration)
           cubic-bezier(0.16, 1, 0.3, 1) both;
       }
 
-      .cpk-launcher-hud[data-cpk-hud-intro="true"][data-cpk-hud-side="right"] {
+      .cpk-launcher-drawer[data-cpk-hud-intro="true"][data-cpk-hud-side="right"] {
         animation-name: cpk-launcher-hud-intro-right;
       }
 
-      .cpk-launcher-hud[data-cpk-hud-intro="true"]
-        .cpk-launcher-hud__row {
+      .cpk-launcher-drawer[data-cpk-hud-intro="true"]
+        .cpk-launcher-drawer__row {
         animation: cpk-launcher-hud-row-online
           var(--cpk-launcher-hud-row-duration)
           cubic-bezier(0.16, 1, 0.3, 1) both;
         animation-delay: var(--cpk-hud-row-delay);
       }
 
-      .cpk-launcher-hud[data-cpk-hud-intro="true"]
-        .cpk-launcher-hud__check {
+      .cpk-launcher-drawer[data-cpk-hud-intro="true"]
+        .cpk-launcher-drawer__check {
         animation: cpk-launcher-hud-check-online 220ms
           cubic-bezier(0.16, 1, 0.3, 1) both;
         animation-delay: calc(var(--cpk-hud-row-delay) + 90ms);
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .cpk-launcher-hud[data-cpk-hud-intro="true"],
-        .cpk-launcher-hud[data-cpk-hud-intro="true"]
-          .cpk-launcher-hud__row,
-        .cpk-launcher-hud[data-cpk-hud-intro="true"]
-          .cpk-launcher-hud__check {
+        .cpk-launcher-drawer[data-cpk-hud-intro="true"],
+        .cpk-launcher-drawer[data-cpk-hud-intro="true"]
+          .cpk-launcher-drawer__row,
+        .cpk-launcher-drawer[data-cpk-hud-intro="true"]
+          .cpk-launcher-drawer__check {
           animation: none !important;
           opacity: 1;
           transform: none;

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9943,19 +9943,6 @@ export class WebInspectorElement extends LitElement {
         }
       }
 
-      @keyframes cpk-launcher-hud-intro-right {
-        0% {
-          opacity: 0;
-        }
-        8%,
-        88% {
-          opacity: 1;
-        }
-        100% {
-          opacity: 0;
-        }
-      }
-
       @keyframes cpk-launcher-hud-row-online {
         from {
           opacity: 0;
@@ -9982,10 +9969,6 @@ export class WebInspectorElement extends LitElement {
         animation: cpk-launcher-hud-intro
           var(--cpk-launcher-hud-intro-duration)
           cubic-bezier(0.16, 1, 0.3, 1) both;
-      }
-
-      .cpk-launcher-drawer[data-cpk-hud-intro="true"][data-cpk-drawer-side="right"] {
-        animation-name: cpk-launcher-hud-intro-right;
       }
 
       .cpk-launcher-drawer[data-cpk-hud-intro="true"]

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9536,6 +9536,7 @@ export class WebInspectorElement extends LitElement {
        * z-index (4, 3, 1) instead of leaning on DOM paint order, because a
        * relative order in which only one member states its position is not
        * an order. The mark's own ring and shadow are deliberately left
+       * alone for the whole gesture - the circle's outline staying visible
        * inside the open pill was looked at against the alternative and kept.
        *
        * A column, not a row: the pill carries a heading and a subline stacked,
@@ -10726,7 +10727,7 @@ export class WebInspectorElement extends LitElement {
             >${this.getGestureLabel() ?? ""}</span
           >`
         }
-        ${this.renderLauncherHud()}
+        ${this.renderLauncherDrawer()}
       </div>
     `;
   }
@@ -10977,7 +10978,7 @@ export class WebInspectorElement extends LitElement {
   private renderHudCheck(): TemplateResult {
     return html`
       <svg
-        class="cpk-launcher-hud__check"
+        class="cpk-launcher-drawer__check"
         viewBox="0 0 16 16"
         aria-hidden="true"
         focusable="false"
@@ -10998,17 +10999,13 @@ export class WebInspectorElement extends LitElement {
   private renderHudRow(args: {
     id: LauncherHudRowId;
     label: string;
-    detail: string;
-    connected?: boolean;
+    connected: boolean;
     introIndex: number;
   }): TemplateResult {
-    const helpOpen = this.launcherHudHelp === args.id;
-    const detailId = `cpk-hud-detail-${args.id}`;
     return html`
       <li
-        class="cpk-launcher-hud__row"
+        class="cpk-launcher-drawer__row"
         data-cpk-hud-row=${args.id}
-        data-cpk-hud-help=${helpOpen ? "open" : nothing}
         style=${styleMap({
           "--cpk-hud-row-index": `${args.introIndex}`,
           "--cpk-hud-row-delay": `${
@@ -11018,33 +11015,20 @@ export class WebInspectorElement extends LitElement {
         })}
         @click=${(event: Event) => this.handleHudRowClick(event, args.id)}
       >
+        ${args.connected ? this.renderHudCheck() : nothing}
         <button
+          class="cpk-launcher-drawer__action"
           type="button"
-          class="cpk-launcher-hud__action"
           data-cpk-hud-action
-          aria-describedby=${detailId}
           @click=${(event: Event) => this.handleHudActionClick(event, args.id)}
-          @pointerdown=${(event: Event) => event.stopPropagation()}
         >
-          ${args.connected ? this.renderHudCheck() : nothing}${args.label}
+          ${args.label}
         </button>
-        <button
-          type="button"
-          class="cpk-launcher-hud__help"
-          aria-expanded=${helpOpen ? "true" : "false"}
-          aria-controls=${detailId}
-          aria-label=${`About ${args.label}`}
-          @click=${(event: Event) => this.handleHudHelpClick(event, args.id)}
-          @pointerdown=${(event: Event) => event.stopPropagation()}
-        >
-          <span aria-hidden="true">?</span>
-        </button>
-        <p class="cpk-launcher-hud__detail" id=${detailId}>${args.detail}</p>
       </li>
     `;
   }
 
-  private renderLauncherHud(): TemplateResult | typeof nothing {
+  private renderLauncherDrawer(): TemplateResult | typeof nothing {
     if (!this.launcherHudOpen) return nothing;
     // The launcher must agree with Home about feature availability. Raw
     // transport flags can be present for a runtime that is not entitled to use
@@ -11059,10 +11043,10 @@ export class WebInspectorElement extends LitElement {
     const intelligenceOn = homeModel.hero.connection === "connected";
     return html`
       <div
-        class="cpk-launcher-hud"
+        class="cpk-launcher-drawer"
         id="cpk-launcher-hud"
-        data-cpk-launcher-hud
-        data-cpk-hud-side=${this.launcherHudSide}
+        data-cpk-launcher-drawer
+        data-cpk-drawer-side=${this.launcherHudSide}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
         data-color-scheme=${this.colorScheme}
         style=${styleMap({
@@ -11070,50 +11054,28 @@ export class WebInspectorElement extends LitElement {
           "--cpk-launcher-hud-row-duration": `${LAUNCHER_HUD_INTRO_MS.rowDuration}ms`,
         })}
       >
-        <span class="cpk-launcher-hud__arrow" aria-hidden="true"></span>
-        <div class="cpk-launcher-hud__card">
-          <ul class="cpk-launcher-hud__list" role="list">
-            ${this.renderHudRow({
-              id: "inspector",
-              label: HUD_OPEN_INSPECTOR_LABEL,
-              detail: HUD_OPEN_INSPECTOR_DETAIL,
-              introIndex: 0,
-            })}
-          </ul>
-          <ul class="cpk-launcher-hud__list" role="list">
-            ${this.renderHudRow({
-              id: "threads",
-              label: threadsOn ? HUD_THREADS_ON_LABEL : HUD_THREADS_OFF_LABEL,
-              detail: threadsOn
-                ? HUD_THREADS_ON_DETAIL
-                : HUD_THREADS_OFF_DETAIL,
-              connected: threadsOn,
-              introIndex: 1,
-            })}
-            ${this.renderHudRow({
-              id: "intelligence",
-              label: intelligenceOn
-                ? HUD_INTELLIGENCE_ON_LABEL
-                : HUD_INTELLIGENCE_OFF_LABEL,
-              detail: intelligenceOn
-                ? HUD_INTELLIGENCE_ON_DETAIL
-                : HUD_INTELLIGENCE_OFF_DETAIL,
-              connected: intelligenceOn,
-              introIndex: 2,
-            })}
-            ${this.renderHudRow({
-              id: "learning",
-              label: learningOn
-                ? HUD_LEARNING_ON_LABEL
-                : HUD_LEARNING_OFF_LABEL,
-              detail: learningOn
-                ? HUD_LEARNING_ON_DETAIL
-                : HUD_LEARNING_OFF_DETAIL,
-              connected: learningOn,
-              introIndex: 3,
-            })}
-          </ul>
-        </div>
+        <ul class="cpk-launcher-drawer__list" role="list">
+          ${this.renderHudRow({
+            id: "threads",
+            label: threadsOn ? HUD_THREADS_ON_LABEL : HUD_THREADS_OFF_LABEL,
+            connected: threadsOn,
+            introIndex: 0,
+          })}
+          ${this.renderHudRow({
+            id: "intelligence",
+            label: intelligenceOn
+              ? HUD_INTELLIGENCE_ON_LABEL
+              : HUD_INTELLIGENCE_OFF_LABEL,
+            connected: intelligenceOn,
+            introIndex: 1,
+          })}
+          ${this.renderHudRow({
+            id: "learning",
+            label: learningOn ? HUD_LEARNING_ON_LABEL : HUD_LEARNING_OFF_LABEL,
+            connected: learningOn,
+            introIndex: 2,
+          })}
+        </ul>
       </div>
     `;
   }

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -361,24 +361,14 @@ const EVENT_ERROR_GUIDANCE: Readonly<
  */
 const PILL_SUBLINE_LABEL = "Open Inspector for details";
 
-type LauncherHudRowId = "inspector" | "threads" | "intelligence" | "learning";
+type LauncherHudRowId = "threads" | "intelligence" | "learning";
 
-const HUD_OPEN_INSPECTOR_LABEL = "Open Inspector";
 const HUD_THREADS_OFF_LABEL = "Turn on Threads";
 const HUD_THREADS_ON_LABEL = "Threads on";
 const HUD_INTELLIGENCE_OFF_LABEL = "Turn on Intelligence";
 const HUD_INTELLIGENCE_ON_LABEL = "Intelligence connected";
-const HUD_THREADS_OFF_DETAIL = "Inspect conversations from this app.";
-const HUD_THREADS_ON_DETAIL = "Threads is on. Opens the Threads view.";
-const HUD_INTELLIGENCE_OFF_DETAIL =
-  "Connect Intelligence to use Threads and Learning.";
-const HUD_INTELLIGENCE_ON_DETAIL = "Intelligence is connected. Opens Home.";
 const HUD_LEARNING_OFF_LABEL = "Turn on Learning";
 const HUD_LEARNING_ON_LABEL = "Learning on";
-const HUD_LEARNING_OFF_DETAIL = "Connect Intelligence to use Learning.";
-const HUD_LEARNING_ON_DETAIL = "Learning is on. Opens the Learning view.";
-const HUD_OPEN_INSPECTOR_DETAIL =
-  "Same as clicking the circle. Opens the full Inspector.";
 
 const LAUNCHER_SIGNALS: Readonly<
   Record<LauncherSignalKey, LauncherSignalDefinition>
@@ -6714,7 +6704,6 @@ export class WebInspectorElement extends LitElement {
    * drawer to show.
    */
   private launcherHudSide: LauncherIslandSide | null = null;
-  private launcherHudHelp: LauncherHudRowId | null = null;
   private launcherHudCloseTimer: ReturnType<typeof setTimeout> | null = null;
   private launcherHudIntro = false;
   private launcherHudIntroStartTimer: ReturnType<typeof setTimeout> | null =
@@ -10873,7 +10862,6 @@ export class WebInspectorElement extends LitElement {
         this.launcherHudIntroEndTimer = null;
         this.launcherHudIntro = false;
         this.launcherHudOpen = false;
-        this.launcherHudHelp = null;
         this.requestUpdate();
       }, LAUNCHER_HUD_INTRO_MS.duration);
     }, delay);
@@ -10942,9 +10930,8 @@ export class WebInspectorElement extends LitElement {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
     }
-    if (!this.launcherHudOpen && this.launcherHudHelp === null) return;
+    if (!this.launcherHudOpen) return;
     this.launcherHudOpen = false;
-    this.launcherHudHelp = null;
     this.requestUpdate();
   }
 
@@ -10999,30 +10986,14 @@ export class WebInspectorElement extends LitElement {
     event.preventDefault();
     event.stopPropagation();
     this.hudLandingMenu =
-      row === "inspector"
-        ? null
-        : row === "threads"
-          ? "threads"
-          : row === "learning"
-            ? "memories"
-            : "home";
+      row === "threads" ? "threads" : row === "learning" ? "memories" : "home";
     this.closeLauncherHud();
     this.openInspector("floating_button");
   };
 
-  private handleHudHelpClick = (event: Event, row: LauncherHudRowId): void => {
-    event.preventDefault();
-    event.stopPropagation();
-    this.launcherHudHelp = this.launcherHudHelp === row ? null : row;
-    this.requestUpdate();
-  };
-
   private handleHudRowClick = (event: Event, row: LauncherHudRowId): void => {
     const target = event.target;
-    if (
-      target instanceof Element &&
-      target.closest(".cpk-launcher-hud__help, [data-cpk-hud-action]")
-    ) {
+    if (target instanceof Element && target.closest("[data-cpk-hud-action]")) {
       return;
     }
     this.handleHudActionClick(event, row);
@@ -11060,7 +11031,6 @@ export class WebInspectorElement extends LitElement {
         class="cpk-launcher-drawer__row"
         data-cpk-hud-row=${args.id}
         style=${styleMap({
-          "--cpk-hud-row-index": `${args.introIndex}`,
           "--cpk-hud-row-delay": `${
             LAUNCHER_HUD_INTRO_MS.rowStart +
             args.introIndex * LAUNCHER_HUD_INTRO_MS.rowStagger
@@ -11107,7 +11077,6 @@ export class WebInspectorElement extends LitElement {
         data-cpk-launcher-drawer
         data-cpk-drawer-side=${side}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
-        data-color-scheme=${this.colorScheme}
         style=${styleMap({
           "--cpk-launcher-hud-intro-duration": `${LAUNCHER_HUD_INTRO_MS.duration}ms`,
           "--cpk-launcher-hud-row-duration": `${LAUNCHER_HUD_INTRO_MS.rowDuration}ms`,

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -8884,6 +8884,11 @@ export class WebInspectorElement extends LitElement {
         height: var(--cpk-launcher-size);
         /* Keep the 1px border inside the declared outer size. */
         box-sizing: border-box;
+        /* Stacks above the capsule and the drawer. See spec decision on
+           the launcher's z-index table. Declaring this makes the button
+           a stacking context, which is harmless: its own pseudo-elements
+           and children (mark, signal dot) keep their relative order. */
+        z-index: 4;
         transition:
           transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1),
           scale 300ms cubic-bezier(0.34, 1.56, 0.64, 1),
@@ -9527,9 +9532,10 @@ export class WebInspectorElement extends LitElement {
        * halo would become ellipses.
        *
        * The launcher's own face and border are repeated here so the two form
-       * one capsule: the button paints last and therefore on top, with no
-       * z-index needed. The mark's own ring and shadow are deliberately left
-       * alone for the whole gesture — the circle's outline staying visible
+       * one capsule: button, capsule and drawer each declare an explicit
+       * z-index (4, 3, 1) instead of leaning on DOM paint order, because a
+       * relative order in which only one member states its position is not
+       * an order. The mark's own ring and shadow are deliberately left
        * inside the open pill was looked at against the alternative and kept.
        *
        * A column, not a row: the pill carries a heading and a subline stacked,
@@ -9541,6 +9547,7 @@ export class WebInspectorElement extends LitElement {
         position: absolute;
         top: 50%;
         margin-top: calc(var(--cpk-launcher-size) / -2);
+        z-index: 3;
         height: var(--cpk-launcher-size);
         /* One width in every state, so the capsule and the drawer cannot
            drift apart. See spec decision 9.
@@ -9820,6 +9827,7 @@ export class WebInspectorElement extends LitElement {
         border-radius: 999px;
         font-size: 12px;
         font-weight: 500;
+        cursor: pointer;
       }
 
       .cpk-launcher-drawer__row:hover,
@@ -9836,7 +9844,12 @@ export class WebInspectorElement extends LitElement {
       }
 
       .cpk-launcher-drawer__action:focus-visible {
-        outline: 2px solid var(--cpk-launcher-edge);
+        /* Deliberately NOT --cpk-launcher-edge: that token is a hairline
+           colour at 25% alpha (~1.82:1 over the drawer face), fine for a
+           decorative separator but below the 3:1 floor WCAG 2.1 SC 1.4.11
+           sets for a focus indicator. The opaque colour matches the
+           launcher button's own focus ring. */
+        outline: 2px solid #bec2ff;
         outline-offset: 2px;
       }
 
@@ -9913,7 +9926,7 @@ export class WebInspectorElement extends LitElement {
           cubic-bezier(0.16, 1, 0.3, 1) both;
       }
 
-      .cpk-launcher-drawer[data-cpk-hud-intro="true"][data-cpk-hud-side="right"] {
+      .cpk-launcher-drawer[data-cpk-hud-intro="true"][data-cpk-drawer-side="right"] {
         animation-name: cpk-launcher-hud-intro-right;
       }
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -11578,6 +11578,27 @@ export class WebInspectorElement extends LitElement {
    * away, rather than opening over the edge of the window and being clipped by
    * it.
    */
+  /**
+   * Re-answer the placement question for an island that is already open.
+   *
+   * The placement is resolved on pointerenter. A drag captures the pointer, so
+   * dragging the mark to another corner fires no re-entry and the island keeps
+   * pointing the way it did before - downward off the foot of the window, in
+   * the case that made this visible. It self-corrects on the next dwell, which
+   * is why it went unnoticed on the horizontal axis for as long as it did.
+   *
+   * If the new corner has room for neither direction the resolver reports so,
+   * and the island closes rather than staying open in a place it does not fit.
+   */
+  private rePlaceOpenIsland(): void {
+    if (!this.launcherHudOpen) return;
+    if (!this.resolveLauncherHudPlacement()) {
+      this.closeLauncherHud();
+      return;
+    }
+    this.requestUpdate();
+  }
+
   private resolveLauncherHudPlacement(): boolean {
     const button =
       this.activeRoot.querySelector<HTMLElement>(".console-button");
@@ -14030,6 +14051,7 @@ export class WebInspectorElement extends LitElement {
         // Snap button to nearest corner
         this.snapButtonToCorner();
         this.hasCustomPosition.button = true;
+        this.rePlaceOpenIsland();
         if (this.draggedDuringInteraction) {
           this.ignoreNextButtonClick = true;
         }

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -6917,6 +6917,15 @@ export class WebInspectorElement extends LitElement {
    * announcement, which has no tail and therefore behaves exactly as before.
    */
   private gestureSignal: LauncherSignalKey | null = null;
+  /**
+   * Whether a dwell has stopped this gesture's clock.
+   *
+   * The gesture is parked, not cancelled: its signal and its phase both stay,
+   * so the live region keeps its sentence and the held impression still gets
+   * its answer. Only the timers are gone, and they do not come back — the
+   * dwell ending ends the gesture (decision 13).
+   */
+  private gestureHeldByDwell = false;
   /** Where the running gesture's pill is, or null when it has none. */
   private pillPhase: LauncherPillPhase | null = null;
   /**
@@ -11267,71 +11276,163 @@ export class WebInspectorElement extends LitElement {
   }
 
   /**
-   * The island's front half. One capsule, fed by either driver.
+   * Whether the reader is on the launcher right now — pointer or focus.
    *
-   * It is laid out at its full width and clipped in both cases, and in both
-   * cases it renders from the first frame — clipped to the mark's own
+   * This is the dwell driver's whole state: no edge, no clock, no history.
+   * The page-load preview is excluded because nobody is there for it, and the
+   * closing phase is excluded because it plays *after* the pointer has left.
+   * Both of those are "the island is on screen", which is a different
+   * question from "the reader is here", and only the second one may stop a
+   * clock or suppress a beat.
+   */
+  private isLauncherDwelling(): boolean {
+    return (
+      this.launcherHudOpen &&
+      !this.launcherHudIntro &&
+      !this.launcherIslandClosing
+    );
+  }
+
+  /**
+   * Which driver owns the capsule, and everything that follows from it.
+   *
+   * The dwell wins the *presentation* whenever the island is open, because
+   * the island is one surface and a dwelling reader is looking at all of it:
+   * the drawer below is opening on the dwell's clock, so the capsule above it
+   * cannot be running the gesture's. What the capsule *says* is a separate
+   * question, answered by `getCapsuleSignal` — the two slots are arbitrated
+   * apart, which is the whole point of the split.
+   *
+   * A gesture never reaches this branch while a dwell is up. `startSignalPulse`
+   * declines to start one under the pointer (decisions 12 and 13), and a dwell
+   * that begins over a running one parks it in `holdGestureForDwell`.
+   */
+  private getCapsuleDriver():
+    | { driver: "dwell"; placement: LauncherIslandPlacement }
+    | { driver: "signal"; key: LauncherSignalKey; label: string }
+    | null {
+    if (this.launcherHudOpen && this.launcherHudPlacement !== null) {
+      return { driver: "dwell", placement: this.launcherHudPlacement };
+    }
+    const key = this.gestureSignal;
+    if (key === null || this.pillPhase === null) return null;
+    const label = LAUNCHER_SIGNALS[key].pillLabel;
+    if (label === undefined) return null;
+    return { driver: "signal", key, label };
+  }
+
+  /**
+   * The highest-priority armed signal that has words for the capsule, or null.
+   *
+   * `LAUNCHER_SIGNAL_PRIORITY_ORDER` is already sorted, so this is the dot's
+   * own precedence rule with one extra filter: a signal that declares no
+   * `pillLabel` has nothing to put here. That is how `whats-new` stays out of
+   * the capsule without the arbitration having to name it — the registry says
+   * so, not this method.
+   */
+  private getArmedCapsuleSignal(): LauncherSignalKey | null {
+    for (const key of LAUNCHER_SIGNAL_PRIORITY_ORDER) {
+      if (LAUNCHER_SIGNALS[key].pillLabel === undefined) continue;
+      if (this.isSignalArmed(key)) return key;
+    }
+    return null;
+  }
+
+  /**
+   * The signal whose words the capsule is carrying, or null when it carries
+   * the services summary instead — or nothing at all.
+   *
+   * Under a dwell this is a *state* question, not an event one: whichever
+   * signal is armed right now owns the words, so one arming mid-dwell swaps
+   * them in and one healing mid-dwell swaps them back out, both without a
+   * beat and without a second gesture. Off a dwell it is the running gesture,
+   * which is the only other thing that can put words on the launcher.
+   *
+   * The page-load preview is deliberately not a dwell: it previews the
+   * services island, on its own clock, for a reader who did not ask for it.
+   */
+  private getCapsuleSignal(): LauncherSignalKey | null {
+    const owner = this.getCapsuleDriver();
+    if (owner === null) return null;
+    if (owner.driver === "signal") return owner.key;
+    if (this.launcherHudIntro) return null;
+    return this.getArmedCapsuleSignal();
+  }
+
+  /**
+   * The island's front half. One capsule, two slots.
+   *
+   * It is laid out at its full width and clipped in every case, and in every
+   * case it renders from the first frame — clipped to the mark's own
    * footprint, so it shows nothing that is not already the circle — because
    * the side is decided from the room around the launcher, which cannot be
    * read until the launcher is laid out.
    *
-   * **A signal beats a dwell.** An error has a moment and the moment is what
-   * is worth saying; the connection state underneath it has not changed and
-   * comes back the instant the gesture ends. That is arbitration between two
-   * things competing for one slot, not a priority between two features.
+   * **The driver decides how it opens; the armed signal decides what it
+   * says.** Those are two questions and they get two answers. A dwelling
+   * reader with a red dot beside them gets the island's own reveal carrying
+   * the failure's words — not the services summary they already know, and not
+   * a 2.5-second hold that expires under their pointer.
    */
   private renderLauncherCapsule(): TemplateResult | typeof nothing {
-    const gestureKey = this.gestureSignal;
-    const gestureSignal =
-      gestureKey === null ? null : LAUNCHER_SIGNALS[gestureKey];
-    const gestureLabel = gestureSignal?.pillLabel;
+    const owner = this.getCapsuleDriver();
+    if (owner === null) return nothing;
 
-    // Which driver owns the capsule, and therefore what it says.
-    let subject: string;
-    let heading: string;
-    let placement: LauncherIslandPlacement;
+    const signalKey = this.getCapsuleSignal();
+    const signal = signalKey === null ? null : LAUNCHER_SIGNALS[signalKey];
     const styles: Record<string, string> = {};
 
-    if (
-      gestureKey !== null &&
-      gestureSignal !== null &&
-      gestureLabel !== undefined &&
-      this.pillPhase !== null
-    ) {
-      subject = gestureKey;
-      heading = gestureLabel;
-      // Before the measurement the pill is laid out at the island's default
-      // placement, which is size-identical to every other one and shows
-      // nothing whichever it turns out to be while the clip is closed.
-      placement = this.pillPlacement ?? LAUNCHER_ISLAND_DEFAULT_PLACEMENT;
-      styles["--cpk-launcher-signal"] =
-        LAUNCHER_SIGNAL_COLORS[gestureSignal.tone];
-      styles["--cpk-launcher-capsule-open"] = `${ERROR_GESTURE_MS.open}ms`;
-      styles["--cpk-launcher-capsule-close"] = `${ERROR_GESTURE_MS.close}ms`;
-    } else if (this.launcherHudOpen && this.launcherHudPlacement !== null) {
-      // The dwell state. Intelligence is the island's title rather than one of
-      // the rows below it, because the rows are features and this is the
-      // connection they are carried over: a parent listed among its own
-      // children reads as a peer of them.
-      subject = "intelligence";
-      heading =
-        this.getHomeModel().hero.connection === "connected"
-          ? ISLAND_INTELLIGENCE_ON_TITLE
-          : ISLAND_INTELLIGENCE_OFF_TITLE;
-      placement = this.launcherHudPlacement;
+    // How it opens.
+    const placement =
+      owner.driver === "dwell"
+        ? owner.placement
+        : // Before the measurement the pill is laid out at the island's
+          // default placement, which is size-identical to every other one and
+          // shows nothing whichever it turns out to be while the clip is
+          // closed.
+          (this.pillPlacement ?? LAUNCHER_ISLAND_DEFAULT_PLACEMENT);
+    if (owner.driver === "dwell") {
       styles["--cpk-launcher-island-open"] = `${LAUNCHER_ISLAND_MS.open}ms`;
       styles["--cpk-launcher-island-close"] = `${LAUNCHER_ISLAND_MS.close}ms`;
       styles["--cpk-launcher-hud-intro-duration"] =
         `${LAUNCHER_HUD_INTRO_MS.duration}ms`;
     } else {
-      return nothing;
+      styles["--cpk-launcher-capsule-open"] = `${ERROR_GESTURE_MS.open}ms`;
+      styles["--cpk-launcher-capsule-close"] = `${ERROR_GESTURE_MS.close}ms`;
+    }
+
+    // What it says.
+    let subject: string;
+    let heading: string;
+    if (signalKey !== null && signal?.pillLabel !== undefined) {
+      subject = signalKey;
+      heading = signal.pillLabel;
+      styles["--cpk-launcher-signal"] = LAUNCHER_SIGNAL_COLORS[signal.tone];
+    } else {
+      // Intelligence is the island's title rather than one of the rows below
+      // it, because the rows are features and this is the connection they are
+      // carried over: a parent listed among its own children reads as a peer
+      // of them.
+      subject = "intelligence";
+      heading =
+        this.getHomeModel().hero.connection === "connected"
+          ? ISLAND_INTELLIGENCE_ON_TITLE
+          : ISLAND_INTELLIGENCE_OFF_TITLE;
     }
 
     return html`
       <span
         class="cpk-launcher-capsule"
         data-cpk-launcher-capsule=${subject}
-        data-cpk-capsule-phase=${this.pillPhase ?? nothing}
+        data-cpk-capsule-phase=${
+          // The gesture's phase attribute drives the gesture's own reveal and
+          // its hold, so it is emitted only while the gesture is the one
+          // opening the capsule. A parked gesture keeps its phase in the
+          // state — that is what the placement measurement and the held
+          // telemetry impression still read — but must not paint with it,
+          // or the hold's static clip would fight the dwell's animation.
+          owner.driver === "signal" ? this.pillPhase : nothing
+        }
         data-cpk-island-phase=${this.getLauncherIslandPhase()}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
         data-cpk-capsule-direction=${placement.side}
@@ -11354,13 +11455,13 @@ export class WebInspectorElement extends LitElement {
    * The dwell reveal's phase, shared by both halves of the island so the two
    * cannot be told to do different things.
    *
-   * Absent during a running gesture, whose own phase attribute owns the
-   * capsule, and absent during the page-load preview, which fades the island
-   * in and out whole on its own clock rather than opening it.
+   * Absent while the gesture owns the capsule, whose own phase attribute
+   * drives it, and absent during the page-load preview, which fades the
+   * island in and out whole on its own clock rather than opening it.
    */
   private getLauncherIslandPhase(): "open" | "closing" | typeof nothing {
-    if (this.pillPhase !== null) return nothing;
-    if (!this.launcherHudOpen || this.launcherHudIntro) return nothing;
+    if (this.getCapsuleDriver()?.driver !== "dwell") return nothing;
+    if (this.launcherHudIntro) return nothing;
     return this.launcherIslandClosing ? "closing" : "open";
   }
 
@@ -11377,26 +11478,28 @@ export class WebInspectorElement extends LitElement {
    * The gesture ends with the open, because `openInspector` cancels the tail —
    * the panel is over the launcher, so there is nothing left to reveal.
    *
-   * This one click fires for both of `renderLauncherCapsule`'s states, and
-   * they disagree about where to land. A running gesture already declares its
-   * own `landingTarget` — `openInspector` applies it from `activeSignalAtOpen`
-   * — and that must keep winning here; a signal owns the gesture slot exactly
-   * when `gestureSignal` and `pillPhase` are both set (see `beginGestureTail`,
-   * which clears both together for a signal with no pill), so that is the
-   * check that rules this click out of routing at all. Only the dwell state
-   * is left to decide, and only its disconnected reading routes: Home is
-   * where Intelligence gets set up, and connected leaves the destination
-   * alone so the capsule matches the plain launcher mark it sits beside. The
-   * connection test is read from `getHomeModel`, the same source the title
-   * above already reads, so the two can never disagree. Routed the same way
-   * a HUD row does — through `hudLandingMenu`, which `openInspector` already
-   * gives precedence over a signal's landing target.
+   * This one click fires for every state `renderLauncherCapsule` has, and
+   * they disagree about where to land. **The words decide.** A capsule
+   * carrying a signal's failure class lands where that failure is explained —
+   * `openInspector` already applies it from `activeSignalAtOpen` — and that
+   * has to keep winning whether the words got there through a timed gesture
+   * or through a dwell that swapped them in, because the reader is clicking
+   * the sentence in front of them either way. So the check is
+   * `getCapsuleSignal`, the same method the render reads, rather than a
+   * condition on which driver happens to be open.
+   *
+   * Only the summary state is left to decide, and only its disconnected
+   * reading routes: Home is where Intelligence gets set up, and connected
+   * leaves the destination alone so the capsule matches the plain launcher
+   * mark it sits beside. The connection test is read from `getHomeModel`, the
+   * same source the title above already reads, so the two can never disagree.
+   * Routed the same way a HUD row does — through `hudLandingMenu`, which
+   * `openInspector` already gives precedence over a signal's landing target.
    */
   private handlePillClick = (event: Event): void => {
     event.preventDefault();
     event.stopPropagation();
-    const signalOwnsCapsule =
-      this.gestureSignal !== null && this.pillPhase !== null;
+    const signalOwnsCapsule = this.getCapsuleSignal() !== null;
     if (
       !signalOwnsCapsule &&
       this.getHomeModel().hero.connection !== "connected"
@@ -11406,7 +11509,15 @@ export class WebInspectorElement extends LitElement {
     this.openInspector("floating_button");
   };
 
-  private isLauncherHudBlocked(): boolean {
+  /**
+   * Whether the one-shot page-load preview has to wait.
+   *
+   * The preview only, never a dwell. A dwell is the reader asking, and an
+   * answer that is refused because a timer elsewhere is running is not an
+   * answer — see `openLauncherHud`. The preview is nobody asking, so it
+   * yields to a gesture and tries again shortly.
+   */
+  private isLauncherIntroBlocked(): boolean {
     return this.gestureSignal !== null;
   }
 
@@ -11419,7 +11530,7 @@ export class WebInspectorElement extends LitElement {
     this.launcherHudIntroStartTimer = setTimeout(() => {
       this.launcherHudIntroStartTimer = null;
       if (!this.isConnected || this.isOpen) return;
-      if (this.isLauncherHudBlocked()) {
+      if (this.isLauncherIntroBlocked()) {
         this.scheduleLauncherHudIntro(LAUNCHER_HUD_INTRO_MS.blockedRetry);
         return;
       }
@@ -11480,8 +11591,17 @@ export class WebInspectorElement extends LitElement {
     return this.launcherHudPlacement !== null;
   }
 
+  /**
+   * The dwell opens the island. It is never refused for a running gesture.
+   *
+   * It used to be: a hover during the 3.4 seconds after a failure opened
+   * nothing at all, which is the reader looking at a launcher that has just
+   * asked them to look and getting silence back. The gesture is *attention*
+   * and the dwell is *inspection* — the second is what the first was for, so
+   * the first cannot be what blocks it.
+   */
   private openLauncherHud(): void {
-    if (this.isLauncherHudBlocked() || this.isOpen) return;
+    if (this.isOpen) return;
     if (!this.resolveLauncherHudPlacement()) {
       // The room went away under an open drawer. Closing keeps the wrapper's
       // data-cpk-hud, the button's aria-expanded and the rendered drawer
@@ -11489,6 +11609,11 @@ export class WebInspectorElement extends LitElement {
       this.closeLauncherHud();
       return;
     }
+    // Before the early return below: the pointer may be arriving on an island
+    // that is already open — converting the page-load preview into a dwell,
+    // or coming back mid-close — and a gesture running underneath either of
+    // those still has to stop.
+    this.holdGestureForDwell();
     if (this.launcherHudCloseTimer !== null) {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
@@ -11513,9 +11638,70 @@ export class WebInspectorElement extends LitElement {
       this.launcherHudCloseTimer = null;
     }
     this.launcherIslandClosing = false;
+    // The one funnel every dwell ends through — pointer out, focus out,
+    // Escape, no room left, the panel opening over it — so a gesture parked
+    // by that dwell cannot be left parked by any of them.
+    this.closeGestureAfterHold();
     if (!this.launcherHudOpen) return;
     this.launcherHudOpen = false;
     this.requestUpdate();
+  }
+
+  /**
+   * Dwell stops the clock.
+   *
+   * WCAG 2.1 SC 1.4.13 requires hover-triggered content to stay until the
+   * pointer leaves or the reader dismisses it, so a hold that expires under
+   * the pointer is a conformance failure, not a matter of feel. The beat in
+   * flight stops with it: motion under an aiming pointer causes mis-clicks,
+   * which is the same objection decision 12 makes about starting one.
+   *
+   * The gesture is parked rather than dropped. `gestureSignal` stays set, so
+   * the sentence already in the polite live region stays there for as long as
+   * the island does; `pillPhase` stays set, so the placement measurement and
+   * the impression it releases still complete. What stops is only the clock.
+   */
+  private holdGestureForDwell(): void {
+    if (this.gestureSignal === null || this.gestureHeldByDwell) return;
+    this.gestureHeldByDwell = true;
+    this.stopSignalPulse();
+    this.cancelPillTimeout();
+    this.requestUpdate();
+  }
+
+  /**
+   * The parked gesture, released when the reader leaves — and it does not
+   * resume.
+   *
+   * Decision 13: hover counts as shown. The words were on the launcher for
+   * as long as the reader chose, which is more than the 2.5-second hold would
+   * have given them; replaying the gesture on pointer-out is the doubling
+   * OSS-903 decision 5 refuses. What is lost is the announcement, not the
+   * information — the dot stays lit for as long as the signal is armed.
+   */
+  private closeGestureAfterHold(): void {
+    if (!this.gestureHeldByDwell) return;
+    this.gestureHeldByDwell = false;
+    this.endGesture();
+  }
+
+  /**
+   * The reader has gone. Everything the dwell was holding back is released.
+   *
+   * Two things can be held: the parked gesture, which ends rather than resumes
+   * (`closeGestureAfterHold`), and a beat that was deferred because the
+   * pointer was here — the announcement's, typically, which declares no
+   * `pillLabel` and so was never shown in the capsule. That one was deferred
+   * rather than spent precisely so it could run now.
+   *
+   * Deliberately called from the three places a *reader* leaves, and not from
+   * `closeLauncherHud`, which also serves the panel opening over the launcher:
+   * there is no launcher left to beat on at that point, and flushing into it
+   * would start a gesture nobody can see.
+   */
+  private endLauncherDwell(): void {
+    this.closeLauncherHud();
+    this.flushPendingSignalPulse();
   }
 
   private handleLauncherHudEnter = (): void => {
@@ -11543,7 +11729,7 @@ export class WebInspectorElement extends LitElement {
     }
     this.launcherHudCloseTimer = setTimeout(() => {
       this.launcherHudCloseTimer = null;
-      this.closeLauncherHud();
+      this.endLauncherDwell();
     }, LAUNCHER_ISLAND_MS.close);
   };
 
@@ -11562,7 +11748,7 @@ export class WebInspectorElement extends LitElement {
     ) {
       return;
     }
-    this.closeLauncherHud();
+    this.endLauncherDwell();
   };
 
   private handleLauncherHudKeydown = (event: KeyboardEvent): void => {
@@ -11570,7 +11756,7 @@ export class WebInspectorElement extends LitElement {
     if (!this.launcherHudOpen) return;
     event.preventDefault();
     event.stopPropagation();
-    this.closeLauncherHud();
+    this.endLauncherDwell();
     this.activeRoot
       .querySelector<HTMLButtonElement>(".console-button")
       ?.focus();
@@ -20394,8 +20580,40 @@ export class WebInspectorElement extends LitElement {
    * holds this one slot for its full duration. That is not a second scheduling
    * concept: reason 3 already says "another beat is running", and a gesture is
    * simply a longer beat.
+   *
+   * Ahead of all four sits a fifth situation that is *not* "run later": the
+   * reader is already on the launcher. See the dwell branch below.
    */
   private startSignalPulse(key: LauncherSignalKey): void {
+    // Decision 12: no beat when the pointer is already there. Motion exists to
+    // catch an eye that is elsewhere, and a launcher that twitches under an
+    // aiming pointer causes mis-clicks — the same reason an open menu does not
+    // reflow.
+    if (this.isLauncherDwelling()) {
+      if (this.getArmedCapsuleSignal() === key) {
+        // Decision 13: this signal wins the capsule, so its words are on the
+        // launcher from the next render — a swap, not an arrival. The reader
+        // got the information; only the announcement is lost, and the dot
+        // stays lit while the signal is armed. The once-per-subject token is
+        // spent here for exactly that reason: nothing may replay on the way
+        // out.
+        this.spendPulseToken(key);
+        // The words landed, so this outage's pill question is answered. Left
+        // null it would never be, and `maybeTrackErrorSignalViewed` holds the
+        // impression until it is — the dwell counts no impression of its own,
+        // but it must not swallow the signal driver's.
+        this.pillOutcome = "shown";
+        this.requestUpdate();
+        return;
+      }
+      // Nothing of this signal reached the capsule — a lower-priority failure
+      // behind a worse one, or the announcement, which declares no `pillLabel`
+      // and so has no words to swap in. Nothing was shown, so nothing is
+      // spent: the beat waits for the pointer to leave.
+      this.deferSignalPulse(key);
+      return;
+    }
+
     const deferred =
       // 1. The panel is open, so there is no visible launcher. Pop-out is the
       //    same case: the host page renders only a portal anchor.
@@ -20409,33 +20627,14 @@ export class WebInspectorElement extends LitElement {
       this.getActiveLauncherSignal() !== key;
 
     if (deferred) {
-      // One slot, and the more urgent beat keeps it. A lower-priority beat must
-      // not evict a nudge about something worse — and it would fail the
-      // re-check on the way out anyway, because it is not the active signal.
-      // The evicted beat is not lost for good: its once-per-subject token is
-      // still unspent, so it is offered again the next time it arms.
-      const pending = this.pendingPulseSignal;
-      if (
-        pending === null ||
-        LAUNCHER_SIGNALS[key].priority >= LAUNCHER_SIGNALS[pending].priority
-      ) {
-        this.pendingPulseSignal = key;
-      }
-      this.requestUpdate();
+      this.deferSignalPulse(key);
       return;
     }
 
     this.stopSignalPulse();
     this.pendingPulseSignal = null;
     this.pulsingSignal = key;
-    // The once-per-subject token is written HERE, where the beat actually
-    // runs — never when a signal arms. Spending it on arming would burn a
-    // deferred beat unfired.
-    if (isWiringErrorKey(key)) {
-      this.errorBeatSpent = true;
-    } else if (this.announcementTimestamp && key === NEWS_SIGNAL_ID) {
-      saveAnnouncementPulsedTimestamp(this.announcementTimestamp);
-    }
+    this.spendPulseToken(key);
     this.beginGestureTail(key);
     this.requestUpdate();
     if (typeof window === "undefined") return;
@@ -20457,6 +20656,41 @@ export class WebInspectorElement extends LitElement {
       // Reason 3 has just cleared.
       this.flushPendingSignalPulse();
     }, LAUNCHER_SIGNALS[key].cadence);
+  }
+
+  /**
+   * Parks a beat that could not land, keeping the more urgent of the two.
+   *
+   * A lower-priority beat must not evict a nudge about something worse — and
+   * it would fail the re-check on the way out anyway, because it is not the
+   * active signal. The evicted beat is not lost for good: its once-per-subject
+   * token is still unspent, so it is offered again the next time it arms.
+   */
+  private deferSignalPulse(key: LauncherSignalKey): void {
+    const pending = this.pendingPulseSignal;
+    if (
+      pending === null ||
+      LAUNCHER_SIGNALS[key].priority >= LAUNCHER_SIGNALS[pending].priority
+    ) {
+      this.pendingPulseSignal = key;
+    }
+    this.requestUpdate();
+  }
+
+  /**
+   * Marks this subject as having had its one nudge.
+   *
+   * Written where the nudge actually reaches the reader — never when a signal
+   * arms. Spending it on arming would burn a deferred beat unfired. There are
+   * two such places: the beat starting, and a dwelling capsule swapping the
+   * words in without one (decision 13).
+   */
+  private spendPulseToken(key: LauncherSignalKey): void {
+    if (isWiringErrorKey(key)) {
+      this.errorBeatSpent = true;
+    } else if (this.announcementTimestamp && key === NEWS_SIGNAL_ID) {
+      saveAnnouncementPulsedTimestamp(this.announcementTimestamp);
+    }
   }
 
   private stopSignalPulse(): void {
@@ -20519,6 +20753,19 @@ export class WebInspectorElement extends LitElement {
    */
   private beginGestureTail(key: LauncherSignalKey): void {
     this.cancelPillTimeout();
+    // The one-shot page-load preview yields to a gesture — nobody asked for
+    // it, and it has no business sitting under a failure's words. This also
+    // drops the preview that has not started yet, which is the shipped
+    // behaviour: `cancelLauncherHudIntro` clears the start timer and nothing
+    // re-arms it, so a failure inside the first half-second costs the reader
+    // the preview rather than postponing it.
+    //
+    // A DWELL is exempt, and that is the change. It cannot actually be open
+    // here — `startSignalPulse` never starts a gesture under the pointer — so
+    // this is the guard that keeps it that way if a fourth caller ever
+    // appears. Run before the fields below are written, so releasing a parked
+    // gesture on the way through cannot take this new one with it.
+    if (!this.isLauncherDwelling()) this.closeLauncherHud();
     if (LAUNCHER_SIGNALS[key].pillLabel === undefined) {
       this.gestureSignal = null;
       this.pillPhase = null;
@@ -20528,7 +20775,6 @@ export class WebInspectorElement extends LitElement {
     this.gestureSignal = key;
     this.pillPhase = "closed";
     this.pillPlacement = null;
-    this.closeLauncherHud();
   }
 
   /**
@@ -20617,6 +20863,15 @@ export class WebInspectorElement extends LitElement {
    * never cut short.
    */
   private closePillEarly(): void {
+    // Parked under the pointer, so there is no clock to cut short and no
+    // closing animation to play: the dwell owns the capsule, and the words
+    // fall back to the services summary on the next render simply because the
+    // signal has stopped being armed. Starting a 250ms close here would be
+    // motion under an aiming pointer, which is what decision 12 rules out.
+    if (this.gestureHeldByDwell) {
+      this.closeGestureAfterHold();
+      return;
+    }
     // No pill in this gesture — there was no room for one — so the tail is
     // only the spoken sentence, and it ends here.
     if (this.pillPhase === null) {
@@ -20652,6 +20907,7 @@ export class WebInspectorElement extends LitElement {
   private cancelGestureTail(): void {
     this.cancelPillTimeout();
     this.gestureSignal = null;
+    this.gestureHeldByDwell = false;
     this.pillPhase = null;
     this.pillPlacement = null;
   }

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -8856,6 +8856,8 @@ export class WebInspectorElement extends LitElement {
           7vw,
           ${LAUNCHER_MAX_SIZE}px
         );
+        /* The island's width, shared by the capsule and the drawer so the two are bündig by construction rather than by two matching literals. Provisional: chosen by eye and not yet checked against both ends of the size clamp. */
+        --cpk-launcher-island: 252px;
       }
 
       .console-button {
@@ -9516,18 +9518,19 @@ export class WebInspectorElement extends LitElement {
        * centres the pair vertically and "align-items" keeps both lines flush
        * left, so the pill never grows taller than the launcher it opens from.
        */
-      .cpk-launcher-pill {
+      .cpk-launcher-capsule {
         position: absolute;
         top: 50%;
         margin-top: calc(var(--cpk-launcher-size) / -2);
         height: var(--cpk-launcher-size);
+        width: var(--cpk-launcher-island);
         display: inline-flex;
         flex-direction: column;
         justify-content: center;
         align-items: flex-start;
         gap: 1px;
         box-sizing: border-box;
-        border-radius: 999px;
+        border-radius: calc(var(--cpk-launcher-size) / 2);
         border: 1px solid var(--cpk-launcher-edge);
         background: var(--cpk-launcher-face);
         color: #ffffff;
@@ -9537,7 +9540,7 @@ export class WebInspectorElement extends LitElement {
       }
 
       /* The failure class, word-identical to the panel's own wording. */
-      .cpk-launcher-pill__heading {
+      .cpk-launcher-capsule__heading {
         font-size: 12px;
         font-weight: 600;
         line-height: 1.2;
@@ -9553,7 +9556,7 @@ export class WebInspectorElement extends LitElement {
        * delivered through an announcement, and it would double the spoken
        * length — so the live region carries the failure class alone.
        */
-      .cpk-launcher-pill__subline {
+      .cpk-launcher-capsule__subline {
         font-size: 10.5px;
         font-weight: 500;
         line-height: 1.2;
@@ -9570,13 +9573,13 @@ export class WebInspectorElement extends LitElement {
        * straight edge begins. A literal 14px put it 16px inside the curve at the
        * production launcher size, which is itself a clamp on the viewport.
        */
-      .cpk-launcher-pill[data-cpk-pill-direction="left"] {
+      .cpk-launcher-capsule[data-cpk-capsule-direction="left"] {
         right: 0;
         padding: 0 calc(var(--cpk-launcher-size) + 12px) 0
           calc(var(--cpk-launcher-size) / 2);
         clip-path: inset(0 0 0 calc(100% - var(--cpk-launcher-size)));
       }
-      .cpk-launcher-pill[data-cpk-pill-direction="right"] {
+      .cpk-launcher-capsule[data-cpk-capsule-direction="right"] {
         left: 0;
         padding: 0 calc(var(--cpk-launcher-size) / 2) 0
           calc(var(--cpk-launcher-size) + 12px);
@@ -9589,7 +9592,7 @@ export class WebInspectorElement extends LitElement {
        * wiping across it. An unrounded inset reads as a wipe; this reads as an
        * opening. It adds no animated property: the clip is still the clip.
        */
-      @keyframes cpk-launcher-pill-left {
+      @keyframes cpk-launcher-capsule-left {
         0% {
           opacity: 0;
           clip-path: inset(
@@ -9602,7 +9605,7 @@ export class WebInspectorElement extends LitElement {
         }
       }
 
-      @keyframes cpk-launcher-pill-right {
+      @keyframes cpk-launcher-capsule-right {
         0% {
           opacity: 0;
           clip-path: inset(
@@ -9626,39 +9629,39 @@ export class WebInspectorElement extends LitElement {
        * The button paints last and therefore wins the pointer where the two
        * overlap, so dragging the launcher is unaffected throughout.
        */
-      .cpk-launcher-pill[data-cpk-pill-phase="opening"],
-      .cpk-launcher-pill[data-cpk-pill-phase="holding"],
-      .cpk-launcher-pill[data-cpk-pill-phase="closing"] {
+      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"],
+      .cpk-launcher-capsule[data-cpk-capsule-phase="holding"],
+      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"] {
         pointer-events: auto;
         cursor: pointer;
       }
 
       /* Closing is the same animation played backwards, so the two phases can
          never drift apart. */
-      .cpk-launcher-pill[data-cpk-pill-phase="opening"],
-      .cpk-launcher-pill[data-cpk-pill-phase="closing"] {
+      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"],
+      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"] {
         animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
         animation-iteration-count: 1;
         animation-fill-mode: forwards;
       }
-      .cpk-launcher-pill[data-cpk-pill-phase="opening"] {
-        animation-duration: var(--cpk-launcher-pill-open);
+      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"] {
+        animation-duration: var(--cpk-launcher-capsule-open);
       }
-      .cpk-launcher-pill[data-cpk-pill-phase="closing"] {
-        animation-duration: var(--cpk-launcher-pill-close);
+      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"] {
+        animation-duration: var(--cpk-launcher-capsule-close);
         animation-direction: reverse;
       }
-      .cpk-launcher-pill[data-cpk-pill-phase="opening"][data-cpk-pill-direction="left"],
-      .cpk-launcher-pill[data-cpk-pill-phase="closing"][data-cpk-pill-direction="left"] {
-        animation-name: cpk-launcher-pill-left;
+      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"][data-cpk-capsule-direction="left"],
+      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"][data-cpk-capsule-direction="left"] {
+        animation-name: cpk-launcher-capsule-left;
       }
-      .cpk-launcher-pill[data-cpk-pill-phase="opening"][data-cpk-pill-direction="right"],
-      .cpk-launcher-pill[data-cpk-pill-phase="closing"][data-cpk-pill-direction="right"] {
-        animation-name: cpk-launcher-pill-right;
+      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"][data-cpk-capsule-direction="right"],
+      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"][data-cpk-capsule-direction="right"] {
+        animation-name: cpk-launcher-capsule-right;
       }
 
       /* The hold is the end state of the reveal, held. */
-      .cpk-launcher-pill[data-cpk-pill-phase="holding"] {
+      .cpk-launcher-capsule[data-cpk-capsule-phase="holding"] {
         opacity: 1;
         clip-path: inset(0 0 0 0);
       }
@@ -9673,9 +9676,9 @@ export class WebInspectorElement extends LitElement {
          * same hold. The instruction is to reduce motion, not to withhold
          * information, and this reader needs the label as much as anyone.
          */
-        .cpk-launcher-pill[data-cpk-pill-phase="opening"],
-        .cpk-launcher-pill[data-cpk-pill-phase="holding"],
-        .cpk-launcher-pill[data-cpk-pill-phase="closing"] {
+        .cpk-launcher-capsule[data-cpk-capsule-phase="opening"],
+        .cpk-launcher-capsule[data-cpk-capsule-phase="holding"],
+        .cpk-launcher-capsule[data-cpk-capsule-phase="closing"] {
           animation: none !important;
           opacity: 1;
           clip-path: inset(0 0 0 0);
@@ -10720,7 +10723,7 @@ export class WebInspectorElement extends LitElement {
         @focusout=${this.handleLauncherHudFocusOut}
         @keydown=${this.handleLauncherHudKeydown}
       >
-        ${this.renderLauncherPill()}
+        ${this.renderLauncherCapsule()}
         <button
           class=${buttonClasses}
           type="button"
@@ -10833,7 +10836,7 @@ export class WebInspectorElement extends LitElement {
    * shows nothing — because the room it needs cannot be measured until it has
    * been laid out, and the direction is decided at gesture start.
    */
-  private renderLauncherPill(): TemplateResult | typeof nothing {
+  private renderLauncherCapsule(): TemplateResult | typeof nothing {
     const key = this.gestureSignal;
     if (key === null || this.pillPhase === null) return nothing;
     const signal = LAUNCHER_SIGNALS[key];
@@ -10841,10 +10844,10 @@ export class WebInspectorElement extends LitElement {
     if (label === undefined) return nothing;
     return html`
       <span
-        class="cpk-launcher-pill"
-        data-cpk-launcher-pill=${key}
-        data-cpk-pill-phase=${this.pillPhase}
-        data-cpk-pill-direction=${
+        class="cpk-launcher-capsule"
+        data-cpk-launcher-capsule=${key}
+        data-cpk-capsule-phase=${this.pillPhase}
+        data-cpk-capsule-direction=${
           // Before the measurement the pill is laid out as if it were opening
           // left, which is width-identical to the other side and shows nothing
           // either way while the clip is closed.
@@ -10852,16 +10855,16 @@ export class WebInspectorElement extends LitElement {
         }
         style=${styleMap({
           "--cpk-launcher-signal": LAUNCHER_SIGNAL_COLORS[signal.tone],
-          "--cpk-launcher-pill-open": `${ERROR_GESTURE_MS.open}ms`,
-          "--cpk-launcher-pill-close": `${ERROR_GESTURE_MS.close}ms`,
+          "--cpk-launcher-capsule-open": `${ERROR_GESTURE_MS.open}ms`,
+          "--cpk-launcher-capsule-close": `${ERROR_GESTURE_MS.close}ms`,
         })}
         aria-hidden="true"
         @click=${this.handlePillClick}
       >
-        <span class="cpk-launcher-pill__heading" data-cpk-pill-heading
+        <span class="cpk-launcher-capsule__heading" data-cpk-capsule-heading
           >${label}</span
         >
-        <span class="cpk-launcher-pill__subline" data-cpk-pill-subline
+        <span class="cpk-launcher-capsule__subline" data-cpk-capsule-subline
           >${PILL_SUBLINE_LABEL}</span
         >
       </span>
@@ -20017,7 +20020,7 @@ export class WebInspectorElement extends LitElement {
       ".console-button-wrapper",
     );
     const button = wrapper?.querySelector<HTMLElement>(".console-button");
-    const pill = wrapper?.querySelector<HTMLElement>(".cpk-launcher-pill");
+    const pill = wrapper?.querySelector<HTMLElement>(".cpk-launcher-capsule");
     if (!button || !pill || typeof window === "undefined") return;
 
     const mark = button.getBoundingClientRect();

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -275,6 +275,20 @@ const LAUNCHER_SIGNAL_COLORS: Readonly<Record<LauncherSignalTone, string>> = {
 };
 
 /**
+ * The two row glyphs' colours, named rather than written into the stylesheet,
+ * so the pair reads as one decision made once.
+ *
+ * The off tone is the launcher's own error red rather than a second red: a
+ * disabled feature and a failed one are the same news to the eye, and two
+ * near-identical reds a few pixels apart would be a difference that means
+ * nothing. The on tone has no such twin to reuse — nothing else on the
+ * launcher is ever green — so it is declared here beside its opposite instead
+ * of sitting alone in the sheet, which is where it used to drift.
+ */
+const HUD_ENABLED_COLOR = "#6EE7A8";
+const HUD_DISABLED_COLOR = ERROR_SIGNAL_COLOR;
+
+/**
  * The failure gesture, four phases in series:
  *
  * ```
@@ -347,7 +361,8 @@ const EVENT_ERROR_GUIDANCE: Readonly<
 };
 
 /**
- * The pill's second line, shared by every subject that carries a pill.
+ * The island's second line, under whichever title the capsule is carrying -
+ * a signal's failure class, or the Intelligence state on a plain dwell.
  *
  * **This is the one string in the feature that exists nowhere else in the
  * product.** Every other word the launcher shows is word-identical to the
@@ -359,16 +374,39 @@ const EVENT_ERROR_GUIDANCE: Readonly<
  * alone. A screen-reader user cannot act on an instruction delivered through
  * an announcement, and it would double the spoken length.
  */
-const PILL_SUBLINE_LABEL = "Open Inspector for details";
+const PILL_SUBLINE_LABEL = "Click to open Inspector";
 
-type LauncherHudRowId = "threads" | "intelligence" | "learning";
+/**
+ * The island's title, which is the state every row beneath it depends on.
+ *
+ * Intelligence is deliberately NOT one of the rows. The rows are features;
+ * Intelligence is the parent connection those features are carried over, and a
+ * parent listed among its own children reads as a peer of them. Putting it in
+ * the capsule says the same thing the layout does: this is what the island is
+ * about, and the list below is what it currently gives you.
+ *
+ * Product-authored constants, exactly as the pill's labels are, and for the
+ * same two reasons: a fixed width budget, and a surface that renders over a
+ * customer's production page in front of their end users.
+ */
+const ISLAND_INTELLIGENCE_ON_TITLE = "Intelligence connected";
+const ISLAND_INTELLIGENCE_OFF_TITLE = "Intelligence not connected";
 
-const HUD_THREADS_OFF_LABEL = "Turn on Threads";
-const HUD_THREADS_ON_LABEL = "Threads on";
-const HUD_INTELLIGENCE_OFF_LABEL = "Turn on Intelligence";
-const HUD_INTELLIGENCE_ON_LABEL = "Intelligence connected";
-const HUD_LEARNING_OFF_LABEL = "Turn on Learning";
-const HUD_LEARNING_ON_LABEL = "Learning on";
+type LauncherHudRowId = "threads" | "learning";
+
+/**
+ * The two feature rows, each in both of its states.
+ *
+ * `enabled`/`disabled` rather than `on`/`Turn on`: the row is a statement of
+ * what the runtime currently offers, not an instruction. The old off-state
+ * copy read as a button that turns the feature on, which no row has ever
+ * done — every row opens the view that explains the feature, and for a
+ * feature that is off that view is the one carrying the Enable action.
+ */
+const HUD_THREADS_ON_LABEL = "Threads enabled";
+const HUD_THREADS_OFF_LABEL = "Threads disabled";
+const HUD_LEARNING_ON_LABEL = "Learning enabled";
+const HUD_LEARNING_OFF_LABEL = "Learning disabled";
 
 const LAUNCHER_SIGNALS: Readonly<
   Record<LauncherSignalKey, LauncherSignalDefinition>
@@ -573,8 +611,8 @@ const EDGE_MARGIN = 16;
 /**
  * One page-load preview of the launcher's feature HUD.
  *
- * The card arrives after the host page has had a beat to settle. Its four rows
- * then come online in order, stay readable, and leave together. Nothing is
+ * The card arrives after the host page has had a beat to settle. Its rows then
+ * come online in order, stay readable, and leave together. Nothing is
  * persisted: a new Inspector element means a new preview.
  */
 const LAUNCHER_HUD_INTRO_MS = {
@@ -584,6 +622,26 @@ const LAUNCHER_HUD_INTRO_MS = {
   rowStagger: 170,
   rowDuration: 300,
   blockedRetry: 250,
+} as const;
+
+/**
+ * The dwell reveal: the mark opening out into the island, and closing back
+ * into it.
+ *
+ * Deliberately slower than the pill's 250ms. The pill's reveal is one beat
+ * inside a longer timed sequence and has to get out of the way; this is the
+ * whole event, and at a tooltip's pace a 272px surface arriving from a 62px
+ * circle reads as a card appearing rather than as the circle itself opening.
+ * The return is quicker than the departure, which is the usual asymmetry: the
+ * reader has already left, and the only thing left to say is that it is over.
+ *
+ * Both live here and nowhere else. The stylesheet reads them as custom
+ * properties injected from these numbers, exactly as the gesture's two
+ * animated phases are, because they are taste and will be tuned by eye.
+ */
+const LAUNCHER_ISLAND_MS = {
+  open: 320,
+  close: 220,
 } as const;
 const DRAG_THRESHOLD = 6;
 const MIN_WINDOW_WIDTH = 880;
@@ -6705,6 +6763,16 @@ export class WebInspectorElement extends LitElement {
    */
   private launcherHudSide: LauncherIslandSide | null = null;
   private launcherHudCloseTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * The island is playing its reveal in reverse, on its way back into the
+   * mark.
+   *
+   * The drawer's markup is dropped the moment the dwell ends, so without a
+   * state that outlives the pointer there is nothing left on the page to
+   * close: the island would arrive as a gesture and leave as a disappearance.
+   * This is what the pointer-out timer now waits for.
+   */
+  private launcherIslandClosing = false;
   private launcherHudIntro = false;
   private launcherHudIntroStartTimer: ReturnType<typeof setTimeout> | null =
     null;
@@ -8935,9 +9003,12 @@ export class WebInspectorElement extends LitElement {
            a stacking context, which is harmless: its own pseudo-elements
            and children (mark, signal dot) keep their relative order. */
         z-index: 4;
+        /* Colour only. The transform and scale entries this list used to open
+           with were here for a hover scale that no longer exists — the mark
+           holds its size and the island is the thing that moves — and a
+           transition on a property nothing ever sets is a rule that reads as
+           an intention while doing nothing. */
         transition:
-          transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1),
-          scale 300ms cubic-bezier(0.34, 1.56, 0.64, 1),
           background-color 200ms ease,
           border-color 200ms ease,
           box-shadow 200ms ease,
@@ -9411,16 +9482,26 @@ export class WebInspectorElement extends LitElement {
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.07),
           0 4px 14px rgba(1, 5, 7, 0.28) !important;
-        /* Promotes the launcher to its own compositing layer, which the
-           backdrop-filter this replaces used to do as a side effect. Without
-           a layer the hover scale re-rasterises the mark every frame and it
-           visibly jitters; with one, the compositor scales it as a texture. */
+        /* Keeps the launcher on its own compositing layer, which the
+           backdrop-filter this replaces used to do as a side effect. It is
+           retained now that the hover scale it was first added for is gone:
+           the ripple rings and the wash are this element's own descendants
+           and animate every frame while a signal beats, and the mark is what
+           has to stay legible underneath them. */
         will-change: transform;
       }
+      /*
+       * Hover changes the launcher's COLOUR and nothing else. It used to also
+       * carry "transform: scale(1.05)", and that scale was the third thing
+       * happening on hover: the mark stepped up, the island arrived beside it,
+       * and the two motions disagreed about what was opening. The island's own
+       * reveal starts from the mark's exact footprint, so a mark that is no
+       * longer that size while it opens breaks the one thing the reveal is
+       * for. One motion, and it belongs to the island.
+       */
       .console-button:hover {
         background-color: var(--cpk-launcher-face-solid) !important;
         border-color: rgba(190, 194, 255, 0.45) !important;
-        transform: scale(1.05);
       }
       .console-button:focus-visible {
         outline-color: #bec2ff !important;
@@ -9678,48 +9759,133 @@ export class WebInspectorElement extends LitElement {
        * straight edge begins. A literal 14px put it 16px inside the curve at the
        * production launcher size, which is itself a clamp on the viewport.
        */
+      /*
+       * The closed clip carries the island's own radius, which at this size
+       * is a circle exactly covering the mark. It is also the value the
+       * closing transition travels back to, so an unrounded corner here would
+       * square off the last frame of every close.
+       */
       .cpk-launcher-capsule[data-cpk-capsule-direction="left"] {
         right: 0;
         padding: 0 calc(var(--cpk-launcher-size) + 12px) 0
           calc(var(--cpk-launcher-size) / 2);
-        clip-path: inset(0 0 0 calc(100% - var(--cpk-launcher-size)));
+        clip-path: inset(
+          0 0 0 calc(100% - var(--cpk-launcher-size)) round
+            calc(var(--cpk-launcher-size) / 2)
+        );
       }
       .cpk-launcher-capsule[data-cpk-capsule-direction="right"] {
         left: 0;
         padding: 0 calc(var(--cpk-launcher-size) / 2) 0
           calc(var(--cpk-launcher-size) + 12px);
-        clip-path: inset(0 calc(100% - var(--cpk-launcher-size)) 0 0);
+        clip-path: inset(
+          0 calc(100% - var(--cpk-launcher-size)) 0 0 round
+            calc(var(--cpk-launcher-size) / 2)
+        );
       }
 
       /*
-       * "round" on both stops, so the revealing edge is the capsule's own
-       * rounded end travelling sideways rather than a straight vertical line
-       * wiping across it. An unrounded inset reads as a wipe; this reads as an
-       * opening. It adds no animated property: the clip is still the clip.
+       * ONE reveal for the whole island, in each of the two directions.
+       *
+       * The 0% stop is the mark's own footprint: a square of the launcher's
+       * size in the island's top corner on the launcher's side, rounded by
+       * half that size, which is a circle exactly covering the mark. So the
+       * island is never smaller or larger than the circle before it opens —
+       * it IS the circle, and what follows is that circle opening out.
+       *
+       * The bottom inset is what makes one pair of keyframes serve both
+       * halves. On the capsule, whose height is exactly the launcher size,
+       * "100% - size" resolves to 0 and the clip only travels sideways, which
+       * is the pill's original behaviour unchanged. On the drawer, which is
+       * taller, the same expression holds the reveal back to the top band
+       * until it opens downward as well. Capsule and drawer therefore arrive
+       * as one surface rather than as two things that happen to be animated
+       * at the same time.
+       *
+       * "round" is on BOTH stops, so the revealing edge is the island's own
+       * rounded corner travelling rather than a straight line wiping across
+       * it — and because a clip-path only interpolates between shapes of the
+       * same kind, a "round" on one stop alone would stop it animating at
+       * all. The radius is the island's own, not a 999px that happens to
+       * clamp to the right number on a 62px-tall capsule and to the wrong one
+       * on a 174px-tall drawer.
+       *
+       * It adds no animated property: the clip is still the clip.
        */
-      @keyframes cpk-launcher-capsule-left {
+      @keyframes cpk-launcher-island-left {
         0% {
           opacity: 0;
           clip-path: inset(
-            0 0 0 calc(100% - var(--cpk-launcher-size)) round 999px
+            0 0 calc(100% - var(--cpk-launcher-size))
+              calc(100% - var(--cpk-launcher-size)) round
+              calc(var(--cpk-launcher-size) / 2)
           );
         }
         100% {
           opacity: 1;
-          clip-path: inset(0 0 0 0 round 999px);
+          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
         }
       }
 
-      @keyframes cpk-launcher-capsule-right {
+      @keyframes cpk-launcher-island-right {
         0% {
           opacity: 0;
           clip-path: inset(
-            0 calc(100% - var(--cpk-launcher-size)) 0 0 round 999px
+            0 calc(100% - var(--cpk-launcher-size))
+              calc(100% - var(--cpk-launcher-size)) 0 round
+              calc(var(--cpk-launcher-size) / 2)
           );
         }
         100% {
           opacity: 1;
-          clip-path: inset(0 0 0 0 round 999px);
+          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
+        }
+      }
+
+      /*
+       * The way back, written out rather than expressed as the two above with
+       * "animation-direction: reverse".
+       *
+       * That was the first attempt and it is measurably wrong: a CSS
+       * animation only restarts when its NAME changes, so flipping the
+       * direction on an animation that has already finished leaves it
+       * finished, and the island disappeared in a single frame. Handing the
+       * clip back to a transition instead was the second attempt, and it does
+       * not start at all — verified in the browser, where the element's
+       * getAnimations() came back empty and the clip snapped to the closed
+       * value. A second name is what actually restarts, so a second name is
+       * what these are.
+       *
+       * They are the stops of their opposite number in the other order, and
+       * nothing else. Any edit to the shape above belongs here too.
+       */
+      @keyframes cpk-launcher-island-close-left {
+        0% {
+          opacity: 1;
+          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
+        }
+        100% {
+          opacity: 0;
+          clip-path: inset(
+            0 0 calc(100% - var(--cpk-launcher-size))
+              calc(100% - var(--cpk-launcher-size)) round
+              calc(var(--cpk-launcher-size) / 2)
+          );
+        }
+      }
+
+      @keyframes cpk-launcher-island-close-right {
+        0% {
+          opacity: 1;
+          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
+        }
+        100% {
+          opacity: 0;
+          clip-path: inset(
+            0 calc(100% - var(--cpk-launcher-size))
+              calc(100% - var(--cpk-launcher-size)) 0 round
+              calc(var(--cpk-launcher-size) / 2)
+          );
         }
       }
 
@@ -9758,11 +9924,11 @@ export class WebInspectorElement extends LitElement {
       }
       .cpk-launcher-capsule[data-cpk-capsule-phase="opening"][data-cpk-capsule-direction="left"],
       .cpk-launcher-capsule[data-cpk-capsule-phase="closing"][data-cpk-capsule-direction="left"] {
-        animation-name: cpk-launcher-capsule-left;
+        animation-name: cpk-launcher-island-left;
       }
       .cpk-launcher-capsule[data-cpk-capsule-phase="opening"][data-cpk-capsule-direction="right"],
       .cpk-launcher-capsule[data-cpk-capsule-phase="closing"][data-cpk-capsule-direction="right"] {
-        animation-name: cpk-launcher-capsule-right;
+        animation-name: cpk-launcher-island-right;
       }
 
       /* The hold is the end state of the reveal, held. */
@@ -9808,9 +9974,6 @@ export class WebInspectorElement extends LitElement {
         .console-button {
           transition: opacity 160ms ease;
         }
-        .console-button:hover {
-          transform: none;
-        }
       }
 
       .console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-drawer {
@@ -9851,12 +10014,88 @@ export class WebInspectorElement extends LitElement {
         pointer-events: none;
         opacity: 0;
         visibility: hidden;
+        /* The resting state is the mark's own footprint, so the first frame
+           of the drawer's life shows nothing that is not already the circle.
+           The launcher's side is the corner the clip closes toward: the
+           default here is the left-opening island, whose mark is at the top
+           right. */
+        clip-path: inset(
+          0 0 calc(100% - var(--cpk-launcher-size))
+            calc(100% - var(--cpk-launcher-size)) round
+            calc(var(--cpk-launcher-size) / 2)
+        );
         transition: opacity 160ms ease;
       }
 
       .cpk-launcher-drawer[data-cpk-drawer-side="right"] {
         right: auto;
         left: 0;
+        /* Mirrored: the mark is at the top left, so that is the corner the
+           closed clip keeps. */
+        clip-path: inset(
+          0 calc(100% - var(--cpk-launcher-size))
+            calc(100% - var(--cpk-launcher-size)) 0 round
+            calc(var(--cpk-launcher-size) / 2)
+        );
+      }
+
+      /*
+       * The dwell reveal, applied to the capsule and the drawer together.
+       *
+       * Both halves are laid out at full size from their first frame and are
+       * revealed by the clip alone, exactly as the pill is, and for the same
+       * reason: this component is mounted permanently on top of a customer's
+       * application, so a property that forces a layout every frame — a width
+       * or a height — is not something to put on someone else's page. The two
+       * halves share one animation and one pair of durations, so what the
+       * reader sees is the mark itself opening out into the island rather
+       * than a capsule and a list arriving separately and meeting.
+       *
+       * Closing is the same animation played in reverse, so the two
+       * directions of the one gesture cannot drift apart.
+       */
+      .cpk-launcher-capsule[data-cpk-island-phase="open"],
+      .cpk-launcher-drawer[data-cpk-island-phase="open"] {
+        animation-duration: var(--cpk-launcher-island-open);
+        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+        animation-iteration-count: 1;
+        animation-fill-mode: forwards;
+      }
+      .cpk-launcher-capsule[data-cpk-island-phase="open"][data-cpk-capsule-direction="left"],
+      .cpk-launcher-drawer[data-cpk-island-phase="open"][data-cpk-drawer-side="left"] {
+        animation-name: cpk-launcher-island-left;
+      }
+      .cpk-launcher-capsule[data-cpk-island-phase="open"][data-cpk-capsule-direction="right"],
+      .cpk-launcher-drawer[data-cpk-island-phase="open"][data-cpk-drawer-side="right"] {
+        animation-name: cpk-launcher-island-right;
+      }
+
+      .cpk-launcher-capsule[data-cpk-island-phase="closing"],
+      .cpk-launcher-drawer[data-cpk-island-phase="closing"] {
+        animation-duration: var(--cpk-launcher-island-close);
+        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+        animation-iteration-count: 1;
+        animation-fill-mode: forwards;
+      }
+      .cpk-launcher-capsule[data-cpk-island-phase="closing"][data-cpk-capsule-direction="left"],
+      .cpk-launcher-drawer[data-cpk-island-phase="closing"][data-cpk-drawer-side="left"] {
+        animation-name: cpk-launcher-island-close-left;
+      }
+      .cpk-launcher-capsule[data-cpk-island-phase="closing"][data-cpk-capsule-direction="right"],
+      .cpk-launcher-drawer[data-cpk-island-phase="closing"][data-cpk-drawer-side="right"] {
+        animation-name: cpk-launcher-island-close-right;
+      }
+
+      /*
+       * The dwell capsule carries the same subline the pill does, and that
+       * subline is an invitation, so it takes the pointer while it is up —
+       * the same honesty rule the gesture's three visible phases follow. The
+       * button paints last and wins the pointer where the two overlap, so
+       * dragging the launcher is unaffected.
+       */
+      .cpk-launcher-capsule[data-cpk-island-phase="open"] {
+        pointer-events: auto;
+        cursor: pointer;
       }
 
       .cpk-launcher-drawer__list {
@@ -9900,16 +10139,48 @@ export class WebInspectorElement extends LitElement {
         outline-offset: 2px;
       }
 
-      .cpk-launcher-drawer__check {
+      /*
+       * The two row glyphs, one shape each way. Same box, same weight, same
+       * 12px square, so the row's text starts in the same place whichever
+       * state it is in and a column of rows has one text edge rather than
+       * two. Only the mark inside and its colour differ.
+       *
+       * Both colours come from named constants beside each other in this file
+       * rather than from two literals a few hundred lines apart, and the off
+       * one is the launcher's own error red rather than a second red of its
+       * own.
+       */
+      .cpk-launcher-drawer__check,
+      .cpk-launcher-drawer__cross {
         flex: none;
         width: 12px;
         height: 12px;
-        color: #6ee7a8;
+      }
+
+      .cpk-launcher-drawer__check {
+        color: ${unsafeCSS(HUD_ENABLED_COLOR)};
+      }
+
+      .cpk-launcher-drawer__cross {
+        color: ${unsafeCSS(HUD_DISABLED_COLOR)};
       }
 
       @media (prefers-reduced-motion: reduce) {
         .cpk-launcher-drawer {
           transition: none;
+        }
+        /*
+         * The island arrives at its final size instead of opening out to it.
+         * The instruction is to reduce motion, not to withhold information:
+         * the title and the rows are exactly what this reader came for, and
+         * the pill's own treatment a few rules above does the same thing.
+         */
+        .cpk-launcher-capsule[data-cpk-island-phase],
+        .cpk-launcher-drawer[data-cpk-island-phase] {
+          animation: none;
+          transition: none;
+          opacity: 1;
+          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
         }
       }
 
@@ -9954,10 +10225,19 @@ export class WebInspectorElement extends LitElement {
         }
       }
 
+      /*
+       * The preview is the island fading in and out whole, not the dwell
+       * reveal on a timer, so the clip is simply held open for it. Both
+       * halves carry the same declaration: a preview that showed the list
+       * without the title it belongs to would be the empty top band this
+       * change exists to close.
+       */
+      .cpk-launcher-capsule[data-cpk-hud-intro="true"],
       .cpk-launcher-drawer[data-cpk-hud-intro="true"] {
         animation: cpk-launcher-hud-intro
           var(--cpk-launcher-hud-intro-duration)
           cubic-bezier(0.16, 1, 0.3, 1) both;
+        clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
       }
 
       .cpk-launcher-drawer[data-cpk-hud-intro="true"]
@@ -9969,18 +10249,23 @@ export class WebInspectorElement extends LitElement {
       }
 
       .cpk-launcher-drawer[data-cpk-hud-intro="true"]
-        .cpk-launcher-drawer__check {
+        .cpk-launcher-drawer__check,
+      .cpk-launcher-drawer[data-cpk-hud-intro="true"]
+        .cpk-launcher-drawer__cross {
         animation: cpk-launcher-hud-check-online 220ms
           cubic-bezier(0.16, 1, 0.3, 1) both;
         animation-delay: calc(var(--cpk-hud-row-delay) + 90ms);
       }
 
       @media (prefers-reduced-motion: reduce) {
+        .cpk-launcher-capsule[data-cpk-hud-intro="true"],
         .cpk-launcher-drawer[data-cpk-hud-intro="true"],
         .cpk-launcher-drawer[data-cpk-hud-intro="true"]
           .cpk-launcher-drawer__row,
         .cpk-launcher-drawer[data-cpk-hud-intro="true"]
-          .cpk-launcher-drawer__check {
+          .cpk-launcher-drawer__check,
+        .cpk-launcher-drawer[data-cpk-hud-intro="true"]
+          .cpk-launcher-drawer__cross {
           animation: none !important;
           opacity: 1;
           transform: none;
@@ -10773,45 +11058,100 @@ export class WebInspectorElement extends LitElement {
   }
 
   /**
-   * The pill, laid out at its full width and clipped, for the whole gesture.
+   * The island's front half. One capsule, fed by either driver.
    *
-   * It renders from the first frame of the beat — clipped to nothing, so it
-   * shows nothing — because the direction is decided at gesture start, and the
-   * room around the launcher cannot be read until the launcher is laid out.
+   * It is laid out at its full width and clipped in both cases, and in both
+   * cases it renders from the first frame — clipped to the mark's own
+   * footprint, so it shows nothing that is not already the circle — because
+   * the side is decided from the room around the launcher, which cannot be
+   * read until the launcher is laid out.
+   *
+   * **A signal beats a dwell.** An error has a moment and the moment is what
+   * is worth saying; the connection state underneath it has not changed and
+   * comes back the instant the gesture ends. That is arbitration between two
+   * things competing for one slot, not a priority between two features.
    */
   private renderLauncherCapsule(): TemplateResult | typeof nothing {
-    const key = this.gestureSignal;
-    if (key === null || this.pillPhase === null) return nothing;
-    const signal = LAUNCHER_SIGNALS[key];
-    const label = signal.pillLabel;
-    if (label === undefined) return nothing;
+    const gestureKey = this.gestureSignal;
+    const gestureSignal =
+      gestureKey === null ? null : LAUNCHER_SIGNALS[gestureKey];
+    const gestureLabel = gestureSignal?.pillLabel;
+
+    // Which driver owns the capsule, and therefore what it says.
+    let subject: string;
+    let heading: string;
+    let direction: LauncherIslandSide;
+    const styles: Record<string, string> = {};
+
+    if (
+      gestureKey !== null &&
+      gestureSignal !== null &&
+      gestureLabel !== undefined &&
+      this.pillPhase !== null
+    ) {
+      subject = gestureKey;
+      heading = gestureLabel;
+      // Before the measurement the pill is laid out as if it were opening
+      // left, which is width-identical to the other side and shows nothing
+      // either way while the clip is closed.
+      direction = this.pillDirection ?? "left";
+      styles["--cpk-launcher-signal"] =
+        LAUNCHER_SIGNAL_COLORS[gestureSignal.tone];
+      styles["--cpk-launcher-capsule-open"] = `${ERROR_GESTURE_MS.open}ms`;
+      styles["--cpk-launcher-capsule-close"] = `${ERROR_GESTURE_MS.close}ms`;
+    } else if (this.launcherHudOpen && this.launcherHudSide !== null) {
+      // The dwell state. Intelligence is the island's title rather than one of
+      // the rows below it, because the rows are features and this is the
+      // connection they are carried over: a parent listed among its own
+      // children reads as a peer of them.
+      subject = "intelligence";
+      heading =
+        this.getHomeModel().hero.connection === "connected"
+          ? ISLAND_INTELLIGENCE_ON_TITLE
+          : ISLAND_INTELLIGENCE_OFF_TITLE;
+      direction = this.launcherHudSide;
+      styles["--cpk-launcher-island-open"] = `${LAUNCHER_ISLAND_MS.open}ms`;
+      styles["--cpk-launcher-island-close"] = `${LAUNCHER_ISLAND_MS.close}ms`;
+      styles["--cpk-launcher-hud-intro-duration"] =
+        `${LAUNCHER_HUD_INTRO_MS.duration}ms`;
+    } else {
+      return nothing;
+    }
+
     return html`
       <span
         class="cpk-launcher-capsule"
-        data-cpk-launcher-capsule=${key}
-        data-cpk-capsule-phase=${this.pillPhase}
-        data-cpk-capsule-direction=${
-          // Before the measurement the pill is laid out as if it were opening
-          // left, which is width-identical to the other side and shows nothing
-          // either way while the clip is closed.
-          this.pillDirection ?? "left"
-        }
-        style=${styleMap({
-          "--cpk-launcher-signal": LAUNCHER_SIGNAL_COLORS[signal.tone],
-          "--cpk-launcher-capsule-open": `${ERROR_GESTURE_MS.open}ms`,
-          "--cpk-launcher-capsule-close": `${ERROR_GESTURE_MS.close}ms`,
-        })}
+        data-cpk-launcher-capsule=${subject}
+        data-cpk-capsule-phase=${this.pillPhase ?? nothing}
+        data-cpk-island-phase=${this.getLauncherIslandPhase()}
+        data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
+        data-cpk-capsule-direction=${direction}
+        style=${styleMap(styles)}
         aria-hidden="true"
         @click=${this.handlePillClick}
       >
         <span class="cpk-launcher-capsule__heading" data-cpk-capsule-heading
-          >${label}</span
+          >${heading}</span
         >
         <span class="cpk-launcher-capsule__subline" data-cpk-capsule-subline
           >${PILL_SUBLINE_LABEL}</span
         >
       </span>
     `;
+  }
+
+  /**
+   * The dwell reveal's phase, shared by both halves of the island so the two
+   * cannot be told to do different things.
+   *
+   * Absent during a running gesture, whose own phase attribute owns the
+   * capsule, and absent during the page-load preview, which fades the island
+   * in and out whole on its own clock rather than opening it.
+   */
+  private getLauncherIslandPhase(): "open" | "closing" | typeof nothing {
+    if (this.pillPhase !== null) return nothing;
+    if (!this.launcherHudOpen || this.launcherHudIntro) return nothing;
+    return this.launcherIslandClosing ? "closing" : "open";
   }
 
   /**
@@ -10919,6 +11259,14 @@ export class WebInspectorElement extends LitElement {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
     }
+    // A pointer that comes back mid-close takes the island back off its way
+    // out. Cleared before the early return below, because the island is still
+    // open at that point and the flag would otherwise survive the re-entry and
+    // leave a reopened island playing its own departure.
+    if (this.launcherIslandClosing) {
+      this.launcherIslandClosing = false;
+      this.requestUpdate();
+    }
     if (this.launcherHudOpen) return;
     this.launcherHudOpen = true;
     this.requestUpdate();
@@ -10930,6 +11278,7 @@ export class WebInspectorElement extends LitElement {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
     }
+    this.launcherIslandClosing = false;
     if (!this.launcherHudOpen) return;
     this.launcherHudOpen = false;
     this.requestUpdate();
@@ -10940,14 +11289,28 @@ export class WebInspectorElement extends LitElement {
     this.openLauncherHud();
   };
 
+  /**
+   * The pointer left: play the reveal backwards, then drop the markup.
+   *
+   * The wait is the closing animation's own duration rather than a separate
+   * grace period, so the island is on screen for exactly as long as it is
+   * still saying something. A pointer that returns inside it is caught by
+   * `openLauncherHud`, which cancels both the timer and the phase.
+   */
   private handleLauncherHudLeave = (): void => {
     if (this.launcherHudCloseTimer !== null) {
       clearTimeout(this.launcherHudCloseTimer);
+      this.launcherHudCloseTimer = null;
+    }
+    if (!this.launcherHudOpen) return;
+    if (!this.launcherIslandClosing) {
+      this.launcherIslandClosing = true;
+      this.requestUpdate();
     }
     this.launcherHudCloseTimer = setTimeout(() => {
       this.launcherHudCloseTimer = null;
       this.closeLauncherHud();
-    }, 160);
+    }, LAUNCHER_ISLAND_MS.close);
   };
 
   private handleLauncherHudFocusIn = (): void => {
@@ -10985,8 +11348,7 @@ export class WebInspectorElement extends LitElement {
   ): void => {
     event.preventDefault();
     event.stopPropagation();
-    this.hudLandingMenu =
-      row === "threads" ? "threads" : row === "learning" ? "memories" : "home";
+    this.hudLandingMenu = row === "threads" ? "threads" : "memories";
     this.closeLauncherHud();
     this.openInspector("floating_button");
   };
@@ -11020,10 +11382,41 @@ export class WebInspectorElement extends LitElement {
     `;
   }
 
+  /**
+   * The off state's glyph, drawn exactly as the tick beside it: the same 16
+   * viewBox, the same stroked path with no fill, the same round joins and the
+   * same 12px box, so the pair reads as one family and the row's text starts
+   * in the same place either way.
+   *
+   * Decorative, like the tick: the row's own words already say which state it
+   * is in, and a screen reader that also announced the glyph would say it
+   * twice.
+   */
+  private renderHudCross(): TemplateResult {
+    return html`
+      <svg
+        class="cpk-launcher-drawer__cross"
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+        focusable="false"
+        data-cpk-hud-cross
+      >
+        <path
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M4 4 12 12 M12 4 4 12"
+        />
+      </svg>
+    `;
+  }
+
   private renderHudRow(args: {
     id: LauncherHudRowId;
     label: string;
-    connected: boolean;
+    enabled: boolean;
     introIndex: number;
   }): TemplateResult {
     return html`
@@ -11038,7 +11431,7 @@ export class WebInspectorElement extends LitElement {
         })}
         @click=${(event: Event) => this.handleHudRowClick(event, args.id)}
       >
-        ${args.connected ? this.renderHudCheck() : nothing}
+        ${args.enabled ? this.renderHudCheck() : this.renderHudCross()}
         <button
           class="cpk-launcher-drawer__action"
           type="button"
@@ -11069,39 +11462,38 @@ export class WebInspectorElement extends LitElement {
     const learningOn = homeModel.services.some(
       (service) => service.id === "memory" && service.enabled,
     );
-    const intelligenceOn = homeModel.hero.connection === "connected";
     return html`
       <div
         class="cpk-launcher-drawer"
         id="cpk-launcher-hud"
         data-cpk-launcher-drawer
         data-cpk-drawer-side=${side}
+        data-cpk-island-phase=${this.getLauncherIslandPhase()}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
         style=${styleMap({
+          "--cpk-launcher-island-open": `${LAUNCHER_ISLAND_MS.open}ms`,
+          "--cpk-launcher-island-close": `${LAUNCHER_ISLAND_MS.close}ms`,
           "--cpk-launcher-hud-intro-duration": `${LAUNCHER_HUD_INTRO_MS.duration}ms`,
           "--cpk-launcher-hud-row-duration": `${LAUNCHER_HUD_INTRO_MS.rowDuration}ms`,
         })}
       >
         <ul class="cpk-launcher-drawer__list" role="list">
-          ${this.renderHudRow({
-            id: "threads",
-            label: threadsOn ? HUD_THREADS_ON_LABEL : HUD_THREADS_OFF_LABEL,
-            connected: threadsOn,
-            introIndex: 0,
-          })}
-          ${this.renderHudRow({
-            id: "intelligence",
-            label: intelligenceOn
-              ? HUD_INTELLIGENCE_ON_LABEL
-              : HUD_INTELLIGENCE_OFF_LABEL,
-            connected: intelligenceOn,
-            introIndex: 1,
-          })}
+          ${
+            // Two features, and Intelligence is not among them: it is the
+            // capsule's title above, because it is the connection these two
+            // are carried over rather than a third thing beside them.
+            this.renderHudRow({
+              id: "threads",
+              label: threadsOn ? HUD_THREADS_ON_LABEL : HUD_THREADS_OFF_LABEL,
+              enabled: threadsOn,
+              introIndex: 0,
+            })
+          }
           ${this.renderHudRow({
             id: "learning",
             label: learningOn ? HUD_LEARNING_ON_LABEL : HUD_LEARNING_OFF_LABEL,
-            connected: learningOn,
-            introIndex: 2,
+            enabled: learningOn,
+            introIndex: 1,
           })}
         </ul>
       </div>

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9151,8 +9151,15 @@ export class WebInspectorElement extends LitElement {
            the two cannot drift apart. A dark grey rather than near-black: the
            launcher sits on a customer's page, and 1,5,7 against white is a
            harder edge than this surface needs. */
-        --cpk-launcher-face: rgba(24, 28, 31, 0.95);
-        --cpk-launcher-face-solid: rgb(24, 28, 31);
+        /* Opaque, and that is load-bearing rather than a rounding of 0.95.
+           The capsule spans the whole island and reaches under the mark, so
+           two translucent faces used to stack in the circle: 0.95 over 0.95
+           composites to 0.9975, and against a white page that is channel 24.6
+           under the mark against 35.6 beside it. The circle read as a darker
+           disc sitting ON the pill instead of as the same surface grown, which
+           is the one thing this shape is for. One opaque token, one surface.
+           The 5% bleed it gives up was never visible at this size. */
+        --cpk-launcher-face: rgb(24, 28, 31);
         --cpk-launcher-edge: rgba(190, 194, 255, 0.25);
         /* The launcher's own size, exposed so the signal dot can be placed
            against the OUTER rim with a length rather than a percentage.
@@ -9649,29 +9656,23 @@ export class WebInspectorElement extends LitElement {
       /* ── Floating button ─────────────────────────────────────────── */
       .console-button {
         background-color: var(--cpk-launcher-face) !important;
-        /* Width and style declared here, not left to the Tailwind utility on
-           the element. That utility resolves border-style from a registered
-           custom property, and @property inside an adopted stylesheet does not
-           register document-wide - so the ring only appeared when the HOST page
-           happened to load Tailwind v4 and register it for us. On a plain host
-           it computed to none, which takes the width to zero, and the launcher
-           lost its only outline. Measured: face against a dark host page is
-           1.10:1, so this hairline is the whole contour there. This block is
-           unlayered and the generated sheet is all layered, so it wins without
-           needing to shout. */
-        border-width: 1px;
-        border-style: solid;
-        border-color: var(--cpk-launcher-edge) !important;
-        /* One hairline, not two. The border above is it; a second ring used to
-           sit 1px outside as a box-shadow and hardcoded the lilac instead of
-           reading the --cpk-launcher-edge token, so it could not follow it.
-           What replaces it is a one-pixel light edge along the top, which is
-           what keeps the face from reading flat without drawing a frame.
+        border: 0;
+        /* No ring, and explicitly none on every host.
+           The element carries Tailwind's own border utility, which resolves its
+           style from a registered custom property; @property inside an adopted
+           stylesheet does not register document-wide, so that utility drew a
+           hairline only where the HOST page happened to load Tailwind v4 and
+           register it for us. Ringless was therefore never a design - it was
+           whatever the host had. Declaring it makes it one, and makes the two
+           hosts agree.
 
-           The border is not decoration: the face is #181C1F, which against a
-           dark host page (GitHub dark 1.10:1, Tailwind slate-900 1.04:1) is
-           indistinguishable from the page. It is the only thing that gives the
-           launcher an outline there, so it stays. */
+           What carries the shape instead is the light edge along the top and
+           the shadow below. The cost is real and belongs here rather than in a
+           commit message: the face is #181C1F, which against a dark host page
+           (GitHub dark 1.10:1, Tailwind slate-900 1.04:1) barely separates
+           from it, and that top edge is now the whole contour there. Putting
+           the hairline back is one declaration:
+           border: 1px solid var(--cpk-launcher-edge). */
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.07),
           0 4px 14px rgba(1, 5, 7, 0.28) !important;
@@ -9684,18 +9685,25 @@ export class WebInspectorElement extends LitElement {
         will-change: transform;
       }
       /*
-       * Hover changes the launcher's COLOUR and nothing else. It used to also
-       * carry "transform: scale(1.05)", and that scale was the third thing
-       * happening on hover: the mark stepped up, the island arrived beside it,
-       * and the two motions disagreed about what was opening. The island's own
-       * reveal starts from the mark's exact footprint, so a mark that is no
-       * longer that size while it opens breaks the one thing the reveal is
-       * for. One motion, and it belongs to the island.
+       * Hover changes nothing about the launcher, and the rule that used to is
+       * gone rather than emptied.
+       *
+       * It had two declarations and both have lost their subject. The tint
+       * moved the face from 0.95 to opaque, and the face is opaque now. The
+       * border brightened a ring the launcher no longer draws.
+       *
+       * Keeping either would work against the shape: the circle and the island
+       * are one surface, so a circle that tints on hover is a circle that
+       * stops matching the thing it grows into. The affordance is the island
+       * opening. Its one gap is a launcher with no room to open - hover then
+       * has no answer at all, where it used to at least tint.
+       *
+       * The rule also used to carry "transform: scale(1.05)". That scale was a
+       * third motion: the mark stepped up while the island arrived beside it,
+       * and the two disagreed about what was opening. The reveal starts from
+       * the mark's exact footprint, so a mark that is no longer that size
+       * while it opens breaks the one thing the reveal is for.
        */
-      .console-button:hover {
-        background-color: var(--cpk-launcher-face-solid) !important;
-        border-color: rgba(190, 194, 255, 0.45) !important;
-      }
       .console-button:focus-visible {
         /* Declared here for the same reason the resting ring is, and with a
            worse failure if it is not: the Tailwind focus utilities resolve

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -8866,7 +8866,7 @@ export class WebInspectorElement extends LitElement {
            MEMORY_LOAD_ERROR_LABEL at 12px/600 in Plus Jakarta Sans,
            measures ~155px, leaving ~10px of slack at the tightest end.
            At 252px it overflowed the frame, because the capsule is nowrap
-           and pinned - it can no longer grow the way the old auto-width
+           and pinned - it can no longer expand the way the old auto-width
            pill did.
 
            The slack is stated to the nearest pixel on purpose. Canvas and

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9824,27 +9824,27 @@ export class WebInspectorElement extends LitElement {
         }
       }
 
-      /*
-       * The drawer sits BEHIND the capsule and shares its top edge, so it can
-       * only ever be seen below it. The row/mark overlap is not fixed here,
-       * it is made impossible: the top of this box is covered by the capsule,
-       * which is covered in turn by the mark.
-       *
-       * Because it grows downward from behind a capsule that never moves,
-       * the only thing that changes between states is this element's height.
-       * Nothing morphs and no edge travels.
-       *
-       * No shadow, no second surface token, no blur. The capsule's own bottom
-       * border is the whole separator, measured at 1.82:1 against this
-       * surface on both light and dark host pages - the edge is internal, so
-       * the host page cannot reach it. See spec decision 6.
-       */
       .console-button-wrapper[data-cpk-hud="open"] .cpk-launcher-drawer {
         pointer-events: auto;
         opacity: 1;
         visibility: visible;
       }
 
+      /*
+       * The drawer sits BEHIND the capsule and shares its top edge, so it can
+       * only ever be seen below it. The row/mark overlap is not fixed here,
+       * it is made impossible: the top of this box is covered by the capsule,
+       * which is covered in turn by the mark.
+       *
+       * It grows downward from behind a capsule that never moves, so once it
+       * has more than one state, height will be the only thing that changes
+       * between them. Nothing will morph and no edge will travel.
+       *
+       * No shadow, no second surface token, no blur. The capsule's own bottom
+       * border is the whole separator, measured at 1.82:1 against this
+       * surface on both light and dark host pages - the edge is internal, so
+       * the host page cannot reach it. See spec decision 6.
+       */
       .cpk-launcher-drawer {
         position: absolute;
         top: 50%;
@@ -10920,7 +10920,13 @@ export class WebInspectorElement extends LitElement {
 
   private openLauncherHud(): void {
     if (this.isLauncherHudBlocked() || this.isOpen) return;
-    if (!this.resolveLauncherHudSide()) return;
+    if (!this.resolveLauncherHudSide()) {
+      // The room went away under an open drawer. Closing keeps the wrapper's
+      // data-cpk-hud, the button's aria-expanded and the rendered drawer
+      // agreeing; returning early leaves the first two claiming the third.
+      this.closeLauncherHud();
+      return;
+    }
     if (this.launcherHudCloseTimer !== null) {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
@@ -11077,9 +11083,10 @@ export class WebInspectorElement extends LitElement {
 
   private renderLauncherDrawer(): TemplateResult | typeof nothing {
     if (!this.launcherHudOpen) return nothing;
-    // Neither side had room. Both of the island's surfaces stand down together
-    // in that case, so this is the drawer's half of the honest degrade rather
-    // than a second, weaker rule.
+    // Last line of defence, not where the degrade happens: room is resolved
+    // and the state is kept consistent at the open path (openLauncherHud
+    // closes rather than leaving launcherHudOpen true with no side). This
+    // guard only covers a state this render should never actually observe.
     const side = this.launcherHudSide;
     if (side === null) return nothing;
     // The launcher must agree with Home about feature availability. Raw

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9656,23 +9656,31 @@ export class WebInspectorElement extends LitElement {
       /* ── Floating button ─────────────────────────────────────────── */
       .console-button {
         background-color: var(--cpk-launcher-face) !important;
-        border: 0;
-        /* No ring, and explicitly none on every host.
-           The element carries Tailwind's own border utility, which resolves its
-           style from a registered custom property; @property inside an adopted
-           stylesheet does not register document-wide, so that utility drew a
-           hairline only where the HOST page happened to load Tailwind v4 and
-           register it for us. Ringless was therefore never a design - it was
-           whatever the host had. Declaring it makes it one, and makes the two
-           hosts agree.
+        /* Width and style declared here, not left to the Tailwind utility on
+           the element. That utility resolves border-style from a registered
+           custom property, and @property inside an adopted stylesheet does not
+           register document-wide - so the ring appeared only where the HOST
+           page happened to load Tailwind v4 and register it for us. On a plain
+           host it computed to none, which takes the width to zero, and the
+           launcher lost its only outline.
 
-           What carries the shape instead is the light edge along the top and
-           the shadow below. The cost is real and belongs here rather than in a
-           commit message: the face is #181C1F, which against a dark host page
-           (GitHub dark 1.10:1, Tailwind slate-900 1.04:1) barely separates
-           from it, and that top edge is now the whole contour there. Putting
-           the hairline back is one declaration:
-           border: 1px solid var(--cpk-launcher-edge). */
+           That is why the ring is declared rather than merely kept: the reason
+           it exists is to separate the launcher from a DARK page, and on a
+           dark page without Tailwind v4 the inherited version was not there.
+           The intent was in the sheet; the pixels were up to the host.
+
+           Measured: the face is #181C1F, 1.10:1 against GitHub dark and 1.04:1
+           against Tailwind slate-900 - indistinguishable from the page on its
+           own. This hairline is the whole contour there, which is what makes it
+           structure rather than decoration. This block is unlayered and the
+           generated sheet is all layered, so it wins without needing to shout.
+
+           It reads --cpk-launcher-edge, the same token the capsule and the
+           drawer read, so the circle and the island are ringed alike and the
+           growth has no seam. */
+        border-width: 1px;
+        border-style: solid;
+        border-color: var(--cpk-launcher-edge) !important;
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.07),
           0 4px 14px rgba(1, 5, 7, 0.28) !important;
@@ -9688,15 +9696,17 @@ export class WebInspectorElement extends LitElement {
        * Hover changes nothing about the launcher, and the rule that used to is
        * gone rather than emptied.
        *
-       * It had two declarations and both have lost their subject. The tint
-       * moved the face from 0.95 to opaque, and the face is opaque now. The
-       * border brightened a ring the launcher no longer draws.
+       * It had two declarations and both work against the shape now. The tint
+       * moved the face from 0.95 to opaque, and the face is opaque always. The
+       * border brightened the circle's hairline to 0.45 while the capsule's
+       * stayed at 0.25 - so the ring the circle grows out of would have
+       * stopped matching the ring it grows into, on the one gesture where the
+       * two are visible at once.
        *
-       * Keeping either would work against the shape: the circle and the island
-       * are one surface, so a circle that tints on hover is a circle that
-       * stops matching the thing it grows into. The affordance is the island
-       * opening. Its one gap is a launcher with no room to open - hover then
-       * has no answer at all, where it used to at least tint.
+       * The affordance is the island opening. Its one gap is a launcher with
+       * no room to open - hover then has no answer at all, where it used to at
+       * least tint. Restoring feedback means giving it to the whole island
+       * rather than to the circle alone.
        *
        * The rule also used to carry "transform: scale(1.05)". That scale was a
        * third motion: the mark stepped up while the island arrived beside it,

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -8856,8 +8856,21 @@ export class WebInspectorElement extends LitElement {
           7vw,
           ${LAUNCHER_MAX_SIZE}px
         );
-        /* The island's width, shared by the capsule and the drawer so the two are bündig by construction rather than by two matching literals. Provisional: chosen by eye and not yet checked against both ends of the size clamp. */
-        --cpk-launcher-island: 252px;
+        /* The island's width, shared by the capsule and the drawer so the
+           two are flush by construction rather than by two matching
+           literals.
+
+           272px, not 252: the content budget is
+           width - (size + 12) - (size / 2) - 2, which at the 62.208px
+           maximum clamp gives 164.7px. The widest label,
+           MEMORY_LOAD_ERROR_LABEL at 12px/600 in Plus Jakarta Sans, is
+           155.4px, so 9.3px of slack at the tightest end. At 252px that
+           label overflowed the frame by 10.7px, because the capsule is
+           nowrap and pinned - it can no longer grow the way the old
+           auto-width pill did. Measured in a browser against the loaded
+           font; an earlier figure taken against the wrong font said this
+           fitted, and it did not. */
+        --cpk-launcher-island: 272px;
       }
 
       .console-button {
@@ -9523,6 +9536,9 @@ export class WebInspectorElement extends LitElement {
         top: 50%;
         margin-top: calc(var(--cpk-launcher-size) / -2);
         height: var(--cpk-launcher-size);
+        /* One width in every state. The two-width proposal was measured at
+           11px, because both states share the same subline and that subline
+           sets the floor. See spec decision 9. */
         width: var(--cpk-launcher-island);
         display: inline-flex;
         flex-direction: column;
@@ -9530,6 +9546,8 @@ export class WebInspectorElement extends LitElement {
         align-items: flex-start;
         gap: 1px;
         box-sizing: border-box;
+        /* One radius for every shape: a circle at 62x62, a capsule at
+           272x62, a rounded rectangle at 272x174. See spec decision 10. */
         border-radius: calc(var(--cpk-launcher-size) / 2);
         border: 1px solid var(--cpk-launcher-edge);
         background: var(--cpk-launcher-face);
@@ -9539,11 +9557,21 @@ export class WebInspectorElement extends LitElement {
         opacity: 0;
       }
 
+      /*
+       * The capsule is pinned to --cpk-launcher-island and is nowrap, so a
+       * label longer than the budget would paint past the frame onto the
+       * host page. These three lines make it truncate instead. With today's
+       * labels the ellipsis never appears - it is the guard for the next
+       * label added without measuring, not a layout the design expects.
+       */
       /* The failure class, word-identical to the panel's own wording. */
       .cpk-launcher-capsule__heading {
         font-size: 12px;
         font-weight: 600;
         line-height: 1.2;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       /*
@@ -9561,6 +9589,9 @@ export class WebInspectorElement extends LitElement {
         font-weight: 500;
         line-height: 1.2;
         opacity: 0.72;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       /*

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -8863,13 +8863,19 @@ export class WebInspectorElement extends LitElement {
            272px, not 252: the content budget is
            width - (size + 12) - (size / 2) - 2, which at the 62.208px
            maximum clamp gives 164.7px. The widest label,
-           MEMORY_LOAD_ERROR_LABEL at 12px/600 in Plus Jakarta Sans, is
-           155.4px, so 9.3px of slack at the tightest end. At 252px that
-           label overflowed the frame by 10.7px, because the capsule is
-           nowrap and pinned - it can no longer grow the way the old
-           auto-width pill did. Measured in a browser against the loaded
-           font; an earlier figure taken against the wrong font said this
-           fitted, and it did not. */
+           MEMORY_LOAD_ERROR_LABEL at 12px/600 in Plus Jakarta Sans,
+           measures ~155px, leaving ~10px of slack at the tightest end.
+           At 252px it overflowed the frame, because the capsule is nowrap
+           and pinned - it can no longer grow the way the old auto-width
+           pill did.
+
+           The slack is stated to the nearest pixel on purpose. Canvas and
+           DOM measurement of the same string disagree by ~0.9px, and the
+           font arrives by @import from an external host, so a customer
+           page with a restrictive font-src CSP renders the fallback and
+           voids the figure entirely. Sizing to the measured width is the
+           optimisation; the truncation on the two text lines is the
+           guarantee. */
         --cpk-launcher-island: 272px;
       }
 
@@ -9536,9 +9542,14 @@ export class WebInspectorElement extends LitElement {
         top: 50%;
         margin-top: calc(var(--cpk-launcher-size) / -2);
         height: var(--cpk-launcher-size);
-        /* One width in every state. The two-width proposal was measured at
-           11px, because both states share the same subline and that subline
-           sets the floor. See spec decision 9. */
+        /* One width in every state, so the capsule and the drawer cannot
+           drift apart. See spec decision 9.
+           The floor is the widest heading (MEMORY_LOAD_ERROR_LABEL, ~155px
+           at 12px/600), not the subline (~131px at 10.5px/500). The
+           "11px apart" figure decision 9 was argued from came from the
+           round that assumed the subline was the widest line - the same
+           assumption behind the old 252px overflow - so it is not
+           restated here. */
         width: var(--cpk-launcher-island);
         display: inline-flex;
         flex-direction: column;
@@ -9572,6 +9583,13 @@ export class WebInspectorElement extends LitElement {
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
+        /* The clip box needs a hair more than the line box: at
+           line-height 1.2 the font's content area is taller than the
+           line, and overflow:hidden would otherwise shave the tips of
+           descenders. The negative margin cancels the padding, so the
+           text sits exactly where it did. */
+        padding-block: 1px;
+        margin-block: -1px;
       }
 
       /*
@@ -9592,6 +9610,8 @@ export class WebInspectorElement extends LitElement {
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding-block: 1px;
+        margin-block: -1px;
       }
 
       /*

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -9468,6 +9468,18 @@ export class WebInspectorElement extends LitElement {
       /* ── Floating button ─────────────────────────────────────────── */
       .console-button {
         background-color: var(--cpk-launcher-face) !important;
+        /* Width and style declared here, not left to the Tailwind utility on
+           the element. That utility resolves border-style from a registered
+           custom property, and @property inside an adopted stylesheet does not
+           register document-wide - so the ring only appeared when the HOST page
+           happened to load Tailwind v4 and register it for us. On a plain host
+           it computed to none, which takes the width to zero, and the launcher
+           lost its only outline. Measured: face against a dark host page is
+           1.10:1, so this hairline is the whole contour there. This block is
+           unlayered and the generated sheet is all layered, so it wins without
+           needing to shout. */
+        border-width: 1px;
+        border-style: solid;
         border-color: var(--cpk-launcher-edge) !important;
         /* One hairline, not two. The border above is it; a second ring used to
            sit 1px outside as a box-shadow and hardcoded the lilac instead of
@@ -9504,6 +9516,17 @@ export class WebInspectorElement extends LitElement {
         border-color: rgba(190, 194, 255, 0.45) !important;
       }
       .console-button:focus-visible {
+        /* Declared here for the same reason the resting ring is, and with a
+           worse failure if it is not: the Tailwind focus utilities resolve
+           outline-style from a registered custom property, which an adopted
+           shadow stylesheet does not register, so on a host page without
+           Tailwind v4 the style fell back to none and took the width to zero.
+           A missing resting outline is a contrast problem. A missing FOCUS
+           outline is a keyboard user with no idea where they are, which is
+           what WCAG 2.4.7 exists to prevent. */
+        outline-style: solid;
+        outline-width: 2px;
+        outline-offset: 2px;
         outline-color: #bec2ff !important;
       }
 

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -554,12 +554,16 @@ const LAUNCHER_BASE_LABEL = "Web Inspector";
 type LauncherPillPhase = "closed" | "opening" | "holding" | "closing";
 
 /**
- * Which side the pill grows towards. The launcher is anchored top-right, so
- * the natural direction is leftwards, away from its own edge — but it is
- * draggable and its position persists, so a reader who parked it near the left
- * edge would otherwise get a permanently truncated pill.
+ * Which side of the mark the island grows towards. The launcher is anchored
+ * top-right, so the natural direction is leftwards, away from its own edge —
+ * but it is draggable and its position persists, so a reader who parked it
+ * near the left edge would otherwise get a permanently truncated pill.
+ *
+ * One type for both of the island's surfaces, because they are two halves of
+ * one object and there is exactly one answer for the pair. See
+ * `resolveLauncherIslandSide`.
  */
-type LauncherPillDirection = "left" | "right";
+type LauncherIslandSide = "left" | "right";
 
 /**
  * Whether the reader actually got a pill. `suppressed` is the honest-degrade
@@ -576,8 +580,6 @@ type CoreStatusSummary = Readonly<{
 type InspectorColorScheme = "light" | "dark";
 
 const EDGE_MARGIN = 16;
-/** HUD card plus the hover bridge. Used to pick left vs right. */
-const LAUNCHER_HUD_WIDTH = 248;
 /**
  * One page-load preview of the launcher's feature HUD.
  *
@@ -603,6 +605,70 @@ const ANNOUNCEMENT_URL = "https://cdn.copilotkit.ai/announcements.json";
 // an exactly 20% larger desktop cap. `box-sizing` makes these OUTER sizes.
 const LAUNCHER_MIN_SIZE = 51.84;
 const LAUNCHER_MAX_SIZE = 62.208;
+/**
+ * The island's width, shared by the capsule and the drawer so the two are
+ * flush by construction rather than by two matching literals.
+ *
+ * It lives here rather than in the stylesheet because the rule that picks the
+ * island's side needs the same number. `--cpk-launcher-island` is
+ * interpolated from this constant, exactly as the two launcher sizes above
+ * are, so the token and the geometry cannot come apart. A second literal for
+ * the geometry is what let the drawer go on choosing its side from a stale
+ * 248 long after the capsule had stopped agreeing with it.
+ *
+ * 272, not 252: the content budget is
+ * width - (size + 12) - (size / 2) - 2, which at the 62.208px
+ * maximum clamp gives 164.7px. The widest label,
+ * MEMORY_LOAD_ERROR_LABEL at 12px/600 in Plus Jakarta Sans,
+ * measures ~155px, leaving ~10px of slack at the tightest end.
+ * At 252px it overflowed the frame, because the capsule is nowrap
+ * and pinned - it can no longer expand the way the old auto-width
+ * pill did.
+ *
+ * The slack is stated to the nearest pixel on purpose. Canvas and
+ * DOM measurement of the same string disagree by ~0.9px, and the
+ * font arrives by @import from an external host, so a customer
+ * page with a restrictive font-src CSP renders the fallback and
+ * voids the figure entirely. Sizing to the measured width is the
+ * optimisation; the truncation on the two text lines is the
+ * guarantee.
+ */
+const LAUNCHER_ISLAND_WIDTH = 272;
+
+/**
+ * Which side of the mark the island opens on, or null when neither side has
+ * room for it.
+ *
+ * ONE rule for the whole island. Its two surfaces are pinned to the same
+ * width and anchored to the same edge of the same mark, so a pair that
+ * answered this question apart could end up pointing away from each other —
+ * which is exactly what happened while the drawer still measured itself as a
+ * card standing beside the mark instead of an island drawn over it.
+ *
+ * What has to fit is therefore the overhang, not the whole island: the part
+ * that hangs past the mark is the only part needing room it does not already
+ * have.
+ *
+ * Leftwards is the natural direction, away from the launcher's own edge.
+ * Where neither side has room there is no island at all rather than a cut-off
+ * one — for the capsule the dot and the beat still fire, so the signal is
+ * intact and only the label is lost, and for the drawer there is simply
+ * nothing to reveal on dwell. Constraining where the reader may drag the
+ * control to protect these surfaces was considered and rejected: the page is
+ * theirs.
+ */
+function resolveLauncherIslandSide(
+  mark: DOMRect,
+  viewportWidth: number,
+): LauncherIslandSide | null {
+  const overhang = Math.max(0, LAUNCHER_ISLAND_WIDTH - mark.width);
+  // Nothing extends past the mark, so there is nothing to fit.
+  if (overhang === 0) return "left";
+  if (mark.left - overhang >= EDGE_MARGIN) return "left";
+  if (mark.right + overhang <= viewportWidth - EDGE_MARGIN) return "right";
+  return null;
+}
+
 const DEFAULT_BUTTON_SIZE: Size = {
   width: LAUNCHER_MIN_SIZE,
   height: LAUNCHER_MIN_SIZE,
@@ -6637,11 +6703,17 @@ export class WebInspectorElement extends LitElement {
    * Which side the pill opens from, or null before the room has been measured.
    * Decided once, at gesture start, and never revisited mid-gesture.
    */
-  private pillDirection: LauncherPillDirection | null = null;
+  private pillDirection: LauncherIslandSide | null = null;
   private pillTimeoutId: ReturnType<typeof setTimeout> | null = null;
   /** Hover/focus menu on the closed launcher. */
   private launcherHudOpen = false;
-  private launcherHudSide: "left" | "right" = "left";
+  /**
+   * Which side the drawer opens from — the same answer the pill gets, from the
+   * same rule. Null means nothing has been measured yet, or that the last
+   * measurement found no room on either side, and in both cases there is no
+   * drawer to show.
+   */
+  private launcherHudSide: LauncherIslandSide | null = null;
   private launcherHudHelp: LauncherHudRowId | null = null;
   private launcherHudCloseTimer: ReturnType<typeof setTimeout> | null = null;
   private launcherHudIntro = false;
@@ -8858,25 +8930,10 @@ export class WebInspectorElement extends LitElement {
         );
         /* The island's width, shared by the capsule and the drawer so the
            two are flush by construction rather than by two matching
-           literals.
-
-           272px, not 252: the content budget is
-           width - (size + 12) - (size / 2) - 2, which at the 62.208px
-           maximum clamp gives 164.7px. The widest label,
-           MEMORY_LOAD_ERROR_LABEL at 12px/600 in Plus Jakarta Sans,
-           measures ~155px, leaving ~10px of slack at the tightest end.
-           At 252px it overflowed the frame, because the capsule is nowrap
-           and pinned - it can no longer expand the way the old auto-width
-           pill did.
-
-           The slack is stated to the nearest pixel on purpose. Canvas and
-           DOM measurement of the same string disagree by ~0.9px, and the
-           font arrives by @import from an external host, so a customer
-           page with a restrictive font-src CSP renders the fallback and
-           voids the figure entirely. Sizing to the measured width is the
-           optimisation; the truncation on the two text lines is the
-           guarantee. */
-        --cpk-launcher-island: 272px;
+           literals. Interpolated from LAUNCHER_ISLAND_WIDTH, which the rule
+           that picks the island's side reads too - see that constant for
+           why the number is 272 and not 252. */
+        --cpk-launcher-island: ${LAUNCHER_ISLAND_WIDTH}px;
       }
 
       .console-button {
@@ -10535,9 +10592,9 @@ export class WebInspectorElement extends LitElement {
     this.syncThreadsExampleOverviewVideo();
     this.maybeTrackInspectorMetadataViews();
     this.maybeTrackNewsSignalViewed();
-    // The pill's full width is only measurable once it has been laid out, and
-    // the answer decides both the direction and the telemetry label below, so
-    // this runs before the visibility event rather than after it.
+    // The room around the launcher is only measurable once it has been laid
+    // out, and the answer decides both the direction and the telemetry label
+    // below, so this runs before the visibility event rather than after it.
     this.resolvePillDirection();
     this.maybeTrackErrorSignalViewed();
     // "Rendered with content" is a property of the finished render, so the
@@ -10747,8 +10804,8 @@ export class WebInspectorElement extends LitElement {
    * The pill, laid out at its full width and clipped, for the whole gesture.
    *
    * It renders from the first frame of the beat — clipped to nothing, so it
-   * shows nothing — because the room it needs cannot be measured until it has
-   * been laid out, and the direction is decided at gesture start.
+   * shows nothing — because the direction is decided at gesture start, and the
+   * room around the launcher cannot be read until the launcher is laid out.
    */
   private renderLauncherCapsule(): TemplateResult | typeof nothing {
     const key = this.gestureSignal;
@@ -10822,7 +10879,10 @@ export class WebInspectorElement extends LitElement {
         return;
       }
 
-      this.resolveLauncherHudSide();
+      // No room for the island on either side, so there is nothing to preview.
+      // The preview is a one-shot page-load courtesy; it is dropped rather
+      // than retried, exactly as a blocked gesture's pill is.
+      if (!this.resolveLauncherHudSide()) return;
       this.launcherHudIntro = true;
       this.launcherHudOpen = true;
       this.requestUpdate();
@@ -10852,28 +10912,32 @@ export class WebInspectorElement extends LitElement {
     }
   }
 
-  private resolveLauncherHudSide(): void {
-    if (typeof window === "undefined") {
-      this.launcherHudSide = "left";
-      return;
-    }
+  /**
+   * Measures the room around the mark for the drawer, and reports whether it
+   * has any.
+   *
+   * The measurement is `resolveLauncherIslandSide` — the pill's rule, and the
+   * only one — so the two halves of the island cannot open on opposite sides.
+   * A false answer means neither side fits, and the drawer then does what the
+   * capsule does in the same position: it stays away, rather than opening over
+   * the edge of the window and being clipped by it.
+   */
+  private resolveLauncherHudSide(): boolean {
     const button =
       this.activeRoot.querySelector<HTMLElement>(".console-button");
-    if (!button) {
-      this.launcherHudSide = "left";
-      return;
-    }
-    const mark = button.getBoundingClientRect();
-    if (mark.left - LAUNCHER_HUD_WIDTH >= EDGE_MARGIN) {
-      this.launcherHudSide = "left";
-      return;
-    }
-    this.launcherHudSide = "right";
+    this.launcherHudSide =
+      button && typeof window !== "undefined"
+        ? resolveLauncherIslandSide(
+            button.getBoundingClientRect(),
+            window.innerWidth,
+          )
+        : null;
+    return this.launcherHudSide !== null;
   }
 
   private openLauncherHud(): void {
     if (this.isLauncherHudBlocked() || this.isOpen) return;
-    this.resolveLauncherHudSide();
+    if (!this.resolveLauncherHudSide()) return;
     if (this.launcherHudCloseTimer !== null) {
       clearTimeout(this.launcherHudCloseTimer);
       this.launcherHudCloseTimer = null;
@@ -11030,6 +11094,11 @@ export class WebInspectorElement extends LitElement {
 
   private renderLauncherDrawer(): TemplateResult | typeof nothing {
     if (!this.launcherHudOpen) return nothing;
+    // Neither side had room. Both of the island's surfaces stand down together
+    // in that case, so this is the drawer's half of the honest degrade rather
+    // than a second, weaker rule.
+    const side = this.launcherHudSide;
+    if (side === null) return nothing;
     // The launcher must agree with Home about feature availability. Raw
     // transport flags can be present for a runtime that is not entitled to use
     // Intelligence, which previously made the HUD show every service as on.
@@ -11046,7 +11115,7 @@ export class WebInspectorElement extends LitElement {
         class="cpk-launcher-drawer"
         id="cpk-launcher-hud"
         data-cpk-launcher-drawer
-        data-cpk-drawer-side=${this.launcherHudSide}
+        data-cpk-drawer-side=${side}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
         data-color-scheme=${this.colorScheme}
         style=${styleMap({
@@ -19858,8 +19927,8 @@ export class WebInspectorElement extends LitElement {
   /**
    * Opens the gesture's tail alongside the beat, for a signal that carries a
    * pill. The pill is rendered immediately — clipped to nothing, so it shows
-   * nothing — because its full width has to be on the page before the room
-   * either side of the launcher can be measured.
+   * nothing — so the side it opens on is settled while it is still invisible,
+   * against a launcher already in its final place on the page.
    *
    * A signal with no pill label gets no tail at all, so the announcement's
    * gesture is exactly the beat it has always been.
@@ -19884,10 +19953,14 @@ export class WebInspectorElement extends LitElement {
    * draggable and its position persists: a reader who parked it near the left
    * edge would otherwise get a permanently truncated pill.
    *
-   * Where neither side has room there is no pill at all rather than a cut-off
-   * one — the dot and the beat still fire, so the signal is intact and only
-   * the label is lost. Constraining where the reader may drag the control to
-   * protect this animation was considered and rejected: the page is theirs.
+   * The rule itself is `resolveLauncherIslandSide`, which the drawer follows
+   * too — including its verdict that neither side has room, which drops both
+   * surfaces rather than one.
+   *
+   * The capsule still has to be on the page before the side is chosen. Not to
+   * be measured — its width is the island's, a constant — but because a
+   * gesture that has not rendered yet is a gesture whose telemetry has no
+   * answer to report, and `pillOutcome` IS that answer.
    */
   private resolvePillDirection(): void {
     if (this.pillDirection !== null || this.pillPhase === null) return;
@@ -19898,34 +19971,16 @@ export class WebInspectorElement extends LitElement {
     const pill = wrapper?.querySelector<HTMLElement>(".cpk-launcher-capsule");
     if (!button || !pill || typeof window === "undefined") return;
 
-    const mark = button.getBoundingClientRect();
-    // A clip changes what is painted, never the layout box, so this is the
-    // pill's full width whichever phase it is in.
-    const overhang = Math.max(
-      0,
-      pill.getBoundingClientRect().width - mark.width,
+    this.setPillOutcome(
+      resolveLauncherIslandSide(
+        button.getBoundingClientRect(),
+        window.innerWidth,
+      ),
     );
-    const viewportWidth = window.innerWidth;
-
-    if (overhang === 0) {
-      // Nothing extends past the mark, so there is nothing to fit.
-      this.setPillOutcome("left");
-      return;
-    }
-    if (mark.left - overhang >= EDGE_MARGIN) {
-      // Leftwards is the natural direction: away from the launcher's own edge.
-      this.setPillOutcome("left");
-      return;
-    }
-    if (mark.right + overhang <= viewportWidth - EDGE_MARGIN) {
-      this.setPillOutcome("right");
-      return;
-    }
-    this.setPillOutcome(null);
   }
 
   /** Records the measurement's verdict, and drops the pill when it is null. */
-  private setPillOutcome(direction: LauncherPillDirection | null): void {
+  private setPillOutcome(direction: LauncherIslandSide | null): void {
     if (direction === null) {
       this.pillPhase = null;
       this.pillDirection = null;

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -86,6 +86,7 @@ import type {
   HomeHeroAction,
   HomeModel,
   HomeRuntimeHealthTone,
+  HomeServiceId,
 } from "./lib/home-briefing.js";
 import {
   INSPECTOR_GROUPS,
@@ -392,10 +393,19 @@ const PILL_SUBLINE_LABEL = "Click to open Inspector";
 const ISLAND_INTELLIGENCE_ON_TITLE = "Intelligence connected";
 const ISLAND_INTELLIGENCE_OFF_TITLE = "Intelligence not connected";
 
-type LauncherHudRowId = "threads" | "learning";
-
 /**
- * The two feature rows, each in both of its states.
+ * The drawer's feature rows, in the order they appear, each in both of its
+ * states and each naming the Home service it reads its state from.
+ *
+ * ONE list, read twice: `renderLauncherDrawer` renders it, and
+ * `launcherIslandHeight` counts it. The island's width is a constant that
+ * also generates its own token, so the geometry rule and the stylesheet
+ * cannot come apart; its HEIGHT has no such constant available, because it is
+ * the capsule's band plus however many rows there are. Making the row count a
+ * fact of the program rather than a figure written down beside it gives the
+ * height the same property: add a row here and the island grows, the rule
+ * that picks the island's corner grows with it, and nothing else has to be
+ * told.
  *
  * `enabled`/`disabled` rather than `on`/`Turn on`: the row is a statement of
  * what the runtime currently offers, not an instruction. The old off-state
@@ -403,10 +413,27 @@ type LauncherHudRowId = "threads" | "learning";
  * done — every row opens the view that explains the feature, and for a
  * feature that is off that view is the one carrying the Enable action.
  */
-const HUD_THREADS_ON_LABEL = "Threads enabled";
-const HUD_THREADS_OFF_LABEL = "Threads disabled";
-const HUD_LEARNING_ON_LABEL = "Learning enabled";
-const HUD_LEARNING_OFF_LABEL = "Learning disabled";
+const LAUNCHER_HUD_ROWS = [
+  {
+    id: "threads",
+    service: "threads",
+    onLabel: "Threads enabled",
+    offLabel: "Threads disabled",
+  },
+  {
+    id: "learning",
+    service: "memory",
+    onLabel: "Learning enabled",
+    offLabel: "Learning disabled",
+  },
+] as const satisfies readonly {
+  id: string;
+  service: HomeServiceId;
+  onLabel: string;
+  offLabel: string;
+}[];
+
+type LauncherHudRowId = (typeof LAUNCHER_HUD_ROWS)[number]["id"];
 
 const LAUNCHER_SIGNALS: Readonly<
   Record<LauncherSignalKey, LauncherSignalDefinition>
@@ -589,9 +616,51 @@ type LauncherPillPhase = "closed" | "opening" | "holding" | "closing";
  *
  * One type for both of the island's surfaces, because they are two halves of
  * one object and there is exactly one answer for the pair. See
- * `resolveLauncherIslandSide`.
+ * `resolveLauncherIslandPlacement`.
  */
 type LauncherIslandSide = "left" | "right";
+
+/**
+ * Which way the island grows from the mark's own band: downward from the
+ * mark's top edge, or upward from its bottom edge.
+ *
+ * The same argument as the side, on the other axis. The launcher is dragged
+ * and its position persists, so a reader who parked it near the bottom of the
+ * window would otherwise get an island whose rows are off the screen — and
+ * unlike a truncated pill there is nothing left on screen to say they exist.
+ */
+type LauncherIslandDrop = "down" | "up";
+
+/**
+ * Where the island opens: one answer, both axes, for both surfaces.
+ *
+ * A pair rather than four cases of one string, because the two axes are
+ * genuinely independent — the capsule's padding and the drawer's left/right
+ * anchor read the side and nothing else, the padding band and the vertical
+ * anchor read the drop and nothing else — and a `"left-up"` string would have
+ * every one of those places splitting it back apart. What makes this ONE
+ * answer is not that it is one word but that it is one value, resolved once
+ * by `resolveLauncherIslandPlacement`, stored once, and rendered onto both
+ * surfaces from that single field. Nothing downstream re-measures anything,
+ * which is the property the horizontal fix was about.
+ */
+type LauncherIslandPlacement = Readonly<{
+  side: LauncherIslandSide;
+  drop: LauncherIslandDrop;
+}>;
+
+/**
+ * Where the island is laid out before the room around the mark has been read.
+ *
+ * The launcher's own anchor is the top right of the window, so this is the
+ * overwhelmingly common answer as well as the historical one. It is only ever
+ * on screen while the clip still covers nothing but the mark, so it shows
+ * nothing either way.
+ */
+const LAUNCHER_ISLAND_DEFAULT_PLACEMENT: LauncherIslandPlacement = {
+  side: "left",
+  drop: "down",
+};
 
 /**
  * Whether the reader actually got a pill. `suppressed` is the honest-degrade
@@ -684,37 +753,140 @@ const LAUNCHER_MAX_SIZE = 62.208;
 const LAUNCHER_ISLAND_WIDTH = 272;
 
 /**
- * Which side of the mark the island opens on, or null when neither side has
- * room for it.
+ * The drawer's own chrome, in the same relationship to the stylesheet that
+ * `LAUNCHER_ISLAND_WIDTH` has: every one of these numbers is interpolated into
+ * the drawer's rules below AND read by `launcherIslandHeight`, so the shape
+ * the reader sees and the shape the placement rule reasons about cannot come
+ * apart. A second literal for the geometry is what let the drawer go on
+ * choosing its side from a stale 248 long after the capsule had stopped
+ * agreeing with it.
+ */
+const LAUNCHER_ISLAND_DRAWER = {
+  /** The hairline the island is drawn with, top and bottom. */
+  border: 1,
+  /** Space between the band the capsule covers and the first row. */
+  markClearance: 6,
+  /** Room past the last row, and inline on both sides. */
+  pad: 8,
+  /** One row. */
+  rowHeight: 32,
+} as const;
+
+/**
+ * The same four numbers as the lengths the stylesheet writes.
  *
- * ONE rule for the whole island. Its two surfaces are pinned to the same
- * width and anchored to the same edge of the same mark, so a pair that
- * answered this question apart could end up pointing away from each other —
- * which is exactly what happened while the drawer still measured itself as a
+ * Aliased rather than interpolated inline purely so the rules that use them
+ * stay one declaration to a line, which is what the suite reads them as.
+ */
+const ISLAND_HAIRLINE = unsafeCSS(`${LAUNCHER_ISLAND_DRAWER.border}px`);
+const ISLAND_PAD = unsafeCSS(`${LAUNCHER_ISLAND_DRAWER.pad}px`);
+const ISLAND_ROW_HEIGHT = unsafeCSS(`${LAUNCHER_ISLAND_DRAWER.rowHeight}px`);
+/** The band the capsule covers: the mark, plus the gap past it. */
+const ISLAND_BAND = unsafeCSS(
+  `calc(var(--cpk-launcher-size) + ${LAUNCHER_ISLAND_DRAWER.markClearance}px)`,
+);
+
+/**
+ * How tall the island stands at this mark.
+ *
+ * Computed, not measured and not a constant. Not measured, because the number
+ * is needed at a moment when there is nothing to measure: the capsule resolves
+ * its placement during a gesture, and the drawer — the taller half, and
+ * therefore the half that decides the answer — is not on the page at all then.
+ * A rule that could only answer once one surface existed would be two rules
+ * again. Not a constant either, because the island's height is not constant:
+ * its top band is the launcher itself, whose size is a clamp on the viewport,
+ * so the only honest source for that part is the mark actually in front of us.
+ *
+ * Everything else is arithmetic over the same numbers the stylesheet is
+ * generated from: two hairlines, the band that clears the mark, the room past
+ * the last row, and the rows themselves counted from `LAUNCHER_HUD_ROWS`. A
+ * third row changes exactly one thing — the length of that list — and this
+ * number, the corner the island opens into, and the drawer on screen all
+ * follow it together.
+ */
+function launcherIslandHeight(mark: DOMRect): number {
+  return (
+    mark.height +
+    2 * LAUNCHER_ISLAND_DRAWER.border +
+    LAUNCHER_ISLAND_DRAWER.markClearance +
+    LAUNCHER_ISLAND_DRAWER.pad +
+    LAUNCHER_HUD_ROWS.length * LAUNCHER_ISLAND_DRAWER.rowHeight
+  );
+}
+
+/**
+ * One axis of the placement: the preferred answer if its room takes the
+ * overhang, the other answer if that one does, and null when neither does.
+ *
+ * The two axes ask an identical question about different numbers, so they ask
+ * it through the same function rather than through two rules written out
+ * separately — which is how the vertical axis came to have no rule at all
+ * while the horizontal one had a careful one.
+ *
+ * The rooms are passed in preference order rather than in coordinate order,
+ * because the preferred direction is not the same way along both axes: the
+ * launcher's own anchor is the top right of the window, so the island's
+ * natural directions are leftwards and downwards — away from its own edge on
+ * one axis and along it on the other.
+ */
+function resolveIslandAxis<T>(
+  overhang: number,
+  preferred: { room: number; answer: T },
+  fallback: { room: number; answer: T },
+): T | null {
+  // Nothing extends past the mark, so there is nothing to fit.
+  if (overhang <= 0) return preferred.answer;
+  if (preferred.room >= overhang) return preferred.answer;
+  if (fallback.room >= overhang) return fallback.answer;
+  return null;
+}
+
+/**
+ * Where the island opens, or null when it does not fit anywhere.
+ *
+ * ONE rule for the whole island, on both axes. Its two surfaces are pinned to
+ * the same width and anchored to the same band of the same mark, so a pair
+ * that answered this question apart could end up pointing away from each other
+ * — which is exactly what happened while the drawer still measured itself as a
  * card standing beside the mark instead of an island drawn over it.
  *
- * What has to fit is therefore the overhang, not the whole island: the part
- * that hangs past the mark is the only part needing room it does not already
- * have.
+ * What has to fit is the overhang, not the whole island: the part that hangs
+ * past the mark is the only part needing room it does not already have. On the
+ * horizontal axis that is the width past a mark the island is drawn over; on
+ * the vertical it is the rows past the band the capsule covers.
  *
- * Leftwards is the natural direction, away from the launcher's own edge.
- * Where neither side has room there is no island at all rather than a cut-off
- * one — for the capsule the dot and the beat still fire, so the signal is
- * intact and only the label is lost, and for the drawer there is simply
- * nothing to reveal on dwell. Constraining where the reader may drag the
- * control to protect these surfaces was considered and rejected: the page is
- * theirs.
+ * The capsule is exactly the mark's own height, so the vertical answer moves
+ * it nowhere at all — its top edge on the mark's top edge and its bottom edge
+ * on the mark's bottom edge are the same line. It still follows the same
+ * answer rather than being exempted from the axis, because "the surface that
+ * happens not to care re-derives its own" is the shape of the bug this rule
+ * exists to prevent, and an exemption is a second rule however small.
+ *
+ * Where neither answer fits on either axis there is no island at all rather
+ * than a cut-off one — the same standing-down the horizontal axis has always
+ * done, now for the whole question rather than half of it. For the capsule the
+ * dot and the beat still fire, so the signal is intact and only the label is
+ * lost; for the drawer there is simply nothing to reveal on dwell.
+ * Constraining where the reader may drag the control to protect these surfaces
+ * was considered and rejected: the page is theirs.
  */
-function resolveLauncherIslandSide(
+function resolveLauncherIslandPlacement(
   mark: DOMRect,
-  viewportWidth: number,
-): LauncherIslandSide | null {
-  const overhang = Math.max(0, LAUNCHER_ISLAND_WIDTH - mark.width);
-  // Nothing extends past the mark, so there is nothing to fit.
-  if (overhang === 0) return "left";
-  if (mark.left - overhang >= EDGE_MARGIN) return "left";
-  if (mark.right + overhang <= viewportWidth - EDGE_MARGIN) return "right";
-  return null;
+  viewport: { width: number; height: number },
+): LauncherIslandPlacement | null {
+  const side = resolveIslandAxis<LauncherIslandSide>(
+    Math.max(0, LAUNCHER_ISLAND_WIDTH - mark.width),
+    { room: mark.left - EDGE_MARGIN, answer: "left" },
+    { room: viewport.width - EDGE_MARGIN - mark.right, answer: "right" },
+  );
+  const drop = resolveIslandAxis<LauncherIslandDrop>(
+    Math.max(0, launcherIslandHeight(mark) - mark.height),
+    { room: viewport.height - EDGE_MARGIN - mark.bottom, answer: "down" },
+    { room: mark.top - EDGE_MARGIN, answer: "up" },
+  );
+  if (side === null || drop === null) return null;
+  return { side, drop };
 }
 
 const DEFAULT_BUTTON_SIZE: Size = {
@@ -6748,20 +6920,20 @@ export class WebInspectorElement extends LitElement {
   /** Where the running gesture's pill is, or null when it has none. */
   private pillPhase: LauncherPillPhase | null = null;
   /**
-   * Which side the pill opens from, or null before the room has been measured.
-   * Decided once, at gesture start, and never revisited mid-gesture.
+   * Where the pill opens, or null before the room has been measured. Decided
+   * once, at gesture start, and never revisited mid-gesture.
    */
-  private pillDirection: LauncherIslandSide | null = null;
+  private pillPlacement: LauncherIslandPlacement | null = null;
   private pillTimeoutId: ReturnType<typeof setTimeout> | null = null;
   /** Hover/focus menu on the closed launcher. */
   private launcherHudOpen = false;
   /**
-   * Which side the drawer opens from — the same answer the pill gets, from the
-   * same rule. Null means nothing has been measured yet, or that the last
-   * measurement found no room on either side, and in both cases there is no
-   * drawer to show.
+   * Where the drawer opens — the same answer the pill gets, from the same
+   * rule. Null means nothing has been measured yet, or that the last
+   * measurement found no room on one of the two axes, and in every one of
+   * those cases there is no drawer to show.
    */
-  private launcherHudSide: LauncherIslandSide | null = null;
+  private launcherHudPlacement: LauncherIslandPlacement | null = null;
   private launcherHudCloseTimer: ReturnType<typeof setTimeout> | null = null;
   /**
    * The island is playing its reveal in reverse, on its way back into the
@@ -9716,7 +9888,10 @@ export class WebInspectorElement extends LitElement {
         gap: 1px;
         box-sizing: border-box;
         /* One radius for every shape: a circle at 62x62, a capsule at
-           272x62, a rounded rectangle at 272x174. See spec decision 10. */
+           272x62, a rounded rectangle at 272x142 - the height
+           launcherIslandHeight computes, which is where the figure comes
+           from rather than from a measurement taken once. See spec
+           decision 10. */
         border-radius: calc(var(--cpk-launcher-size) / 2);
         border: 1px solid var(--cpk-launcher-edge);
         background: var(--cpk-launcher-face);
@@ -9773,6 +9948,67 @@ export class WebInspectorElement extends LitElement {
       }
 
       /*
+       * The island's closed shape: the mark's own circle, in whichever of the
+       * four corners the mark occupies.
+       *
+       * The mark can be at any corner because the island answers on two axes
+       * now, and the naive spelling of that is eight hard-coded insets - four
+       * resting values and four more inside the keyframes - each of which has
+       * to agree with a position rule stated somewhere else. That is the same
+       * arrangement, one axis over, that let the capsule and the drawer point
+       * away from each other.
+       *
+       * So the corner is stated once per axis, as a pair of custom
+       * properties, and composed here into one value. The rule that anchors
+       * the island to an edge is the same rule that sets the property for that
+       * edge, so the corner the clip closes into cannot disagree with the
+       * corner the island is actually pinned to. Every surface and every
+       * keyframe below reads this one composed value.
+       *
+       * The defaults are the historical island: leftwards and downwards, so
+       * the mark is at the top right.
+       *
+       * The radius is the island's own, which at the capsule's height is a
+       * circle exactly covering the mark. It is also the value every close
+       * travels back to, so an unrounded corner here would square off the last
+       * frame of every one of them.
+       */
+      .cpk-launcher-capsule,
+      .cpk-launcher-drawer {
+        --cpk-island-clip-top: 0;
+        --cpk-island-clip-right: 0;
+        --cpk-island-clip-bottom: calc(100% - var(--cpk-launcher-size));
+        --cpk-island-clip-left: calc(100% - var(--cpk-launcher-size));
+        --cpk-island-closed: inset(
+          var(--cpk-island-clip-top) var(--cpk-island-clip-right)
+            var(--cpk-island-clip-bottom) var(--cpk-island-clip-left) round
+            calc(var(--cpk-launcher-size) / 2)
+        );
+        clip-path: var(--cpk-island-closed);
+      }
+
+      /*
+       * The island opening upward, for a launcher parked too near the foot of
+       * the window for the rows to fit below it.
+       *
+       * The mark does not move, so what changes is which of its edges the
+       * island hangs from: the bottom one, with the surface above it. Both
+       * halves flip together, from the one answer, and the capsule's flip is a
+       * no-op by construction - its height IS the mark's, so its two edges are
+       * the same line - which is exactly why it can follow the same answer
+       * without needing a rule of its own.
+       */
+      .cpk-launcher-capsule[data-cpk-island-drop="up"],
+      .cpk-launcher-drawer[data-cpk-island-drop="up"] {
+        top: auto;
+        margin-top: 0;
+        bottom: 50%;
+        margin-bottom: calc(var(--cpk-launcher-size) / -2);
+        --cpk-island-clip-top: calc(100% - var(--cpk-launcher-size));
+        --cpk-island-clip-bottom: 0;
+      }
+
+      /*
        * Two directions, one animation with the inset on the other side. The
        * padding on the launcher's side clears the mark, so the words never sit
        * under it. The text-side padding is derived from the capsule's radius
@@ -9782,82 +10018,59 @@ export class WebInspectorElement extends LitElement {
        * straight edge begins. A literal 14px put it 16px inside the curve at the
        * production launcher size, which is itself a clamp on the viewport.
        */
-      /*
-       * The closed clip carries the island's own radius, which at this size
-       * is a circle exactly covering the mark. It is also the value the
-       * closing transition travels back to, so an unrounded corner here would
-       * square off the last frame of every close.
-       */
       .cpk-launcher-capsule[data-cpk-capsule-direction="left"] {
         right: 0;
         padding: 0 calc(var(--cpk-launcher-size) + 12px) 0
           calc(var(--cpk-launcher-size) / 2);
-        clip-path: inset(
-          0 0 0 calc(100% - var(--cpk-launcher-size)) round
-            calc(var(--cpk-launcher-size) / 2)
-        );
       }
       .cpk-launcher-capsule[data-cpk-capsule-direction="right"] {
         left: 0;
         padding: 0 calc(var(--cpk-launcher-size) / 2) 0
           calc(var(--cpk-launcher-size) + 12px);
-        clip-path: inset(
-          0 calc(100% - var(--cpk-launcher-size)) 0 0 round
-            calc(var(--cpk-launcher-size) / 2)
-        );
+        --cpk-island-clip-left: 0;
+        --cpk-island-clip-right: calc(100% - var(--cpk-launcher-size));
       }
 
       /*
-       * ONE reveal for the whole island, in each of the two directions.
+       * ONE reveal for the whole island, in every direction it can open.
        *
-       * The 0% stop is the mark's own footprint: a square of the launcher's
-       * size in the island's top corner on the launcher's side, rounded by
-       * half that size, which is a circle exactly covering the mark. So the
-       * island is never smaller or larger than the circle before it opens —
-       * it IS the circle, and what follows is that circle opening out.
+       * The 0% stop is the mark's own footprint, read from the composed
+       * property above rather than written out per corner: a square of the
+       * launcher's size in whichever corner the mark occupies, rounded by half
+       * that size, which is a circle exactly covering it. So the island is
+       * never smaller or larger than the circle before it opens - it IS the
+       * circle, and what follows is that circle opening out.
        *
-       * The bottom inset is what makes one pair of keyframes serve both
-       * halves. On the capsule, whose height is exactly the launcher size,
-       * "100% - size" resolves to 0 and the clip only travels sideways, which
-       * is the pill's original behaviour unchanged. On the drawer, which is
-       * taller, the same expression holds the reveal back to the top band
-       * until it opens downward as well. Capsule and drawer therefore arrive
-       * as one surface rather than as two things that happen to be animated
-       * at the same time.
+       * That indirection is what collapses eight keyframes into two. The
+       * corner used to be spelled into the keyframe itself, so every direction
+       * needed its own pair and every pair had to be kept in step with a
+       * position rule elsewhere; now the keyframe asks the element where its
+       * mark is and the element answers from the same properties that pinned
+       * it there.
+       *
+       * The property also carries the vertical inset that makes one reveal
+       * serve both halves. On the capsule, whose height is exactly the
+       * launcher size, "100% - size" resolves to 0 and the clip only travels
+       * sideways, which is the pill's original behaviour unchanged. On the
+       * drawer, which is taller, the same expression holds the reveal back to
+       * the mark's own band until it opens along the other axis as well.
+       * Capsule and drawer therefore arrive as one surface rather than as two
+       * things that happen to be animated at the same time.
        *
        * "round" is on BOTH stops, so the revealing edge is the island's own
        * rounded corner travelling rather than a straight line wiping across
-       * it — and because a clip-path only interpolates between shapes of the
+       * it - and because a clip-path only interpolates between shapes of the
        * same kind, a "round" on one stop alone would stop it animating at
        * all. The radius is the island's own, not a 999px that happens to
        * clamp to the right number on a 62px-tall capsule and to the wrong one
-       * on a 174px-tall drawer.
+       * on a 142px-tall drawer.
        *
        * It adds no animated property: the clip is still the clip.
        */
-      @keyframes cpk-launcher-island-left {
+      @keyframes cpk-launcher-island-open {
         0% {
           opacity: 0;
-          clip-path: inset(
-            0 0 calc(100% - var(--cpk-launcher-size))
-              calc(100% - var(--cpk-launcher-size)) round
-              calc(var(--cpk-launcher-size) / 2)
-          );
-        }
-        100% {
-          opacity: 1;
-          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
-        }
-      }
-
-      @keyframes cpk-launcher-island-right {
-        0% {
-          opacity: 0;
-          clip-path: inset(
-            0 calc(100% - var(--cpk-launcher-size))
-              calc(100% - var(--cpk-launcher-size)) 0 round
-              calc(var(--cpk-launcher-size) / 2)
-          );
+          clip-path: var(--cpk-island-closed);
         }
         100% {
           opacity: 1;
@@ -9866,7 +10079,7 @@ export class WebInspectorElement extends LitElement {
       }
 
       /*
-       * The way back, written out rather than expressed as the two above with
+       * The way back, written out rather than expressed as the one above with
        * "animation-direction: reverse".
        *
        * That was the first attempt and it is measurably wrong: a CSS
@@ -9877,38 +10090,24 @@ export class WebInspectorElement extends LitElement {
        * not start at all — verified in the browser, where the element's
        * getAnimations() came back empty and the clip snapped to the closed
        * value. A second name is what actually restarts, so a second name is
-       * what these are.
+       * what this is.
        *
-       * They are the stops of their opposite number in the other order, and
-       * nothing else. Any edit to the shape above belongs here too.
+       * It is the stops of the reveal in the other order, and nothing else.
+       * Any edit to the shape above belongs here too.
+       *
+       * The gesture's own close is the exception that proves the rule: its
+       * capsule passes through a "holding" phase that carries no
+       * animation-name at all, so the name genuinely changes there and it can
+       * and does reuse the reveal in reverse.
        */
-      @keyframes cpk-launcher-island-close-left {
+      @keyframes cpk-launcher-island-close {
         0% {
           opacity: 1;
           clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
         }
         100% {
           opacity: 0;
-          clip-path: inset(
-            0 0 calc(100% - var(--cpk-launcher-size))
-              calc(100% - var(--cpk-launcher-size)) round
-              calc(var(--cpk-launcher-size) / 2)
-          );
-        }
-      }
-
-      @keyframes cpk-launcher-island-close-right {
-        0% {
-          opacity: 1;
-          clip-path: inset(0 0 0 0 round calc(var(--cpk-launcher-size) / 2));
-        }
-        100% {
-          opacity: 0;
-          clip-path: inset(
-            0 calc(100% - var(--cpk-launcher-size))
-              calc(100% - var(--cpk-launcher-size)) 0 round
-              calc(var(--cpk-launcher-size) / 2)
-          );
+          clip-path: var(--cpk-island-closed);
         }
       }
 
@@ -9934,6 +10133,7 @@ export class WebInspectorElement extends LitElement {
          never drift apart. */
       .cpk-launcher-capsule[data-cpk-capsule-phase="opening"],
       .cpk-launcher-capsule[data-cpk-capsule-phase="closing"] {
+        animation-name: cpk-launcher-island-open;
         animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
         animation-iteration-count: 1;
         animation-fill-mode: forwards;
@@ -9944,14 +10144,6 @@ export class WebInspectorElement extends LitElement {
       .cpk-launcher-capsule[data-cpk-capsule-phase="closing"] {
         animation-duration: var(--cpk-launcher-capsule-close);
         animation-direction: reverse;
-      }
-      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"][data-cpk-capsule-direction="left"],
-      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"][data-cpk-capsule-direction="left"] {
-        animation-name: cpk-launcher-island-left;
-      }
-      .cpk-launcher-capsule[data-cpk-capsule-phase="opening"][data-cpk-capsule-direction="right"],
-      .cpk-launcher-capsule[data-cpk-capsule-phase="closing"][data-cpk-capsule-direction="right"] {
-        animation-name: cpk-launcher-island-right;
       }
 
       /* The hold is the end state of the reveal, held. */
@@ -10006,13 +10198,14 @@ export class WebInspectorElement extends LitElement {
       }
 
       /*
-       * The drawer sits BEHIND the capsule and shares its top edge, so it can
-       * only ever be seen below it. The row/mark overlap is not fixed here,
-       * it is made impossible: the top of this box is covered by the capsule,
-       * which is covered in turn by the mark.
+       * The drawer sits BEHIND the capsule and shares the mark's own band, so
+       * it can only ever be seen past it. The row/mark overlap is not fixed
+       * here, it is made impossible: the band of this box the capsule covers
+       * is reserved as padding, and the capsule is covered in turn by the
+       * mark.
        *
-       * It grows downward from behind a capsule that never moves, so once it
-       * has more than one state, height will be the only thing that changes
+       * It grows away from behind a capsule that never moves, so once it has
+       * more than one state, height will be the only thing that changes
        * between them. Nothing will morph and no edge will travel.
        *
        * No shadow, no second surface token, no blur. The capsule's own bottom
@@ -10028,38 +10221,43 @@ export class WebInspectorElement extends LitElement {
         z-index: 1;
         width: var(--cpk-launcher-island);
         box-sizing: border-box;
-        /* Top padding clears the capsule that covers this band. */
-        padding: calc(var(--cpk-launcher-size) + 6px) 8px 8px;
+        /* The leading padding clears the capsule that covers that band. Every
+           number here is interpolated from LAUNCHER_ISLAND_DRAWER, which
+           launcherIslandHeight adds up to decide whether the island fits past
+           the mark or has to open the other way - so the height the rule
+           reasons about is the height this rule draws. */
+        padding: ${ISLAND_BAND} ${ISLAND_PAD} ${ISLAND_PAD};
         border-radius: calc(var(--cpk-launcher-size) / 2);
-        border: 1px solid var(--cpk-launcher-edge);
+        border: ${ISLAND_HAIRLINE} solid var(--cpk-launcher-edge);
         background: var(--cpk-launcher-face);
         color: #fff;
         pointer-events: none;
         opacity: 0;
         visibility: hidden;
-        /* The resting state is the mark's own footprint, so the first frame
-           of the drawer's life shows nothing that is not already the circle.
-           The launcher's side is the corner the clip closes toward: the
-           default here is the left-opening island, whose mark is at the top
-           right. */
-        clip-path: inset(
-          0 0 calc(100% - var(--cpk-launcher-size))
-            calc(100% - var(--cpk-launcher-size)) round
-            calc(var(--cpk-launcher-size) / 2)
-        );
         transition: opacity 160ms ease;
       }
 
+      /*
+       * Mirrored: the mark is on the other side, so the island hangs from that
+       * edge and the closed clip keeps that corner. The corner comes from the
+       * same two properties that do the hanging - see the composed footprint
+       * above.
+       */
       .cpk-launcher-drawer[data-cpk-drawer-side="right"] {
         right: auto;
         left: 0;
-        /* Mirrored: the mark is at the top left, so that is the corner the
-           closed clip keeps. */
-        clip-path: inset(
-          0 calc(100% - var(--cpk-launcher-size))
-            calc(100% - var(--cpk-launcher-size)) 0 round
-            calc(var(--cpk-launcher-size) / 2)
-        );
+        --cpk-island-clip-left: 0;
+        --cpk-island-clip-right: calc(100% - var(--cpk-launcher-size));
+      }
+
+      /*
+       * Opening upward puts the mark at the FOOT of the drawer, so the band
+       * the capsule covers is the one at the bottom and the padding that
+       * reserves it swaps ends with the room past the last row. The rows
+       * themselves keep their order and their reading direction.
+       */
+      .cpk-launcher-drawer[data-cpk-island-drop="up"] {
+        padding: ${ISLAND_PAD} ${ISLAND_PAD} ${ISLAND_BAND};
       }
 
       /*
@@ -10079,34 +10277,20 @@ export class WebInspectorElement extends LitElement {
        */
       .cpk-launcher-capsule[data-cpk-island-phase="open"],
       .cpk-launcher-drawer[data-cpk-island-phase="open"] {
+        animation-name: cpk-launcher-island-open;
         animation-duration: var(--cpk-launcher-island-open);
         animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
         animation-iteration-count: 1;
         animation-fill-mode: forwards;
       }
-      .cpk-launcher-capsule[data-cpk-island-phase="open"][data-cpk-capsule-direction="left"],
-      .cpk-launcher-drawer[data-cpk-island-phase="open"][data-cpk-drawer-side="left"] {
-        animation-name: cpk-launcher-island-left;
-      }
-      .cpk-launcher-capsule[data-cpk-island-phase="open"][data-cpk-capsule-direction="right"],
-      .cpk-launcher-drawer[data-cpk-island-phase="open"][data-cpk-drawer-side="right"] {
-        animation-name: cpk-launcher-island-right;
-      }
 
       .cpk-launcher-capsule[data-cpk-island-phase="closing"],
       .cpk-launcher-drawer[data-cpk-island-phase="closing"] {
+        animation-name: cpk-launcher-island-close;
         animation-duration: var(--cpk-launcher-island-close);
         animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
         animation-iteration-count: 1;
         animation-fill-mode: forwards;
-      }
-      .cpk-launcher-capsule[data-cpk-island-phase="closing"][data-cpk-capsule-direction="left"],
-      .cpk-launcher-drawer[data-cpk-island-phase="closing"][data-cpk-drawer-side="left"] {
-        animation-name: cpk-launcher-island-close-left;
-      }
-      .cpk-launcher-capsule[data-cpk-island-phase="closing"][data-cpk-capsule-direction="right"],
-      .cpk-launcher-drawer[data-cpk-island-phase="closing"][data-cpk-drawer-side="right"] {
-        animation-name: cpk-launcher-island-close-right;
       }
 
       /*
@@ -10131,7 +10315,9 @@ export class WebInspectorElement extends LitElement {
         display: flex;
         align-items: center;
         gap: 9px;
-        height: 32px;
+        /* Counted by launcherIslandHeight, so a taller row moves the point at
+           which the island has to open the other way. */
+        height: ${ISLAND_ROW_HEIGHT};
         padding: 0 20px;
         border-radius: 999px;
         font-size: 12px;
@@ -10873,9 +11059,9 @@ export class WebInspectorElement extends LitElement {
     this.maybeTrackInspectorMetadataViews();
     this.maybeTrackNewsSignalViewed();
     // The room around the launcher is only measurable once it has been laid
-    // out, and the answer decides both the direction and the telemetry label
+    // out, and the answer decides both the placement and the telemetry label
     // below, so this runs before the visibility event rather than after it.
-    this.resolvePillDirection();
+    this.resolvePillPlacement();
     this.maybeTrackErrorSignalViewed();
     // "Rendered with content" is a property of the finished render, so the
     // news signal is retired here rather than from a render method.
@@ -11103,7 +11289,7 @@ export class WebInspectorElement extends LitElement {
     // Which driver owns the capsule, and therefore what it says.
     let subject: string;
     let heading: string;
-    let direction: LauncherIslandSide;
+    let placement: LauncherIslandPlacement;
     const styles: Record<string, string> = {};
 
     if (
@@ -11114,15 +11300,15 @@ export class WebInspectorElement extends LitElement {
     ) {
       subject = gestureKey;
       heading = gestureLabel;
-      // Before the measurement the pill is laid out as if it were opening
-      // left, which is width-identical to the other side and shows nothing
-      // either way while the clip is closed.
-      direction = this.pillDirection ?? "left";
+      // Before the measurement the pill is laid out at the island's default
+      // placement, which is size-identical to every other one and shows
+      // nothing whichever it turns out to be while the clip is closed.
+      placement = this.pillPlacement ?? LAUNCHER_ISLAND_DEFAULT_PLACEMENT;
       styles["--cpk-launcher-signal"] =
         LAUNCHER_SIGNAL_COLORS[gestureSignal.tone];
       styles["--cpk-launcher-capsule-open"] = `${ERROR_GESTURE_MS.open}ms`;
       styles["--cpk-launcher-capsule-close"] = `${ERROR_GESTURE_MS.close}ms`;
-    } else if (this.launcherHudOpen && this.launcherHudSide !== null) {
+    } else if (this.launcherHudOpen && this.launcherHudPlacement !== null) {
       // The dwell state. Intelligence is the island's title rather than one of
       // the rows below it, because the rows are features and this is the
       // connection they are carried over: a parent listed among its own
@@ -11132,7 +11318,7 @@ export class WebInspectorElement extends LitElement {
         this.getHomeModel().hero.connection === "connected"
           ? ISLAND_INTELLIGENCE_ON_TITLE
           : ISLAND_INTELLIGENCE_OFF_TITLE;
-      direction = this.launcherHudSide;
+      placement = this.launcherHudPlacement;
       styles["--cpk-launcher-island-open"] = `${LAUNCHER_ISLAND_MS.open}ms`;
       styles["--cpk-launcher-island-close"] = `${LAUNCHER_ISLAND_MS.close}ms`;
       styles["--cpk-launcher-hud-intro-duration"] =
@@ -11148,7 +11334,8 @@ export class WebInspectorElement extends LitElement {
         data-cpk-capsule-phase=${this.pillPhase ?? nothing}
         data-cpk-island-phase=${this.getLauncherIslandPhase()}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
-        data-cpk-capsule-direction=${direction}
+        data-cpk-capsule-direction=${placement.side}
+        data-cpk-island-drop=${placement.drop}
         style=${styleMap(styles)}
         aria-hidden="true"
         @click=${this.handlePillClick}
@@ -11240,7 +11427,7 @@ export class WebInspectorElement extends LitElement {
       // No room for the island on either side, so there is nothing to preview.
       // The preview is a one-shot page-load courtesy; it is dropped rather
       // than retried, exactly as a blocked gesture's pill is.
-      if (!this.resolveLauncherHudSide()) return;
+      if (!this.resolveLauncherHudPlacement()) return;
       this.launcherHudIntro = true;
       this.launcherHudOpen = true;
       this.requestUpdate();
@@ -11273,28 +11460,29 @@ export class WebInspectorElement extends LitElement {
    * Measures the room around the mark for the drawer, and reports whether it
    * has any.
    *
-   * The measurement is `resolveLauncherIslandSide` — the pill's rule, and the
-   * only one — so the two halves of the island cannot open on opposite sides.
-   * A false answer means neither side fits, and the drawer then does what the
-   * capsule does in the same position: it stays away, rather than opening over
-   * the edge of the window and being clipped by it.
+   * The measurement is `resolveLauncherIslandPlacement` — the pill's rule, and
+   * the only one — so the two halves of the island cannot open away from each
+   * other on either axis. A false answer means the island does not fit, and
+   * the drawer then does what the capsule does in the same position: it stays
+   * away, rather than opening over the edge of the window and being clipped by
+   * it.
    */
-  private resolveLauncherHudSide(): boolean {
+  private resolveLauncherHudPlacement(): boolean {
     const button =
       this.activeRoot.querySelector<HTMLElement>(".console-button");
-    this.launcherHudSide =
+    this.launcherHudPlacement =
       button && typeof window !== "undefined"
-        ? resolveLauncherIslandSide(
-            button.getBoundingClientRect(),
-            window.innerWidth,
-          )
+        ? resolveLauncherIslandPlacement(button.getBoundingClientRect(), {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          })
         : null;
-    return this.launcherHudSide !== null;
+    return this.launcherHudPlacement !== null;
   }
 
   private openLauncherHud(): void {
     if (this.isLauncherHudBlocked() || this.isOpen) return;
-    if (!this.resolveLauncherHudSide()) {
+    if (!this.resolveLauncherHudPlacement()) {
       // The room went away under an open drawer. Closing keeps the wrapper's
       // data-cpk-hud, the button's aria-expanded and the rendered drawer
       // agreeing; returning early leaves the first two claiming the third.
@@ -11494,26 +11682,22 @@ export class WebInspectorElement extends LitElement {
     if (!this.launcherHudOpen) return nothing;
     // Last line of defence, not where the degrade happens: room is resolved
     // and the state is kept consistent at the open path (openLauncherHud
-    // closes rather than leaving launcherHudOpen true with no side). This
-    // guard only covers a state this render should never actually observe.
-    const side = this.launcherHudSide;
-    if (side === null) return nothing;
+    // closes rather than leaving launcherHudOpen true with no placement).
+    // This guard only covers a state this render should never actually
+    // observe.
+    const placement = this.launcherHudPlacement;
+    if (placement === null) return nothing;
     // The launcher must agree with Home about feature availability. Raw
     // transport flags can be present for a runtime that is not entitled to use
     // Intelligence, which previously made the HUD show every service as on.
     const homeModel = this.getHomeModel();
-    const threadsOn = homeModel.services.some(
-      (service) => service.id === "threads" && service.enabled,
-    );
-    const learningOn = homeModel.services.some(
-      (service) => service.id === "memory" && service.enabled,
-    );
     return html`
       <div
         class="cpk-launcher-drawer"
         id="cpk-launcher-hud"
         data-cpk-launcher-drawer
-        data-cpk-drawer-side=${side}
+        data-cpk-drawer-side=${placement.side}
+        data-cpk-island-drop=${placement.drop}
         data-cpk-island-phase=${this.getLauncherIslandPhase()}
         data-cpk-hud-intro=${this.launcherHudIntro ? "true" : nothing}
         style=${styleMap({
@@ -11528,19 +11712,22 @@ export class WebInspectorElement extends LitElement {
             // Two features, and Intelligence is not among them: it is the
             // capsule's title above, because it is the connection these two
             // are carried over rather than a third thing beside them.
-            this.renderHudRow({
-              id: "threads",
-              label: threadsOn ? HUD_THREADS_ON_LABEL : HUD_THREADS_OFF_LABEL,
-              enabled: threadsOn,
-              introIndex: 0,
+            //
+            // Rendered FROM the list the island's height is counted from, so
+            // a third row cannot arrive on screen without the rule that places
+            // the island knowing it is there.
+            LAUNCHER_HUD_ROWS.map((row, introIndex) => {
+              const enabled = homeModel.services.some(
+                (service) => service.id === row.service && service.enabled,
+              );
+              return this.renderHudRow({
+                id: row.id,
+                label: enabled ? row.onLabel : row.offLabel,
+                enabled,
+                introIndex,
+              });
             })
           }
-          ${this.renderHudRow({
-            id: "learning",
-            label: learningOn ? HUD_LEARNING_ON_LABEL : HUD_LEARNING_OFF_LABEL,
-            enabled: learningOn,
-            introIndex: 1,
-          })}
         </ul>
       </div>
     `;
@@ -20335,32 +20522,32 @@ export class WebInspectorElement extends LitElement {
     if (LAUNCHER_SIGNALS[key].pillLabel === undefined) {
       this.gestureSignal = null;
       this.pillPhase = null;
-      this.pillDirection = null;
+      this.pillPlacement = null;
       return;
     }
     this.gestureSignal = key;
     this.pillPhase = "closed";
-    this.pillDirection = null;
+    this.pillPlacement = null;
     this.closeLauncherHud();
   }
 
   /**
-   * Chooses the side, or suppresses the pill, from the room actually available
-   * at gesture start. Measured once, from the DOM, because the launcher is
-   * draggable and its position persists: a reader who parked it near the left
-   * edge would otherwise get a permanently truncated pill.
+   * Chooses the placement, or suppresses the pill, from the room actually
+   * available at gesture start. Measured once, from the DOM, because the
+   * launcher is draggable and its position persists: a reader who parked it
+   * near the left edge would otherwise get a permanently truncated pill.
    *
-   * The rule itself is `resolveLauncherIslandSide`, which the drawer follows
-   * too — including its verdict that neither side has room, which drops both
-   * surfaces rather than one.
+   * The rule itself is `resolveLauncherIslandPlacement`, which the drawer
+   * follows too — including its verdict that the island does not fit, which
+   * drops both surfaces rather than one.
    *
-   * The capsule still has to be on the page before the side is chosen. Not to
-   * be measured — its width is the island's, a constant — but because a
-   * gesture that has not rendered yet is a gesture whose telemetry has no
-   * answer to report, and `pillOutcome` IS that answer.
+   * The capsule still has to be on the page before the placement is chosen.
+   * Not to be measured — its size is the island's, and the island's is
+   * arithmetic — but because a gesture that has not rendered yet is a gesture
+   * whose telemetry has no answer to report, and `pillOutcome` IS that answer.
    */
-  private resolvePillDirection(): void {
-    if (this.pillDirection !== null || this.pillPhase === null) return;
+  private resolvePillPlacement(): void {
+    if (this.pillPlacement !== null || this.pillPhase === null) return;
     const wrapper = this.activeRoot.querySelector<HTMLElement>(
       ".console-button-wrapper",
     );
@@ -20369,23 +20556,23 @@ export class WebInspectorElement extends LitElement {
     if (!button || !pill || typeof window === "undefined") return;
 
     this.setPillOutcome(
-      resolveLauncherIslandSide(
-        button.getBoundingClientRect(),
-        window.innerWidth,
-      ),
+      resolveLauncherIslandPlacement(button.getBoundingClientRect(), {
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }),
     );
   }
 
   /** Records the measurement's verdict, and drops the pill when it is null. */
-  private setPillOutcome(direction: LauncherIslandSide | null): void {
-    if (direction === null) {
+  private setPillOutcome(placement: LauncherIslandPlacement | null): void {
+    if (placement === null) {
       this.pillPhase = null;
-      this.pillDirection = null;
+      this.pillPlacement = null;
       this.pillOutcome = "suppressed";
       this.requestUpdate();
       return;
     }
-    this.pillDirection = direction;
+    this.pillPlacement = placement;
     this.pillOutcome = "shown";
     this.requestUpdate();
   }
@@ -20394,7 +20581,7 @@ export class WebInspectorElement extends LitElement {
   private openPill(): void {
     // Normally already measured during the beat; measured here too so the
     // gesture cannot depend on a render having happened in between.
-    this.resolvePillDirection();
+    this.resolvePillPlacement();
     if (this.pillPhase === null) {
       // The measurement found no room after all.
       this.endGesture();
@@ -20466,7 +20653,7 @@ export class WebInspectorElement extends LitElement {
     this.cancelPillTimeout();
     this.gestureSignal = null;
     this.pillPhase = null;
-    this.pillDirection = null;
+    this.pillPlacement = null;
   }
 
   private cancelPillTimeout(): void {

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -11189,10 +11189,33 @@ export class WebInspectorElement extends LitElement {
    *
    * The gesture ends with the open, because `openInspector` cancels the tail —
    * the panel is over the launcher, so there is nothing left to reveal.
+   *
+   * This one click fires for both of `renderLauncherCapsule`'s states, and
+   * they disagree about where to land. A running gesture already declares its
+   * own `landingTarget` — `openInspector` applies it from `activeSignalAtOpen`
+   * — and that must keep winning here; a signal owns the gesture slot exactly
+   * when `gestureSignal` and `pillPhase` are both set (see `beginGestureTail`,
+   * which clears both together for a signal with no pill), so that is the
+   * check that rules this click out of routing at all. Only the dwell state
+   * is left to decide, and only its disconnected reading routes: Home is
+   * where Intelligence gets set up, and connected leaves the destination
+   * alone so the capsule matches the plain launcher mark it sits beside. The
+   * connection test is read from `getHomeModel`, the same source the title
+   * above already reads, so the two can never disagree. Routed the same way
+   * a HUD row does — through `hudLandingMenu`, which `openInspector` already
+   * gives precedence over a signal's landing target.
    */
   private handlePillClick = (event: Event): void => {
     event.preventDefault();
     event.stopPropagation();
+    const signalOwnsCapsule =
+      this.gestureSignal !== null && this.pillPhase !== null;
+    if (
+      !signalOwnsCapsule &&
+      this.getHomeModel().hero.connection !== "connected"
+    ) {
+      this.hudLandingMenu = "home";
+    }
     this.openInspector("floating_button");
   };
 


### PR DESCRIPTION
## What this changes

The launcher had two things overlaying it that were not related to each other. The **error pill** was a capsule at launcher height, `border-radius: 999px`, painted from the launcher's own face and edge tokens, revealed by a rounded `clip-path`. The **services HUD** was a 228px rectangle at the panel radius, with a dotted border at twice the edge token's opacity, a `backdrop-filter` blur that an earlier PR had deliberately removed from the launcher, a drop shadow, and an arrow pointing back at the mark.

They shared no token. The arrow was the symptom: the pill needs none because it grows out of the launcher, while the HUD floated beside it and had to point home.

Now there is one component. A **capsule** in front, a **drawer** behind it sharing its top edge, both clipped to the mark's own circle when closed and growing out of it on hover. The capsule is the shape that already ships as the error message — same height, radius, face, edge, two text lines. Only the words change.

It carries the Intelligence state as the island's title (`Intelligence connected` / `Intelligence not connected`), with `Threads enabled` / `Learning disabled` as rows beneath it, each with a check or a cross. Intelligence sat among those rows before, which read as a peer of the features that actually depend on it.

**The state logic is untouched.** `home-briefing.ts` and `inspector-metadata.ts` are not in the diff. The island reads the same `getHomeModel()` projection the Home view reads, so the two cannot disagree.

## Bugs on `main` that this fixes

**The HUD's rows overlapped the mark by 23px**, and the mark's stacking swallowed the click — a row that looked like a link was not one. That is not patched: the drawer now shares the capsule's top edge and reserves the mark's band as padding, so the overlap cannot recur.

**Both of the launcher's rings depended on the host page.** The resting hairline came from Tailwind's `border` utility and the focus ring from `focus-visible:outline`; both resolve their style from a registered custom property, and `@property` inside a stylesheet adopted into a shadow root does not register document-wide. Measured on two hosts, same browser, identical bytes:

| host | `--tw-border-style` | `border-style` | `border-width` |
|---|---|---|---|
| plain page | *(empty)* | `none` | **0px** |
| page with Tailwind v4 | `solid` | `solid` | 1px |

The resting ring exists to separate the launcher from a **dark** page — the face is `#181C1F`, measured at 1.10:1 against GitHub dark — so on precisely the hosts it is for, the inherited version was the one that vanished. Both rings now declare their own values.

**The island only checked horizontal room.** Dragged near the foot of the window it opened on the correct side and then ran off the bottom (measured at 1280×720: drawer bottom 784). One resolver now answers both axes.

**The two halves could open on opposite sides of the mark.** The capsule used the overhang; the drawer still used a stale 248px constant and the old beside-the-launcher geometry. For `mark.left` in [225.8, 264) they pointed away from each other.

**The circle read darker than the pill.** The capsule spans the island and passes under the mark, and both faces were `rgba(24, 28, 31, 0.95)` — 0.9975 in the overlap, channel 24.6 under the mark against 35.6 beside it on white. One opaque token now, shared by button, capsule and drawer.

## Behaviour under a signal

`isLauncherHudBlocked()` returned `gestureSignal !== null`, so hovering during an error gesture opened nothing at all. And `beginGestureTail` ended in `closeLauncherHud()`, so an error arriving mid-hover slammed the drawer shut under the pointer — which also fails WCAG 2.1 SC 1.4.13.

The two slots are now arbitrated separately:

| | capsule | drawer | beat |
|---|---|---|---|
| nothing armed, no dwell | — | — | — |
| signal fires, no dwell | its words | — | yes, self-closing |
| dwell, nothing armed | Intelligence state | services | — |
| dwell begins during a gesture | the signal's words | services | clock stops, never resumes |
| signal fires during dwell | swaps in | unchanged | **no** |
| signal heals during dwell | back to the summary | unchanged | no |
| dwell ends after a signal showed | — | — | none |
| two signals armed | higher `priority` | — | existing |

The gesture is parked rather than cancelled: the live region keeps its sentence and the held telemetry impression is still released. One case fell outside the table — a signal with no words to show cannot count as shown, so its beat is deferred under the pointer rather than spent.

Click destinations keep their precedence, with one case filled in: a capsule reading `Intelligence not connected` lands on Home, where Intelligence is set up. Connected, it stays neutral and restores the reader's view.

## Testing

**644 → 664, 33 files, green.** Every new guard was mutation-proven: the regression it names was introduced deliberately, the test confirmed red, then reverted.

Three guards close classes rather than instances and are worth a look:

- **A bidirectional reachability join** — every `.cpk-launcher-*` selector and `data-cpk-*` attribute in the sheet must reach a rendered element, and every rendered one must have a rule. It exists because a commit on this branch renamed the stylesheet while the markup still emitted the old names: every drawer rule matched nothing, the launcher rendered unstyled, and 611 tests passed.
- **A z-order guard that asserts presence**, not values. The bug was not a wrong number, it was two missing ones: the drawer declared `z-index: 1` while the capsule and button declared none.
- **The closed clip**, asserted through `--cpk-launcher-size` at all four corners, so "the circle becomes the island" is checked rather than claimed.

## Two traps for whoever reviews this

`index.ts` is a Tailwind `@source` and the glob covers `__tests__/`, so a bare utility word in a **code comment** emits a real rule into the committed `generated.css`. It bit three times here. A clean `git status` is not proof — a word only produces a diff when that utility is not already in the sheet from real usage.

The pre-commit hooks do not typecheck the spec files. A `tsc` error in a test can land green; one did, and is fixed here.

## Not verified, and not in scope

The **visual result has not been checked in a browser by CI or by the author's tooling** — it was reviewed by hand. Worth a look on a dark host page in particular, since that is where the ring argument lives.

Out of scope deliberately: **touch** (the island opens on `pointerenter`; a tap opens the Inspector — pre-existing), a **signal-supplied drawer payload** (listing failed runs under a `run` error rather than the services; the registry slot is designed and unbuilt), and the **word cross-fade** when a signal swaps into a dwelling capsule — the behavioural half is implemented and tested, the swap itself is a hard cut. The dot still turns red, so the change is not unsignalled.

One known gap introduced here: the hover rule was deleted rather than emptied, so a launcher with **no room to open** now gives no hover feedback at all, where it used to tint. Restoring it belongs on the whole island, not on the circle alone.
