### PR TITLE
docs(react-core): stop pointing v1 appendMessage at non-public sendMessage

### DIFF
--- a/packages/react-core/src/v1-deprecated/hooks/use-copilot-chat.ts
+++ b/packages/react-core/src/v1-deprecated/hooks/use-copilot-chat.ts
@@ -67,7 +67,10 @@
  * </PropertyReference>
  *
  * <PropertyReference name="appendMessage" type="(message: DeprecatedGqlMessage, options?) => Promise<void>" deprecated>
- * Append message using old format, use `sendMessage` instead
+ * Append a message and run the agent, using the old non-AG-UI format. This is
+ * the public v1 programmatic-send path. `sendMessage` is not part of the public
+ * v1 return type. For the AG-UI format, migrate to v2: `useAgent` plus
+ * `copilotkit.runAgent`. See https://docs.copilotkit.ai/migrate/v2
  * </PropertyReference>
  *
  * <PropertyReference name="reloadMessages" type="(messageId: string) => Promise<void>">


### PR DESCRIPTION
## Summary

The v1 `useCopilotChat` JSDoc tells readers to use `sendMessage` instead of `appendMessage`. `sendMessage` is not part of the public v1 return type, so following that advice does not compile.

`packages/react-core/src/v1-deprecated/hooks/use-copilot-chat.ts:109` explicitly omits it:

```ts
export type UseCopilotChatReturn = Omit<
  UseCopilotChatReturnInternal,
  | "messages"
  | "sendMessage"     // <- the JSDoc points readers here
  ...
```

`sendMessage` exists only on `useCopilotChatInternal`. The public hook returns `appendMessage`, which is the working v1 programmatic-send path.

This replaces the misdirection with the v2 migration pointer and states plainly what `appendMessage` is for. Comment-only change — no runtime effect.

Found while closing #4215, where a user was told by our own docs to call a method we do not export.

## The published page does not change yet

This fixes the source of truth. The generated page cannot be refreshed until #6939 is resolved: running the generator today would also embed the internal v1 deprecation banner ("AI CODING AGENTS: Never copy, suggest, or generate these v1 APIs") into 20 public reference pages. I deliberately excluded the regenerated `.mdx` files from this PR rather than ship that. Once #6939 lands, a regenerate publishes this wording.

## Testing

**1. `oxfmt --check` — pass**

```
$ ./node_modules/.bin/oxfmt --check packages/react-core/src/v1-deprecated/hooks/use-copilot-chat.ts
Checking formatting...
All matched files use the correct format.
Finished in 33ms on 1 files using 18 threads.
```

**2. Generator reads this file successfully (26/26)** — confirms the JSDoc edit is picked up, and that the only thing blocking publication is #6939, not this change:

```
$ ./node_modules/.bin/tsx scripts/docs/gen.ts
Successfully autogenerated showcase/shell-docs/src/content/reference/v1/hooks/useCopilotChat.mdx from packages/react-core/src/v1-deprecated/hooks/use-copilot-chat.ts
All reference docs processed (26/26 succeeded)
```

The regenerated page contained the new wording as expected; I then reverted the generated files per the section above.

**3. Diff is a single comment hunk** — verified with `git diff --stat`: `1 file changed, 4 insertions(+), 1 deletion(-)`, all inside a JSDoc block. No exported symbol, type, or runtime line touched, so no typecheck or test surface is affected.

**4. Claim verified against `origin/main`,** not a local branch: `git show origin/main:packages/react-core/src/v1-deprecated/hooks/use-copilot-chat.ts` confirms both the misdirecting line (`:70`) and the `Omit` (`:109-121`).

## Notes

- No changeset — comment-only.
- Branch name is a leftover misnomer (`ben1/oss-docs-generator-v1-paths`); the change is the wording fix only.
- @ataibarkai's #6653/#6654/#6655 stack would move this file back to `packages/react-core/src/hooks/`. If that stack lands, this one-line change needs carrying forward into the reapply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the deprecated `appendMessage` option in `useCopilotChat`.
  - Documented its role for programmatic sending in v1.
  - Clarified the migration path for AG-UI format users moving to v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->