### PR TITLE
docs(runtime): add Parallel Search MCP setup example

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/mcp-servers.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/mcp-servers.mdx
@@ -69,6 +69,20 @@ const builtInAgent = new BuiltInAgent({
 
 The HTTP transport also accepts optional `options` for advanced configuration of the underlying `StreamableHTTPClientTransport`.
 
+### Example: web search with Parallel
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides `web_search` for public web search and `web_fetch` for extracting page content. Its free, rate-limited endpoint requires no Parallel account or API key.
+
+Add this entry to your existing `BuiltInAgent` configuration's `mcpServers` array, keeping any other servers you use:
+
+```typescript
+{ type: "http", url: "https://search.parallel.ai/mcp" }
+```
+
+Once configured, the agent can call these tools automatically when relevant. Tool calls send queries, requested URLs, and any supplied objectives, context, or metadata to Parallel. Your agent's existing model credentials are still required. Remove the entry to disconnect Parallel.
+
+To try it, ask your agent to find CopilotKit's official documentation, then fetch a page from the results. The connection uses Streamable HTTP, so keep `type: "http"` and omit authentication headers for this anonymous endpoint.
+
 ## Multiple servers
 
 Connect multiple MCP servers — tools from all servers are available to the agent:


### PR DESCRIPTION
## What does this PR do?

Adds a working Parallel Search example to the built-in agent's MCP guide. Copy one HTTP entry into `mcpServers` and your agent gets `web_search` and `web_fetch`, with no Parallel account or API key.

I checked the [built-in agent's MCP loader](https://github.com/CopilotKit/CopilotKit/blob/8c629c147bcd5a85a80ac434633756a7aaf3ee8b/packages/runtime/src/agent/index.ts#L1354-L1372): it starts with no MCP servers unless you configure them. [Some demos use Tavily's SDK](https://github.com/CopilotKit/CopilotKit/blob/8c629c147bcd5a85a80ac434633756a7aaf3ee8b/examples/showcases/deep-agents/agent/tools.py#L31-L40), but there isn't a built-in search default to replace here.

The reason I think this is worth adding: in [Artificial Analysis's August 31 results](https://artificialanalysis.ai/agents/search-api), Parallel fast scored **80.2 on DeepSearchQA**, the benchmark for research questions that need multiple searches. That's ahead of every tested variant from Exa, Brave, You.com, Firecrawl, Tavily, TinyFish, and Keenable. The biggest gaps are against Brave web (62.3), You.com snippets (63.4), and TinyFish web (67.2); Parallel also beats Brave and You.com's stronger variants, shown below.

Parallel fast also has the **lowest average time per task of all 19 tested configurations: 19.4 seconds**. Perplexity medium takes 28.8 seconds, Tavily basic 46.1, and Firecrawl 63.2. Those results make it worth trying for agents that need to research the web and respond quickly.

Perplexity medium still leads the overall Search Index and scores slightly higher on DeepSearchQA. These are [Search API benchmark results](https://artificialanalysis.ai/methodology/search-api), with the same answer model and harness across providers, not a benchmark of this CopilotKit example. Time per task includes model time and search time. The [anonymous MCP endpoint uses fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp), so that's the Parallel configuration I'm highlighting.

<details>
<summary>All 19 configurations from Artificial Analysis</summary>

Scores are on a 0–100 scale, rounded to one decimal from the data published on the [leaderboard](https://artificialanalysis.ai/agents/search-api). Search Index combines DeepSearchQA, BrowseComp, and AA-Omniscience. Retrieved September 4, 2026.

| Search API configuration | DeepSearchQA F1 ↑ | Search Index ↑ | Time per task ↓ |
| --- | ---: | ---: | ---: |
| Perplexity Search (medium) | 80.8 | 80.0 | 28.8s |
| Parallel Search (advanced) | 80.6 | 74.8 | 42.9s |
| Perplexity Search (high) | 80.5 | 78.9 | 29.7s |
| Parallel Search (fast) | 80.2 | 73.1 | 19.4s |
| Parallel Search (basic) | 79.5 | 73.2 | 27.9s |
| Brave Search (LLM context) | 78.1 | 74.6 | 24.3s |
| Exa Search (auto) | 77.8 | 73.7 | 33.2s |
| You.com Search (highlights) | 76.7 | 74.1 | 20.7s |
| Exa Search (fast) | 75.7 | 68.4 | 28.8s |
| Perplexity Search (low) | 75.6 | 76.9 | 37.3s |
| Tavily Search (basic) | 74.4 | 65.6 | 46.1s |
| Firecrawl Search | 73.6 | 73.5 | 63.2s |
| Exa Search (instant) | 73.0 | 68.4 | 20.2s |
| Parallel Search (turbo) | 70.2 | 67.1 | 27.1s |
| Keenable Search (pro) | 70.1 | 67.0 | 30.1s |
| Keenable Search (realtime) | 69.9 | 66.5 | 22.4s |
| TinyFish Search (web) | 67.2 | 71.2 | 60.4s |
| You.com Search (snippets) | 63.4 | 67.6 | 42.7s |
| Brave Search (web) | 62.3 | 64.6 | 36.2s |

</details>

The guide explains rate limits, what tool calls send to Parallel, automatic tool use, and how to remove the connection. This is documentation only; it does not configure a server for existing users.

I work at Parallel, which operates this service.

Validation:

- Compiled the full edited page with `@mdx-js/mdx` 3 and ran `git diff --check`.
- Loaded the exact documented entry through published `@copilotkit/runtime` 1.70.1 `BuiltInAgent`, with a deterministic local model fixture and `maxSteps: 3`. Real MCP discovery exposed both tools; search returned 10 results and fetch returned the official setup page with zero per-URL errors. The test environment had no credentials, and the requests had no authentication headers.
- No repository build or full documentation site build was run.

## Related PRs and Issues

None.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an example showing how to connect a Parallel web search MCP server to the built-in agent.
  - Documented available web search and fetch tools, configuration details, data handling, authentication requirements, and how to disconnect the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->