### PR TITLE
feat: allow agentId to differ from human-friendly name

### DIFF
--- a/packages/runtime/src/v2/runtime/handlers/__tests__/get-runtime-info.test.ts
+++ b/packages/runtime/src/v2/runtime/handlers/__tests__/get-runtime-info.test.ts
@@ -1,0 +1,51 @@
+import { handleGetRuntimeInfo } from "../get-runtime-info";
+import type { CopilotRuntimeLike } from "../../core/runtime";
+import { AbstractAgent } from "@ag-ui/client";
+
+// Create a dummy agent that overrides the name property
+class TestAgent extends AbstractAgent {
+    public name = "Human Friendly Name";
+    public agentId = "internal-id-123";
+    public description = "Test Description";
+    public async getCapabilities() {
+        return {};
+    }
+}
+
+class TestAgentNoName extends AbstractAgent {
+    public description = "Test Description 2";
+    public async getCapabilities() {
+        return {};
+    }
+}
+
+describe("handleGetRuntimeInfo", () => {
+    it("should use agent.name if available, otherwise fallback to the dictionary key", async () => {
+        const runtime: Partial<CopilotRuntimeLike> = {
+            agents: {
+                "internal-id-123": new TestAgent(),
+                "another-agent-id": new TestAgentNoName(),
+            },
+            mode: "sse",
+            identifyUser: undefined,
+        };
+
+        const request = new Request("http://localhost/info");
+        const response = await handleGetRuntimeInfo({
+            runtime: runtime as CopilotRuntimeLike,
+            request,
+        });
+
+        const body = await response.json();
+        expect(response.status).toBe(200);
+        expect(body.agents).toBeDefined();
+
+        // The key should remain the internal ID
+        expect(body.agents["internal-id-123"]).toBeDefined();
+        expect(body.agents["internal-id-123"].name).toBe("Human Friendly Name");
+
+        // Fallback to key
+        expect(body.agents["another-agent-id"]).toBeDefined();
+        expect(body.agents["another-agent-id"].name).toBe("another-agent-id");
+    });
+});

--- a/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
+++ b/packages/runtime/src/v2/runtime/handlers/get-runtime-info.ts
@@ -1,15 +1,15 @@
 import type { AgentCapabilities } from "@ag-ui/core";
 import type { CopilotRuntimeLike } from "../core/runtime";
 import {
-  isA2UIEnabled,
-  isIntelligenceRuntime,
-  resolveAgents,
+    isA2UIEnabled,
+    isIntelligenceRuntime,
+    resolveAgents,
 } from "../core/runtime";
 import type {
-  AgentDescription,
-  RuntimeInfo,
-  RuntimeEntitlementResponse,
-  ThreadEndpointRuntimeInfo,
+    AgentDescription,
+    RuntimeInfo,
+    RuntimeEntitlementResponse,
+    ThreadEndpointRuntimeInfo,
 } from "@copilotkit/shared";
 import type { RuntimeLicenseStatus } from "@copilotkit/shared";
 import { VERSION } from "../core/runtime";
