### PR TITLE
feat(core): let an app trim the history it sends to a runtime agent

### DIFF
--- a/packages/core/src/__tests__/message-filter.test.ts
+++ b/packages/core/src/__tests__/message-filter.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Message } from "@ag-ui/client";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+import { CopilotKitCore } from "../core";
+import { ɵrepairToolCallPairs } from "../core/message-filter";
+import {
+  waitForCondition,
+  createAssistantMessage,
+  createMessage,
+  createToolCallMessage,
+  createToolResultMessage,
+} from "./test-utils";
+
+const encoder = new TextEncoder();
+
+function createSseResponse(): Response {
+  const events = [
+    { type: "RUN_STARTED", threadId: "test-thread", runId: "test-run" },
+    {
+      type: "RUN_FINISHED",
+      threadId: "test-thread",
+      runId: "test-run",
+      result: { newMessages: [] },
+    },
+  ];
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+        ),
+      );
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function infoResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      version: "1.0.0",
+      agents: {
+        default: {
+          name: "default",
+          className: "HttpAgent",
+          description: "assistant",
+        },
+      },
+      audioFileTranscriptionEnabled: false,
+      mode: "sse",
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function toolCallIdOf(message: Message): string {
+  const calls = (message as { toolCalls?: { id: string }[] }).toolCalls;
+  if (!calls?.[0]) throw new Error("message carries no tool call");
+  return calls[0].id;
+}
+
+/** The messages that actually went on the wire for a REST run request. */
+function sentMessages(init: RequestInit): Message[] {
+  return JSON.parse(init.body as string).messages;
+}
+
+describe("ɵrepairToolCallPairs", () => {
+  it("drops a tool result whose assistant call was trimmed away", () => {
+    const call = createToolCallMessage("lookup");
+    const result = createToolResultMessage(toolCallIdOf(call), "done");
+    const full = [createMessage({ id: "u1" }), call, result];
+
+    const repaired = ɵrepairToolCallPairs([result], full);
+
+    expect(repaired).toEqual([]);
+  });
+
+  it("restores the result of a kept call, directly after the call", () => {
+    const call = createToolCallMessage("lookup");
+    const result = createToolResultMessage(toolCallIdOf(call), "done");
+    const followUp = createAssistantMessage({ id: "a2" });
+    const full = [createMessage({ id: "u1" }), call, result, followUp];
+
+    const repaired = ɵrepairToolCallPairs([call, followUp], full);
+
+    expect(repaired.map((m) => m.id)).toEqual([call.id, result.id, "a2"]);
+  });
+
+  it("leaves an open call alone when no result exists yet", () => {
+    // Mid-HITL: the call is awaiting a human, so the pair is not broken.
+    const call = createToolCallMessage("askUser");
+    const full = [createMessage({ id: "u1" }), call];
+
+    const repaired = ɵrepairToolCallPairs([call], full);
+
+    expect(repaired.map((m) => m.id)).toEqual([call.id]);
+  });
+
+  it("keeps a tool result whose issuing call is not in this thread", () => {
+    // No issuer to reason about, so dropping it would be the client inventing
+    // a rule the backend never stated.
+    const orphan = createToolResultMessage("call-from-elsewhere", "done");
+    const full = [createMessage({ id: "u1" }), orphan];
+
+    const repaired = ɵrepairToolCallPairs([orphan], full);
+
+    expect(repaired.map((m) => m.id)).toEqual([orphan.id]);
+  });
+
+  it("preserves the filter's order and never duplicates a message", () => {
+    const call = createToolCallMessage("lookup");
+    const result = createToolResultMessage(toolCallIdOf(call), "done");
+    const full = [call, result];
+
+    const repaired = ɵrepairToolCallPairs([call, result], full);
+
+    expect(repaired.map((m) => m.id)).toEqual([call.id, result.id]);
+  });
+
+  it("returns the list untouched when the filter kept everything", () => {
+    const full = [
+      createMessage({ id: "u1" }),
+      createAssistantMessage({ id: "a1" }),
+    ];
+
+    expect(ɵrepairToolCallPairs(full, full)).toEqual(full);
+  });
+});
+
+describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(createSseResponse());
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  const history = (): Message[] => [
+    createMessage({ id: "u1", content: "first" }),
+    createAssistantMessage({ id: "a1" }),
+    createMessage({ id: "u2", content: "latest" }),
+  ];
+
+  it("sends the whole thread when no filter is set", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+  });
+
+  it("sends only what the filter kept", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u2"]);
+  });
+
+  it("leaves the rendered transcript at full length", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    expect(agent.messages.map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+  });
+
+  it("repairs the tool-call pair a blunt filter would have split", async () => {
+    // The #1482 failure in reverse: trimming to the last message on a thread
+    // that ends in a tool result leaves the provider a result with no call.
+    const call = createToolCallMessage("lookup");
+    const result = createToolResultMessage(toolCallIdOf(call), "done");
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages([createMessage({ id: "u1" }), call, result]);
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual([]);
+  });
+
+  it("restores a dropped result so a kept call is never left unanswered", async () => {
+    const call = createToolCallMessage("lookup");
+    const result = createToolResultMessage(toolCallIdOf(call), "done");
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => messages.filter((m) => m.role !== "tool"),
+    });
+    agent.setMessages([createMessage({ id: "u1" }), call, result]);
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual([
+      "u1",
+      call.id,
+      result.id,
+    ]);
+  });
+
+  it("tells the filter which agent is running", async () => {
+    const seen: string[] = [];
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "billing-agent",
+      transport: "rest",
+      messageFilter: (messages, context) => {
+        seen.push(context.agentId);
+        return messages;
+      },
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    expect(seen).toEqual(["billing-agent"]);
+  });
+
+  it("hides activity messages from the filter", async () => {
+    const seen: Message[][] = [];
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => {
+        seen.push(messages);
+        return messages;
+      },
+    });
+    agent.setMessages([
+      createMessage({ id: "u1" }),
+      createMessage({ id: "act1", role: "activity" } as never),
+      createMessage({ id: "u2" }),
+    ]);
+
+    await agent.runAgent();
+
+    expect(seen[0].map((m) => m.id)).toEqual(["u1", "u2"]);
+  });
+
+  it("cannot corrupt the transcript by mutating the array it is handed", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => {
+        messages.length = 0;
+        (messages as { push: (m: Message) => void }).push(
+          createMessage({ id: "injected" }),
+        );
+        return messages;
+      },
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    expect(agent.messages.map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+  });
+
+  it("falls back to the full thread when the filter returns a non-array", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (() => undefined) as never,
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("messageFilter returned a non-array value"),
+    );
+  });
+
+  it("applies a filter assigned after construction", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+    });
+    agent.setMessages(history());
+    agent.messageFilter = (messages) => messages.slice(-1);
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u2"]);
+  });
+
+  it("survives clone(), which the runtime does once per run", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages(history());
+
+    const cloned = agent.clone();
+    await cloned.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u2"]);
+  });
+
+  it("trims the payload on the single-route transport too", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "single",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages(history());
+
+    await agent.runAgent();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const envelope = JSON.parse(init.body as string);
+    expect(envelope.body.messages.map((m: Message) => m.id)).toEqual(["u2"]);
+  });
+});
+
+describe("CopilotKitCore messageFilter reaches runtime-discovered agents", () => {
+  const originalFetch = global.fetch;
+  const originalWindow = (global as { window?: unknown }).window;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(
+          String(url).includes("/info") ? infoResponse() : createSseResponse(),
+        ),
+      );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    // The core only opens its `/info` connection in a browser.
+    (global as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalWindow === undefined) {
+      delete (global as { window?: unknown }).window;
+    } else {
+      (global as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  const runRequestBody = (): Message[] => {
+    // `endsWith`, not `includes`: the `/info` URL contains "/runtime.example".
+    const call = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/run"),
+    ) as [string, RequestInit];
+    return sentMessages(call[1]);
+  };
+
+  it("trims the payload of an agent the runtime advertised", async () => {
+    // The case #1482 reporters actually have: no agent instance of their own,
+    // just `<CopilotKit runtimeUrl>` and an agent discovered from `/info`.
+    const core = new CopilotKitCore({
+      runtimeUrl: "https://runtime.example",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    await waitForCondition(() => Boolean(core.getAgent("default")));
+
+    const agent = core.getAgent("default")!;
+    agent.setMessages([
+      createMessage({ id: "u1" }),
+      createAssistantMessage({ id: "a1" }),
+      createMessage({ id: "u2" }),
+    ]);
+    await agent.runAgent();
+
+    expect(runRequestBody().map((m) => m.id)).toEqual(["u2"]);
+  });
+
+  it("applies a filter set after the agent was discovered", async () => {
+    const core = new CopilotKitCore({ runtimeUrl: "https://runtime.example" });
+    await waitForCondition(() => Boolean(core.getAgent("default")));
+
+    core.setMessageFilter((messages) => messages.slice(-1));
+
+    const agent = core.getAgent("default")!;
+    agent.setMessages([
+      createMessage({ id: "u1" }),
+      createMessage({ id: "u2" }),
+    ]);
+    await agent.runAgent();
+
+    expect(runRequestBody().map((m) => m.id)).toEqual(["u2"]);
+  });
+
+  it("goes back to the full thread when the filter is cleared", async () => {
+    const core = new CopilotKitCore({
+      runtimeUrl: "https://runtime.example",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    await waitForCondition(() => Boolean(core.getAgent("default")));
+
+    core.setMessageFilter(undefined);
+
+    const agent = core.getAgent("default")!;
+    agent.setMessages([
+      createMessage({ id: "u1" }),
+      createMessage({ id: "u2" }),
+    ]);
+    await agent.runAgent();
+
+    expect(runRequestBody().map((m) => m.id)).toEqual(["u1", "u2"]);
+  });
+});

--- a/packages/core/src/__tests__/message-filter.test.ts
+++ b/packages/core/src/__tests__/message-filter.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Message } from "@ag-ui/client";
+import { EMPTY } from "rxjs";
 import { ProxiedCopilotRuntimeAgent } from "../agent";
 import { CopilotKitCore } from "../core";
 import { ɵrepairToolCallPairs } from "../core/message-filter";
 import {
+  createSuggestionsConfig,
   waitForCondition,
   createAssistantMessage,
   createMultipleToolCallsMessage,
@@ -285,6 +287,46 @@ describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
     expect(input?.messages.map((m) => m.id)).toEqual(["u2"]);
   });
 
+  it("drops a non-message entry the filter smuggled in, without failing the run", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      // The shape a `m.filter(x => x.content.length > 0)` mistake produces.
+      messageFilter: () => [undefined as never],
+    });
+    agent.setMessages(history());
+
+    await expect(agent.runAgent()).resolves.toMatchObject({
+      newMessages: expect.any(Array),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("leaves Intelligence runs untrimmed, because that runtime is the store of record", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      runtimeMode: "intelligence",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages(history());
+    const run = vi.spyOn(agent, "run").mockReturnValue(EMPTY);
+
+    await agent.runAgent().catch(() => undefined);
+
+    expect(run.mock.calls[0]?.[0].messages.map((m) => m.id)).toEqual([
+      "u1",
+      "a1",
+      "u2",
+    ]);
+  });
+
   it("tells the filter which agent is running", async () => {
     const seen: string[] = [];
     const agent = new ProxiedCopilotRuntimeAgent({
@@ -385,7 +427,7 @@ describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(sentMessages(init).map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("messageFilter threw"),
+      expect.stringContaining("messageFilter failed"),
       expect.any(Error),
     );
   });
@@ -527,5 +569,88 @@ describe("CopilotKitCore messageFilter reaches runtime-discovered agents", () =>
     await agent.runAgent();
 
     expect(runRequestBody().map((m) => m.id)).toEqual(["u1", "u2"]);
+  });
+});
+
+describe("messageFilter and suggestions", () => {
+  const originalFetch = global.fetch;
+  const originalWindow = (global as { window?: unknown }).window;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // No `suggestions` capability advertised, so the engine takes the
+    // clone + runAgent fallback rather than the stateless /suggest path.
+    fetchMock = vi.fn().mockImplementation((url: string) =>
+      Promise.resolve(
+        String(url).includes("/info")
+          ? new Response(
+              JSON.stringify({
+                version: "1.0.0",
+                mode: "sse",
+                audioFileTranscriptionEnabled: false,
+                agents: {
+                  default: { name: "default", className: "HttpAgent" },
+                  consumer: { name: "consumer", className: "HttpAgent" },
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            )
+          : createSseResponse(),
+      ),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+    (global as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalWindow === undefined) {
+      delete (global as { window?: unknown }).window;
+    } else {
+      (global as { window?: unknown }).window = originalWindow;
+    }
+  });
+
+  it("keeps the seeded context on a suggestion run", async () => {
+    // A suggestion clone runs under a fresh thread id, so no backend store can
+    // fill in what a filter withheld: the seeded messages ARE the context. If
+    // the app's filter rode the clone, the provider would be asked to suggest
+    // from a single message.
+    const core = new CopilotKitCore({
+      runtimeUrl: "https://runtime.example",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    await waitForCondition(() => Boolean(core.getAgent("consumer")));
+
+    core
+      .getAgent("consumer")!
+      .setMessages([
+        createMessage({ id: "c1", content: "first" }),
+        createAssistantMessage({ id: "c2" }),
+        createMessage({ id: "c3", content: "latest" }),
+      ]);
+    core.addSuggestionsConfig(
+      createSuggestionsConfig({
+        providerAgentId: "default",
+        consumerAgentId: "consumer",
+      }),
+    );
+
+    core.reloadSuggestions("consumer");
+
+    await vi.waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([url]) =>
+          String(url).endsWith("/agent/default/run"),
+        ),
+      ).toBe(true);
+    });
+
+    const call = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/agent/default/run"),
+    ) as [string, RequestInit];
+    // Trimmed, this would be exactly one message.
+    expect(sentMessages(call[1]).length).toBeGreaterThan(1);
   });
 });

