### PR TITLE
docs(showcase): explain the AgentCore 401 "Missing Authentication Token"

### DIFF
--- a/showcase/shell-docs/src/content/docs/deploy/agentcore.mdx
+++ b/showcase/shell-docs/src/content/docs/deploy/agentcore.mdx
@@ -411,6 +411,39 @@ Browser → CopilotKit Runtime → AgentCore Runtime → your agent
   </TailoredContent>
 </Steps>
 
+## Troubleshooting
+
+### HTTP 401: `Missing Authentication Token`
+
+```
+Agent execution failed: Error: HTTP 401:
+{"jsonrpc":"2.0","error":{"code":-32001,"message":"Missing Authentication Token"},"id":"null"}
+```
+
+`Missing Authentication Token` is AWS's own error, not a CopilotKit or agent error. AWS returns it
+when a request reaches an AgentCore or API Gateway endpoint with no credentials, or when the request
+path matches no deployed route. Check the following, in order:
+
+- **The runtime is actually sending a token.** Set `AGENTCORE_ACCESS_TOKEN` in the environment of the
+  Copilot Runtime **server**, not the frontend. If the variable is unset, the `Authorization` header
+  interpolates to `Bearer undefined`, which AWS rejects exactly like a missing header.
+- **The token has not expired.** Cognito access tokens are short-lived. Mint a fresh one and retry
+  before you debug anything else.
+- **`AGENTCORE_ENDPOINT_URL` is the full invocation URL**, ending in `/invocations`, with the agent
+  ARN URL-encoded:
+  `https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{encoded-arn}/invocations`. A URL that
+  stops short of `/invocations` matches no route, and AWS reports that as
+  `Missing Authentication Token` rather than as a 404.
+- **The browser is not calling AgentCore directly.** AgentCore requires SigV4 or OAuth2 signing,
+  which a browser cannot perform. Point the frontend at your Copilot Runtime endpoint and let the
+  runtime make the AgentCore call server-side.
+
+<Callout type="warn" title="This error does not apply to the local quickstart">
+  The framework quickstarts run the agent locally on `http://localhost:8000`, and a local agent
+  server never returns `Missing Authentication Token`. If you see this error, the runtime is pointed
+  at a deployed AWS endpoint.
+</Callout>
+
 ## What's next?
 
 - [Generative UI](/generative-ui/tool-rendering) — render application

--- a/showcase/shell-docs/src/content/snippets/integrations/agentcore/index.mdx
+++ b/showcase/shell-docs/src/content/snippets/integrations/agentcore/index.mdx
@@ -338,6 +338,39 @@ Browser → CopilotKit Runtime → AgentCore Runtime → your agent
   </TailoredContent>
 </Steps>
 
+## Troubleshooting
+
+### HTTP 401: `Missing Authentication Token`
+
+```
+Agent execution failed: Error: HTTP 401:
+{"jsonrpc":"2.0","error":{"code":-32001,"message":"Missing Authentication Token"},"id":"null"}
+```
+
+`Missing Authentication Token` is AWS's own error, not a CopilotKit or agent error. AWS returns it
+when a request reaches an AgentCore or API Gateway endpoint with no credentials, or when the request
+path matches no deployed route. Check the following, in order:
+
+- **The runtime is actually sending a token.** Set `AGENTCORE_ACCESS_TOKEN` in the environment of the
+  Copilot Runtime **server**, not the frontend. If the variable is unset, the `Authorization` header
+  interpolates to `Bearer undefined`, which AWS rejects exactly like a missing header.
+- **The token has not expired.** Cognito access tokens are short-lived. Mint a fresh one and retry
+  before you debug anything else.
+- **`AGENTCORE_ENDPOINT_URL` is the full invocation URL**, ending in `/invocations`, with the agent
+  ARN URL-encoded:
+  `https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{encoded-arn}/invocations`. A URL that
+  stops short of `/invocations` matches no route, and AWS reports that as
+  `Missing Authentication Token` rather than as a 404.
+- **The browser is not calling AgentCore directly.** AgentCore requires SigV4 or OAuth2 signing,
+  which a browser cannot perform. Point the frontend at your Copilot Runtime endpoint and let the
+  runtime make the AgentCore call server-side.
+
+<Callout type="warn" title="This error does not apply to the local quickstart">
+  The framework quickstarts run the agent locally on `http://localhost:8000`, and a local agent
+  server never returns `Missing Authentication Token`. If you see this error, the runtime is pointed
+  at a deployed AWS endpoint.
+</Callout>
+
 ## What's next?
 
 <Cards>


