### PR TITLE
fix(angular): render slots with createComponent bindings

### DIFF
--- a/packages/angular/API.md
+++ b/packages/angular/API.md
@@ -196,6 +196,7 @@ Import these symbols from `@copilotkit/angular`.
 - `SendButtonContext`
 - `SlotConfig`
 - `SlotContext`
+- `SlotOutputs`
 - `SlotRegistryEntry`
 - `SlotValue`
 - `StaticSuggestionsConfig`

--- a/packages/angular/src/lib/slots/__tests__/copilot-slot.spec.ts
+++ b/packages/angular/src/lib/slots/__tests__/copilot-slot.spec.ts
@@ -1,0 +1,98 @@
+import {
+  Component,
+  TemplateRef,
+  Type,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { CopilotSlot } from "../copilot-slot";
+import { SlotOutputs } from "../slot.types";
+
+@Component({
+  selector: "test-content",
+  template: `
+    <button (click)="selected.emit(label())">{{ label() }}</button>
+  `,
+})
+class TestContent {
+  readonly label = input("default");
+  readonly selected = output<string>();
+}
+
+@Component({
+  imports: [CopilotSlot],
+  template: `
+    <ng-template #template let-label="label">
+      <span class="template">{{ label }}</span>
+    </ng-template>
+    <copilot-slot
+      [slot]="slot()"
+      [defaultComponent]="defaultComponent()"
+      [context]="context()"
+      [outputs]="outputs()"
+    >
+      <span class="fallback">fallback</span>
+    </copilot-slot>
+  `,
+})
+class TestHost {
+  readonly template = viewChild.required<TemplateRef<unknown>>("template");
+  readonly slot = signal<TemplateRef<unknown> | Type<unknown> | undefined>(
+    undefined,
+  );
+  readonly defaultComponent = signal<Type<unknown> | undefined>(undefined);
+  readonly context = signal<Record<string, unknown> | undefined>(undefined);
+  readonly outputs = signal<SlotOutputs | undefined>(undefined);
+}
+
+describe("CopilotSlot", () => {
+  let fixture: ComponentFixture<TestHost>;
+  let host: TestHost;
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestHost);
+    host = fixture.componentInstance;
+    element = fixture.nativeElement;
+  });
+
+  it("renders projected content or the default component", () => {
+    fixture.detectChanges();
+    expect(element.querySelector(".fallback")).not.toBeNull();
+
+    host.defaultComponent.set(TestContent);
+    fixture.detectChanges();
+    expect(element.querySelector("button")?.textContent).toContain("default");
+    expect(element.querySelector(".fallback")).toBeNull();
+  });
+
+  it("renders a template slot with context", () => {
+    fixture.detectChanges();
+    host.slot.set(host.template());
+    host.context.set({ label: "template" });
+    fixture.detectChanges();
+
+    expect(element.querySelector(".template")?.textContent).toContain(
+      "template",
+    );
+    expect(element.querySelector(".fallback")).toBeNull();
+  });
+
+  it("binds component inputs and outputs", () => {
+    let selected: string | undefined;
+    host.slot.set(TestContent);
+    host.context.set({ label: "component" });
+    host.outputs.set({ selected: (value) => (selected = value) });
+    fixture.detectChanges();
+
+    const button = element.querySelector("button") as HTMLButtonElement;
+    expect(button.textContent).toContain("component");
+
+    button.click();
+    expect(selected).toBe("component");
+  });
+});

--- a/packages/angular/src/lib/slots/__tests__/copilot-slot.spec.ts
+++ b/packages/angular/src/lib/slots/__tests__/copilot-slot.spec.ts
@@ -7,8 +7,8 @@ import {
   signal,
   viewChild,
 } from "@angular/core";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { TestBed } from "@angular/core/testing";
+import { describe, expect, it } from "vitest";
 import { CopilotSlot } from "../copilot-slot";
 import { SlotOutputs } from "../slot.types";
 