--- a/packages/core/src/__tests__/message-filter.test.ts
+++ b/packages/core/src/__tests__/message-filter.test.ts
@@ -265,6 +265,26 @@ describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
     ]);
   });
 
+  it("hands the filtered list to run(), whichever transport it dispatches to", async () => {
+    // `run()` is the fork between the HTTP transports and the Intelligence
+    // delegate, and the delegate forwards this input rather than rebuilding
+    // one. Asserting here covers the delegate path without standing up a
+    // gateway.
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: (messages) => messages.slice(-1),
+    });
+    agent.setMessages(history());
+    const run = vi.spyOn(agent, "run");
+
+    await agent.runAgent();
+
+    const input = run.mock.calls[0]?.[0];
+    expect(input?.messages.map((m) => m.id)).toEqual(["u2"]);
+  });
+
   it("tells the filter which agent is running", async () => {
     const seen: string[] = [];
     const agent = new ProxiedCopilotRuntimeAgent({

--- a/packages/core/src/__tests__/message-filter.test.ts
+++ b/packages/core/src/__tests__/message-filter.test.ts
@@ -364,6 +364,32 @@ describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
     );
   });
 
+  it("falls back to the full thread when the filter throws", async () => {
+    // Trimming is an optimization. A bug in it must not take the user's
+    // message down with it.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl: "https://runtime.example",
+      agentId: "a",
+      transport: "rest",
+      messageFilter: () => {
+        throw new Error("boom");
+      },
+    });
+    agent.setMessages(history());
+
+    await expect(agent.runAgent()).resolves.toMatchObject({
+      newMessages: expect.any(Array),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(sentMessages(init).map((m) => m.id)).toEqual(["u1", "a1", "u2"]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("messageFilter threw"),
+      expect.any(Error),
+    );
+  });
+
   it("applies a filter assigned after construction", async () => {
     const agent = new ProxiedCopilotRuntimeAgent({
       runtimeUrl: "https://runtime.example",

--- a/packages/core/src/__tests__/message-filter.test.ts
+++ b/packages/core/src/__tests__/message-filter.test.ts
@@ -6,6 +6,7 @@ import { ɵrepairToolCallPairs } from "../core/message-filter";
 import {
   waitForCondition,
   createAssistantMessage,
+  createMultipleToolCallsMessage,
   createMessage,
   createToolCallMessage,
   createToolResultMessage,
@@ -57,6 +58,11 @@ function infoResponse(): Response {
   );
 }
 
+function toolCallIdsOf(message: Message): string[] {
+  const calls = (message as { toolCalls?: { id: string }[] }).toolCalls ?? [];
+  return calls.map((call) => call.id);
+}
+
 function toolCallIdOf(message: Message): string {
   const calls = (message as { toolCalls?: { id: string }[] }).toolCalls;
   if (!calls?.[0]) throw new Error("message carries no tool call");
@@ -69,14 +75,37 @@ function sentMessages(init: RequestInit): Message[] {
 }
 
 describe("ɵrepairToolCallPairs", () => {
-  it("drops a tool result whose assistant call was trimmed away", () => {
+  it("restores the assistant call in front of a kept tool result", () => {
     const call = createToolCallMessage("lookup");
     const result = createToolResultMessage(toolCallIdOf(call), "done");
     const full = [createMessage({ id: "u1" }), call, result];
 
     const repaired = ɵrepairToolCallPairs([result], full);
 
-    expect(repaired).toEqual([]);
+    // Dropping the result would be valid but would throw away the only new
+    // information in a human-in-the-loop turn.
+    expect(repaired.map((m) => m.id)).toEqual([call.id, result.id]);
+  });
+
+  it("restores every sibling result when it restores a parallel call", () => {
+    const call = createMultipleToolCallsMessage([
+      { name: "lookupA" },
+      { name: "lookupB" },
+    ]);
+    const [callA, callB] = toolCallIdsOf(call);
+    const resultA = createToolResultMessage(callA!, "a");
+    const resultB = createToolResultMessage(callB!, "b");
+    const full = [call, resultA, resultB];
+
+    // Keeping only the second result: a provider rejects the turn unless the
+    // first call is answered too.
+    const repaired = ɵrepairToolCallPairs([resultB], full);
+
+    expect(repaired.map((m) => m.id)).toEqual([
+      call.id,
+      resultA.id,
+      resultB.id,
+    ]);
   });
 
   it("restores the result of a kept call, directly after the call", () => {
@@ -209,8 +238,10 @@ describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
 
     await agent.runAgent();
 
+    // The call comes back, the earlier user turn stays trimmed. Sending `[]`
+    // here would hand a resuming backend nothing to act on.
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(sentMessages(init).map((m) => m.id)).toEqual([]);
+    expect(sentMessages(init).map((m) => m.id)).toEqual([call.id, result.id]);
   });
 
   it("restores a dropped result so a kept call is never left unanswered", async () => {
@@ -271,7 +302,7 @@ describe("ProxiedCopilotRuntimeAgent messageFilter", () => {
 
     await agent.runAgent();
 
-    expect(seen[0].map((m) => m.id)).toEqual(["u1", "u2"]);
+    expect(seen[0]?.map((m) => m.id)).toEqual(["u1", "u2"]);
   });
 
   it("cannot corrupt the transcript by mutating the array it is handed", async () => {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -4,7 +4,6 @@ import type {
   AgentSubscriber,
   BaseEvent,
   HttpAgentConfig,
-  Message,
   RunAgentInput,
   RunAgentParameters,
   RunAgentResult,
@@ -102,11 +101,7 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
   runtimeAgentId?: string;
   /**
    * Rewrites the outbound message list on every run. See
-   * {@link CopilotKitMessageFilter}.
-   *
-   * Applies in every runtime mode, Intelligence included: `#runViaDelegate`
-   * forwards the input this agent built, so the delegate sends the filtered
-   * list rather than rebuilding one of its own.
+   * {@link CopilotKitMessageFilter}. Not applied in Intelligence mode.
    */
   messageFilter?: CopilotKitMessageFilter;
 }
@@ -190,9 +185,12 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   }
 
   /**
-   * The filter applied to the outbound message list on every run. Set by
-   * `AgentRegistry` whenever the core-level filter changes, so an agent
-   * discovered before the app configured one still picks it up.
+   * The filter applied to the outbound message list on every run.
+   *
+   * Registry-owned. `AgentRegistry` writes it whenever the core-level filter
+   * changes, so an agent discovered before the app configured one still picks
+   * it up — and so a value written here by hand is replaced on the registry's
+   * next sweep. Configure it through `CopilotKitCore` instead.
    */
   get messageFilter(): CopilotKitMessageFilter | undefined {
     return this._messageFilter;
@@ -222,31 +220,42 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     const filter = this._messageFilter;
     if (!filter) return input;
 
-    // A filter that throws or returns the wrong shape falls back to the
-    // untrimmed thread rather than failing the run. Trimming is an
-    // optimization, and taking the user's message down with it would be the
-    // worse outcome; the warning is what surfaces the bug.
-    let kept: Message[];
+    // Intelligence is exempt. The managed runtime is the store of record for
+    // the thread — the threads drawer and the Slack transcript read from it —
+    // so a client-side truncation there has a blast radius nobody asked for:
+    // every reporter on #1482 is self-hosted. It also keeps this agent
+    // self-consistent, because the Intelligence connect path runs through
+    // `delegate.connectAgent`, which builds its own input and could not be
+    // filtered here even if we wanted it to be.
+    //
+    // A "pending" mode still filters: the agent has not yet learned what the
+    // runtime is, and agents discovered from `/info` arrive with a resolved
+    // mode.
+    if (this.runtimeMode === RUNTIME_MODE_INTELLIGENCE) return input;
+
+    // A filter that throws, returns the wrong shape, or hands back entries the
+    // repair cannot read falls back to the untrimmed thread rather than
+    // failing the run. Trimming is an optimization, and taking the user's
+    // message down with it would be the worse outcome; the warning is what
+    // surfaces the bug.
     try {
-      const returned = filter([...input.messages], {
+      const kept = filter([...input.messages], {
         agentId: this.agentId ?? "",
       });
-      if (!Array.isArray(returned)) {
+      if (!Array.isArray(kept)) {
         console.warn(
           "ProxiedCopilotRuntimeAgent: messageFilter returned a non-array value; sending the full message history instead.",
         );
         return input;
       }
-      kept = returned;
+      return { ...input, messages: ɵrepairToolCallPairs(kept, input.messages) };
     } catch (error) {
       console.warn(
-        "ProxiedCopilotRuntimeAgent: messageFilter threw; sending the full message history instead.",
+        "ProxiedCopilotRuntimeAgent: messageFilter failed; sending the full message history instead.",
         error,
       );
       return input;
     }
-
-    return { ...input, messages: ɵrepairToolCallPairs(kept, input.messages) };
   }
 
   override requestInit(input: RunAgentInput): RequestInit {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -4,6 +4,7 @@ import type {
   AgentSubscriber,
   BaseEvent,
   HttpAgentConfig,
+  Message,
   RunAgentInput,
   RunAgentParameters,
   RunAgentResult,
@@ -221,13 +222,26 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     const filter = this._messageFilter;
     if (!filter) return input;
 
-    const kept = filter([...input.messages], { agentId: this.agentId ?? "" });
-    if (!Array.isArray(kept)) {
-      // Sending the untrimmed thread is the recoverable half of this mistake:
-      // the run still succeeds, and the payload is merely as large as it was
-      // before the filter existed.
+    // A filter that throws or returns the wrong shape falls back to the
+    // untrimmed thread rather than failing the run. Trimming is an
+    // optimization, and taking the user's message down with it would be the
+    // worse outcome; the warning is what surfaces the bug.
+    let kept: Message[];
+    try {
+      const returned = filter([...input.messages], {
+        agentId: this.agentId ?? "",
+      });
+      if (!Array.isArray(returned)) {
+        console.warn(
+          "ProxiedCopilotRuntimeAgent: messageFilter returned a non-array value; sending the full message history instead.",
+        );
+        return input;
+      }
+      kept = returned;
+    } catch (error) {
       console.warn(
-        "ProxiedCopilotRuntimeAgent: messageFilter returned a non-array value; sending the full message history instead.",
+        "ProxiedCopilotRuntimeAgent: messageFilter threw; sending the full message history instead.",
+        error,
       );
       return input;
     }

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -101,8 +101,11 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
   runtimeAgentId?: string;
   /**
    * Rewrites the outbound message list on every run. See
-   * {@link CopilotKitMessageFilter}. Ignored in Intelligence mode, where the
-   * runtime owns the canonical transcript.
+   * {@link CopilotKitMessageFilter}.
+   *
+   * Applies in every runtime mode, Intelligence included: `#runViaDelegate`
+   * forwards the input this agent built, so the delegate sends the filtered
+   * list rather than rebuilding one of its own.
    */
   messageFilter?: CopilotKitMessageFilter;
 }

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -30,6 +30,8 @@ import { IntelligenceAgent } from "./intelligence-agent";
 import type { CopilotRuntimeTransport } from "./types";
 import { runtimeInfoError } from "./utils/runtime-info-error";
 import { ɵconnectWithoutEventVerification } from "./utils/connect-replay";
+import type { CopilotKitMessageFilter } from "./core/message-filter";
+import { ɵrepairToolCallPairs } from "./core/message-filter";
 
 type ResolvedRuntimeMode = RuntimeMode | "pending";
 
@@ -97,6 +99,12 @@ export interface ProxiedCopilotRuntimeAgentConfig extends Omit<
    * bookkeeping; only outbound routing is overridden.
    */
   runtimeAgentId?: string;
+  /**
+   * Rewrites the outbound message list on every run. See
+   * {@link CopilotKitMessageFilter}. Ignored in Intelligence mode, where the
+   * runtime owns the canonical transcript.
+   */
+  messageFilter?: CopilotKitMessageFilter;
 }
 
 export class ProxiedCopilotRuntimeAgent extends HttpAgent {
@@ -114,6 +122,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   private _capabilities?: AgentCapabilities;
   private delegate?: AbstractAgent;
   private runtimeInfoPromise?: Promise<void>;
+  private _messageFilter?: CopilotKitMessageFilter;
 
   constructor(config: ProxiedCopilotRuntimeAgentConfig) {
     const normalizedRuntimeUrl = config.runtimeUrl
@@ -143,6 +152,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     this.runtimeMode = config.runtimeMode ?? RUNTIME_MODE_SSE;
     this.intelligence = config.intelligence;
     this._capabilities = config.capabilities;
+    this._messageFilter = config.messageFilter;
     if (config.debug) {
       this.debug = config.debug;
     }
@@ -173,6 +183,53 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
 
   get capabilities(): AgentCapabilities | undefined {
     return this._capabilities;
+  }
+
+  /**
+   * The filter applied to the outbound message list on every run. Set by
+   * `AgentRegistry` whenever the core-level filter changes, so an agent
+   * discovered before the app configured one still picks it up.
+   */
+  get messageFilter(): CopilotKitMessageFilter | undefined {
+    return this._messageFilter;
+  }
+
+  set messageFilter(filter: CopilotKitMessageFilter | undefined) {
+    this._messageFilter = filter;
+  }
+
+  /**
+   * Apply the configured message filter to the outbound payload.
+   *
+   * This is the only place the proxy narrows what goes on the wire. Both run
+   * paths build their input here (`#runViaHttp`, and `#runViaDelegate`, which
+   * forwards this exact input to the Intelligence delegate), and so does the
+   * self-hosted connect replay, so a filter set on this agent reaches every
+   * outbound request without each transport having to remember it.
+   *
+   * `super.prepareRunAgentInput` already deep-cloned the thread and stripped
+   * `activity` messages, so the filter cannot reach the messages the UI
+   * renders no matter what it does with the array it is handed.
+   */
+  protected override prepareRunAgentInput(
+    parameters?: RunAgentParameters,
+  ): RunAgentInput {
+    const input = super.prepareRunAgentInput(parameters);
+    const filter = this._messageFilter;
+    if (!filter) return input;
+
+    const kept = filter([...input.messages], { agentId: this.agentId ?? "" });
+    if (!Array.isArray(kept)) {
+      // Sending the untrimmed thread is the recoverable half of this mistake:
+      // the run still succeeds, and the payload is merely as large as it was
+      // before the filter existed.
+      console.warn(
+        "ProxiedCopilotRuntimeAgent: messageFilter returned a non-array value; sending the full message history instead.",
+      );
+      return input;
+    }
+
+    return { ...input, messages: ɵrepairToolCallPairs(kept, input.messages) };
   }
 
   override requestInit(input: RunAgentInput): RequestInit {
@@ -459,6 +516,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       capabilities: this._capabilities,
       debug: this.debug,
       fetch: this.fetch,
+      messageFilter: this._messageFilter,
     });
     cloned.threadId = this.threadId;
     cloned.setState(this.state);

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -1350,6 +1350,7 @@ export class AgentRegistry {
             ) {
               this.applyHeadersToAgent(existing);
               this.applyCredentialsToAgent(existing);
+              this.applyMessageFilterToAgent(existing);
               this.applyRuntimeFetchToAgent(existing);
               return [id, existing];
             }

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -291,6 +291,7 @@ export class AgentRegistry {
     this.localAgents = this.assignAgentIds(agents);
     this.applyHeadersToAgents(this.localAgents);
     this.applyCredentialsToAgents(this.localAgents);
+    this.applyMessageFilterToAgents(this.localAgents);
     this.applyRuntimeFetchToAgents(this.localAgents);
     this._agents = this.localAgents;
   }
@@ -439,6 +440,7 @@ export class AgentRegistry {
     this._agents = { ...this.localAgents, ...this.remoteAgents };
     this.applyHeadersToAgents(this._agents);
     this.applyCredentialsToAgents(this._agents);
+    this.applyMessageFilterToAgents(this._agents);
     this.applyRuntimeFetchToAgents(this._agents);
     void this.notifyAgentsChanged();
   }
@@ -509,6 +511,7 @@ export class AgentRegistry {
         : RUNTIME_MODE_SSE,
       intelligence: this._intelligence,
       debug: debug ? resolveDebugConfig(debug) : undefined,
+      messageFilter: friends.messageFilter,
     });
     this.applyHeadersToAgent(agent);
     this.applyRuntimeFetchToAgent(agent);
@@ -603,6 +606,32 @@ export class AgentRegistry {
   applyCredentialsToAgents(agents: Record<string, AbstractAgent>): void {
     Object.values(agents).forEach((agent) => {
       this.applyCredentialsToAgent(agent);
+    });
+  }
+
+  /**
+   * Apply the core's message filter to an agent.
+   *
+   * Only `ProxiedCopilotRuntimeAgent` carries the hook. Agents the app
+   * constructed itself (`agents__unsafe_dev_only`) are left untouched: their
+   * owner can already rewrite the outbound payload with an AG-UI middleware,
+   * and quietly reaching into an instance the app owns would be the more
+   * surprising behavior.
+   */
+  applyMessageFilterToAgent(agent: AbstractAgent): void {
+    if (agent instanceof ProxiedCopilotRuntimeAgent) {
+      agent.messageFilter = (
+        this.core as unknown as CopilotKitCoreFriendsAccess
+      ).messageFilter;
+    }
+  }
+
+  /**
+   * Apply the core's message filter to all agents
+   */
+  applyMessageFilterToAgents(agents: Record<string, AbstractAgent>): void {
+    Object.values(agents).forEach((agent) => {
+      this.applyMessageFilterToAgent(agent);
     });
   }
 
@@ -1334,6 +1363,9 @@ export class AgentRegistry {
               intelligence: runtimeInfoResponse.intelligence,
               capabilities,
               debug: rawDebug ? resolveDebugConfig(rawDebug) : undefined,
+              messageFilter: (
+                this.core as unknown as CopilotKitCoreFriendsAccess
+              ).messageFilter,
             });
             this.applyHeadersToAgent(agent);
             this.applyRuntimeFetchToAgent(agent);

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -612,11 +612,17 @@ export class AgentRegistry {
   /**
    * Apply the core's message filter to an agent.
    *
-   * Only `ProxiedCopilotRuntimeAgent` carries the hook. Agents the app
-   * constructed itself (`agents__unsafe_dev_only`) are left untouched: their
-   * owner can already rewrite the outbound payload with an AG-UI middleware,
-   * and quietly reaching into an instance the app owns would be the more
-   * surprising behavior.
+   * The test is the class, not which bucket the agent is registered in: every
+   * `ProxiedCopilotRuntimeAgent` gets the core filter, whether it came from
+   * `/info` or from `registerProxiedAgent` (which files its proxy under
+   * `localAgents`). Agents of any other class are left untouched — an
+   * `AbstractAgent` the app built has no such hook, and its owner already has
+   * the AG-UI middleware seam.
+   *
+   * This is the sole writer of `agent.messageFilter` in normal operation. The
+   * public setter exists for the registry and for tests; a value written
+   * directly onto an agent is replaced the next time the registry sweeps, the
+   * same way per-agent credentials are.
    */
   applyMessageFilterToAgent(agent: AbstractAgent): void {
     if (agent instanceof ProxiedCopilotRuntimeAgent) {

--- a/packages/core/src/core/core.ts
+++ b/packages/core/src/core/core.ts
@@ -17,6 +17,7 @@ import type {
   CopilotKitCoreRegisterProxiedAgentParams,
   CopilotKitCoreRegisterProxiedAgentResult,
 } from "./agent-registry";
+import type { CopilotKitMessageFilter } from "./message-filter";
 import { AgentRegistry } from "./agent-registry";
 import type { ScopedContext } from "./context-store";
 import { ContextStore } from "./context-store";
@@ -66,6 +67,12 @@ export interface CopilotKitCoreConfig {
   headers?: Record<string, string>;
   /** Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies). */
   credentials?: RequestCredentials;
+  /**
+   * Rewrites the message list sent to runtime agents on every run. Use it when
+   * the backend already stores the conversation and re-sending it is waste or
+   * duplication. See `setMessageFilter` and {@link CopilotKitMessageFilter}.
+   */
+  messageFilter?: CopilotKitMessageFilter;
   /** Properties sent as `forwardedProps` to the AG-UI agent. */
   properties?: Record<string, unknown>;
   /** Ordered collection of frontend tools available to the core. */
@@ -75,6 +82,8 @@ export interface CopilotKitCoreConfig {
   /** Enable debug logging for the client-side event pipeline. */
   debug?: DebugConfig;
 }
+
+export type { CopilotKitMessageFilter } from "./message-filter";
 
 export type {
   CopilotKitCoreAddAgentParams,
@@ -347,6 +356,7 @@ export interface CopilotKitCoreFriendsAccess {
   // Getters for internal state
   readonly headers: Readonly<Record<string, string>>;
   readonly credentials: RequestCredentials | undefined;
+  readonly messageFilter: CopilotKitMessageFilter | undefined;
   readonly properties: Readonly<Record<string, unknown>>;
   readonly context: Readonly<Record<string, Context>>;
   readonly debug?: DebugConfig;
@@ -402,6 +412,7 @@ function normalizeHeaders(
 export class CopilotKitCore {
   private _headers: Record<string, string>;
   private _credentials?: RequestCredentials;
+  private _messageFilter?: CopilotKitMessageFilter;
   private _properties: Record<string, unknown>;
   private _defaultThrottleMs?: number;
   private _debug?: DebugConfig;
@@ -436,6 +447,7 @@ export class CopilotKitCore {
     deferInitialConnection = false,
     headers = {},
     credentials,
+    messageFilter,
     properties = {},
     agents__unsafe_dev_only = {},
     tools = [],
@@ -444,6 +456,7 @@ export class CopilotKitCore {
   }: CopilotKitCoreConfig) {
     this._headers = normalizeHeaders(headers);
     this._credentials = credentials;
+    this._messageFilter = messageFilter;
     this._properties = properties;
     this._debug = debug;
 
@@ -667,6 +680,10 @@ export class CopilotKitCore {
     return this._credentials;
   }
 
+  get messageFilter(): CopilotKitMessageFilter | undefined {
+    return this._messageFilter;
+  }
+
   get properties(): Readonly<Record<string, unknown>> {
     return this._properties;
   }
@@ -845,6 +862,20 @@ export class CopilotKitCore {
       this.agentRegistry.agents as Record<string, AbstractAgent>,
     );
     this.agentRegistry.handleCredentialsChanged();
+  }
+
+  /**
+   * Replace the message filter applied to every runtime agent.
+   *
+   * Applies to agents already discovered as well as ones discovered later, so
+   * a filter set before `/info` lands is not lost. Pass `undefined` to go back
+   * to sending the full thread.
+   */
+  setMessageFilter(messageFilter: CopilotKitMessageFilter | undefined): void {
+    this._messageFilter = messageFilter;
+    this.agentRegistry.applyMessageFilterToAgents(
+      this.agentRegistry.agents as Record<string, AbstractAgent>,
+    );
   }
 
   setProperties(properties: Record<string, unknown>): void {

--- a/packages/core/src/core/message-filter.ts
+++ b/packages/core/src/core/message-filter.ts
@@ -1,0 +1,118 @@
+import type { Message } from "@ag-ui/client";
+
+/**
+ * Rewrites the message list a runtime agent sends on each run.
+ *
+ * CopilotKit sends the whole thread on every request. When the backend already
+ * stores the conversation (a LangGraph checkpointer, a Mastra memory store, a
+ * Strands `SessionManager`, an Agent Framework chat history provider), that
+ * history is dead weight: the payload grows without bound, and an agent that
+ * merges the inbound list with its own store can show the model every turn
+ * twice. See https://github.com/CopilotKit/CopilotKit/issues/1482.
+ *
+ * The filter runs on the outbound payload only. It never touches the messages
+ * the UI renders, so trimming here does not shorten the visible transcript.
+ *
+ * Return the messages to send. Returning an empty array is valid and means
+ * "send nothing but the run metadata".
+ *
+ * @param messages - The thread as the client holds it, in order, with
+ *   `activity`-role messages already removed.
+ * @param context - Which agent is about to run.
+ */
+export type CopilotKitMessageFilter = (
+  messages: Message[],
+  context: { agentId: string },
+) => Message[];
+
+interface AssistantToolCall {
+  id: string;
+}
+
+function toolCallIdsOf(message: Message): string[] {
+  const calls = (message as { toolCalls?: AssistantToolCall[] }).toolCalls;
+  if (!Array.isArray(calls)) return [];
+  return calls.map((call) => call.id).filter((id): id is string => Boolean(id));
+}
+
+function resultCallIdOf(message: Message): string | undefined {
+  if (message.role !== "tool") return undefined;
+  return (message as { toolCallId?: string }).toolCallId;
+}
+
+/**
+ * Repair the tool-call pairs a filter broke.
+ *
+ * Every provider rejects a half pair. A tool result whose call is gone reads as
+ * a reply to nothing, and an assistant tool call whose result is gone leaves
+ * the turn unanswered — the failure reporters hit on #1482 when a trimmed
+ * history landed mid-HITL and Anthropic answered "a tool result is expected".
+ * A filter written as `messages.slice(-1)` cannot know this, so the repair runs
+ * for every filter rather than being something each caller opts into.
+ *
+ * Two directions, both anchored on the untrimmed thread:
+ *
+ * - A kept tool result whose assistant call was dropped is dropped too.
+ * - A kept assistant call whose result was dropped gets that result restored,
+ *   placed directly after the call.
+ *
+ * A call with no result anywhere in `full` is left alone. That is an open call
+ * (a pending frontend tool, an unanswered interrupt), not a broken pair.
+ *
+ * The filter's own ordering is preserved. Restored results are the only
+ * insertions, and messages the filter synthesized (absent from `full`) pass
+ * through untouched.
+ */
+export function ɵrepairToolCallPairs(
+  kept: Message[],
+  full: Message[],
+): Message[] {
+  const keptIds = new Set(kept.map((message) => message.id));
+
+  // Both maps are built from the untrimmed thread: the repair has to reason
+  // about pairs the filter already broke, so the kept list cannot answer
+  // "did this call have a result".
+  const callIdToIssuer = new Map<string, Message>();
+  const callIdToResult = new Map<string, Message>();
+  for (const message of full) {
+    for (const callId of toolCallIdsOf(message)) {
+      callIdToIssuer.set(callId, message);
+    }
+    const resultCallId = resultCallIdOf(message);
+    if (resultCallId !== undefined) {
+      callIdToResult.set(resultCallId, message);
+    }
+  }
+
+  const repaired: Message[] = [];
+  const emitted = new Set<string>();
+
+  const emit = (message: Message) => {
+    if (emitted.has(message.id)) return;
+    emitted.add(message.id);
+    repaired.push(message);
+  };
+
+  for (const message of kept) {
+    const resultCallId = resultCallIdOf(message);
+    if (resultCallId !== undefined) {
+      const issuer = callIdToIssuer.get(resultCallId);
+      // Unknown issuer means the pair never existed in this thread — the
+      // result stands on its own and is not ours to drop.
+      if (issuer && !keptIds.has(issuer.id)) continue;
+      emit(message);
+      continue;
+    }
+
+    emit(message);
+
+    for (const callId of toolCallIdsOf(message)) {
+      const result = callIdToResult.get(callId);
+      if (result && !keptIds.has(result.id)) {
+        emit(result);
+      }
+    }
+  }
+
+  return repaired;
+}

--- a/packages/core/src/core/message-filter.ts
+++ b/packages/core/src/core/message-filter.ts
@@ -50,25 +50,34 @@ function resultCallIdOf(message: Message): string | undefined {
  * A filter written as `messages.slice(-1)` cannot know this, so the repair runs
  * for every filter rather than being something each caller opts into.
  *
- * Two directions, both anchored on the untrimmed thread:
+ * Both repairs restore, never discard, and both are anchored on the untrimmed
+ * thread:
  *
- * - A kept tool result whose assistant call was dropped is dropped too.
- * - A kept assistant call whose result was dropped gets that result restored,
+ * - A kept tool result whose assistant call was trimmed away gets that call put
+ *   back in front of it. Dropping the result instead would be protocol-safe and
+ *   semantically wrong: on a human-in-the-loop turn the result IS the new
+ *   information, and a backend that already holds the call would be asked to
+ *   resume with nothing.
+ * - A kept assistant call whose result was trimmed gets that result restored,
  *   placed directly after the call.
  *
- * A call with no result anywhere in `full` is left alone. That is an open call
- * (a pending frontend tool, an unanswered interrupt), not a broken pair.
+ * Restoring a call pulls in every result for that call, not only the one the
+ * filter kept. Providers reject an assistant turn with a parallel tool call
+ * left unanswered, so a half-answered set is as invalid as a missing one.
  *
- * The filter's own ordering is preserved. Restored results are the only
- * insertions, and messages the filter synthesized (absent from `full`) pass
- * through untouched.
+ * A call with no result anywhere in `full` is left alone. That is an open call
+ * (a pending frontend tool, an unanswered interrupt), not a broken pair. A
+ * result whose call is nowhere in `full` is left alone too: it was already
+ * unpaired before the filter ran, so it is not this function's to fix.
+ *
+ * The filter's own ordering is preserved. Restorations are the only insertions,
+ * and messages the filter synthesized (absent from `full`) pass through
+ * untouched.
  */
 export function ɵrepairToolCallPairs(
   kept: Message[],
   full: Message[],
 ): Message[] {
-  const keptIds = new Set(kept.map((message) => message.id));
-
   // Both maps are built from the untrimmed thread: the repair has to reason
   // about pairs the filter already broke, so the kept list cannot answer
   // "did this call have a result".
@@ -93,25 +102,29 @@ export function ɵrepairToolCallPairs(
     repaired.push(message);
   };
 
+  /** Emit an assistant turn together with every result it is owed. */
+  const emitWithResults = (message: Message) => {
+    emit(message);
+    for (const callId of toolCallIdsOf(message)) {
+      const result = callIdToResult.get(callId);
+      if (result) emit(result);
+    }
+  };
+
   for (const message of kept) {
     const resultCallId = resultCallIdOf(message);
-    if (resultCallId !== undefined) {
-      const issuer = callIdToIssuer.get(resultCallId);
-      // Unknown issuer means the pair never existed in this thread — the
-      // result stands on its own and is not ours to drop.
-      if (issuer && !keptIds.has(issuer.id)) continue;
-      emit(message);
+    if (resultCallId === undefined) {
+      emitWithResults(message);
       continue;
     }
 
-    emit(message);
-
-    for (const callId of toolCallIdsOf(message)) {
-      const result = callIdToResult.get(callId);
-      if (result && !keptIds.has(result.id)) {
-        emit(result);
-      }
+    const issuer = callIdToIssuer.get(resultCallId);
+    if (issuer) {
+      // Emits the issuer first, then this result along with its siblings.
+      emitWithResults(issuer);
+      continue;
     }
+    emit(message);
   }
 
   return repaired;

--- a/packages/core/src/core/suggestion-engine.ts
+++ b/packages/core/src/core/suggestion-engine.ts
@@ -1,5 +1,6 @@
 import type { AbstractAgent, Message, Tool } from "@ag-ui/client";
 import { HttpAgent } from "@ag-ui/client";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
 import { randomUUID, partialJSONParse } from "@copilotkit/shared";
 import type { CopilotKitCore } from "./core";
 import type { CopilotKitCoreGetSuggestionsResult } from "./core";
@@ -242,6 +243,14 @@ export class SuggestionEngine {
         });
       } else {
         suggestionAgent = suggestionsProviderAgent.clone();
+        // A suggestion run gets a brand-new thread id, so no backend store can
+        // fill in history the client withheld. An app-level `messageFilter`
+        // trimmed for a persisted conversation would therefore leave the
+        // provider with only the tail of the seeded context and generate
+        // suggestions about nothing. The seeded messages ARE the context here.
+        if (suggestionAgent instanceof ProxiedCopilotRuntimeAgent) {
+          suggestionAgent.messageFilter = undefined;
+        }
       }
 
       suggestionAgent.threadId = suggestionId;

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { AbstractAgent } from "@ag-ui/client";
-import type { FrontendTool } from "@copilotkit/core";
+import type { CopilotKitMessageFilter, FrontendTool } from "@copilotkit/core";
 import type React from "react";
 import {
   useMemo,
@@ -121,6 +121,32 @@ export interface CopilotKitProviderProps {
    * Credentials mode for fetch requests (e.g., "include" for HTTP-only cookies in cross-origin requests).
    */
   credentials?: RequestCredentials;
+  /**
+   * Rewrites the message list sent to runtime agents on every run.
+   *
+   * CopilotKit sends the whole thread each time. When your agent already
+   * stores the conversation, most of that payload is waste, and an agent that
+   * merges the inbound list with its own store can show the model every turn
+   * twice. Return the messages to send:
+   *
+   * ```tsx
+   * <CopilotKit
+   *   runtimeUrl="/api/copilotkit"
+   *   messageFilter={(messages) => messages.slice(-1)}
+   * />
+   * ```
+   *
+   * The filter changes the request body only. The transcript the UI renders is
+   * untouched. Broken tool-call pairs are repaired before the request is sent,
+   * so a filter this blunt cannot strand a tool result mid-HITL.
+   *
+   * Only agents discovered from the runtime honor this. An agent your app
+   * constructs itself takes an AG-UI middleware instead.
+   *
+   * Prefer a stable reference (`useCallback`). An inline arrow re-registers the
+   * filter on every render, which is harmless but needless.
+   */
+  messageFilter?: CopilotKitMessageFilter;
   /** Your CopilotKit public license key. */
   publicApiKey?: string;
   /** Your public license key for accessing CopilotKit Intelligence features. */
@@ -279,6 +305,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
   runtimeUrl,
   headers: headersProp = EMPTY_HEADERS,
   credentials,
+  messageFilter,
   publicApiKey,
   publicLicenseKey,
   licenseToken,
@@ -639,6 +666,7 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
             : "auto",
       headers: mergedHeaders,
       credentials,
+      messageFilter,
       properties,
       agents__unsafe_dev_only: mergedAgents,
       tools: allTools,
@@ -793,6 +821,13 @@ export const CopilotKitProvider: React.FC<CopilotKitProviderProps> = ({
       subscription.unsubscribe();
     };
   }, [copilotkit]);
+
+  // Declared before the effect that calls `connect()` so React runs it first:
+  // an agent discovered by that connection is then constructed with the filter
+  // already in place, rather than making its first run with the full thread.
+  useEffect(() => {
+    copilotkit.setMessageFilter(messageFilter);
+  }, [copilotkit, messageFilter]);
 
   useEffect(() => {
     copilotkit.setRuntimeUrl(chatApiEndpoint);

--- a/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
+++ b/packages/react-core/src/v2/providers/CopilotKitProvider.tsx
@@ -140,8 +140,9 @@ export interface CopilotKitProviderProps {
    * untouched. Broken tool-call pairs are repaired before the request is sent,
    * so a filter this blunt cannot strand a tool result mid-HITL.
    *
-   * Only agents discovered from the runtime honor this. An agent your app
-   * constructs itself takes an AG-UI middleware instead.
+   * Agents reached through your CopilotRuntime honor this. An agent your app
+   * passes in directly does not, and neither Intelligence runs nor suggestion
+   * runs are ever filtered.
    *
    * Prefer a stable reference (`useCallback`). An inline arrow re-registers the
    * filter on every render, which is harmless but needless.

--- a/showcase/shell-docs/src/content/reference/core/classes/CopilotKitCore.mdx
+++ b/showcase/shell-docs/src/content/reference/core/classes/CopilotKitCore.mdx
@@ -187,6 +187,10 @@ new CopilotKitCore(config: CopilotKitCoreConfig)
   Replaces the fetch credentials mode and re-applies it to existing agents. Core clears trusted Inspector metadata before refreshing it with the new mode.
 </PropertyReference>
 
+<PropertyReference name="setMessageFilter(messageFilter: CopilotKitMessageFilter | undefined): void" type="method">
+  Replaces the filter applied to the outbound message list and re-applies it to existing agents. Agents discovered later pick it up too, so a filter set before `/info` lands is not lost. Pass `undefined` to go back to sending the full thread.
+</PropertyReference>
+
 <PropertyReference name="setProperties(properties: Record<string, unknown>): void" type="method">
   Replaces the forwarded properties sent to agents.
 </PropertyReference>

--- a/showcase/shell-docs/src/content/reference/core/types/CopilotKitCoreConfig.mdx
+++ b/showcase/shell-docs/src/content/reference/core/types/CopilotKitCoreConfig.mdx
@@ -22,6 +22,7 @@ interface CopilotKitCoreConfig {
   agents__unsafe_dev_only?: Record<string, AbstractAgent>;
   headers?: Record<string, string>;
   credentials?: RequestCredentials;
+  messageFilter?: CopilotKitMessageFilter;
   properties?: Record<string, unknown>;
   tools?: FrontendTool<any>[];
   suggestionsConfig?: SuggestionsConfig[];
@@ -49,6 +50,14 @@ interface CopilotKitCoreConfig {
 
 <PropertyReference name="credentials" type="RequestCredentials">
   Credentials mode for fetch requests (e.g. `"include"` for HTTP-only cookies).
+</PropertyReference>
+
+<PropertyReference name="messageFilter" type="CopilotKitMessageFilter">
+  Rewrites the message list sent to runtime agents on every run. Use it when the
+  agent already stores the conversation and re-sending it is waste or
+  duplication. The filter changes the request body only — the transcript the UI
+  renders is untouched — and broken tool-call pairs are repaired before the
+  request goes out. Change it later with `setMessageFilter`.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, unknown>" default="{}">

--- a/showcase/shell-docs/src/content/reference/core/types/CopilotKitCoreConfig.mdx
+++ b/showcase/shell-docs/src/content/reference/core/types/CopilotKitCoreConfig.mdx
@@ -57,7 +57,8 @@ interface CopilotKitCoreConfig {
   agent already stores the conversation and re-sending it is waste or
   duplication. The filter changes the request body only — the transcript the UI
   renders is untouched — and broken tool-call pairs are repaired before the
-  request goes out. Change it later with `setMessageFilter`.
+  request goes out. Intelligence runs and suggestion runs are never filtered.
+  Change it later with `setMessageFilter`.
 </PropertyReference>
 
 <PropertyReference name="properties" type="Record<string, unknown>" default="{}">

--- a/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
@@ -146,12 +146,17 @@ gets that call put back in front of it, and a kept call whose result was trimmed
 gets the result back. A filter as blunt as `slice(-1)` therefore cannot strand a
 tool result mid-approval, and it cannot silently throw away the approval either.
 
-Two limits to know:
+Limits to know:
 
-- Only agents discovered from your runtime honor this. An agent your app
-  constructs itself takes an AG-UI middleware instead.
 - Your agent must really store the conversation. Against a stateless agent, a
   filter this aggressive means the model forgets the thread.
+- Agents reached through your CopilotRuntime honor this. An agent your app
+  constructs itself and passes in directly does not — use an AG-UI middleware
+  for those.
+- CopilotKit Intelligence runs are never filtered. That runtime is the store of
+  record for the thread, so the client does not get to decide what reaches it.
+- Suggestions are never filtered. A suggestion run uses a fresh thread, so the
+  messages sent with it are the only context the provider has.
 
 If the filter throws or returns something other than an array, CopilotKit warns
 and sends the full thread. Trimming is an optimization, so a bug in it does not

--- a/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
@@ -140,10 +140,11 @@ Return the messages to send:
 The filter changes the request body only. The transcript the UI renders is
 untouched, so the chat still shows the full conversation.
 
-Broken tool-call pairs are repaired before the request goes out: a tool result
-whose call was trimmed away is dropped, and a kept call whose result was trimmed
-gets it back. A filter as blunt as `slice(-1)` therefore cannot strand a tool
-result mid-approval.
+Broken tool-call pairs are repaired before the request goes out, and the repair
+always restores rather than discards: a tool result whose call was trimmed away
+gets that call put back in front of it, and a kept call whose result was trimmed
+gets the result back. A filter as blunt as `slice(-1)` therefore cannot strand a
+tool result mid-approval, and it cannot silently throw away the approval either.
 
 Two limits to know:
 

--- a/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
@@ -118,6 +118,45 @@ copilotRuntimeNextJSAppRouterEndpoint({
 
 </PropertyReference>
 
+<PropertyReference name="messageFilter" type="(messages: Message[], context: { agentId: string }) => Message[]"  >
+Rewrites the message list sent to the agent on every run.
+
+CopilotKit sends the whole thread with each request. When your agent already
+stores the conversation — a LangGraph checkpointer, a Mastra memory store, a
+Strands `SessionManager` — most of that payload is waste, and an agent that
+merges the inbound list with its own store can show the model every turn twice.
+
+Return the messages to send:
+
+```tsx
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  messageFilter={(messages) => messages.slice(-1)}
+>
+  {children}
+</CopilotKit>
+```
+
+The filter changes the request body only. The transcript the UI renders is
+untouched, so the chat still shows the full conversation.
+
+Broken tool-call pairs are repaired before the request goes out: a tool result
+whose call was trimmed away is dropped, and a kept call whose result was trimmed
+gets it back. A filter as blunt as `slice(-1)` therefore cannot strand a tool
+result mid-approval.
+
+Two limits to know:
+
+- Only agents discovered from your runtime honor this. An agent your app
+  constructs itself takes an AG-UI middleware instead.
+- Your agent must really store the conversation. Against a stateless agent, a
+  filter this aggressive means the model forgets the thread.
+
+Prefer a stable reference (`useCallback`). An inline arrow re-registers the
+filter on every render, which is harmless but needless.
+
+</PropertyReference>
+
 <PropertyReference name="showDevConsole" type="boolean"  >
 Whether to show the dev console.
 

--- a/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/reference/copilotkit-component.mdx
@@ -153,6 +153,10 @@ Two limits to know:
 - Your agent must really store the conversation. Against a stateless agent, a
   filter this aggressive means the model forgets the thread.
 
+If the filter throws or returns something other than an array, CopilotKit warns
+and sends the full thread. Trimming is an optimization, so a bug in it does not
+fail the run.
+
 Prefer a stable reference (`useCallback`). An inline arrow re-registers the
 filter on every render, which is harmless but needless.
 


### PR DESCRIPTION
Closes #1482.

## The problem

CopilotKit sends the whole thread on every run. When the backend already stores the conversation — a LangGraph checkpointer, a Mastra memory store, a Strands `SessionManager`, an Agent Framework chat history provider — that costs the reporters on #1482 twice:

- the request body grows with the thread until a proxy rejects it (the original HTTP 413 report), and
- an agent that merges the inbound list with its own store shows the model every turn twice. @theofanis hit this as a HITL flow dying on "a tool result is expected".

The issue has been open since March 2025 with ten-plus "any update?" comments. Workarounds in the thread are a `window.fetch` monkey-patch that strips `agentStates`, and a no-op chat history provider on the agent side.

## The change

A `messageFilter` on `<CopilotKit>` and on `CopilotKitCore`:

```tsx
<CopilotKit runtimeUrl="/api/copilotkit" messageFilter={(messages) => messages.slice(-1)}>
  {children}
</CopilotKit>
```

It is applied in `ProxiedCopilotRuntimeAgent.prepareRunAgentInput` — the one place both run transports (`#runViaHttp`, and `#runViaDelegate`, which forwards the same input) and the self-hosted connect replay build their payload.

**It rewrites the request body only.** `super.prepareRunAgentInput` has already deep-cloned the thread and stripped `activity` messages, so nothing the filter does can reach the transcript the UI renders. There is a test that hands the filter the array and has it wipe and repopulate it, then asserts the transcript is intact.

### Why runtime-discovered agents are the point

An app that constructs its own agent could already rewrite `input.messages` with an AG-UI middleware. An agent that arrived from `/info` could not: `AgentRegistry` builds `ProxiedCopilotRuntimeAgent` from a fixed config object at two sites, with no seam for the app. That is the case the #1482 reporters actually have. The filter is threaded through both sites and re-applied on change, so an agent discovered *after* the app set a filter still picks it up.

Agents in `agents__unsafe_dev_only` are deliberately left alone — their owner already has the middleware seam, and reaching into an instance the app owns would be the more surprising behavior.

### Tool-call repair is not opt-in

Every provider rejects a half pair, and a filter written as `messages.slice(-1)` cannot know which messages pair up. So the repair runs for every filter, and **it restores rather than discards**:

- a kept tool result whose assistant call was trimmed away gets that call put back in front of it;
- a kept assistant call whose result was trimmed gets the result back, placed after the call.

Restoring a call pulls in every result that call is owed, not only the one the filter kept, because providers reject an assistant turn with a parallel tool call left unanswered.

Dropping the orphan result would also be protocol-safe, and it is what the first cut of this PR did. It is wrong: on a human-in-the-loop turn the tool result *is* the new information, so `slice(-1)` would have handed a resuming backend an empty list and silently thrown away the approval the user just gave. Fixed in 8d0b7c9.

A call with no result anywhere in the thread is left alone — that is an open call (a pending frontend tool, an unanswered interrupt), not a broken pair. A result whose call is nowhere in the thread is left alone too: it was already unpaired before the filter ran.

### A broken filter does not break the chat

If the filter throws, returns something that is not an array, or returns entries the repair cannot read, CopilotKit warns and sends the untrimmed thread. Trimming is an optimization; failing the user's message because that optimization has a bug would be the worse trade.

### Where the filter is deliberately not applied

- **Intelligence runs.** `IntelligenceAgent` posts the whole `RunAgentInput`, so a filter would reach the managed runtime — which is the store of record for the thread, read by the threads drawer and the Slack transcript. Every #1482 reporter is self-hosted, so the client does not get to truncate what reaches it. This also removes an asymmetry, since the Intelligence connect path builds its own input via `delegate.connectAgent` and could not be filtered here anyway.
- **Suggestion runs.** `SuggestionEngine` clones the provider agent and gives the clone a fresh thread id, so no backend store can fill in what a filter withheld — the seeded messages *are* the context. `SuggestionEngine` clears the filter on that clone.

Both were caught in review after the first push, in 45bfd28.

## Testing

27 new tests in `packages/core/src/__tests__/message-filter.test.ts`, all asserting on the **actual outbound request body**, not on a mock of the filter.

```
 ✓ src/__tests__/message-filter.test.ts (27 tests)

 Test Files  1 passed (1)
      Tests  27 passed (27)
```

What they cover, per item:

| Behavior | Assertion |
| --- | --- |
| No filter set | full thread `["u1","a1","u2"]` on the wire |
| `slice(-1)` | only `["u2"]` on the wire |
| Rendered transcript after a filtered run | still `["u1","a1","u2"]` |
| Trim that strands a tool result | issuing call restored in front of it |
| Trim that drops a result for a kept call | result restored after the call |
| Trim that keeps one result of a parallel call | call plus **both** results restored |
| Open call, no result in thread | left alone |
| Result whose issuer is not in this thread | left alone |
| Filter mutates the array it is handed | transcript uncorrupted |
| Filter returns a non-array | full thread sent, warning raised |
| Filter throws | run still resolves, full thread sent, warning raised |
| Filter returns an array with a non-message entry | same graceful fallback |
| Intelligence runtime mode | never filtered |
| Suggestion run (real `SuggestionEngine` fallback path) | seeded context still sent in full |
| `run()` receives the filtered input | covers the Intelligence delegate fork without a gateway |
| Filter assigned after construction | applied |
| `clone()` (runtime does one per run) | filter survives |
| Single-route transport | trimmed inside the envelope |
| `agentId` passed to the filter | `["billing-agent"]` |
| `activity` messages | never shown to the filter |
| Core → agent discovered from `/info` | trimmed |
| `core.setMessageFilter` after discovery | trimmed |
| `core.setMessageFilter(undefined)` | back to the full thread |

### Mutation checks

Each mechanism was broken to confirm the tests are not self-fulfilling:

| Mutation | Result |
| --- | --- |
| `prepareRunAgentInput` never applies the filter | **13 failed**, 10 passed |
| The repair is skipped entirely | **2 failed**, 20 passed |
| A trimmed issuer is never restored | **3 failed**, 19 passed |
| Sibling results are never restored | **6 failed**, 16 passed |
| The catch rethrows instead of degrading | **1 failed**, 23 passed |
| `AgentRegistry` no longer propagates the filter | **2 failed**, 20 passed |
| `SuggestionEngine` stops clearing the filter | **1 failed** — "expected 1 to be greater than 1", the exact silent degradation |

Restored after each, back to 27 passing.

### Suite, types, lint

- Full `packages/core` suite: **819 → 846 passing**, with the same 20 pre-existing failures before and after (`core-inspector-metadata`, a stale `@copilotkit/shared` dist in my worktree — identical on a clean baseline).
- `tsc --noEmit`: 15 pre-existing errors on a pre-change baseline, 15 after. Comparing with line numbers normalized, the set is byte-identical — **no new type errors**.
- `oxlint`: 0 warnings, 0 errors on every file touched. `oxfmt` applied.
- `check:public-api-manifest`: current, nothing to regenerate.

### Not covered here

- react-core's vitest could not run on my machine: `@modelcontextprotocol/ext-apps` is not installed, which fails the same way on `main` and is unrelated to this change. The provider change is 4 lines and typechecks against the rebuilt core dist with no error.
- Angular and Vue providers have no parity yet. Worth a follow-up if we want the prop everywhere.
- The `/info` resync branch that reuses an existing agent now re-applies the filter alongside the headers and credentials already re-applied there. The instance keeps its own filter across reuse, so that line is symmetry with its neighbors, not a fix, and it has no dedicated test.

## Relationship to other work

- **#6898** (open) documents the AG-UI middleware recipe for the self-constructed-agent case. This PR adds the first-class prop for the runtime-discovered case; the two are complements, and #6898 should gain a pointer to this prop once both land. Docs here went into the existing reference pages to avoid colliding with that PR.
- **ag-ui-protocol/ag-ui#2063** proposed `messageFilter` on `AgentConfig` upstream. It is a draft, 1274 commits behind, and now conflicts with `main`. This PR needs nothing from it and stays compatible if it later lands.
- **ag-ui-protocol/ag-ui#2186** argues for a protocol-level incremental sync (a capability flag or a `sinceMessageId` cursor) as the better long-term answer. That decision is still open in the #2162 triage umbrella. This is the client-side escape hatch users have been asking for meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable message filtering for runtime agent requests through the core configuration and React provider.
  - Filters can rewrite outbound conversation history while preserving tool-call and result pairing.
  - Filter changes apply to existing and newly discovered runtime agents.

- **Behavior Updates**
  - Intelligence and suggestion runs bypass message filtering to preserve managed or seeded context.
  - Invalid filter results or errors fall back to the full message history with a warning.

- **Documentation**
  - Documented configuration, runtime limitations, and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->