### PR TITLE
docs(microsoft-agent-framework): document backend approval interrupts

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/custom-look-and-feel/headless-ui.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/custom-look-and-feel/headless-ui.mdx
@@ -43,4 +43,4 @@ export const Chat = () => {
 };
 ```
 
-See [Human-in-the-Loop](/microsoft-agent-framework/human-in-the-loop) for more details on approval workflows.
+See [Human-in-the-Loop](/microsoft-agent-framework/human-in-the-loop) for more details on approval workflows. When the approval belongs to a backend tool, mark that tool as approval-gated and render it with [`useInterrupt`](/microsoft-agent-framework/human-in-the-loop/interrupt-flow) instead of matching its name here.

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Human-in-the-Loop
+icon: lucide/User
+description: Learn how to implement Human-in-the-Loop (HITL) using Microsoft Agent Framework agents.
+---
+
+## What is Human-in-the-Loop (HITL)?
+
+Human-in-the-loop (HITL) lets an agent ask for human input or approval while it runs. Use it when an action is expensive, destructive, or needs judgment the agent does not have.
+
+## How can I use this?
+
+Microsoft Agent Framework supports two patterns, and they solve different problems.
+
+Use **interrupt-based** HITL when the backend owns the decision. You mark a backend tool as approval-gated, and the agent pauses before it runs. The frontend does not need to know the tool's name.
+
+Use **tool-based** HITL when the frontend owns the work. You define a tool that runs in the browser, and the agent calls it like any other tool.
+
+<CTACards
+  columns={2}
+  cards={[
+    {
+      iconKey: "circlePause",
+      title: "Interrupt-based",
+      description:
+        "Mark a backend tool as approval-gated. The agent pauses, useInterrupt renders your approval UI, and your answer resumes the run.",
+      href: "/microsoft-agent-framework/human-in-the-loop/interrupt-flow",
+    },
+    {
+      iconKey: "share2",
+      title: "Tool-based",
+      description:
+        "Register a frontend tool with useHumanInTheLoop that renders UI and waits for the user's response before returning a result.",
+      href: "/microsoft-agent-framework/human-in-the-loop/tool-based",
+    },
+  ]}
+/>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/interrupt-flow.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/interrupt-flow.mdx
@@ -1,0 +1,142 @@
+---
+title: Interrupt-based
+icon: "lucide/CirclePause"
+description: Gate a backend tool behind an approval that the agent raises itself, and render it with useInterrupt.
+---
+
+## What is this?
+
+Microsoft Agent Framework can mark a backend tool as approval-gated. When the agent decides to call that tool, it does not run it. It ends the run with an AG-UI interrupt, which carries the pending tool call to your frontend. Your UI asks the user, and your answer resumes the agent.
+
+The backend owns the decision, so the frontend does not register a tool with the same name as the backend tool. Any agent that raises AG-UI interrupts uses this same path.
+
+## When should I use this?
+
+Use this when the action lives on the server and the approval is a property of that action:
+
+- Destructive or irreversible operations, such as deleting a record
+- Spending money, sending mail, or calling a third-party API
+- Anything where the approval rule must hold no matter which frontend is attached
+
+Use [tool-based HITL](/microsoft-agent-framework/human-in-the-loop/tool-based) instead when the work itself runs in the browser.
+
+## Requirements
+
+| Package | Version |
+| --- | --- |
+| `@copilotkit/react-core` | 1.61.2 or later |
+| `agent-framework-ag-ui` (Python) | 1.2.0 or later |
+| `AGUI.Server` (.NET) | 0.0.6 or later |
+
+## Implementation
+
+<Steps>
+  <Step>
+    ### Run and connect your agent
+
+    <RunAndConnect />
+  </Step>
+
+  <Step>
+    ### Mark the backend tool as approval-gated
+
+    Nothing else about the tool changes. The framework holds the call and raises the approval for you.
+
+    <Tabs groupId="language_microsoft-agent-framework_agent" items={['.NET', 'Python']} persist>
+      <Tab value="Python">
+        ```python title="agent/src/agent.py"
+        from agent_framework import tool
+
+        @tool(
+            name="delete_file",
+            description="Delete a file",
+            approval_mode="always_require", # [!code highlight]
+        )
+        def delete_file(filename: str) -> str:
+            return f"Deleted {filename}."
+        ```
+      </Tab>
+      <Tab value=".NET">
+        ```csharp title="Program.cs"
+        // Wrap the function so the framework requests approval before it runs.
+        var deleteFileTool = new ApprovalRequiredAIFunction( // [!code highlight]
+            AIFunctionFactory.Create(DeleteFile, "delete_file", "Deletes a file"));
+
+        builder.Services.AddChatClient(/* ... */)
+            .ConfigureOptions(options =>
+            {
+                options.Tools ??= [];
+                options.Tools.Add(deleteFileTool);
+            })
+            .UseFunctionInvocation();
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step>
+    ### Render the approval with `useInterrupt`
+
+    `useInterrupt` receives every AG-UI interrupt the agent raises. Call `resolve` to approve and resume, or `cancel` to decline.
+
+    ```tsx title="page.tsx"
+    import { useInterrupt } from "@copilotkit/react-core/v2"; // [!code highlight]
+
+    export function ApprovalPanel() {
+      // renderInChat: false makes useInterrupt return the element, so render it yourself.
+      const approval = useInterrupt({
+        renderInChat: false,
+        render: ({ interrupt, resolve, cancel }) => {
+          if (!interrupt) return <></>;
+          return (
+            <div>
+              <p>{interrupt.message}</p>
+              {/* [!code highlight:2] */}
+              <button onClick={() => resolve({ approved: true })}>Approve</button>
+              <button onClick={() => cancel()}>Deny</button>
+            </div>
+          );
+        },
+      });
+
+      return <div>{approval}</div>;
+    }
+    ```
+
+    <Callout type="info">
+      `renderInChat` defaults to `true`, which draws your UI inside the chat. If no `<CopilotChat />` is mounted, nothing appears and there is no warning. Pass `renderInChat: false`, as above, and place the returned element yourself.
+    </Callout>
+  </Step>
+
+  <Step>
+    ### Give it a try!
+
+    Ask the agent to delete a file. The run stops, your approval UI appears, and the tool only runs after you approve.
+  </Step>
+</Steps>
+
+## What the interrupt contains
+
+An approval-gated call arrives with `reason` set to `"tool_call"`. These fields are the same for both backends:
+
+| Field | Description |
+| --- | --- |
+| `id` | The interrupt's identity. Pass it to `resolve` or `cancel` when several are open. |
+| `reason` | `"tool_call"` for an approval-gated call. |
+| `message` | A human-readable summary, such as `Approve running delete_file?` |
+| `toolCallId` | The pending call's id. It matches the `TOOL_CALL_START` event both backends emit, so you can correlate the two. |
+| `responseSchema` | JSON Schema for the payload the agent expects. Both backends ask for a boolean `approved`. |
+
+The Python adapter also puts the whole request under `interrupt.metadata.agent_framework.function_call`, which gives you the tool `name` and its `arguments`. The .NET server does not send that field, so read the tool name from `message` if you support both.
+
+## Approving, denying, and cancelling
+
+`cancel()` and `resolve({ approved: false })` both leave the tool unrun, but they end the turn differently:
+
+- `resolve({ approved: true })` resumes the agent and the tool runs.
+- `resolve({ approved: false })` hands the refusal to the agent, which continues and can reply to the user.
+- `cancel()` ends the run immediately.
+
+<Callout type="warn">
+  Do not register a frontend tool with the same name as a backend tool. Tool names must be unique across both, and a collision fails the run with `Duplicate tool name`.
+</Callout>

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/meta.json
@@ -1,0 +1,3 @@
+{
+  "pages": ["tool-based", "interrupt-flow"]
+}

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/tool-based.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/tool-based.mdx
@@ -1,7 +1,7 @@
 ---