@@ -18,16 +18,16 @@ import { isTelemetryDisabled } from "../telemetry/telemetry-client";
 import { supportsLocalThreadEndpoints } from "../runner/agent-runner";
 
 function resolveLicenseStatus(
-  runtime: CopilotRuntimeLike,
+    runtime: CopilotRuntimeLike,
 ): RuntimeLicenseStatus {
-  if (!runtime.licenseChecker) return "none";
-  const status = runtime.licenseChecker.getStatus();
-  if (status.warningSeverity === "none") return "valid";
-  if (status.error === "expired") return "expired";
-  if (status.warningSeverity === "warning") return "expiring";
-  if (status.error) return "invalid";
-  if (status.warningSeverity === "info") return "none";
-  return "unknown";
+    if (!runtime.licenseChecker) return "none";
+    const status = runtime.licenseChecker.getStatus();
+    if (status.warningSeverity === "none") return "valid";
+    if (status.error === "expired") return "expired";
+    if (status.warningSeverity === "warning") return "expiring";
+    if (status.error) return "invalid";
+    if (status.warningSeverity === "info") return "none";
+    return "unknown";
 }
 
 /**
@@ -38,41 +38,42 @@ function resolveLicenseStatus(
  * remains unknown until it resolves.
  */
 function resolveCompatibilityLicenseStatus(
-  runtime: CopilotRuntimeLike,
-  runtimeEntitlements: RuntimeEntitlementResponse | undefined,
+    runtime: CopilotRuntimeLike,
+    runtimeEntitlements: RuntimeEntitlementResponse | undefined,
 ): RuntimeLicenseStatus {
-  if (runtimeEntitlements?.status === "ready") {
+    if (runtimeEntitlements?.status === "ready") {
+        if (
+            runtimeEntitlements.entitlement.source ===
+                "managedOrgSubscription" ||
+            runtimeEntitlements.entitlement.source ===
+                "awsMarketplaceDeploymentLicense"
+        ) {
+            return runtimeEntitlements.entitlement.active ? "valid" : "none";
+        }
+
+        if (runtimeEntitlements.entitlement.active) {
+            return "valid";
+        }
+    }
+
+    const legacyLicenseStatus = resolveLicenseStatus(runtime);
     if (
-      runtimeEntitlements.entitlement.source === "managedOrgSubscription" ||
-      runtimeEntitlements.entitlement.source ===
-        "awsMarketplaceDeploymentLicense"
+        legacyLicenseStatus === "none" &&
+        runtimeEntitlements?.status !== "ready" &&
+        runtimeEntitlements?.error.retryable
     ) {
-      return runtimeEntitlements.entitlement.active ? "valid" : "none";
+        return "unknown";
     }
 
-    if (runtimeEntitlements.entitlement.active) {
-      return "valid";
-    }
-  }
-
-  const legacyLicenseStatus = resolveLicenseStatus(runtime);
-  if (
-    legacyLicenseStatus === "none" &&
-    runtimeEntitlements?.status !== "ready" &&
-    runtimeEntitlements?.error.retryable
-  ) {
-    return "unknown";
-  }
-
-  return legacyLicenseStatus;
+    return legacyLicenseStatus;
 }
 
 interface HandleGetRuntimeInfoParameters {
-  runtime: CopilotRuntimeLike;
-  request: Request;
-  threadEndpointsEnabled?: boolean;
-  inspectorLearningEnabled?: boolean;
-  singleRouteResourceOperationsEnabled?: boolean;
+    runtime: CopilotRuntimeLike;
+    request: Request;
+    threadEndpointsEnabled?: boolean;
+    inspectorLearningEnabled?: boolean;
+    singleRouteResourceOperationsEnabled?: boolean;
 }
 
 /**
@@ -83,178 +84,195 @@ interface HandleGetRuntimeInfoParameters {
  * error is not exposed because it may contain upstream response details.
  */
 async function resolveRuntimeEntitlements(
-  runtime: CopilotRuntimeLike,
+    runtime: CopilotRuntimeLike,
 ): Promise<RuntimeEntitlementResponse | undefined> {
-  if (!isIntelligenceRuntime(runtime)) {
-    return undefined;
-  }
-
-  try {
-    return await runtime.intelligence.getRuntimeEntitlements();
-  } catch (error) {
-    if (error instanceof PlatformRequestError && error.retryable === false) {
-      return {
-        status: "misconfigured",
-        error: {
-          code: "runtime_entitlements_misconfigured",
-          message: "Runtime entitlement lookup is misconfigured",
-          retryable: false,
-        },
-      };
+    if (!isIntelligenceRuntime(runtime)) {
+        return undefined;
     }
 
-    return {
-      status: "unavailable",
-      error: {
-        code: "runtime_entitlements_unavailable",
-        message: "Runtime entitlement lookup failed",
-        retryable: true,
-      },
-    };
-  }
+    try {
+        return await runtime.intelligence.getRuntimeEntitlements();
+    } catch (error) {
+        if (
+            error instanceof PlatformRequestError &&
+            error.retryable === false
+        ) {
+            return {
+                status: "misconfigured",
+                error: {
+                    code: "runtime_entitlements_misconfigured",
+                    message: "Runtime entitlement lookup is misconfigured",
+                    retryable: false,
+                },
+            };
+        }
+
+        return {
+            status: "unavailable",
+            error: {
+                code: "runtime_entitlements_unavailable",
+                message: "Runtime entitlement lookup failed",
+                retryable: true,
+            },
+        };
+    }
 }
 
 export async function handleGetRuntimeInfo({
-  runtime,
-  request,
-  threadEndpointsEnabled = true,
-  inspectorLearningEnabled = false,
-  singleRouteResourceOperationsEnabled = false,
+    runtime,
+    request,
+    threadEndpointsEnabled = true,
+    inspectorLearningEnabled = false,
+    singleRouteResourceOperationsEnabled = false,
 }: HandleGetRuntimeInfoParameters) {
-  try {
-    const runtimeEntitlementsPromise = resolveRuntimeEntitlements(runtime);
-    const webEnabled =
-      !isIntelligenceRuntime(runtime) || runtime.identifyUser !== undefined;
-    const agents = webEnabled
-      ? await resolveAgents(runtime.agents, request)
-      : {};
+    try {
+        const runtimeEntitlementsPromise = resolveRuntimeEntitlements(runtime);
+        const webEnabled =
+            !isIntelligenceRuntime(runtime) ||
+            runtime.identifyUser !== undefined;
+        const agents = webEnabled
+            ? await resolveAgents(runtime.agents, request)
+            : {};
 
-    const agentEntries = await Promise.all(
-      Object.entries(agents).map(async ([name, agent]) => {
-        let capabilities: AgentCapabilities | undefined;
-        try {
-          capabilities = agent.getCapabilities
-            ? await agent.getCapabilities()
-            : undefined;
-        } catch (error) {
-          // Per-agent isolation: a single agent failing to report capabilities
-          // must not take down the entire /info endpoint.
-          console.warn(
-            `Failed to fetch capabilities for agent "${name}":`,
-            error instanceof Error ? error.message : error,
-          );
-          capabilities = undefined;
-        }
+        const agentEntries = await Promise.all(
+            Object.entries(agents).map(async ([agentId, agent]) => {
+                let capabilities: AgentCapabilities | undefined;
+                try {
+                    capabilities = agent.getCapabilities
+                        ? await agent.getCapabilities()
+                        : undefined;
+                } catch (error) {
+                    // Per-agent isolation: a single agent failing to report capabilities
+                    // must not take down the entire /info endpoint.
+                    console.warn(
+                        `Failed to fetch capabilities for agent "${agentId}":`,
+                        error instanceof Error ? error.message : error,
+                    );
+                    capabilities = undefined;
+                }
 
-        const description: AgentDescription = {
-          name,
-          description: agent.description,
-          className: agent.constructor.name,
-          ...(capabilities ? { capabilities } : {}),
+                const resolvedName =
+                    "name" in agent && typeof agent.name === "string"
+                        ? agent.name
+                        : agentId;
+
+                const description: AgentDescription = {
+                    name: resolvedName,
+                    description: agent.description,
+                    className: agent.constructor.name,
+                    ...(capabilities ? { capabilities } : {}),
+                };
+
+                return [agentId, description] as const;
+            }),
+        );
+
+        const agentsDict: Record<string, AgentDescription> =
+            Object.fromEntries(agentEntries);
+        const runtimeEntitlements = await runtimeEntitlementsPromise;
+
+        const runtimeInfo: RuntimeInfo = {
+            version: VERSION,
+            agents: agentsDict,
+            audioFileTranscriptionEnabled:
+                webEnabled && !!runtime.transcriptionService,
+            mode: runtime.mode,
+            threadEndpoints: resolveThreadEndpointInfo(
+                runtime,
+                threadEndpointsEnabled && webEnabled,
+            ),
+            ...(singleRouteResourceOperationsEnabled
+                ? {
+                      singleRoute: {
+                          resourceOperations: true,
+                          threadEndpoints: resolveThreadEndpointInfo(
+                              runtime,
+                              webEnabled,
+                          ),
+                      },
+                  }
+                : {}),
+            // Advertised unconditionally. Multi-route runtimes expose the dedicated
+            // POST /agent/:agentId/suggest path; single-route clients fall back to a
+            // client-side run (they don't construct the single-route envelope for
+            // suggest). The flag lets multi-route clients detect the stateless path.
+            suggestions: webEnabled,
+            ...(isIntelligenceRuntime(runtime) && webEnabled
+                ? {
+                      intelligence: {
+                          wsUrl: runtime.intelligence.ɵgetClientWsUrl(),
+                      },
+                      inspectorMetadata: true,
+                      ...(runtime.debug?.enabled === true &&
+                      inspectorLearningEnabled
+                          ? { inspectorLearning: true }
+                          : {}),
+                  }
+                : {}),
+            // Legacy flat flag, kept for older clients. The `a2ui` object below is
+            // the source of truth: it preserves the per-agent scoping that this
+            // boolean discards (see CopilotKit/CopilotKit#5369). Both go through the
+            // shared isA2UIEnabled() predicate so an explicit `enabled: false`
+            // disables a2ui here exactly as it does on the run path.
+            a2uiEnabled: webEnabled && isA2UIEnabled(runtime.a2ui),
+            ...(webEnabled && isA2UIEnabled(runtime.a2ui)
+                ? {
+                      a2ui: {
+                          enabled: true,
+                          ...(runtime.a2ui.agents
+                              ? { agents: runtime.a2ui.agents }
+                              : {}),
+                      },
+                  }
+                : {}),
+            openGenerativeUIEnabled: webEnabled && !!runtime.openGenerativeUI,
+            ...(isIntelligenceRuntime(runtime)
+                ? {
+                      licenseStatus: resolveCompatibilityLicenseStatus(
+                          runtime,
+                          runtimeEntitlements,
+                      ),
+                  }
+                : {}),
+            ...(runtimeEntitlements ? { runtimeEntitlements } : {}),
+            telemetryDisabled: isTelemetryDisabled(),
         };
 
-        return [name, description] as const;
-      }),
-    );
-
-    const agentsDict: Record<string, AgentDescription> =
-      Object.fromEntries(agentEntries);
-    const runtimeEntitlements = await runtimeEntitlementsPromise;
-
-    const runtimeInfo: RuntimeInfo = {
-      version: VERSION,
-      agents: agentsDict,
-      audioFileTranscriptionEnabled:
-        webEnabled && !!runtime.transcriptionService,
-      mode: runtime.mode,
-      threadEndpoints: resolveThreadEndpointInfo(
-        runtime,
-        threadEndpointsEnabled && webEnabled,
-      ),
-      ...(singleRouteResourceOperationsEnabled
-        ? {
-            singleRoute: {
-              resourceOperations: true,
-              threadEndpoints: resolveThreadEndpointInfo(runtime, webEnabled),
+        return new Response(JSON.stringify(runtimeInfo), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (error) {
+        return new Response(
+            JSON.stringify({
+                error: "Failed to retrieve runtime information",
+                message:
+                    error instanceof Error ? error.message : "Unknown error",
+            }),
+            {
+                status: 500,
+                headers: { "Content-Type": "application/json" },
             },
-          }
-        : {}),
-      // Advertised unconditionally. Multi-route runtimes expose the dedicated
-      // POST /agent/:agentId/suggest path; single-route clients fall back to a
-      // client-side run (they don't construct the single-route envelope for
-      // suggest). The flag lets multi-route clients detect the stateless path.
-      suggestions: webEnabled,
-      ...(isIntelligenceRuntime(runtime) && webEnabled
-        ? {
-            intelligence: {
-              wsUrl: runtime.intelligence.ɵgetClientWsUrl(),
-            },
-            inspectorMetadata: true,
-            ...(runtime.debug?.enabled === true && inspectorLearningEnabled
-              ? { inspectorLearning: true }
-              : {}),
-          }
-        : {}),
-      // Legacy flat flag, kept for older clients. The `a2ui` object below is
-      // the source of truth: it preserves the per-agent scoping that this
-      // boolean discards (see CopilotKit/CopilotKit#5369). Both go through the
-      // shared isA2UIEnabled() predicate so an explicit `enabled: false`
-      // disables a2ui here exactly as it does on the run path.
-      a2uiEnabled: webEnabled && isA2UIEnabled(runtime.a2ui),
-      ...(webEnabled && isA2UIEnabled(runtime.a2ui)
-        ? {
-            a2ui: {
-              enabled: true,
-              ...(runtime.a2ui.agents ? { agents: runtime.a2ui.agents } : {}),
-            },
-          }
-        : {}),
-      openGenerativeUIEnabled: webEnabled && !!runtime.openGenerativeUI,
-      ...(isIntelligenceRuntime(runtime)
-        ? {
-            licenseStatus: resolveCompatibilityLicenseStatus(
-              runtime,
-              runtimeEntitlements,
-            ),
-          }
-        : {}),
-      ...(runtimeEntitlements ? { runtimeEntitlements } : {}),
-      telemetryDisabled: isTelemetryDisabled(),
-    };
-
-    return new Response(JSON.stringify(runtimeInfo), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
-  } catch (error) {
-    return new Response(
-      JSON.stringify({
-        error: "Failed to retrieve runtime information",
-        message: error instanceof Error ? error.message : "Unknown error",
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+        );
+    }
 }
 
 function resolveThreadEndpointInfo(
-  runtime: CopilotRuntimeLike,
-  threadEndpointsEnabled: boolean,
+    runtime: CopilotRuntimeLike,
+    threadEndpointsEnabled: boolean,
 ): ThreadEndpointRuntimeInfo {
-  const hasRestThreadBackend =
-    isIntelligenceRuntime(runtime) ||
-    supportsLocalThreadEndpoints(runtime.runner);
-  const restEndpointsAvailable = threadEndpointsEnabled && hasRestThreadBackend;
-  const managedThreadMetadata =
-    threadEndpointsEnabled && isIntelligenceRuntime(runtime);
+    const hasRestThreadBackend =
+        isIntelligenceRuntime(runtime) ||
+        supportsLocalThreadEndpoints(runtime.runner);
+    const restEndpointsAvailable =
+        threadEndpointsEnabled && hasRestThreadBackend;
+    const managedThreadMetadata =
+        threadEndpointsEnabled && isIntelligenceRuntime(runtime);
 
-  return {
-    list: restEndpointsAvailable,
-    inspect: restEndpointsAvailable,
-    mutations: managedThreadMetadata,
-    realtimeMetadata: managedThreadMetadata,
-  };
+    return {
+        list: restEndpointsAvailable,
+        inspect: restEndpointsAvailable,
+        mutations: managedThreadMetadata,
+        realtimeMetadata: managedThreadMetadata,
+    };
 }

--- a/packages/runtime/src/v2/runtime/handlers/handle-run.ts
+++ b/packages/runtime/src/v2/runtime/handlers/handle-run.ts
@@ -2,140 +2,143 @@ import { isIntelligenceRuntime } from "../core/runtime";
 import { telemetry } from "../telemetry";
 import type { RunAgentParameters } from "./shared/agent-utils";
 import {
-  attachIntelligenceEnterpriseLearning,
-  cloneAgentForRequest,
-  configureAgentForRequest,
-  parseRunRequest,
+    attachIntelligenceEnterpriseLearning,
+    cloneAgentForRequest,
+    configureAgentForRequest,
+    parseRunRequest,
 } from "./shared/agent-utils";
 import { handleIntelligenceRun } from "./intelligence/run";
 import { handleSseRun } from "./sse/run";
 import { getRuntimeErrorReporter } from "../core/runtime-error-reporter";
 
 export async function handleRunAgent({
-  runtime,
-  request,
-  agentId,
+    runtime,
+    request,
+    agentId,
 }: RunAgentParameters) {
-  const startTime = Date.now();
-  (runtime.telemetry ?? telemetry).capture(
-    "oss.runtime.copilot_request_created",
-    {
-      "cloud.guardrails.enabled": false,
-      requestType: "run",
-      "cloud.api_key_provided": !!request.headers.get(
-        "x-copilotcloud-public-api-key",
-      ),
-      ...(request.headers.get("x-copilotcloud-public-api-key")
-        ? {
-            "cloud.public_api_key": request.headers.get(
-              "x-copilotcloud-public-api-key",
-            )!,
-          }
-        : {}),
-    },
-  );
-
-  try {
-    const agent = await cloneAgentForRequest(runtime, agentId, request);
-    if (agent instanceof Response) {
-      return agent;
-    }
-
-    // Ensure the clone carries the registry key so InMemoryAgentRunner can
-    // tag historic runs with the correct agentId for filtering.
-    agent.agentId = agentId;
-
-    // Parse the body before configuring middleware: the request is single-read,
-    // and middleware configuration needs the A2UI catalog signal the React
-    // provider forwards (see `a2uiCatalogAvailable` below). Middleware is applied
-    // to the agent here; the run itself is kicked off later, so this is safe.
-    const input = await parseRunRequest(request);
-    if (input instanceof Response) {
-      return input;
-    }
-
-    // `<CopilotKit a2ui={{ catalog }}>` forwards this flag on every run. Its
-    // presence alone is enough to turn A2UI on end-to-end — no runtime-side
-    // `a2ui` config required.
-    const providerA2UIHasCatalog =
-      (input.forwardedProps as Record<string, unknown> | undefined)
-        ?.a2uiCatalogAvailable === true;
-
-    configureAgentForRequest({
-      runtime,
-      request,
-      agentId,
-      agent,
-      providerA2UIHasCatalog,
-    });
-    const memoryResponse = await attachIntelligenceEnterpriseLearning({
-      runtime,
-      request,
-      agent,
-    });
-    if (memoryResponse instanceof Response) return memoryResponse;
-
-    agent.setMessages(input.messages);
-    agent.setState(input.state);
-    agent.threadId = input.threadId;
-
-    if (runtime.debug?.lifecycle && runtime.debugLogger) {
-      runtime.debugLogger.debug(
-        { agentName: agentId, threadId: input.threadId },
-        "Agent run started",
-      );
-    }
-
-    if (isIntelligenceRuntime(runtime)) {
-      return handleIntelligenceRun({
-        runtime,
-        request,
-        agentId,
-        agent,
-        input,
-        startTime,
-      });
-    }
-
-    return handleSseRun({
-      runtime,
-      request,
-      agent,
-      input,
-      agentId,
-      debug: runtime.debug,
-      logger: runtime.debugLogger,
-      startTime,
-    });
-  } catch (error) {
-    getRuntimeErrorReporter(runtime)?.report({
-      request,
-      error,
-      operation: "agent.run",
-      agentId,
-      phase: "common",
-      startTime,
-    });
-    console.error("Error running agent:", error);
-    console.error(
-      "Error stack:",
-      error instanceof Error ? error.stack : "No stack trace",
+    const startTime = Date.now();
+    (runtime.telemetry ?? telemetry).capture(
+        "oss.runtime.copilot_request_created",
+        {
+            "cloud.guardrails.enabled": false,
+            requestType: "run",
+            "cloud.api_key_provided": !!request.headers.get(
+                "x-copilotcloud-public-api-key",
+            ),
+            ...(request.headers.get("x-copilotcloud-public-api-key")
+                ? {
+                      "cloud.public_api_key": request.headers.get(
+                          "x-copilotcloud-public-api-key",
+                      )!,
+                  }
+                : {}),
+        },
     );
-    console.error("Error details:", {
-      name: error instanceof Error ? error.name : "Unknown",
-      message: error instanceof Error ? error.message : String(error),
-      cause: error instanceof Error ? error.cause : undefined,
-    });
 
-    return new Response(
-      JSON.stringify({
-        error: "Failed to run agent",
-        message: error instanceof Error ? error.message : "Unknown error",
-      }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
-  }
+    try {
+        const agent = await cloneAgentForRequest(runtime, agentId, request);
+        if (agent instanceof Response) {
+            return agent;
+        }
+
+        // Ensure the clone carries the registry key so InMemoryAgentRunner can
+        // tag historic runs with the correct agentId for filtering.
+        if (!("agentId" in agent) || !(agent as any).agentId) {
+            agent.agentId = agentId;
+        }
+
+        // Parse the body before configuring middleware: the request is single-read,
+        // and middleware configuration needs the A2UI catalog signal the React
+        // provider forwards (see `a2uiCatalogAvailable` below). Middleware is applied
+        // to the agent here; the run itself is kicked off later, so this is safe.
+        const input = await parseRunRequest(request);
+        if (input instanceof Response) {
+            return input;
+        }
+
+        // `<CopilotKit a2ui={{ catalog }}>` forwards this flag on every run. Its
+        // presence alone is enough to turn A2UI on end-to-end — no runtime-side
+        // `a2ui` config required.
+        const providerA2UIHasCatalog =
+            (input.forwardedProps as Record<string, unknown> | undefined)
+                ?.a2uiCatalogAvailable === true;
+
+        configureAgentForRequest({
+            runtime,
+            request,
+            agentId,
+            agent,
+            providerA2UIHasCatalog,
+        });
+        const memoryResponse = await attachIntelligenceEnterpriseLearning({
+            runtime,
+            request,
+            agent,
+        });
+        if (memoryResponse instanceof Response) return memoryResponse;
+
+        agent.setMessages(input.messages);
+        agent.setState(input.state);
+        agent.threadId = input.threadId;
+
+        if (runtime.debug?.lifecycle && runtime.debugLogger) {
+            runtime.debugLogger.debug(
+                { agentName: agentId, threadId: input.threadId },
+                "Agent run started",
+            );
+        }
+
+        if (isIntelligenceRuntime(runtime)) {
+            return handleIntelligenceRun({
+                runtime,
+                request,
+                agentId,
+                agent,
+                input,
+                startTime,
+            });
+        }
+
+        return handleSseRun({
+            runtime,
+            request,
+            agent,
+            input,
+            agentId,
+            debug: runtime.debug,
+            logger: runtime.debugLogger,
+            startTime,
+        });
+    } catch (error) {
+        getRuntimeErrorReporter(runtime)?.report({
+            request,
+            error,
+            operation: "agent.run",
+            agentId,
+            phase: "common",
+            startTime,
+        });
+        console.error("Error running agent:", error);
+        console.error(
+            "Error stack:",
+            error instanceof Error ? error.stack : "No stack trace",
+        );
+        console.error("Error details:", {
+            name: error instanceof Error ? error.name : "Unknown",
+            message: error instanceof Error ? error.message : String(error),
+            cause: error instanceof Error ? error.cause : undefined,
+        });
+
+        return new Response(
+            JSON.stringify({
+                error: "Failed to run agent",
+                message:
+                    error instanceof Error ? error.message : "Unknown error",
+            }),
+            {
+                status: 500,
+                headers: { "Content-Type": "application/json" },
+            },
+        );
+    }
 }


### PR DESCRIPTION
Fixes #4775

This PR solves the issue where the `/info` request handler forces `agentId` (the dictionary key) to be exactly the same as the human-friendly `name` in the UI. 

**Changes:**
1. In `get-runtime-info.ts`: If the agent instance explicitly has a `name` property, that name is used as the `AgentDescription.name` (which the React UI consumes as the human-readable display name), while the dictionary key remains the correct internal `agentId`.
2. In `handle-run.ts`: Prevented the run handler from destructively mutating `agent.agentId` if the developer explicitly provided one on the instance, satisfying the constraint where internal IDs were being blindly overwritten by the router.
3. Added `get-runtime-info.test.ts` to verify the `name` property is correctly extracted without modifying the dictionary key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime information now displays each agent’s configured friendly name when available, with the agent identifier used as a fallback.
  - Agent-specific identifiers are preserved during agent runs when already provided, improving consistency across runtime processing and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->