### PR TITLE
docs(showcase): document frontend-driven activity cards (refs #3388)

### DIFF
--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatFrontendActivityCard.e2e.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatFrontendActivityCard.e2e.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Frontend-driven activity cards (issue #3388).
+ *
+ * A `role: "activity"` message added from frontend code renders standalone in
+ * the transcript, and `AbstractAgent.prepareRunAgentInput` strips it from the
+ * run payload — so the card never reaches the agent or the LLM. This is the
+ * supported way to put a card in the transcript without a tool call and
+ * without polluting the conversation.
+ */
+import React from "react";
+import { screen, waitFor, act } from "@testing-library/react";
+import { z } from "zod";
+import type { RunAgentInput } from "@ag-ui/core";
+import {
+  MockStepwiseAgent,
+  renderWithCopilotKit,
+} from "../../../__tests__/utils/test-helpers";
+import { CopilotChat } from "../CopilotChat";
+import { useAgent } from "../../../hooks/use-agent";
+import { CopilotKitCoreReact } from "../../../lib/react-core";
+import type { ReactActivityMessageRenderer } from "../../../types";
+
+// Test shim: some environments lack setCredentials on CopilotKitCoreReact.
+if (!(CopilotKitCoreReact.prototype as any).setCredentials) {
+  (CopilotKitCoreReact.prototype as any).setCredentials = () => {};
+}
+
+const contentSchema = z.object({ title: z.string() });
+
+const cardRenderer: ReactActivityMessageRenderer<
+  z.infer<typeof contentSchema>
+> = {
+  activityType: "app-event-card",
+  content: contentSchema,
+  render: ({ content }) => (
+    <div data-testid="app-event-card">{content.title}</div>
+  ),
+};
+
+/** Captures the RunAgentInput the agent is actually invoked with. */
+class InputCapturingAgent extends MockStepwiseAgent {
+  lastInput?: RunAgentInput;
+  run(input: RunAgentInput) {
+    this.lastInput = input;
+    return super.run(input);
+  }
+}
+
+/**
+ * Stands in for application code that reacts to a frontend event — a websocket
+ * push, an `agent.subscribe` callback, a button — and drops a card into the
+ * transcript. `useAgent()` is what hands back the live agent instance; a raw
+ * agent reference held outside React is not the instance the chat renders.
+ */
+function CardEmitter({ onAgent }: { onAgent: (agent: any) => void }) {
+  const { agent } = useAgent();
+  React.useEffect(() => {
+    onAgent(agent);
+  }, [agent, onAgent]);
+  return null;
+}
+
+describe("frontend-driven activity cards (#3388)", () => {
+  it("renders a card added from frontend code, with no tool call", async () => {
+    let liveAgent: any;
+    renderWithCopilotKit({
+      agent: new InputCapturingAgent(),
+      renderActivityMessages: [cardRenderer],
+      children: (
+        <>
+          <CardEmitter onAgent={(a) => (liveAgent = a)} />
+          <CopilotChat />
+        </>
+      ),
+    });
+
+    await waitFor(() => expect(liveAgent).toBeDefined());
+
+    await act(async () => {
+      liveAgent.addMessage({
+        id: "card-1",
+        role: "activity",
+        activityType: "app-event-card",
+        content: { title: "Deployment finished" },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("app-event-card").textContent).toBe(
+        "Deployment finished",
+      );
+    });
+  });
+
+  it("excludes the card from the run payload sent to the agent", async () => {
+    let liveAgent: any;
+    renderWithCopilotKit({
+      agent: new InputCapturingAgent(),
+      renderActivityMessages: [cardRenderer],
+      children: (
+        <>
+          <CardEmitter onAgent={(a) => (liveAgent = a)} />
+          <CopilotChat />
+        </>
+      ),
+    });
+
+    await waitFor(() => expect(liveAgent).toBeDefined());
+
+    await act(async () => {
+      liveAgent.addMessage({ id: "u1", role: "user", content: "hello" });
+      liveAgent.addMessage({
+        id: "card-1",
+        role: "activity",
+        activityType: "app-event-card",
+        content: { title: "Deployment finished" },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Kick off a run without awaiting it: the mock agent's stream stays open,
+    // and the payload is captured synchronously when run() is invoked.
+    void liveAgent.runAgent({});
+    await waitFor(() => expect(liveAgent.lastInput).toBeDefined());
+
+    // The card stays in the client transcript...
+    expect(liveAgent.messages.map((m: any) => m.role)).toEqual([
+      "user",
+      "activity",
+    ]);
+    // ...but never reaches the agent.
+    expect(liveAgent.lastInput.messages.map((m: any) => m.role)).toEqual([
+      "user",
+    ]);
+  });
+});

--- a/showcase/shell-docs/src/content/docs/generative-ui/frontend-cards.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/frontend-cards.mdx
@@ -1,0 +1,140 @@
+---
+title: Frontend-Driven Cards
+icon: "lucide/MousePointerClick"
+description: Insert a card into the chat transcript from frontend code, without a tool call and without adding to the conversation.
+---
+
+## What is this?
+
+Sometimes your application, not your agent, has something to show in the chat.
+A background job finishes, a websocket pushes an alert, or the user clicks a
+button. You want a card in the transcript, but there is no agent turn to hang it
+on, and you do not want to add a fake message to the conversation.
+
+Activity messages solve this. An activity message is a message with
+`role: "activity"`. It renders in the transcript like any other message, and it
+is stripped from the payload sent to your agent on every run. The agent and the
+model never see it.
+
+## When should I use this?
+
+Use a frontend-driven card when:
+
+- A frontend event, not the agent, is the source of the card.
+- The card must not become part of the conversation the model reads.
+- Session-only is acceptable. The card is not persisted with the thread.
+
+Use [tool-based generative UI](/generative-ui/tool-based) instead when the
+agent decides to show the card, or when the card must survive a page reload.
+
+## How it works in code
+
+### 1. Write the renderer
+
+A renderer pairs an `activityType` with a component and a schema for the card's
+content.
+
+```tsx title="app/event-card.tsx"
+import { z } from "zod";
+import type { ReactActivityMessageRenderer } from "@copilotkit/react-core/v2";
+
+const contentSchema = z.object({
+  title: z.string(),
+  detail: z.string().optional(),
+});
+
+export const eventCardRenderer: ReactActivityMessageRenderer<
+  z.infer<typeof contentSchema>
+> = {
+  activityType: "app-event-card", // [!code highlight]
+  content: contentSchema,
+  render: ({ content }) => (
+    <div className="rounded-lg border p-4">
+      <strong>{content.title}</strong>
+      {content.detail ? <p>{content.detail}</p> : null}
+    </div>
+  ),
+};
+```
+
+### 2. Register it on the provider
+
+```tsx title="app/page.tsx"
+import { CopilotKit, CopilotChat } from "@copilotkit/react-core/v2";
+import { eventCardRenderer } from "./event-card";
+
+export default function Page() {
+  return (
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      renderActivityMessages={[eventCardRenderer]} // [!code highlight]
+    >
+      <CopilotChat />
+    </CopilotKit>
+  );
+}
+```
+
+### 3. Add the card from frontend code
+
+Get the live agent with `useAgent()`, then call `addMessage` with
+`role: "activity"`.
+
+```tsx title="app/deployment-watcher.tsx"
+import { useEffect } from "react";
+import { useAgent } from "@copilotkit/react-core/v2";
+
+export function DeploymentWatcher() {
+  const { agent } = useAgent();
+
+  useEffect(() => {
+    const socket = new WebSocket("wss://example.com/deployments");
+    socket.onmessage = (event) => {
+      const deployment = JSON.parse(event.data);
+      agent.addMessage({
+        id: crypto.randomUUID(),
+        role: "activity", // [!code highlight]
+        activityType: "app-event-card",
+        content: { title: "Deployment finished", detail: deployment.sha },
+      });
+    };
+    return () => socket.close();
+  }, [agent]);
+
+  return null;
+}
+```
+
+<Callout type="warn">
+  Use the agent returned by `useAgent()`. An agent instance you construct and
+  hold yourself is not the instance the chat renders, so messages added to it
+  never appear.
+</Callout>
+
+The same works inside an `agent.subscribe` handler, a button `onClick`, or any
+other frontend code that can reach the agent.
+
+## What the agent receives
+
+Activity messages stay in `agent.messages` so the transcript renders them, and
+`prepareRunAgentInput` removes them before the run payload leaves the browser.
+
+Given a transcript of one user message and one card:
+
+| Where | Roles present |
+| --- | --- |
+| `agent.messages` (what the chat renders) | `user`, `activity` |
+| Run payload (what your agent receives) | `user` |
+
+A `MESSAGES_SNAPSHOT` from the backend does not remove your card either. The
+snapshot merge preserves activity messages, so a card added in the browser
+survives a server-side history replay.
+
+## Limitations
+
+- **Not persisted.** The card never reaches the backend, so it is gone after a
+  reload. If you need the card to come back, emit it from the agent as an
+  activity event instead.
+- **One renderer per activity type.** Register a renderer whose `activityType`
+  matches, or use `"*"` as a wildcard. An activity message with no matching
+  renderer renders nothing.

--- a/showcase/shell-docs/src/content/docs/generative-ui/meta.json
+++ b/showcase/shell-docs/src/content/docs/generative-ui/meta.json
@@ -9,6 +9,12 @@
       "pages": ["tool-based", "tool-rendering", "state-rendering"]
     },
     {
+      "title": "Frontend-Driven",
+      "icon": "lucide/MousePointerClick",
+      "defaultOpen": true,
+      "pages": ["frontend-cards"]
+    },
+    {
       "title": "Declarative",
       "icon": "lucide/FileJson",
       "defaultOpen": true,


### PR DESCRIPTION
## What

Issue #3388 asked for a way to put a card into the chat transcript from frontend code, without a tool call and without adding to the conversation the model reads.

**That already ships.** A message with `role: "activity"` renders standalone in the transcript, and `AbstractAgent.prepareRunAgentInput` strips every activity message from the run payload:

```js
prepareRunAgentInput(e) {
  let t = structuredClone_(this.messages).filter(e => e.role !== `activity`);
  ...
}
```

The gap was documentation. `renderActivityMessages` is only documented for **backend-emitted** activities (mastra background-tasks, a2a, mcp-apps), so the frontend-driven path was undiscoverable.

This PR adds the missing guide page and a test that pins the behavior.

## Changes

| File | Why |
| --- | --- |
| `showcase/shell-docs/.../generative-ui/frontend-cards.mdx` | New "Frontend-Driven Cards" guide |
| `showcase/shell-docs/.../generative-ui/meta.json` | Sidebar entry (6-line insertion) |
| `packages/react-core/.../CopilotChatFrontendActivityCard.e2e.test.tsx` | Pins both halves of the contract |

No source changes. Behavior is unchanged; this documents and locks what already works.

## The non-obvious part

The card must be added via the agent returned by `useAgent()`. An agent instance constructed and held outside React is **not** the instance the chat renders, so messages added to it silently never appear. This cost me a debugging round while verifying, and it is called out as a warning callout in the docs.

## Testing

**1. New test passes against clean `origin/main`** (run in a worktree at `96cf7aa55f`, with `@copilotkit/shared` and `@copilotkit/core` rebuilt from the worktree so the test is not reading a stale dist):

```
✓ src/v2/components/chat/__tests__/CopilotChatFrontendActivityCard.e2e.test.tsx (2 tests) 72ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**2. Mutation-checked, so neither assertion is self-fulfilling.**

Drop the renderer registration → the render test fails:
```
× renders a card added from frontend code, with no tool call 1068ms
      Tests  1 failed | 1 passed (2)
```

Swap the card from `role: "activity"` to `role: "assistant"` → it reappears in the payload, so the exclusion is real and specific to `activity`:
```
AssertionError: expected [ 'user', 'assistant' ] to deeply equal [ 'user' ]
```

**3. Neighboring test unaffected on the same base:**

```
✓ src/v2/components/chat/__tests__/CopilotChatMessageView.test.tsx (16 tests) 53ms
      Tests  16 passed (16)
```

**4. Independent probe of the filter** against the pinned `@ag-ui/client` 0.0.57:

```
agent.messages roles: [ 'user', 'activity' ]
run input roles     : [ 'user' ]
```

**5. `tsc --noEmit`** — zero errors in the new file. Remaining errors in this workspace are in files this PR does not touch (`MCPAppsActivityRenderer.tsx`, `CopilotKitInspector.tsx`) and are artifacts of a hand-assembled local `node_modules`; CI has the real install.

**6. `oxfmt --check`** — clean.

**7. Docs checks** — `meta.json` validated as JSON; internal link uses the house `/generative-ui/...` form (no `/docs` prefix); `Callout type="warn"` matches the dominant existing usage; import paths verified against the real `@copilotkit/react-core/v2` barrel exports.

## Follow-up

Leaving #3388 open until this lands, then closing it with a pointer to the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for frontend-driven activity cards that render in chat transcripts without being sent to the agent or language model.
  - Added documentation covering activity card renderers, schemas, registration, payload filtering, snapshots, and limitations.
  - Added a new “Frontend-Driven” section to the Generative UI documentation navigation.

- **Tests**
  - Added end-to-end coverage for activity card rendering and payload exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->