-title: Human-in-the-loop
-icon: "lucide/User"
-description: Create frontend tools and use them within your agent framework agent.
+title: Tool-based
+icon: "lucide/Share2"
+description: Gate an action behind a frontend tool that renders UI and waits for the user.
 ---
 {/* TODO: Swap these links for Microsoft Agent Framework links once Microsoft Agent Framework is officially added to the feature viewer */}
 <IframeSwitcher

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/meta.json
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/meta.json
@@ -31,6 +31,7 @@
     "shared-state",
     "agent-app-context",
     "---Microsoft Agent Framework---",
+    "...human-in-the-loop",
     "auth",
     "---Backend---",
     "copilot-runtime",


### PR DESCRIPTION
Closes #2770.

## Problem

Our Microsoft Agent Framework human-in-the-loop page taught exactly one pattern: register a frontend tool whose name matches a backend tool. That is why #2770 was filed asking for a feature we already ship, and why two more people asked for an update on it.

Backend-raised approvals have worked for months. Mark a tool with `approval_mode="always_require"` (Python) or wrap it in `ApprovalRequiredAIFunction` (.NET), and the agent ends the run with an AG-UI interrupt that `useInterrupt` renders. No name matching. Nothing on the docs site said so.

## What changed

Split the page the way Mastra's already is, and add the missing half:

