### PR TITLE
fix(react-core): let a custom catch-all renderer return null

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool-types.test-d.ts
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool-types.test-d.ts
@@ -1,0 +1,27 @@
+// Type-only assertions. A return-type widening cannot be observed by a runtime
+// test — TypeScript types are erased, so a `null`-returning render forwards
+// identically before and after the widening — which makes this file the only
+// real guard. Same mechanism as `v2/__tests__/headless-type-exports.test-d.ts`:
+// the `.test-d.ts` basename is outside vitest's `include` globs and the package
+// configures no `test.typecheck`, so nothing here executes. `tsc --noEmit`
+// (`check-types`) is what reads it, and an `expectTypeOf` failure is a compile
+// error.
+//
+// The assertion is `toEqualTypeOf` — EXACT identity, never assignability. A
+// function returning `React.ReactElement` IS assignable to one returning
+// `React.ReactElement | null`, so an assignability check would pass against the
+// un-widened type and assert nothing.
+import { expectTypeOf } from "vitest";
+import type React from "react";
+import type { useDefaultRenderTool } from "../use-default-render-tool";
+import type { DefaultRenderProps } from "../use-default-render-tool";
+
+type DefaultRenderToolConfig = NonNullable<
+  Parameters<typeof useDefaultRenderTool>[0]
+>;
+
+// A custom catch-all renderer must be allowed to render nothing, so that a
+// caller can suppress the built-in default for tool calls it does not handle.
+expectTypeOf<DefaultRenderToolConfig["render"]>().toEqualTypeOf<
+  ((props: DefaultRenderProps) => React.ReactElement | null) | undefined
+>();

--- a/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-default-render-tool.test.tsx
@@ -138,6 +138,54 @@ describe("useDefaultRenderTool", () => {
     expect(forwardedDeps).toBe(deps);
   });
 
