### PR TITLE
docs(intelligence): document the Query API

### DIFF
--- a/showcase/shell-docs/src/content/docs/intelligence/meta.json
+++ b/showcase/shell-docs/src/content/docs/intelligence/meta.json
@@ -11,6 +11,7 @@
     "self-hosting",
     "intelligence-platform",
     "threads-explained",
-    "memories"
+    "memories",
+    "query-api"
   ]
 }

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -215,10 +215,32 @@ new pagination rather than continuing the old one.
 | `start`, `end` | Half-open time window `[start, end)` on the resource's time field, as RFC 3339 timestamps. |
 | `include_deleted` | Include soft-deleted rows, which are excluded by default. |
 | `include_total` | Add `page.total`, the count of rows matching the filters. Absent unless asked for. |
+| `expand` | Attach a declared related resource, one level deep. |
 
 A parameter this API does not implement is refused by name rather than accepted
 and ignored, so a request that returns rows is a request that did what you
 asked.
+
+### Expanding related rows
+
+`expand` attaches a related resource that the model declares, one level deep:
+
+```bash
+curl -G https://your-deployment/v1/threads \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  --data-urlencode "expand=runs"
+```
+
+A many-to-one relation attaches a single object, a one-to-many attaches an
+array, and an empty result attaches an empty array rather than omitting the key,
+so "expanded, nothing there" is distinguishable from "not expanded". Asking for
+a relation the resource does not declare is refused, and the error names the
+ones it does.
+
+Each side is fetched separately rather than joined, so the expanded resource is
+gated by its own scopes: expanding into something your key cannot read is
+refused rather than quietly returning it. `GET /v1/meta/resources/:name` lists
+what a resource can expand, with a cost for each.
 
 ## Aggregating
 

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -53,6 +53,31 @@ The Query API is gated behind a `query-api` feature flag that defaults to off.
 Turn it on for the deployment before minting a key.
 </Callout>
 
