### PR TITLE
docs(examples): fix stale counts and add missing integration/showcase rows

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # CopilotKit Examples
 
-This directory contains 52 consolidated demo repositories showcasing CopilotKit integrations, canvas apps, and showcases.
+This directory contains 61 consolidated demo repositories showcasing CopilotKit integrations, canvas apps, and showcases.
 
 Each example is a self-contained project. To get started:
 
@@ -14,7 +14,7 @@ cd examples/<category>/<name>
 
 ---
 
-## Integrations (20)
+## Integrations (22)
 
 Framework integration starters demonstrating CopilotKit with various agent frameworks.
 
@@ -40,6 +40,8 @@ Framework integration starters demonstrating CopilotKit with various agent frame
 | [a2a-middleware](./integrations/a2a-middleware/)                       | Multi-agent starter with A2A Protocol and AG-UI Protocol (LangGraph + ADK)           |
 | [claude-sdk-python](./integrations/claude-sdk-python/)                 | Starter template using the Claude Agent SDK (Python) and CopilotKit                  |
 | [claude-sdk-typescript](./integrations/claude-sdk-typescript/)         | Starter template using the Claude Agent SDK (TypeScript) and CopilotKit              |
+| [adk-angular](./integrations/adk-angular/)                             | Starter template using Google ADK with an Angular frontend and CopilotKit            |
+| [agentcore](./integrations/agentcore/)                                 | Chat UI with generative charts deployed on AWS Bedrock AgentCore                     |
 
 ## Canvas (7)
 
@@ -55,7 +57,7 @@ AI-powered canvas applications with visual card interfaces, real-time state sync
 | [gemini](./canvas/gemini/)                           | Open Gemini Canvas — post generator and stack analyzer agents (Gemini + LangGraph)      |
 | [mastra-pm](./canvas/mastra-pm/)                     | AG-UI + Mastra workshop — shared state, multiple clients, generative UI                 |
 
-## Showcases (25)
+## Showcases (32)
 
 Full-featured demo applications highlighting CopilotKit capabilities in real-world scenarios.
 
@@ -86,3 +88,10 @@ Full-featured demo applications highlighting CopilotKit capabilities in real-wor
 | [spreadsheet](./showcases/spreadsheet/)                                 | AI-powered Excel-like spreadsheet web app                                                                           |
 | [todo](./showcases/todo/)                                               | Simple todo app built with CopilotKit                                                                               |
 | [strands-crm](./showcases/strands-crm/)                                 | Enterprise sales CRM — dashboard, pipeline, products, quotes, reports & agentic canvas (TypeScript Strands + AG-UI) |
+| [a2ui-pdf-analyst](./showcases/a2ui-pdf-analyst/)                       | Chat with your PDF — A2UI analyst that builds UI for each answer                                                    |
+| [arcade-tools](./showcases/arcade-tools/)                               | CopilotKit Built-in Agent with authenticated Arcade tools (Gmail, Google News)                                      |
+| [claude-managed-agents](./showcases/claude-managed-agents/)             | Hosted Claude Managed Agent connected to CopilotKit chat over AG-UI                                                 |
+| [daytona-runcode](./showcases/daytona-runcode/)                         | Built-in Agent with a runCode tool executing code in an isolated Daytona sandbox                                    |
+| [deep-agents-finance-erp](./showcases/deep-agents-finance-erp/)         | Finance ERP showcase — invoices, accounts, inventory, HR, and reports (deep agents)                                 |
+| [open-mcp-client](./showcases/open-mcp-client/)                         | Open MCP client builder — render and create MCP Apps with CopilotKit                                                |
+| [oracle-agent-memory](./showcases/oracle-agent-memory/)                 | Travel concierge demo — Oracle Agent Spec, generative UI, and cross-session memory                                  |


### PR DESCRIPTION
The examples index drifted from reality: header says 52 repos / 20 integrations / 25 showcases, but the tree has 61 consolidated demos (22 integrations excl _parity, 7 canvas, 32 showcases). The integrations table omits adk-angular + agentcore and the showcases table omits 7 demos (a2ui-pdf-analyst, arcade-tools, claude-managed-agents, daytona-runcode, deep-agents-finance-erp, open-mcp-client, oracle-agent-memory).

This PR corrects the counts and adds the missing rows with descriptions taken from each demo README. Verified: every linked path in the file resolves to an existing directory (61 links, 0 missing); oxfmt check passes. No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the examples documentation to reflect the current example counts.
  - Added integration examples for Angular and AgentCore.
  - Added seven showcase examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->