- `human-in-the-loop/index.mdx` — picks between the two patterns. It keeps `/microsoft-agent-framework/human-in-the-loop` resolving, so the three existing pages that link there need no edit.
- `human-in-the-loop/interrupt-flow.mdx` — new; the approval path.
- `human-in-the-loop/tool-based.mdx` — the old page, retitled, content unchanged.
- `custom-look-and-feel/headless-ui.mdx` — one sentence pointing backend approvals at the new page.

The new page records four details that are easy to get wrong from reading the source. I got each of them wrong myself before running it:

- `reason` is `"tool_call"`, not `"approval"`.
- The tool name and arguments live under `metadata.agent_framework` **only on Python**. .NET sends no such field and names the tool in `message`.
- `cancel()` and `resolve({ approved: false })` both leave the tool unrun, but cancel ends the run while a false approval lets the agent keep talking.
- `renderInChat` defaults to `true`, so the UI renders nothing — silently, no warning — unless a `<CopilotChat />` is mounted.

## Testing

Every claim on the new page was executed, not inferred.

**End to end against a real agent.** Published `@copilotkit/react-core` over real HTTP against a real Microsoft Agent Framework agent on released `agent-framework-ag-ui` 1.2.2, with a tool marked `approval_mode="always_require"`, served through the real AG-UI FastAPI endpoint. A deterministic stub chat client stands in for the model, so no API key is needed.

```
✓ CopilotKit <-> real Microsoft Agent Framework approval (2 tests)
  ✓ renders the backend approval and, on approve, the backend runs the tool
  ✓ on cancel, the backend does not run the tool
  Tests  2 passed (2)
```

Approving produced `TOOL_CALL_RESULT ... "content":"Deleted notes.txt."` from the backend and surfaced it in the frontend. Cancelling produced no tool result.

**Version floors are measured, not read off a changelog.** The same test passes on `@copilotkit/react-core` 1.61.2 and fails on 1.61.1 (`Unable to find an element by: [data-testid="reason"]`), which is where the 1.61.2 in the requirements table comes from. `agent-framework-ag-ui` 1.2.0 ships byte-identical interrupt-conversion logic to the 1.2.2 I ran. `AGUI.Server` 0.0.6's shipped DLL contains the `tool_call` reason and the `Approval required for tool call` message, and ag-ui's own verified .NET baseline shows the same wire shape.

**Mutation-checked.** Changing the backend tool's return string fails the approve test; clicking Approve in the cancel test fails it. An earlier version of the cancel test passed under that mutation — it settled with a bare `setTimeout` outside `act()` — so it was rewritten to poll with `waitFor` and require a timeout.

**Docs suite.** Generators plus the node-environment tests that cover routing and the nav tree:

```
 Test Files  4 passed (4)
      Tests  30 passed (30)
```
(`sitemap`, `page-tree-bridge`, `llms.txt`, `llms-mdx`)

All three routes appear in the generated search index, including the preserved index URL:

```
microsoft-agent-framework/human-in-the-loop
microsoft-agent-framework/human-in-the-loop/interrupt-flow
microsoft-agent-framework/human-in-the-loop/tool-based
```

The jsdom-environment tests could not run locally — this checkout's `showcase/shell-docs` install predates `jsdom`, and it resolves through symlinks to the main checkout. CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Human-in-the-Loop section for Microsoft Agent Framework integrations.
  * Documented interrupt-based and tool-based workflows, including approval, denial, cancellation, and frontend interaction guidance.
  * Added details on approval-gated backend tools, interrupt payloads, and rendering requirements.
  * Updated the tool-based guide’s title and description.
  * Added the new section and page ordering to the documentation navigation.
  * Clarified how headless UI examples should render backend-tool approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->