### PR TITLE
docs: persist the reader's code-tab choice, and link out to provider key pages

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/api-key-hint.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/api-key-hint.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ApiKeyHint } from "@/components/api-key-hint";
+import { docsComponents } from "@/lib/mdx-registry";
+
+describe("ApiKeyHint", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("links out to the provider's key page in a new tab", () => {
+    render(<ApiKeyHint provider="openai" />);
+
+    const link = screen.getByRole("link", { name: /OpenAI API key/ });
+    expect(link.getAttribute("href")).toBe(
+      "https://platform.openai.com/api-keys",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it.each([
+    ["anthropic", "https://console.anthropic.com/"],
+    ["google", "https://aistudio.google.com/apikey"],
+    ["langsmith", "https://smith.langchain.com/"],
+    ["copilotkit", "https://dashboard.operations.copilotkit.ai/"],
+  ])("resolves the %s provider", (provider, url) => {
+    const { container } = render(<ApiKeyHint provider={provider} />);
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe(url);
+  });
+
+  it("renders nothing for an unknown provider", () => {
+    const { container } = render(<ApiKeyHint provider="not-a-provider" />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  // MDX pages call `<ApiKeyHint />` by name, so an unregistered component
+  // fails at page-render time rather than at build time.
+  it("is registered as an MDX component", () => {
+    expect(docsComponents.ApiKeyHint).toBe(ApiKeyHint);
+  });
+});

--- a/showcase/shell-docs/src/components/__tests__/docs-tabs.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-tabs.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Tab, Tabs } from "@/components/docs-tabs";
+
+const STORAGE_KEY = "shell-docs.tab.pm";
+
+function PersistGroup(): React.ReactElement {
+  return (
+    <Tabs groupId="pm" persist items={["npm", "pnpm"]}>
+      <Tab value="npm">npm content</Tab>
+      <Tab value="pnpm">pnpm content</Tab>
+    </Tabs>
+  );
+}
+
+function PanelFor(text: string): HTMLElement | null {
+  return screen.getByText(text).closest('[role="tabpanel"]');
+}
+
+describe("DocsTabs", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("selects the first item when no default is given", () => {
+    render(<PersistGroup />);
+
+    expect(PanelFor("npm content")?.getAttribute("data-state")).toBe("active");
+    expect(PanelFor("pnpm content")?.getAttribute("data-state")).toBe(
+      "inactive",
+    );
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("persists a groupId pick and reapplies it on a fresh mount", () => {
+    render(<PersistGroup />);
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "pnpm" }));
+
+    expect(PanelFor("pnpm content")?.getAttribute("data-state")).toBe("active");
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("pnpm");
+
+    cleanup();
+    render(<PersistGroup />);
+
+    // No `default` on the new instance — the stored pick wins over the
+    // first-item fallback.
+    expect(PanelFor("pnpm content")?.getAttribute("data-state")).toBe("active");
+  });
+
+  // 45 of the 101 `persist` groups in the content tree also carry an
+  // author `default=`. If the author default outranked storage, the
+  // stored pick would be unreachable on almost half of them.
+  it("ranks a stored pick above the author's MDX default", () => {
+    window.localStorage.setItem(STORAGE_KEY, "pnpm");
+    render(
+      <Tabs groupId="pm" persist default="npm" items={["npm", "pnpm"]}>
+        <Tab value="npm">npm content</Tab>
+        <Tab value="pnpm">pnpm content</Tab>
+      </Tabs>,
+    );
+
+    expect(PanelFor("pnpm content")?.getAttribute("data-state")).toBe("active");
+  });
+
+  it("uses the author's MDX default when nothing is stored", () => {
+    render(
+      <Tabs groupId="pm" persist default="pnpm" items={["npm", "pnpm"]}>
+        <Tab value="npm">npm content</Tab>
+        <Tab value="pnpm">pnpm content</Tab>
+      </Tabs>,
+    );
+
+    expect(PanelFor("pnpm content")?.getAttribute("data-state")).toBe("active");
+  });
+
+  // urlDefault comes from the framework route (TAB_DEFAULTS_BY_SLUG), so
+  // the snippets on screen must match the URL the reader followed.
+  it("ranks a urlDefault above a stored pick", () => {
+    window.localStorage.setItem(STORAGE_KEY, "pnpm");
+    render(
+      <Tabs groupId="pm" persist urlDefault="npm" items={["npm", "pnpm"]}>
+        <Tab value="npm">npm content</Tab>
+        <Tab value="pnpm">pnpm content</Tab>
+      </Tabs>,
+    );
+
+    expect(PanelFor("npm content")?.getAttribute("data-state")).toBe("active");
+  });
+
+  it("ranks a urlDefault above the author's MDX default", () => {
+    render(
+      <Tabs
+        groupId="pm"
+        persist
+        default="npm"
+        urlDefault="pnpm"
+        items={["npm", "pnpm"]}
+      >
+        <Tab value="npm">npm content</Tab>
+        <Tab value="pnpm">pnpm content</Tab>
+      </Tabs>,
+    );
+
+    expect(PanelFor("pnpm content")?.getAttribute("data-state")).toBe("active");
+  });
+
+  it("ignores a stored pick that is not in items", () => {
+    window.localStorage.setItem(STORAGE_KEY, "bun");
+    render(<PersistGroup />);
+
+    expect(PanelFor("npm content")?.getAttribute("data-state")).toBe("active");
+  });
+
+  it("does not write to storage when persist is not set", () => {
+    render(
+      <Tabs groupId="pm" items={["npm", "pnpm"]}>
+        <Tab value="npm">npm content</Tab>
+        <Tab value="pnpm">pnpm content</Tab>
+      </Tabs>,
+    );
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "pnpm" }));
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/showcase/shell-docs/src/components/api-key-hint.tsx
+++ b/showcase/shell-docs/src/components/api-key-hint.tsx
@@ -1,0 +1,65 @@
+// ApiKeyHint — compact inline callout shown below code blocks that need
+// a provider API key (e.g. `.env` snippets).
+//
+// Renders a small muted row with a link to the provider's key/credential
+// page. Does NOT inject or expose any key — it's purely a navigational
+// hint. Usage:
+//
+//   <ApiKeyHint provider="openai" />
+
+import { ExternalLink, KeyRound } from "lucide-react";
+
+interface ProviderMeta {
+  label: string;
+  url: string;
+}
+
+const PROVIDERS: Record<string, ProviderMeta> = {
+  openai: {
+    label: "OpenAI API key",
+    url: "https://platform.openai.com/api-keys",
+  },
+  anthropic: {
+    label: "Anthropic API key",
+    url: "https://console.anthropic.com/",
+  },
+  google: {
+    label: "Google AI Studio API key",
+    url: "https://aistudio.google.com/apikey",
+  },
+  langsmith: {
+    label: "LangSmith API key",
+    url: "https://smith.langchain.com/",
+  },
+  copilotkit: {
+    label: "CopilotKit Intelligence API key",
+    url: "https://dashboard.operations.copilotkit.ai/",
+  },
+};
+
+export function ApiKeyHint({ provider }: { provider: string }) {
+  const meta = PROVIDERS[provider];
+  if (!meta) {
+    return null;
+  }
+  return (
+    <div className="not-prose mt-2 flex items-center gap-1.5 text-[0.8125rem] text-fd-muted-foreground">
+      <KeyRound className="size-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        Get your{" "}
+        <a
+          href={meta.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 decoration-fd-foreground/20 transition-colors hover:decoration-fd-foreground/40"
+        >
+          {meta.label}
+          <ExternalLink
+            className="ml-0.5 inline-block size-3"
+            aria-hidden="true"
+          />
+        </a>
+      </span>
+    </div>
+  );
+}

--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -415,6 +415,12 @@ export async function DocsPageView({
                         // TAB_DEFAULTS_BY_SLUG) fall through to the MDX
                         // `default` and the component's first-label
                         // fallback unchanged.
+                        //
+                        // Pass this as `urlDefault`, NOT by overwriting
+                        // `default`: <Tabs> ranks a persisted pick above
+                        // the author's `default` but below the URL, and
+                        // it can only tell the two apart if they arrive
+                        // on separate props.
                         Tabs: (props: {
                           groupId?: string;
                           default?: string;
@@ -427,10 +433,7 @@ export async function DocsPageView({
                             props.groupId,
                           );
                           return (
-                            <DocsTabs
-                              {...props}
-                              default={urlDefault ?? props.default}
-                            >
+                            <DocsTabs {...props} urlDefault={urlDefault}>
                               {props.children}
                             </DocsTabs>
                           );

--- a/showcase/shell-docs/src/components/docs-tabs.tsx
+++ b/showcase/shell-docs/src/components/docs-tabs.tsx
@@ -13,12 +13,24 @@
 //     "JSON Configuration File" (two spaces → only first replaced →
 //     residual space in trigger but not in double-escaped content).
 //
-//   - We accept `groupId` / `persist` / `default` props that the legacy
-//     custom-Tabs MDX content was written against, so existing pages
-//     don't need to be rewritten. `groupId` and `persist` are accepted
-//     and currently ignored (Fumadocs's built-in tabs don't persist
-//     cross-page state in this configuration); `default` is mapped to
-//     Fumadocs's `defaultValue`.
+//   - We implement cross-page persistence for `groupId` + `persist`.
+//     Fumadocs's own tabs hold selection in local component state and
+//     expose no persistence hook, so this wrapper takes over the
+//     controlled `value`/`onValueChange`. The precedence for the initial
+//     selection is:
+//
+//       1. `urlDefault` — the framework-route override the docs page
+//          shell derives from the URL (see TAB_DEFAULTS_BY_SLUG). The
+//          reader followed a `/langgraph-typescript/*` link, so the
+//          TypeScript snippets must be the ones on screen.
+//       2. A previously persisted pick for the same `groupId`.
+//       3. The author's `default`/`defaultValue` written in the MDX.
+//       4. The first item.
+//
+//     Keeping 1 and 3 as separate props matters: 45 of the 101 `persist`
+//     tab groups in the content tree also carry an author `default=`, so
+//     collapsing the two sources would make the stored pick unreachable
+//     on almost half of the pages the feature exists for.
 //
 // All other props (className, etc.) forward through to Fumadocs.
 
@@ -37,32 +49,61 @@ import type {
 /**
  * Mirror Fumadocs's internal `escapeValue` — keep this in sync with
  * `node_modules/fumadocs-ui/dist/components/tabs.js`. Used ONLY for
- * the `Tabs` defaultValue so the initial-selection value matches the
- * trigger values Fumadocs generates from `items`. Do NOT apply to
- * individual `Tab` values — Fumadocs's Tab component calls this
- * internally; pre-escaping here would double-escape and break the
- * trigger↔content pairing for multi-word labels.
+ * the `Tabs` value so it matches the trigger values Fumadocs generates
+ * from `items`. Do NOT apply to individual `Tab` values — Fumadocs's
+ * Tab component calls this internally; pre-escaping here would
+ * double-escape and break the trigger↔content pairing for multi-word
+ * labels.
  */
 function escapeValue(v: string): string {
   return v.toLowerCase().replace(/\s/, "-");
+}
+
+function storageKeyFor(groupId: string): string {
+  return `shell-docs.tab.${groupId}`;
 }
 
 interface ExtendedTabsProps extends Omit<FumadocsTabsProps, "defaultValue"> {
   /**
    * Initial active tab label. MDX authors write `default="Python"`
    * (legacy convention from when this component shimmed fumadocs);
-   * we also accept Fumadocs's `defaultValue`.
+   * we also accept Fumadocs's `defaultValue`. A persisted pick wins
+   * over both — the author's default is only the cold-start choice.
    */
   default?: string;
   defaultValue?: string;
-  /** Accepted for source compat — fumadocs persistent-tab feature. */
+  /**
+   * Framework-route override supplied by the docs page shell, not by
+   * MDX. This one DOES win over a persisted pick: it reflects the URL
+   * the reader followed.
+   */
+  urlDefault?: string;
+  /** Groups tabs across pages so a `persist` pick carries over. */
   groupId?: string;
+  /** Persist the active tab under `groupId` in localStorage. */
   persist?: boolean;
+  /**
+   * Controlled selection. Fumadocs's TabsProps omits these (it forwards
+   * them to the Radix root untyped), so re-declare them here for our
+   * persistence wiring.
+   */
+  value?: string;
+  onValueChange?: (value: string) => void;
 }
 
 type TabChildProps = {
   value?: unknown;
   title?: unknown;
+};
+
+/**
+ * Fumadocs's TabsProps type omits `value` / `onValueChange` even though
+ * Fumadocs forwards them to the Radix root at runtime. Re-declare them
+ * for our persistence wiring.
+ */
+type FumadocsTabsRuntimeProps = FumadocsTabsProps & {
+  value?: string;
+  onValueChange?: (value: string) => void;
 };
 
 function deriveItemsFromChildren(
@@ -82,23 +123,89 @@ function deriveItemsFromChildren(
   return items.length > 0 ? items : undefined;
 }
 
+function readStoredValue(storageKey: string | null): string | null {
+  if (!storageKey) {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(storageKey);
+  } catch {
+    // Storage blocked (private mode, disabled cookies) — fall through.
+    return null;
+  }
+}
+
+function writeStoredValue(storageKey: string | null, value: string): void {
+  if (!storageKey) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(storageKey, value);
+  } catch {
+    // Ignore quota / privacy-mode errors; persistence is best-effort.
+  }
+}
+
 export function Tabs({
   default: defaultProp,
   defaultValue,
-  groupId: _groupId,
-  persist: _persist,
+  urlDefault,
+  groupId,
+  persist: shouldPersist,
   items: itemsProp,
   children,
   ...rest
 }: ExtendedTabsProps) {
   const items = itemsProp ?? deriveItemsFromChildren(children);
-  const resolvedDefault = defaultValue ?? defaultProp ?? items?.[0];
+  const hasUrlDefault = Boolean(urlDefault);
+  const resolvedDefault =
+    urlDefault ?? defaultValue ?? defaultProp ?? items?.[0];
+  const storageKey = groupId ? storageKeyFor(groupId) : null;
+  const canPersist = Boolean(shouldPersist && groupId);
+
+  const [active, setActive] = React.useState<string>(
+    resolvedDefault ? escapeValue(resolvedDefault) : "",
+  );
+
+  React.useEffect(() => {
+    // A URL-seeded override from the docs page shell always wins over a
+    // stored pick. The author's MDX `default` does not — it is only the
+    // cold-start choice for a reader who has never picked a tab.
+    if (!canPersist || !items || hasUrlDefault) {
+      return;
+    }
+    const stored = readStoredValue(storageKey);
+    if (
+      stored &&
+      items.some((item) => escapeValue(item) === stored) &&
+      stored !== active
+    ) {
+      setActive(stored);
+    }
+    // `hasUrlDefault` is fixed per render tree; `items` may be
+    // re-derived each render, so guard via the equality checks above
+    // rather than changing what the effect depends on.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canPersist, storageKey, items]);
+
+  const handleValueChange = (value: string) => {
+    if (items && !items.some((item) => escapeValue(item) === value)) {
+      return;
+    }
+    setActive(value);
+    if (canPersist) {
+      writeStoredValue(storageKey, value);
+    }
+  };
 
   return (
     <FumadocsTabs
-      {...rest}
-      items={items}
-      defaultValue={resolvedDefault ? escapeValue(resolvedDefault) : undefined}
+      {...({
+        ...rest,
+        items,
+        value: active,
+        onValueChange: handleValueChange,
+      } as FumadocsTabsRuntimeProps)}
     >
       {children}
     </FumadocsTabs>

--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -73,6 +73,8 @@ Before you begin, you'll need the following:
                 OPENAI_API_KEY=your_openai_api_key
                 ```
 
+                <ApiKeyHint provider="openai" />
+
                 <Callout type="info" title="What about other models?">
                   The starter template is configured to use OpenAI's GPT-4o by default, but you can modify it to use any language model supported by LangGraph.
                 </Callout>
@@ -303,6 +305,8 @@ Before you begin, you'll need the following:
               ```plaintext title=".env"
               OPENAI_API_KEY=your_openai_api_key
               ```
+
+              <ApiKeyHint provider="openai" />
 
               <Callout type="info" title="What about other models?">
                 The starter template is configured to use OpenAI's GPT-4o by default, but you can modify it to use any language model supported by LangGraph.

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -33,6 +33,7 @@ import { DocsLandingNext } from "@/components/docs-landing-next";
 import { WhenFrameworkHas } from "@/components/when-framework-has";
 import { WhenAngularBackend } from "@/components/when-angular-backend";
 import { AgentCoreCommandTabs } from "@/components/agentcore-command-tabs";
+import { ApiKeyHint } from "@/components/api-key-hint";
 import { WebMCPSetupPrompt } from "@/components/webmcp-setup-prompt";
 import { DemoSource } from "@/components/demo-source";
 import { AngularFeatureCatalog } from "@/components/angular-feature-catalog";
@@ -273,6 +274,7 @@ export const docsComponents = {
   PropertyReference,
   OpsPlatformCTA,
   SignupLink,
+  ApiKeyHint,
   DocsTrackedCopy,
   DocsTrackedLink,
   WebMCPSetupPrompt,


### PR DESCRIPTION
Two independent docs-frontend improvements in `showcase/shell-docs`. Rebased onto current `main` (the branch was 158 commits behind).

## 1. `<Tabs persist>` now actually persists

101 tab groups in the content tree are authored as `<Tabs groupId="..." persist>`. The wrapper accepted both props and ignored them — the comment in `docs-tabs.tsx` said so outright:

> `groupId` and `persist` are accepted and currently ignored

So every page reopened on its own default. A reader working through the LangGraph guide in TypeScript had to reselect TypeScript on each page.

Fumadocs holds tab selection in local component state and exposes no persistence hook, so the wrapper takes over the controlled `value`/`onValueChange` pair and mirrors the pick into `localStorage` under `shell-docs.tab.<groupId>`.

**Selection precedence**, strongest first:

| # | Source | Where it comes from |
|---|--------|---------------------|
| 1 | `urlDefault` | The framework-route override the page shell derives from the URL (`TAB_DEFAULTS_BY_SLUG`) |
| 2 | Stored pick | `localStorage`, same `groupId` |
| 3 | `default=` | The author's value in the MDX |
| 4 | First item | Fallback |

The page shell passes its URL-derived value as a **separate `urlDefault` prop** rather than overwriting `default`. This matters: 45 of the 101 `persist` groups also carry an author `default=`. Collapsing the two sources into one prop ranks the author's default above storage, which would leave the stored pick unreachable on almost half of the pages the feature exists for. `language_langgraph_agent` appears both ways (30 sites with `default="Python"`, 8 without), so the same group would have behaved inconsistently within one guide.

Two details worth noting for review:

- The stored value is read in an **effect**, not in the initial state, so server and client render identical markup and hydration stays clean.
- Every `localStorage` read and write is wrapped in `try`/`catch`. Private mode and quota errors leave the tabs fully working, just without persistence.

## 2. API-key hints under `.env` snippets

The LangGraph quickstart tells the reader to put `OPENAI_API_KEY` in `.env` and leaves them to go find the key page. `<ApiKeyHint provider="openai" />` renders a muted one-line link under the snippet.

The component maps a provider id to a label and URL — `openai`, `anthropic`, `google`, `langsmith`, `copilotkit`. An unknown id renders nothing, so a typo degrades to today's behaviour instead of throwing. It is navigational only: it neither reads nor writes a key. Both `.env` steps on the LangGraph quickstart use it.

## Removed from this branch

The earlier revision led the LangGraph quickstart with a `<InlineDemo demo="agentic-chat" />` block under a "See it working" heading. That is gone, along with the `inline-demo.test.tsx` file that covered it — `InlineDemo` is pre-existing `main` code this PR no longer touches.

Two tests in `docs-page-view-toc.test.tsx` were also dropped rather than kept. They were named for this PR's components but did not exercise them: `docs-page-view-toc.test.tsx` asserts on `DocsPage` props, and the page body is never rendered. Verified by mutation — deleting `ApiKeyHint` from the MDX registry left the test titled `renders the LangGraph quickstart (InlineDemo + ApiKeyHint) without errors` **passing**. Real coverage lives in `api-key-hint.test.tsx` instead.

## Testing

No CI job runs the `showcase/shell-docs` vitest suite. `test_unit-showcase.yml` covers only `harness` and `shell-dashboard`; `showcase_validate.yml` runs vitest only in `showcase/scripts`. Everything below was therefore run locally.

**Full suite, branch vs. pristine `origin/main` in the same environment** — `main` carries 6 pre-existing failures here, so the failure *set* is the comparison, not zero:

```
base   (origin/main)  843 tests, 6 failed
branch (this PR)      858 tests, 6 failed
NEW failures: none
```

The 6 are identical on both sides: `brand-nav` layout cap, 3 × `angular-docs-content`, `llm-text` mastra, `ms-agent-python-stable-api`.

**Mutation checks** — every new test was verified to fail when the mechanism it claims to cover is broken:

| Mutation | Result |
|----------|--------|
| `canPersist = false` (persistence off) | ✅ `persists a groupId pick and reapplies it on a fresh mount` fails |
| Author `default` outranks storage (the pre-fix precedence) | ✅ `ranks a stored pick above the author's MDX default` fails |
| `urlDefault` demoted below author `default` | ✅ `ranks a urlDefault above the author's MDX default` fails |
| `ApiKeyHint` removed from the MDX registry | ✅ `is registered as an MDX component` fails |
| `href={meta.url}` → `href={undefined}` | ✅ 5 of 7 `ApiKeyHint` tests fail |

**End-to-end render** — `ApiKeyHint` was rendered through the real `MDXRemote` pipeline (same `remarkGfm` options, nested in `<Steps>/<Step>` as the quickstart uses it) to confirm the `provider` prop survives compilation and the anchor reaches the HTML:

```
✓ ApiKeyHint through the real MDX pipeline > survives compilation with its provider prop
  expect(html).toContain("https://platform.openai.com/api-keys")
```

**Typecheck and lint** (`showcase/shell-docs`):

```
$ npx tsc --noEmit      → exit 0
$ npx oxlint .          → Found 28 warnings and 0 errors
$ npx oxfmt --check <touched files>  → All matched files use the correct format
```

The 28 lint warnings are pre-existing. The only two in a file this PR touches (`mdx-registry.tsx`) are `iframe-missing-sandbox` on pre-existing `InlineDemo` iframes, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline API key guidance below relevant documentation code blocks, with links to provider credential pages.
  * Added tab selection persistence across documentation pages, with support for URL and author-defined defaults.
  * Added API key guidance to the LangGraph quickstart.
* **Tests**
  * Added coverage for tab persistence, selection precedence, invalid values, disabled persistence, and API key hint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->