@@ -50,31 +50,29 @@ class TestHost {
 }
 
 describe("CopilotSlot", () => {
-  let fixture: ComponentFixture<TestHost>;
-  let host: TestHost;
-  let element: HTMLElement;
+  const setup = async () => {
+    const fixture = TestBed.createComponent(TestHost);
+    const host = fixture.componentInstance;
+    const element = fixture.nativeElement as HTMLElement;
+    await fixture.whenStable();
+    return { fixture, host, element };
+  };
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(TestHost);
-    host = fixture.componentInstance;
-    element = fixture.nativeElement;
-  });
-
-  it("renders projected content or the default component", () => {
-    fixture.detectChanges();
+  it("renders projected content or the default component", async () => {
+    const { fixture, host, element } = await setup();
     expect(element.querySelector(".fallback")).not.toBeNull();
 
     host.defaultComponent.set(TestContent);
-    fixture.detectChanges();
+    await fixture.whenStable();
     expect(element.querySelector("button")?.textContent).toContain("default");
     expect(element.querySelector(".fallback")).toBeNull();
   });
 
-  it("renders a template slot with context", () => {
-    fixture.detectChanges();
+  it("renders a template slot with context", async () => {
+    const { fixture, host, element } = await setup();
     host.slot.set(host.template());
     host.context.set({ label: "template" });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     expect(element.querySelector(".template")?.textContent).toContain(
       "template",
@@ -82,17 +80,19 @@ describe("CopilotSlot", () => {
     expect(element.querySelector(".fallback")).toBeNull();
   });
 
-  it("binds component inputs and outputs", () => {
+  it("binds component inputs and outputs", async () => {
+    const { fixture, host, element } = await setup();
     let selected: string | undefined;
     host.slot.set(TestContent);
     host.context.set({ label: "component" });
     host.outputs.set({ selected: (value) => (selected = value) });
-    fixture.detectChanges();
+    await fixture.whenStable();
 
     const button = element.querySelector("button") as HTMLButtonElement;
     expect(button.textContent).toContain("component");
 
     button.click();
+    await fixture.whenStable();
     expect(selected).toBe("component");
   });
 });

--- a/packages/angular/src/lib/slots/__tests__/slot.utils.spec.ts
+++ b/packages/angular/src/lib/slots/__tests__/slot.utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  ComponentRef,
   Input,
   TemplateRef,
   ViewChild,
@@ -42,6 +43,17 @@ class DefaultComponent {
 })
 class CustomComponent {
   @Input() text = "Custom";
+}
+
+@Component({
+  standalone: true,
+  selector: "props-component",
+  template: `
+    <div class="props">{{ props.text }}</div>
+  `,
+})
+class PropsComponent {
+  @Input() props = { text: "Default" };
 }
 
 describe("slot utils", () => {
@@ -106,7 +118,7 @@ describe("slot utils", () => {
       expect(span?.textContent?.trim()).toBe("from template");
     });
 
-    it("applies inputs using setInput", () => {
+    it("binds declared inputs on the next change detection", () => {
       @Component({
         standalone: true,
         template: `
@@ -126,15 +138,44 @@ describe("slot utils", () => {
         defaultComponent: DefaultComponent,
         props: { text: "Updated" },
       });
+      fixture.detectChanges();
 
       expect(ref).toBeTruthy();
       expect((ref as any).instance.text).toBe("Updated");
+    });
+
+    it("binds the full context to a legacy props input", () => {
+      @Component({
+        standalone: true,
+        template: `
+          <div #container></div>
+        `,
+        imports: [PropsComponent],
+      })
+      class HostComponent {
+        @ViewChild("container", { read: ViewContainerRef })
+        container!: ViewContainerRef;
+      }
+
+      const fixture = TestBed.createComponent(HostComponent);
+      fixture.detectChanges();
+
+      const ref = renderSlot<any>(fixture.componentInstance.container, {
+        defaultComponent: PropsComponent,
+        props: { text: "Updated" },
+      });
+      fixture.detectChanges();
+
+      expect((ref as ComponentRef<PropsComponent>).instance.props).toEqual({
+        text: "Updated",
+      });
     });
   });
 
   describe("type guards", () => {
     it("detects component types", () => {
       expect(isComponentType(DefaultComponent)).toBe(true);
+      expect(isComponentType(class NotAnAngularComponent {})).toBe(false);
       expect(isComponentType(() => {})).toBe(false);
       expect(isComponentType(null)).toBe(false);
     });

--- a/packages/angular/src/lib/slots/__tests__/slot.utils.spec.ts
+++ b/packages/angular/src/lib/slots/__tests__/slot.utils.spec.ts
@@ -1,174 +1,177 @@
 import {
   Component,
-  ComponentRef,
-  Input,
-  TemplateRef,
-  ViewChild,
-  ViewContainerRef,
   createEnvironmentInjector,
   EnvironmentInjector,
+  input,
   runInInjectionContext,
+  TemplateRef,
+  viewChild,
+  ViewContainerRef,
 } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { assertDefined } from "../../utils";
+import { SLOT_CONFIG } from "../slot.types";
 import {
-  renderSlot,
+  createSlotConfig,
+  createSlotRenderer,
+  getSlotConfig,
   isComponentType,
   isSlotValue,
   normalizeSlotValue,
-  createSlotConfig,
   provideSlots,
-  getSlotConfig,
-  createSlotRenderer,
+  renderSlot,
 } from "../slot.utils";
-import { SLOT_CONFIG } from "../slot.types";
 
 @Component({
-  standalone: true,
   selector: "default-component",
   template: `
-    <div class="default">{{ text }}</div>
+    <div data-testid="default">{{ text() }}</div>
   `,
 })
 class DefaultComponent {
-  @Input() text = "Default";
+  readonly text = input("Default");
 }
 
 @Component({
-  standalone: true,
   selector: "custom-component",
   template: `
-    <div class="custom">{{ text }}</div>
+    <div data-testid="custom">{{ text() }}</div>
   `,
 })
 class CustomComponent {
-  @Input() text = "Custom";
+  readonly text = input("Custom");
 }
 
 @Component({
-  standalone: true,
   selector: "props-component",
   template: `
-    <div class="props">{{ props.text }}</div>
+    <div data-testid="props">{{ props().text }}</div>
   `,
 })
 class PropsComponent {
-  @Input() props = { text: "Default" };
+  protected readonly props = input({ text: "Default" });
 }
 
 describe("slot utils", () => {
-  beforeEach(() => {
-    TestBed.resetTestingModule();
-  });
-
   describe("renderSlot", () => {
-    it("renders default component when no slot provided", () => {
+    it("renders default component when no slot provided", async () => {
       @Component({
-        standalone: true,
         template: `
           <div #container></div>
         `,
         imports: [DefaultComponent],
       })
       class HostComponent {
-        @ViewChild("container", { read: ViewContainerRef })
-        container!: ViewContainerRef;
+        container = viewChild.required("container", { read: ViewContainerRef });
       }
 
       const fixture = TestBed.createComponent(HostComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
-      const ref = renderSlot(fixture.componentInstance.container, {
+      const container = fixture.componentInstance.container();
+      assertDefined(container);
+
+      renderSlot(container, {
         defaultComponent: DefaultComponent,
       });
 
-      expect(ref).toBeTruthy();
-      expect(
-        (ref as any).location.nativeElement.querySelector(".default"),
-      ).toBeTruthy();
+      await expect
+        .poll(() => document.querySelector('[data-testid="default"]'))
+        .toBeTruthy();
     });
 
-    it("renders template slot with provided context", () => {
+    it("renders template slot with provided context", async () => {
       @Component({
-        standalone: true,
         template: `
           <div #container></div>
           <ng-template #tpl let-props="props">
-            <span class="template">{{ props?.value }}</span>
+            <span data-testid="template">{{ props?.value }}</span>
           </ng-template>
         `,
       })
       class HostComponent {
-        @ViewChild("container", { read: ViewContainerRef })
-        container!: ViewContainerRef;
-        @ViewChild("tpl") tpl!: TemplateRef<any>;
+        container = viewChild.required("container", { read: ViewContainerRef });
+        tpl = viewChild.required<TemplateRef<unknown>>("tpl");
       }
 
       const fixture = TestBed.createComponent(HostComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
+      const container = fixture.componentInstance.container();
+      const tpl = fixture.componentInstance.tpl();
 
-      renderSlot(fixture.componentInstance.container, {
+      assertDefined(container);
+      assertDefined(tpl);
+
+      renderSlot(container, {
         defaultComponent: DefaultComponent,
-        slot: fixture.componentInstance.tpl,
+        slot: tpl,
         props: { value: "from template" },
       });
-      fixture.detectChanges();
 
-      const span = fixture.nativeElement.querySelector(".template");
-      expect(span?.textContent?.trim()).toBe("from template");
+      await expect
+        .poll(
+          () => document.querySelector('[data-testid="template"]')?.textContent,
+        )
+        .toContain("from template");
     });
 
-    it("binds declared inputs on the next change detection", () => {
+    it("binds declared inputs on the next change detection", async () => {
       @Component({
-        standalone: true,
         template: `
           <div #container></div>
         `,
         imports: [DefaultComponent],
       })
       class HostComponent {
-        @ViewChild("container", { read: ViewContainerRef })
-        container!: ViewContainerRef;
+        container = viewChild.required("container", { read: ViewContainerRef });
       }
 
       const fixture = TestBed.createComponent(HostComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
-      const ref = renderSlot(fixture.componentInstance.container, {
+      const container = fixture.componentInstance.container();
+      assertDefined(container);
+
+      renderSlot(container, {
         defaultComponent: DefaultComponent,
         props: { text: "Updated" },
       });
-      fixture.detectChanges();
 
-      expect(ref).toBeTruthy();
-      expect((ref as any).instance.text).toBe("Updated");
+      await expect
+        .poll(
+          () => document.querySelector('[data-testid="default"]')?.textContent,
+        )
+        .toContain("Updated");
     });
 
-    it("binds the full context to a legacy props input", () => {
+    it("binds the full context to a legacy props input", async () => {
       @Component({
-        standalone: true,
         template: `
           <div #container></div>
         `,
         imports: [PropsComponent],
       })
       class HostComponent {
-        @ViewChild("container", { read: ViewContainerRef })
-        container!: ViewContainerRef;
+        container = viewChild.required("container", { read: ViewContainerRef });
       }
 
       const fixture = TestBed.createComponent(HostComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
-      const ref = renderSlot<any>(fixture.componentInstance.container, {
+      const container = fixture.componentInstance.container();
+      assertDefined(container);
+
+      renderSlot(container, {
         defaultComponent: PropsComponent,
         props: { text: "Updated" },
       });
-      fixture.detectChanges();
 
-      expect((ref as ComponentRef<PropsComponent>).instance.props).toEqual({
-        text: "Updated",
-      });
+      await expect
+        .poll(
+          () => document.querySelector('[data-testid="props"]')?.textContent,
+        )
+        .toContain("Updated");
     });
   });
 
@@ -180,22 +183,24 @@ describe("slot utils", () => {
       expect(isComponentType(null)).toBe(false);
     });
 
-    it("detects slot values", () => {
+    it("detects slot values", async () => {
       @Component({
-        standalone: true,
         template: `
           <ng-template #tpl></ng-template>
         `,
       })
       class HostComponent {
-        @ViewChild("tpl") tpl!: TemplateRef<any>;
+        tpl = viewChild.required<TemplateRef<unknown>>("tpl");
       }
 
       const fixture = TestBed.createComponent(HostComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const tpl = fixture.componentInstance.tpl();
+      assertDefined(tpl);
 
       expect(isSlotValue(DefaultComponent)).toBe(true);
-      expect(isSlotValue(fixture.componentInstance.tpl)).toBe(true);
+      expect(isSlotValue(tpl)).toBe(true);
       expect(isSlotValue("string")).toBe(false);
     });
   });
@@ -226,7 +231,7 @@ describe("slot utils", () => {
         providers: [{ provide: SLOT_CONFIG, useValue: slots }],
       });
 
-      @Component({ standalone: true, template: "" })
+      @Component({ template: "" })
       class HostComponent {
         config = getSlotConfig();
       }
@@ -235,7 +240,7 @@ describe("slot utils", () => {
       expect(fixture.componentInstance.config).toBe(slots);
     });
 
-    it("createSlotRenderer uses DI overrides when slot name provided", () => {
+    it("createSlotRenderer uses DI overrides when slot name provided", async () => {
       const parent = TestBed.inject(EnvironmentInjector);
       const env = createEnvironmentInjector(
         [provideSlots({ button: CustomComponent })],
@@ -247,24 +252,26 @@ describe("slot utils", () => {
       );
 
       @Component({
-        standalone: true,
         template: `
           <div #container></div>
         `,
         imports: [DefaultComponent, CustomComponent],
       })
       class HostComponent {
-        @ViewChild("container", { read: ViewContainerRef })
-        container!: ViewContainerRef;
+        container = viewChild.required("container", { read: ViewContainerRef });
       }
 
       const fixture = TestBed.createComponent(HostComponent);
-      fixture.detectChanges();
+      await fixture.whenStable();
 
-      const ref = renderer(fixture.componentInstance.container);
-      expect(
-        (ref as any).location.nativeElement.querySelector(".custom"),
-      ).toBeTruthy();
+      const container = fixture.componentInstance.container();
+      assertDefined(container);
+
+      renderer(container);
+
+      await expect
+        .poll(() => document.querySelector('[data-testid="custom"]'))
+        .toBeTruthy();
     });
   });
 });

--- a/packages/angular/src/lib/slots/copilot-slot.ts
+++ b/packages/angular/src/lib/slots/copilot-slot.ts
@@ -1,150 +1,100 @@
 import {
   Component,
   TemplateRef,
+  Type,
   ViewContainerRef,
-  OnInit,
-  OnChanges,
-  SimpleChanges,
-  Inject,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
+  computed,
+  effect,
   input,
-  ViewChild,
+  untracked,
+  viewChild,
 } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { renderSlot } from "./slot.utils";
-import { Type } from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
+import { SlotOutputs } from "./slot.types";
+import { slotBindings, slotInputNames } from "./slot.utils";
 
 /**
  * @internal - This component is for internal use only.
- * Simple slot component for rendering custom content or defaults.
- * Supports templates and components only.
+ * Renders a slot override, a default component, or the projected fallback.
+ *
+ * - A `TemplateRef` slot is rendered with `context` as its template context,
+ *   so context keys are available as `let-` variables.
+ * - A component slot (or `defaultComponent`) is created with `context` keys
+ *   bound to its matching inputs and `outputs` handlers bound to its matching
+ *   outputs. Bound values stay live; the component is only recreated when the
+ *   resolved type or set of bound input names changes.
+ * - With neither a slot nor a default component, the projected content shows.
  *
  * @example
  * ```html
- * <!-- With template -->
  * <copilot-slot [slot]="sendButtonTemplate" [context]="buttonContext">
  *   <button class="default-btn">Default</button>
  * </copilot-slot>
  * ```
  */
 @Component({
-  standalone: true,
   selector: "copilot-slot",
-  imports: [CommonModule],
+  imports: [NgTemplateOutlet],
   template: `
-    <!-- If slot template provided, render it -->
-    @if (slot() && isTemplate(slot)) {
-      <ng-container
-        [ngTemplateOutlet]="slot"
-        [ngTemplateOutletContext]="context || {}"
-      >
-      </ng-container>
+    @if (template(); as tpl) {
+      <ng-container *ngTemplateOutlet="tpl; context: context()" />
     }
-
-    <!-- If not a template, we'll handle in code -->
-    <ng-container #slotContainer></ng-container>
-
-    <!-- Default content (only shown if no slot) -->
-    @if (!slot && !defaultComponent) {
-      <ng-content></ng-content>
+    <ng-container #host />
+    @if (!slot() && !defaultComponent()) {
+      <ng-content />
     }
   `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CopilotSlot implements OnInit, OnChanges {
-  slot = input<TemplateRef<any> | Type<any> | undefined>(undefined);
-  context = input<any | undefined>(undefined);
-  defaultComponent = input<Type<any> | undefined>(undefined);
-  outputs = input<Record<string, (event: any) => void> | undefined>(undefined);
+export class CopilotSlot {
+  readonly slot = input<TemplateRef<unknown> | Type<unknown>>();
+  readonly context = input<object>();
+  readonly defaultComponent = input<Type<unknown>>();
+  readonly outputs = input<SlotOutputs>();
 
-  @ViewChild("slotContainer", { read: ViewContainerRef, static: true })
-  private slotContainer!: ViewContainerRef;
+  private readonly host = viewChild.required("host", {
+    read: ViewContainerRef,
+  });
 
-  private componentRef?: any;
+  protected readonly template = computed(() => {
+    const slot = this.slot();
+    return slot instanceof TemplateRef ? slot : undefined;
+  });
 
-  constructor(
-    @Inject(ViewContainerRef) private viewContainer: ViewContainerRef,
-    private cdr: ChangeDetectorRef,
-  ) {}
+  private readonly componentType = computed(() => {
+    const slot = this.slot();
+    return slot instanceof TemplateRef
+      ? undefined
+      : (slot ?? this.defaultComponent());
+  });
 
-  ngOnInit(): void {
-    this.renderSlot();
-  }
+  private readonly inputNames = computed(
+    () => {
+      const type = this.componentType();
+      return type ? slotInputNames(type, this.context()) : [];
+    },
+    {
+      equal: (previous, current) =>
+        previous.length === current.length &&
+        previous.every((name, index) => name === current[index]),
+    },
+  );
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes["slot"]) {
-      // Slot changed, need to re-render completely
-      this.renderSlot();
-    } else if (changes["context"] && this.componentRef) {
-      // Just context changed, update existing component
-      this.updateComponentProps();
-      this.cdr.detectChanges();
-    } else if (changes["context"]) {
-      // No component ref yet, render the slot
-      this.renderSlot();
-    }
-  }
-
-  isTemplate(value: any): value is TemplateRef<any> {
-    return value instanceof TemplateRef;
-  }
-
-  private renderSlot(): void {
-    // Skip if it's a template (handled by ngTemplateOutlet)
-    if (this.slot() && this.isTemplate(this.slot())) {
-      this.componentRef = null;
-      return;
-    }
-
-    // Clear previous content
-    this.slotContainer.clear();
-    this.componentRef = null;
-
-    // Skip if no slot and no default component
-    if (!this.slot() && !this.defaultComponent()) {
-      return;
-    }
-
-    // Use the utility to render other slot types
-    if (this.slot() || this.defaultComponent()) {
-      this.componentRef = renderSlot(this.slotContainer, {
-        slot: this.slot(),
-        defaultComponent: this.defaultComponent()!,
-        props: this.context(),
-        outputs: this.outputs(),
-      });
-    }
-  }
-
-  private updateComponentProps(): void {
-    if (!this.componentRef || !this.componentRef.instance) {
-      return;
-    }
-
-    const props = this.context();
-
-    // Update props using setInput, only for declared inputs
-    if (props) {
-      const ctor = this.componentRef.instance.constructor as any;
-      const cmpDef: any = ctor?.ɵcmp;
-      const declaredInputs = new Set<string>(Object.keys(cmpDef?.inputs ?? {}));
-
-      if (declaredInputs.has("props")) {
-        this.componentRef.setInput("props", props);
-      } else {
-        for (const key in props) {
-          if (declaredInputs.has(key)) {
-            const value = props[key];
-            this.componentRef.setInput(key, value);
-          }
-        }
-      }
-    }
-
-    // Trigger change detection
-    if (this.componentRef.changeDetectorRef) {
-      this.componentRef.changeDetectorRef.detectChanges();
-    }
+  constructor() {
+    effect((onCleanup) => {
+      const type = this.componentType();
+      if (!type) return;
+      const inputNames = this.inputNames();
+      const ref = untracked(() =>
+        this.host().createComponent(type, {
+          bindings: slotBindings(
+            type,
+            inputNames,
+            () => this.context(),
+            () => this.outputs(),
+          ),
+        }),
+      );
+      onCleanup(() => ref.destroy());
+    });
   }
 }

--- a/packages/angular/src/lib/slots/index.ts
+++ b/packages/angular/src/lib/slots/index.ts
@@ -1,3 +1,12 @@
 export * from "./slot.types";
-export * from "./slot.utils";
+export {
+  createSlotConfig,
+  createSlotRenderer,
+  getSlotConfig,
+  isComponentType,
+  isSlotValue,
+  normalizeSlotValue,
+  provideSlots,
+  renderSlot,
+} from "./slot.utils";
 export { CopilotSlot } from "./copilot-slot";

--- a/packages/angular/src/lib/slots/slot.types.ts
+++ b/packages/angular/src/lib/slots/slot.types.ts
@@ -1,4 +1,4 @@
-import { Type, TemplateRef, InjectionToken } from "@angular/core";
+import { Type, TemplateRef, InjectionToken, Injector } from "@angular/core";
 
 /**
  * Represents a value that can be used as a slot override.
@@ -6,6 +6,12 @@ import { Type, TemplateRef, InjectionToken } from "@angular/core";
  * @internal - This type is for internal use only
  */
 export type SlotValue<T = any> = Type<T> | TemplateRef<T>;
+
+/**
+ * Handlers for a slot component's outputs, keyed by the output's public
+ * (template) name. Keys that do not match a declared output are ignored.
+ */
+export type SlotOutputs = Record<string, (event: any) => void>;
 
 /**
  * Configuration for a slot
@@ -41,8 +47,8 @@ export interface RenderSlotOptions<T = any> {
   slot?: SlotValue<T>;
   defaultComponent: Type<T>;
   props?: Partial<T>;
-  injector?: any;
-  outputs?: Record<string, (event: any) => void>;
+  injector?: Injector;
+  outputs?: SlotOutputs;
 }
 
 /**

--- a/packages/angular/src/lib/slots/slot.utils.ts
+++ b/packages/angular/src/lib/slots/slot.utils.ts
@@ -1,22 +1,91 @@
 import {
-  Type,
-  TemplateRef,
-  ViewContainerRef,
+  Binding,
   ComponentRef,
   EmbeddedViewRef,
-  Injector,
+  TemplateRef,
+  Type,
+  ViewContainerRef,
   inject,
+  inputBinding,
+  outputBinding,
+  reflectComponentType,
 } from "@angular/core";
 import {
   SlotValue,
+  SlotOutputs,
   RenderSlotOptions,
   SlotRegistryEntry,
   SLOT_CONFIG,
 } from "./slot.types";
 
 /**
+ * Returns the component inputs that should be bound for the current context.
+ *
+ * Context keys are matched against public (template) input names so unknown
+ * keys are ignored without overwriting defaults for omitted inputs. A `props`
+ * input retains the legacy aggregate-context behavior.
+ */
+export function slotInputNames(
+  type: Type<unknown>,
+  context: unknown,
+): string[] {
+  const mirror = reflectComponentType(type);
+  if (!mirror) return [];
+
+  if (
+    context != null &&
+    mirror.inputs.some(({ templateName }) => templateName === "props")
+  ) {
+    return ["props"];
+  }
+
+  const contextKeys = new Set(
+    Object.keys((context as Record<string, unknown> | undefined) ?? {}),
+  );
+  return mirror.inputs
+    .filter(({ templateName }) => contextKeys.has(templateName))
+    .map(({ templateName }) => templateName);
+}
+
+/**
+ * Builds `createComponent` bindings for a slot component.
+ *
+ * The input-name set is fixed for the lifetime of the component; callers must
+ * recreate the component when {@link slotInputNames} changes. Input values and
+ * output handlers remain live through their getters. Every declared output is
+ * bound so handlers can be added, replaced, or removed without recreation.
+ */
+export function slotBindings(
+  type: Type<unknown>,
+  inputNames: readonly string[],
+  context: () => unknown,
+  outputs: () => SlotOutputs | undefined,
+): Binding[] {
+  const mirror = reflectComponentType(type);
+  if (!mirror) return [];
+  const values = () => context() as Record<string, unknown> | undefined;
+  return [
+    ...inputNames.map((templateName) =>
+      inputBinding(templateName, () =>
+        templateName === "props" ? context() : values()?.[templateName],
+      ),
+    ),
+    ...mirror.outputs.map(({ templateName }) =>
+      outputBinding(templateName, (event) =>
+        outputs()?.[templateName]?.(event),
+      ),
+    ),
+  ];
+}
+
+/**
  * Renders a slot value into a ViewContainerRef.
- * This is the core utility for slot rendering.
+ *
+ * Templates receive `{ $implicit: props, props }` as their context. Components
+ * get individual `props` keys bound to matching inputs, or the entire object
+ * when the component declares a `props` input. `outputs` are matched by public
+ * name via {@link slotBindings}; bindings are applied on the next change
+ * detection pass.
  *
  * @param viewContainer - The ViewContainerRef to render into
  * @param options - Options for rendering the slot
@@ -41,116 +110,45 @@ import {
 export function renderSlot<T = any>(
   viewContainer: ViewContainerRef,
   options: RenderSlotOptions<T>,
-): ComponentRef<T> | EmbeddedViewRef<T> | null {
+): ComponentRef<T> | EmbeddedViewRef<T> {
   const { slot, defaultComponent, props, injector, outputs } = options;
 
   viewContainer.clear();
 
   const effectiveSlot = slot ?? defaultComponent;
-  const effectiveInjector = injector ?? viewContainer.injector;
 
   if (effectiveSlot instanceof TemplateRef) {
-    // TemplateRef: render template
     return viewContainer.createEmbeddedView(effectiveSlot, {
       $implicit: props ?? {},
       props: props ?? {},
     } as any);
-  } else if (isComponentType(effectiveSlot)) {
-    // Component type - wrap in try/catch for safety
-    try {
-      return createComponent(
-        viewContainer,
-        effectiveSlot as Type<T>,
-        props,
-        effectiveInjector,
-        outputs,
-      );
-    } catch (error) {
-      console.warn("Failed to create component:", effectiveSlot, error);
-      // Fall through to default component
-    }
   }
 
-  // Default: render default component if provided
-  return defaultComponent
-    ? createComponent(
-        viewContainer,
-        defaultComponent,
-        props,
-        effectiveInjector,
-        outputs,
-      )
-    : null;
-}
-
-/**
- * Creates a component and applies properties.
- */
-function createComponent<T>(
-  viewContainer: ViewContainerRef,
-  component: Type<T>,
-  props?: Partial<T>,
-  injector?: Injector,
-  outputs?: Record<string, (event: any) => void>,
-): ComponentRef<T> {
-  const componentRef = viewContainer.createComponent(component, {
-    injector,
+  return viewContainer.createComponent(effectiveSlot, {
+    injector: injector ?? viewContainer.injector,
+    bindings: slotBindings(
+      effectiveSlot,
+      slotInputNames(effectiveSlot, props),
+      () => props,
+      () => outputs,
+    ),
   });
-
-  if (props) {
-    // Apply props using setInput, but only for declared inputs
-    const cmpDef: any = (component as any).ɵcmp;
-    const declaredInputs = new Set<string>(Object.keys(cmpDef?.inputs ?? {}));
-
-    if (declaredInputs.has("props")) {
-      componentRef.setInput("props", props as any);
-    } else {
-      for (const key in props) {
-        if (declaredInputs.has(key)) {
-          const value = (props as any)[key];
-          componentRef.setInput(key, value);
-        }
-      }
-    }
-  }
-
-  if (outputs) {
-    // Wire up output event handlers with proper cleanup
-    const instance = componentRef.instance as any;
-    const subscriptions: any[] = [];
-
-    for (const [eventName, handler] of Object.entries(outputs)) {
-      if (instance[eventName]?.subscribe) {
-        const subscription = instance[eventName].subscribe(handler);
-        subscriptions.push(subscription);
-      }
-    }
-
-    // Register cleanup on component destroy
-    componentRef.onDestroy(() => {
-      subscriptions.forEach((sub) => sub.unsubscribe());
-    });
-  }
-
-  // Trigger change detection
-  componentRef.changeDetectorRef.detectChanges();
-
-  return componentRef;
 }
 
 /**
- * Checks if a value is a component type.
- * Simplified check - rely on try/catch for actual validation.
+ * Checks if a value is an Angular component type.
  */
-export function isComponentType(value: any): boolean {
-  // Arrow functions and regular functions without a prototype are not components
-  return typeof value === "function" && !!value.prototype;
+export function isComponentType(value: unknown): value is Type<unknown> {
+  return (
+    typeof value === "function" &&
+    reflectComponentType(value as Type<unknown>) !== null
+  );
 }
 
 /**
  * Checks if a value is a valid slot value.
  */
-export function isSlotValue(value: any): value is SlotValue {
+export function isSlotValue(value: unknown): value is SlotValue {
   return value instanceof TemplateRef || isComponentType(value);
 }
 
@@ -178,12 +176,11 @@ export function normalizeSlotValue<T = any>(
 
 /**
  * Creates a slot configuration map for a component.
- * 
+ *
  * @example
  * ```typescript
  * const slots = createSlotConfig({
-    standalone: true,
-*   sendButton: CustomSendButton,
+ *   sendButton: CustomSendButton,
  *   toolbar: 'custom-toolbar-class',
  *   footer: footerTemplate
  * }, {
@@ -210,12 +207,11 @@ export function createSlotConfig<T extends Record<string, Type<any>>>(
 
 /**
  * Provides slot configuration to child components via DI.
- * 
+ *
  * @example
  * ```typescript
  * @Component({
-  standalone: true,
-*   providers: [
+ *   providers: [
  *     provideSlots({
  *       sendButton: CustomSendButton,
  *       toolbar: CustomToolbar
@@ -285,7 +281,7 @@ export function createSlotRenderer<T>(
     viewContainer: ViewContainerRef,
     slot?: SlotValue<T>,
     props?: Partial<T>,
-    outputs?: Record<string, (event: any) => void>,
+    outputs?: SlotOutputs,
   ) => {
     // Check DI for overrides if slot name provided
     if (slotName && !slot && config) {


### PR DESCRIPTION
Updates Angular slot rendering to use modern `createComponent` bindings and signal APIs.
Fixes broken Angular slot rendering in Storybook. 

### Verification
- Angular package build and type-check
- 332 tests passing, 1 skipped
- Publint and package type validation
- Angular 22 SSR, hydration, and zoneless browser smoke test

## Checklist
- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Angular slot components now support reactive rendering with template context, default components, and projected fallback content.
  - Component inputs and outputs bind consistently, including custom output event handlers.
  - Added the `SlotOutputs` type to the public Angular API.

- **Documentation**
  - Updated Angular API documentation and slot usage examples to reflect available exports and binding behavior.

- **Tests**
  - Added coverage for fallback rendering, template context, component inputs, output events, and legacy property binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->