### PR TITLE
Support Intelligence over the single Runtime route

### DIFF
--- a/packages/angular/src/lib/memories.spec.ts
+++ b/packages/angular/src/lib/memories.spec.ts
@@ -76,9 +76,6 @@ class CopilotKitStub {
   readonly store: ɵMemoryStore;
 
   constructor(fetchMock: Mock) {
-    // rxjs `fromFetch` ultimately calls `globalThis.fetch`, so stub it with the
-    // same routed mock that is injected into the store (mirrors the React test).
-    vi.stubGlobal("fetch", fetchMock);
     this.store = ɵcreateMemoryStore({
       fetch: fetchMock as unknown as typeof fetch,
     });

--- a/packages/core/src/__tests__/single-route-resource-transport.test.ts
+++ b/packages/core/src/__tests__/single-route-resource-transport.test.ts
@@ -1,0 +1,224 @@
+import { expect, test, vi } from "vitest";
+
+import { CopilotKitCore, CopilotKitCoreRuntimeConnectionStatus } from "../core";
+
+const RUNTIME_URL = "https://runtime.example.com/api/copilotkit";
+
+interface SetupOptions {
+  capability?: boolean;
+  transport?: "rest" | "single";
+}
+
+/** Connects a core to a mocked runtime and returns isolated cleanup. */
+async function setup(options: SetupOptions = {}) {
+  const originalFetch = globalThis.fetch;
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  (globalThis as { window?: unknown }).window = {};
+
+  const fetchMock = vi.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          version: "1.0.0",
+          agents: {},
+          audioFileTranscriptionEnabled: false,
+          mode: "intelligence",
+          intelligence: { wsUrl: "wss://runtime.example.com/client" },
+          threadEndpoints: {
+            list: false,
+            inspect: false,
+            mutations: false,
+            realtimeMetadata: false,
+          },
+          ...(options.capability
+            ? {
+                singleRoute: {
+                  resourceOperations: true,
+                  threadEndpoints: {
+                    list: true,
+                    inspect: true,
+                    mutations: true,
+                    realtimeMetadata: true,
+                  },
+                },
+              }
+            : {}),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    ),
+  );
+  globalThis.fetch = fetchMock;
+
+  const core = new CopilotKitCore({
+    runtimeUrl: RUNTIME_URL,
+    runtimeTransport: options.transport ?? "single",
+  });
+  await vi.waitFor(() => {
+    expect(core.runtimeConnectionStatus).toBe(
+      CopilotKitCoreRuntimeConnectionStatus.Connected,
+    );
+  });
+
+  return {
+    core,
+    fetchMock,
+    teardown: () => {
+      core.setRuntimeUrl(undefined);
+      globalThis.fetch = originalFetch;
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+      vi.restoreAllMocks();
+    },
+  };
+}
+
+test("single transport sends every Intelligence resource operation to one URL", async () => {
+  const context = await setup({ capability: true });
+  const controller = new AbortController();
+  const cases = [
+    { path: "/threads?agentId=researcher", method: "GET" },
+    { path: "/threads/subscribe", method: "POST", body: {} },
+    { path: "/threads/thread-1", method: "PATCH", body: { name: "New" } },
+    { path: "/threads/thread-1", method: "DELETE", body: {} },
+    {
+      path: "/threads/thread-1/archive",
+      method: "POST",
+      body: { archived: true },
+    },
+    { path: "/threads/thread-1/messages", method: "GET" },
+    { path: "/threads/thread-1/events", method: "GET" },
+    { path: "/threads/thread-1/state", method: "GET" },
+    { path: "/threads/clear", method: "POST", body: {} },
+    { path: "/memories", method: "GET" },
+    { path: "/memories", method: "POST", body: { content: "Fact" } },
+    { path: "/memories/recall", method: "POST", body: { query: "Fact" } },
+    { path: "/memories/subscribe", method: "POST", body: {} },
+    {
+      path: "/memories/memory-1",
+      method: "PATCH",
+      body: { content: "New fact" },
+    },
+    { path: "/memories/memory-1", method: "DELETE", body: {} },
+    { path: "/annotate", method: "POST", body: { threadId: "thread-1" } },
+  ];
+
+  try {
+    context.fetchMock.mockClear();
+    for (const input of cases) {
+      await context.core.ɵruntimeFetch(`${RUNTIME_URL}${input.path}`, {
+        method: input.method,
+        headers: {
+          Authorization: "Bearer browser-token",
+          ...(input.body ? { "Content-Type": "application/json" } : {}),
+        },
+        credentials: "include",
+        signal: controller.signal,
+        ...(input.body ? { body: JSON.stringify(input.body) } : {}),
+      });
+    }
+
+    expect(context.fetchMock).toHaveBeenCalledTimes(cases.length);
+    for (const [index, input] of cases.entries()) {
+      const [url, init] = context.fetchMock.mock.calls[index] as [
+        RequestInfo | URL,
+        RequestInit,
+      ];
+      expect(url).toBe(RUNTIME_URL);
+      expect(init.method).toBe("POST");
+      expect(init.credentials).toBe("include");
+      expect(init.signal).toBe(controller.signal);
+      expect(new Headers(init.headers).get("authorization")).toBe(
+        "Bearer browser-token",
+      );
+      expect(JSON.parse(init.body as string)).toEqual({
+        method: "resource/request",
+        params: { path: input.path, httpMethod: input.method },
+        ...(input.body ? { body: input.body } : {}),
+      });
+    }
+    expect(context.core.threadEndpoints).toEqual({
+      list: true,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: true,
+    });
+  } finally {
+    context.teardown();
+  }
+});
+
+test("single transport keeps legacy resource behavior without the capability", async () => {
+  const context = await setup();
+  const url = `${RUNTIME_URL}/threads`;
+
+  try {
+    context.fetchMock.mockClear();
+    await context.core.ɵruntimeFetch(url, { method: "GET" });
+
+    expect(context.fetchMock).toHaveBeenCalledWith(url, { method: "GET" });
+    expect(context.core.threadEndpoints).toEqual({
+      list: false,
+      inspect: false,
+      mutations: false,
+      realtimeMetadata: false,
+    });
+  } finally {
+    context.teardown();
+  }
+});
+
+test("REST transport ignores the single-route capability", async () => {
+  const context = await setup({ capability: true, transport: "rest" });
+  const url = `${RUNTIME_URL}/threads`;
+
+  try {
+    context.fetchMock.mockClear();
+    await context.core.ɵruntimeFetch(url, { method: "GET" });
+
+    expect(context.fetchMock).toHaveBeenCalledWith(url, { method: "GET" });
+    expect(context.core.threadEndpoints).toEqual({
+      list: false,
+      inspect: false,
+      mutations: false,
+      realtimeMetadata: false,
+    });
+  } finally {
+    context.teardown();
+  }
+});
+
+test("the core memory store uses the single-route resource transport", async () => {
+  const context = await setup({ capability: true });
+
+  try {
+    context.fetchMock.mockClear();
+    context.fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ memories: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const store = context.core.getMemoryStore();
+    const refresh = store.refresh();
+    await vi.waitFor(() => {
+      expect(context.fetchMock).toHaveBeenCalled();
+    });
+
+    const [url, init] = context.fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
+    expect(url).toBe(RUNTIME_URL);
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      method: "resource/request",
+      params: { path: "/memories", httpMethod: "GET" },
+    });
+    await refresh;
+  } finally {
+    context.teardown();
+  }
+});

--- a/packages/core/src/__tests__/single-route-resource-transport.test.ts
+++ b/packages/core/src/__tests__/single-route-resource-transport.test.ts
@@ -171,6 +171,30 @@ test("single transport keeps legacy resource behavior without the capability", a
   }
 });
 
