### PR TITLE
fix(react-core): restore code block line breaks in packaged CSS (#3330)

### DIFF
--- a/packages/react-core/src/v2/styles/__tests__/streamdown-code-block-lines.test.tsx
+++ b/packages/react-core/src/v2/styles/__tests__/streamdown-code-block-lines.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * #3330: fenced code blocks collapsed onto a single line in the packaged UI.
+ *
+ * streamdown renders one <span> per source line inside
+ * `pre[data-streamdown="code-block-body"] > code`, and the line break comes
+ * entirely from the raw Tailwind utility `block` on that span — the <pre> text
+ * itself holds no newline characters. CopilotKit builds Tailwind with
+ * `prefix(cpk)`, so `.block` never reaches the packaged CSS and every line ran
+ * inline. globals.css therefore scopes the display rule structurally, because
+ * the line spans carry no `data-streamdown` attribute:
+ * `[data-streamdown="code-block-body"] > code > span { @apply cpk:block }`.
+ *
+ * A source-string test (streamdown-styles.test.ts) guards that the selector
+ * exists. This DOM test guards the OTHER half: that streamdown still renders the
+ * structure that selector assumes. If streamdown changes its code-block markup
+ * (adds a data-streamdown attribute to the lines, renests them, or starts
+ * emitting real newlines), this fails — signalling the scoped CSS must be
+ * revisited.
+ */
+import { describe, it, expect } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { Streamdown } from "streamdown";
+
+const CODE_LINES = [
+  "function greet(name) {",
+  "  const msg = `hi ${name}`;",
+  "  return msg;",
+  "}",
+];
+const CODE_MARKDOWN = ["```js", ...CODE_LINES, "```", ""].join("\n");
+
+describe("Streamdown code block lines DOM (#3330)", () => {
+  it("renders one line span per source line, matching the scoped selector", async () => {
+    const { container } = render(
+      <div data-copilotkit="">
+        <Streamdown>{CODE_MARKDOWN}</Streamdown>
+      </div>,
+    );
+
+    // Highlighting is async: the first paint is a loading skeleton.
+    await waitFor(
+      () => {
+        expect(
+          container.querySelector('pre[data-streamdown="code-block-body"]'),
+        ).not.toBeNull();
+      },
+      { timeout: 15000 },
+    );
+
+    const body = container.querySelector<HTMLElement>(
+      'pre[data-streamdown="code-block-body"]',
+    )!;
+
+    // One span per source line, directly under <code> — exactly what
+    // `> code > span` scopes.
+    const lineSpans = body.querySelectorAll(":scope > code > span");
+    expect(lineSpans.length).toBeGreaterThanOrEqual(CODE_LINES.length);
+    CODE_LINES.forEach((line, index) => {
+      expect(lineSpans[index]!.textContent).toBe(line);
+    });
+
+    // The lines have no data-streamdown attribute (the reason the CSS targets
+    // them structurally) and carry the unprefixed `block` utility, which the
+    // cpk-prefixed build never emits.
+    expect(lineSpans[0]!.getAttribute("data-streamdown")).toBeNull();
+    expect(lineSpans[0]!.classList.contains("block")).toBe(true);
+
+    // There is no newline anywhere in the code body, so `white-space: pre` on
+    // the <pre> cannot produce the line breaks on its own.
+    expect(body.textContent).not.toContain("\n");
+  }, 20000);
+});

--- a/packages/react-core/src/v2/styles/__tests__/streamdown-styles.test.ts
+++ b/packages/react-core/src/v2/styles/__tests__/streamdown-styles.test.ts
@@ -30,6 +30,17 @@ describe("Streamdown styles", () => {
     );
   });
 
