### PR TITLE
fix(runtime): build the logger without pino redact so edge runtimes work

### DIFF
--- a/packages/runtime/src/v1-deprecated/lib/__tests__/logger.test.ts
+++ b/packages/runtime/src/v1-deprecated/lib/__tests__/logger.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createPinoLogger } = vi.hoisted(() => ({
+  createPinoLogger: vi.fn(() => ({
+    child: vi.fn(() => ({ __child: true })),
+  })),
+}));
+
+vi.mock("pino", () => ({ default: createPinoLogger }));
+vi.mock("pino-pretty", () => ({ default: vi.fn(() => ({ __stream: true })) }));
+
+import { createLogger } from "../logger";
+
+function optionsPassedToPino() {
+  expect(createPinoLogger).toHaveBeenCalled();
+  return createPinoLogger.mock.calls.at(-1)![0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.LOG_LEVEL;
+});
+
+describe("createLogger", () => {
+  // Regression guard for issue #2355. pino 9 hands `redact.paths` to
+  // fast-redact, which validates each path by calling `Function(...)`.
+  // Cloudflare Workers and other edge runtimes forbid code generation from
+  // strings, so building the logger throws there and the validator blames the
+  // first path in the array ("invalid path (pid)"). Any redact path fails, not
+  // just `pid`, so the only safe configuration is to pass none.
+  //
+  // This monorepo pins pino to 10 through a pnpm override, and pino 10 swapped
+  // fast-redact for @pinojs/redact, which uses no code generation. That means
+  // the failure cannot be reproduced by running a logger here; the assertion
+  // has to be on the options we hand pino.
+  it("passes no redact option to pino, because redact paths need code generation", () => {
+    createLogger();
+
+    expect(optionsPassedToPino()).not.toHaveProperty("redact");
+  });
+
+  it("suppresses pid and hostname with base instead", () => {
+    createLogger();
+
+    expect(optionsPassedToPino().base).toBeNull();
+  });
+
+  it("defaults to the error level and honours LOG_LEVEL over the argument", () => {
+    createLogger();
+    expect(optionsPassedToPino().level).toBe("error");
+
+    createLogger({ level: "warn" });
+    expect(optionsPassedToPino().level).toBe("warn");
+
+    process.env.LOG_LEVEL = "debug";
+    createLogger({ level: "warn" });
+    expect(optionsPassedToPino().level).toBe("debug");
+  });
+
+  it("returns a child logger only when a component is named", () => {
+    const plain = createLogger();
+    expect(plain).not.toHaveProperty("__child");
+
+    const scoped = createLogger({ component: "copilotkit-debug" });
+    expect(scoped).toHaveProperty("__child", true);
+  });
+});

--- a/packages/runtime/src/v1-deprecated/lib/__tests__/logger.test.ts
+++ b/packages/runtime/src/v1-deprecated/lib/__tests__/logger.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// Typed so the call tuple carries pino's own (options, stream) shape. An
+// untyped vi.fn() has an empty tuple, and reading calls[0] then fails
+// `tsc --noEmit` with TS2493.
 const { createPinoLogger } = vi.hoisted(() => ({
-  createPinoLogger: vi.fn(() => ({
-    child: vi.fn(() => ({ __child: true })),
-  })),
+  createPinoLogger: vi.fn(
+    (_options: Record<string, unknown>, _stream?: unknown) => ({
+      child: vi.fn(() => ({ __child: true })),
+    }),
+  ),
 }));
 
 vi.mock("pino", () => ({ default: createPinoLogger }));
@@ -11,9 +16,13 @@ vi.mock("pino-pretty", () => ({ default: vi.fn(() => ({ __stream: true })) }));
 
 import { createLogger } from "../logger";
 
