### PR TITLE
docs: document Intelligence Learning

### DIFF
--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/intelligence-overview.test.tsx
@@ -118,13 +118,9 @@ describe("IntelligenceOverview", () => {
     );
     expect(
       screen
-        .getByRole("link", {
-          name: "See Automatic Learning on the product page",
-        })
+        .getByRole("link", { name: "Open the Learning guide" })
         .getAttribute("href"),
-    ).toBe(
-      "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
-    );
+    ).toBe("/learning");
     expect(
       screen
         .getByRole("link", { name: "Open the self-hosting guide" })

--- a/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/intelligence-overview.tsx
@@ -39,8 +39,8 @@ const FEATURES = [
   {
     title: "Automatic Learning",
     body: "Agents improve from real usage. No fine-tuning pipeline required.",
-    href: "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
-    cta: "See Automatic Learning on the product page",
+    href: "/learning",
+    cta: "Open the Learning guide",
     icon: Sparkles,
   },
   {

--- a/showcase/shell-docs/src/content/docs/learning.mdx
+++ b/showcase/shell-docs/src/content/docs/learning.mdx
@@ -1,17 +1,20 @@
 ---
 title: Learning
-description: Give agents durable memory and turn evidence from real application use into reviewed, reusable Skills.
+description: Turn real application use into evidence-backed Insights and reviewed, reusable Skills.
 icon: "lucide/Sparkles"
 frontend: universal
 doc_type: how-to
 ---
 
-Learning gives an agent two ways to improve from real use:
+## Overview
 
-- **Memory** carries useful facts, preferences, events, and procedures into future runs.
-- **Learning containers** turn patterns across completed runs into evidence-backed Insights and reusable Skills.
+Learning turns completed agent runs into reusable instructions. It studies the messages, tool calls, and application interactions already stored in [Rich Threads](/threads), finds patterns in how work gets done, and proposes those patterns as Skills.
 
-Together, they let an agent remember how a user likes work done and learn workflows that can be reused in another thread, surface, or agent. Learning works from the messages and application activity already stored in [Rich Threads](/threads); it does not fine-tune your model or require your Runtime to upload a second transcript.
+The result is a controlled improvement loop: your application supplies real evidence, Learning explains what it found, and a person decides which changes are safe to publish. Learning does not fine-tune your model or silently change agent behavior.
+
+<Callout type="info" title="Learning is powered by CopilotKit Intelligence">
+  Before you begin, [connect your Runtime to CopilotKit Intelligence](/intelligence/quickstart) and confirm that new conversations appear as [Rich Threads](/threads).
+</Callout>
 
 <div className="not-prose shell-docs-radius-surface aspect-[7/4] w-full overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
   <iframe
@@ -23,45 +26,73 @@ Together, they let an agent remember how a user likes work done and learn workfl
   />
 </div>
 
-In the walkthrough, Memory recalls how spend summaries should be grouped, ordered, and rounded. Learning then observes how an unfamiliar charge is investigated and how a policy exception is filed, proposes those workflows as Skills, and makes the approved behavior reusable in a new thread.
-
-<Callout type="info" title="Learning is an Intelligence capability">
-  Connect your Runtime to [CopilotKit Intelligence](/intelligence/quickstart) before you continue. Learning must also be enabled for your organization.
-</Callout>
-
-## Memory and Learning solve different problems
-
-| Capability | Best for | When it becomes available |
-| --- | --- | --- |
-| User Memory | A person's preferences, facts, and recurring procedures | As soon as the agent saves the Memory; it can be recalled in later threads for that user |
-| Project Memory | Shared product or team knowledge | As soon as the agent saves the Memory; it can be recalled by authorized users in the project |
-| Learning container | Patterns supported by evidence from completed runs | After you run Learning, review the resulting Insights, and approve a Skill candidate |
-
-Memory is contextual data supplied to an agent. A learned Skill is a versioned set of instructions stored as `SKILL.md`. Neither changes the model's weights.
+The walkthrough begins with Memory, which is a separate Intelligence capability, and then shows Learning capturing an expense-review workflow. After that workflow becomes a published Skill, an agent can reuse it in a new thread and elsewhere in the application.
 
 ## How Learning works
 
-1. **You define the boundary.** Create a Learning container for a stable problem area such as support quality, expense review, or onboarding. A container groups the Threads that should learn together.
-2. **The Runtime assigns Threads.** `getLearningContainerId` returns the container's stable ID when a run starts. A Thread binds to one container before its first agent run and cannot move later.
-3. **Intelligence records exact evidence.** When an assigned run finishes or errors, Intelligence derives a canonical snapshot from the persisted AG-UI events. Messages, tool calls, and application interactions remain traceable to their source Thread.
-4. **You start a Learning run.** Learning freezes a repeatable input set, analyzes the new snapshots in bounded batches, and combines the findings with the container's current Insights and published Skills.
-5. **Learning produces Insights and candidates.** Each Insight includes a statement, expected impact, and evidence references. Patterns suitable for reuse can produce a Skill addition, update, or removal candidate.
-6. **A human reviews the change.** Approving a candidate publishes a new immutable Skill revision. Rejecting it leaves the published registry unchanged.
-7. **You make published Skills available to agents.** Download the container's bundle and load the generated Skill directories with the skill loader used by your agents.
+<Cards>
+  <Card
+    title="1. Group related work"
+    description="Create a Learning container for one stable domain, such as expense review, support quality, or customer onboarding."
+  />
+  <Card
+    title="2. Capture completed runs"
+    description="Assign new Threads to that container. Intelligence captures their terminal runs from the AG-UI events it already stores."
+  />
+  <Card
+    title="3. Generate Insights"
+    description="Start a Learning run. It analyzes the container's new evidence and produces Insights plus any supported Skill candidates."
+  />
+  <Card
+    title="4. Review and publish"
+    description="Inspect the cited evidence and proposed SKILL.md. Approve a candidate to publish a new Skill revision, or reject it without changing the registry."
+  />
+</Cards>
 
-Only terminal runs that occur after the Thread is assigned are eligible. Existing Threads can be assigned only if they have not run an agent yet, so Learning does not backfill earlier runs.
+### Learning containers define the boundary
+
+A Learning container answers one question: **which runs should improve the same behavior?** Threads in an `expense-review` container can teach the same review workflow without mixing in unrelated support or onboarding conversations.
+
+The Runtime assigns each Thread before its first agent run. That assignment is permanent: a Thread cannot move between containers, and earlier runs are not backfilled when an existing Thread is assigned.
+
+### Completed runs become evidence
+
+When an assigned run finishes or errors, Intelligence derives a canonical snapshot from its persisted AG-UI events. This keeps messages, tool calls, and application interactions traceable to the source Thread without asking your Runtime to upload a second transcript.
+
+### A Learning run creates proposals
+
+When you select **Run Learning**, Learning freezes the new evidence available at that moment and analyzes it together with the container's current Insights and published Skills. It can produce:
+
+- **Insights** that describe a pattern, its expected impact, and the Threads that support it.
+- **Skill candidates** that propose adding, updating, or removing reusable instructions.
+
+A successful run can produce Insights without producing a Skill candidate. That means Learning found useful evidence but not a procedure that was strong or reusable enough to publish.
+
+### Review controls what agents can reuse
+
+Skill candidates remain pending until someone reviews them. Approving a candidate publishes an immutable Skill revision; rejecting it leaves the published registry unchanged. Candidates are reviewed independently, so one rejected proposal does not block another.
+
+<Callout type="info" title="What happens automatically?">
+  Evidence capture happens automatically for assigned Threads. Starting the analysis and publishing proposed Skills are deliberate actions: you select **Run Learning**, then approve or reject each Skill candidate.
+</Callout>
 
 ## Configure Learning
+
+Before configuring a container:
+
+1. Complete the [CopilotKit Intelligence quickstart](/intelligence/quickstart).
+2. Send a message and confirm that the conversation appears in [Rich Threads](/threads).
+3. Open your project in [CopilotKit Intelligence](https://dashboard.operations.copilotkit.ai/) and confirm that Learning is available for your organization.
 
 <Steps>
   <Step>
     ### Create a Learning container
 
-    Open your project in CopilotKit Intelligence, select **Learning**, and choose **Create Learning container**. Set:
+    In your Intelligence project, open **Learning** and choose **Create Learning container**. Give it:
 
     - a stable ID, such as `expense-review`;
     - a descriptive name; and
-    - optional prompt context that tells Learning what good behavior looks like in this domain.
+    - optional prompt context describing the outcome, policy, or constraints Learning should look for.
 
     Stable IDs contain 1–64 lowercase letters, numbers, or single hyphens. Treat the ID as application configuration rather than a display label.
   </Step>
@@ -69,7 +100,7 @@ Only terminal runs that occur after the Thread is assigned are eligible. Existin
   <Step>
     ### Assign Threads from your Runtime
 
-    Return the stable ID from `getLearningContainerId` on your `CopilotKitIntelligence` client.
+    Return the container's stable ID from `getLearningContainerId` on your `CopilotKitIntelligence` client.
 
     ```ts title="Your CopilotKit runtime"
     import {
@@ -90,80 +121,55 @@ Only terminal runs that occur after the Thread is assigned are eligible. Existin
     });
     ```
 
-    Return `null` or `undefined` when a run should not participate in Learning. The callback also receives the resolved application user, surface (`web` or `channel`), and AG-UI run input, so you can route different workflows to different containers.
+    Return `null` or `undefined` when a run should not participate in Learning. The callback also receives the application user, surface (`web` or `channel`), and AG-UI run input, so one Runtime can route different workflows to different containers.
 
     <Callout type="warn" title="Keep a Thread's assignment stable">
-      The callback must return the same container ID for every run in a Thread. Changing the result later causes a container conflict instead of moving the Thread or mixing two learning domains.
+      The callback must return the same container ID for every run in one Thread. Changing the result later causes a container conflict instead of moving the Thread or mixing two learning domains.
     </Callout>
   </Step>
 
   <Step>
-    ### Generate representative runs
+    ### Complete representative runs
 
-    Use the application normally and complete the workflows that Learning should study. Include corrections, tool use, and application interactions that demonstrate the desired outcome. A container benefits from a focused set of related work more than a mix of unrelated tasks.
+    Use the application normally and finish the workflows that Learning should study. Corrections, tool calls, and application interactions are valuable when they demonstrate the desired outcome.
+
+    Keep the evidence focused. A container full of related work produces clearer Insights than one that mixes unrelated tasks.
   </Step>
 
   <Step>
-    ### Run Learning and review the evidence
+    ### Run Learning and review the result
 
-    Return to the container's **Runs** tab and select **Run Learning**. Only one run can be active for a container at a time, although different containers can run concurrently.
+    Open the container's **Runs** tab and select **Run Learning**. Only one run can be active for a container at a time, although different containers can run concurrently.
 
-    After the run succeeds:
+    After it succeeds:
 
     1. Open **Insights** and follow the evidence back to the source Threads.
-    2. Open **Candidates**, inspect the proposed `SKILL.md` and supporting Insights, then approve or reject each candidate independently.
-    3. Open **Skills** to see the published revision history.
-
-    A successful run can produce Insights without a Skill candidate. That means Learning found useful evidence but did not find a sufficiently reusable procedure to publish.
+    2. Open **Candidates** and inspect the proposed `SKILL.md` and supporting Insights.
+    3. Approve or reject each candidate.
+    4. Open **Skills** to see the published revision history.
   </Step>
 </Steps>
 
-## Enable long-term Memory
-
-Memory access is controlled per authenticated request. Add a policy to the Intelligence Runtime to choose whether the agent and browser client can read or write user- and project-scoped Memory.
-
-```ts title="Your CopilotKit runtime"
-const runtime = new CopilotRuntime({
-  agents,
-  intelligence,
-  identifyUser,
-  memory: {
-    access: ({ consumer }) => ({
-      user: "read-write",
-      project: consumer === "agent" ? "read-write" : "read",
-    }),
-  },
-});
-```
-
-The Intelligence middleware gives compatible agents three tools: `recall_memory`, `save_memory`, and `forget_memory`. Memories have a scope and a kind:
-
-| Dimension | Values |
-| --- | --- |
-| Scope | `user` for one person's context; `project` for knowledge shared across authorized users |
-| Kind | `topical` for facts and preferences; `episodic` for past events; `operational` for triggers, steps, and reusable procedures |
-
-Base the access policy on your server-side authorization rules. Do not save secrets or unnecessary personal data. `forget_memory` retires a Memory so it is no longer recalled while preserving its audit history.
-
 ## Use published Skills
 
-From a directory connected to the same Intelligence project, download the published registry:
+From a directory connected to the same Intelligence project, download the container's published Skills:
 
 ```bash title="Terminal"
 copilotkit project select
 copilotkit skills download expense-review --output ./learned-skills
 ```
 
-The output contains a directory and `SKILL.md` for each published Skill. The command verifies the bundle and refuses to overwrite an existing output directory. Downloading is the handoff from Intelligence to your agent environment; configure that environment to load `./learned-skills` before expecting the new behavior in a run.
+The output contains one directory and `SKILL.md` for each published Skill. The command verifies the bundle and refuses to overwrite an existing output directory.
 
-## Design good learning boundaries
+Downloading is the handoff from Intelligence to your agent environment. Configure that environment to load `./learned-skills` before expecting the new behavior in a run.
 
-- Create containers around one enduring workflow or quality bar, not around individual users or temporary Threads.
-- Use user Memory for personal preferences and project Memory only for information that is safe and useful to share.
-- Write prompt context as evaluation guidance: describe the outcome, policy, or constraints Learning should look for.
+## Choose a useful learning boundary
+
+- Create a container around one enduring workflow or quality bar, not one user or temporary Thread.
+- Write prompt context as evaluation guidance rather than a long agent prompt.
 - Let representative runs accumulate before starting Learning. Sparse or unrelated evidence produces weaker Insights.
-- Review the cited Threads and proposed `SKILL.md` before approval. Publishing is deliberately separate from generation.
-- Keep Skills small enough to reuse. A procedure tied to one UI state or one customer is usually better represented as Memory.
+- Review the cited Threads and proposed `SKILL.md` before approval.
+- Keep published Skills small enough to reuse across agents and surfaces.
 
 ## Troubleshooting
 
@@ -171,12 +177,13 @@ The output contains a directory and `SKILL.md` for each published Skill. The com
 | --- | --- |
 | A Thread never appears in the container | Confirm the callback returned an existing stable ID before the Thread's first run and that the run reached a terminal state. |
 | The Runtime reports a container conflict | The selector returned a different ID for an already-bound Thread. Restore the original mapping or start a new Thread. |
-| A run has no new evidence | Learning consumes new terminal snapshots. Runs created before assignment, still in progress, or already included in an earlier Learning run are not new input. |
-| A run succeeds without a Skill candidate | Inspect the Insights. The evidence may be useful but not eligible for a reusable procedural Skill. |
+| A run has no new evidence | Runs created before assignment, still in progress, or already included in an earlier Learning run are not new input. |
+| A run succeeds without a Skill candidate | Inspect the Insights. The evidence may be useful without supporting a reusable procedural Skill. |
 | An approved Skill does not affect the agent | Download the latest bundle and confirm that your agent environment loads the generated Skill directory. |
 
 ## Related guides
 
+- [CopilotKit Intelligence overview](/intelligence/overview)
 - [Connect CopilotKit Intelligence](/intelligence/quickstart)
 - [Rich Threads](/threads)
 - [Threads & Persistence Architecture](/intelligence/threads-explained)

--- a/showcase/shell-docs/src/content/docs/learning.mdx
+++ b/showcase/shell-docs/src/content/docs/learning.mdx
@@ -8,13 +8,7 @@ doc_type: how-to
 
 ## Overview
 
-Learning turns completed agent runs into reusable instructions. It studies the messages, tool calls, and application interactions already stored in [Rich Threads](/threads), finds patterns in how work gets done, and proposes those patterns as Skills.
-
-The result is a controlled improvement loop: your application supplies real evidence, Learning explains what it found, and a person decides which changes are safe to publish. Learning does not fine-tune your model or silently change agent behavior.
-
-<Callout type="info" title="Learning is powered by CopilotKit Intelligence">
-  Before you begin, [connect your Runtime to CopilotKit Intelligence](/intelligence/quickstart) and confirm that new conversations appear as [Rich Threads](/threads).
-</Callout>
+Learning turns patterns from real agent runs into reusable Skills. It looks at completed conversations and application interactions in [Rich Threads](/threads), produces evidence-backed Insights, and proposes instructions you can review before publishing.
 
 <div className="not-prose shell-docs-radius-surface aspect-[7/4] w-full overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
   <iframe
@@ -26,75 +20,46 @@ The result is a controlled improvement loop: your application supplies real evid
   />
 </div>
 
-The walkthrough begins with Memory, which is a separate Intelligence capability, and then shows Learning capturing an expense-review workflow. After that workflow becomes a published Skill, an agent can reuse it in a new thread and elsewhere in the application.
+The walkthrough begins with Memory, a separate Intelligence capability, then shows an expense-review workflow becoming a reusable Skill.
 
 ## How Learning works
 
+Learning follows one review loop:
+
 <Cards>
   <Card
-    title="1. Group related work"
-    description="Create a Learning container for one stable domain, such as expense review, support quality, or customer onboarding."
+    title="1. Observe real work"
+    description="Assign related Threads to a Learning container. Intelligence automatically captures each completed run as evidence."
   />
   <Card
-    title="2. Capture completed runs"
-    description="Assign new Threads to that container. Intelligence captures their terminal runs from the AG-UI events it already stores."
+    title="2. Find repeatable patterns"
+    description="Run Learning to turn new evidence into Insights and proposed Skills."
   />
   <Card
-    title="3. Generate Insights"
-    description="Start a Learning run. It analyzes the container's new evidence and produces Insights plus any supported Skill candidates."
-  />
-  <Card
-    title="4. Review and publish"
-    description="Inspect the cited evidence and proposed SKILL.md. Approve a candidate to publish a new Skill revision, or reject it without changing the registry."
+    title="3. Review and reuse"
+    description="Check the source Threads, approve useful Skill candidates, and load the published Skills into your agents."
   />
 </Cards>
 
-### Learning containers define the boundary
-
-A Learning container answers one question: **which runs should improve the same behavior?** Threads in an `expense-review` container can teach the same review workflow without mixing in unrelated support or onboarding conversations.
-
-The Runtime assigns each Thread before its first agent run. That assignment is permanent: a Thread cannot move between containers, and earlier runs are not backfilled when an existing Thread is assigned.
-
-### Completed runs become evidence
-
-When an assigned run finishes or errors, Intelligence derives a canonical snapshot from its persisted AG-UI events. This keeps messages, tool calls, and application interactions traceable to the source Thread without asking your Runtime to upload a second transcript.
-
-### A Learning run creates proposals
-
-When you select **Run Learning**, Learning freezes the new evidence available at that moment and analyzes it together with the container's current Insights and published Skills. It can produce:
-
-- **Insights** that describe a pattern, its expected impact, and the Threads that support it.
-- **Skill candidates** that propose adding, updating, or removing reusable instructions.
-
-A successful run can produce Insights without producing a Skill candidate. That means Learning found useful evidence but not a procedure that was strong or reusable enough to publish.
-
-### Review controls what agents can reuse
-
-Skill candidates remain pending until someone reviews them. Approving a candidate publishes an immutable Skill revision; rejecting it leaves the published registry unchanged. Candidates are reviewed independently, so one rejected proposal does not block another.
-
-<Callout type="info" title="What happens automatically?">
-  Evidence capture happens automatically for assigned Threads. Starting the analysis and publishing proposed Skills are deliberate actions: you select **Run Learning**, then approve or reject each Skill candidate.
+<Callout type="info" title="You stay in control">
+  Evidence capture is automatic. Running the analysis, approving a proposed Skill, and loading it into an agent are deliberate actions. Learning never fine-tunes your model or silently changes agent behavior.
 </Callout>
 
 ## Configure Learning
 
-Before configuring a container:
-
-1. Complete the [CopilotKit Intelligence quickstart](/intelligence/quickstart).
-2. Send a message and confirm that the conversation appears in [Rich Threads](/threads).
-3. Open your project in [CopilotKit Intelligence](https://dashboard.operations.copilotkit.ai/) and confirm that Learning is available for your organization.
-
 <Steps>
+  <Step>
+    ### Connect CopilotKit Intelligence
+
+    Complete the [Intelligence quickstart](/intelligence/quickstart), then send a message and confirm that it appears in [Rich Threads](/threads). Open your project in [CopilotKit Intelligence](https://dashboard.operations.copilotkit.ai/) and confirm that Learning is available.
+  </Step>
+
   <Step>
     ### Create a Learning container
 
-    In your Intelligence project, open **Learning** and choose **Create Learning container**. Give it:
+    In your Intelligence project, open **Learning** and choose **Create Learning container**. Give the container a stable ID, a descriptive name, and optional guidance about what good work looks like.
 
-    - a stable ID, such as `expense-review`;
-    - a descriptive name; and
-    - optional prompt context describing the outcome, policy, or constraints Learning should look for.
-
-    Stable IDs contain 1–64 lowercase letters, numbers, or single hyphens. Treat the ID as application configuration rather than a display label.
+    Keep each container focused on one kind of work, such as expense review, support quality, or customer onboarding. Stable IDs contain 1–64 lowercase letters, numbers, or single hyphens; for example, `expense-review`.
   </Step>
 
   <Step>
@@ -121,32 +86,23 @@ Before configuring a container:
     });
     ```
 
-    Return `null` or `undefined` when a run should not participate in Learning. The callback also receives the application user, surface (`web` or `channel`), and AG-UI run input, so one Runtime can route different workflows to different containers.
+    Return `null` or `undefined` when a run should not participate. You can use the callback's user, surface, agent, and run input to route different workflows to different containers.
 
     <Callout type="warn" title="Keep a Thread's assignment stable">
-      The callback must return the same container ID for every run in one Thread. Changing the result later causes a container conflict instead of moving the Thread or mixing two learning domains.
+      Assign a Thread before its first agent run and return the same container ID for every later run. Existing evidence is not backfilled, and a Thread cannot move between containers.
     </Callout>
   </Step>
 
   <Step>
-    ### Complete representative runs
+    ### Collect examples
 
-    Use the application normally and finish the workflows that Learning should study. Corrections, tool calls, and application interactions are valuable when they demonstrate the desired outcome.
-
-    Keep the evidence focused. A container full of related work produces clearer Insights than one that mixes unrelated tasks.
+    Use the application normally and complete several related workflows. Corrections, tool calls, and application interactions all help Learning understand what a good result looks like.
   </Step>
 
   <Step>
-    ### Run Learning and review the result
+    ### Run Learning and review
 
-    Open the container's **Runs** tab and select **Run Learning**. Only one run can be active for a container at a time, although different containers can run concurrently.
-
-    After it succeeds:
-
-    1. Open **Insights** and follow the evidence back to the source Threads.
-    2. Open **Candidates** and inspect the proposed `SKILL.md` and supporting Insights.
-    3. Approve or reject each candidate.
-    4. Open **Skills** to see the published revision history.
+    Open the container's **Runs** tab and select **Run Learning**. Review the resulting Insights and their source Threads, then approve or reject each proposed Skill. Approved revisions appear under **Skills**.
   </Step>
 </Steps>
 
@@ -159,17 +115,7 @@ copilotkit project select
 copilotkit skills download expense-review --output ./learned-skills
 ```
 
-The output contains one directory and `SKILL.md` for each published Skill. The command verifies the bundle and refuses to overwrite an existing output directory.
-
-Downloading is the handoff from Intelligence to your agent environment. Configure that environment to load `./learned-skills` before expecting the new behavior in a run.
-
-## Choose a useful learning boundary
-
-- Create a container around one enduring workflow or quality bar, not one user or temporary Thread.
-- Write prompt context as evaluation guidance rather than a long agent prompt.
-- Let representative runs accumulate before starting Learning. Sparse or unrelated evidence produces weaker Insights.
-- Review the cited Threads and proposed `SKILL.md` before approval.
-- Keep published Skills small enough to reuse across agents and surfaces.
+The output contains a directory and `SKILL.md` for each published Skill. Configure your agent environment to load `./learned-skills` before expecting the new behavior in a run.
 
 ## Troubleshooting
 

--- a/showcase/shell-docs/src/content/docs/learning.mdx
+++ b/showcase/shell-docs/src/content/docs/learning.mdx
@@ -1,0 +1,183 @@
+---
+title: Learning
+description: Give agents durable memory and turn evidence from real application use into reviewed, reusable Skills.
+icon: "lucide/Sparkles"
+frontend: universal
+doc_type: how-to
+---
+
+Learning gives an agent two ways to improve from real use:
+
+- **Memory** carries useful facts, preferences, events, and procedures into future runs.
+- **Learning containers** turn patterns across completed runs into evidence-backed Insights and reusable Skills.
+
+Together, they let an agent remember how a user likes work done and learn workflows that can be reused in another thread, surface, or agent. Learning works from the messages and application activity already stored in [Rich Threads](/threads); it does not fine-tune your model or require your Runtime to upload a second transcript.
+
+<div className="not-prose shell-docs-radius-surface aspect-[7/4] w-full overflow-hidden border border-[var(--border)] bg-[var(--bg-surface)] shadow-[var(--shadow-panel)]">
+  <iframe
+    src="https://www.loom.com/embed/2978fbfe42324e509057ac5fd46b7a70"
+    title="Learning and Memory in CopilotKit"
+    className="h-full w-full"
+    frameBorder="0"
+    allowFullScreen
+  />
+</div>
+
+In the walkthrough, Memory recalls how spend summaries should be grouped, ordered, and rounded. Learning then observes how an unfamiliar charge is investigated and how a policy exception is filed, proposes those workflows as Skills, and makes the approved behavior reusable in a new thread.
+
+<Callout type="info" title="Learning is an Intelligence capability">
+  Connect your Runtime to [CopilotKit Intelligence](/intelligence/quickstart) before you continue. Learning must also be enabled for your organization.
+</Callout>
+
+## Memory and Learning solve different problems
+
+| Capability | Best for | When it becomes available |
+| --- | --- | --- |
+| User Memory | A person's preferences, facts, and recurring procedures | As soon as the agent saves the Memory; it can be recalled in later threads for that user |
+| Project Memory | Shared product or team knowledge | As soon as the agent saves the Memory; it can be recalled by authorized users in the project |
+| Learning container | Patterns supported by evidence from completed runs | After you run Learning, review the resulting Insights, and approve a Skill candidate |
+
+Memory is contextual data supplied to an agent. A learned Skill is a versioned set of instructions stored as `SKILL.md`. Neither changes the model's weights.
+
+## How Learning works
+
+1. **You define the boundary.** Create a Learning container for a stable problem area such as support quality, expense review, or onboarding. A container groups the Threads that should learn together.
+2. **The Runtime assigns Threads.** `getLearningContainerId` returns the container's stable ID when a run starts. A Thread binds to one container before its first agent run and cannot move later.
+3. **Intelligence records exact evidence.** When an assigned run finishes or errors, Intelligence derives a canonical snapshot from the persisted AG-UI events. Messages, tool calls, and application interactions remain traceable to their source Thread.
+4. **You start a Learning run.** Learning freezes a repeatable input set, analyzes the new snapshots in bounded batches, and combines the findings with the container's current Insights and published Skills.
+5. **Learning produces Insights and candidates.** Each Insight includes a statement, expected impact, and evidence references. Patterns suitable for reuse can produce a Skill addition, update, or removal candidate.
+6. **A human reviews the change.** Approving a candidate publishes a new immutable Skill revision. Rejecting it leaves the published registry unchanged.
+7. **You make published Skills available to agents.** Download the container's bundle and load the generated Skill directories with the skill loader used by your agents.
+
+Only terminal runs that occur after the Thread is assigned are eligible. Existing Threads can be assigned only if they have not run an agent yet, so Learning does not backfill earlier runs.
+
+## Configure Learning
+
+<Steps>
+  <Step>
+    ### Create a Learning container
+
+    Open your project in CopilotKit Intelligence, select **Learning**, and choose **Create Learning container**. Set:
+
+    - a stable ID, such as `expense-review`;
+    - a descriptive name; and
+    - optional prompt context that tells Learning what good behavior looks like in this domain.
+
+    Stable IDs contain 1–64 lowercase letters, numbers, or single hyphens. Treat the ID as application configuration rather than a display label.
+  </Step>
+
+  <Step>
+    ### Assign Threads from your Runtime
+
+    Return the stable ID from `getLearningContainerId` on your `CopilotKitIntelligence` client.
+
+    ```ts title="Your CopilotKit runtime"
+    import {
+      CopilotKitIntelligence,
+      CopilotRuntime,
+    } from "@copilotkit/runtime/v2";
+
+    const intelligence = new CopilotKitIntelligence({
+      apiKey: process.env.CPK_INTELLIGENCE_API_KEY!,
+      getLearningContainerId: ({ agentId }) =>
+        agentId === "expense-agent" ? "expense-review" : undefined,
+    });
+
+    const runtime = new CopilotRuntime({
+      agents,
+      intelligence,
+      identifyUser,
+    });
+    ```
+
+    Return `null` or `undefined` when a run should not participate in Learning. The callback also receives the resolved application user, surface (`web` or `channel`), and AG-UI run input, so you can route different workflows to different containers.
+
+    <Callout type="warn" title="Keep a Thread's assignment stable">
+      The callback must return the same container ID for every run in a Thread. Changing the result later causes a container conflict instead of moving the Thread or mixing two learning domains.
+    </Callout>
+  </Step>
+
+  <Step>
+    ### Generate representative runs
+
+    Use the application normally and complete the workflows that Learning should study. Include corrections, tool use, and application interactions that demonstrate the desired outcome. A container benefits from a focused set of related work more than a mix of unrelated tasks.
+  </Step>
+
+  <Step>
+    ### Run Learning and review the evidence
+
+    Return to the container's **Runs** tab and select **Run Learning**. Only one run can be active for a container at a time, although different containers can run concurrently.
+
+    After the run succeeds:
+
+    1. Open **Insights** and follow the evidence back to the source Threads.
+    2. Open **Candidates**, inspect the proposed `SKILL.md` and supporting Insights, then approve or reject each candidate independently.
+    3. Open **Skills** to see the published revision history.
+
+    A successful run can produce Insights without a Skill candidate. That means Learning found useful evidence but did not find a sufficiently reusable procedure to publish.
+  </Step>
+</Steps>
+
+## Enable long-term Memory
+
+Memory access is controlled per authenticated request. Add a policy to the Intelligence Runtime to choose whether the agent and browser client can read or write user- and project-scoped Memory.
+
+```ts title="Your CopilotKit runtime"
+const runtime = new CopilotRuntime({
+  agents,
+  intelligence,
+  identifyUser,
+  memory: {
+    access: ({ consumer }) => ({
+      user: "read-write",
+      project: consumer === "agent" ? "read-write" : "read",
+    }),
+  },
+});
+```
+
+The Intelligence middleware gives compatible agents three tools: `recall_memory`, `save_memory`, and `forget_memory`. Memories have a scope and a kind:
+
+| Dimension | Values |
+| --- | --- |
+| Scope | `user` for one person's context; `project` for knowledge shared across authorized users |
+| Kind | `topical` for facts and preferences; `episodic` for past events; `operational` for triggers, steps, and reusable procedures |
+
+Base the access policy on your server-side authorization rules. Do not save secrets or unnecessary personal data. `forget_memory` retires a Memory so it is no longer recalled while preserving its audit history.
+
+## Use published Skills
+
+From a directory connected to the same Intelligence project, download the published registry:
+
+```bash title="Terminal"
+copilotkit project select
+copilotkit skills download expense-review --output ./learned-skills
+```
+
+The output contains a directory and `SKILL.md` for each published Skill. The command verifies the bundle and refuses to overwrite an existing output directory. Downloading is the handoff from Intelligence to your agent environment; configure that environment to load `./learned-skills` before expecting the new behavior in a run.
+
+## Design good learning boundaries
+
+- Create containers around one enduring workflow or quality bar, not around individual users or temporary Threads.
+- Use user Memory for personal preferences and project Memory only for information that is safe and useful to share.
+- Write prompt context as evaluation guidance: describe the outcome, policy, or constraints Learning should look for.
+- Let representative runs accumulate before starting Learning. Sparse or unrelated evidence produces weaker Insights.
+- Review the cited Threads and proposed `SKILL.md` before approval. Publishing is deliberately separate from generation.
+- Keep Skills small enough to reuse. A procedure tied to one UI state or one customer is usually better represented as Memory.
+
+## Troubleshooting
+
+| Problem | What to check |
+| --- | --- |
+| A Thread never appears in the container | Confirm the callback returned an existing stable ID before the Thread's first run and that the run reached a terminal state. |
+| The Runtime reports a container conflict | The selector returned a different ID for an already-bound Thread. Restore the original mapping or start a new Thread. |
+| A run has no new evidence | Learning consumes new terminal snapshots. Runs created before assignment, still in progress, or already included in an earlier Learning run are not new input. |
+| A run succeeds without a Skill candidate | Inspect the Insights. The evidence may be useful but not eligible for a reusable procedural Skill. |
+| An approved Skill does not affect the agent | Download the latest bundle and confirm that your agent environment loads the generated Skill directory. |
+
+## Related guides
+
+- [Connect CopilotKit Intelligence](/intelligence/quickstart)
+- [Rich Threads](/threads)
+- [Threads & Persistence Architecture](/intelligence/threads-explained)
+- [CopilotKit CLI](/cli)

--- a/showcase/shell-docs/src/content/docs/learning.mdx
+++ b/showcase/shell-docs/src/content/docs/learning.mdx
@@ -24,28 +24,13 @@ The walkthrough begins with Memory, a separate Intelligence capability, then sho
 
 ## How Learning works
 
-Learning follows one review loop:
+Learning starts with a container, which groups Threads from the same kind of work. Intelligence analyzes completed runs in that container and summarizes recurring patterns as Insights.
 
-<Cards>
-  <Card
-    title="1. Observe real work"
-    description="Assign related Threads to a Learning container. Intelligence automatically captures each completed run as evidence."
-  />
-  <Card
-    title="2. Find repeatable patterns"
-    description="Run Learning to turn new evidence into Insights and proposed Skills."
-  />
-  <Card
-    title="3. Review and reuse"
-    description="Check the source Threads, approve useful Skill candidates, and load the published Skills into your agents."
-  />
-</Cards>
+When a pattern can be reused, Learning proposes a Skill. You review the supporting Threads and decide whether to publish it. A published Skill is a versioned set of instructions that you load into your agent; Learning does not change the model itself.
 
-<Callout type="info" title="You stay in control">
-  Evidence capture is automatic. Running the analysis, approving a proposed Skill, and loading it into an agent are deliberate actions. Learning never fine-tunes your model or silently changes agent behavior.
-</Callout>
+## Set up Learning
 
-## Configure Learning
+When you are done, your Runtime will send selected Threads to a Learning container, ready to be analyzed and turned into reviewed Skills.
 
 <Steps>
   <Step>

--- a/showcase/shell-docs/src/content/docs/meta.json
+++ b/showcase/shell-docs/src/content/docs/meta.json
@@ -33,6 +33,7 @@
     "---Add Agent Powers---",
     "frontend-tools",
     "webmcp",
+    "learning",
     {
       "title": "Shared State",
       "pages": [

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/overview.mdx
@@ -18,7 +18,7 @@ Ready to connect an existing app? Follow the [CopilotKit Intelligence quickstart
 |---|---|---|
 | Durable threads and persistence | Resumable conversations that survive reloads, devices, and browser sessions. | [Threads](/threads) and [Threads & Persistence Architecture](/intelligence/threads-explained) |
 | Analytics | See what your agents do and where users get value, from the same interaction data. | [Analytics](https://www.copilotkit.ai/copilotkit-intelligence#analytics-insights) |
-| Automatic learning | Agents improve from real usage. No fine-tuning pipeline required. | [Automatic Learning](https://www.copilotkit.ai/copilotkit-intelligence#self-improvement) |
+| Automatic learning | Agents improve from real usage. No fine-tuning pipeline required. | [Learning](/learning) |
 | Cloud-hosted Intelligence features | Projects, project API keys, conversation history, thread inspection, and plan management. | [Cloud-hosted CopilotKit Intelligence](/intelligence/managed-intelligence-platform) |
 | Platform-gated UI capabilities | Platform-gated UI surfaces such as Fully Headless Chat UI. | [Fully Headless Chat UI](/intelligence/headless-ui) |
 | Self-hosting | The same platform running inside your own Kubernetes cluster, VPC, or data boundary. | [Self-host CopilotKit Intelligence](/intelligence/self-hosting) |
@@ -60,6 +60,7 @@ Self-hosted access is available on the Team self-hosted plan or a custom Enterpr
 | Run the platform in your own cluster | [Self-host CopilotKit Intelligence](/intelligence/self-hosting) |
 | Understand the runtime/platform architecture | [CopilotKit Intelligence architecture](/intelligence/intelligence-platform) |
 | Add persistent conversations to an app | [Threads](/threads) |
+| Turn real usage into reusable agent behavior | [Learning](/learning) |
 | Understand thread replay and realtime sync | [Threads & Persistence Architecture](/intelligence/threads-explained) |
 
 ## FAQs

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -551,9 +551,7 @@ describe("framework nav", () => {
       ),
     ).toMatchObject({ icon: "lucide/Sparkles" });
     expect(
-      navTree.find(
-        (node) => node.type === "section" && node.title === "Other",
-      ),
+      navTree.find((node) => node.type === "section" && node.title === "Other"),
     ).toMatchObject({ icon: "lucide/Wrench" });
     expect(
       navTree
@@ -580,7 +578,7 @@ describe("framework nav", () => {
       { title: "Rich threads", slug: "threads" },
       {
         title: "Automatic learning",
-        slug: "intelligence/automatic-learning",
+        slug: "learning",
       },
     ]);
     expect(groupPageEntries(navTree, "Hosting")).toEqual([
@@ -588,11 +586,14 @@ describe("framework nav", () => {
       { title: "Self-hosted", slug: "intelligence/self-hosting" },
     ]);
     expect(findPageByTitle(navTree, "Automatic learning")).toMatchObject({
-      href: "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
+      slug: "learning",
     });
     expect(findPageByTitle(navTree, "WebMCP")).toMatchObject({
       slug: "webmcp",
     });
+    expect(hasSectionPage(navTree, "Agent capabilities", "Learning")).toBe(
+      true,
+    );
     expect(sectionNodes(navTree, "Backend").map((node) => node.title)).toEqual([
       "Runtime",
       "Deployment",
@@ -645,9 +646,7 @@ describe("framework nav", () => {
     expect(hasSectionPage(authoredNav, "Backend", "Copilot Runtime")).toBe(
       true,
     );
-    expect(hasSectionPage(authoredNav, "Intelligence", "Overview")).toBe(
-      true,
-    );
+    expect(hasSectionPage(authoredNav, "Intelligence", "Overview")).toBe(true);
     expect(
       sectionNodes(generatedNav, "Agent capabilities").some(
         (node) => node.type === "group" && node.title === "LangGraph (Python)",
@@ -901,7 +900,7 @@ describe("framework nav", () => {
       { title: "Rich threads", slug: "threads" },
       {
         title: "Automatic learning",
-        slug: "intelligence/automatic-learning",
+        slug: "learning",
       },
     ]);
     expect(groupPageEntries(navTree, "Hosting")).toEqual([

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -88,9 +88,12 @@ test("the Learning guide stays focused on the reviewed Learning workflow", () =>
   expect(guide).toContain("## Overview");
   expect(guide).toContain("## How Learning works");
   expect(guide).toContain("## Configure Learning");
+  expect(guide).toContain("### Connect CopilotKit Intelligence");
   expect(guide).toContain("](/intelligence/quickstart)");
   expect(guide).toContain("https://dashboard.operations.copilotkit.ai/");
-  expect(guide).toContain("What happens automatically?");
+  expect(guide).toContain("You stay in control");
+  expect(guide).not.toContain("Before configuring a container:");
+  expect(guide).not.toContain("## Choose a useful learning boundary");
   expect(guide).not.toContain("## Enable long-term Memory");
   expect(guide).not.toContain("memory: {");
 });

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -82,6 +82,19 @@ test("the shared Intelligence overview mounts the landing then keeps platform co
   expect(snippet).toContain("## Hosting options");
 });
 
+test("the Learning guide stays focused on the reviewed Learning workflow", () => {
+  const guide = read("content/docs/learning.mdx");
+
+  expect(guide).toContain("## Overview");
+  expect(guide).toContain("## How Learning works");
+  expect(guide).toContain("## Configure Learning");
+  expect(guide).toContain("](/intelligence/quickstart)");
+  expect(guide).toContain("https://dashboard.operations.copilotkit.ai/");
+  expect(guide).toContain("What happens automatically?");
+  expect(guide).not.toContain("## Enable long-term Memory");
+  expect(guide).not.toContain("memory: {");
+});
+
 test("the MDX registry and page view wire IntelligenceOverview and its chrome", () => {
   const registry = read("lib/mdx-registry.tsx");
   const pageView = read("components/docs-page-view.tsx");

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -87,11 +87,15 @@ test("the Learning guide stays focused on the reviewed Learning workflow", () =>
 
   expect(guide).toContain("## Overview");
   expect(guide).toContain("## How Learning works");
-  expect(guide).toContain("## Configure Learning");
+  expect(guide).toContain("## Set up Learning");
   expect(guide).toContain("### Connect CopilotKit Intelligence");
   expect(guide).toContain("](/intelligence/quickstart)");
   expect(guide).toContain("https://dashboard.operations.copilotkit.ai/");
-  expect(guide).toContain("You stay in control");
+  expect(guide).toContain(
+    "your Runtime will send selected Threads to a Learning container",
+  );
+  expect(guide).not.toContain("<Cards>");
+  expect(guide).not.toContain("You stay in control");
   expect(guide).not.toContain("Before configuring a container:");
   expect(guide).not.toContain("## Choose a useful learning boundary");
   expect(guide).not.toContain("## Enable long-term Memory");

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-landing.test.ts
@@ -54,6 +54,7 @@ test("the shared Intelligence overview mounts the landing then keeps platform co
   expect(snippet).toContain("## What the platform adds");
   expect(snippet).toContain("| Analytics |");
   expect(snippet).toContain("| Automatic learning |");
+  expect(snippet).toContain("[Learning](/learning)");
   expect(snippet).toContain("<IntelligenceFeatureCards");
   expect(snippet).toContain(
     "Follow the Intelligence quickstart to connect your runtime and confirm threads work.",
@@ -62,6 +63,9 @@ test("the shared Intelligence overview mounts the landing then keeps platform co
   expect(
     existsSync(resolve(here, "../../content/docs/intelligence/quickstart.mdx")),
   ).toBe(true);
+  expect(existsSync(resolve(here, "../../content/docs/learning.mdx"))).toBe(
+    true,
+  );
   expect(snippet.indexOf("## What the platform adds")).toBeLessThan(
     snippet.indexOf("<IntelligenceFeatureCards"),
   );

--- a/showcase/shell-docs/src/lib/docs-render.tsx
+++ b/showcase/shell-docs/src/lib/docs-render.tsx
@@ -804,7 +804,8 @@ function splitSidebarSections(navTree: NavNode[]): SidebarBuckets {
       continue;
     }
 
-    const title = SIDEBAR_SECTION_TITLES[node.title.toLowerCase()] ?? node.title;
+    const title =
+      SIDEBAR_SECTION_TITLES[node.title.toLowerCase()] ?? node.title;
     const existing = sectionsByTitle.get(title);
     if (existing) {
       current = existing;
@@ -941,6 +942,7 @@ function isSharedFrameworkNode(node: NavNode): boolean {
   return (
     slug === "frontend-tools" ||
     slug === "webmcp" ||
+    slug === "learning" ||
     slug === "inspector" ||
     slug === "vs-code-extension" ||
     slug === "telemetry" ||
@@ -1090,8 +1092,7 @@ export function normalizeSidebarNav(
     findGroup(interactivitySources, "Human in the loop") ??
     findNavNode(
       interactivitySources,
-      (node) =>
-        node.type === "group" && node.slug === "human-in-the-loop",
+      (node) => node.type === "group" && node.slug === "human-in-the-loop",
     );
 
   const existingAgentCapabilities = sidebarSectionChildren(
@@ -1101,9 +1102,7 @@ export function normalizeSidebarNav(
   const existingFrameworkGroups = existingAgentCapabilities.filter(
     (node) =>
       node.type === "group" &&
-      !["automatic learning", "sub-agents"].includes(
-        node.title.toLowerCase(),
-      ),
+      !["automatic learning", "sub-agents"].includes(node.title.toLowerCase()),
   );
   const frameworkGroups =
     existingFrameworkGroups.length > 0
@@ -1128,12 +1127,11 @@ export function normalizeSidebarNav(
           );
   const subagents = findPage("multi-agent/subagents");
   const webMcp = findPage("webmcp");
+  const learning = findPage("learning");
 
   const intelligencePage = (slug: string, title: string): NavNode | null => {
     const page = findPage(slug);
-    return page?.type === "page"
-      ? { ...page, title, icon: undefined }
-      : null;
+    return page?.type === "page" ? { ...page, title, icon: undefined } : null;
   };
   const intelligenceOverview = intelligencePage(
     "intelligence/overview",
@@ -1160,12 +1158,10 @@ export function normalizeSidebarNav(
     "intelligence/self-hosting",
     "Self-hosted",
   );
-  const intelligenceAutomaticLearning: NavNode = {
-    type: "page",
-    title: "Automatic learning",
-    slug: "intelligence/automatic-learning",
-    href: "https://www.copilotkit.ai/copilotkit-intelligence#self-improvement",
-  };
+  const intelligenceAutomaticLearning = intelligencePage(
+    "learning",
+    "Automatic learning",
+  );
 
   const existingBackend = sidebarSectionChildren(input, "Backend");
   const inputDeployment = sidebarSectionChildren(input, "Deployment");
@@ -1208,9 +1204,7 @@ export function normalizeSidebarNav(
     sidebarTopicGroup(
       "Troubleshooting",
       "sidebar#troubleshooting-source",
-      flattenUntitledGroups(
-        sidebarSectionChildren(input, "Troubleshooting"),
-      ),
+      flattenUntitledGroups(sidebarSectionChildren(input, "Troubleshooting")),
     );
   const telemetry =
     findNavNode(
@@ -1245,6 +1239,9 @@ export function normalizeSidebarNav(
     ...sidebarSection("Agent capabilities", [
       webMcp?.type === "page"
         ? { ...webMcp, title: "WebMCP", icon: undefined }
+        : null,
+      learning?.type === "page"
+        ? { ...learning, title: "Learning", icon: undefined }
         : null,
       ...frameworkGroups,
       subagents?.type === "page"


### PR DESCRIPTION
## Summary

- Adds a comprehensive Learning guide under Agent capabilities.
- Embeds the product walkthrough and documents setup, review, and Skill publishing.
- Makes Learning discoverable from the Intelligence overview and docs navigation.

## Why

Learning needs a clear, human-readable guide that explains how real Threads become reviewed, reusable Skills without mixing in the separate Memory workflow.

## How

- Explains the Learning lifecycle in plain language.
- Walks through connecting Intelligence, creating a container, routing Threads, collecting examples, reviewing results, and downloading published Skills.
- Keeps Memory documentation separate; that work is tracked in [Memory documentation PR #6854](https://github.com/CopilotKit/CopilotKit/pull/6854).
- Adds navigation, Intelligence landing-page coverage, and regression tests.
- Verified with the shell-docs build and typecheck, 37 focused tests, and local visual QA.