### PR TITLE
fix(showcase): guard the public $PORT in every dual-process watchdog

### DIFF
--- a/showcase/integrations/ag2/entrypoint.sh
+++ b/showcase/integrations/ag2/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[ag2] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/agno/entrypoint.sh
+++ b/showcase/integrations/agno/entrypoint.sh
@@ -81,6 +81,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -94,6 +95,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[agno] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/claude-sdk-typescript/entrypoint.sh
+++ b/showcase/integrations/claude-sdk-typescript/entrypoint.sh
@@ -84,6 +84,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
     echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
   fi
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -96,6 +97,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[claude-sdk-typescript] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/crewai-conversational-flows/entrypoint.sh
+++ b/showcase/integrations/crewai-conversational-flows/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # logging.
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[crewai-conversational-flows] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/crewai-crews/entrypoint.sh
+++ b/showcase/integrations/crewai-crews/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # logging.
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[crewai-crews] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/google-adk/entrypoint.sh
+++ b/showcase/integrations/google-adk/entrypoint.sh
@@ -97,6 +97,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # showcase/integrations/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -109,6 +110,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[google-adk] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/langgraph-fastapi/entrypoint.sh
+++ b/showcase/integrations/langgraph-fastapi/entrypoint.sh
@@ -110,6 +110,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
     echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
   fi
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -122,6 +123,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[langgraph-fastapi] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/langgraph-python/entrypoint.sh
+++ b/showcase/integrations/langgraph-python/entrypoint.sh
@@ -147,6 +147,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
     echo "[watchdog] Grace window elapsed without successful probe — arming strike counter anyway"
   fi
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $LANGGRAPH_PID 2>/dev/null; then
       break
@@ -159,6 +160,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $LANGGRAPH_PID to trigger container restart"
         kill -9 $LANGGRAPH_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[langgraph-python] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/langgraph-typescript/entrypoint.sh
+++ b/showcase/integrations/langgraph-typescript/entrypoint.sh
@@ -578,6 +578,7 @@ _require_int HEALTH_STRIKE_LIMIT      3 "LangGraph health strike limit"
   fi
 
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep "$HEALTH_CHECK_INTERVAL"; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -593,6 +594,39 @@ _require_int HEALTH_STRIKE_LIMIT      3 "LangGraph health strike limit"
         # process-sub subshell; a single-PID kill would orphan npm→node and
         # leave :8123 bound to a hung agent that `wait -n` never observes dying.
         _kill_agent_tree "$AGENT_PID"
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge "$HEALTH_STRIKE_LIMIT" ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~$((HEALTH_CHECK_INTERVAL * HEALTH_STRIKE_LIMIT))s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[langgraph-typescript] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~$((HEALTH_CHECK_INTERVAL * HEALTH_STRIKE_LIMIT))s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        # Tree-kill (not a bare `kill -9`): NEXTJS_PID is the process-sub
+        # subshell wrapping `npx next start` (which forks npm→node), so a
+        # single-PID kill reaps only the wrapper and ORPHANS the real
+        # Next.js node server — reparented to PID 1, still holding $PORT.
+        _kill_agent_tree "$NEXTJS_PID"
         break
       fi
     fi

--- a/showcase/integrations/langroid/entrypoint.sh
+++ b/showcase/integrations/langroid/entrypoint.sh
@@ -315,6 +315,7 @@ NEXT_PID=$!
 # showcase/integrations/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
 (
     FAILS=0
+    PUBLIC_FAILS=0
     while sleep 30; do
         if ! kill -0 "$AGENT_PID" 2>/dev/null; then
             break
@@ -327,6 +328,35 @@ NEXT_PID=$!
             if [ $FAILS -ge 3 ]; then
                 echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart" >&2
                 kill -9 "$AGENT_PID" 2>/dev/null || true
+                break
+            fi
+        fi
+
+        # Public front door guard. The same silent-hang class that wedges the
+        # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+        # users and the Railway healthcheck actually hit (`/api/health`). The Node
+        # event loop parks in a blocking write(2) and stops serving, but the
+        # process stays alive: `wait -n` never fires AND the agent probe above is
+        # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+        # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+        # killing $NEXT_PID so the restart is never silent. Ported from
+        # showcase/integrations/claude-sdk-python/entrypoint.sh.
+        if curl -fsS --max-time 5 "http://127.0.0.1:${PORT:-10000}/api/health" > /dev/null 2>&1; then
+            PUBLIC_FAILS=0
+        else
+            PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+            echo "[watchdog] Public /api/health probe failed on port ${PORT:-10000} (count=$PUBLIC_FAILS)" >&2
+            if [ $PUBLIC_FAILS -ge 3 ]; then
+                WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+                echo "[watchdog] Public port ${PORT:-10000} unresponsive for ~90s — killing PID $NEXT_PID to trigger container restart" >&2
+                # LOUD alert before we kill. Never let a failed or absent webhook
+                # crash the watchdog — only attempt if the var is set, swallow errors.
+                if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+                    curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+                      --data "{\"text\":\"[langroid] env=${WEDGE_ENV} public \$PORT (${PORT:-10000}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXT_PID)\"}" \
+                      "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+                fi
+                kill -9 "$NEXT_PID" 2>/dev/null || true
                 break
             fi
         fi

--- a/showcase/integrations/llamaindex/entrypoint.sh
+++ b/showcase/integrations/llamaindex/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[llamaindex] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/ms-agent-dotnet/entrypoint.sh
+++ b/showcase/integrations/ms-agent-dotnet/entrypoint.sh
@@ -50,6 +50,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # showcase/integrations/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -62,6 +63,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[ms-agent-dotnet] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/ms-agent-harness-dotnet/entrypoint.sh
+++ b/showcase/integrations/ms-agent-harness-dotnet/entrypoint.sh
@@ -67,6 +67,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # showcase/integrations/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -83,6 +84,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[ms-agent-harness-dotnet] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/ms-agent-harness-dotnet/src/app/api/health/route.ts
+++ b/showcase/integrations/ms-agent-harness-dotnet/src/app/api/health/route.ts
@@ -27,6 +27,15 @@ export async function GET() {
       agent_detail: agentDetail,
       timestamp: new Date().toISOString(),
     },
-    { status: agentStatus === "ok" ? 200 : 503 },
+    // ALWAYS 200. This route is the PUBLIC front door: the container
+    // watchdog polls it to decide whether the Next.js listener itself is
+    // wedged, and Railway's healthcheckPath points at it. Returning 503 for
+    // an unhealthy AGENT conflates two different faults — a slow agent would
+    // make the watchdog kill a perfectly healthy frontend, and would fail the
+    // Railway healthcheck for a frontend that is serving fine. Agent health is
+    // reported in the `agent` field above; the container's agent-side watchdog
+    // branch (:8000/health) is what acts on it. Matches the other 20
+    // integrations, which all return an unconditional 200 here.
+    { status: 200 },
   );
 }