-function optionsPassedToPino() {
+function optionsPassedToPino(): Record<string, unknown> {
   expect(createPinoLogger).toHaveBeenCalled();
-  return createPinoLogger.mock.calls.at(-1)![0] as Record<string, unknown>;
+  const lastCall = createPinoLogger.mock.calls.at(-1);
+  if (lastCall === undefined) {
+    throw new Error("createLogger did not call pino");
+  }
+  return lastCall[0];
 }
 
 beforeEach(() => {

--- a/packages/runtime/src/v1-deprecated/lib/logger.ts
+++ b/packages/runtime/src/v1-deprecated/lib/logger.ts
@@ -45,10 +45,15 @@ export function createLogger(options?: {
   const logger = createPinoLogger(
     {
       level: process.env.LOG_LEVEL || level || "error",
-      redact: {
-        paths: ["pid", "hostname"],
-        remove: true,
-      },
+      // Drop `pid` and `hostname` with pino's own `base` switch rather than
+      // with `redact`. pino 9 validates every redact path by calling
+      // `Function(...)`, and edge runtimes such as Cloudflare Workers forbid
+      // code generation from strings. That throws while the logger is being
+      // built, and the validator reports the first path in the array, so the
+      // failure surfaces as the misleading "redact paths array contains an
+      // invalid path (pid)". `base: null` produces identical output and needs
+      // no code generation. See issue #2355.
+      base: null,
     },
     stream,
   );


### PR DESCRIPTION
Closes #2355 (OSS-547).

## The bug

`@copilotkit/runtime` cannot build its logger on Cloudflare Workers. The deployed worker throws:

```
⨯ Error: pino – redact paths array contains an invalid path (pid)
```

## The cause, which is not what earlier triage said

The support-bot answer on the issue said `pid` is rejected because Workers have no process ID, and suggested dropping `pid` from the array. That is wrong, and the reporter said it did not help.

pino 9 hands `redact.paths` to `fast-redact`, whose validator checks each path by **calling `Function(...)`**:

```js
// fast-redact/lib/validator.js
try {
  ...
  Function(`
      'use strict'
      const o = new Proxy({}, ...);
      o${expr}
      ...`)()
} catch (e) {
  throw Error(ERR_INVALID_PATH(s))   // <- swallows the real EvalError
}
```

Cloudflare Workers forbid code generation from strings, so the `Function(...)` call throws an `EvalError`. The `catch` swallows it and reports the **first path in the array**, which happens to be `pid`. Every path fails, not just `pid` — removing `pid` only moves the error to `hostname`.

## The fix

Use pino's own `base` switch, which is what the `redact` block was emulating. It omits `pid` and `hostname`, produces identical output, and needs no code generation.

```diff
-      redact: {
-        paths: ["pid", "hostname"],
-        remove: true,
-      },
+      base: null,
```

The file lives under `v1-deprecated/`, but v2 still reaches into it: `v2/runtime/core/runtime.ts` and `v2/runtime/handlers/shared/sse-response.ts` both call `createLogger` when `debug.enabled`. So this fixes both major versions. In v1 the call is at module scope (`v1-deprecated/lib/integrations/shared.ts:90`), so the import throws unconditionally, which is why the reporter hit it on v1.

## Testing

**1. Reproduced the exact reported error.** `node --disallow-code-generation-from-strings` applies the same restriction Workers apply. Run against pino 9.2.0 + pino-pretty 11.2.1 with the pre-fix logger options:

```
$ node --disallow-code-generation-from-strings current.js
Error: pino – redact paths array contains an invalid path (pid)
    at .../fast-redact/lib/validator.js:29:15
    at Array.forEach (<anonymous>)
    at validate (.../fast-redact/lib/validator.js:12:11)
    at handle (.../pino/lib/redaction.js:113:3)
    at redaction (.../pino/lib/redaction.js:16:29)
    at pino (.../pino/pino.js:129:33)
```

**2. Confirmed `pid` is not special.** Same flag, other paths:

```
hostname-only FAILED: pino – redact paths array contains an invalid path (hostname)
unrelated path FAILED: pino – redact paths array contains an invalid path (req.headers.authorization)
```

**3. Confirmed the fix builds the logger under the same restriction**, with the post-fix `createLogger` verbatim (both the plain and the `component` child path):

```
$ node --disallow-code-generation-from-strings final.js
[13:18:27.986] DEBUG: debug line
    component: "copilotkit-debug"
[13:18:27.988] ERROR: error line
OK: createLogger works with code generation disabled
exit=0
```

**4. Confirmed output parity.** `base: null` emits exactly what the `redact` block emitted:

```
--- redact variant ---          {"level":30,"time":1788545869311,"msg":"x"}
--- base:null variant ---       {"level":30,"time":1788545869311,"msg":"x"}
--- child component ---         {"level":30,"time":...,"component":"copilotkit-debug","msg":"y"}
```

**5. Confirmed the fix is safe on pino 10** (which this monorepo pins via a pnpm override), same flag:

```
{"level":50,"time":1788545913844,"msg":"p10 base:null ok"}
```

**6. New unit test, mutation-checked.** `packages/runtime/src/v1-deprecated/lib/__tests__/logger.test.ts`. Passing:

```
 ✓ src/v1-deprecated/lib/__tests__/logger.test.ts (4 tests) 2ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Restoring the `redact` block fails it, so it is not self-fulfilling:

```
 FAIL  ... > createLogger > suppresses pid and hostname with base instead
AssertionError: expected undefined to be null
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

**7. Full `@copilotkit/runtime` suite:**

```
 Test Files  1 failed | 153 passed (154)
      Tests  3 failed | 2273 passed (2276)
```

The one failing file is `v1-deprecated/service-adapters/google/google-genai-adapter.test.ts`. It fails identically on pristine `origin/main` with this change reverted (`Test Files 1 failed (1) / Tests 3 failed (3)`), so it is pre-existing and unrelated.

**8. Pre-commit hook green** — `check-binaries`, `lint-fix` (0 warnings, 0 errors), `check-intelligence-env-names`, and `test-and-check-packages` (`test`, `publint`, `attw` across 7 projects) all passed on the commit.

`tsc --noEmit --strict` on the changed file exits 0. `oxfmt --write` produced no changes.

## What this does not claim

This removes one proven blocker, not "Cloudflare support". I did not deploy to workerd end to end, so `pino-pretty` and other Node dependencies in the runtime may block separately.

## Separate observation, not fixed here

`packages/runtime/package.json` declares `"pino": "^9.2.0"`, but the root `pnpm.overrides` pins `pino@<=10.1.1: 10.1.1`. pino 10 swapped `fast-redact` for `@pinojs/redact`, which uses no code generation. So this class of bug is invisible to local dev and CI here and only appears in published installs. Worth closing that gap, but it is a major-version bump for a published package and does not belong in this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger compatibility in edge runtimes by preventing startup failures caused by logger configuration.
  * Preserved existing log output while suppressing process-specific details such as process ID and hostname.
  * Maintained default and environment-configured log levels, including component-specific child loggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->