### PR TITLE
feat(runtime): warn when assembled agent context is oversized

### DIFF
--- a/packages/runtime/src/agent/__tests__/agent-context-size.test.ts
+++ b/packages/runtime/src/agent/__tests__/agent-context-size.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD,
+  getAgentContextWarnThreshold,
+  resetAgentContextWarnState,
+  warnIfAssembledAgentContextOversized,
+} from "../agent-context-size";
+
+describe("getAgentContextWarnThreshold", () => {
+  const originalThreshold = process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+
+  afterEach(() => {
+    if (originalThreshold === undefined) {
+      delete process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+    } else {
+      process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = originalThreshold;
+    }
+  });
+
+  it("uses the default when the env value is unset, empty, or whitespace", () => {
+    delete process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+    expect(getAgentContextWarnThreshold()).toBe(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD,
+    );
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "";
+    expect(getAgentContextWarnThreshold()).toBe(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD,
+    );
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "  ";
+    expect(getAgentContextWarnThreshold()).toBe(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD,
+    );
+  });
+
+  it("rejects partially parsed or malformed values and falls back to the default", () => {
+    for (const bad of ["100abc", "1.5", "-1oops", "abc", "12px", "-2", "--1"]) {
+      process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = bad;
+      expect(getAgentContextWarnThreshold()).toBe(
+        DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD,
+      );
+    }
+  });
+
+  it("accepts a complete non-negative integer and the -1 disable sentinel", () => {
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "10";
+    expect(getAgentContextWarnThreshold()).toBe(10);
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "0";
+    expect(getAgentContextWarnThreshold()).toBe(0);
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "-1";
+    expect(getAgentContextWarnThreshold()).toBe(-1);
+  });
+});
+
+describe("warnIfAssembledAgentContextOversized", () => {
+  const originalThreshold = process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    resetAgentContextWarnState();
+    delete process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalThreshold === undefined) {
+      delete process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+    } else {
+      process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = originalThreshold;
+    }
+  });
+
+  it("warns as soon as the assembled size exceeds the default threshold", () => {
+    warnIfAssembledAgentContextOversized(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD + 1,
+      "builtIn",
+    );
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warn when the assembled size is within the threshold", () => {
+    warnIfAssembledAgentContextOversized(10, "builtIn");
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns only once per call-site variant, even across repeated turns", () => {
+    warnIfAssembledAgentContextOversized(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD + 1,
+      "builtIn",
+    );
+    warnIfAssembledAgentContextOversized(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD + 1,
+      "builtIn",
+    );
+    expect(console.warn).toHaveBeenCalledTimes(1);
+
+    vi.mocked(console.warn).mockClear();
+    warnIfAssembledAgentContextOversized(
+      DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD + 1,
+      "tanstack",
+    );
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours an env-overridable threshold and disables with -1", () => {
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "10";
+    warnIfAssembledAgentContextOversized(50, "tanstack");
+    expect(console.warn).toHaveBeenCalledTimes(1);
+
+    vi.mocked(console.warn).mockClear();
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "-1";
+    warnIfAssembledAgentContextOversized(50, "tanstack");
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns on any non-empty prompt when the threshold is 0", () => {
+    process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD = "0";
+    warnIfAssembledAgentContextOversized(1, "builtIn");
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/src/agent/__tests__/basic-agent.test.ts
+++ b/packages/runtime/src/agent/__tests__/basic-agent.test.ts
@@ -396,6 +396,32 @@ describe("BasicAgent", () => {
       expect(systemMessage.content).toContain('"items"');
     });
 
+    it("should serialize state exactly once per assembly (toJSON is not re-run by the warning path)", async () => {
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([finish()]) as any,
+      );
+
+      const toJSON = vi.fn(() => ({ counter: 1 }));
+      const input: RunAgentInput = {
+        threadId: "thread1",
+        runId: "run1",
+        messages: [],
+        tools: [],
+        context: [],
+        state: { toJSON },
+      };
+
+      await collectEvents(agent["run"](input));
+
+      // The prompt builder serializes once and passes the text to the warning
+      // helper, so a stateful toJSON() must not be invoked a second time.
+      expect(toJSON).toHaveBeenCalledTimes(1);
+    });
+
     it("should combine prompt, context, and state", async () => {
       const agent = new BasicAgent({
         model: "openai/gpt-4o",

--- a/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
+++ b/packages/runtime/src/agent/__tests__/converter-tanstack-input.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { convertInputToTanStackAI } from "../converters/tanstack";
 import { createDefaultInput } from "./agent-test-helpers";
 
@@ -272,6 +272,23 @@ describe("convertInputToTanStackAI", () => {
       expect(
         systemPrompts.find((p) => p.startsWith("Application State:")),
       ).toBeUndefined();
+    });
+
+    it("serializes state exactly once per assembly (toJSON is not re-run by the warning path)", () => {
+      const toJSON = vi.fn(() => ({ count: 42 }));
+      const input = createDefaultInput({
+        state: { toJSON },
+      });
+
+      const { systemPrompts } = convertInputToTanStackAI(input);
+
+      const statePrompt = systemPrompts.find((p) =>
+        p.startsWith("Application State:"),
+      );
+      expect(statePrompt).toBeDefined();
+      // The prompt builder serializes once and passes the text to the warning
+      // helper, so a stateful toJSON() must not be invoked a second time.
+      expect(toJSON).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/runtime/src/agent/agent-context-size.ts
+++ b/packages/runtime/src/agent/agent-context-size.ts
@@ -1,0 +1,87 @@
+/**
+ * Default threshold (in characters) for the assembled agent system prompt.
+ *
+ * We warn rather than truncate: an application legitimately shares large state
+ * (a whole document, sheet or research report), and silently dropping it would
+ * corrupt the conversation. Characters are not tokens, so this is a heuristic
+ * signal, not a hard budget. The value is configurable via
+ * `COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD`:
+ *
+ *  - `-1` disables the warning entirely.
+ *  - `0` warns on any non-empty assembled prompt.
+ */
+export const DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD = 100_000;
+
+/** Which prompt-assembly path we are measuring (used only to dedupe the warning). */
+export type AgentContextAssembleVariant = "builtIn" | "tanstack";
+
+/**
+ * Module-level bookkeeping so each call site warns at most once **per process**.
+ * This is intentional: a long-running server should surface the oversized-prompt
+ * signal once rather than on every turn. It is only reset in tests via
+ * `resetAgentContextWarnState`; in production it stays set for the lifetime of
+ * the process.
+ */
+const warnedVariants = new Set<AgentContextAssembleVariant>();
+
+/** Reads the (optional, environment-overridable) warning threshold. */
+export function getAgentContextWarnThreshold(): number {
+  const raw = process.env.COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD;
+  }
+  // `parseInt` accepts a valid prefix and silently ignores trailing input
+  // ("100abc" -> 100, "1.5" -> 1). Only accept a complete non-negative integer,
+  // plus the documented `-1` disable sentinel; any other value falls back to the
+  // default so a malformed env value cannot silently lower or disable warnings.
+  const trimmed = raw.trim();
+  if (trimmed === "-1") {
+    return -1;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+  return DEFAULT_AGENT_CONTEXT_WARN_THRESHOLD;
+}
+
+/** Test-only: clears the per-variant "already warned" bookkeeping. */
+export function resetAgentContextWarnState(): void {
+  warnedVariants.clear();
+}
+
+/**
+ * Warns (once per call site) when the assembled agent system prompt is large
+ * enough to inflate token cost, without discarding any data.
+ *
+ * Callers pass the actual size of the prompt they assembled, so the measurement
+ * can never drift from what is injected:
+ *
+ *  - `builtIn`: the exact `systemPrompt.length` (includes the developer prompt).
+ *  - `tanstack`: the summed length of the `systemPrompts` entries (approximate —
+ *    the provider adapter performs the final join, so entry separators are not
+ *    counted and differ between adapters).
+ */
+export function warnIfAssembledAgentContextOversized(
+  assembledSize: number,
+  variant: AgentContextAssembleVariant,
+): void {
+  const threshold = getAgentContextWarnThreshold();
+  if (threshold < 0) {
+    return;
+  }
+  if (assembledSize <= threshold) {
+    return;
+  }
+  if (warnedVariants.has(variant)) {
+    return;
+  }
+  warnedVariants.add(variant);
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[CopilotKit] Assembled agent system prompt is large (" +
+      `${assembledSize.toLocaleString()} characters). ` +
+      "This goes into the prompt and can inflate token cost. " +
+      "Consider trimming what you share, or raise " +
+      "COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD if this is intentional.",
+  );
+}

--- a/packages/runtime/src/agent/converters/tanstack.ts
+++ b/packages/runtime/src/agent/converters/tanstack.ts
@@ -18,6 +18,7 @@ import type {
 } from "@ag-ui/client";
 import { EventType } from "@ag-ui/client";
 import { randomUUID } from "@copilotkit/shared";
+import { warnIfAssembledAgentContextOversized } from "../agent-context-size";
 import { createStateEventNormalizer } from "../state-delta";
 import {
   aggregateRunUsage,
@@ -302,16 +303,28 @@ export function convertInputToTanStackAI(
     }
   }
 
-  if (
+  const hasState =
     input.state !== undefined &&
     input.state !== null &&
     typeof input.state === "object" &&
-    Object.keys(input.state).length > 0
-  ) {
+    Object.keys(input.state).length > 0;
+  const serializedState = hasState
+    ? String(JSON.stringify(input.state, null, 2))
+    : undefined;
+
+  if (hasState) {
     systemPrompts.push(
-      `Application State:\n\`\`\`json\n${JSON.stringify(input.state, null, 2)}\n\`\`\``,
+      `Application State:\n\`\`\`json\n${serializedState}\n\`\`\``,
     );
   }
+
+  // Approximate: `chat()` returns the array and the provider adapter performs
+  // the final join, so the separator is adapter-dependent. Sum the entry lengths
+  // without counting separators — good enough for a warning.
+  warnIfAssembledAgentContextOversized(
+    systemPrompts.reduce((sum, prompt) => sum + prompt.length, 0),
+    "tanstack",
+  );
 
   // Frontend-provided tools become client-side TanStack tools (no executor):
   // the model can call them, TanStack pauses the run, and the AG-UI client

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -49,6 +49,7 @@ import { z } from "zod";
 import type { StandardSchemaV1, InferSchemaOutput } from "@copilotkit/shared";
 import { schemaToJsonSchema } from "@copilotkit/shared";
 import { jsonSchema as aiJsonSchema } from "ai";
+import { warnIfAssembledAgentContextOversized } from "./agent-context-size";
 import {
   convertAISDKStream,
   getAISDKRunFinishedDetails,
@@ -1066,15 +1067,22 @@ export class BuiltInAgent extends AbstractAgent {
         }
 
         // Third: state from the application that can be edited
+        const serializedState = hasState
+          ? String(JSON.stringify(input.state, null, 2))
+          : undefined;
         if (hasState) {
           parts.push(
             "\n## Application State\n" +
               "This is state from the application that you can edit by calling AGUISendStateSnapshot or AGUISendStateDelta.\n" +
-              `\`\`\`json\n${JSON.stringify(input.state, null, 2)}\n\`\`\`\n`,
+              `\`\`\`json\n${serializedState}\n\`\`\`\n`,
           );
         }
 
         systemPrompt = parts.join("");
+        // Measure the exact assembled string — it cannot drift from what is sent,
+        // and it also covers the developer's own `config.prompt` (the most likely
+        // thing to bloat the prompt).
+        warnIfAssembledAgentContextOversized(systemPrompt.length, "builtIn");
       }
 
       // Convert messages and prepend system message if we have a prompt


### PR DESCRIPTION
## Summary

Follow-up to #6754 (closed) per maintainer review: replace the truncation approach with warn, do not mutate. The previous PR silently truncated context values, which (a) left the usually-larger input.state uncapped, (b) changed the public convertInputToTanStackAI contract, and (c) could throw on null/object values. This iteration keeps all data intact and only emits a single console.warn when the assembled context block exceeds a threshold.

- Warnings cover **both** injection sites (BuiltInAgent and convertInputToTanStackAI).
- Measures the **assembled total** across context + serialized state, matching the actual prompt shape.
- Adds an env knob COPILOTKIT_AGENT_CONTEXT_WARN_THRESHOLD (default 100,000 chars; -1 disables).
- No data mutation, no public contract change.

Closes #6754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warnings when assembled agent context exceeds the configured size threshold.
  * Context size calculations include supplied context details and serialized state without changing the data.
  * Warning thresholds can be configured through the environment, including an option to disable warnings.
  * Warnings are limited to one per processing path across supported agent workflows.

* **Tests**
  * Added coverage for size calculations, threshold boundaries, configuration, disabled warnings, deduplication, and data preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->