+## Getting a key
+
+Mint one from the CLI:
+
+```bash
+copilotkit query-keys create --name reporting
+```
+
+That prints the token once. Only a hash is stored, so it cannot be recovered:
+if you lose it, mint another. Omitting `--scopes` gives the key every scope, and
+it expires in a year. Narrow it when you know what you need:
+
+```bash
+copilotkit query-keys create \
+  --name nightly-export \
+  --scopes threads:read,analytics:read \
+  --projects 4 \
+  --expires-in-days 90
+```
+
+`copilotkit query-keys list` shows what exists, marking any key that has
+expired, and `copilotkit query-keys revoke <id>` retires one. The same
+operations are available over REST at `/api/query-keys`, which is
+session-authenticated: a query key cannot mint another query key.
+
 ## Authentication
 
 Authentication is a single bearer token. There is no user header and no cookie,

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -1,0 +1,356 @@
+---
+title: "Query API"
+description: "Read and query every piece of your own Intelligence data from a script, a notebook, or an agent: threads, utterances, memories, learning provenance, channels, and analytics, over REST, arbitrary read-only SQL, or MCP."
+icon: "lucide/Database"
+doc_type: how-to
+---
+
+Everything Intelligence stores about your organization is yours, and you should
+not have to open a browser to read it. The Query API is a machine credential and
+a JSON surface over the whole of it: list a resource, aggregate it, or write SQL
+against it, with tenancy enforced underneath rather than requested politely.
+
+If you want the conversation persistence model itself, read
+[Threads & Persistence Architecture](/intelligence/threads-explained). If you
+want long-term memory, read [Memories & Recall](/intelligence/memories). This
+page is about reading all of it from the outside.
+
+## What you can reach
+
+Every table that holds your data is addressable as a resource, not a curated
+subset of them. That includes the ones no UI has ever shown you: the full
+learning provenance chain from a run through candidates and review events to a
+published skill, the raw AG-UI event stream behind a thread, per-channel
+delivery records, and the tenancy tables.
+
+| Domain | Examples |
+|--------|----------|
+| Conversations | `threads`, `runs`, `thread_messages`, `run_events`, `utterances` |
+| Memory | `memories` |
+| Learning | `learning_runs`, `learning_skill_candidates`, `learning_skill_candidate_events`, `learning_skills`, `learning_insights`, `learning_skill_insights` |
+| Channels | `channels`, `channel_messages`, `channel_deliveries`, `channel_provider_conversations` |
+| Tenancy | `organizations`, `projects`, `api_keys`, `user_identities` |
+| Governance | `audit_events` |
+| Analytics | `events` |
+
+Ask the deployment rather than trusting this table, because the catalog is
+generated from the same definitions the query planner uses and cannot drift
+from them:
+
+```bash
+curl https://your-deployment/v1/meta/resources \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>"
+```
+
+A few tables are deliberately not reachable, and it is worth knowing which so
+their absence does not read as a bug: deployment-level licence and break-glass
+tables, this API's own bookkeeping, and the cross-tenant actor registry. The
+parts of that registry that belong to you are reachable through
+`user_identities` and `audit_events`.
+
+<Callout type="info">
+The Query API is gated behind a `query-api` feature flag that defaults to off.
+Turn it on for the deployment before minting a key.
+</Callout>
+
+## Authentication
+
+Authentication is a single bearer token. There is no user header and no cookie,
+because a query key is an organization credential rather than a user session.
+
+```bash
+curl https://your-deployment/v1/threads?limit=10 \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>"
+```
+
+The key carries three things: the organization it may read, the scopes it holds,
+and optionally a project allowlist. The organization is not a parameter you can
+pass. Every statement the API compiles is constrained to the key's organization
+before any filter you supply, and the database enforces the same constraint
+again underneath through row-level security, so a bug in the query layer cannot
+turn into a cross-tenant read.
+
+### Scopes
+
+Scopes are `<domain>:<sensitivity>`. The `:read` scope of a domain gets you the
+rows and their low-sensitivity fields. The `:content` scope of the same domain
+is what unlocks the free text inside them, and it is independent: a key can list
+every thread without ever reading a message body.
+
+| Scope | Grants |
+|-------|--------|
+| `tenancy:read` | Organizations, projects, API key metadata |
+| `threads:read` / `threads:content` | Threads, runs and utterances / their text |
+| `memory:read` / `memory:content` | Memory rows / memory text |
+| `learning:read` / `learning:content` | Learning provenance / skill and insight text |
+| `channels:read` / `channels:content` | Channel activity / message bodies |
+| `analytics:read` / `analytics:events` | Aggregated telemetry / raw event payloads and user ids |
+| `audit:read` | The audit trail, including this API's own reads |
+| `governance:read` | Governance decisions |
+| `meta:read` | The catalog |
+
+When a key lacks the `:content` scope for a resource it still gets the rows. The
+omitted field names come back in `meta.fields_omitted_for_scope`, so a caller
+can tell a redacted field from an empty one. Naming an ungranted field
+explicitly in `fields` is an error rather than a silent omission, because you
+asked for it by name.
+
+Some scopes also depend on the deployment's licence: `analytics:*` needs the
+analytics feature, `memory:*` needs memory, and `learning:*` needs self-learning.
+Both have to allow the read.
+
+<Callout type="warn">
+Secret columns are not reachable at any scope. API key hashes, OAuth client
+secrets, encrypted channel credentials and memory vectors are excluded from the
+projection and withheld at the database grant, so no combination of scopes
+returns them.
+</Callout>
+
+## Reading rows
+
+`GET /v1/:resource` lists any resource, newest first, keyset-paginated.
+
+```bash
+curl -G https://your-deployment/v1/utterances \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  --data-urlencode "limit=50" \
+  --data-urlencode "author_class[eq]=human" \
+  --data-urlencode "fields=author_class,word_count,occurred_at"
+```
+
+Every response has the same three parts:
+
+```json
+{
+  "data": [{ "author_class": "human", "word_count": 12 }],
+  "page": { "limit": 50, "next_cursor": "eyJ2Ijoi…", "has_more": true },
+  "meta": {
+    "resource": "utterances",
+    "scope": { "organization_id": "your-org" },
+    "fields_omitted_for_scope": [],
+    "request_id": "…",
+    "trace_id": "…"
+  }
+}
+```
+
+### Filtering
+
+Filters are query parameters of the form `field[operator]=value`. Which
+operators a field accepts is a property of that field, and
+`GET /v1/meta/resources/:name` lists them.
+
+| Operator | Meaning |
+|----------|---------|
+| `eq`, `ne` | Equality, inequality |
+| `in`, `nin` | Comma-separated set membership |
+| `gt`, `gte`, `lt`, `lte` | Ordering |
+| `null` | `true` for null, `false` for not null |
+| `prefix` | Starts with |
+| `search` | Full-text match, index-backed |
+| `contains` | Substring |
+
+Several operators on one field narrow rather than replace, so a range is two
+parameters:
+
+```bash
+--data-urlencode "word_count[gte]=10" \
+--data-urlencode "word_count[lt]=100"
+```
+
+### Paging
+
+Follow `page.next_cursor` until `page.has_more` is false. Cursors are keyset
+based rather than offset based, so a page does not shift under you when rows are
+written while you read.
+
+```bash
+curl -G https://your-deployment/v1/utterances \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  --data-urlencode "limit=50" \
+  --data-urlencode "cursor=eyJ2Ijoi…"
+```
+
+A cursor is tied to the sort it was issued for. Change `sort` and you start a
+new pagination rather than continuing the old one.
+
+### Other parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `fields` | Comma-separated projection. Naming a field that does not exist is an error, not a silent omission. |
+| `sort` | Field name, `-` prefix for descending. All terms must share a direction, because keyset pagination compares them as one row. |
+| `limit` | Page size. |
+| `project_id` | Restrict to one project, subject to the key's allowlist. |
+| `include_deleted` | Include soft-deleted rows, which are excluded by default. |
+| `include_total` | Add `page.total`, the count of rows matching the filters. Absent unless asked for. |
+
+## Aggregating
+
+`POST /v1/query` groups and aggregates without pulling rows across the network.
+
+```bash
+curl -X POST https://your-deployment/v1/query \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource": "utterances",
+    "group_by": ["author_class"],
+    "aggregate": [{ "op": "count", "as": "n" }],
+    "having": { "n": { "gt": 50 } },
+    "sort": ["-n"]
+  }'
+```
+
+Aggregate operations are `count`, `count_distinct`, `sum`, `avg`, `min`, `max`,
+`stddev`, `rate`, `percentile`, and `measure`.
+
+`percentile` requires an explicit `p` and is computed in the database rather
+than by sampling into the client:
+
+```json
+{
+  "resource": "utterances",
+  "aggregate": [{ "op": "percentile", "field": "word_count", "p": 95, "as": "p95" }]
+}
+```
+
+`measure` invokes a named measure defined on the resource, which is how
+parameterized questions are asked safely. The parameter is bound, never
+interpolated:
+
+```json
+{
+  "resource": "utterances",
+  "group_by": ["author_class"],
+  "aggregate": [
+    { "op": "count", "as": "total" },
+    { "op": "measure", "name": "word_hits", "params": { "term": "refund" }, "as": "hits" }
+  ]
+}
+```
+
+<Callout type="info">
+A measure's own filter applies to that measure alone. In the request above
+`total` is every utterance in the group and `hits` counts only occurrences of
+the term, so the two columns answer different questions on the same row rather
+than the term quietly narrowing both.
+</Callout>
+
+Add a `window` to bucket by time. The response carries a `bucket` column:
+
+```json
+{
+  "resource": "utterances",
+  "window": {
+    "start": "2026-01-01T00:00:00Z",
+    "end": "2026-02-01T00:00:00Z",
+    "granularity": "daily"
+  },
+  "aggregate": [{ "op": "count", "as": "n" }]
+}
+```
+
+Granularity is one of `minutely`, `hourly`, `daily`, `weekly`, `monthly`.
+`filter` and `having` both accept either `{"n": {"gt": 50}}` or
+`{"n[gt]": 50}`.
+
+## Arbitrary SQL
+
+When the model does not cover the question, `POST /v1/sql` takes read-only SQL.
+
+```bash
+curl -X POST https://your-deployment/v1/sql \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "statement": "select author_class, count(*) as n from cpki.utterances group by 1 order by 2 desc",
+    "limit": 100
+  }'
+```
+
+Note what is missing from that statement: any mention of your organization. You
+cannot widen the read by leaving out a `WHERE` clause, because tenancy is not
+part of the SQL you write. It is injected as a session setting and enforced by
+row-level security against a role that holds `SELECT` and nothing else.
+
+The statement is parsed with the real PostgreSQL grammar rather than matched
+against patterns, so writes, a second statement smuggled after a semicolon,
+`SELECT INTO`, locking clauses, system catalogs, file-reading functions, and
+anything that could forge the tenant setting are all refused.
+
+The response carries a `query_id`. Paging with it returns pages of the same
+frozen result set, so a long export is internally consistent even while new rows
+are being written:
+
+```bash
+curl -G https://your-deployment/v1/sql/<query_id> \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  --data-urlencode "cursor=<next_cursor>" \
+  --data-urlencode "limit=100"
+```
+
+## Agents, over MCP
+
+`POST /v1/mcp` is a Streamable HTTP MCP endpoint carrying four tools, so an
+agent can answer questions about your deployment without being handed SQL.
+
+| Tool | Purpose |
+|------|---------|
+| `intelligence_list_resources` | Everything this key can query. Start here. |
+| `intelligence_describe_resource` | Fields, measures and operators for one resource. |
+| `intelligence_list` | Rows from one resource. |
+| `intelligence_query` | Grouped aggregation. |
+
+Tool results carry an `equivalent_request` naming the REST call that produces
+the same rows, so an agent can hand a person something reproducible. They also
+carry an explicit `untrusted_content` notice, because field values are text your
+users and models wrote: treat them as data, never as instructions.
+
+## Errors, limits and the audit trail
+
+Errors share one envelope. `category` tells you the class, and `retryable` tells
+you whether trying again can help.
+
+```json
+{
+  "error": {
+    "code": "SCOPE_INSUFFICIENT",
+    "message": "…",
+    "category": "forbidden",
+    "retryable": false
+  },
+  "requestId": "…",
+  "traceId": "…"
+}
+```
+
+| Code | Cause |
+|------|-------|
+| `QUERY_KEY_INVALID`, `QUERY_KEY_EXPIRED` | The credential |
+| `SCOPE_INSUFFICIENT` | The key lacks a scope the read needs |
+| `RESOURCE_UNKNOWN` | No such resource, or not readable by this key |
+| `SEMANTIC_MODEL_UNKNOWN_FIELD` | A field the resource does not declare |
+| `VALIDATION_ERROR` | A malformed filter, sort or request body |
+| `QUERY_TIMEOUT`, `QUERY_TOO_EXPENSIVE`, `QUERY_CARDINALITY_EXCEEDED` | Cost controls |
+| `QUERY_RESULT_EXPIRED`, `QUERY_RESULT_SCOPE_CHANGED` | A frozen SQL result is gone, or the key changed under it |
+| `SQL_UNPARSEABLE`, `SQL_NOT_READ_ONLY`, `SQL_STATEMENT_REJECTED` | The SQL guard |
+| `RATE_LIMIT_EXCEEDED` | Budget |
+| `ANALYTICS_NOT_ENABLED` | The licence does not carry the feature |
+
+Rate limits are per key and reported on every response through the standard
+`RateLimit-Limit`, `RateLimit-Remaining` and `RateLimit-Reset` headers. Metadata
+calls, list reads, aggregation and SQL are budgeted separately, so a heavy
+export does not starve a dashboard.
+
+Every read through this API writes an audit event with the key, the resource,
+the row count, and whether content fields were projected. Those events are
+themselves queryable as the `audit_events` resource with `audit:read`, so the
+API can account for its own use.
+
+## Next steps
+
+- **Threads:** [Threads & Persistence Architecture](/intelligence/threads-explained)
+- **Memory:** [Memories & Recall](/intelligence/memories)
+- **Platform:** [CopilotKit Intelligence](/intelligence/overview)
+- **Self-hosting:** [Self-hosting Intelligence](/intelligence/self-hosting)

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -27,7 +27,7 @@ delivery records, and the tenancy tables.
 |--------|----------|
 | Conversations | `threads`, `runs`, `thread_messages`, `run_events`, `utterances` |
 | Memory | `memories` |
