### PR TITLE
docs(repo): point contributor issue links at the CopilotKit tracker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ We love community contributions! That said, we want to make sure we're all on th
 Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
 It also helps to make sure the work you're planning isn't already in progress.
 
-As described in our contributing guide, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
+As described in our contributing guide, please file an issue first: https://github.com/CopilotKit/CopilotKit/issues
 Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We love community contributions! That said, we want to make sure we're all on th
 Investing a lot of time and effort just to find out it doesn't align with the upstream project feels awful, and we don't want that to happen.
 It also helps to make sure the work you're planning isn't already in progress.
 
-As described below, please file an issue first: https://github.com/ag-ui-protocol/ag-ui/issues
+As described below, please file an issue first: https://github.com/CopilotKit/CopilotKit/issues
 Or, reach out to us on Discord: https://discord.com/invite/6dffbvGU3D
 
 Ready to contribute but seeking guidance, we have several avenues to assist you. Explore the upcoming segment for clarity on the kind of contributions we appreciate and how to jump in. Reach out to us directly on [Discord](https://discord.gg/6dffbvGU3D) for immediate assistance! Alternatively, you're welcome to raise an issue and one of our dedicated maintainers will promptly steer you in the right direction!


### PR DESCRIPTION
## What does this PR do?

`CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` both told contributors to file an issue at `ag-ui-protocol/ag-ui` before starting significant work. Both now point at this repo's own tracker.

This is a copy artifact, not intent:

- The sentence in `CONTRIBUTING.md` says "As described below" — but the sections below ("Found a bug?", "Missing a feature?") link to `CopilotKit/CopilotKit` issue templates. It contradicted its own cross-reference.
- Both lines came in together in 398adf3, and the identical sentence already existed in ag-ui's own contributing guide (whose copy predates it). The paragraph was lifted from there and the link travelled with it.
- This repo maintains active issue forms (`1-bug-report.yml`, `2-feature-request.yml`, `3-documentation.yml`), `ISSUE_TEMPLATE/config.yml` has no redirect to ag-ui, and the tracker carries 264 issues labelled "feature request" — feature requests demonstrably belong here.

I used the plain `/issues` URL rather than a `?template=` deep link: this pointer covers any significant work, and the two sections below already route to the specific bug and feature forms.

The AG-UI reference in the documentation-domains section is untouched — protocol docs really are authored upstream in `ag-ui-protocol/ag-ui`.

## Related PRs and Issues

- Introduced in 398adf3fd0

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

---

While in these files I found three further stale links, left out to keep this diff to the one reported problem — happy to fold them in or split them off:

- `CONTRIBUTING.md:22` and `:26` deep-link to `template=bug_report.yaml` and `template=feature_request.yaml`. Those filenames have never existed (the forms are `1-bug-report.yml` / `2-feature-request.yml`), so GitHub silently drops the template and serves the chooser instead. `labels=feature-request` is also wrong; the real label is `feature request`.
- `.github/PULL_REQUEST_TEMPLATE.md:19` and `:35` link to `blob/master/CONTRIBUTING.md`. There is no `master` branch on this remote, so both 404.
- `.github/ISSUE_TEMPLATE/config.yml` points its docs contact link at `https://docs.copilot.ai` — very likely meant to be `https://docs.copilotkit.ai`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated issue-reporting links in contribution guidance and pull request templates to point to the CopilotKit issue tracker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->