### PR TITLE
fix(runtime): pass SSE MCP headers via requestInit

### DIFF
--- a/packages/runtime/src/agent/__tests__/mcp-servers-integration.test.ts
+++ b/packages/runtime/src/agent/__tests__/mcp-servers-integration.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import { BasicAgent } from "../index";
 import { EventType } from "@ag-ui/client";
 import { streamText } from "ai";
@@ -107,6 +109,58 @@ describe("mcpServers — real MCP server integration", () => {
 
     const callArgs = vi.mocked(streamText).mock.calls[0][0];
     expect(callArgs.tools).toHaveProperty("get_weather");
+  });
+
+  it("SSE transport attaches Authorization headers from mcpServers config", async () => {
+    // MCPMock only speaks Streamable HTTP. A raw HTTP listener is enough to
+    // assert what the SSE client actually puts on the wire — the handshake
+    // will fail, and the run must still complete (same skip path as below).
+    const received: http.IncomingHttpHeaders[] = [];
+    const server = http.createServer((req, res) => {
+      received.push(req.headers);
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      const agent = new BasicAgent({
+        model: "openai/gpt-4o",
+        mcpServers: [
+          {
+            type: "sse",
+            url: `http://127.0.0.1:${port}/sse`,
+            headers: {
+              Authorization: "Bearer SENTINEL-TOKEN",
+            },
+          },
+        ],
+      });
+
+      vi.mocked(streamText).mockReturnValue(
+        mockStreamTextResponse([textDelta("ok"), finish()]) as any,
+      );
+
+      const events = await collectEvents(agent["run"](baseInput));
+
+      expect(events.some((e: any) => e.type === EventType.RUN_ERROR)).toBe(
+        false,
+      );
+      expect(received.length).toBeGreaterThan(0);
+      expect(received[0].authorization).toBe("Bearer SENTINEL-TOKEN");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
   });
 
   it("an unreachable MCP server (SSE vs HTTP-only mock) is skipped, not fatal", async () => {

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -1387,9 +1387,14 @@ export class BuiltInAgent extends AbstractAgent {
                 // actually ask for SSE ever load it.
                 const { SSEClientTransport } =
                   await import("@modelcontextprotocol/sdk/client/sse.js");
+                // SSEClientTransport's second arg is SSEClientTransportOptions
+                // (`requestInit.headers`), not a raw header map. Passing
+                // `{ Authorization: ... }` as options is silently ignored.
                 transport = new SSEClientTransport(
                   new URL(serverConfig.url),
-                  serverConfig.headers,
+                  serverConfig.headers
+                    ? { requestInit: { headers: serverConfig.headers } }
+                    : undefined,
                 );
               }
 


### PR DESCRIPTION
## What does this PR do?

v2 MCP `sse` servers accepted a `headers` auth map on `mcpServers` (the documented `Authorization: Bearer …` example) but never put those headers on the wire.

`SSEClientTransport`'s second argument is `SSEClientTransportOptions`, not a raw header map. Passing `{ Authorization: "…" }` matches none of `authProvider` / `requestInit` / `eventSourceInit` / `fetch`, so the SDK ignored it. Auth-required servers then 401'd, and the run skipped the server (`MCP server … failed to connect — skipping it for this run`) — the agent just had no tools.

This wraps `serverConfig.headers` as `{ requestInit: { headers } }`, matching the HTTP transport's options-object pattern. No public type change: `MCPClientConfigSSE.headers` stays as documented.

Adds a small regression test that stands up a local HTTP listener and asserts the outbound SSE request carries `Authorization: Bearer SENTINEL-TOKEN`.

Verified locally:

```
nx run @copilotkit/runtime:test -- src/agent/__tests__/mcp-servers-integration.test.ts
# 10 tests passed
```

No changeset: this repo migrated off Changesets; CI fails on new `.changeset/*` files. The conventional commit subject is the release note.

Intended for upstream `CopilotKit/CopilotKit` `main`:
https://github.com/CopilotKit/CopilotKit/compare/main...Zsanz3:CopilotKit:cursor/fix-mcp-sse-headers-22fc?expand=1

## Related PRs and Issues

- Fixes #6927

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation (no docs change — this is a bugfix of documented behavior)
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSE-based MCP connections so configured authorization and other request headers are correctly sent.
  * Added coverage to verify authenticated SSE connections complete successfully without runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->