-| Learning | `learning_runs`, `learning_skill_candidates`, `learning_skill_candidate_events`, `learning_skills`, `learning_insights`, `learning_skill_insights` |
+| Learning | `learning_runs`, `learning_skill_candidates`, `learning_skill_candidate_events`, `learning_skills`, `learning_skill_sections`, `skill_usage_events`, `learning_insights`, `learning_skill_insights` |
 | Channels | `channels`, `channel_messages`, `channel_deliveries`, `channel_provider_conversations` |
 | Tenancy | `organizations`, `projects`, `api_keys`, `user_identities` |
 | Governance | `audit_events` |
@@ -299,6 +299,27 @@ curl -G https://your-deployment/v1/sql/<query_id> \
   --data-urlencode "cursor=<next_cursor>" \
   --data-urlencode "limit=100"
 ```
+
+## Skills, in pieces and in use
+
+Two resources make skills answerable rather than opaque.
+
+`learning_skill_sections` is a published skill split into its heading-path
+sections at publish time, versioned with the skill revision. So "which skills
+mention this term" and "how did this section change between revisions" are
+ordinary queries against an indexed table rather than a scan of one markdown
+blob. The body is full-text indexed, so `body[search]=...` is index-backed.
+
+`skill_usage_events` records that a skill reached an agent: which skill, which
+revision, in which thread or run, and how it was delivered. Run outcome is not
+copied here. It comes by joining to the analytics events, so the definition of a
+successful run can change without rewriting history.
+
+<Callout type="warn">
+A zero-usage answer for a period before this instrumentation existed is
+indistinguishable from a skill nobody used. Check the earliest `occurred_at`
+before concluding a skill was never loaded.
+</Callout>
 
 ## Exports
 

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -432,6 +432,16 @@ agent can answer questions about your deployment without being handed SQL.
 | `intelligence_describe_resource` | Fields, measures and operators for one resource. |
 | `intelligence_list` | Rows from one resource. |
 | `intelligence_query` | Grouped aggregation. |
+| `intelligence_get` | One row by primary key. |
+| `intelligence_thread_timeline` | A thread as ordered turns. |
+| `intelligence_learning_provenance` | The insights a skill was learned from. |
+| `intelligence_recall_memory` | Memories by meaning, across every user in a project. |
+| `intelligence_sql` | Read-only SQL, when the deployment allows it. |
+
+`intelligence_recall_memory` searches by meaning rather than keyword, across
+every user in the project unless `user_id` narrows it. The key is an
+organization credential, so it recalls the whole project's memories the same way
+it already lists them; it needs `memory:content` to return the text.
 
 Tool results carry an `equivalent_request` naming the REST call that produces
 the same rows, so an agent can hand a person something reproducible. They also

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -127,13 +127,18 @@ asked for it by name.
 
 Some scopes also depend on the deployment's licence: `analytics:*` needs the
 analytics feature, `memory:*` needs memory, and `learning:*` needs self-learning.
-Both have to allow the read.
+The key's scope and the deployment's licence both have to allow a read; either
+one refusing is enough to refuse it.
 
 <Callout type="warn">
-Secret columns are not reachable at any scope. API key hashes, OAuth client
-secrets, encrypted channel credentials and memory vectors are excluded from the
-projection and withheld at the database grant, so no combination of scopes
-returns them.
+Credential columns are not reachable at any scope. API key hashes, OAuth client
+secrets and encrypted channel credentials are excluded from the projection and
+withheld at the database grant, so no combination of scopes returns them.
+
+Memory vectors are a different case: they are your data, not a credential. They
+are absent from every list and query response because 1024 floats are noise
+inline, and [an export returns them](#exports-carry-your-vectors) with
+`memory:content`.
 </Callout>
 
 ## Reading rows
@@ -465,6 +470,11 @@ you whether trying again can help.
   "traceId": "…"
 }
 ```