--- a/showcase/integrations/ms-agent-python/entrypoint.sh
+++ b/showcase/integrations/ms-agent-python/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[ms-agent-python] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/pydantic-ai/entrypoint.sh
+++ b/showcase/integrations/pydantic-ai/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[pydantic-ai] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/integrations/spring-ai/entrypoint.sh
+++ b/showcase/integrations/spring-ai/entrypoint.sh
@@ -82,6 +82,7 @@ NODE_PID=$!
 # showcase/integrations/crewai-crews/entrypoint.sh (PRs #4114 + #4115).
 (
     FAILS=0
+    PUBLIC_FAILS=0
     while sleep 30; do
         if ! kill -0 "$JAVA_PID" 2>/dev/null; then
             break
@@ -94,6 +95,35 @@ NODE_PID=$!
             if [ $FAILS -ge 3 ]; then
                 echo "[watchdog] Agent unresponsive for ~90s — killing PID $JAVA_PID to trigger container restart"
                 kill -9 "$JAVA_PID" 2>/dev/null || true
+                break
+            fi
+        fi
+
+        # Public front door guard. The same silent-hang class that wedges the
+        # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+        # users and the Railway healthcheck actually hit (`/api/health`). The Node
+        # event loop parks in a blocking write(2) and stops serving, but the
+        # process stays alive: `wait -n` never fires AND the agent probe above is
+        # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+        # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+        # killing $NODE_PID so the restart is never silent. Ported from
+        # showcase/integrations/claude-sdk-python/entrypoint.sh.
+        if curl -fsS --max-time 5 "http://127.0.0.1:${PORT:-10000}/api/health" > /dev/null 2>&1; then
+            PUBLIC_FAILS=0
+        else
+            PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+            echo "[watchdog] Public /api/health probe failed on port ${PORT:-10000} (count=$PUBLIC_FAILS)"
+            if [ $PUBLIC_FAILS -ge 3 ]; then
+                WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+                echo "[watchdog] Public port ${PORT:-10000} unresponsive for ~90s — killing PID $NODE_PID to trigger container restart"
+                # LOUD alert before we kill. Never let a failed or absent webhook
+                # crash the watchdog — only attempt if the var is set, swallow errors.
+                if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+                    curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+                      --data "{\"text\":\"[spring-ai] env=${WEDGE_ENV} public \$PORT (${PORT:-10000}) /api/health unresponsive ~90s — restarting (Next.js PID $NODE_PID)\"}" \
+                      "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+                fi
+                kill -9 "$NODE_PID" 2>/dev/null || true
                 break
             fi
         fi

--- a/showcase/integrations/strands-typescript/entrypoint.sh
+++ b/showcase/integrations/strands-typescript/entrypoint.sh
@@ -317,6 +317,7 @@ _require_int HEALTH_STRIKE_LIMIT      3 "Strands health strike limit"
   fi
 
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep "$HEALTH_CHECK_INTERVAL"; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       break
@@ -332,6 +333,39 @@ _require_int HEALTH_STRIKE_LIMIT      3 "Strands health strike limit"
         # subshell, so a single-PID kill would orphan the real npm→node server,
         # leaving :8000 bound to a hung agent that `wait -n` never observes dying.
         _kill_agent_tree "$AGENT_PID"
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge "$HEALTH_STRIKE_LIMIT" ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~$((HEALTH_CHECK_INTERVAL * HEALTH_STRIKE_LIMIT))s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[strands-typescript] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~$((HEALTH_CHECK_INTERVAL * HEALTH_STRIKE_LIMIT))s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        # Tree-kill (not a bare `kill -9`): NEXTJS_PID is the process-sub
+        # subshell wrapping `npx next start` (which forks npm→node), so a
+        # single-PID kill reaps only the wrapper and ORPHANS the real
+        # Next.js node server — reparented to PID 1, still holding $PORT.
+        _kill_agent_tree "$NEXTJS_PID"
         break
       fi
     fi

--- a/showcase/integrations/strands/entrypoint.sh
+++ b/showcase/integrations/strands/entrypoint.sh
@@ -72,6 +72,7 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
 # (PRs #4114 + #4115).
 (
   FAILS=0
+  PUBLIC_FAILS=0
   while sleep 30; do
     if ! kill -0 $AGENT_PID 2>/dev/null; then
       # Agent already dead — wait -n in the main shell will handle it.
@@ -85,6 +86,35 @@ echo "[entrypoint] Next.js started (PID: $NEXTJS_PID)"
       if [ $FAILS -ge 3 ]; then
         echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
         kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard. The same silent-hang class that wedges the
+    # agent can wedge the PUBLIC Next.js listener on $PORT — the surface real
+    # users and the Railway healthcheck actually hit (`/api/health`). The Node
+    # event loop parks in a blocking write(2) and stops serving, but the
+    # process stays alive: `wait -n` never fires AND the agent probe above is
+    # satisfied (agent idle-alive), so nothing restarts the container. Poll the
+    # public surface on its own counter, same tick, and page #oss-alerts BEFORE
+    # killing $NEXTJS_PID so the restart is never silent. Ported from
+    # showcase/integrations/claude-sdk-python/entrypoint.sh.
+    if curl -fsS --max-time 5 "http://127.0.0.1:${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port ${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port ${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"[strands] env=${WEDGE_ENV} public \$PORT (${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\"}" \
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
         break
       fi
     fi

--- a/showcase/scripts/__tests__/create-integration.test.ts
+++ b/showcase/scripts/__tests__/create-integration.test.ts
@@ -828,10 +828,24 @@ describe("Template Generator — hardening regressions", () => {
     // to the in-process status.
     expect(healthRoute).toContain("IS_IN_PROCESS = true");
     expect(healthRoute).toContain('"in-process"');
-    // And the happy-path must treat in-process as 200 alongside "ok"
-    expect(healthRoute).toMatch(
-      /agentStatus\s*===\s*"ok"\s*\|\|\s*agentStatus\s*===\s*"in-process"/,
+    // The in-process status must never be reported as a failure. It used to be
+    // checked via `agentStatus === "ok" || agentStatus === "in-process"`
+    // driving a 200/503 choice. The route now always answers 200 — it is the
+    // PUBLIC front door that the container watchdog and Railway's
+    // healthcheckPath poll, and a 503 for an unhealthy AGENT made a slow
+    // agent restart-loop a healthy frontend. Agent health moved to the
+    // `agent` field, asserted above. See
+    // showcase/scripts/__tests__/entrypoint-watchdog.test.ts.
+    expect(healthRoute).toContain(
+      "return NextResponse.json(publicResponse, { status: 200 });",
     );
+    // Code only — the route carries a comment explaining why 503 was dropped,
+    // and prose must not decide this assertion either way.
+    const code = healthRoute
+      .split("\n")
+      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      .join("\n");
+    expect(code).not.toMatch(/status:\s*(?:[^,}]*\?[^,}]*:\s*)?5\d\d/);
   });
 
   it("generated health route has an out-of-process probe for Python integrations", async () => {

--- a/showcase/scripts/__tests__/entrypoint-watchdog.test.ts
+++ b/showcase/scripts/__tests__/entrypoint-watchdog.test.ts
@@ -1,0 +1,261 @@
+// entrypoint-watchdog.test.ts — CI gate for the dual-process container
+// watchdog in every showcase integration's entrypoint.sh.
+//
+// Why this exists: the public-$PORT guard was added to claude-sdk-python in
+// July 2026 and to nowhere else, so 18 integrations spent months able to serve
+// 502s from a wedged Next.js while Railway still reported the service Online
+// (its healthcheck reached the still-alive agent). Nothing detected the drift,
+// because nothing asserted the guard fleet-wide.
+//
+// The mechanism itself — detect, alert, kill the right PID — is proven against
+// the REAL extracted guard by showcase/tests/repro/stdout-wedge/watchdog-fleet.sh.
+// This suite is the cheap always-on half: it proves the guard is PRESENT and
+// structurally intact in every dual-process entrypoint, and that the
+// create-integration scaffolder emits it for new integrations.
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const INTEGRATIONS = path.resolve(__dirname, "../../integrations");
+
+interface Entrypoint {
+  slug: string;
+  source: string;
+}
+
+/**
+ * `wait -n` is the dual-process marker: the entrypoint supervises an agent AND
+ * Next.js, so a hang in either can strand the container. Single-process
+ * integrations (`exec next start`) have one process whose death Railway already
+ * observes, and carry no watchdog.
+ */
+function dualProcessEntrypoints(): Entrypoint[] {
+  return fs
+    .readdirSync(INTEGRATIONS, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("_"))
+    .map((e) => ({
+      slug: e.name,
+      file: path.join(INTEGRATIONS, e.name, "entrypoint.sh"),
+    }))
+    .filter((e) => fs.existsSync(e.file))
+    .map((e) => ({ slug: e.slug, source: fs.readFileSync(e.file, "utf8") }))
+    .filter((e) => e.source.includes("wait -n"));
+}
+
+/**
+ * Shell code only — comment lines dropped, so prose cannot satisfy or fail a
+ * code assertion.
+ */
+function codeOnly(shell: string): string {
+  return shell
+    .split("\n")
+    .filter((l) => !/^\s*#/.test(l))
+    .join("\n");
+}
+
+/**
+ * The guard block: from its comment header to the `fi` that closes it at the
+ * same indentation. Returned verbatim so the assertions below read the real
+ * shell, not a paraphrase of it.
+ */
+function extractGuard(source: string): string | null {
+  const lines = source.split("\n");
+  const start = lines.findIndex((l) => l.includes("# Public front door guard"));
+  if (start === -1) return null;
+  const indent = lines[start].match(/^[ \t]*/)![0];
+  const end = lines.findIndex((l, n) => n > start && l === `${indent}fi`);
+  if (end === -1) return null;
+  return lines.slice(start, end + 1).join("\n");
+}
+
+const entrypoints = dualProcessEntrypoints();
+
+describe("dual-process entrypoint watchdogs", () => {
+  it("finds the dual-process integrations to gate", () => {
+    // Guards the guard: if discovery silently returned [], every per-slug
+    // assertion below would vacuously pass.
+    expect(entrypoints.length).toBeGreaterThanOrEqual(19);
+  });
+
+  describe.each(entrypoints.map((e) => [e.slug, e.source] as const))(
+    "%s",
+    (slug, source) => {
+      const guard = extractGuard(source);
+
+      it("has a public $PORT front-door guard", () => {
+        expect(
+          guard,
+          `${slug}/entrypoint.sh supervises two processes but only probes the ` +
+            `agent. A wedged Next.js would serve 502s indefinitely while the ` +
+            `container stays up. Port the guard from claude-sdk-python.`,
+        ).not.toBeNull();
+      });
+
+      it("probes /api/health on the public port", () => {
+        // The port must come from $PORT — a hardcoded port would probe the
+        // wrong listener on Railway, where $PORT is assigned at runtime.
+        expect(guard).toMatch(
+          /curl -fsS --max-time 5 "http:\/\/127\.0\.0\.1:\$\{PORT(:-\d+)?\}\/api\/health"/,
+        );
+      });
+
+      it("counts strikes on its own counter", () => {
+        // A shared counter would let a flapping agent kill the frontend.
+        expect(guard).toContain("PUBLIC_FAILS=$((PUBLIC_FAILS + 1))");
+        expect(guard).toMatch(
+          /if \[ \$PUBLIC_FAILS -ge (3|"\$HEALTH_STRIKE_LIMIT") \]; then/,
+        );
+        expect(source).toMatch(/^\s*PUBLIC_FAILS=0$/m);
+      });
+
+      it("pages #oss-alerts before killing", () => {
+        expect(guard).toContain("SLACK_WEBHOOK_OSS_ALERTS");
+        expect(guard).toContain("-X POST -H 'Content-type: application/json'");
+        // The alert must name the integration, or an on-call page cannot say
+        // which service wedged.
+        expect(guard).toContain(`[${slug}]`);
+        // Alert BEFORE kill, never after: a kill-first ordering loses the page
+        // whenever the restart races the webhook.
+        const alertAt = guard!.indexOf("SLACK_WEBHOOK_OSS_ALERTS");
+        const killAt = guard!.search(/kill -9 |_kill_agent_tree /);
+        expect(alertAt).toBeGreaterThan(-1);
+        expect(killAt).toBeGreaterThan(alertAt);
+      });
+
+      it("kills the frontend, never the agent", () => {
+        const pidVar = guard!.match(/killing PID \$([A-Z_]+)/)?.[1];
+        expect(pidVar, "guard does not name the PID it kills").toBeTruthy();
+        expect(guard).toMatch(
+          new RegExp(
+            `(kill -9 "?\\$${pidVar}"?|_kill_agent_tree "\\$${pidVar}")`,
+          ),
+        );
+        // Killing the agent here would restart the wrong process and leave the
+        // wedged listener holding $PORT.
+        expect(guard).not.toMatch(/kill -9 "?\$(AGENT|LANGGRAPH|JAVA)_PID/);
+      });
+
+      it("uses the same tree-kill as the agent branch when the file has one", () => {
+        // In the entrypoints that wrap their processes in process substitution,
+        // a single-PID kill reaps only the wrapper and orphans the real node
+        // server — which keeps holding $PORT across the restart. Those files
+        // define _kill_agent_tree; the frontend kill must route through it too.
+        if (!source.includes("_kill_agent_tree()")) return;
+        const code = codeOnly(guard!);
+        expect(code).toContain("_kill_agent_tree");
+        expect(code).not.toContain("kill -9");
+      });
+    },
+  );
+});
+
+describe("public health routes stay decoupled from the agent", () => {
+  // The watchdog reads /api/health as "is the Next.js listener serving?".
+  // A route that returns 503 because the AGENT is unhealthy turns a slow agent
+  // into a frontend restart loop, and fails the Railway healthcheck for a
+  // frontend that is serving fine. Agent health belongs in the response body.
+  it.each(entrypoints.map((e) => e.slug))("%s", (slug) => {
+    const file = path.join(INTEGRATIONS, slug, "src/app/api/health/route.ts");
+    if (!fs.existsSync(file)) {
+      throw new Error(
+        `${slug} has a public $PORT watchdog probe but no /api/health route — ` +
+          `the probe would 404 and restart-loop the container.`,
+      );
+    }
+    const route = fs
+      .readFileSync(file, "utf8")
+      .split("\n")
+      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      .join("\n");
+    expect(route).not.toMatch(/status:\s*(?:[^,}]*\?[^,}]*:\s*)?5\d\d/);
+    expect(route).not.toMatch(/status:\s*httpStatus/);
+  });
+});
+
+describe("create-integration scaffolder", () => {
+  // Asserts on GENERATED OUTPUT, not on the generator's source text. Grepping
+  // index.ts only proves a string exists somewhere in a 2000-line file — it
+  // stayed green when the template's webhook var was renamed. So run the real
+  // generator into a tmpdir and read what a new integration would actually get.
+  let entrypoint = "";
+  let healthRoute = "";
+
+  beforeAll(() => {
+    const out = fs.mkdtempSync(path.join(os.tmpdir(), "wd-scaffold-"));
+    const workflows = fs.mkdtempSync(path.join(os.tmpdir(), "wd-workflows-"));
+    execFileSync(
+      process.execPath,
+      [
+        path.resolve(__dirname, "../node_modules/tsx/dist/cli.mjs"),
+        path.resolve(__dirname, "../create-integration/index.ts"),
+        "--name",
+        "Watchdog Probe",
+        "--slug",
+        "watchdog-probe",
+        "--category",
+        "emerging",
+        "--language",
+        "python",
+        "--features",
+        "agentic-chat",
+      ],
+      {
+        env: {
+          ...process.env,
+          CREATE_INTEGRATION_PACKAGES_DIR: out,
+          CREATE_INTEGRATION_WORKFLOWS_DIR: workflows,
+        },
+        stdio: "pipe",
+      },
+    );
+    const pkg = path.join(out, "watchdog-probe");
+    entrypoint = fs.readFileSync(path.join(pkg, "entrypoint.sh"), "utf8");
+    healthRoute = fs.readFileSync(
+      path.join(pkg, "src/app/api/health/route.ts"),
+      "utf8",
+    );
+  });
+
+  it("emits a runnable entrypoint", () => {
+    expect(entrypoint).toMatch(/^#!\/bin\/bash/);
+    // Proves the emitted shell parses — a template with a quoting slip would
+    // otherwise ship broken to every new integration.
+    execFileSync("bash", ["-n", "/dev/stdin"], { input: entrypoint });
+  });
+
+  it("emits the agent probe", () => {
+    expect(entrypoint).toContain("http://127.0.0.1:8000/health");
+    expect(entrypoint).toMatch(/kill -9 \$AGENT_PID/);
+  });
+
+  it("emits the public front-door guard", () => {
+    const guard = extractGuard(entrypoint);
+    expect(
+      guard,
+      "the scaffolder emits no public $PORT guard, so every new integration " +
+        "starts with the gap this suite exists to close",
+    ).not.toBeNull();
+    expect(guard).toMatch(
+      /curl -fsS --max-time 5 "http:\/\/127\.0\.0\.1:\$\{PORT\}\/api\/health"/,
+    );
+    expect(guard).toContain("PUBLIC_FAILS=$((PUBLIC_FAILS + 1))");
+    expect(guard).toContain("SLACK_WEBHOOK_OSS_ALERTS");
+    // The alert must interpolate the real slug, not a placeholder.
+    expect(guard).toContain("[watchdog-probe]");
+    expect(guard).toMatch(/kill -9 \$NEXTJS_PID/);
+    expect(codeOnly(guard!)).not.toMatch(/kill -9 \$AGENT_PID/);
+  });
+
+  it("emits a health route that does not 503 on agent trouble", () => {
+    const code = healthRoute
+      .split("\n")
+      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      .join("\n");
+    expect(code).not.toMatch(/status:\s*(?:[^,}]*\?[^,}]*:\s*)?5\d\d/);
+    expect(code).not.toMatch(/status:\s*httpStatus/);
+    expect(code).toContain("status: 200");
+  });
+});

--- a/showcase/scripts/__tests__/entrypoint-watchdog.test.ts
+++ b/showcase/scripts/__tests__/entrypoint-watchdog.test.ts
@@ -181,6 +181,7 @@ describe("create-integration scaffolder", () => {
   // stayed green when the template's webhook var was renamed. So run the real
   // generator into a tmpdir and read what a new integration would actually get.
   let entrypoint = "";
+  let entrypointPath = "";
   let healthRoute = "";
 
   beforeAll(() => {
@@ -212,7 +213,8 @@ describe("create-integration scaffolder", () => {
       },
     );
     const pkg = path.join(out, "watchdog-probe");
-    entrypoint = fs.readFileSync(path.join(pkg, "entrypoint.sh"), "utf8");
+    entrypointPath = path.join(pkg, "entrypoint.sh");
+    entrypoint = fs.readFileSync(entrypointPath, "utf8");
     healthRoute = fs.readFileSync(
       path.join(pkg, "src/app/api/health/route.ts"),
       "utf8",
@@ -222,8 +224,11 @@ describe("create-integration scaffolder", () => {
   it("emits a runnable entrypoint", () => {
     expect(entrypoint).toMatch(/^#!\/bin\/bash/);
     // Proves the emitted shell parses — a template with a quoting slip would
-    // otherwise ship broken to every new integration.
-    execFileSync("bash", ["-n", "/dev/stdin"], { input: entrypoint });
+    // otherwise ship broken to every new integration. Check the file the
+    // generator wrote, not stdin: `bash -n /dev/stdin` exits 126 on the CI
+    // runner, which made this assertion fail for a reason unrelated to the
+    // shell it was meant to check.
+    execFileSync("bash", ["-n", entrypointPath], { stdio: "pipe" });
   });
 
   it("emits the agent probe", () => {

--- a/showcase/scripts/create-integration/index.ts
+++ b/showcase/scripts/create-integration/index.ts
@@ -914,8 +914,14 @@ export async function GET(req: NextRequest) {
         };
     }
 
-    const httpStatus = agentStatus === "ok" || agentStatus === "in-process" ? 200 : 503;
-    return NextResponse.json(publicResponse, { status: httpStatus });
+    // ALWAYS 200. This route is the PUBLIC front door: the container
+    // watchdog in entrypoint.sh polls it to decide whether the Next.js
+    // listener itself is wedged, and Railway's healthcheckPath points at it.
+    // Returning 503 for an unhealthy AGENT conflates two different faults —
+    // a slow agent would make the watchdog kill a healthy frontend in a
+    // restart loop. Agent health is reported in the \`agent\` field; the
+    // agent-side watchdog branch (:8000/health) is what acts on it.
+    return NextResponse.json(publicResponse, { status: 200 });
 }
 `;
 }
@@ -1136,14 +1142,80 @@ exec npx next start --port \${PORT:-10000}
   return `#!/bin/bash
 set -e
 
-# Start agent backend
-python -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+PORT=\${PORT:-10000}
 
-# Start Next.js frontend
-npx next start --port \${PORT:-10000} &
+# Start agent backend on :8000. \`-u\` forces unbuffered stdout so a crash
+# during import reaches the log stream instead of sitting in a pipe buffer.
+python -u -m uvicorn agent_server:app --host 0.0.0.0 --port 8000 &
+AGENT_PID=$!
+
+# Start Next.js frontend on the public $PORT. NODE_ENV is scoped to this exec
+# so it does not leak into the agent process.
+env NODE_ENV=production npx next start --port $PORT &
+NEXTJS_PID=$!
+
+# Watchdog — BOTH probes are load-bearing; do not ship one without the other.
+#
+# Either process can hang WITHOUT exiting: the process stays alive, so
+# \`wait -n\` never fires and Railway never restarts the container. Probe both
+# every 30s and kill the offending process after 3 strikes (~90s) so \`wait -n\`
+# returns through the normal path.
+#
+#   agent   :8000/health       -> kill $AGENT_PID
+#   public  $PORT/api/health   -> kill $NEXTJS_PID, paging #oss-alerts first
+#
+# The public probe is the surface real users and the Railway healthcheck hit.
+# An agent-only watchdog leaves a wedged frontend returning 502 indefinitely
+# while the service still reports Online — that is the outage class this
+# guard exists to end. Reference: showcase/integrations/claude-sdk-python.
+(
+  FAILS=0
+  PUBLIC_FAILS=0
+  while sleep 30; do
+    if ! kill -0 $AGENT_PID 2>/dev/null; then
+      # Agent already dead — wait -n in the main shell will handle it.
+      break
+    fi
+    if curl -fsS --max-time 5 http://127.0.0.1:8000/health > /dev/null 2>&1; then
+      FAILS=0
+    else
+      FAILS=$((FAILS + 1))
+      echo "[watchdog] Agent health probe failed (count=$FAILS)"
+      if [ $FAILS -ge 3 ]; then
+        echo "[watchdog] Agent unresponsive for ~90s — killing PID $AGENT_PID to trigger container restart"
+        kill -9 $AGENT_PID 2>/dev/null || true
+        break
+      fi
+    fi
+
+    # Public front door guard.
+    if curl -fsS --max-time 5 "http://127.0.0.1:\${PORT}/api/health" > /dev/null 2>&1; then
+      PUBLIC_FAILS=0
+    else
+      PUBLIC_FAILS=$((PUBLIC_FAILS + 1))
+      echo "[watchdog] Public /api/health probe failed on port \${PORT} (count=$PUBLIC_FAILS)"
+      if [ $PUBLIC_FAILS -ge 3 ]; then
+        WEDGE_ENV="\${RAILWAY_ENVIRONMENT_NAME:-$(hostname)}"
+        echo "[watchdog] Public port \${PORT} unresponsive for ~90s — killing PID $NEXTJS_PID to trigger container restart"
+        # LOUD alert before we kill. Never let a failed or absent webhook
+        # crash the watchdog — only attempt if the var is set, swallow errors.
+        if [ -n "$SLACK_WEBHOOK_OSS_ALERTS" ]; then
+          curl -fsS -m 10 -X POST -H 'Content-type: application/json' \\
+            --data "{\\"text\\":\\"[${args.slug}] env=\${WEDGE_ENV} public \\$PORT (\${PORT}) /api/health unresponsive ~90s — restarting (Next.js PID $NEXTJS_PID)\\"}" \\
+            "$SLACK_WEBHOOK_OSS_ALERTS" > /dev/null 2>&1 || true
+        fi
+        kill -9 $NEXTJS_PID 2>/dev/null || true
+        break
+      fi
+    fi
+  done
+) &
+WATCHDOG_PID=$!
+
+trap 'kill $AGENT_PID $NEXTJS_PID $WATCHDOG_PID 2>/dev/null || true' EXIT
 
 # Wait for either process to exit
-wait -n
+wait -n $AGENT_PID $NEXTJS_PID
 exit $?
 `;
 }

--- a/showcase/tests/repro/stdout-wedge/watchdog-fleet.sh
+++ b/showcase/tests/repro/stdout-wedge/watchdog-fleet.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Fleet driver for the public-front-door watchdog guard.
+#
+# `watchdog.sh` (next to this file) proves the guard for claude-sdk-python by
+# running a hand-lifted copy of its loop, with grep needles asserting the copy
+# still matches the real file. This driver removes the copy: for each
+# integration it EXTRACTS the guard block out of the real entrypoint.sh at
+# runtime and runs THAT, so there is nothing to drift.
+#
+# Per integration it proves, end to end:
+#   (a) the extracted guard detects a wedged public $PORT after its
+#       consecutive-failure threshold. The real cadence is the entrypoint's own
+#       `sleep` (30s, or $HEALTH_CHECK_INTERVAL); we drive the extracted body
+#       from a WATCHDOG_SLEEP loop (default 1s) for speed. The logic — the
+#       >=3-strike threshold, the probe, the alert, the kill — is unedited.
+#   (b) it POSTs the LOUD alert to $SLACK_WEBHOOK_OSS_ALERTS BEFORE killing,
+#       and the body names THAT integration.
+#   (c) it kills the frontend PID (never the agent PID).
+#   (d) a HEALTHY public port keeps the counter at 0 and kills nothing — the
+#       guard cannot restart-loop a serving frontend.
+#
+# Usage:
+#   ./watchdog-fleet.sh              # every dual-process integration
+#   ./watchdog-fleet.sh crewai-crews langroid
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEGRATIONS="$HERE/../../../integrations"
+WATCHDOG_SLEEP="${WATCHDOG_SLEEP:-1}"
+TRANSCRIPT="${TRANSCRIPT:-/tmp/watchdog-fleet.txt}"
+: > "$TRANSCRIPT"
+
+log() { echo "$@" | tee -a "$TRANSCRIPT"; }
+
+FAILED=0
+CHECKED=0
+
+# ── Which integrations carry a dual-process watchdog? ─────────────────────────
+# `wait -n` in the entrypoint is the dual-process marker; single-process
+# integrations (`exec next start`) have no watchdog and need no guard.
+discover() {
+  local d slug
+  for d in "$INTEGRATIONS"/*/; do
+    slug="$(basename "$d")"
+    [ -f "$d/entrypoint.sh" ] || continue
+    grep -q 'wait -n' "$d/entrypoint.sh" || continue
+    echo "$slug"
+  done
+}
+
+# ── Extract the guard block verbatim from a real entrypoint ───────────────────
+# From the `# Public front door guard` comment to the `fi` that closes it at
+# the same indentation. Nothing is rewritten.
+extract_guard() {
+  awk '
+    /# Public front door guard/ && !seen {
+      seen = 1
+      match($0, /^[ \t]*/)
+      indent = substr($0, 1, RLENGTH)
+      print
+      next
+    }
+    seen {
+      print
+      if ($0 == indent "fi") exit
+    }
+  ' "$1"
+}
+
+# Every `_helper() { ... }` in the file, so an extracted block that calls
+# _kill_agent_tree runs the REAL tree-kill, not a stub.
+extract_helpers() {
+  awk '/^_[a-z_]+\(\) \{/ { inb = 1 } inb { print } /^\}/ { inb = 0 }' "$1"
+}
+
+run_one() {
+  local slug="$1"
+  local ep="$INTEGRATIONS/$slug/entrypoint.sh"
+  local guard helpers pidvar threshold
+  log ""
+  log "==================== $slug ===================="
+
+  guard="$(extract_guard "$ep")"
+  if [ -z "$guard" ]; then
+    log "  [FAIL] no public front-door guard found in $ep"
+    FAILED=1
+    return
+  fi
+
+  # Derive the shape from the extracted block itself — never hardcoded.
+  pidvar="$(printf '%s' "$guard" | grep -oE 'killing PID \$[A-Z_]+' | head -1 | sed 's/.*\$//')"
+  threshold="$(printf '%s' "$guard" | grep -oE 'PUBLIC_FAILS -ge [^]]+' | head -1 | sed 's/PUBLIC_FAILS -ge //')"
+  log "  frontend PID var : \$$pidvar"
+  log "  threshold        : $threshold"
+
+  # Load-bearing lines. Without these the guard could lose its probe, its
+  # alert, or its kill and a text-only test would still pass.
+  local needle ok=1
+  for needle in \
+    '/api/health' \
+    'PUBLIC_FAILS=$((PUBLIC_FAILS + 1))' \
+    'curl -fsS --max-time 5 "http://127.0.0.1:' \
+    'SLACK_WEBHOOK_OSS_ALERTS' \
+    "-X POST -H 'Content-type: application/json'"
+  do
+    if printf '%s' "$guard" | grep -qF -e "$needle"; then
+      log "  [ok]   $needle"
+    else
+      log "  [FAIL] MISSING: $needle"
+      ok=0
+    fi
+  done
+  # The kill must target the FRONTEND, never the agent.
+  if printf '%s' "$guard" | grep -qE "(kill -9 \"?\\\$$pidvar\"?|_kill_agent_tree \"\\\$$pidvar\")"; then
+    log "  [ok]   kills the frontend (\$$pidvar)"
+  else
+    log "  [FAIL] guard does not kill \$$pidvar"
+    ok=0
+  fi
+  if printf '%s' "$guard" | grep -qE 'kill -9 \"?\$(AGENT|LANGGRAPH|JAVA)_PID'; then
+    log "  [FAIL] guard kills the AGENT — wrong process"
+    ok=0
+  fi
+  [ "$ok" = 1 ] || { FAILED=1; return; }
+
+  helpers="$(extract_helpers "$ep")"
+
+  # ── Mock Slack receiver ─────────────────────────────────────────────────────
+  local cap="/tmp/wf-webhook-$slug.json"
+  local wport=$((19100 + RANDOM % 400))
+  rm -f "$cap"
+  WEBHOOK_CAPTURE="$cap" WEBHOOK_PORT="$wport" node -e '
+    const http = require("node:http"), fs = require("node:fs");
+    http.createServer((req, res) => {
+      let b = ""; req.on("data", c => b += c);
+      req.on("end", () => { fs.writeFileSync(process.env.WEBHOOK_CAPTURE, b);
+        res.writeHead(200); res.end("{}"); });
+    }).listen(parseInt(process.env.WEBHOOK_PORT, 10));
+  ' >/dev/null 2>&1 &
+  local hook_pid=$!
+
+  # ── Agent stand-in: a resident process the guard must never touch ──────────
+  sleep 100000 & local agent_pid=$!
+  sleep 0.5
+
+  # ── Case 1: WEDGED public port — alive process, nothing listening ───────────
+  sleep 100000 & local wedged=$!
+  local wport_pub=$((19600 + RANDOM % 300))
+  local out="/tmp/wf-loop-$slug.txt"
+
+  # Bind the entrypoint's own variable names, then drive its extracted body.
+  # HEALTH_* are exported for the shapes whose threshold is a variable.
+  env \
+    SLACK_WEBHOOK_OSS_ALERTS="http://127.0.0.1:${wport}/hook" \
+    RAILWAY_ENVIRONMENT_NAME="fleet-test" \
+    PORT="$wport_pub" \
+    HEALTH_STRIKE_LIMIT=3 HEALTH_CHECK_INTERVAL=30 \
+    "$pidvar=$wedged" \
+    AGENT_PID="$agent_pid" LANGGRAPH_PID="$agent_pid" JAVA_PID="$agent_pid" \
+    bash -c "
+      $helpers
+      PUBLIC_FAILS=0
+      TICKS=0
+      while sleep $WATCHDOG_SLEEP; do
+$guard
+        TICKS=\$((TICKS + 1))
+        echo tick=\$TICKS
+        if [ \$TICKS -ge 8 ]; then
+          echo fleet-guard-never-fired
+          break
+        fi
+      done
+    " > "$out" 2>&1
+
+  CHECKED=$((CHECKED + 1))
+
+  if grep -q 'syntax error' "$out"; then
+    log "  [FAIL] (a) extracted guard is not runnable:"; sed 's/^/         /' "$out" | tee -a "$TRANSCRIPT"; FAILED=1
+  elif grep -qE "probe failed on port .* \(count=3\)" "$out"; then
+    log "  [PASS] (a) reached the 3-strike threshold on a wedged port"
+  else
+    log "  [FAIL] (a) threshold never reached; loop output:"; sed 's/^/         /' "$out" | tee -a "$TRANSCRIPT"; FAILED=1
+  fi
+
+  sleep 0.4
+  if [ -s "$cap" ]; then
+    local body; body="$(cat "$cap")"
+    if printf '%s' "$body" | grep -qF "[$slug]" && printf '%s' "$body" | grep -qF "fleet-test"; then
+      log "  [PASS] (b) alert POSTed naming this integration: $(printf '%s' "$body" | head -c 150)"
+    else
+      log "  [FAIL] (b) alert body does not name $slug: $body"; FAILED=1
+    fi
+  else
+    log "  [FAIL] (b) no Slack alert captured"; FAILED=1
+  fi
+
+  if kill -0 "$wedged" 2>/dev/null; then
+    log "  [FAIL] (c) wedged frontend PID $wedged SURVIVED — guard did not kill it"; FAILED=1
+    kill -9 "$wedged" 2>/dev/null || true
+  else
+    log "  [PASS] (c) wedged frontend PID $wedged was killed"
+  fi
+  if kill -0 "$agent_pid" 2>/dev/null; then
+    log "  [PASS] (c) agent PID $agent_pid untouched"
+  else
+    log "  [FAIL] (c) the AGENT was killed — wrong process"; FAILED=1
+  fi
+
+  # ── Case 2: HEALTHY public port — must NOT kill anything ────────────────────
+  rm -f "$cap"
+  local hport=$((19900 + RANDOM % 90))
+  PORT2=$hport node -e '
+    const http = require("node:http");
+    http.createServer((_q, r) => { r.writeHead(200); r.end("{}"); })
+      .listen(parseInt(process.env.PORT2, 10));
+  ' >/dev/null 2>&1 &
+  local frontend=$!
+  sleep 0.6
+  local out2="/tmp/wf-loop-healthy-$slug.txt"
+  env \
+    SLACK_WEBHOOK_OSS_ALERTS="http://127.0.0.1:${wport}/hook" \
+    RAILWAY_ENVIRONMENT_NAME="fleet-test" \
+    PORT="$hport" \
+    HEALTH_STRIKE_LIMIT=3 HEALTH_CHECK_INTERVAL=30 \
+    "$pidvar=$frontend" \
+    AGENT_PID="$agent_pid" LANGGRAPH_PID="$agent_pid" JAVA_PID="$agent_pid" \
+    bash -c "
+      $helpers
+      PUBLIC_FAILS=0
+      TICKS=0
+      while sleep $WATCHDOG_SLEEP; do
+$guard
+        TICKS=\$((TICKS + 1))
+        echo tick=\$TICKS
+        [ \$TICKS -lt 4 ] || break
+      done
+    " > "$out2" 2>&1
+
+  # A loop that failed to run at all must NOT pass here, so require the tick
+  # markers before believing the "no strikes" result.
+  local ticks2; ticks2="$(grep -c '^tick=' "$out2")"
+  if [ "$ticks2" -lt 4 ]; then
+    log "  [FAIL] (d) guard loop did not run ($ticks2 ticks):"; sed 's/^/         /' "$out2" | tee -a "$TRANSCRIPT"; FAILED=1
+  elif grep -q 'probe failed' "$out2"; then
+    log "  [FAIL] (d) healthy port reported a failure:"; sed 's/^/         /' "$out2" | tee -a "$TRANSCRIPT"; FAILED=1
+  elif kill -0 "$frontend" 2>/dev/null; then
+    log "  [PASS] (d) healthy port: $ticks2 ticks, zero strikes, frontend alive"
+  else
+    log "  [FAIL] (d) healthy frontend was killed"; FAILED=1
+  fi
+
+  kill -9 "$frontend" "$agent_pid" "$hook_pid" 2>/dev/null || true
+}
+
+TARGETS=("$@")
+if [ ${#TARGETS[@]} -eq 0 ]; then
+  TARGETS=()
+  while IFS= read -r line; do TARGETS+=("$line"); done < <(discover)
+fi
+
+log "=== public front-door watchdog: fleet driver ==="
+log "date_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ) host=$(uname -s) bash=$BASH_VERSION"
+log "integrations under test: ${#TARGETS[@]} (${TARGETS[*]})"
+
+for slug in "${TARGETS[@]}"; do run_one "$slug"; done
+
+log ""
+log "=== summary: $CHECKED integration(s) exercised ==="
+if [ "$FAILED" = 0 ]; then
+  log "ALL PASS"
+else
+  log "FAILURES PRESENT"
+fi
+log "transcript: $TRANSCRIPT"
+exit "$FAILED"


### PR DESCRIPTION
## Why

Every dual-process showcase container runs Next.js on the public `$PORT` and an agent on a private port. The watchdog in each `entrypoint.sh` polled only the agent. A wedged Next.js was therefore invisible:

1. The Next.js process stays alive, so `wait -n` never fires and the container never restarts.
2. The agent probe still passes, so the watchdog stays satisfied.
3. The public `$PORT` is unbound or unresponsive, so the edge returns 502 for every request.

`claude-sdk-python` received a public-`$PORT` guard in 9299533bfd on 2026-07-15. No other integration did. On `main` today, **1 of 19** dual-process entrypoints guards the public port.

This supersedes #5048, which found the same gap in May. That branch is stale and conflicts in the two files that drifted most. It also predates the alerting version of the guard and misses two newer integrations. And it uses a bare `kill` in the file that now requires a process-tree kill.

## What

**1. The guard, ported to the 18 remaining dual-process entrypoints.** Each file keeps its own conventions: PID variable names, indentation, quoting style, log redirection, and strike and interval variables. Files that define a process-tree kill route the frontend kill through it. The patch anchored structurally on each file's own steady-state loop, never on line numbers. Per-file conventions were read off each file's existing agent-probe branch.

| Shape | Integrations | Frontend PID | Port expression | Kill |
|---|---|---|---|---|
| flat loop | ag2, agno, crewai-conversational-flows, crewai-crews, llamaindex, ms-agent-python, pydantic-ai, strands, google-adk, ms-agent-dotnet, ms-agent-harness-dotnet | `$NEXTJS_PID` | `${PORT}` | `kill -9` |
| 180s agent grace | claude-sdk-typescript, langgraph-fastapi, langgraph-python | `$NEXTJS_PID` | `${PORT}` | `kill -9` |
| tuned interval, tree-kill | langgraph-typescript, strands-typescript | `$NEXTJS_PID` | `${PORT}` | `_kill_agent_tree` |
| no `PORT=` assignment | langroid, spring-ai | `$NEXT_PID`, `$NODE_PID` | `${PORT:-10000}` | `kill -9` |

`mastra` and `built-in-agent` are single-process (`exec next start`). They carry no watchdog and need no guard.

**2. Two health routes decoupled from the agent.** `ms-agent-harness-dotnet/src/app/api/health/route.ts` returned 503 whenever the agent was unhealthy. The watchdog reads that route as "is the Next.js listener serving?". A slow agent therefore made the guard kill a healthy frontend, repeatedly. That route now answers 200 and reports agent state in the `agent` field, matching the other 20 integrations. The same coupling existed in the scaffolder's generated route and is fixed there too.

This is a required companion change, not scope creep. Without it the new probe is harmful in that integration. It also removes a live defect. Railway's `healthcheckPath` points at `/api/health` (`showcase/RAILWAY.md:128`), so a slow .NET agent already failed the healthcheck for a frontend that was serving fine.

**3. The `create-integration` scaffolder.** `generateEntrypoint` emitted a bare `wait -n` with no watchdog. Every new dual-process integration therefore started with this gap, and someone hand-added a watchdog later. That is how the drift was produced. The template now emits both probes, with the slug interpolated into the alert.

**4. Two gates.**

- `showcase/scripts/__tests__/entrypoint-watchdog.test.ts` (new, runs in CI). It asserts that the guard is present and intact in every dual-process entrypoint. It also asserts five properties of that guard. The probe reads `$PORT` rather than a hardcoded port. Strikes accrue on its own counter. The page fires before the kill, never after. The kill targets the frontend, never the agent. Files defining `_kill_agent_tree` route through it. It then runs the real scaffolder into a tmpdir and asserts on generated output.
- `showcase/tests/repro/stdout-wedge/watchdog-fleet.sh` (new). It extracts the guard block out of each real `entrypoint.sh` at runtime and runs **that**, so no replica can drift. The existing `watchdog.sh` beside it runs a hand-lifted copy for one integration.

## Known limitation

Three integrations have a 180s agent startup grace. There the frontend guard arms only after that grace window resolves, because it lives in the steady-state loop. A frontend wedged during a cold start is not caught for up to 180s. Arming it from `t=0` needs a second counter outside the grace loop. I left that out to keep this diff to one mechanism.

## Testing

Originally measured at `origin/main` `f8ee95eb3e`. Rebased onto `origin/main` `ad6d42a74a` and every figure below re-measured there. The rebase was conflict-free (main touched none of the 23 files) and the resulting diff is byte-identical to the pre-rebase diff.

**Coverage, measured rather than asserted.** Selects entrypoints containing `wait -n`, then checks for a `curl` against `127.0.0.1:${PORT}`:

```
origin/main: 1 / 19 dual-process entrypoints guard the public port
HEAD:       19 / 19 dual-process entrypoints guard the public port
```

**Shell syntax.** All 21 entrypoints plus both harnesses: `bash -n` clean.

**Mechanism, on the real extracted guard, all 19 integrations.** Setup: a fake healthy agent, a resident process standing in for a wedged public listener, and a local HTTP server that captures the Slack POST. Sample output for `spring-ai`, the `$NODE_PID` shape:

```
==================== spring-ai ====================
  frontend PID var : $NODE_PID
  threshold        : 3
  [PASS] (a) reached the 3-strike threshold on a wedged port
  [PASS] (b) alert POSTed naming this integration: {"text":"[spring-ai] env=fleet-test
         public $PORT (19625) /api/health unresponsive ~90s - restarting (Next.js PID 1149)"}
  [PASS] (c) wedged frontend PID 1149 was killed
  [PASS] (c) agent PID 99576 untouched
  [PASS] (d) healthy port: 4 ticks, zero strikes, frontend alive
```

Full run: `=== summary: 19 integration(s) exercised === ALL PASS`, with 95 PASS assertions. That set includes `claude-sdk-python`, which this PR does not touch. So the harness is checked against the already-landed reference implementation.

**Mutation checks on the harness.** Each mutation was applied to a real entrypoint, the harness re-run, then the file reverted:

| Mutation | Result |
|---|---|
| Probe can never fail | FAILURES PRESENT |
| Kill the agent instead of the frontend | FAILURES PRESENT |
| Threshold set to `-ge 99` | FAILURES PRESENT |
| Slack alert block removed | FAILURES PRESENT |
| restored | ALL PASS |

**Mutation checks on the CI gate.** Same method against `entrypoint-watchdog.test.ts`:

| Mutation | Result |
|---|---|
| Remove the guard from one entrypoint | 5 failed |
| Hardcode the probe port | 1 failed |
| Move the Slack alert after the kill | 1 failed |
| Re-couple a health route to the agent (503) | 1 failed |
| Revert the template to a bare `wait -n` | 2 failed |
| Drop only the public guard from the template | 1 failed |
| Re-couple the generated health route | 1 failed |
| Leave the slug placeholder uninterpolated | 1 failed |
| restored | 138 passed |

An earlier version of the scaffolder assertion grepped `index.ts` for a string. It stayed green when the template's webhook variable was renamed. It was rewritten to run the real generator and assert on generated output. That generator-based test then caught a real bug in my own change. A comment I added to the generated health route used backticks inside a TypeScript template literal, which broke the generator.

**Full `showcase/scripts` suite.** Measured in the rebased worktree and, with an identical setup, in a pristine worktree at clean `origin/main` `ad6d42a74a`:

```
this branch:  Test Files  5 failed | 74 passed (79)   Tests  8 failed | 2643 passed | 30 skipped (2681)
clean main:   Test Files  5 failed | 73 passed (78)   Tests  8 failed | 2505 passed | 30 skipped (2543)
```

The branch adds one test file and 138 tests, all passing. The 8 failures are the same 8 on both sides, in the same 5 files, none of which this PR touches:

```
 __tests__/emit-railway-envs-json.test.ts      (4 tests  | 4 failed)
 emit-railway-envs-json.test.ts                (11 tests | 4 failed | 5 skipped)
 __tests__/generate-catalog.test.ts            (13 tests | 13 skipped)  beforeAll generator hook
 __tests__/generate-registry.test.ts           (5 tests  | 5 skipped)   beforeAll generator hook
 __tests__/integration-smoke-registry.test.ts  (7 tests  | 7 skipped)   beforeAll generator hook
```

These are pre-existing environment failures, not caused by this change. Both `emit-railway-envs-json` files were re-run in isolation on each side to confirm they fail identically. An earlier revision of this description reported three such files, measured at the old base `f8ee95eb3e`; the two `emit-railway-envs-json` files became failures over the intervening 178 commits on main.

**Lint.** `oxlint` reports 2 warnings and 0 errors on `create-integration/index.ts`. Both are `no-shadow` on `probePath`, and both appear on clean `main` at the same count. Formatting used `oxfmt`.

## Not done

No Railway redeploy. Production services need a redeploy to pick up the new entrypoints. The `#oss-alerts` page stays silent until `SLACK_WEBHOOK_OSS_ALERTS` is set on each service. That is the same condition the existing `claude-sdk-python` guard already runs under.

---

Supersedes #5048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

