### PR TITLE
feat(react-core): controlled open/onOpenChange props for CopilotSidebar and CopilotPopup

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotPopup.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopup.tsx
@@ -8,6 +8,7 @@ import type { CopilotChatViewProps } from "./CopilotChatView";
 import CopilotChatView from "./CopilotChatView";
 import type { CopilotPopupViewProps } from "./CopilotPopupView";
 import CopilotPopupView from "./CopilotPopupView";
+import { ModalOpenControlProvider } from "./modal-open-control";
 
 /**
  * Carries the popup shell props (header, toggle, width, height, …) to the
@@ -74,6 +75,19 @@ export type CopilotPopupProps = Omit<CopilotChatProps, "chatView"> & {
   header?: CopilotPopupViewProps["header"];
   toggleButton?: CopilotPopupViewProps["toggleButton"];
   defaultOpen?: boolean;
+  /**
+   * Controlled open state. When supplied, the host owns whether the popup is
+   * open: the popup renders this value and never changes it on its own. Pair it
+   * with `onOpenChange` to react to the toggle button and to click-outside.
+   * Omit it (and use `defaultOpen`) to let the popup manage its own state.
+   */
+  open?: boolean;
+  /**
+   * Called with the requested state whenever the popup asks to open or close
+   * (the toggle button, click-outside, or the thread drawer on mobile). In
+   * controlled mode nothing moves until the host updates `open`.
+   */
+  onOpenChange?: (open: boolean) => void;
   width?: CopilotPopupViewProps["width"];
   height?: CopilotPopupViewProps["height"];
   clickOutsideToClose?: CopilotPopupViewProps["clickOutsideToClose"];