+
+Note that the two envelopes key their correlation ids differently: a success
+response nests them as `meta.request_id` and `meta.trace_id`, while an error
+response carries them at the top level as `requestId` and `traceId`. Read both
+spellings if your client logs ids for every response.
 
 | Code | Cause |
 |------|-------|

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -182,8 +182,13 @@ new pagination rather than continuing the old one.
 | `sort` | Field name, `-` prefix for descending. All terms must share a direction, because keyset pagination compares them as one row. |
 | `limit` | Page size. |
 | `project_id` | Restrict to one project, subject to the key's allowlist. |
+| `start`, `end` | Half-open time window `[start, end)` on the resource's time field, as RFC 3339 timestamps. |
 | `include_deleted` | Include soft-deleted rows, which are excluded by default. |
 | `include_total` | Add `page.total`, the count of rows matching the filters. Absent unless asked for. |
+
+A parameter this API does not implement is refused by name rather than accepted
+and ignored, so a request that returns rows is a request that did what you
+asked.
 
 ## Aggregating
 

--- a/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/query-api.mdx
@@ -89,6 +89,11 @@ every thread without ever reading a message body.
 | `governance:read` | Governance decisions |
 | `meta:read` | The catalog |
 
+Scopes apply on every surface, `/v1/sql` included: a statement selecting a
+gated column with a key that lacks its scope is refused before it runs, whether
+the column is named directly, reached through `SELECT *`, used in a `WHERE`
+clause, or read inside a CTE.
+
 When a key lacks the `:content` scope for a resource it still gets the rows. The
 omitted field names come back in `meta.fields_omitted_for_scope`, so a caller
 can tell a redacted field from an empty one. Naming an ungranted field