+  it("lets a custom catch-all renderer suppress output by returning null", () => {
+    // A caller who only wants to render *some* tool calls needs the catch-all
+    // render to be allowed to return nothing. Adapted from #5509.
+    const customRender = vi.fn(({ status }: DefaultRenderProps) => {
+      expect(status).toBe("inProgress");
+      return null;
+    });
+
+    const Harness: React.FC = () => {
+      useDefaultRenderTool({ render: customRender });
+      return null;
+    };
+
+    render(<Harness />);
+
+    expect(mockUseRenderTool).toHaveBeenCalledTimes(1);
+    const [config] = mockUseRenderTool.mock.calls[0] as [
+      {
+        name: string;
+        render: (props: {
+          name: string;
+          toolCallId: string;
+          args: unknown;
+          status: string;
+          result: string | undefined;
+        }) => React.ReactElement | null;
+      },
+    ];
+
+    const rendered = config.render({
+      name: "searchDocs",
+      toolCallId: "tc-null-catchall",
+      args: { query: "copilot" },
+      status: "inProgress",
+      result: undefined,
+    });
+
+    expect(rendered).toBeNull();
+    expect(customRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "searchDocs",
+        toolCallId: "tc-null-catchall",
+        parameters: { query: "copilot" },
+        status: "inProgress",
+      }),
+    );
+  });
+
   it("default renderer shows status and expands to show parameters/result", () => {
     // Render DefaultToolCallRenderer directly with the documented prop shape.
     // (The registered `*` render wraps the framework-internal RawRendererProps;

--- a/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
+++ b/packages/react-core/src/v2/hooks/use-default-render-tool.tsx
@@ -127,7 +127,7 @@ export function adaptRendererProps(
  */
 export function useDefaultRenderTool(
   config?: {
-    render?: (props: DefaultRenderProps) => React.ReactElement;
+    render?: (props: DefaultRenderProps) => React.ReactElement | null;
   },
   deps?: ReadonlyArray<unknown>,
 ): void {
@@ -137,16 +137,18 @@ export function useDefaultRenderTool(
   // documented {@link DefaultRenderProps} (parameters, string-union status)
   // even though `useRenderToolCall` invokes the registered render with the
   // framework-internal `{ args, status: ToolCallStatus, ... }` shape.
-  const registered: (props: RawRendererProps) => React.ReactElement = userRender
-    ? (raw) => userRender(adaptRendererProps(raw))
-    : (raw) => <DefaultToolCallRenderer {...adaptRendererProps(raw)} />;
+  const registered: (props: RawRendererProps) => React.ReactElement | null =
+    userRender
+      ? (raw) => userRender(adaptRendererProps(raw))
+      : (raw) => <DefaultToolCallRenderer {...adaptRendererProps(raw)} />;
 
   useRenderTool(
     {
       name: "*",
-      // `useRenderTool` types the render with the raw framework signature;
-      // the wrapper above adapts to the documented shape. We cast through
-      // `unknown` to bridge the public type without `as any`.
+      // `useRenderTool` types the render with the raw framework signature
+      // and still requires a `React.ReactElement` return; the wrapper above
+      // adapts to the documented shape and may return `null`. We cast through
+      // `unknown` to bridge both gaps without `as any`.
       render: registered as unknown as (props: unknown) => React.ReactElement,
     },
     deps,

--- a/showcase/shell-docs/src/content/reference/hooks/useDefaultRenderTool.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useDefaultRenderTool.mdx
@@ -26,7 +26,7 @@ function useDefaultRenderTool(
       parameters: any;
       status: string;
       result: string | undefined;
-    }) => React.ReactElement;
+    }) => React.ReactElement | null;
   },
   deps?: ReadonlyArray<unknown>,
 ): void;
@@ -37,6 +37,7 @@ function useDefaultRenderTool(
 - Internally calls `useRenderTool({ name: "*", ... })`.
 - If `config.render` is omitted, uses an expandable default card UI that shows status, parameters, and result.
 - If `config.render` is provided, your renderer is used instead.
+- Your renderer can return `null` to draw nothing. Use this to render only the tool calls you care about and suppress the rest.
 - Inherits `useRenderTool` registration behavior and dependency semantics.
 
 ## Usage


### PR DESCRIPTION
## Summary

`useDefaultRenderTool`'s `render` was typed to return `React.ReactElement`. A caller who wants to render only *some* tool calls therefore could not return `null` to suppress the built-in default for the rest — the value flowed through correctly at runtime, but the type rejected it.

This widens the public `render` return type, and the wrapper local that carries the user's value, to `React.ReactElement | null`.

```diff
-    render?: (props: DefaultRenderProps) => React.ReactElement;
+    render?: (props: DefaultRenderProps) => React.ReactElement | null;
```

The reference page hand-writes the same signature, so it is updated to match, with one behavior bullet describing what `null` does.

## Scope, and its relationship to #6533

#6533 already widens the same return type to `React.ReactElement | null` in `defineToolCallRenderer.ts` and `use-render-tool.tsx`. It does **not** touch `use-default-render-tool.tsx`, which is the remaining gap and the whole of this PR. There is **no file overlap**, so the two can land in either order.

A structural sweep of `react-core/src/v2` for renders still typed `=> React.ReactElement` with no `| null` confirms this leaves nothing behind on this surface:

```
types/defineToolCallRenderer.ts:40,48,56   <- #6533
hooks/use-render-tool.tsx:41,72,109        <- #6533
hooks/use-default-render-tool.tsx:152      <- the deliberate bridge cast, below
hooks/use-interrupt.tsx:89                 <- different surface, out of scope
components/chat/CopilotChatMessageView.tsx:418  <- different surface, out of scope
```

The `as unknown as` cast into `useRenderTool` is deliberately left in place: `useRenderTool` still requires a `ReactElement` return on `main` (verified again after the rebase — `use-render-tool.tsx:41`). Once #6533 lands, that cast can be tightened. The bridge comment is updated to say so.

`DefaultToolCallRenderer`'s own return type stays `React.ReactElement` — the built-in default always renders an element.

The Vue counterpart needs no equivalent change: its `render` already returns `VNodeChild`, which admits `null`, and `reference/vue/hooks/useDefaultRenderTool.mdx` already matches.

## Why the guard is a type test, not a runtime test

TypeScript types are erased, so a `null`-returning render forwards identically before and after the widening. The runtime test passes against un-widened source, which makes it worthless as a guard for this change. So the real guard is `use-default-render-tool-types.test-d.ts`, using the `expectTypeOf` + `toEqualTypeOf` convention already documented in `v2/__tests__/headless-type-exports.test-d.ts`.

`toEqualTypeOf` is required rather than assignability: a function returning `ReactElement` **is** assignable to one returning `ReactElement | null`, so an assignability check would pass against the un-widened type and assert nothing.

The `.test-d.ts` basename is outside vitest's `include` globs, so nothing there executes; `tsc --noEmit` (`check-types`) is what reads it. Confirmed on this base:

```
$ vitest list --filesOnly | grep -c "test-d"
0
$ grep -n include -A4 packages/react-core/vitest.config.mjs
    include: [
      "src/**/__tests__/**/*.{test,spec}.{ts,tsx}",
      "src/**/*.{test,spec}.{ts,tsx}",
    ],
$ grep include packages/react-core/tsconfig.json
  "include": ["src/**/*"],
```

The runtime test is kept as well, since it still covers prop adaptation and forwarding.

## Testing

All numbers below were re-measured after the rebase onto `main` (`42494df`).

**Mutation check of the type guard** — revert the widening in the source, confirm the guard goes red:

```
########## RUN A: rebased HEAD as-is ##########
total errors: 63
--- errors in touched files ---
  none

########## RUN B: MUTATION - widening reverted in source ##########
total errors: 65
--- guard file errors (expect FAIL) ---
use-default-render-tool-types.test-d.ts(26,3): error TS2344:
  Type '((props: DefaultRenderProps) => ReactElement<...> | null) | undefined'
  does not satisfy the constraint
  '"Expected: undefined, Actual: never" | "Expected: function, Actual: never"'.
use-default-render-tool.test.tsx(150,30): error TS2322:
  Type 'Mock<({ status }: DefaultRenderProps) => null>' is not assignable to
  type '(props: DefaultRenderProps) => ReactElement<...>'.
  Type 'null' is not assignable to type 'ReactElement<...>'.
```

The guard fails when the widening is reverted, and the two new errors are exactly the guard plus the runtime test's own use of it. Nothing else moves.

**Typecheck** (`tsc -p packages/react-core --noEmit`) — error set byte-identical to pristine `origin/main` in the same worktree, none in the touched files:

```
########## RUN C: pristine origin/main baseline ##########
total errors on pristine main: 63
=== diff: pristine-main errors vs HEAD errors ===
IDENTICAL -> the change introduces no new type errors
```

The 63 are pre-existing worktree noise: `react-core` resolves `@copilotkit/core` and `@copilotkit/shared` from a sibling checkout's `dist`, so unrelated exports read as missing. They are present on pristine `origin/main` in the same worktree, which is what the diff above shows.

**Target test file:**

```
 ✓ src/v2/hooks/__tests__/use-default-render-tool.test.tsx (13 tests) 38ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

**Broader `src/v2/hooks` + `src/v2/types`** — failure counts identical to pristine `origin/main` in the same worktree, plus exactly the one new passing test:

```
=== BASELINE (pristine origin/main in this worktree) ===
 Test Files  22 failed | 17 passed (39)
      Tests  9 failed | 201 passed (210)

=== WITH my change ===
 Test Files  22 failed | 17 passed (39)
      Tests  9 failed | 202 passed (211)
```

**Lint:** `oxlint packages/react-core/src/v2/hooks/` — `Found 62 warnings and 0 errors.` (all pre-existing exhaustive-deps warnings, none in the touched files).

**Formatting:** `oxfmt --check` on the three source/test files — `All matched files use the correct format.` `oxfmt` does not process `.mdx`, so the reference page is out of its scope.

**Public-API manifest:** no regeneration needed — `scripts/release/public-api/manifest.v1.json` records no type signatures and does not mention `useDefaultRenderTool` (`grep -c ReactElement` → `0`).

## Provenance

Extracted from #5509 (@ataibarkai), which is 3915 commits behind `main` and being closed. That PR also changed `defineToolCallRenderer`'s schema default from `def.name === "*" && !def.args ? z.any() : def.args` to `def.args ?? z.any()`. **That change is deliberately not carried here** — it alters runtime behavior for named renderers declared without `args` (from `args: undefined` to `args: z.any()`) and deserves its own PR and its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom renderers can now return `null` to suppress output when no UI should be displayed.

* **Documentation**
  * Updated `useDefaultRenderTool` guidance to describe null-return behavior and selectively rendering tool calls.

* **Tests**
  * Added coverage confirming null-render behavior and forwarded renderer properties.
  * Added compile-time validation for supported renderer return types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->