### PR TITLE
test(sdk-js): document header propagation API and cover async/edge cases

### DIFF
--- a/packages/sdk-js/src/__tests__/header-propagation.test.ts
+++ b/packages/sdk-js/src/__tests__/header-propagation.test.ts
@@ -127,5 +127,29 @@ describe("header-propagation", () => {
         expect(getForwardedHeaders()).toEqual({ "x-aimock-strict": "true" });
       });
     });
+
+    it("preserves header values verbatim (including special chars)", () => {
+      withForwardedHeaders({ "x-trace": "a=b&c/d;e:f" }, () => {
+        expect(getForwardedHeaders()).toEqual({ "x-trace": "a=b&c/d;e:f" });
+      });
+    });
+
+    it("supports async callbacks and propagates the promise value", async () => {
+      const result = await withForwardedHeaders(
+        { "x-request-id": "async-1" },
+        async () => {
+          await new Promise((r) => setTimeout(r, 1));
+          expect(getForwardedHeaders()).toEqual({ "x-request-id": "async-1" });
+          return "done";
+        },
+      );
+      expect(result).toBe("done");
+    });
+
+    it("handles empty headers input", () => {
+      withForwardedHeaders({}, () => {
+        expect(getForwardedHeaders()).toEqual({});
+      });
+    });
   });
 });

--- a/packages/sdk-js/src/header-propagation.ts
+++ b/packages/sdk-js/src/header-propagation.ts
@@ -46,6 +46,22 @@ function filterForwardableHeaders(headers: HeaderMap): HeaderMap {
 /**
  * Run a callback with forwarded headers available via getForwardedHeaders().
  * Call this at the AG-UI request entry point.
+ *
+ * Only `x-*` prefixed headers are forwarded (case-insensitive); all other
+ * headers are dropped. Keys are normalized to lowercase.
+ *
+ * @param headers - Incoming request headers (any casing).
+ * @param fn - Callback to run inside the forwarded-headers scope.
+ * @returns The callback's return value (supports async callbacks).
+ *
+ * @example
+ * ```ts
+ * import { withForwardedHeaders, getForwardedHeaders } from "@copilotkit/sdk-js";
+ *
+ * withForwardedHeaders({ "x-request-id": "abc", authorization: "Bearer s" }, () => {
+ *   getForwardedHeaders(); // { "x-request-id": "abc" }
+ * });
+ * ```
  */
 export function withForwardedHeaders<T>(headers: HeaderMap, fn: () => T): T {
   return headerStorage.run(filterForwardableHeaders(headers), fn);
@@ -55,6 +71,13 @@ export function withForwardedHeaders<T>(headers: HeaderMap, fn: () => T): T {
  * Get x-* prefixed headers that should be forwarded to outgoing LLM calls.
  * Returns empty object when called outside a withForwardedHeaders() scope
  * (demo traffic).
+ *
+ * @returns A map of lowercased `x-*` headers, or `{}` outside a scope.
+ *
+ * @example
+ * ```ts
+ * getForwardedHeaders(); // {} when no scope is active
+ * ```
  */
 export function getForwardedHeaders(): HeaderMap {
   return headerStorage.getStore() ?? {};


### PR DESCRIPTION
Expands the JSDoc for withForwardedHeaders/getForwardedHeaders (params, returns, example) and adds 3 additive tests: verbatim value preservation, async callback propagation, and empty-input handling. No behavior change; existing tests untouched. Verified: oxfmt passes; header-propagation logic unmodified (AsyncLocalStorage x-* filtering preserved); new expectations match the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified forwarded-header behavior, including case handling, key normalization, return values, and behavior outside an active scope.
* **Tests**
  * Added coverage for special characters, asynchronous callbacks, promise propagation, and empty header inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->