@@ -294,6 +299,59 @@ curl -G https://your-deployment/v1/sql/<query_id> \
   --data-urlencode "cursor=<next_cursor>" \
   --data-urlencode "limit=100"
 ```
+
+## Exports
+
+A query can only return what the database still holds, and raw analytics events
+are retained for 90 days. If you want a year of history, or you want this data
+in your own warehouse, export it.
+
+```bash
+curl -X POST https://your-deployment/v1/exports \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource": "utterances",
+    "format": "parquet",
+    "query": { "start": "2026-01-01T00:00:00Z", "end": "2026-02-01T00:00:00Z" }
+  }'
+```
+
+Formats are `ndjson`, `csv` and `parquet`. The request returns `202` with a job
+id. Poll it, and a completed job carries a short-lived `download_url`:
+
+```bash
+curl https://your-deployment/v1/exports/<job_id> \
+  -H "Authorization: Bearer cpkq-<org>_<short>_<long>"
+```
+
+A malformed filter is rejected when you request the job, not an hour later when
+it runs. Jobs are scoped to the key that created them, so a second key in the
+same organization cannot collect your output. Quota is 20 jobs a day and one at
+a time; asking for a second while one is running returns
+`EXPORT_QUOTA_EXCEEDED`.
+
+Parquet columns are typed rather than all-text, so the file re-imports into a
+warehouse with dates as dates and counts as integers.
+
+### Exports carry your vectors
+
+This is the one place `memories.embedding` is available. It is deliberately
+absent from every list and query response, because 1024 floats are noise inline
+and similarity search is the first-class operation. Naming it in `fields`
+returns `FIELD_EXPORT_ONLY` rather than silently omitting it.
+
+An export includes it, as a list of doubles rather than a string, alongside
+`embedding_model`. That combination is what makes the file self-describing: you
+can load your memories elsewhere without re-embedding them, and you know which
+vector space they are in. It still requires `memory:content`, so a key without
+that scope exports the memory rows without the vector rather than being refused.
+
+<Callout type="warn">
+A download URL is minted per request and expires in 15 minutes. It carries no
+authentication of its own, so treat it as a credential: anyone holding it can
+fetch the file until it expires.
+</Callout>
 
 ## Agents, over MCP
 


### PR DESCRIPTION
## What this is

A developer-facing page for the Intelligence Query API: how to read every piece of your own Intelligence data from a script, a notebook, or an agent, without a browser session.

Companion to the implementation in the Intelligence repo. Sits alongside [Memories & Recall](/intelligence/memories) and [Threads & Persistence Architecture](/intelligence/threads-explained), and follows the same shape.

## What it covers

- The resource catalog, and the instruction to ask the deployment rather than trust the page, because the catalog generates from the same definitions the query planner uses
- The scope model, and specifically that `:read` and `:content` are independent, so a key can list every thread without reading a single message body
- List and filter syntax, keyset paging, projection
- Declarative aggregation, including percentiles and parameterized measures
- Arbitrary read-only SQL with frozen-result paging
- The four MCP tools
- Errors, rate-limit headers, and the audit trail the API keeps of its own reads

## The parts worth reviewing

The page states the things that are easy to get wrong and expensive to discover late:

- **A measure's filter scopes to that measure alone.** In a request that asks for both a count and a term measure, the count is every row in the group and the measure counts only matches. Reading it the other way gives you a number that looks right and is not.
- **The organization is never a parameter.** A SQL statement with no `WHERE` clause still reads exactly one tenant, because tenancy is injected as a session setting and enforced by row-level security rather than being part of the SQL you write.
- **A field omitted for scope is named in the response**, while a field named in `fields` that does not exist is an error. Those are different failures and the page says so.
- **Secret columns are unreachable at any scope**, withheld at the database grant as well as excluded from the projection.

## Verification

Every route, parameter, filter operator, aggregate operation, error code and response header on this page was exercised against a running deployment rather than read out of the source. That sweep is what turned up four defects in the API itself, fixed separately in the Intelligence repo: filters that could not work at all over HTTP, pagination that silently capped a narrowed projection at one page, an `include_total` parameter that was accepted and ignored, and `having` accepting only one of the two shapes `filter` accepts.

Rendered locally and read end to end: tables, callouts, code blocks and all four cross-links resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive Intelligence Query API guide.
  - Documented resource discovery, bearer-key authentication, scopes, tenancy enforcement, redaction, filtering, pagination, aggregation, read-only SQL, MCP tools, errors, rate limits, and audit events.
  - Clarified security constraints, licensing requirements, time-window parameters, and unsupported parameter handling.
  - Documented exports, vector access, and downloads.
  - Added instructions for managing query keys through the CLI and REST API.
  - Added the Query API page to the Intelligence documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->