+test("single transport parses JSON media types without case sensitivity", async () => {
+  const context = await setup({ capability: true });
+
+  try {
+    context.fetchMock.mockClear();
+    await context.core.ɵruntimeFetch(`${RUNTIME_URL}/annotate`, {
+      method: "POST",
+      headers: { "Content-Type": "Application/JSON; Charset=UTF-8" },
+      body: JSON.stringify({ threadId: "thread-1" }),
+    });
+
+    const [, init] = context.fetchMock.mock.calls[0] as [
+      RequestInfo | URL,
+      RequestInit,
+    ];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      method: "resource/request",
+      body: { threadId: "thread-1" },
+    });
+  } finally {
+    context.teardown();
+  }
+});
+
 test("REST transport ignores the single-route capability", async () => {
   const context = await setup({ capability: true, transport: "rest" });
   const url = `${RUNTIME_URL}/threads`;

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -32,6 +32,7 @@ import {
   RUNTIME_REQUEST_WATCHDOG_MS,
   runtimeRequestMeta,
 } from "../utils/runtime-request";
+import { createSingleRouteResourceRequest } from "../utils/single-route-resource-request";
 
 type ResolvedCopilotRuntimeTransport = Exclude<CopilotRuntimeTransport, "auto">;
 
@@ -152,6 +153,7 @@ export class AgentRegistry {
   private _runtimeMode: RuntimeMode = RUNTIME_MODE_SSE;
   private _intelligence?: IntelligenceRuntimeInfo;
   private _threadEndpoints?: ThreadEndpointRuntimeInfo;
+  private _singleRouteResourceOperations = false;
   private _suggestions?: boolean;
   private _inspectorMetadata?: InspectorMetadataV1;
   private _inspectorMetadataSupported: boolean = false;
@@ -310,6 +312,7 @@ export class AgentRegistry {
     // before subscribers observe the replacement target connecting.
     this._licenseStatus = undefined;
     this._runtimeEntitlements = undefined;
+    this._singleRouteResourceOperations = false;
     this._runtimeUrl = normalizedRuntimeUrl;
 
     // Deferred construction (see CopilotKitCore.connect / #5801): record the URL
@@ -366,6 +369,7 @@ export class AgentRegistry {
     this.resetRuntimeEntitlementRetry();
     this._requestedTransport = runtimeTransport;
     this._runtimeTransport = runtimeTransport;
+    this._singleRouteResourceOperations = false;
     void this.updateRuntimeConnection({
       preserveOnFailure: this.hasLiveRuntimeKnowledgeToProtect(),
     });
@@ -606,7 +610,19 @@ export class AgentRegistry {
         const meta = () => runtimeRequestMeta(init);
         const watchdog = this.armRuntimeRequestWatchdog(meta());
         try {
-          const response = await fetch(input, init);
+          const singleRouteRequest =
+            this._runtimeTransport === "single" &&
+            this._singleRouteResourceOperations &&
+            this._runtimeUrl
+              ? await createSingleRouteResourceRequest(
+                  input,
+                  init,
+                  this._runtimeUrl,
+                )
+              : null;
+          const response = singleRouteRequest
+            ? await fetch(singleRouteRequest.input, singleRouteRequest.init)
+            : await fetch(input, init);
           watchdog.clear();
           this.handleRuntimeRequestOutcome(
             response.ok ? "ok" : meta()?.nonCritical ? "ignored" : "failed",
@@ -1211,6 +1227,7 @@ export class AgentRegistry {
       this._runtimeMode = RUNTIME_MODE_SSE;
       this._intelligence = undefined;
       this._threadEndpoints = undefined;
+      this._singleRouteResourceOperations = false;
       this._suggestions = undefined;
       this._a2uiEnabled = false;
       this._a2uiAgents = undefined;
@@ -1340,7 +1357,12 @@ export class AgentRegistry {
         runtimeInfoResponse.audioFileTranscriptionEnabled ?? false;
       this._runtimeMode = runtimeInfoResponse.mode ?? RUNTIME_MODE_SSE;
       this._intelligence = runtimeInfoResponse.intelligence;
-      this._threadEndpoints = runtimeInfoResponse.threadEndpoints;
+      this._singleRouteResourceOperations =
+        resolvedTransport === "single" &&
+        runtimeInfoResponse.singleRoute?.resourceOperations === true;
+      this._threadEndpoints = this._singleRouteResourceOperations
+        ? runtimeInfoResponse.singleRoute?.threadEndpoints
+        : runtimeInfoResponse.threadEndpoints;
       this._suggestions = runtimeInfoResponse.suggestions;
       this._inspectorMetadataSupported =
         runtimeInfoResponse.inspectorMetadata === true;
@@ -1419,6 +1441,7 @@ export class AgentRegistry {
         this._runtimeMode = RUNTIME_MODE_SSE;
         this._intelligence = undefined;
         this._threadEndpoints = undefined;
+        this._singleRouteResourceOperations = false;
         this._suggestions = undefined;
         this._a2uiEnabled = false;
         this._a2uiAgents = undefined;

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -970,13 +970,13 @@ export class CopilotKitCore {
   /**
    * Lazily creates, starts, and context-syncs the core-owned memory store on
    * first access, then returns it. Subsequent calls return the existing store.
-   * The store is constructed with a bound `globalThis.fetch` and immediately
-   * has its runtime context synced from the current connection state.
+   * The store uses the Core Runtime fetch so REST and single-route transports
+   * share the same resource behavior. Its Runtime context is synced at once.
    */
   private ensureMemoryStore(): ɵMemoryStore {
     if (!this._memoryStore) {
       this._memoryStore = ɵcreateMemoryStore({
-        fetch: globalThis.fetch.bind(globalThis),
+        fetch: this.ɵruntimeFetch,
       });
       this._memoryStore.start();
       this.syncMemoryContext();

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,15 +1,15 @@
 import { phoenixExponentialBackoff } from "@copilotkit/shared";
-import type { Observable } from "rxjs";
 import {
   EMPTY,
   asapScheduler,
   defer,
   firstValueFrom,
+  from,
   merge,
+  Observable,
   observeOn,
   of,
 } from "rxjs";
-import { fromFetch } from "rxjs/fetch";
 import {
   catchError,
   concatWith,
@@ -594,6 +594,7 @@ interface MemoryStore {
 
 const MEMORY_METADATA_EVENT = "memory_metadata";
 
+/** Runs a memory request through the injected fetch and aborts on unsubscribe. */
 function memoryFromFetch<T>(
   input: string,
   init: RequestInit & {
@@ -601,7 +602,37 @@ function memoryFromFetch<T>(
     fetch: typeof fetch;
   },
 ): Observable<T> {
-  return fromFetch(input, init);
+  const {
+    selector,
+    fetch: fetchImplementation,
+    signal: outerSignal,
+    ...requestInit
+  } = init;
+
+  return new Observable<T>((subscriber) => {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    if (outerSignal?.aborted) {
+      controller.abort();
+    } else {
+      outerSignal?.addEventListener("abort", abort);
+    }
+
+    const subscription = from(
+      fetchImplementation(input, {
+        ...requestInit,
+        signal: controller.signal,
+      }),
+    )
+      .pipe(mergeMap((response) => from(selector(response))))
+      .subscribe(subscriber);
+
+    return () => {
+      outerSignal?.removeEventListener("abort", abort);
+      controller.abort();
+      subscription.unsubscribe();
+    };
+  });
 }
 
 /**

--- a/packages/core/src/utils/single-route-resource-request.ts
+++ b/packages/core/src/utils/single-route-resource-request.ts
@@ -31,7 +31,7 @@ async function readResourceBody(
   }
   if (!text) return undefined;
 
-  if (headers.get("content-type")?.includes("application/json")) {
+  if (headers.get("content-type")?.toLowerCase().includes("application/json")) {
     try {
       return JSON.parse(text) as unknown;
     } catch {

--- a/packages/core/src/utils/single-route-resource-request.ts
+++ b/packages/core/src/utils/single-route-resource-request.ts
@@ -1,0 +1,111 @@
+interface SingleRouteResourceRequest {
+  input: RequestInfo | URL;
+  init: RequestInit;
+}
+
+/** Returns true when a path belongs to an Intelligence resource API. */
+function isIntelligenceResourcePath(path: string): boolean {
+  return (
+    path === "/threads" ||
+    path.startsWith("/threads/") ||
+    path === "/memories" ||
+    path.startsWith("/memories/") ||
+    path === "/annotate"
+  );
+}
+
+/** Reads a JSON resource body without changing invalid JSON error behavior. */
+async function readResourceBody(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  headers: Headers,
+  method: string,
+): Promise<unknown | undefined> {
+  if (method === "GET" || method === "HEAD") return undefined;
+
+  let text: string | undefined;
+  if (init?.body != null) {
+    text = await new Response(init.body).text();
+  } else if (input instanceof Request) {
+    text = await input.clone().text();
+  }
+  if (!text) return undefined;
+
+  if (headers.get("content-type")?.includes("application/json")) {
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      return text;
+    }
+  }
+  return text;
+}
+
+/**
+ * Converts one Runtime resource fetch into a single-route JSON envelope.
+ * Requests outside the mounted Runtime or outside its resource APIs pass
+ * through unchanged.
+ */
+export async function createSingleRouteResourceRequest(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  runtimeUrl: string,
+): Promise<SingleRouteResourceRequest | null> {
+  const runtime = new URL(runtimeUrl);
+  const inputUrl =
+    input instanceof Request
+      ? input.url
+      : input instanceof URL
+        ? input.href
+        : input;
+  const target = new URL(inputUrl, runtime);
+  const runtimePath = runtime.pathname.replace(/\/$/, "");
+  if (target.origin !== runtime.origin) return null;
+  if (!target.pathname.startsWith(`${runtimePath}/`)) return null;
+
+  const resourcePath = target.pathname.slice(runtimePath.length);
+  if (!isIntelligenceResourcePath(resourcePath)) return null;
+
+  const method = (
+    init?.method ?? (input instanceof Request ? input.method : "GET")
+  ).toUpperCase();
+  const headers = new Headers(
+    init?.headers ?? (input instanceof Request ? input.headers : undefined),
+  );
+  const body = await readResourceBody(input, init, headers, method);
+  headers.set("content-type", "application/json");
+  headers.delete("content-length");
+
+  const requestDefaults: RequestInit =
+    input instanceof Request
+      ? {
+          cache: input.cache,
+          credentials: input.credentials,
+          integrity: input.integrity,
+          keepalive: input.keepalive,
+          mode: input.mode,
+          redirect: input.redirect,
+          referrer: input.referrer,
+          referrerPolicy: input.referrerPolicy,
+          signal: input.signal,
+        }
+      : {};
+
+  return {
+    input: runtimeUrl,
+    init: {
+      ...requestDefaults,
+      ...init,
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        method: "resource/request",
+        params: {
+          path: `${resourcePath}${target.search}`,
+          httpMethod: method,
+        },
+        ...(body === undefined ? {} : { body }),
+      }),
+    },
+  };
+}

--- a/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-memories.test.tsx
@@ -1,15 +1,7 @@
 import * as React from "react";
 import { renderToString } from "react-dom/server";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import { useCopilotKit } from "../../context";
 import { ɵcreateMemoryStore } from "@copilotkit/core";
@@ -98,11 +90,7 @@ function makeFetchMock(
   });
 }
 
-// Stub the global fetch once for the entire module — RxJS's fromFetch always
-// calls globalThis.fetch, so injected fetch in ɵcreateMemoryStore is a
-// pass-through. vi.stubGlobal restores the original automatically on afterAll.
 const fetchMock = vi.fn();
-vi.stubGlobal("fetch", fetchMock);
 
 let store: ɵMemoryStore;
 
@@ -145,10 +133,6 @@ describe("useMemories", () => {
     // pending fetches don't leak across tests.
     store?.stop();
     vi.clearAllMocks();
-  });
-
-  afterAll(() => {
-    vi.unstubAllGlobals();
   });
 
   it("exposes empty memories and isAvailable true on initial render", () => {

--- a/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
+++ b/packages/react-core/src/v2/hooks/use-learn-from-user-action.tsx
@@ -99,6 +99,7 @@ export function useLearnFromUserAction(): UseLearnFromUserActionRecorder {
       };
 
       return recordAnnotation({
+        fetch: copilotkit.ɵruntimeFetch,
         runtimeUrl,
         headers: copilotkit.headers ?? {},
         type: "user_action",

--- a/packages/react-core/src/v2/hooks/use-learning-containers.tsx
+++ b/packages/react-core/src/v2/hooks/use-learning-containers.tsx
@@ -82,8 +82,10 @@ export function useLearningContainers({
     copilotkit.runtimeUrl,
   );
   const headersRef = useRef<Record<string, string>>(copilotkit.headers ?? {});
+  const runtimeFetchRef = useRef(copilotkit.ɵruntimeFetch);
   runtimeUrlRef.current = copilotkit.runtimeUrl;
   headersRef.current = copilotkit.headers ?? {};
+  runtimeFetchRef.current = copilotkit.ɵruntimeFetch;
 
   // Content-stable dependency: same items in same order → same key string.
   const key = JSON.stringify(learningContainers);
@@ -114,6 +116,7 @@ export function useLearningContainers({
         return;
       }
       recordAnnotation({
+        fetch: copilotkit.ɵruntimeFetch,
         runtimeUrl,
         headers,
         type: "set_learning_containers",
@@ -161,6 +164,7 @@ export function useLearningContainers({
 
       if (capturedRuntimeUrl) {
         recordAnnotation({
+          fetch: runtimeFetchRef.current,
           runtimeUrl: capturedRuntimeUrl,
           headers: capturedHeaders,
           type: "set_learning_containers",

--- a/packages/react-core/src/v2/lib/__tests__/record-annotation-transport.test.ts
+++ b/packages/react-core/src/v2/lib/__tests__/record-annotation-transport.test.ts
@@ -1,0 +1,36 @@
+import { expect, test, vi } from "vitest";
+
+import { recordAnnotation } from "../record-annotation";
+
+test("recordAnnotation uses the caller's Runtime fetch", async () => {
+  const runtimeFetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ id: "annotation-1", duplicate: false }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+
+  const result = await recordAnnotation({
+    runtimeUrl: "https://runtime.example.com/api/copilotkit",
+    headers: { Authorization: "Bearer browser-token" },
+    type: "user_action",
+    payload: { title: "Renamed project" },
+    threadId: "thread-1",
+    clientEventId: "event-1",
+    fetch: runtimeFetch,
+  });
+
+  expect(result).toEqual({ id: "annotation-1", duplicate: false });
+  expect(runtimeFetch).toHaveBeenCalledWith(
+    "https://runtime.example.com/api/copilotkit/annotate",
+    expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({
+        type: "user_action",
+        threadId: "thread-1",
+        clientEventId: "event-1",
+        payload: { title: "Renamed project" },
+      }),
+    }),
+  );
+});

--- a/packages/react-core/src/v2/lib/record-annotation.ts
+++ b/packages/react-core/src/v2/lib/record-annotation.ts
@@ -21,6 +21,8 @@ export interface RecordAnnotationResult {
  * auth server-side and the browser must never send it.
  */
 export interface RecordAnnotationArgs {
+  /** Runtime-aware fetch implementation. Defaults to the global fetch. */
+  fetch?: typeof globalThis.fetch;
   /**
    * Base URL of the customer's CopilotKit runtime
    * (e.g. `https://bff.example.com/api/copilotkit`).
@@ -84,7 +86,15 @@ export interface RecordAnnotationArgs {
 export async function recordAnnotation(
   args: RecordAnnotationArgs,
 ): Promise<RecordAnnotationResult> {
-  const { runtimeUrl, headers, type, payload, threadId, occurredAt } = args;
+  const {
+    runtimeUrl,
+    headers,
+    type,
+    payload,
+    threadId,
+    occurredAt,
+    fetch: fetchImplementation = globalThis.fetch,
+  } = args;
 
   const clientEventId = args.clientEventId ?? randomUUID();
 
@@ -96,7 +106,7 @@ export async function recordAnnotation(
     ...(occurredAt !== undefined ? { occurredAt } : {}),
   };
 
-  const response = await fetch(`${runtimeUrl}/annotate`, {
+  const response = await fetchImplementation(`${runtimeUrl}/annotate`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
@@ -2,7 +2,11 @@ import { expect, test, vi } from "vitest";
 
 import type { CopilotRuntimeLike } from "../core/runtime";
 import { createCopilotRuntimeHandler } from "../core/fetch-handler";
-import type { HandlerHookContext, RouteInfo } from "../core/hooks";
+import type {
+  HandlerHookContext,
+  ResponseHookContext,
+  RouteInfo,
+} from "../core/hooks";
 import { CopilotRuntime } from "../core/runtime";
 
 /** Builds an Intelligence runtime whose thread-list dependency is observable. */
@@ -332,12 +336,14 @@ test("single-route resource requests reject unsafe paths and non-resource routes
 });
 
 test("single-route resource requests preserve REST method errors", async () => {
+  const onResponse = vi.fn(({ response }: ResponseHookContext) => response);
   const runtime = new CopilotRuntime({ agents: {} });
   const handler = createCopilotRuntimeHandler({
     runtime,
     basePath: "/api/copilotkit",
     mode: "single-route",
     activateChannels: false,
+    hooks: { onResponse },
   });
 
   const response = await handler(
@@ -350,6 +356,12 @@ test("single-route resource requests preserve REST method errors", async () => {
 
   expect(response.status).toBe(405);
   expect(response.headers.get("allow")).toBe("GET");
+  expect(onResponse).toHaveBeenCalledWith(
+    expect.objectContaining({
+      path: "/api/copilotkit/threads/thread-1/messages",
+      route: { method: "threads/messages", threadId: "thread-1" },
+    }),
+  );
 });
 
 test("single-route resource errors report the matched resource path", async () => {

--- a/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
@@ -1,0 +1,332 @@
+import { expect, test, vi } from "vitest";
+
+import type { CopilotRuntimeLike } from "../core/runtime";
+import { createCopilotRuntimeHandler } from "../core/fetch-handler";
+import type { HandlerHookContext, RouteInfo } from "../core/hooks";
+import { CopilotRuntime } from "../core/runtime";
+
+/** Builds an Intelligence runtime whose thread-list dependency is observable. */
+function setup() {
+  const listThreads = vi.fn().mockResolvedValue({
+    threads: [{ id: "thread-1", agentId: "researcher" }],
+    nextCursor: null,
+  });
+  const identifyUser = vi
+    .fn()
+    .mockResolvedValue({ id: "user-1", name: "User One" });
+  const runtime = {
+    agents: Promise.resolve({}),
+    mode: "intelligence",
+    identifyUser,
+    intelligence: {
+      listThreads,
+      getRuntimeEntitlements: vi.fn().mockResolvedValue(undefined),
+      ɵgetClientWsUrl: vi.fn().mockReturnValue("wss://example.com/client"),
+    },
+    runner: {
+      run: vi.fn(),
+      connect: vi.fn(),
+      isRunning: vi.fn(),
+      stop: vi.fn(),
+    },
+  } as unknown as CopilotRuntimeLike;
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+  });
+
+  return { handler, identifyUser, listThreads };
+}
+
+interface ResourceCase {
+  path: string;
+  httpMethod: string;
+  body?: Record<string, unknown>;
+  route: RouteInfo;
+}
+
+/** Sends one REST-shaped operation through the single-route resource envelope. */
+function resourceRequest(input: ResourceCase): Request {
+  return new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      method: "resource/request",
+      params: { path: input.path, httpMethod: input.httpMethod },
+      ...(input.body ? { body: input.body } : {}),
+    }),
+  });
+}
+
+test("single-route resource requests dispatch to the thread list handler", async () => {
+  const { handler, identifyUser, listThreads } = setup();
+  const request = new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer browser-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      method: "resource/request",
+      params: {
+        path: "/threads?agentId=researcher",
+        httpMethod: "GET",
+      },
+    }),
+  });
+
+  const response = await handler(request);
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({
+    threads: [{ id: "thread-1", agentId: "researcher" }],
+    nextCursor: null,
+  });
+  expect(identifyUser).toHaveBeenCalledTimes(1);
+  expect(listThreads).toHaveBeenCalledWith({
+    userId: "user-1",
+    agentId: "researcher",
+  });
+});
+
+test("single-route resource requests preserve every Intelligence REST operation", async () => {
+  const observed: Array<{
+    route: RouteInfo;
+    method: string;
+    path: string;
+    search: string;
+    body: unknown;
+  }> = [];
+  const cases: ResourceCase[] = [
+    {
+      path: "/threads?agentId=researcher&limit=20",
+      httpMethod: "GET",
+      route: { method: "threads/list" },
+    },
+    {
+      path: "/threads/subscribe",
+      httpMethod: "POST",
+      body: {},
+      route: { method: "threads/subscribe" },
+    },
+    {
+      path: "/threads/thread%201",
+      httpMethod: "PATCH",
+      body: { name: "Renamed" },
+      route: { method: "threads/update", threadId: "thread 1" },
+    },
+    {
+      path: "/threads/thread-1",
+      httpMethod: "DELETE",
+      body: {},
+      route: { method: "threads/update", threadId: "thread-1" },
+    },
+    {
+      path: "/threads/thread-1/archive",
+      httpMethod: "POST",
+      body: { archived: true },
+      route: { method: "threads/archive", threadId: "thread-1" },
+    },
+    {
+      path: "/threads/thread-1/messages",
+      httpMethod: "GET",
+      route: { method: "threads/messages", threadId: "thread-1" },
+    },
+    {
+      path: "/threads/thread-1/events",
+      httpMethod: "GET",
+      route: { method: "threads/events", threadId: "thread-1" },
+    },
+    {
+      path: "/threads/thread-1/state",
+      httpMethod: "GET",
+      route: { method: "threads/state", threadId: "thread-1" },
+    },
+    {
+      path: "/threads/clear",
+      httpMethod: "POST",
+      body: {},
+      route: { method: "threads/clear" },
+    },
+    {
+      path: "/memories?includeInvalidated=true",
+      httpMethod: "GET",
+      route: { method: "memories/list" },
+    },
+    {
+      path: "/memories",
+      httpMethod: "POST",
+      body: { content: "Prefers short answers" },
+      route: { method: "memories/list" },
+    },
+    {
+      path: "/memories/recall",
+      httpMethod: "POST",
+      body: { query: "answer style" },
+      route: { method: "memories/recall" },
+    },
+    {
+      path: "/memories/subscribe",
+      httpMethod: "POST",
+      body: {},
+      route: { method: "memories/subscribe" },
+    },
+    {
+      path: "/memories/memory%201",
+      httpMethod: "PATCH",
+      body: { content: "Prefers concise answers" },
+      route: { method: "memories/mutate", memoryId: "memory 1" },
+    },
+    {
+      path: "/memories/memory-1",
+      httpMethod: "DELETE",
+      body: {},
+      route: { method: "memories/mutate", memoryId: "memory-1" },
+    },
+    {
+      path: "/annotate",
+      httpMethod: "POST",
+      body: { type: "user_action", threadId: "thread-1" },
+      route: { method: "annotate" },
+    },
+  ];
+  const runtime = new CopilotRuntime({
+    agents: {},
+    exposeMemoryRoutes: true,
+  });
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+    hooks: {
+      onBeforeHandler: async ({ request, route, path }: HandlerHookContext) => {
+        observed.push({
+          route,
+          method: request.method,
+          path,
+          search: new URL(request.url).search,
+          body:
+            request.method === "GET" ? undefined : await request.clone().json(),
+        });
+        throw new Response(null, { status: 204 });
+      },
+    },
+  });
+
+  for (const input of cases) {
+    const response = await handler(resourceRequest(input));
+    expect(response.status).toBe(204);
+  }
+
+  expect(observed).toEqual(
+    cases.map((input) => ({
+      route: input.route,
+      method: input.httpMethod,
+      path: `/api/copilotkit${input.path.split("?")[0]}`,
+      search: input.path.includes("?") ? `?${input.path.split("?")[1]}` : "",
+      body: input.body,
+    })),
+  );
+});
+
+test("single-route info advertises resource operations without changing legacy thread flags", async () => {
+  const { handler } = setup();
+  const request = new Request("https://example.com/api/copilotkit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ method: "info" }),
+  });
+
+  const response = await handler(request);
+  const info = await response.json();
+
+  expect(response.status).toBe(200);
+  expect(info.threadEndpoints).toEqual({
+    list: false,
+    inspect: false,
+    mutations: false,
+    realtimeMetadata: false,
+  });
+  expect(info.singleRoute).toEqual({
+    resourceOperations: true,
+    threadEndpoints: {
+      list: true,
+      inspect: true,
+      mutations: true,
+      realtimeMetadata: true,
+    },
+  });
+});
+
+test("single-route resource requests reject hidden memory routes before hooks", async () => {
+  const onBeforeHandler = vi.fn(({ request }: HandlerHookContext) => request);
+  const runtime = new CopilotRuntime({ agents: {} });
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+    hooks: { onBeforeHandler },
+  });
+
+  const response = await handler(
+    resourceRequest({
+      path: "/memories",
+      httpMethod: "GET",
+      route: { method: "memories/list" },
+    }),
+  );
+
+  expect(response.status).toBe(404);
+  expect(onBeforeHandler).not.toHaveBeenCalled();
+});
+
+test("single-route resource requests reject unsafe paths and non-resource routes", async () => {
+  const runtime = new CopilotRuntime({ agents: {} });
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+  });
+  const cases = [
+    { path: "https://attacker.example/threads", status: 400 },
+    { path: "//attacker.example/threads", status: 400 },
+    { path: "/agent/researcher/run", status: 404 },
+  ];
+
+  for (const input of cases) {
+    const response = await handler(
+      resourceRequest({
+        path: input.path,
+        httpMethod: "GET",
+        route: { method: "threads/list" },
+      }),
+    );
+    expect(response.status).toBe(input.status);
+  }
+});
+
+test("single-route resource requests preserve REST method errors", async () => {
+  const runtime = new CopilotRuntime({ agents: {} });
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+  });
+
+  const response = await handler(
+    resourceRequest({
+      path: "/threads/thread-1/messages",
+      httpMethod: "POST",
+      route: { method: "threads/messages", threadId: "thread-1" },
+    }),
+  );
+
+  expect(response.status).toBe(405);
+  expect(response.headers.get("allow")).toBe("GET");
+});

--- a/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
@@ -330,3 +330,35 @@ test("single-route resource requests preserve REST method errors", async () => {
   expect(response.status).toBe(405);
   expect(response.headers.get("allow")).toBe("GET");
 });
+
+test("single-route resource errors report the matched resource path", async () => {
+  const onError = vi.fn().mockReturnValue(new Response(null, { status: 503 }));
+  const runtime = new CopilotRuntime({ agents: {} });
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+    hooks: {
+      onBeforeHandler: () => {
+        throw new Error("resource failed");
+      },
+      onError,
+    },
+  });
+
+  const response = await handler(
+    resourceRequest({
+      path: "/threads/thread-1/messages",
+      httpMethod: "GET",
+      route: { method: "threads/messages", threadId: "thread-1" },
+    }),
+  );
+
+  expect(response.status).toBe(503);
+  expect(onError).toHaveBeenCalledWith(
+    expect.objectContaining({
+      path: "/api/copilotkit/threads/thread-1/messages",
+    }),
+  );
+});

--- a/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
+++ b/packages/runtime/src/v2/runtime/__tests__/single-route-resource-operations.test.ts
@@ -284,6 +284,27 @@ test("single-route resource requests reject hidden memory routes before hooks", 
   expect(onBeforeHandler).not.toHaveBeenCalled();
 });
 
+test("single-route hidden memory routes return 404 before method validation", async () => {
+  const runtime = new CopilotRuntime({ agents: {} });
+  const handler = createCopilotRuntimeHandler({
+    runtime,
+    basePath: "/api/copilotkit",
+    mode: "single-route",
+    activateChannels: false,
+  });
+
+  const response = await handler(
+    resourceRequest({
+      path: "/memories",
+      httpMethod: "PUT",
+      route: { method: "memories/list" },
+    }),
+  );
+
+  expect(response.status).toBe(404);
+  expect(response.headers.get("allow")).toBeNull();
+});
+
 test("single-route resource requests reject unsafe paths and non-resource routes", async () => {
   const runtime = new CopilotRuntime({ agents: {} });
   const handler = createCopilotRuntimeHandler({

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -386,13 +386,11 @@ export function createCopilotRuntimeHandler(
         request = resolved.request;
         handlerPath = resolved.path;
         const { methodCall } = resolved;
-        // Match multi-route's secure memory gate: hidden routes must return a
-        // uniform 404 before route-aware hooks can observe them.
-        if (
-          route.method.startsWith("memories/") &&
-          runtime.exposeMemoryRoutes !== true
-        ) {
-          throw jsonResponse({ error: "Not found" }, 404);
+        if (methodCall.method === "resource/request") {
+          const methodError = validateHttpMethod(request.method, route);
+          if (methodError) {
+            throw methodError;
+          }
         }
         // 5. onBeforeHandler hook
         request = await runOnBeforeHandler(hooks, {
@@ -800,13 +798,6 @@ async function resolveSingleRoute(
         !memoryRoutesExposed
       ) {
         throw jsonResponse({ error: "Not found" }, 404);
-      }
-      const methodError = validateHttpMethod(
-        resourceRequest.method,
-        resourceRoute,
-      );
-      if (methodError) {
-        throw methodError;
       }
       return {
         route: resourceRoute,

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -376,7 +376,12 @@ export function createCopilotRuntimeHandler(
       let response: Response;
 
       if (mode === "single-route") {
-        const resolved = await resolveSingleRoute(request, basePath, path);
+        const resolved = await resolveSingleRoute(
+          request,
+          basePath,
+          path,
+          runtime.exposeMemoryRoutes === true,
+        );
         route = resolved.route;
         request = resolved.request;
         handlerPath = resolved.path;
@@ -724,6 +729,7 @@ async function resolveSingleRoute(
   request: Request,
   basePath: string | undefined,
   pathname: string,
+  memoryRoutesExposed: boolean,
 ): Promise<SingleRouteResolution> {
   if (basePath) {
     const normalizedBase =
@@ -787,6 +793,12 @@ async function resolveSingleRoute(
       const resourceUrl = new URL(resourceRequest.url);
       const resourceRoute = matchRoute(resourceUrl.pathname, pathname);
       if (!resourceRoute || !isSingleRouteResourceRoute(resourceRoute)) {
+        throw jsonResponse({ error: "Not found" }, 404);
+      }
+      if (
+        resourceRoute.method.startsWith("memories/") &&
+        !memoryRoutesExposed
+      ) {
         throw jsonResponse({ error: "Not found" }, 404);
       }
       const methodError = validateHttpMethod(

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -110,6 +110,7 @@ import { handleAnnotate } from "../handlers/handle-user-actions";
 import {
   parseMethodCall,
   createJsonRequest,
+  createResourceRequest,
   expectString,
   detectSingleRouteEnvelope,
 } from "../endpoints/single-route-helpers";
@@ -332,6 +333,7 @@ export function createCopilotRuntimeHandler(
   ): Promise<Response> => {
     const url = new URL(request.url, "http://localhost");
     const path = url.pathname;
+    let handlerPath = path;
     const requestOrigin = request.headers.get("origin");
 
     // Base hook context (route not yet known)
@@ -376,11 +378,21 @@ export function createCopilotRuntimeHandler(
       if (mode === "single-route") {
         const resolved = await resolveSingleRoute(request, basePath, path);
         route = resolved.route;
+        request = resolved.request;
+        handlerPath = resolved.path;
         const { methodCall } = resolved;
+        // Match multi-route's secure memory gate: hidden routes must return a
+        // uniform 404 before route-aware hooks can observe them.
+        if (
+          route.method.startsWith("memories/") &&
+          runtime.exposeMemoryRoutes !== true
+        ) {
+          throw jsonResponse({ error: "Not found" }, 404);
+        }
         // 5. onBeforeHandler hook
         request = await runOnBeforeHandler(hooks, {
           request,
-          path,
+          path: handlerPath,
           runtime,
           route,
         });
@@ -394,7 +406,8 @@ export function createCopilotRuntimeHandler(
           request = createJsonRequest(request, methodCall.body);
         }
         response = await dispatchRoute(runtime, request, route, {
-          threadEndpointsEnabled: false,
+          threadEndpointsEnabled: methodCall.method === "resource/request",
+          singleRouteResourceOperationsEnabled: true,
         });
       } else {
         // Multi-route: match URL pattern
@@ -455,6 +468,7 @@ export function createCopilotRuntimeHandler(
         // 6. Handler dispatch
         response = await dispatchRoute(runtime, request, route, {
           threadEndpointsEnabled: true,
+          singleRouteResourceOperationsEnabled: false,
         });
       }
 
@@ -462,7 +476,7 @@ export function createCopilotRuntimeHandler(
       response = await runOnResponse(hooks, {
         request,
         response,
-        path,
+        path: handlerPath,
         runtime,
         route,
       });
@@ -476,7 +490,7 @@ export function createCopilotRuntimeHandler(
       callAfterRequestMiddleware({
         runtime,
         response: response.clone(),
-        path,
+        path: handlerPath,
       }).catch((error: unknown) => {
         logger.error(
           { err: error, url: request.url, path },
@@ -491,7 +505,7 @@ export function createCopilotRuntimeHandler(
         const finalResponse = await runOnResponse(hooks, {
           request,
           response: error,
-          path,
+          path: handlerPath,
           runtime,
           route: route ?? { method: "info" },
         });
@@ -562,7 +576,10 @@ function dispatchRoute(
   runtime: CopilotRuntimeLike,
   request: Request,
   route: RouteInfo,
-  options: { threadEndpointsEnabled: boolean },
+  options: {
+    threadEndpointsEnabled: boolean;
+    singleRouteResourceOperationsEnabled: boolean;
+  },
 ): Promise<Response> {
   if (
     isIntelligenceRuntime(runtime) &&
@@ -616,6 +633,8 @@ function dispatchRoute(
         runtime,
         request,
         threadEndpointsEnabled: options.threadEndpointsEnabled,
+        singleRouteResourceOperationsEnabled:
+          options.singleRouteResourceOperationsEnabled,
       });
     case "inspector/metadata":
       return handleInspectorMetadata({ runtime, request });
@@ -692,6 +711,8 @@ function dispatchRoute(
 interface SingleRouteResolution {
   route: RouteInfo;
   methodCall: MethodCall;
+  request: Request;
+  path: string;
 }
 
 async function resolveSingleRoute(
@@ -751,6 +772,32 @@ async function resolveSingleRoute(
     case "transcribe":
       route = { method: "transcribe" };
       break;
+    case "resource/request": {
+      const resourceRequest = createResourceRequest(
+        request,
+        expectString(methodCall.params, "path"),
+        expectString(methodCall.params, "httpMethod"),
+        methodCall.body,
+      );
+      const resourceUrl = new URL(resourceRequest.url);
+      const resourceRoute = matchRoute(resourceUrl.pathname, pathname);
+      if (!resourceRoute || !isSingleRouteResourceRoute(resourceRoute)) {
+        throw jsonResponse({ error: "Not found" }, 404);
+      }
+      const methodError = validateHttpMethod(
+        resourceRequest.method,
+        resourceRoute,
+      );
+      if (methodError) {
+        throw methodError;
+      }
+      return {
+        route: resourceRoute,
+        methodCall,
+        request: resourceRequest,
+        path: resourceUrl.pathname,
+      };
+    }
     default: {
       // Exhaustiveness guard: a new `METHOD_NAMES`/`EndpointMethod` variant
       // added without a case above becomes a compile error here instead of
@@ -760,7 +807,29 @@ async function resolveSingleRoute(
     }
   }
 
-  return { route, methodCall };
+  return { route, methodCall, request, path: pathname };
+}
+
+/** Limits the generic envelope bridge to the Runtime's resource APIs. */
+function isSingleRouteResourceRoute(route: RouteInfo): boolean {
+  switch (route.method) {
+    case "threads/list":
+    case "threads/subscribe":
+    case "threads/update":
+    case "threads/archive":
+    case "threads/messages":
+    case "threads/events":
+    case "threads/state":
+    case "threads/clear":
+    case "memories/list":
+    case "memories/recall":
+    case "memories/subscribe":
+    case "memories/mutate":
+    case "annotate":
+      return true;
+    default:
+      return false;
+  }
 }
 
 /* ------------------------------------------------------------------------------------------------

--- a/packages/runtime/src/v2/runtime/core/fetch-handler.ts
+++ b/packages/runtime/src/v2/runtime/core/fetch-handler.ts
@@ -493,7 +493,7 @@ export function createCopilotRuntimeHandler(
         path: handlerPath,
       }).catch((error: unknown) => {
         logger.error(
-          { err: error, url: request.url, path },
+          { err: error, url: request.url, path: handlerPath },
           "Error running after request middleware",
         );
       });
@@ -517,7 +517,7 @@ export function createCopilotRuntimeHandler(
         const errorResponse = await runOnError(hooks, {
           request,
           error,
-          path,
+          path: handlerPath,
           runtime,
           route,
         });
@@ -527,13 +527,18 @@ export function createCopilotRuntimeHandler(
         }
       } catch (hookError: unknown) {
         logger.error(
-          { err: hookError, originalErr: error, url: request.url, path },
+          {
+            err: hookError,
+            originalErr: error,
+            url: request.url,
+            path: handlerPath,
+          },
           "onError hook threw",
         );
       }
 
       logger.error(
-        { err: error, url: request.url, path },
+        { err: error, url: request.url, path: handlerPath },
         "Unhandled error in CopilotKit runtime handler",
       );
 

--- a/packages/runtime/src/v2/runtime/endpoints/single-route-helpers.ts
+++ b/packages/runtime/src/v2/runtime/endpoints/single-route-helpers.ts
@@ -6,6 +6,7 @@ const METHOD_NAMES = [
   "info",
   "inspector/metadata",
   "transcribe",
+  "resource/request",
 ] as const;
 
 export type EndpointMethod = (typeof METHOD_NAMES)[number];
@@ -115,6 +116,45 @@ export function createJsonRequest(base: Request, body: unknown): Request {
     method: "POST",
     headers,
     body: serializedBody,
+    signal: base.signal,
+  });
+}
+
+/**
+ * Rebuild a resource request carried inside the single-route JSON envelope.
+ *
+ * The resource path must stay relative to the mounted Runtime. This prevents
+ * the envelope from becoming an open HTTP proxy while preserving the method,
+ * query string, headers, and cancellation signal used by the REST handler.
+ */
+export function createResourceRequest(
+  base: Request,
+  path: string,
+  httpMethod: string,
+  body: unknown,
+): Request {
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw createResponseError("Resource path must be Runtime-relative", 400);
+  }
+
+  const resourceUrl = new URL(path, "http://copilotkit.resource");
+  if (resourceUrl.origin !== "http://copilotkit.resource") {
+    throw createResponseError("Resource path must be Runtime-relative", 400);
+  }
+
+  const targetUrl = new URL(base.url);
+  targetUrl.pathname = `${targetUrl.pathname.replace(/\/$/, "")}${resourceUrl.pathname}`;
+  targetUrl.search = resourceUrl.search;
+
+  const method = httpMethod.toUpperCase();
+  const headers = new Headers(base.headers);
+  headers.delete("content-length");
+  const hasBody = method !== "GET" && method !== "HEAD" && body != null;
+
+  return new Request(targetUrl, {
+    method,
+    headers,
+    ...(hasBody ? { body: serializeJsonBody(body) } : {}),
     signal: base.signal,
   });
 }

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -71,6 +71,7 @@ interface HandleGetRuntimeInfoParameters {
   runtime: CopilotRuntimeLike;
   request: Request;
   threadEndpointsEnabled?: boolean;
+  singleRouteResourceOperationsEnabled?: boolean;
 }
 
 /**
@@ -116,6 +117,7 @@ export async function handleGetRuntimeInfo({
   runtime,
   request,
   threadEndpointsEnabled = true,
+  singleRouteResourceOperationsEnabled = false,
 }: HandleGetRuntimeInfoParameters) {
   try {
     const runtimeEntitlementsPromise = resolveRuntimeEntitlements(runtime);
@@ -167,6 +169,14 @@ export async function handleGetRuntimeInfo({
         runtime,
         threadEndpointsEnabled && webEnabled,
       ),
+      ...(singleRouteResourceOperationsEnabled
+        ? {
+            singleRoute: {
+              resourceOperations: true,
+              threadEndpoints: resolveThreadEndpointInfo(runtime, webEnabled),
+            },
+          }
+        : {}),
       // Advertised unconditionally. Multi-route runtimes expose the dedicated
       // POST /agent/:agentId/suggest path; single-route clients fall back to a
       // client-side run (they don't construct the single-route envelope for

--- a/packages/shared/src/utils/types.ts
+++ b/packages/shared/src/utils/types.ts
@@ -107,6 +107,14 @@ export interface A2UIRuntimeInfo {
   agents?: string[];
 }
 
+/** Intelligence resource support available through a single runtime route. */
+export interface SingleRouteRuntimeInfo {
+  /** Whether the runtime accepts resource requests through the single route. */
+  resourceOperations: boolean;
+  /** Thread features available through the single-route resource bridge. */
+  threadEndpoints: ThreadEndpointRuntimeInfo;
+}
+
 export interface RuntimeInfo {
   version: string;
   agents: Record<string, AgentDescription>;
@@ -114,6 +122,8 @@ export interface RuntimeInfo {
   mode: RuntimeMode;
   intelligence?: IntelligenceRuntimeInfo;
   threadEndpoints?: ThreadEndpointRuntimeInfo;
+  /** Optional capabilities exposed by runtimes that use one HTTP route. */
+  singleRoute?: SingleRouteRuntimeInfo;
   /** Whether this runtime exposes trusted inspector metadata. */
   inspectorMetadata?: boolean;
   /**

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -76,16 +76,12 @@ handler half below applies to you.
 | Single-route                 | Any of the above with `mode: "single-route"`                                                                                                                                            |
 | Single-route only, no option | `copilotRuntimeNextJSAppRouterEndpoint`, `copilotRuntimeNextJSPagesRouterEndpoint`, `copilotRuntimeNodeHttpEndpoint`, `copilotRuntimeNodeExpressEndpoint`, `copilotRuntimeNestEndpoint` |
 
-<Callout type="warn" title="The framework wrappers cannot do Rich Threads">
+<Callout type="info" title="The framework wrappers support Intelligence resources">
   Every `copilotRuntime*Endpoint` wrapper builds its handler with
-  `mode: "single-route"` and exposes no option to change it, so a Runtime mounted
-  through one of them only ever serves the single-route envelope — never the
-  REST sub-routes. Setting `useSingleEndpoint={false}` on the provider does not
-  change that; it just points the browser at routes the wrapper will not serve.
-
-Rich Threads therefore needs one of the handlers above, built on a v2
-`CopilotRuntime` from `@copilotkit/runtime/v2`. That is a server-side change,
-not a provider prop. See [Enable Rich Threads routes](#enable-rich-threads-routes).
+  `mode: "single-route"`. A current client and Runtime carry Rich Threads,
+  Memory, and annotation requests through that endpoint. Setting
+  `useSingleEndpoint={false}` still points the browser at REST routes that these
+  wrappers do not serve.
 
 </Callout>
 
@@ -221,29 +217,34 @@ host/port.
 ## Enable Rich Threads routes
 
 If the Inspector says **Finish setting up Rich Threads**, your Intelligence
-license is active but the Runtime is not exposing the routes used to list and
-inspect saved Threads. Complete these steps so `/info` advertises the Threads
-capabilities and the Inspector can load saved history.
+license is active but the client did not find the features used to list and
+inspect saved Threads. Complete these steps so Runtime info advertises those
+features and the Inspector can load saved history.
 
 <RichThreadsSetupPrompt />
 
 <Steps>
 <Step>
-### Use the multi-route Runtime handler
+### Choose a Runtime route mode
 
-Remove `mode: "single-route"` from your Runtime handler. Multi-route mode is the
-default, so no replacement option is required:
+Single-route and multi-route handlers both expose Rich Threads. Use single-route
+when your server should expose only one `POST` endpoint:
 
 ```ts
 const handler = createCopilotRuntimeHandler({
   runtime,
   basePath: "/api/copilotkit",
+  mode: "single-route",
 });
 ```
 
+For multi-route, omit `mode`. Your server must mount the full Runtime subtree
+and allow `GET`, `POST`, `PATCH`, and `DELETE`.
+
 <FrontendOnly frontend="react">
-With the v2 React provider, remove `useSingleEndpoint` so it can detect the
-multi-route Runtime:
+With the v2 React provider, omit `useSingleEndpoint` to detect the mode. You can
+also pin single-route with `useSingleEndpoint` or multi-route with
+`useSingleEndpoint={false}`.
 
 ```tsx
 import { CopilotKitProvider } from "@copilotkit/react-core/v2";
@@ -253,15 +254,13 @@ import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 </CopilotKitProvider>;
 ```
 
-The `<CopilotKit>` wrapper behaves the same way — omitting the prop lets it
-detect the multi-route Runtime. Passing `useSingleEndpoint={false}` is also
-correct here; it just pins what detection would have found anyway.
+The provider and handler modes must match.
 
 </FrontendOnly>
 
 <FrontendOnly frontend="angular">
 Keep `provideCopilotKit` pointed at the Runtime base URL. The Angular SDK
-discovers the multi-route transport from `/info`; it has no
+discovers the transport from Runtime info; it has no
 `useSingleEndpoint` option to remove.
 </FrontendOnly>
 </Step>
@@ -329,13 +328,17 @@ for the full identity and authorization pattern.
 </Step>
 
 <Step>
-### Mount every Runtime sub-route
+### Mount the Runtime handler
 
-Your framework route or reverse proxy must pass the full `basePath` subtree to
-the Runtime. In file-based routers, use a catch-all or splat route. Export or
-allow GET, POST, PATCH, and DELETE so list, subscription, rename, archive, and
-delete requests can reach the handler. For example, a Next.js App Router route
-exports the same handler for each method:
+For single-route, mount one exact path and allow `POST`:
+
+```ts title="app/api/copilotkit/route.ts"
+export { handler as POST };
+```
+
+For multi-route, pass the full `basePath` subtree to the Runtime. In file-based
+routers, use a catch-all or splat route. Allow `GET`, `POST`, `PATCH`, and
+`DELETE`:
 
 ```ts title="app/api/copilotkit/[[...slug]]/route.ts"
 export { handler as GET, handler as POST, handler as PATCH, handler as DELETE };
@@ -349,7 +352,7 @@ for complete adapter examples.
 <Step>
 ### Verify the advertised capabilities
 
-Restart the Runtime, then request its info endpoint:
+Restart the Runtime. For multi-route, request its info endpoint:
 
 ```bash
 curl -s http://localhost:4000/api/copilotkit/info
@@ -364,6 +367,30 @@ An Intelligence-backed web Runtime that is ready for Rich Threads includes:
     "inspect": true,
     "mutations": true,
     "realtimeMetadata": true
+  }
+}
+```
+
+For single-route, post an info envelope:
+
+```bash
+curl -s http://localhost:4000/api/copilotkit \
+  -H 'content-type: application/json' \
+  -d '{"method":"info"}'
+```
+
+The response advertises the resource bridge and its thread features:
+
+```json
+{
+  "singleRoute": {
+    "resourceOperations": true,
+    "threadEndpoints": {
+      "list": true,
+      "inspect": true,
+      "mutations": true,
+      "realtimeMetadata": true
+    }
   }
 }
 ```
@@ -408,6 +435,10 @@ envelope:
 
 Its response and failure rules match `GET {basePath}/inspector-metadata`.
 
+The client sends thread, memory, and annotation operations through the same
+endpoint with a `resource/request` envelope. The Runtime accepts only known
+resource paths and routes them through the same handlers as multi-route mode.
+
 <FrontendOnly frontend="react">
 The frontend detects this mode on its own, so no prop is required. To pin it
 explicitly, pass `useSingleEndpoint`:
@@ -430,7 +461,7 @@ the client then probes for the mode the runtime actually serves — so pin
 </FrontendOnly>
 
 <FrontendOnly frontend="angular">
-The Angular SDK negotiates the transport from the runtime's `/info` response.
+The Angular SDK negotiates the transport from the Runtime info response.
 Point `provideCopilotKit` at the base endpoint; no second route configuration is
 needed:
 
@@ -441,8 +472,8 @@ provideCopilotKit({
 ```
 
 <Callout type="warn">
-The `/info` route must remain reachable so the Angular client can discover the
-runtime transport and registered agents.
+Runtime info must remain reachable through the selected transport so the
+Angular client can discover the transport and registered agents.
 </Callout>
 </FrontendOnly>
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -338,22 +338,16 @@ Before you begin, you'll need the following:
               mkdir -p app/api/copilotkit && touch app/api/copilotkit/route.ts
               ```
 
-              <Callout type="warn" title="This route is enough for chat, not for Threads or the Inspector">
-                A single `POST /api/copilotkit` is the *minimum* wiring: it runs
-                the runtime in single-route mode, which is all chat needs.
-                Persistent Threads and the Inspector's saved-Threads list need the
-                multi-route handler instead — a catch-all
-                `app/api/copilotkit/[[...slug]]/route.ts` that exports `GET`,
-                `POST`, `PATCH` and `DELETE`, so list, rename, archive and delete
-                requests can reach the runtime. If the Inspector shows **Finish
-                setting up Rich Threads**, this is why. See
-                [Runtime HTTP endpoints](/backend/runtime-endpoints#enable-rich-threads-routes)
-                for the route and the provider setup that goes with it.
+              <Callout type="info" title="One route supports the full Intelligence experience">
+                A current client and Runtime can carry chat, Threads, Memory,
+                annotations, and Inspector requests through one `POST`
+                endpoint. They negotiate this support before sending resource
+                requests. The example below uses that mode.
               </Callout>
 
               <Tabs groupId="deployment_method" items={['LangSmith', 'FastAPI']}>
                 <Tab value="LangSmith">
-                  ```tsx title="app/api/copilotkit/[[...slug]]/route.ts"
+                  ```tsx title="app/api/copilotkit/route.ts"
                   import {
                     CopilotKitIntelligence,
                     CopilotRuntime,
@@ -385,14 +379,14 @@ Before you begin, you'll need the following:
                   const handler = createCopilotRuntimeHandler({
                     runtime,
                     basePath: "/api/copilotkit",
+                    mode: "single-route",
                   });
 
-                  export const GET = handler;
                   export const POST = handler;
                 ```
               </Tab>
               <Tab value="FastAPI">
-                ```tsx title="app/api/copilotkit/[[...slug]]/route.ts"
+                ```tsx title="app/api/copilotkit/route.ts"
                 import {
                   CopilotKitIntelligence,
                   CopilotRuntime,
@@ -422,9 +416,9 @@ Before you begin, you'll need the following:
                 const handler = createCopilotRuntimeHandler({
                   runtime,
                   basePath: "/api/copilotkit",
+                  mode: "single-route",
                 });
 
-                export const GET = handler;
                 export const POST = handler;
               ```
               </Tab>
@@ -450,14 +444,9 @@ Before you begin, you'll need the following:
 
               Wrap your application with the CopilotKit provider:
 
-              <Callout type="info" title="Which provider goes with which handler?">
-                `<CopilotKit>` here is the backward-compatible wrapper, and every
-                released version pins it to the single-route transport — which is why
-                it needs the explicit `useSingleEndpoint={false}` below to reach the
-                multi-route `createCopilotRuntimeHandler` route above.
-                `<CopilotKitProvider>` is the v2 provider from the same package and
-                detects the transport from `/info` on its own. They are not aliases —
-                see
+              <Callout type="info" title="Match the provider to the handler">
+                `useSingleEndpoint` pins the provider to the single-route
+                handler above. See
                 [Provider and handler pairs](/backend/runtime-endpoints#provider-and-handler-pairs).
               </Callout>
 
@@ -474,7 +463,7 @@ Before you begin, you'll need the following:
                   <html lang="en">
                     <body>
                       {/* [!code highlight:3] */}
-                      <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent" useSingleEndpoint={false}>
+                      <CopilotKit runtimeUrl="/api/copilotkit" agent="sample_agent" useSingleEndpoint>
                         {children}
                       </CopilotKit>
                     </body>

--- a/showcase/shell-docs/src/content/docs/intelligence/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/quickstart.mdx
@@ -76,42 +76,41 @@ Before you start, make sure that you have a CopilotKit app with a working agent,
   </Step>
 
   <Step>
-    ### Expose the thread routes
+    ### Expose one Runtime route
 
-    Use the multi-route handler. Mount the complete runtime subtree. Export `GET`, `POST`, `PATCH`, and `DELETE`.
+    Use the single-route handler. It carries chat, thread, memory, and annotation requests through one `POST` endpoint.
 
-    ```ts title="app/api/copilotkit/[[...slug]]/route.ts"
+    ```ts title="app/api/copilotkit/route.ts"
     import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
 
     const handler = createCopilotRuntimeHandler({
       runtime,
       basePath: "/api/copilotkit",
+      mode: "single-route",
     });
 
-    export const GET = handler;
     export const POST = handler;
-    export const PATCH = handler;
-    export const DELETE = handler;
     ```
 
-    This example uses a Next.js catch-all route, but the fetch-based handler works with any server that uses standard Web `Request` and `Response` objects.
+    The client and server negotiate resource support before the client sends Intelligence requests through this route. Multi-route remains supported.
+    The fetch-based handler works with any server that uses standard Web `Request` and `Response` objects.
     For another server, use the [runtime adapter guide](/runtime-server-adapter#multi-route-vs-single-route).
   </Step>
 
   <Step>
-    ### Use the multi-route frontend transport
+    ### Use the single-route frontend transport
 
     Point your frontend provider at the runtime base path.
 
     <FrontendOnly frontend="react">
-      Add the runtimeUrl prop to your `CopilotKitProvider`. The provider uses the multi-route transport to send messages, events, and state to the runtime.
+      Add `runtimeUrl` and `useSingleEndpoint` to your `CopilotKitProvider`.
 
       ```tsx title="Your CopilotKit provider"
       import { CopilotKitProvider } from "@copilotkit/react-core/v2";
 
       export function App() {
         return (
-          <CopilotKitProvider runtimeUrl="/api/copilotkit">
+          <CopilotKitProvider runtimeUrl="/api/copilotkit" useSingleEndpoint>
             <YourApp />
           </CopilotKitProvider>
         );

--- a/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
+++ b/showcase/shell-docs/src/content/docs/runtime-server-adapter.mdx
@@ -33,7 +33,9 @@ The runtime supports two endpoint modes:
   { "method": "agent/run", "params": { "agentId": "default" }, "body": { ... } }
   ```
 
-Single-route mode is useful when your platform only allows a single route handler (e.g. a single serverless function), or when you prefer a simpler URL structure.
+Both modes use the same Runtime handlers. A current client and Runtime also carry Intelligence thread, memory, and annotation operations through the single endpoint. They negotiate this support through Runtime info, so older clients and servers keep their existing behavior.
+
+Single-route mode is useful when your platform only allows one route handler, or when you prefer a simpler URL structure.
 
 <FrontendOnly frontend="react">
 <Callout type="warn" title="The mode you pick here binds the frontend">

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -265,18 +265,19 @@ describe("loadDoc", () => {
     expect(overview).toContain("threads-diagram-dark.png");
   });
 
-  it("links locked Inspector users to a complete Rich Threads Runtime repair journey", () => {
+  it("links locked Inspector users to both Rich Threads Runtime route modes", () => {
     const runtimeEndpoints = loadDoc("backend/runtime-endpoints")?.source ?? "";
     const inspector = loadDoc("inspector")?.source ?? "";
 
     expect(runtimeEndpoints).toContain("## Enable Rich Threads routes");
-    expect(runtimeEndpoints).toContain('Remove `mode: "single-route"`');
+    expect(runtimeEndpoints).toContain('mode: "single-route"');
     expect(runtimeEndpoints).toContain(
       'import { CopilotKitProvider } from "@copilotkit/react-core/v2";',
     );
     expect(runtimeEndpoints).toContain("`useSingleEndpoint={false}`");
     expect(runtimeEndpoints).toContain("`identifyUser`");
-    expect(runtimeEndpoints).toContain("GET, POST, PATCH, and DELETE");
+    expect(runtimeEndpoints).toContain("`GET`, `POST`, `PATCH`, and `DELETE`");
+    expect(runtimeEndpoints).toContain('"resourceOperations": true');
     expect(runtimeEndpoints).toContain('"list": true');
     expect(runtimeEndpoints).toContain('"inspect": true');
     expect(inspector).toContain(
@@ -551,9 +552,7 @@ describe("framework nav", () => {
       ),
     ).toMatchObject({ icon: "lucide/Sparkles" });
     expect(
-      navTree.find(
-        (node) => node.type === "section" && node.title === "Other",
-      ),
+      navTree.find((node) => node.type === "section" && node.title === "Other"),
     ).toMatchObject({ icon: "lucide/Wrench" });
     expect(
       navTree
@@ -645,9 +644,7 @@ describe("framework nav", () => {
     expect(hasSectionPage(authoredNav, "Backend", "Copilot Runtime")).toBe(
       true,
     );
-    expect(hasSectionPage(authoredNav, "Intelligence", "Overview")).toBe(
-      true,
-    );
+    expect(hasSectionPage(authoredNav, "Intelligence", "Overview")).toBe(true);
     expect(
       sectionNodes(generatedNav, "Agent capabilities").some(
         (node) => node.type === "group" && node.title === "LangGraph (Python)",

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-quickstart-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-quickstart-docs.test.ts
@@ -32,7 +32,9 @@ test("guides people and agents to a persistent Intelligence thread", () => {
   expect(source).toContain("npx copilotkit@latest project select");
   expect(source).toContain("new CopilotKitIntelligence");
   expect(source).toContain("identifyUser");
-  expect(source).toContain("export const DELETE = handler");
+  expect(source).toContain('mode: "single-route"');
+  expect(source).toContain("export const POST = handler");
+  expect(source).toContain("useSingleEndpoint");
   expect(source).toContain("Intelligence connected");
   expect(source).toContain("Open **Threads** in Inspector");
   expect(source).toContain("**Messages** contains the message");


### PR DESCRIPTION
## Summary

- carry Intelligence thread, memory, and annotation requests through the single Runtime endpoint
- advertise the bridge through an optional Runtime info capability
- reuse the existing REST route matcher, handlers, method checks, hooks, and memory gate
- route Core memory and React annotation calls through the negotiated Runtime fetch
- make single-route the documented Intelligence quickstart while keeping multi-route supported

## Compatibility

- Multi-route behavior does not change.
- A new client uses the bridge only when a single-route Runtime advertises it.
- An old client ignores the new optional capability.
- A new client keeps the old behavior with a Runtime that does not advertise the capability.

## Validation

- `pnpm nx run-many -t check-types,build --projects=@copilotkit/shared,@copilotkit/core,@copilotkit/runtime,@copilotkit/react-core`
- package pre-commit gate: tests, `publint`, and `attw` passed for all affected packages
- Runtime focused suite: 102 tests passed
- Core focused suite: 108 tests passed
- React focused suite: 53 tests passed
- React full suite: 1,591 Vitest tests and 47 script tests passed
- Angular and React memory tests: 18 tests passed
- docs type-check and production build passed
- changed docs contract tests: 33 tests passed

## Local baseline notes

The full docs test command also reads Git LFS images and generated cross-framework fixtures. It has six unrelated failures in this checkout: three image-pointer checks, two Angular content checks, and one Mastra content check. The changed docs tests pass, and the docs production build passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added single-route support for thread, memory, and annotation operations.
  - Runtime capability discovery now advertises single-route resource support.
  - Resource requests preserve paths, query parameters, headers, methods, and request bodies.
  - Memory and annotation operations consistently use the configured runtime transport.

- **Documentation**
  - Updated setup guides for single-route configuration, capability negotiation, and compatibility.
  - Added guidance for single-route LangGraph deployments.

- **Tests**
  - Added coverage for transport behavior, validation, resource operations, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->