### PR DESCRIPTION
## What

Adds a **Troubleshooting → `HTTP 401: Missing Authentication Token`** section to the AWS AgentCore deploy guide.

Closes #2912.

## Why

#2912 followed the AWS Strands quickstart, pointed the runtime at a deployed AgentCore endpoint, and got:

```
Agent execution failed: Error: HTTP 401:
{"jsonrpc":"2.0","error":{"code":-32001,"message":"Missing Authentication Token"},"id":"null"}
```

That string is AWS's own response to an unsigned request or an unmatched route, not a CopilotKit or agent error — but nothing under `docs/` mentioned it, so it reads like a framework bug. `grep -rin "missing authentication\|401" showcase/shell-docs/src/content/docs/integrations/aws-strands/` returned zero hits before this change.

The section covers the four real causes:

1. `AGENTCORE_ACCESS_TOKEN` unset on the **runtime server** — the header interpolates to `Bearer undefined`, which AWS rejects exactly like a missing header.
2. An expired Cognito access token.
3. `AGENTCORE_ENDPOINT_URL` that stops short of `/invocations` — an unmatched route, which API Gateway reports as `Missing Authentication Token` rather than a 404.
4. A browser calling AgentCore directly, which cannot do SigV4/OAuth2 signing.

## Why two files

The AgentCore guide exists as two near-duplicate copies on `main`, and **both are live**:

| File | Live route(s) |
|---|---|
| `docs/deploy/agentcore.mdx` | `/deploy/agentcore` |
| `snippets/integrations/agentcore/index.mdx` | `/strands/deploy-agentcore`, `/langgraph/deploy-agentcore` |

`src/lib/mdx-registry.tsx:548` resolves a bare `<Content framework="…" />` to `integrations/agentcore/index.mdx`, and both framework stubs use that bare form. The section lands in both so the two copies do not drift further. Deduplicating them is out of scope here.

## Testing

**1. Both routes are live (so both copies need the section)**

```
$ for u in /deploy/agentcore /strands/deploy-agentcore /langgraph/deploy-agentcore; do ... done
200  /deploy/agentcore
200  /strands/deploy-agentcore
200  /langgraph/deploy-agentcore
```

**2. The snippet — not the deploy page — is what renders on the framework routes**

```
$ curl -sL https://docs.copilotkit.ai/strands/deploy-agentcore | grep -o "AGENTCORE_ACCESS_TOKEN" | wc -l
2
```

Matches `snippets/integrations/agentcore/index.mdx:178,324`. Confirms the `<Content>` resolution traced in `mdx-registry.tsx:548`.

**3. Both files compile as MDX**

```
$ node -e "compile(matter(read(f)).content, {jsx:true})"
OK   src/content/docs/deploy/agentcore.mdx 21245 chars
OK   src/content/snippets/integrations/agentcore/index.mdx 18447 chars
```

**4. Mutation-checked that the compile check is not vacuous** — dropped the closing `</Callout>` from the new section:

```
mutated: dropped closing </Callout>
EXPECTED FAIL: Expected a closing tag for `<Callout>` (368:1-368:80)
```

Restored, and re-confirmed clean.

**5. Content test suites — no new failures**

`showcase/shell-docs` `npm test` cannot run locally (its `pretest` generators need `showcase/scripts` deps that are not installed; this fails identically on unmodified `main`). Ran the content-scanning suites directly with `vitest` and baselined them against the same worktree with the change reverted:

| | `llm-text` + `angular-docs-content` |
|---|---|
| unmodified `origin/main` | 12 failing (claude-sdk / google-adk / angular) |
| with this change | **same 12**, same names |

All pre-existing, all unrelated to AgentCore. Full CI is the authority here.

## Note

The two duplicated AgentCore copies are worth collapsing into one shared partial in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for AWS AgentCore `HTTP 401: Missing Authentication Token` errors.
  * Documented checks for runtime credentials, expired tokens, invocation URL formatting, and request routing.
  * Clarified that credentials belong on the runtime server and requests should pass through Copilot Runtime.
  * Noted that the issue applies to deployed environments, not local quickstarts running on `localhost:8000`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->