### PR TITLE
docs(intelligence): update managed credential guidance

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotThreadsDrawer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotThreadsDrawer.tsx
@@ -207,10 +207,10 @@ function findChatInput(origin: Element | null): HTMLElement | null {
  *   thread-list launcher appears, and binds the element `open` state to the
  *   configuration's `drawerOpen`.
  *
- * License gating is two-pronged: the locked view shows when no license is configured
- * (the runtime reported no license status) OR the `threads` feature is
- * explicitly unlicensed. While unlicensed, the thread fetch is skipped entirely
- * so an unlicensed drawer issues no network requests.
+ * Intelligence gating is two-pronged: the locked view shows when the runtime
+ * reports no active entitlement OR the `threads` feature is unavailable. While
+ * unavailable, the thread fetch is skipped entirely so the drawer issues no
+ * network requests.
  *
  * Thread switching needs no host wiring: when `onThreadSelect`/`onNewThread`
  * are omitted, the wrapper drives the surrounding chat configuration directly
@@ -222,7 +222,7 @@ function findChatInput(origin: Element | null): HTMLElement | null {
  * @example
  * ```tsx
  * // Callback-free: the drawer drives the chat configuration itself.
- * <CopilotKitProvider runtimeUrl="/api/copilotkit" publicLicenseKey="ck_pub_...">
+ * <CopilotKitProvider runtimeUrl="/api/copilotkit">
  *   <CopilotChat />
  *   <CopilotThreadsDrawer />
  * </CopilotKitProvider>

--- a/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
@@ -20,9 +20,9 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
 
 <Steps>
   <Step>
-    ### Create a free account
+    ### Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
   </Step>
 
   <Step>
@@ -40,7 +40,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
       description="Get started quickly with our ready-to-go Agent Spec starter."
     >
       <Step>
-          ### Install the Agent Spec AG‑UI adapter (backend) 
+          ### Install the Agent Spec AG‑UI adapter (backend)
 
           The AG‑UI integration for Agent Spec lives in `ag-ui/integrations/agent-spec/python`. You will need it to activate your agent environment in the starter. Here's how to install it:
 
@@ -90,7 +90,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           uv add pyagentspec[langgraph]
           uv add wayflowcore
           ```
-        
+
       </Step>
       <Step>
           ### Configure your environment
@@ -105,7 +105,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           Reference: Agent Spec docs AG‑UI tutorial at https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html.
       </Step>
       <Step>
-          ### Scaffold the UI 
+          ### Scaffold the UI
 
           Use our starter repo template: https://github.com/CopilotKit/with-agent-spec. It includes an example definition of an Agent Spec agent [here](https://github.com/CopilotKit/with-agent-spec/blob/main/agent/src/agentspec_agent.py). Run the following commands
 
@@ -131,7 +131,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           ```bash
           pnpm install
           ```
-          
+
       </Step>
       <Step>
           ### Run your project
@@ -173,7 +173,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
         <OpenInspectorStep components={props.components} />
     </Step>
 
-      
+
     </TailoredContentOption>
     <TailoredContentOption
       id="bring-your-own"
@@ -252,7 +252,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           cd ag_ui_agentspec
           ```
 
-          create a main.py file in the ag_ui_agentspec directory 
+          create a main.py file in the ag_ui_agentspec directory
 
 
           ```bash
@@ -281,7 +281,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
 
           #OR you can specify your own agent_spec_config like below
           #agent_spec_config = <loaded json/yaml string of your Agent Spec agent>
-          
+
           runtime = "langgraph"  # or "wayflow"
 
           app = FastAPI()

--- a/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
@@ -22,13 +22,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
   <Step>
     ### Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-    ```bash title="Terminal"
-    npx copilotkit@latest project select
-    ```
-
-    The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create or clone it below.
   </Step>
 
   <Step>
@@ -126,7 +120,10 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           ```bash
           git clone https://github.com/CopilotKit/with-agent-spec.git
           cd with-agent-spec
+          npx copilotkit@latest project select
           ```
+
+          `project select` writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`.
 
       </Step>
       <Step>
@@ -353,10 +350,15 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           export const POST = handler;
           ```
 
-          The runtime reads the project API key from step 1. Add it to the app that serves
-          this route:
+          From this frontend app directory, connect the runtime to an Intelligence project:
 
-          ```plaintext title=".env.local"
+          ```bash title="Terminal"
+          npx copilotkit@latest project select
+          ```
+
+          The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+          ```plaintext title=".env"
           CPK_INTELLIGENCE_API_KEY=cpk-...
           ```
 

--- a/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/agent-spec/quickstart.mdx
@@ -22,7 +22,13 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
   <Step>
     ### Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_agent_spec_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+    ```bash title="Terminal"
+    npx copilotkit@latest project select
+    ```
+
+    The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
   </Step>
 
   <Step>

--- a/showcase/shell-docs/src/content/docs/inspector.mdx
+++ b/showcase/shell-docs/src/content/docs/inspector.mdx
@@ -216,12 +216,16 @@ Set `enableInspector` to `false` to hide it during development:
 
 ```tsx
 <CopilotKit
-  publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
+  runtimeUrl="/api/copilotkit"
   enableInspector={false}
 >
   {children}
 </CopilotKit>
 ```
+
+For managed Intelligence, keep `CPK_INTELLIGENCE_API_KEY` on the runtime server.
+The runtime reports Inspector access to the browser; do not expose the project
+API key in a `NEXT_PUBLIC_` environment variable.
 
 An explicit `true` keeps it enabled in development but cannot override the
 production or server-rendering guard.

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_a2a_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_a2a_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you clone it below.
     </Step>
 
     <Step>
@@ -41,7 +35,11 @@ Before you begin, you'll need the following:
 
         ```bash
         git clone https://github.com/copilotkit/with-a2a-a2ui.git
+        cd with-a2a-a2ui
+        npx copilotkit@latest project select
         ```
+
+        `project select` creates or selects an Intelligence project and writes its server-side API key to `.env` as `CPK_INTELLIGENCE_API_KEY`.
     </Step>
     <Step>
         ### Install dependencies

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_a2a_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_a2a_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/a2a/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_a2a_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_a2a_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_adk_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_adk_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_adk_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_adk_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -270,10 +264,15 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                ```
 
-                The runtime reads the project API key from step 1. Add it to the app that serves
-                this route:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/adk/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_adk_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_adk_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
@@ -44,9 +44,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_ag2_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_ag2_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>
@@ -81,7 +81,7 @@ Before you begin, you'll need the following:
     </Step>
     <Step>
         ### Set Up the CopilotKit UI
-        
+
         The last step is to use CopilotKit's UI components to render the chat interaction with your agent.
 
         In a new terminal:

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
@@ -46,13 +46,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_ag2_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_ag2_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you clone it below.
     </Step>
 
     <Step>
@@ -61,7 +55,10 @@ Before you begin, you'll need the following:
         ```bash
         git clone https://github.com/ag2ai/ag2-samples.git
         cd ag2-samples
+        npx copilotkit@latest project select
         ```
+
+        `project select` creates or selects an Intelligence project and writes its server-side API key to `.env` as `CPK_INTELLIGENCE_API_KEY`.
     </Step>
     <Step>
         ### Set Up the AG2 Backend

--- a/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/ag2/quickstart.mdx
@@ -46,7 +46,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_ag2_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_ag2_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -20,9 +20,9 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
 
 <Steps>
   <Step>
-    ### Create a free account
+    ### Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
   </Step>
 
   <Step>
@@ -40,7 +40,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
       description="Get started quickly with our ready-to-go Agent Spec starter."
     >
       <Step>
-          ### Install the Agent Spec AG‑UI adapter (backend) 
+          ### Install the Agent Spec AG‑UI adapter (backend)
 
           The AG‑UI integration for Agent Spec lives in `ag-ui/integrations/agent-spec/python`. You will need it to activate your agent environment in the starter. Here's how to install it:
 
@@ -90,7 +90,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           uv add pyagentspec[langgraph]
           uv add wayflowcore
           ```
-        
+
       </Step>
       <Step>
           ### Configure your environment
@@ -105,7 +105,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           Reference: Agent Spec docs AG‑UI tutorial at https://oracle.github.io/agent-spec/26.1.0/howtoguides/howto_ag_ui.html.
       </Step>
       <Step>
-          ### Scaffold the UI 
+          ### Scaffold the UI
 
           Use our starter repo template: https://github.com/CopilotKit/with-agent-spec. It includes an example definition of an Agent Spec agent [here](https://github.com/CopilotKit/with-agent-spec/blob/main/agent/src/agentspec_agent.py). Run the following commands
 
@@ -131,7 +131,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           ```bash
           pnpm install
           ```
-          
+
       </Step>
       <Step>
           ### Run your project
@@ -173,7 +173,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
         <OpenInspectorStep components={props.components} />
     </Step>
 
-      
+
     </TailoredContentOption>
     <TailoredContentOption
       id="bring-your-own"
@@ -252,7 +252,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           cd ag_ui_agentspec
           ```
 
-          create a main.py file in the ag_ui_agentspec directory 
+          create a main.py file in the ag_ui_agentspec directory
 
 
           ```bash
@@ -281,7 +281,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
 
           #OR you can specify your own agent_spec_config like below
           #agent_spec_config = <loaded json/yaml string of your Agent Spec agent>
-          
+
           runtime = "langgraph"  # or "wayflow"
 
           app = FastAPI()

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -22,13 +22,7 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
   <Step>
     ### Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-    ```bash title="Terminal"
-    npx copilotkit@latest project select
-    ```
-
-    The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create or clone it below.
   </Step>
 
   <Step>
@@ -126,7 +120,10 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
           ```bash
           git clone https://github.com/CopilotKit/with-agent-spec.git
           cd with-agent-spec
+          npx copilotkit@latest project select
           ```
+
+          `project select` writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`.
 
       </Step>
       <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agent-spec/quickstart.mdx
@@ -22,7 +22,13 @@ import OpenInspectorStep from "@/snippets/shared/inspector/open-inspector-step.m
   <Step>
     ### Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_agent_spec_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+    <SignupLink surface="docs_agent_spec_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+    ```bash title="Terminal"
+    npx copilotkit@latest project select
+    ```
+
+    The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
   </Step>
 
   <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_agno_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_agno_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_agno_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_agno_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/agno/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_agno_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_agno_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -231,10 +225,15 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                ```
 
-                The runtime reads the project API key from step 1. Add it to the app that serves
-                this route:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_aws_strands_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_aws_strands_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -329,10 +323,15 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                ```
 
-                The runtime reads the project API key from step 1. Add it to the app that serves
-                this route:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_aws_strands_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_aws_strands_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/aws-strands/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_aws_strands_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_aws_strands_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -32,9 +32,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_built_in_agent_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_built_in_agent_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -34,7 +34,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_built_in_agent_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_built_in_agent_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/quickstart.mdx
@@ -34,13 +34,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_built_in_agent_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_built_in_agent_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -134,10 +128,15 @@ Before you begin, you'll need the following:
         export const POST = handler;
         ```
 
-        The runtime reads the project API key from step 1. Add it to the app that serves
-        this route:
+        From this frontend app directory, connect the runtime to an Intelligence project:
 
-        ```plaintext title=".env.local"
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+        ```plaintext title=".env"
         CPK_INTELLIGENCE_API_KEY=cpk-...
         ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/quickstart.mdx
@@ -21,9 +21,9 @@ Before you begin, you need a [CrewAI Flow](https://docs.crewai.com/guides/flows/
 
 <Steps>
 <Step>
-    ### Optional: Create a free account
+    ### Optional: Set up CopilotKit Intelligence
 
-    <SignupLink surface="docs_crewai_flows_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence if you want managed persistent threads and the inspector. A Copilot Cloud account is not required to run a local CrewAI Flow with CopilotKit.
+    <SignupLink surface="docs_crewai_flows_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project if you want managed persistent threads and the inspector. The CLI's `init` flow writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`; managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`. A Copilot Cloud account is not required to run a local CrewAI Flow with CopilotKit.
 </Step>
 
 <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
@@ -25,7 +25,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_deepagents_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_deepagents_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
@@ -23,9 +23,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_deepagents_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_deepagents_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/deepagents/quickstart.mdx
@@ -25,13 +25,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_deepagents_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_deepagents_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -347,10 +341,15 @@ Before you begin, you'll need the following:
             </Tab>
         </Tabs>
 
-        The runtime reads the project API key from step 1. Add it to the app that serves
-        this route:
+        From this frontend app directory, connect the runtime to an Intelligence project:
 
-        ```plaintext title=".env.local"
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+        ```plaintext title=".env"
         CPK_INTELLIGENCE_API_KEY=cpk-...
         ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_langgraph_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_langgraph_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_langgraph_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_langgraph_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_langgraph_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_langgraph_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -430,10 +424,15 @@ Before you begin, you'll need the following:
               </Tab>
             </Tabs>
 
-              The runtime reads the project API key from step 1. Add it to the app that serves
-              this route:
+              From this frontend app directory, connect the runtime to an Intelligence project:
 
-              ```plaintext title=".env.local"
+              ```bash title="Terminal"
+              npx copilotkit@latest project select
+              ```
+
+              The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+              ```plaintext title=".env"
               CPK_INTELLIGENCE_API_KEY=cpk-...
               ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_llamaindex_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_llamaindex_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -278,10 +272,15 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                ```
 
-                The runtime reads the project API key from step 1. Add it to the app that serves
-                this route:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_llamaindex_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_llamaindex_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/llamaindex/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_llamaindex_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_llamaindex_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -48,13 +48,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_mastra_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_mastra_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -292,11 +286,17 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                 ```
 
-                This route needs two values from *this* app's environment — the project
-                API key from step 1, and the address of the agent server you started earlier.
-                It reads them here, not in the Mastra project:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. Add the address of
+                the agent server to the same file; the frontend runtime reads both values here,
+                not in the Mastra project:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 MASTRA_BASE_URL=http://127.0.0.1:4111
                 ```

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -46,9 +46,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_mastra_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_mastra_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/quickstart.mdx
@@ -48,7 +48,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_mastra_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_mastra_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>
@@ -286,8 +292,8 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                 ```
 
-                This route needs two values from *this* app's environment — the license
-                key from step 1, and the address of the agent server you started earlier.
+                This route needs two values from *this* app's environment — the project
+                API key from step 1, and the address of the agent server you started earlier.
                 It reads them here, not in the Mastra project:
 
                 ```plaintext title=".env.local"

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -353,10 +347,15 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                 ```
 
-                The runtime reads the project API key from step 1. Add it to the app that serves
-                this route:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>
@@ -215,7 +215,7 @@ Before you begin, you'll need the following:
                         uv add agent-framework-ag-ui python-dotenv uvicorn agent-framework-openai
                         ```
                         Create a minimal FastAPI server that exposes a Microsoft Agent Framework agent over AG-UI:
-                        Replace main.py file with the following 
+                        Replace main.py file with the following
 
                         ```python title="main.py"
                         from __future__ import annotations

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_microsoft_agent_framework_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -27,13 +27,7 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
-
-        ```bash title="Terminal"
-        npx copilotkit@latest project select
-        ```
-
-        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Sign in to managed Intelligence</SignupLink>. Managed setup uses a server-side project API key and does not issue `COPILOTKIT_LICENSE_TOKEN`. You will connect the app after you create it below.
     </Step>
 
     <Step>
@@ -237,10 +231,15 @@ Before you begin, you'll need the following:
                 export const POST = handler;
                 ```
 
-                The runtime reads the project API key from step 1. Add it to the app that serves
-                this route:
+                From this frontend app directory, connect the runtime to an Intelligence project:
 
-                ```plaintext title=".env.local"
+                ```bash title="Terminal"
+                npx copilotkit@latest project select
+                ```
+
+                The command writes the server-side project API key to `.env`. The runtime reads it here:
+
+                ```plaintext title=".env"
                 CPK_INTELLIGENCE_API_KEY=cpk-...
                 ```
 

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -25,9 +25,9 @@ Before you begin, you'll need the following:
 
 <Steps>
     <Step>
-        ### Create a free account
+        ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Sign up for a free developer account</SignupLink> for CopilotKit Intelligence to get a license key. You'll use it later to enable persistent threads and the inspector.
+        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/quickstart.mdx
@@ -27,7 +27,13 @@ Before you begin, you'll need the following:
     <Step>
         ### Set up CopilotKit Intelligence
 
-        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Start managed onboarding</SignupLink> and create or select a project. The CLI's `create` flow—or `project select` in an existing app—writes the server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
+        <SignupLink surface="docs_pydantic_ai_quickstart_step1">Sign in to managed Intelligence</SignupLink>. When you are in the app directory created or cloned below, connect it to a project:
+
+        ```bash title="Terminal"
+        npx copilotkit@latest project select
+        ```
+
+        The command creates or selects a project and writes its server-side project API key to `.env` as `CPK_INTELLIGENCE_API_KEY`. Managed setup does not issue `COPILOTKIT_LICENSE_TOKEN`.
     </Step>
 
     <Step>

--- a/showcase/shell-docs/src/content/docs/tutorials/multi-conversation-chat.mdx
+++ b/showcase/shell-docs/src/content/docs/tutorials/multi-conversation-chat.mdx
@@ -8,7 +8,7 @@ doc_type: tutorial
 <OpsPlatformCTA
   variant="inline"
   title="Need a CopilotKit Intelligence project?"
-  body="The free Developer tier on cloud-hosted CopilotKit Intelligence has everything this tutorial uses — threads, realtime sync, and a license key."
+  body="The Developer tier on cloud-hosted CopilotKit Intelligence has everything this tutorial uses — threads, realtime sync, and a project-scoped API key for your runtime."
   surface="docs_tutorial_multi_conversation_chat"
 />
 

--- a/showcase/shell-docs/src/content/reference/components/CopilotThreadsDrawer.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotThreadsDrawer.mdx
@@ -194,7 +194,7 @@ function App() {
 - **Deleting the active thread** resets to a fresh thread; **archiving** the active thread keeps you viewing it. Archived threads render italic/muted inline in the "All" view.
 - **Filter**: an Active/All filter lives behind a **funnel** icon popover under the "Recent Conversations" heading; a small indicator dot appears on the funnel when a non-default filter is applied. Toggling the filter refetches server-side.
 - **Mobile**: below 768px the drawer is an off-canvas modal. Closed, it shows the same floating cluster (a launcher to open it + a "New Conversation" button); open, it slides in and is dismissed by tapping the backdrop or pressing Escape. The launcher icon (`launcher-icon` slot) and position (`--cpk-drawer-launcher-*`) are customizable.
-- **License**: threads require CopilotKit Intelligence; without a license key the drawer shows a locked view in place of the list.
+- **Intelligence access**: threads require CopilotKit Intelligence. If the runtime reports that Threads are unavailable, the drawer shows a locked view in place of the list. Managed projects use `CPK_INTELLIGENCE_API_KEY` on the server; licensed self-hosted deployments use `COPILOTKIT_LICENSE_TOKEN` on the server.
 
 ## Related
 

--- a/showcase/shell-docs/src/content/reference/vue/hooks/useThreads.mdx
+++ b/showcase/shell-docs/src/content/reference/vue/hooks/useThreads.mdx
@@ -6,8 +6,8 @@ description: "Vue 3 composable for listing, managing, and syncing conversation t
 <OpsPlatformCTA
   variant="card"
   title="useThreads needs a CopilotKit Intelligence project"
-  body="Sign up for a free account to get a public license key and start syncing threads."
-  ctaLabel="Create a free account"
+  body="Connect your runtime to a managed project to start syncing threads."
+  ctaLabel="Start managed onboarding"
   surface="docs_reference_vue_use_threads"
 />
 
@@ -183,7 +183,7 @@ const { threads, hasMoreThreads, fetchMoreThreads } = useThreads({
 
 <Cards>
   <Card title="CopilotKitProvider" href="/reference/vue/components/CopilotKitProvider">
-    Configure the runtime URL and license key that power thread syncing.
+    Configure the runtime URL that powers thread syncing. For managed Intelligence, keep `CPK_INTELLIGENCE_API_KEY` on the runtime server.
   </Card>
   <Card title="useAgent" href="/reference/vue/hooks/useAgent">
     Access and run the agent whose threads you are listing.

--- a/showcase/shell-docs/src/content/snippets/shared/basics/copilot-threads-drawer.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/basics/copilot-threads-drawer.mdx
@@ -38,7 +38,7 @@ Use the drawer when you want:
 - A mobile-ready off-canvas drawer with its own launcher
 
 It requires CopilotKit Intelligence (threads are stored and synced
-server-side). <SignupLink surface="docs_drawer">Get a free developer account</SignupLink> to set that up.
+server-side). <SignupLink surface="docs_drawer">Start managed onboarding</SignupLink> to create or select a project.
 
 For multi-user applications, configure the Runtime to
 [scope Rich Threads to the signed-in user](/threads-lifecycle#scope-rich-threads-to-the-signed-in-user).
@@ -46,7 +46,7 @@ For multi-user applications, configure the Runtime to
 <OpsPlatformCTA
   variant="inline"
   title="Threads run in CopilotKit Intelligence"
-  body="Get persistent threads and realtime sync on the free Developer tier."
+  body="Connect a managed project to get persistent threads and realtime sync."
   surface="docs_drawer"
 />
 
@@ -72,7 +72,7 @@ import "@copilotkit/react-core/v2/styles.css";
 
 export default function Page() {
   return (
-    <CopilotKitProvider runtimeUrl="/api/copilotkit" publicLicenseKey="ck_pub_...">
+    <CopilotKitProvider runtimeUrl="/api/copilotkit">
       <CopilotChatConfigurationProvider>
         <div style={{ display: "flex", height: "100dvh" }}>
           <CopilotThreadsDrawer />
@@ -123,10 +123,12 @@ Three bounded escape hatches pierce the boundary:
 - **Per-row content**: the `renderRow` prop projects custom content into each row while the element keeps selection, archived styling, and the per-row kebab menu (Archive/Delete).
 - **CSS parts + variable tokens**: restyle structural `::part()`s or override `--cpk-drawer-*` tokens. The full list is in the [reference](/reference/components/CopilotThreadsDrawer#customization).
 
-## License
+## Intelligence access
 
-Threads require CopilotKit Intelligence. Without a license key, the drawer shows
-a locked view in place of the list.
+Threads require CopilotKit Intelligence. If the runtime reports that Threads are
+not available, the drawer shows a locked view in place of the list. Managed
+projects use a server-side `CPK_INTELLIGENCE_API_KEY`; licensed self-hosted
+deployments use `COPILOTKIT_LICENSE_TOKEN` on the server.
 
 ## Related
 

--- a/showcase/shell-docs/src/content/snippets/shared/intelligence/inspector.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/intelligence/inspector.mdx
@@ -103,7 +103,7 @@ By default, the Inspector appears only on `localhost`, `127.0.0.1`, and
 
 ```tsx
 <CopilotKit
-  publicLicenseKey={process.env.NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY}
+  runtimeUrl="/api/copilotkit"
   enableInspector={false}
 >
   {children}
@@ -113,9 +113,8 @@ By default, the Inspector appears only on `localhost`, `127.0.0.1`, and
 Set `enableInspector` to `true` to show it on another host, including in a
 production build. CopilotKit always uses an explicit `true` or `false` value.
 
-`NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY` is a browser-visible publishable key and is
-a **different credential** from the server-side `CPK_INTELLIGENCE_API_KEY` that
-`copilotkit project select` writes into your `.env`. The server-side key is
-consumed by the `CopilotKitIntelligence` client described in
-[Runtime endpoints](/backend/runtime-endpoints). Do not substitute one for the
-other, and never expose the server-side key to the browser.
+For managed Intelligence, `copilotkit project select` writes
+`CPK_INTELLIGENCE_API_KEY` to your server-side `.env`. The
+`CopilotKitIntelligence` client uses that key and reports Inspector access through
+the runtime endpoint. Never expose the project API key to the browser. See
+[Runtime endpoints](/backend/runtime-endpoints) for the complete setup.

--- a/showcase/shell-docs/src/content/snippets/shared/telemetry/anonymous.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/telemetry/anonymous.mdx
@@ -14,10 +14,12 @@ create or write `CPK_TELEMETRY_ID`, and a value you choose does not automaticall
 link Runtime events to a CLI scaffold event. Setting it does not enable
 telemetry, grant product access, or replace the project's Intelligence API key.
 
-Current managed Threads starters receive `COPILOTKIT_LICENSE_TOKEN`, which can
-supply the fallback identity. When it does, Runtime sends identified events
-without sampling. Runtime samples events identified by an explicit `telemetryId`
-or `CPK_TELEMETRY_ID` at the configured rate. With none of these identities,
+Managed Intelligence starters use `CPK_INTELLIGENCE_API_KEY` for platform access
+and do not receive `COPILOTKIT_LICENSE_TOKEN`. The project API key is not a
+telemetry identity. A self-hosted license token can still supply the fallback
+identity. When it does, Runtime sends identified events without sampling.
+Runtime samples events identified by an explicit `telemetryId` or
+`CPK_TELEMETRY_ID` at the configured rate. With none of these identities,
 Runtime sends anonymous sampled telemetry.
 
 The Inspector stores a random browser ID in local storage and sends it directly

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -829,7 +829,7 @@ describe("framework nav", () => {
       "If your project was created from a CopilotKit CLI starter",
     );
     expect(drawer).toContain("add it to an existing CopilotKit application");
-    expect(drawer).toContain("Get a free developer account");
+    expect(drawer).toContain("Start managed onboarding");
     expect(drawer).toContain("## Set up the Threads Drawer");
     expect(drawer).not.toContain(
       "Start with the [Rich Threads overview](/threads)",

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -223,6 +223,25 @@ test("managed quickstarts provision a project API key instead of a license key",
       expect(source).toMatch(
         /npx copilotkit@latest (?:project select|init(?:\s|`))/,
       );
+
+      const projectSelectIndex = source.indexOf(
+        "npx copilotkit@latest project select",
+      );
+      if (projectSelectIndex !== -1) {
+        const appCreationIndexes = [
+          "git clone ",
+          "npx create-next-app@latest ",
+          "npx copilotkit@latest create",
+          "npx copilotkit@latest init",
+        ]
+          .map((command) => source.indexOf(command))
+          .filter((index) => index !== -1);
+
+        expect(appCreationIndexes.length).toBeGreaterThan(0);
+        expect(projectSelectIndex).toBeGreaterThan(
+          Math.min(...appCreationIndexes),
+        );
+      }
     }
   }
 });

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -215,11 +215,14 @@ test("managed quickstarts provision a project API key instead of a license key",
   for (const file of quickstarts) {
     const source = fs.readFileSync(file, "utf8").replace(/\s+/g, " ");
 
-    expect(source).not.toMatch(/(?:get|receive|create) (?:a )?license key/i);
+    expect(source).not.toMatch(/license key/i);
     expect(source).not.toMatch(/free developer account/i);
 
     if (source.includes("`CPK_INTELLIGENCE_API_KEY`")) {
       expect(source).toContain("project API key");
+      expect(source).toMatch(
+        /npx copilotkit@latest (?:project select|init(?:\s|`))/,
+      );
     }
   }
 });

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -213,7 +213,8 @@ test("managed quickstarts provision a project API key instead of a license key",
   expect(quickstarts.length).toBeGreaterThan(0);
 
   for (const file of quickstarts) {
-    const source = fs.readFileSync(file, "utf8").replace(/\s+/g, " ");
+    const rawSource = fs.readFileSync(file, "utf8");
+    const source = rawSource.replace(/\s+/g, " ");
 
     expect(source).not.toMatch(/license key/i);
     expect(source).not.toMatch(/free developer account/i);
@@ -224,22 +225,23 @@ test("managed quickstarts provision a project API key instead of a license key",
         /npx copilotkit@latest (?:project select|init(?:\s|`))/,
       );
 
-      const projectSelectIndex = source.indexOf(
-        "npx copilotkit@latest project select",
-      );
-      if (projectSelectIndex !== -1) {
-        const appCreationIndexes = [
-          "git clone ",
-          "npx create-next-app@latest ",
-          "npx copilotkit@latest create",
-          "npx copilotkit@latest init",
-        ]
-          .map((command) => source.indexOf(command))
-          .filter((index) => index !== -1);
+      for (const match of rawSource.matchAll(
+        /npx copilotkit@latest project select/g,
+      )) {
+        const precedingSource = rawSource.slice(0, match.index);
+        const branchStart = precedingSource.lastIndexOf(
+          "<TailoredContentOption",
+        );
+        const previousBranchEnd = precedingSource.lastIndexOf(
+          "</TailoredContentOption>",
+        );
+        const currentBranchStart =
+          branchStart > previousBranchEnd ? branchStart : 0;
+        const currentBranchBeforeSelection =
+          precedingSource.slice(currentBranchStart);
 
-        expect(appCreationIndexes.length).toBeGreaterThan(0);
-        expect(projectSelectIndex).toBeGreaterThan(
-          Math.min(...appCreationIndexes),
+        expect(currentBranchBeforeSelection).toMatch(
+          /(?:git clone |npx create-next-app@latest |npx copilotkit@latest (?:create|init))/,
         );
       }
     }

--- a/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/managed-starter-docs.test.ts
@@ -203,6 +203,60 @@ test("never names a license key as the value of the project API key", () => {
   expect(offenders).toEqual([]);
 });
 
+test("managed quickstarts provision a project API key instead of a license key", () => {
+  const quickstarts = mdxFilesIn(path.join(CONTENT_DIR, "docs")).filter(
+    (file) =>
+      file.endsWith("quickstart.mdx") &&
+      fs.readFileSync(file, "utf8").includes("<IntelligenceOnboardingPrompt"),
+  );
+
+  expect(quickstarts.length).toBeGreaterThan(0);
+
+  for (const file of quickstarts) {
+    const source = fs.readFileSync(file, "utf8").replace(/\s+/g, " ");
+
+    expect(source).not.toMatch(/(?:get|receive|create) (?:a )?license key/i);
+    expect(source).not.toMatch(/free developer account/i);
+
+    if (source.includes("`CPK_INTELLIGENCE_API_KEY`")) {
+      expect(source).toContain("project API key");
+    }
+  }
+});
+
+test("managed Threads Drawer setup relies on runtime authority", () => {
+  const [source] = readSources([
+    "snippets/shared/basics/copilot-threads-drawer.mdx",
+  ]);
+
+  expect(source).toContain('runtimeUrl="/api/copilotkit"');
+  expect(source).not.toContain("publicLicenseKey");
+});
+
+test("managed Inspector examples keep credentials on the runtime server", () => {
+  const sources = readSources([
+    "docs/inspector.mdx",
+    "snippets/shared/intelligence/inspector.mdx",
+  ]);
+
+  for (const source of sources) {
+    expect(source).toContain('runtimeUrl="/api/copilotkit"');
+    expect(source).not.toContain("NEXT_PUBLIC_COPILOTKIT_LICENSE_KEY");
+  }
+});
+
+test("managed telemetry docs distinguish the project key from self-hosted tokens", () => {
+  const [source] = readSources(["snippets/shared/telemetry/anonymous.mdx"]);
+
+  expect(source).toContain(
+    "Managed Intelligence starters use `CPK_INTELLIGENCE_API_KEY` for platform access",
+  );
+  expect(source).toContain("do not receive `COPILOTKIT_LICENSE_TOKEN`");
+  expect(source).not.toContain(
+    "Current managed Threads starters receive `COPILOTKIT_LICENSE_TOKEN`",
+  );
+});
+
 /** Every MDX page under `dir`, recursively. */
 function mdxFilesIn(dir: string): string[] {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {


### PR DESCRIPTION
## Summary

Managed quickstarts still told users to obtain a license key, and some Inspector and Threads examples implied that a browser key was required. Update those guides to connect a project with `copilotkit project select` and keep `CPK_INTELLIGENCE_API_KEY` on the runtime server.

- Update managed quickstarts, Inspector, Threads, Vue, and tutorial guidance to use runtime-reported access.
- Preserve current development-only Inspector behavior, self-hosted license-token guidance, and telemetry behavior. Clarify that a project API key is not a telemetry identity.
- Validate credential wording and project-selection ordering with docs tests that match the current quickstart structure.

## Validation

Validated with Node 22.23.2:

- Full shell-docs suite: **130 files, 990 tests passed** (`npm run test --ignore-scripts -- --maxWorkers=4`, after generating docs inputs).
- Focused managed-starter, managed-runtime, and docs-render tests: **45 passed**.
- `npm run typecheck` passed.
- `npm run build` passed; **227 static pages generated**.
- `pnpm check:intelligence-env-names` and `pnpm check:intelligence-wiring-block` passed.
- Scoped lint passed; PR diff has no whitespace errors or conflict markers.

The local Node 26 run hit browser-storage test errors; the complete suite passed using CI's Node 22 major version.

Refs ENT-1151

Related internal cleanup: CopilotKit/Intelligence#1160


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quickstarts to use managed CopilotKit Intelligence and the `project select` setup flow.
  * Clarified that project API keys are stored server-side in `.env` and must not be exposed to browsers.
  * Updated Threads, Inspector, telemetry, and tutorial guidance to reflect Intelligence access and managed project setup.
  * Clarified Threads availability and credential requirements for managed and self-hosted deployments.

* **Tests**
  * Added coverage validating managed starter documentation, credential guidance, navigation, and updated onboarding terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->