@@ -83,6 +97,8 @@ export function CopilotPopup({
   header,
   toggleButton,
   defaultOpen,
+  open,
+  onOpenChange,
   width,
   height,
   clickOutsideToClose,
@@ -115,12 +131,14 @@ export function CopilotPopup({
     <>
       {!isPopupLicensed && <InlineFeatureWarning featureName="Popup" />}
       <PopupShellPropsContext.Provider value={shellProps}>
-        <CopilotChat
-          welcomeScreen={CopilotPopupView.WelcomeScreen}
-          {...chatProps}
-          isModalDefaultOpen={defaultOpen}
-          chatView={PopupViewOverrideWithStatics}
-        />
+        <ModalOpenControlProvider open={open} onOpenChange={onOpenChange}>
+          <CopilotChat
+            welcomeScreen={CopilotPopupView.WelcomeScreen}
+            {...chatProps}
+            isModalDefaultOpen={defaultOpen}
+            chatView={PopupViewOverrideWithStatics}
+          />
+        </ModalOpenControlProvider>
       </PopupShellPropsContext.Provider>
     </>
   );

--- a/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotPopupView.tsx
@@ -1,17 +1,21 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import CopilotChatView, {
+import type {
   CopilotChatViewProps,
   WelcomeScreenProps,
 } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
 import CopilotChatToggleButton from "./CopilotChatToggleButton";
 import { CopilotModalHeader } from "./CopilotModalHeader";
 import { cn } from "../../lib/utils";
-import { renderSlot, SlotValue } from "../../lib/slots";
+import type { SlotValue } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 import {
+  ControlledModalOpenScope,
   CopilotChatConfigurationProvider,
   CopilotChatDefaultLabels,
   useCopilotChatConfiguration,
 } from "../../providers/CopilotChatConfigurationProvider";
+import { useModalOpenControl } from "./modal-open-control";
 
 const DEFAULT_POPUP_WIDTH = 420;
 const DEFAULT_POPUP_HEIGHT = 560;
@@ -50,17 +54,37 @@ export function CopilotPopupView({
   className,
   ...restProps
 }: CopilotPopupViewProps) {
+  // Controlled open state supplied by `<CopilotPopup open onOpenChange>`.
+  const { open, onOpenChange } = useModalOpenControl();
+  // The scope is needed for either half: `open` pins the state, and
+  // `onOpenChange` reports requests even while the popup manages itself.
+  const hasOpenControl = open !== undefined || onOpenChange !== undefined;
+
+  const internal = (
+    <CopilotPopupViewInternal
+      header={header}
+      toggleButton={toggleButton}
+      width={width}
+      height={height}
+      clickOutsideToClose={clickOutsideToClose}
+      className={className}
+      {...restProps}
+    />
+  );
+
   return (
-    <CopilotChatConfigurationProvider isModalDefaultOpen={defaultOpen}>
-      <CopilotPopupViewInternal
-        header={header}
-        toggleButton={toggleButton}
-        width={width}
-        height={height}
-        clickOutsideToClose={clickOutsideToClose}
-        className={className}
-        {...restProps}
-      />
+    // Seed the underlying uncontrolled state from `open` so it starts aligned
+    // with the host. The scope below is what the surface actually renders, so
+    // this only matters if the host later drops `open` and hands control back:
+    // the popup then stays where it was instead of jumping to `defaultOpen`.
+    <CopilotChatConfigurationProvider isModalDefaultOpen={open ?? defaultOpen}>
+      {hasOpenControl ? (
+        <ControlledModalOpenScope open={open} onOpenChange={onOpenChange}>
+          {internal}
+        </ControlledModalOpenScope>
+      ) : (
+        internal
+      )}
     </CopilotChatConfigurationProvider>
   );
 }

--- a/packages/react-core/src/v2/components/chat/CopilotSidebar.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotSidebar.tsx
@@ -2,17 +2,31 @@ import React, { useEffect, useMemo } from "react";
 import { useLicenseContext } from "../../providers/CopilotKitProvider";
 import { InlineFeatureWarning } from "../license-warning-banner";
 
-import { CopilotChat, CopilotChatProps } from "./CopilotChat";
-import CopilotChatView, { CopilotChatViewProps } from "./CopilotChatView";
-import {
-  CopilotSidebarView,
-  CopilotSidebarViewProps,
-} from "./CopilotSidebarView";
+import type { CopilotChatProps } from "./CopilotChat";
+import { CopilotChat } from "./CopilotChat";
+import type { CopilotChatViewProps } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
+import type { CopilotSidebarViewProps } from "./CopilotSidebarView";
+import { CopilotSidebarView } from "./CopilotSidebarView";
+import { ModalOpenControlProvider } from "./modal-open-control";
 
 export type CopilotSidebarProps = Omit<CopilotChatProps, "chatView"> & {
   header?: CopilotSidebarViewProps["header"];
   toggleButton?: CopilotSidebarViewProps["toggleButton"];
   defaultOpen?: boolean;
+  /**
+   * Controlled open state. When supplied, the host owns whether the sidebar is
+   * open: the sidebar renders this value and never changes it on its own.
+   * Pair it with `onOpenChange` to react to the toggle button. Omit it (and use
+   * `defaultOpen`) to let the sidebar manage its own state.
+   */
+  open?: boolean;
+  /**
+   * Called with the requested state whenever the sidebar asks to open or close
+   * (the toggle button, or the thread drawer on mobile). In controlled mode
+   * nothing moves until the host updates `open`.
+   */
+  onOpenChange?: (open: boolean) => void;
   width?: number | string;
   position?: CopilotSidebarViewProps["position"];
 };
@@ -21,6 +35,8 @@ export function CopilotSidebar({
   header,
   toggleButton,
   defaultOpen,
+  open,
+  onOpenChange,
   width,
   position,
   ...chatProps
@@ -65,12 +81,20 @@ export function CopilotSidebar({
   return (
     <>
       {!isSidebarLicensed && <InlineFeatureWarning featureName="Sidebar" />}
-      <CopilotChat
-        welcomeScreen={CopilotSidebarView.WelcomeScreen}
-        {...chatProps}
-        isModalDefaultOpen={defaultOpen}
-        chatView={SidebarViewOverride}
-      />
+      {/*
+        `open` / `onOpenChange` travel by context, not through
+        SidebarViewOverride. The override is memoized on its own props, so a
+        changing `open` would mint a new component identity on every toggle and
+        remount the whole chat subtree.
+      */}
+      <ModalOpenControlProvider open={open} onOpenChange={onOpenChange}>
+        <CopilotChat
+          welcomeScreen={CopilotSidebarView.WelcomeScreen}
+          {...chatProps}
+          isModalDefaultOpen={defaultOpen}
+          chatView={SidebarViewOverride}
+        />
+      </ModalOpenControlProvider>
     </>
   );
 }

--- a/packages/react-core/src/v2/components/chat/CopilotSidebarView.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotSidebarView.tsx
@@ -1,17 +1,21 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 
-import CopilotChatView, {
+import type {
   CopilotChatViewProps,
   WelcomeScreenProps,
 } from "./CopilotChatView";
+import CopilotChatView from "./CopilotChatView";
 import {
+  ControlledModalOpenScope,
   CopilotChatConfigurationProvider,
   useCopilotChatConfiguration,
 } from "../../providers/CopilotChatConfigurationProvider";
+import { useModalOpenControl } from "./modal-open-control";
 import CopilotChatToggleButton from "./CopilotChatToggleButton";
 import { cn } from "../../lib/utils";
 import { CopilotModalHeader } from "./CopilotModalHeader";
-import { renderSlot, SlotValue } from "../../lib/slots";
+import type { SlotValue } from "../../lib/slots";
+import { renderSlot } from "../../lib/slots";
 
 const DEFAULT_SIDEBAR_WIDTH = 480;
 const SIDEBAR_TRANSITION_MS = 260;
@@ -32,15 +36,35 @@ export function CopilotSidebarView({
   position = "right",
   ...props
 }: CopilotSidebarViewProps) {
+  // Controlled open state supplied by `<CopilotSidebar open onOpenChange>`.
+  const { open, onOpenChange } = useModalOpenControl();
+  // The scope is needed for either half: `open` pins the state, and
+  // `onOpenChange` reports requests even while the sidebar manages itself.
+  const hasOpenControl = open !== undefined || onOpenChange !== undefined;
+
+  const internal = (
+    <CopilotSidebarViewInternal
+      header={header}
+      toggleButton={toggleButton}
+      width={width}
+      position={position}
+      {...props}
+    />
+  );
+
   return (
-    <CopilotChatConfigurationProvider isModalDefaultOpen={defaultOpen}>
-      <CopilotSidebarViewInternal
-        header={header}
-        toggleButton={toggleButton}
-        width={width}
-        position={position}
-        {...props}
-      />
+    // Seed the underlying uncontrolled state from `open` so it starts aligned
+    // with the host. The scope below is what the surface actually renders, so
+    // this only matters if the host later drops `open` and hands control back:
+    // the sidebar then stays where it was instead of jumping to `defaultOpen`.
+    <CopilotChatConfigurationProvider isModalDefaultOpen={open ?? defaultOpen}>
+      {hasOpenControl ? (
+        <ControlledModalOpenScope open={open} onOpenChange={onOpenChange}>
+          {internal}
+        </ControlledModalOpenScope>
+      ) : (
+        internal
+      )}
     </CopilotChatConfigurationProvider>
   );
 }
@@ -181,7 +205,7 @@ function CopilotSidebarViewInternal({
         style={
           {
             // Use CSS custom property for responsive width
-            ["--sidebar-width" as string]: widthToCss(sidebarWidth),
+            "--sidebar-width": widthToCss(sidebarWidth),
             // Safe area insets for iOS
             paddingTop: "env(safe-area-inset-top)",
             paddingBottom: "env(safe-area-inset-bottom)",

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotSidebar.controlledOpen.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotSidebar.controlledOpen.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * `<CopilotSidebar>` / `<CopilotPopup>` controlled open state (issue #3334).
+ *
+ * v1 exposed `open` + `onSetOpen`, so a host could open and close the chat from
+ * its own UI. v2 shipped only `defaultOpen`, which made the open state
+ * reachable exclusively from inside the chat subtree. These tests cover the
+ * restored controlled contract:
+ *
+ * - `open` is rendered from the first frame (no open-then-close flash).
+ * - A request from inside (toggle button) is reported through `onOpenChange`
+ *   and does NOT move the surface on its own.
+ * - The uncontrolled `defaultOpen` path is unchanged.
+ * - Flipping `open` does not remount the chat subtree (the element-type churn
+ *   trap already fixed for popup resize; see CopilotPopup.resizeRemount).
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { CopilotKitProvider } from "../../../providers/CopilotKitProvider";
+import { CopilotSidebar } from "../CopilotSidebar";
+import { CopilotPopup } from "../CopilotPopup";
+import { MockStepwiseAgent } from "../../../__tests__/utils/test-helpers";
+import type CopilotChatInput from "../CopilotChatInput";
+import type { CopilotChatInputProps } from "../CopilotChatInput";
+
+function getSidebar(container: HTMLElement): Element {
+  const sidebar = container.querySelector("[data-copilot-sidebar]");
+  if (!sidebar) throw new Error("sidebar aside not found");
+  return sidebar;
+}
+
+function isSurfaceOpen(element: Element): boolean {
+  return element.getAttribute("aria-hidden") !== "true";
+}
+
+// The popup mounts its window only while open, so "closed" is absence.
+function isPopupRendered(container: HTMLElement): boolean {
+  return container.querySelector('[data-testid="copilot-popup"]') !== null;
+}
+
+function clickToggle(): void {
+  fireEvent.click(screen.getByTestId("copilot-chat-toggle"));
+}
+
+type SidebarHarnessProps = {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  defaultOpen?: boolean;
+  input?: React.ComponentType<CopilotChatInputProps>;
+};
+
+function SidebarHarness({
+  open,
+  onOpenChange,
+  defaultOpen,
+  input,
+}: SidebarHarnessProps) {
+  const agent = React.useMemo(() => new MockStepwiseAgent(), []);
+  return (
+    <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+      <CopilotSidebar
+        open={open}
+        onOpenChange={onOpenChange}
+        defaultOpen={defaultOpen}
+        input={input as unknown as typeof CopilotChatInput}
+      />
+    </CopilotKitProvider>
+  );
+}
+
+describe("CopilotSidebar controlled open state (#3334)", () => {
+  it("renders closed on the first frame when open={false}", () => {
+    const { container } = render(<SidebarHarness open={false} />);
+
+    // Asserted on the first committed frame: a fix that opened first and
+    // corrected afterwards would leave a visible flash.
+    expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+  });
+
+  it("renders open when open={true}", () => {
+    const { container } = render(<SidebarHarness open={true} />);
+
+    expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+  });
+
+  it("opens and closes as the host flips open", () => {
+    const { container, rerender } = render(<SidebarHarness open={false} />);
+    expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+
+    rerender(<SidebarHarness open={true} />);
+    expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+
+    rerender(<SidebarHarness open={false} />);
+    expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+  });
+
+  it("reports a toggle request through onOpenChange without moving on its own", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <SidebarHarness open={false} onOpenChange={onOpenChange} />,
+    );
+
+    clickToggle();
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    // Controlled contract: the host ignored the request, so nothing moved.
+    expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+  });
+
+  it("reports a close request through onOpenChange while staying open", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <SidebarHarness open={true} onOpenChange={onOpenChange} />,
+    );
+
+    clickToggle();
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+  });
+
+  it("drives the surface when the host echoes onOpenChange back into open", () => {
+    function ControlledHost() {
+      const [open, setOpen] = React.useState(false);
+      const agent = React.useMemo(() => new MockStepwiseAgent(), []);
+      return (
+        <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+          <button data-testid="host-open" onClick={() => setOpen(true)}>
+            open
+          </button>
+          <CopilotSidebar open={open} onOpenChange={setOpen} />
+        </CopilotKitProvider>
+      );
+    }
+
+    const { container } = render(<ControlledHost />);
+    expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+
+    // A button OUTSIDE the sidebar drives it: the case reported in #3334.
+    fireEvent.click(screen.getByTestId("host-open"));
+    expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+
+    // And the built-in toggle closes it through the same state.
+    clickToggle();
+    expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+  });
+
+  describe("uncontrolled path is unchanged", () => {
+    it("honors defaultOpen={false} and still toggles from inside", () => {
+      const { container } = render(<SidebarHarness defaultOpen={false} />);
+      expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+
+      clickToggle();
+      expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+    });
+
+    it("defaults to open when neither open nor defaultOpen is given", () => {
+      const { container } = render(<SidebarHarness />);
+      expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+    });
+
+    it("stays put when the host stops controlling open", () => {
+      const { container, rerender } = render(<SidebarHarness open={false} />);
+      expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+
+      // Handing control back must not jump to defaultOpen (which is `true`):
+      // the underlying state was seeded from `open`.
+      rerender(<SidebarHarness />);
+      expect(isSurfaceOpen(getSidebar(container))).toBe(false);
+    });
+
+    it("reports through onOpenChange and still moves when open is omitted", () => {
+      const onOpenChange = vi.fn();
+      const { container } = render(
+        <SidebarHarness defaultOpen={false} onOpenChange={onOpenChange} />,
+      );
+
+      clickToggle();
+
+      // onOpenChange alone is a notification, not a takeover: the sidebar
+      // still owns its state, so it moved.
+      expect(onOpenChange).toHaveBeenCalledTimes(1);
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+      expect(isSurfaceOpen(getSidebar(container))).toBe(true);
+    });
+  });
+});
+
+// Counts MOUNTS (not renders) of a component inside the chat subtree.
+let inputMountCount = 0;
+function MountCountingInput(_props: CopilotChatInputProps) {
+  React.useEffect(() => {
+    inputMountCount++;
+  }, []);
+  return <div data-testid="mount-probe" />;
+}
+
+describe("CopilotSidebar open changes do not remount the chat subtree", () => {
+  beforeEach(() => {
+    inputMountCount = 0;
+  });
+
+  it("keeps the chat subtree mounted across open flips", async () => {
+    const { rerender } = render(
+      <SidebarHarness open={true} input={MountCountingInput} />,
+    );
+
+    expect(await screen.findByTestId("mount-probe")).toBeTruthy();
+    expect(inputMountCount).toBe(1);
+
+    rerender(<SidebarHarness open={false} input={MountCountingInput} />);
+    rerender(<SidebarHarness open={true} input={MountCountingInput} />);
+    rerender(<SidebarHarness open={false} input={MountCountingInput} />);
+
+    // Threading `open` through the memoized chatView override would mint a new
+    // element type per flip and remount the subtree, resetting scroll state.
+    expect(inputMountCount).toBe(1);
+  });
+});
+
+describe("CopilotPopup controlled open state (#3334)", () => {
+  function PopupHarness({
+    open,
+    onOpenChange,
+  }: {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) {
+    const agent = React.useMemo(() => new MockStepwiseAgent(), []);
+    return (
+      <CopilotKitProvider agents__unsafe_dev_only={{ default: agent }}>
+        <CopilotPopup open={open} onOpenChange={onOpenChange} />
+      </CopilotKitProvider>
+    );
+  }
+
+  it("renders closed on the first frame when open={false}", () => {
+    const { container } = render(<PopupHarness open={false} />);
+
+    expect(isPopupRendered(container)).toBe(false);
+  });
+
+  it("renders open when open={true}", () => {
+    const { container } = render(<PopupHarness open={true} />);
+
+    expect(isPopupRendered(container)).toBe(true);
+  });
+
+  it("defaults to open when neither open nor defaultOpen is given", () => {
+    const { container } = render(<PopupHarness />);
+
+    expect(isPopupRendered(container)).toBe(true);
+  });
+
+  it("reports a toggle request through onOpenChange without moving on its own", () => {
+    const onOpenChange = vi.fn();
+    const { container } = render(
+      <PopupHarness open={false} onOpenChange={onOpenChange} />,
+    );
+
+    clickToggle();
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(isPopupRendered(container)).toBe(false);
+  });
+});

--- a/packages/react-core/src/v2/components/chat/modal-open-control.tsx
+++ b/packages/react-core/src/v2/components/chat/modal-open-control.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useMemo } from "react";
+
+/**
+ * The host-supplied controlled open state for a prebuilt modal surface
+ * (`<CopilotSidebar>`, `<CopilotPopup>`).
+ */
+export interface ModalOpenControl {
+  /** Controlled open state. `undefined` leaves the surface uncontrolled. */
+  open?: boolean;
+  /** Called with the requested state when the surface asks to open or close. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+const ModalOpenControlContext = createContext<ModalOpenControl>({});
+
+export interface ModalOpenControlProviderProps extends ModalOpenControl {
+  children: React.ReactNode;
+}
+
+/**
+ * Carries `open` / `onOpenChange` from a prebuilt surface down to the view that
+ * owns the modal state.
+ *
+ * A context is required rather than plain props because `<CopilotSidebar>`
+ * hands its view to `<CopilotChat>` as a `chatView` **component**. Threading a
+ * value that changes (like `open`) through that component's identity would mint
+ * a new element type on every toggle, and React unmounts and remounts the whole
+ * chat subtree when the element type changes. That is the remount class of bug
+ * already fixed for `<CopilotPopup>` on resize. Context keeps the override
+ * identity stable while still re-rendering the view when `open` changes.
+ */
+export function ModalOpenControlProvider({
+  open,
+  onOpenChange,
+  children,
+}: ModalOpenControlProviderProps) {
+  const value = useMemo<ModalOpenControl>(
+    () => ({ open, onOpenChange }),
+    [open, onOpenChange],
+  );
+
+  return (
+    <ModalOpenControlContext.Provider value={value}>
+      {children}
+    </ModalOpenControlContext.Provider>
+  );
+}
+
+/**
+ * Reads the controlled open state supplied by the surrounding prebuilt
+ * surface. Returns an empty control (uncontrolled) when there is none.
+ *
+ * @returns The host's `open` / `onOpenChange` pair.
+ */
+export function useModalOpenControl(): ModalOpenControl {
+  return useContext(ModalOpenControlContext);
+}

--- a/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotChatConfigurationProvider.tsx
@@ -515,3 +515,96 @@ export const useCopilotChatConfiguration =
     const configuration = useContext(CopilotChatConfiguration);
     return configuration;
   };
+
+/**
+ * Props for {@link ControlledModalOpenScope}.
+ */
+export interface ControlledModalOpenScopeProps {
+  children: ReactNode;
+  /**
+   * The host-owned open state. When this is a boolean, everything inside the
+   * scope reads it as `isModalOpen`, so the host prop is the single source of
+   * truth for what is on screen. Leave it `undefined` to keep the underlying
+   * state in charge and only report requests through `onOpenChange`.
+   */
+  open?: boolean;
+  /**
+   * Called with the requested state whenever something inside the scope asks
+   * to open or close the modal (the toggle button, click-outside, a consumer
+   * calling `setModalOpen`). Fires whether or not `open` is supplied.
+   */
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * Reports modal open/close requests to the host, and — when `open` is
+ * supplied — makes the modal state of an already-established chat
+ * configuration **controlled** for the subtree it wraps.
+ *
+ * This is deliberately a scope component rather than another mode inside
+ * {@link CopilotChatConfigurationProvider}. The provider resolves modal state
+ * across a nested chain (own state, parent sync, drawer mutual-exclusion, the
+ * modal-closer registry); a controlled branch inside that resolution would add
+ * a fourth interacting mode. Overriding the context for the subtree instead
+ * leaves every one of those paths untouched:
+ *
+ * - `isModalOpen` is replaced with the host's `open`, so the rendered surface
+ *   follows the prop from the very first frame (no open-then-close flash).
+ * - `setModalOpen` still calls the underlying setter, so the existing
+ *   parent-sync and drawer mutual-exclusion side effects continue to run, and
+ *   *then* reports the request through `onOpenChange`.
+ * - The wrapped setter is registered as the modal closer, so the drawer's
+ *   mobile mutual-exclusion reaches the host instead of silently flipping
+ *   state that nothing displays.
+ *
+ * A host that supplies `open` and ignores `onOpenChange` gets a modal pinned
+ * to `open`, which is the standard controlled-component contract. A host that
+ * supplies only `onOpenChange` is notified while the modal keeps managing
+ * itself.
+ *
+ * Renders `children` unchanged when no chat configuration is in scope.
+ */
+export const ControlledModalOpenScope: React.FC<
+  ControlledModalOpenScopeProps
+> = ({ children, open, onOpenChange }) => {
+  const parentConfig = useContext(CopilotChatConfiguration);
+  const parentSetModalOpen = parentConfig?.setModalOpen;
+  const registerModalCloser = parentConfig?.ɵregisterModalCloser;
+
+  const setModalOpen = useCallback(
+    (next: boolean) => {
+      parentSetModalOpen?.(next);
+      onOpenChange?.(next);
+    },
+    [parentSetModalOpen, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!registerModalCloser) return;
+    return registerModalCloser(setModalOpen);
+  }, [registerModalCloser, setModalOpen]);
+
+  const configurationValue = useMemo(
+    () =>
+      parentConfig
+        ? {
+            ...parentConfig,
+            isModalOpen: open ?? parentConfig.isModalOpen,
+            setModalOpen,
+          }
+        : null,
+    [parentConfig, open, setModalOpen],
+  );
+
+  if (!configurationValue) {
+    return <>{children}</>;
+  }
+
+  return (
+    <CopilotChatConfiguration.Provider value={configurationValue}>
+      {children}
+    </CopilotChatConfiguration.Provider>
+  );
+};
+
+ControlledModalOpenScope.displayName = "ControlledModalOpenScope";

--- a/showcase/shell-docs/src/content/docs/prebuilt-components/chat-controls.mdx
+++ b/showcase/shell-docs/src/content/docs/prebuilt-components/chat-controls.mdx
@@ -7,11 +7,52 @@ description: "Open and close the prebuilt chat from your UI, and capture assista
 Two common controls for the prebuilt chat are opening it from your own UI and
 capturing thumbs-up / thumbs-down feedback on assistant messages.
 
+## Control the open state from your own UI
+
+Pass `open` and `onOpenChange` to `<CopilotSidebar>` or `<CopilotPopup>` to own
+the open state yourself. This is the controlled pattern: the surface renders
+whatever `open` says, and every request to open or close (the toggle button,
+click-outside on the popup) arrives on `onOpenChange` instead of moving the
+surface directly.
+
+```tsx
+import { useState } from "react";
+import { CopilotSidebar } from "@copilotkit/react-core/v2";
+
+function Layout() {
+  const [chatOpen, setChatOpen] = useState(false);
+
+  return (
+    <>
+      <nav>
+        <button onClick={() => setChatOpen(true)}>Ask the assistant</button>
+      </nav>
+
+      <CopilotSidebar open={chatOpen} onOpenChange={setChatOpen} />
+    </>
+  );
+}
+```
+
+The button lives outside the sidebar, which is the point: nothing has to be
+rendered inside the chat subtree to open or close it. Because `open` is the
+source of truth, you can also keep the chat in sync with a route, a keyboard
+shortcut, or any other state you already have.
+
+<Callout type="info">
+`onOpenChange` reports a request, not a change. If you do not feed the new value
+back into `open`, the surface stays where it is. That is what makes it possible
+to gate opening the chat, for example behind a sign-in check. You can also pass
+`onOpenChange` on its own, without `open`: the surface keeps managing itself and
+you are notified each time it opens or closes.
+</Callout>
+
 ## Programmatically open or close the chat
 
-The modal/open state for `<CopilotPopup>` and `<CopilotSidebar>` lives in the
-**chat configuration context**. Read it with `useCopilotChatConfiguration()` and
-call `setModalOpen(true | false)` from anywhere inside the provider:
+If you would rather not lift the state into your own component, the open state
+for `<CopilotPopup>` and `<CopilotSidebar>` also lives in the **chat
+configuration context**. Read it with `useCopilotChatConfiguration()` and call
+`setModalOpen(true | false)` from anywhere inside the provider:
 
 ```tsx
 import { useCopilotChatConfiguration } from "@copilotkit/react-core/v2";
@@ -48,12 +89,16 @@ exists. See the
 [`useCopilotChatConfiguration` reference](/reference/hooks/useCopilotChatConfiguration#modal-state-management).
 </Callout>
 
-You can also set the **initial** open state declaratively. The prebuilt surfaces
-accept a `defaultOpen` prop:
+You can also set the **initial** open state declaratively, and then let the
+surface manage itself. The prebuilt surfaces accept a `defaultOpen` prop:
 
 ```tsx
-<CopilotSidebar defaultOpen />
+<CopilotSidebar defaultOpen={false} />
 ```
+
+`defaultOpen` and `open` are the usual uncontrolled/controlled pair: use
+`defaultOpen` for a starting point, and `open` when your own state decides. When
+both are passed, `open` wins.
 
 ## Capture message feedback (thumbs up / down)
 

--- a/showcase/shell-docs/src/content/reference/components/CopilotPopup.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotPopup.mdx
@@ -26,8 +26,24 @@ import "@copilotkit/react-core/v2/styles.css";
   default header displays a title and a close button.
 </PropertyReference>
 
-<PropertyReference name="defaultOpen" type="boolean" default="false">
-  Whether the popup should be open when the component first mounts.
+<PropertyReference name="defaultOpen" type="boolean" default="true">
+  Whether the popup is open when the component first mounts. After that the
+  popup owns the state. Use `open` instead to keep control.
+</PropertyReference>
+
+<PropertyReference name="open" type="boolean">
+  Controlled open state. When supplied, your component owns whether the popup is
+  open: the popup renders this value and never changes it on its own. Pair it
+  with `onOpenChange`. When both `open` and `defaultOpen` are passed, `open`
+  wins. See [Open, close, and
+  feedback](/prebuilt-components/chat-controls).
+</PropertyReference>
+
+<PropertyReference name="onOpenChange" type="(open: boolean) => void">
+  Called with the requested state whenever the popup asks to open or close (the
+  toggle button, click-outside, Escape, or the thread drawer on mobile). It
+  reports a request, not a change: in controlled mode nothing moves until you
+  update `open`.
 </PropertyReference>
 
 <PropertyReference name="width" type="number | string">
@@ -133,7 +149,7 @@ function App() {
 ## Behavior
 
 - **Toggle button**: Renders a floating toggle button (typically in the bottom-right corner) that opens and closes the popup. The button uses `CopilotChatToggleButton` internally.
-- **Modal state**: Open/close state is managed via the chat configuration context. The `defaultOpen` prop sets the initial state; after that, state changes come from user interaction (toggle button, close button, clicking outside).
+- **Modal state**: Open/close state is managed via the chat configuration context. The `defaultOpen` prop sets the initial state; after that, state changes come from user interaction (toggle button, close button, clicking outside). Pass `open` and `onOpenChange` to own the state yourself, and to open or close the popup from your own UI.
 - **Click outside**: When `clickOutsideToClose` is `true` (the default), clicking anywhere outside the popup panel closes it.
 - **Layout**: The popup uses `CopilotPopupView` internally, which provides a popup-specific welcome screen layout with the welcome message centered vertically and suggestions just above the input.
 - **Agent connection**: All agent wiring (messages, running state, suggestions) is handled by the parent `CopilotChat` logic.

--- a/showcase/shell-docs/src/content/reference/components/CopilotSidebar.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotSidebar.mdx
@@ -26,8 +26,23 @@ import "@copilotkit/react-core/v2/styles.css";
   default header displays a title and a close button.
 </PropertyReference>
 
-<PropertyReference name="defaultOpen" type="boolean" default="false">
-  Whether the sidebar should be open when the component first mounts.
+<PropertyReference name="defaultOpen" type="boolean" default="true">
+  Whether the sidebar is open when the component first mounts. After that the
+  sidebar owns the state. Use `open` instead to keep control.
+</PropertyReference>
+
+<PropertyReference name="open" type="boolean">
+  Controlled open state. When supplied, your component owns whether the sidebar
+  is open: the sidebar renders this value and never changes it on its own. Pair
+  it with `onOpenChange`. When both `open` and `defaultOpen` are passed, `open`
+  wins. See [Open, close, and
+  feedback](/prebuilt-components/chat-controls).
+</PropertyReference>
+
+<PropertyReference name="onOpenChange" type="(open: boolean) => void">
+  Called with the requested state whenever the sidebar asks to open or close
+  (the toggle button, or the thread drawer on mobile). It reports a request, not
+  a change: in controlled mode nothing moves until you update `open`.
 </PropertyReference>
 
 <PropertyReference name="width" type="number | string">
@@ -118,7 +133,7 @@ function App() {
 ## Behavior
 
 - **Toggle button**: Renders a floating toggle button that opens and closes the sidebar. The button uses `CopilotChatToggleButton` internally.
-- **Modal state**: Open/close state is managed via the chat configuration context. The `defaultOpen` prop sets the initial state; after that, state changes come from user interaction (toggle button, close button in the header).
+- **Modal state**: Open/close state is managed via the chat configuration context. The `defaultOpen` prop sets the initial state; after that, state changes come from user interaction (toggle button, close button in the header). Pass `open` and `onOpenChange` to own the state yourself, and to open or close the sidebar from your own UI.
 - **Layout**: The sidebar uses `CopilotSidebarView` internally, which provides a sidebar-specific welcome screen layout with suggestions at the top, the welcome message in the middle, and the input fixed at the bottom.
 - **Fixed positioning**: The sidebar renders as a fixed panel on one side of the viewport, pushing or overlaying content depending on CSS.
 - **Agent connection**: All agent wiring (messages, running state, suggestions) is handled by the parent `CopilotChat` logic.


### PR DESCRIPTION
Closes #3334 (OSS-524).

## Problem

v1 `<CopilotSidebar>` exposed `open` and `onSetOpen`. Those props let a host open and close the chat from its own UI. v2 shipped only `defaultOpen`. The reporter wanted a button in their own nav bar to close the sidebar.

The reporter's stated root cause is now stale. `shouldCreateModalState` no longer exists. Since CPK-7152 the provider syncs both directions: `setAndSync` upward, and an effect downward. A host that wraps its layout in `<CopilotChatConfigurationProvider>` and calls `setModalOpen` therefore does drive the sidebar on current `main`. I verified that before writing any code.

Two things are genuinely missing. The first is the ergonomic API that v1 had. The second is documentation for the outer-provider pattern that already works.

Two earlier community attempts (#3729, #6418) were closed unmerged.

## What changed

`open` and `onOpenChange` on `<CopilotSidebar>` and `<CopilotPopup>`:

- `open` pins what the surface renders, from the first frame.
- `onOpenChange` reports every request to open or close: the toggle button, click-outside, Escape, and the drawer's mobile mutual-exclusion. It fires with or without `open`, so it also works as a plain notification on the uncontrolled path.
- `defaultOpen` is unchanged. If both are passed, `open` wins.

Two design choices are worth review.

**1. A context-overriding scope, not a fourth mode in the provider.** `ControlledModalOpenScope` replaces `isModalOpen` and `setModalOpen` for the subtree below the provider that owns the state. The resolution chain inside `CopilotChatConfigurationProvider` stays untouched: own state, parent sync, drawer mutual-exclusion, and the `ɵregisterModalCloser` stack. The scope's setter still calls the underlying one, so those side effects keep running. It also registers itself as the modal closer, so the drawer's mobile exclusion reaches the host instead of flipping state that nothing displays. The alternative was a controlled branch threaded through `resolvedIsModalOpen`, `setAndSync`, and the sync effect. That adds a fourth interacting mode to the code CPK-7152 just stabilized.

**2. The props reach the views by context, not as props.** `<CopilotSidebar>` hands its view to `<CopilotChat>` as a memoized `chatView` component. Adding `open` to that memo's deps mints a new element type per toggle, and React then remounts the whole chat subtree. That is the same class of bug #6173 fixed for popup resize. There is a regression test for it.

Scope note: I included `<CopilotPopup>` because it shares the mechanism and the same docs page. The issue named only the sidebar.

## Testing

**New suite, 15 tests** (`CopilotSidebar.controlledOpen.test.tsx`). It covers the controlled contract, the unchanged uncontrolled path, and the remount guard.

```
✓ src/v2/components/chat/__tests__/CopilotSidebar.controlledOpen.test.tsx (15 tests) 155ms
  Test Files  1 passed (1)
       Tests  15 passed (15)
```

**Mutation-checked.** I broke each mechanism to confirm that the tests really fail.

| Mutation | Result |
| --- | --- |
| Drop `ControlledModalOpenScope`, keep only the seeded default | 5 failed: both `onOpenChange` reports, both host-driven open/close cases, the popup report |
| Implement through the memoized override instead (add `open` to the `useMemo` deps) | 1 failed: the remount guard, `expected 4 to be 1`, one extra mount per flip |
| Drop the `open ?? defaultOpen` seeding | 1 failed: "stays put when the host stops controlling open" |

I also mutation-checked the pre-existing two-way sync before I started. That confirmed the outer-provider workaround really works on `main`, instead of only appearing to.

**Full `@copilotkit/react-core` suite.** No regressions.

```
Test Files  141 passed | 1 skipped (142)
     Tests  1604 passed | 2 skipped (1606)
EXIT=0
```

**Adjacent suites re-run explicitly**: sidebar position, sidebar and popup slots, popup resize-remount, drawer launcher, and the provider's own 43 tests.

```
Test Files  6 passed (6)
     Tests  117 passed (117)
```

**Typecheck.** `tsc --noEmit` in `packages/react-core` gave `exit=0` with no output. The tsconfig includes `src/**/*`, so the new test file is typechecked too.

**Format and lint.** `oxfmt --check packages/react-core/src/v2` reported "All matched files use the correct format." `oxlint` on the touched files reported 0 errors.

**Pre-commit hooks.** They ran for real on both commits.

```
NX   Successfully ran targets test, publint, attw for 2 projects and 20 tasks they depend on
✔️ test-and-check-packages (15.33 seconds)
```

## Docs

- `prebuilt-components/chat-controls.mdx` now leads with the controlled pair. Its example drives the sidebar from a nav button outside it, which is the shape #3334 asked about. The `useCopilotChatConfiguration` route stays, reframed as the option for callers who prefer not to lift the state.
- `reference/components/CopilotSidebar.mdx` and `CopilotPopup.mdx` gain `open` and `onOpenChange`. Both pages documented `defaultOpen` as `false`, but both surfaces mount open, so I corrected that. A new test per surface pins the real default.

## Not in this PR

- Vue and Angular parity for the same props.
- The `width` prop of `<CopilotSidebar>` still sits in the memo deps of the `chatView` override. A live-resized sidebar therefore remounts the chat subtree, the way the popup did before #6173. That is pre-existing and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controlled open-state support for chat popups and sidebars through `open` and `onOpenChange`.
  - Preserved uncontrolled usage with `defaultOpen`, while allowing externally managed visibility and toggle requests.
  - Improved coordination between modal and mobile drawer behavior.

- **Documentation**
  - Added usage guidance and reference details for controlled and uncontrolled open-state management.

- **Tests**
  - Added coverage for initial visibility, toggle callbacks, controlled updates, default behavior, and preserving the chat subtree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->