### PR TITLE
feat(examples): add minimal OpenAI Agents SDK starter

### DIFF
--- a/examples/integrations/openai-agents/.gitignore
+++ b/examples/integrations/openai-agents/.gitignore
@@ -1,0 +1,35 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# python
+agent/.venv/
+__pycache__/
+.venv/

--- a/examples/integrations/openai-agents/README.md
+++ b/examples/integrations/openai-agents/README.md
@@ -1,0 +1,53 @@
+# CopilotKit <> OpenAI Agents SDK Starter
+
+Minimal starter template for building AI agents using the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) (`openai-agents` on PyPI) and [CopilotKit](https://copilotkit.ai). It pairs a Next.js chat UI with a small Python agent served over AG-UI.
+
+## Prerequisites
+
+- Node.js 20+
+- Python 3.10+
+- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- OpenAI API Key (for the agent)
+
+## Getting Started
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+> **Note:** Installing dependencies also installs the agent's Python dependencies via the `install:agent` script.
+
+2. Set up your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY="your-openai-api-key-here"
+```
+
+or create a `.env` file:
+
+```bash
+echo "OPENAI_API_KEY=your-openai-api-key-here" > .env
+```
+
+3. Start the development servers:
+
+```bash
+npm run dev
+```
+
+This starts the Next.js UI (`http://localhost:3000`) and the Python agent (`http://localhost:8000`, `/agui` endpoint with a `/health` check).
+
+## Layout
+
+- `src/app/page.tsx` — minimal `CopilotSidebar` chat UI.
+- `src/app/api/copilotkit/[[...slug]]/route.ts` — CopilotKit runtime proxying to the Python agent.
+- `src/agent.ts` — shared `HttpAgent` pointing at `AGENT_URL` (defaults to `http://localhost:8000/agui`).
+- `agent/src/agent.py` — the OpenAI Agents SDK `Agent` definition.
+- `agent/main.py` — FastAPI server exposing the agent over AG-UI SSE (`POST /agui`).
+
+## Notes
+
+- This is a minimal starter, not a full investment-analyst demo: the agent answers with `Runner.run` and streams the final text as AG-UI events.
+- Set `AGENT_URL` in `.env` if the agent runs on a different host or port.

--- a/examples/integrations/openai-agents/agent/main.py
+++ b/examples/integrations/openai-agents/agent/main.py
@@ -1,0 +1,64 @@
+"""Serve the OpenAI Agents SDK agent as an AG-UI endpoint.
+
+Run with: uv sync && uv run python main.py
+Requires OPENAI_API_KEY in the environment (see ../.env).
+"""
+
+import json
+import uuid
+from pathlib import Path
+
+import dotenv
+from agents import Runner
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+
+from src.agent import agent
+
+dotenv.load_dotenv(Path(__file__).resolve().parent.parent / ".env")
+dotenv.load_dotenv()
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.post("/agui")
+async def agui(request: Request):
+    body = await request.json()
+    messages = body.get("messages", [])
+    thread_id = body.get("threadId", str(uuid.uuid4()))
+    run_id = body.get("runId", str(uuid.uuid4()))
+
+    # Flatten AG-UI messages to a single input string for the SDK.
+    turns = []
+    for m in messages:
+        role = m.get("role", "user")
+        content = m.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                part.get("text", "") for part in content if isinstance(part, dict)
+            )
+        turns.append(f"{role}: {content}")
+    user_input = "\n".join(turns) or "Hello"
+
+    async def event_stream():
+        yield f"data: {json.dumps({'type': 'RUN_STARTED', 'threadId': thread_id, 'runId': run_id})}\n\n"
+        message_id = str(uuid.uuid4())
+        yield f"data: {json.dumps({'type': 'TEXT_MESSAGE_START', 'messageId': message_id})}\n\n"
+        result = await Runner.run(agent, user_input)
+        text = str(result.final_output or "")
+        yield f"data: {json.dumps({'type': 'TEXT_MESSAGE_CONTENT', 'messageId': message_id, 'delta': text})}\n\n"
+        yield f"data: {json.dumps({'type': 'TEXT_MESSAGE_END', 'messageId': message_id})}\n\n"
+        yield f"data: {json.dumps({'type': 'RUN_FINISHED', 'threadId': thread_id, 'runId': run_id})}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", port=8000, reload=True)

--- a/examples/integrations/openai-agents/agent/pyproject.toml
+++ b/examples/integrations/openai-agents/agent/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "openai-agents-starter-agent"
+version = "0.1.0"
+description = "An OpenAI Agents SDK agent exposed in an AG-UI compatible way for CopilotKit"
+requires-python = ">=3.10"
+dependencies = [
+  "openai-agents>=0.2.0",
+  "fastapi>=0.115.13",
+  "uvicorn>=0.34.3",
+  "ag-ui-protocol>=0.1.8",
+  "python-dotenv>=1.0.0",
+]

--- a/examples/integrations/openai-agents/agent/src/agent.py
+++ b/examples/integrations/openai-agents/agent/src/agent.py
@@ -1,0 +1,17 @@
+"""OpenAI Agents SDK agent for the CopilotKit starter.
+
+Uses the official `openai-agents` package
+(https://github.com/openai/openai-agents-python):
+
+    from agents import Agent, Runner
+"""
+
+from agents import Agent
+
+agent = Agent(
+    name="Assistant",
+    instructions=(
+        "You are a helpful assistant connected to CopilotKit. "
+        "Format your responses in markdown."
+    ),
+)

--- a/examples/integrations/openai-agents/next.config.ts
+++ b/examples/integrations/openai-agents/next.config.ts
@@ -1,0 +1,8 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  typescript: { ignoreBuildErrors: true },
+  serverExternalPackages: ["pino", "thread-stream"],
+};
+
+export default nextConfig;

