### PR TITLE
fix(react-textarea): stop Cmd+K insert from deleting adjacent text

### DIFF
--- a/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
+++ b/packages/react-textarea/src/components/hovering-toolbar/hovering-toolbar.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Editor, Location, Transforms } from "slate";
+import type { Editor, Location } from "slate";
+import { Transforms } from "slate";
 import { ReactEditor, useSlate, useSlateSelection } from "slate-react";
 import {
   getFullEditorTextWithNewlines,
   getTextAroundSelection,
 } from "../../lib/get-text-around-cursor";
-import {
+import type {
   EditingEditorState,
   InsertionEditorApiConfig,
 } from "../../types/base/autosuggestions-bare-function";
@@ -172,8 +173,16 @@ export const HoveringToolbar = (props: HoveringToolbarProps) => {
           editorState={editorState(editor, selection)}
           apiConfig={props.apiConfig}
           performInsertion={(insertedText) => {
-            // replace the selection with the inserted text
-            Transforms.delete(editor, { at: selection });
+            // Replace the selection with the inserted text.
+            //
+            // `insertText` already deletes an expanded range (via point refs)
+            // before inserting at its start, and inserts in place when the
+            // range is collapsed. Deleting first and then reusing `selection`
+            // destroys text: the range is stale after the delete, so the
+            // delete inside `insertText` runs again at the same offsets and
+            // eats the characters that followed the insertion point. With a
+            // collapsed caret, `Transforms.delete` also deletes one character
+            // forward, because it resolves a collapsed range to a point.
             Transforms.insertText(editor, insertedText, {
               at: selection,
             });


### PR DESCRIPTION
Closes #2192

## Problem

`CopilotTextarea`'s Cmd+K hovering editor destroys text when the user clicks **Insert**. `HoveringToolbar` deleted the selection and then reused the same `selection` range for the insert:

```ts
Transforms.delete(editor, { at: selection });
Transforms.insertText(editor, insertedText, { at: selection });
```

Two separate defects come out of those two lines:

1. **Expanded selection.** The range is stale after the delete, and `Transforms.insertText` already deletes an expanded range before inserting. The delete inside `insertText` therefore runs a second time, at the same offsets in the now-shorter document, and eats the characters that followed the insertion point.
2. **Collapsed caret** (plain insert, no selection). `Transforms.delete` resolves a collapsed range to a point and deletes one character *forward*, so inserting at the caret always destroyed the next character.

The reporter described it as "Insert did not fill in the content". What actually happens is that the insert lands but neighbouring text disappears with it, which is data loss in the user's document.

`@copilotkit/react-textarea` is a deprecated v1 package with **no 1:1 v2 replacement**, so affected users have nowhere to migrate. That is why this is worth a one-line fix rather than a won't-fix.

## Change

Drop the `Transforms.delete` call. `Transforms.insertText` is correct for both cases on its own: it deletes an expanded range through point refs and inserts at its start (`slate@0.94.1`, `TextTransforms.insertText`), and it inserts in place when the range is collapsed.

The two `import type` lines in the diff are the pre-commit `oxlint --fix` hook's own autofix on the touched file, not a hand edit.

No new API surface, no runtime dependency change, no test-harness added to a deprecated package.

## Testing

The package has no component/slate test setup (only two trivial unit test files), so verification is behavioural, against a standalone Vite + React 18 app that mounts `BaseCopilotTextarea` with a stub `insertionOrEditingFunction` that streams the literal `HELLO_FROM_SUGGESTION` (no LLM in the loop). Each run: set the selection, Cmd+K, type a prompt, generate, click **Insert**, then read back both the editor DOM text and the controlled `value` mirrored outside the component.

**Before** — `@copilotkit/react-textarea@1.70.1` from npm (identical to `main`):

| Case | Start | Result |
| --- | --- | --- |
| select `bravo` | `alpha bravo charlie delta echo` | `alpha HELLO_FROM_SUGGESTIONlie delta echo` — ate ` char` |
| caret at offset 6, no selection | `alpha bravo charlie delta echo` | `alpha HELLO_FROM_SUGGESTIONravo charlie delta echo` — ate `b` |

**After** — `packages/react-textarea/dist` built from this branch (`nx run @copilotkit/react-textarea:build`) and swapped into the same app:

| Case | Start | Result |
| --- | --- | --- |
| select `bravo` | `alpha bravo charlie delta echo` | `alpha HELLO_FROM_SUGGESTION charlie delta echo` ✅ |
| caret at offset 6, no selection | `alpha bravo charlie delta echo` | `alpha HELLO_FROM_SUGGESTIONbravo charlie delta echo` ✅ |
| select last word `echo` | `alpha bravo charlie delta echo` | `alpha bravo charlie delta HELLO_FROM_SUGGESTION` ✅ |
| select all (3 lines) | `one alpha\ntwo bravo\nthree charlie` | `HELLO_FROM_SUGGESTION` ✅ |
| select `alpha\ntwo bravo` (mid, spans lines) | `one alpha\ntwo bravo\nthree charlie` | `one HELLO_FROM_SUGGESTION\nthree charlie` ✅ |

The last three cases were already correct before the change (the stale range clamps at the document end), and they stay correct — the fix does not regress them.

Repo checks, in the worktree at `origin/main`:

```
$ pnpm nx run-many -t test,publint,attw --projects=@copilotkit/react-textarea
 ✓ src/lib/utils.test.ts (1 test) 1ms
 ✓ src/esm-compat.test.ts (1 test) 1ms
 Test Files  2 passed (2)
      Tests  2 passed (2)
NX   Successfully ran targets test, publint, attw for project @copilotkit/react-textarea and 19 tasks it depends on

$ pnpm exec tsc --noEmit        # in packages/react-textarea
exit: 0

$ pnpm exec oxlint packages/.../hovering-toolbar.tsx
Found 5 warnings and 0 errors.   # all pre-existing `import type` warnings elsewhere in the file
```

`nx run @copilotkit/react-textarea:check-types` also builds the dependency project `@copilotkit/runtime-client-gql`, which fails locally on missing generated GraphQL modules (`../graphql/@generated/graphql`). That is a pre-existing local codegen gap in an untouched package, not from this change; the direct `tsc --noEmit` above covers this package.

Pre-commit hooks ran on the commit (`check-binaries`, `lint-fix`, `test-and-check-packages`, `check-intelligence-env-names`, `commitlint`) and all passed.

## Not in scope

The screenshot on #2192 also shows the Cmd+K popup rendered far from the selection (bottom-left of the viewport). That is a separate positioning bug; PR #3679 attempted it and was closed. Not touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text insertion behavior in the hovering toolbar, including replacement of selected text and insertion at the current caret position.
  * Prevented issues caused by outdated selection ranges during insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->