+  it("ships a scoped display rule for code block lines (#3330)", () => {
+    // The per-line spans inside a code block carry no data-streamdown
+    // attribute, so they are scoped structurally. They rely on the raw
+    // Tailwind utility `block`, which the cpk-prefixed build never emits, so
+    // without this rule every line renders inline.
+    const normalized = globalsCss.replace(/\s+/g, " ");
+    expect(normalized).toContain(
+      '[data-copilotkit] [data-streamdown="code-block-body"] > code > span { @apply cpk:block; }',
+    );
+  });
+
   it("ships scoped fallback styles for the table action controls row (#5775)", () => {
     // The controls row / buttons / popovers have no stable data-streamdown
     // attribute, so they are scoped structurally under the table wrapper.

--- a/packages/react-core/src/v2/styles/globals.css
+++ b/packages/react-core/src/v2/styles/globals.css
@@ -338,6 +338,17 @@
     @apply cpk:overflow-x-auto cpk:border-t cpk:border-border cpk:p-4 cpk:text-sm;
   }
 
+  /* One <span> per source line inside the code body. streamdown gives each of
+     them the raw Tailwind utility `block` (no `data-streamdown` attribute), and
+     CopilotKit builds Tailwind with `prefix(cpk)`, so `.block` is never emitted
+     into the packaged CSS. Without it every line renders inline and the whole
+     block collapses onto one row (#3330). The <pre> keeps `white-space: pre`
+     from the UA stylesheet, but there are no newlines left in the text to
+     preserve — the line breaks come entirely from this display rule. */
+  [data-copilotkit] [data-streamdown="code-block-body"] > code > span {
+    @apply cpk:block;
+  }
+
   [data-copilotkit] [data-streamdown="code-block-copy-button"],
   [data-copilotkit] [data-streamdown="code-block-download-button"] {
     @apply cpk:cursor-pointer cpk:p-1 cpk:text-muted-foreground cpk:transition-all cpk:hover:text-foreground cpk:disabled:cursor-not-allowed cpk:disabled:opacity-50;


### PR DESCRIPTION
## What does this PR do?

Fixes #3330 — fenced markdown code blocks render as one collapsed line in the packaged v2 React UI.

### Root cause

streamdown renders one `<span>` per source line inside `pre[data-streamdown="code-block-body"] > code`, and leaves **no newline characters** in the text. The line break comes entirely from the raw Tailwind utility `block` on that span:

```js
// streamdown 1.6.11, dist/code-block-*.js
var v = cn("block", "before:content-[counter(line)]", ...);
```

CopilotKit builds Tailwind with `@import "tailwindcss" prefix(cpk)`, so `.block` is never emitted into `dist/v2/index.css` — only `.cpk\:block` is. Every line therefore renders inline and the block collapses onto one row.

The line spans carry no `data-streamdown` attribute, so the rule has to be scoped structurally, the same way the table action controls were in #5944:

```css
[data-copilotkit] [data-streamdown="code-block-body"] > code > span {
  @apply cpk:block;
}
```

### Why the earlier attempts did not work

Three previous PRs (#3441, #3615, #5387) added `whitespace-pre` to the `<pre>`. That is a no-op: the UA stylesheet already applies `white-space: pre` to `<pre>`, nothing in the packaged CSS overrides it, and there are no newlines in the text for it to preserve.

### Knowingly not fixed here

- **Line-number gutter.** streamdown's `before:content-[counter(line)] before:w-4 before:mr-4 …` utilities are unprefixed too, so the gutter never renders. That is cosmetic, and the repo's existing scoped rules do not port it either.
- **The pre-highlight loading skeleton** (`space-y-4`, `divide-y`, `animate-spin`) is unprefixed as well — a brief flash of unstyled skeleton before shiki resolves.
- **The broader class of bug.** Every unprefixed streamdown utility has to be hand-ported like this. streamdown 2.x adds a `prefix` prop that would fix the whole surface at once, and #5147 proposes removing the bundled renderer entirely. Both are larger calls than this bug fix.

## Testing

**1. Live browser verification.** Built `dist/v2/index.css` from `origin/main` and from this branch, rendered streamdown 1.6.11's actual code-block DOM against each, and measured layout in Chromium:

| | `white-space` on `<pre>` | line-span `display` | distinct rendered rows | `<pre>` height |
|---|---|---|---|---|
| main | `pre` | `inline` | **1** | 52px |
| this PR | `pre` | `block` | **5** | 112px |

Indentation is preserved after the fix (`spans[1].textContent` starts with two spaces).


**2. Compiled CSS.** `tailwindcss -i src/v2/styles/globals.css -o … -m` emits exactly:

```css
[data-copilotkit] [data-streamdown=code-block-body]>code>span{display:block}
```

**3. Tests** — `pnpm -C packages/react-core exec vitest run src/v2/styles`

```
 ✓ src/v2/styles/__tests__/streamdown-styles.test.ts (3 tests) 2ms
 ✓ src/v2/styles/__tests__/streamdown-table-controls.test.tsx (1 test) 37ms
 ✓ src/v2/styles/__tests__/streamdown-code-block-lines.test.tsx (1 test) 430ms

 Test Files  3 passed (3)
      Tests  5 passed (5)
```

Two tests, following the split established by #5944 — a source-string test that the selector exists, and a DOM test that streamdown still renders the structure that selector assumes (so a streamdown markup change fails loudly instead of silently un-fixing this).

**4. Mutation-checked both tests.** Removing the CSS rule fails the string test:

```
   × Streamdown styles > ships a scoped display rule for code block lines (#3330) 3ms
      Tests  1 failed | 2 passed (3)
```

Pointing the DOM test at a selector streamdown does not render fails it:

```
   × Streamdown code block lines DOM (#3330) > renders one line span per source line 428ms
      Tests  1 failed (1)
```

**5. Formatting** — `oxfmt --check` clean on all three files; `git diff --check` clean.

`tsc --noEmit` in this worktree reports 58 pre-existing errors, all from a stale cross-package `@copilotkit/core` dist; none are in the changed files (which are CSS plus tests).

## Related PRs and Issues

Fixes #3330
Supersedes #3441, #3615, #5387, #5996 (all added a no-op `whitespace-pre`)

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (not applicable: scoped visual bug fix)
- [x] "Allow edits by maintainers" is checked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed fenced code blocks collapsing into a single line in the packaged UI.
  - Code lines now render vertically as separate rows with the correct layout styling.

- **Tests**
  - Added regression coverage to verify code-line rendering and scoped styles for code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->