--- a/examples/integrations/openai-agents/package.json
+++ b/examples/integrations/openai-agents/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "openai-agents-starter",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"npm run dev:ui\" \"npm run dev:agent\" --names ui,agent --prefix-colors blue,green --kill-others",
+    "dev:agent": "./scripts/run-agent.sh",
+    "dev:ui": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "install:agent": "./scripts/setup-agent.sh",
+    "postinstall": "npm run install:agent"
+  },
+  "dependencies": {
+    "@ag-ui/client": "0.0.58",
+    "@copilotkit/react-core": "1.70.0",
+    "@copilotkit/runtime": "1.70.0",
+    "@hono/node-server": "^1",
+    "clsx": "^2.1.1",
+    "dotenv": "^16.4.7",
+    "hono": "^4",
+    "next": "16.0.7",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "concurrently": "^9.1.2",
+    "tailwindcss": "^4",
+    "tsx": "^4.19.2",
+    "typescript": "^5"
+  }
+}

--- a/examples/integrations/openai-agents/postcss.config.mjs
+++ b/examples/integrations/openai-agents/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/examples/integrations/openai-agents/scripts/run-agent.sh
+++ b/examples/integrations/openai-agents/scripts/run-agent.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Navigate to the agent directory
+cd "$(dirname "$0")/../agent" || exit 1
+
+# Run the agent using uv
+uv run python main.py

--- a/examples/integrations/openai-agents/scripts/setup-agent.sh
+++ b/examples/integrations/openai-agents/scripts/setup-agent.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Navigate to the agent directory
+cd "$(dirname "$0")/../agent" || exit 1
+
+# Install dependencies using uv
+uv sync

--- a/examples/integrations/openai-agents/src/agent.ts
+++ b/examples/integrations/openai-agents/src/agent.ts
@@ -1,0 +1,10 @@
+import { HttpAgent } from "@ag-ui/client";
+
+/** Builds this starter's agent, served by agent/main.py. */
+export function createDefaultAgent(): HttpAgent {
+  return new HttpAgent({
+    url:
+      (process.env.AGENT_URL || "http://localhost:8000").replace(/\/$/, "") +
+      "/agui",
+  });
+}

--- a/examples/integrations/openai-agents/src/app/api/copilotkit/[[...slug]]/route.ts
+++ b/examples/integrations/openai-agents/src/app/api/copilotkit/[[...slug]]/route.ts
@@ -1,0 +1,24 @@
+import {
+  CopilotRuntime,
+  createCopilotEndpoint,
+  InMemoryAgentRunner,
+} from "@copilotkit/runtime/v2";
+import { createDefaultAgent } from "@/agent";
+import { handle } from "hono/vercel";
+
+const runtime = new CopilotRuntime({
+  agents: {
+    default: createDefaultAgent(),
+  },
+  runner: new InMemoryAgentRunner(),
+});
+
+const app = createCopilotEndpoint({
+  runtime,
+  basePath: "/api/copilotkit",
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const PATCH = handle(app);
+export const DELETE = handle(app);

--- a/examples/integrations/openai-agents/src/app/globals.css
+++ b/examples/integrations/openai-agents/src/app/globals.css
@@ -1,0 +1,7 @@
+@import "tailwindcss";
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}

--- a/examples/integrations/openai-agents/src/app/layout.tsx
+++ b/examples/integrations/openai-agents/src/app/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+
+import { CopilotKit } from "@copilotkit/react-core/v2";
+import "./globals.css";
+import "@copilotkit/react-core/v2/styles.css";
+
+export const metadata: Metadata = {
+  title: "OpenAI Agents + CopilotKit Starter",
+  description:
+    "A minimal starter connecting an OpenAI Agents SDK agent to CopilotKit over AG-UI.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className="antialiased" suppressHydrationWarning>
+        <CopilotKit runtimeUrl="/api/copilotkit" useSingleEndpoint={false}>
+          {children}
+        </CopilotKit>
+      </body>
+    </html>
+  );
+}

--- a/examples/integrations/openai-agents/src/app/page.tsx
+++ b/examples/integrations/openai-agents/src/app/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { CopilotSidebar } from "@copilotkit/react-core/v2";
+
+export const dynamic = "force-dynamic";
+
+export default function CopilotKitPage() {
+  return (
+    <main style={{ height: "100vh" }}>
+      <CopilotSidebar
+        defaultOpen
+        labels={{
+          title: "OpenAI Agents Assistant",
+          initial: "Hi! I run on the OpenAI Agents SDK. Ask me anything.",
+        }}
+      />
+    </main>
+  );
+}

--- a/examples/integrations/openai-agents/tsconfig.json
+++ b/examples/integrations/openai-agents/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
New integration starter examples/integrations/openai-agents pairing a minimal Next.js CopilotSidebar UI with a Python agent built on the official openai-agents package (Agent + Runner) served over AG-UI SSE (POST /agui, GET /health). Follows the agno/pydantic-ai layout (package.json, tsconfig, next.config, src/agent.ts, runtime route, agent/pyproject.toml, scripts). Verified: python py_compile passes on agent files; oxfmt passes on all TS/JSON files; no existing parity instances touched (not in _parity/manifest.json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a starter integration combining CopilotKit with the OpenAI Agents SDK.
  - Added a chat interface with a CopilotKit sidebar and markdown-formatted assistant responses.
  - Added streaming agent communication through AG-UI.
  - Added health-check and agent endpoints for local development.
  - Added setup and run scripts for the web app and Python agent.

- **Documentation**
  - Added setup instructions, prerequisites, project layout, and usage guidance for the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->