### PR TITLE
fix(showcase): retry transient staging Railway reads

### DIFF
--- a/showcase/scripts/reconcile-staging.test.ts
+++ b/showcase/scripts/reconcile-staging.test.ts
@@ -741,6 +741,39 @@ describe("liveFetchDeployedDigest Railway read retry", () => {
     },
   );
 
+  it("does not retry fetch-phase request-construction TypeErrors", async () => {
+    const invalidHeaderMessages = [
+      'Headers.append: "Bearer bad\\nheader" is an invalid header value.',
+      'Headers.append: "Bearer bad\\nnetwork" is an invalid header value.',
+    ];
+
+    for (const message of invalidHeaderMessages) {
+      const fetchSpy = vi.fn().mockRejectedValue(new TypeError(message));
+      vi.stubGlobal("fetch", fetchSpy);
+      const slackSpy = vi.fn(async () => true);
+
+      const summary = await reconcileStaging({
+        services: ["showcase-ag2"],
+        fetchDeployedDigest: (serviceId, environmentId) =>
+          liveFetchDeployedDigest("bad\nheader", serviceId, environmentId),
+        fetchLatestDigest: async () => DIGEST_B,
+        redeployStaging: vi.fn(),
+        postSlackAlert: slackSpy,
+        log: () => {},
+      });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(summary.unconfirmed.map((u) => u.service)).toEqual([
+        "showcase-ag2",
+      ]);
+      expect(summary.errors[0]?.error).toContain("invalid header value");
+      expect(slackSpy).toHaveBeenCalledTimes(1);
+      expect(reconcileExitCode(summary)).not.toBe(0);
+
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("exhausts retryable 503s through reconcileStaging as unconfirmed with Slack and non-zero exit", async () => {
     vi.useFakeTimers();
     const fetchSpy = vi

--- a/showcase/scripts/reconcile-staging.test.ts
+++ b/showcase/scripts/reconcile-staging.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  liveFetchDeployedDigest,
   pickNewestSuccessDigest,
   reconcileExitCode,
   reconcileStaging,
@@ -18,6 +19,56 @@ const DIGEST_A =
   "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const DIGEST_B =
   "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const successDeploymentsJson = (digest: string) => ({
+  data: {
+    deployments: {
+      edges: [
+        {
+          node: {
+            id: "deployment-old",
+            status: "SUCCESS",
+            meta: { imageDigest: DIGEST_A },
+            createdAt: "2026-07-01T00:00:00.000Z",
+          },
+        },
+        {
+          node: {
+            id: "deployment-new",
+            status: "SUCCESS",
+            meta: { imageDigest: digest },
+            createdAt: "2026-07-02T00:00:00.000Z",
+          },
+        },
+      ],
+    },
+  },
+});
+
+function mockRailwayResponse(
+  status: number,
+  body: unknown,
+  opts: { textRejects?: unknown; jsonRejects?: unknown } = {},
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: vi.fn(async () => {
+      if (opts.textRejects !== undefined) throw opts.textRejects;
+      return typeof body === "string" ? body : JSON.stringify(body);
+    }),
+    json: vi.fn(async () => {
+      if (opts.jsonRejects !== undefined) throw opts.jsonRejects;
+      if (typeof body === "string") return JSON.parse(body);
+      return body;
+    }),
+  } as unknown as Response;
+}
+
+async function flushRetryTimers<T>(promise: Promise<T>): Promise<T> {
+  await vi.advanceTimersByTimeAsync(2_000);
+  return promise;
+}
 
 describe("selectLaggingServices (pure decision logic)", () => {
   it("returns [] when every service's deployed digest matches :latest", () => {
@@ -619,6 +670,198 @@ describe("reconcileStaging invariant (green ⇔ every service confirmed current)
 
     expect(reconcileExitCode(summary)).toBe(0);
     expect(slackSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("liveFetchDeployedDigest Railway read retry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("retries transient Railway 503 responses and returns the newest SUCCESS digest", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(mockRailwayResponse(503, "try one"))
+      .mockResolvedValueOnce(mockRailwayResponse(503, "try two"))
+      .mockResolvedValueOnce(
+        mockRailwayResponse(200, successDeploymentsJson(DIGEST_B)),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resultPromise = liveFetchDeployedDigest(
+      "token",
+      "service-id",
+      "environment-id",
+    );
+    const result = await flushRetryTimers(resultPromise);
+
+    expect(result).toBe(DIGEST_B);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    const signals = fetchSpy.mock.calls.map(([, init]) => init?.signal);
+    expect(new Set(signals).size).toBe(3);
+  });
+
+  it.each([
+    [
+      "fetch rejection",
+      new TypeError("fetch failed"),
+      mockRailwayResponse(200, successDeploymentsJson(DIGEST_B)),
+    ],
+    [
+      "body timeout",
+      mockRailwayResponse(200, successDeploymentsJson(DIGEST_A), {
+        jsonRejects: new DOMException("read timed out", "TimeoutError"),
+      }),
+      mockRailwayResponse(200, successDeploymentsJson(DIGEST_B)),
+    ],
+  ])(
+    "recovers from %s without real-time sleeping",
+    async (_name, first, second) => {
+      vi.useFakeTimers();
+      const fetchSpy = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          if (first instanceof Error) throw first;
+          return first;
+        })
+        .mockResolvedValueOnce(second);
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const resultPromise = liveFetchDeployedDigest(
+        "token",
+        "service-id",
+        "environment-id",
+      );
+      const result = await flushRetryTimers(resultPromise);
+
+      expect(result).toBe(DIGEST_B);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("exhausts retryable 503s through reconcileStaging as unconfirmed with Slack and non-zero exit", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(mockRailwayResponse(503, "try one"))
+      .mockResolvedValueOnce(mockRailwayResponse(503, "try two"))
+      .mockResolvedValueOnce(mockRailwayResponse(503, "try three"));
+    vi.stubGlobal("fetch", fetchSpy);
+    const slackSpy = vi.fn(async () => true);
+
+    const summaryPromise = reconcileStaging({
+      services: ["showcase-ag2"],
+      fetchDeployedDigest: (serviceId, environmentId) =>
+        liveFetchDeployedDigest("token", serviceId, environmentId),
+      fetchLatestDigest: async () => DIGEST_B,
+      redeployStaging: vi.fn(),
+      postSlackAlert: slackSpy,
+      log: () => {},
+    });
+    const summary = await flushRetryTimers(summaryPromise);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(summary.unconfirmed.map((u) => u.service)).toEqual(["showcase-ag2"]);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+
+  it("uses the live reader in reconcileStaging to recover from one Railway 503 without alerting", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(mockRailwayResponse(503, "temporary"))
+      .mockResolvedValueOnce(
+        mockRailwayResponse(200, successDeploymentsJson(DIGEST_A)),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+    const slackSpy = vi.fn(async () => true);
+
+    const summaryPromise = reconcileStaging({
+      services: ["showcase-ag2"],
+      fetchDeployedDigest: (serviceId, environmentId) =>
+        liveFetchDeployedDigest("token", serviceId, environmentId),
+      fetchLatestDigest: async () => DIGEST_A,
+      redeployStaging: vi.fn(),
+      postSlackAlert: slackSpy,
+      log: () => {},
+    });
+    const summary = await flushRetryTimers(summaryPromise);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(summary.errors).toEqual([]);
+    expect(summary.unconfirmed).toEqual([]);
+    expect(slackSpy).not.toHaveBeenCalled();
+    expect(reconcileExitCode(summary)).toBe(0);
+  });
+
+  it.each([
+    ["401", mockRailwayResponse(401, "unauthorized")],
+    [
+      "401 with unreadable body",
+      mockRailwayResponse(401, "ignored", {
+        textRejects: new DOMException("read timed out", "TimeoutError"),
+      }),
+    ],
+  ])("%s fails fast through reconcileStaging", async (_name, response) => {
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+    const slackSpy = vi.fn(async () => true);
+
+    const summary = await reconcileStaging({
+      services: ["showcase-ag2"],
+      fetchDeployedDigest: (serviceId, environmentId) =>
+        liveFetchDeployedDigest("token", serviceId, environmentId),
+      fetchLatestDigest: async () => DIGEST_B,
+      redeployStaging: vi.fn(),
+      postSlackAlert: slackSpy,
+      log: () => {},
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(summary.unconfirmed.map((u) => u.service)).toEqual(["showcase-ag2"]);
+    expect(summary.errors[0]?.error).toContain(
+      "Railway deployments query HTTP 401",
+    );
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileExitCode(summary)).not.toBe(0);
+  });
+
+  it.each([
+    [
+      "nontransport body TypeError",
+      mockRailwayResponse(200, successDeploymentsJson(DIGEST_A), {
+        jsonRejects: new TypeError("programming error"),
+      }),
+    ],
+    ["malformed JSON", mockRailwayResponse(200, "{not json")],
+    [
+      "GraphQL errors",
+      mockRailwayResponse(200, {
+        errors: [{ message: "GraphQL rejected the query" }],
+      }),
+    ],
+  ])("%s fails fast through reconcileStaging", async (_name, response) => {
+    const fetchSpy = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchSpy);
+    const slackSpy = vi.fn(async () => true);
+
+    const summary = await reconcileStaging({
+      services: ["showcase-ag2"],
+      fetchDeployedDigest: (serviceId, environmentId) =>
+        liveFetchDeployedDigest("token", serviceId, environmentId),
+      fetchLatestDigest: async () => DIGEST_B,
+      redeployStaging: vi.fn(),
+      postSlackAlert: slackSpy,
+      log: () => {},
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(summary.unconfirmed.map((u) => u.service)).toEqual(["showcase-ag2"]);
+    expect(slackSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileExitCode(summary)).not.toBe(0);
   });
 });
 

--- a/showcase/scripts/reconcile-staging.ts
+++ b/showcase/scripts/reconcile-staging.ts
@@ -721,7 +721,47 @@ function isRetryableRailwayReadStatus(status: number): boolean {
   return status === 429 || status >= 500;
 }
 
-function isRetryableTransportError(error: unknown, phase: "fetch" | "body") {
+function hasRetryableTransportSignature(error: TypeError): boolean {
+  if (
+    /^(failed to fetch|fetch failed|terminated)$/i.test(error.message) ||
+    /^networkerror when attempting to fetch resource\.?$/i.test(
+      error.message,
+    ) ||
+    /^the operation (was )?aborted\.?$/i.test(error.message) ||
+    /^the operation timed out\.?$/i.test(error.message)
+  ) {
+    return true;
+  }
+
+  const cause = error.cause;
+  if (cause === null || typeof cause !== "object") return false;
+
+  const code = (cause as { code?: unknown }).code;
+  if (
+    typeof code === "string" &&
+    (code.startsWith("UND_ERR_") ||
+      [
+        "ENOTFOUND",
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "ETIMEDOUT",
+        "EAI_AGAIN",
+      ].includes(code))
+  ) {
+    return true;
+  }
+
+  const message = (cause as { message?: unknown }).message;
+  return (
+    typeof message === "string" &&
+    (/^(failed to fetch|fetch failed|terminated)$/i.test(message) ||
+      /^networkerror when attempting to fetch resource\.?$/i.test(message) ||
+      /^the operation (was )?aborted\.?$/i.test(message) ||
+      /^the operation timed out\.?$/i.test(message))
+  );
+}
+
+function isRetryableTransportError(error: unknown) {
   if (error instanceof DOMException) {
     return (
       error.name === "AbortError" ||
@@ -730,8 +770,7 @@ function isRetryableTransportError(error: unknown, phase: "fetch" | "body") {
     );
   }
   if (!(error instanceof TypeError)) return false;
-  if (phase === "fetch") return true;
-  return /fetch failed|network|terminated|timeout|aborted/i.test(error.message);
+  return hasRetryableTransportSignature(error);
 }
 
 function railwayReadRetryDelay(attempt: number): Promise<void> {
@@ -791,7 +830,7 @@ export async function liveFetchDeployedDigest(
     } catch (e) {
       if (
         attempt < RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS &&
-        isRetryableTransportError(e, "fetch")
+        isRetryableTransportError(e)
       ) {
         await railwayReadRetryDelay(attempt);
         continue;
@@ -826,7 +865,7 @@ export async function liveFetchDeployedDigest(
     } catch (e) {
       if (
         attempt < RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS &&
-        isRetryableTransportError(e, "body")
+        isRetryableTransportError(e)
       ) {
         await railwayReadRetryDelay(attempt);
         continue;

--- a/showcase/scripts/reconcile-staging.ts
+++ b/showcase/scripts/reconcile-staging.ts
@@ -625,6 +625,8 @@ export async function reconcileStaging(
 // ── Live wiring (main) ──────────────────────────────────────────────────────
 
 const RAILWAY_API = RAILWAY_GRAPHQL_ENDPOINT;
+const RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS = 3;
+const RAILWAY_DEPLOYMENTS_QUERY_RETRY_DELAYS_MS = [500, 1_000] as const;
 
 /**
  * Resolve the Railway bearer token, mapping a RailwayTokenError onto the
@@ -715,52 +717,131 @@ export function pickNewestSuccessDigest(
   return digest;
 }
 
+function isRetryableRailwayReadStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function isRetryableTransportError(error: unknown, phase: "fetch" | "body") {
+  if (error instanceof DOMException) {
+    return (
+      error.name === "AbortError" ||
+      error.name === "NetworkError" ||
+      error.name === "TimeoutError"
+    );
+  }
+  if (!(error instanceof TypeError)) return false;
+  if (phase === "fetch") return true;
+  return /fetch failed|network|terminated|timeout|aborted/i.test(error.message);
+}
+
+function railwayReadRetryDelay(attempt: number): Promise<void> {
+  const delay = RAILWAY_DEPLOYMENTS_QUERY_RETRY_DELAYS_MS[attempt - 1] ?? 0;
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+async function readRailwayErrorBody(res: Response): Promise<string> {
+  try {
+    return sanitizeErrorBody(await res.text());
+  } catch (e) {
+    const message = sanitizeErrorBody(
+      e instanceof Error ? e.message : String(e),
+    );
+    return `body unavailable: ${message}`;
+  }
+}
+
 /**
  * Read the digest the staging deployment is ACTUALLY running: the newest
  * SUCCESS deployment's `meta.imageDigest`. Mirrors `showcase/bin/railway`'s
  * `staging_running_digest`. Returns null when no SUCCESS deployment /
  * imageDigest is available.
  */
-async function liveFetchDeployedDigest(
+export async function liveFetchDeployedDigest(
   token: string,
   serviceId: string,
   environmentId: string,
 ): Promise<string | null> {
-  const res = await fetch(RAILWAY_API, {
-    method: "POST",
-    signal: AbortSignal.timeout(30_000),
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      // first:10 is a safe upper bound: a staging service's newest SUCCESS is
-      // effectively always among its 10 most-recent deployments (queued/failed
-      // attempts included). We do NOT rely on the connection's order — see
-      // pickNewestSuccessDigest, which sorts by createdAt.
-      query: `query Deployments($serviceId: String!, $environmentId: String!) {
-        deployments(first: 10, input: { serviceId: $serviceId, environmentId: $environmentId }) {
-          edges { node { id status meta createdAt } }
-        }
-      }`,
-      variables: { serviceId, environmentId },
-    }),
-  });
-  if (!res.ok) {
-    const body = sanitizeErrorBody(await res.text());
-    throw new Error(`Railway deployments query HTTP ${res.status}: ${body}`);
+  for (
+    let attempt = 1;
+    attempt <= RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS;
+    attempt++
+  ) {
+    let res: Response;
+    try {
+      res = await fetch(RAILWAY_API, {
+        method: "POST",
+        signal: AbortSignal.timeout(30_000),
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          // first:10 is a safe upper bound: a staging service's newest SUCCESS is
+          // effectively always among its 10 most-recent deployments (queued/failed
+          // attempts included). We do NOT rely on the connection's order — see
+          // pickNewestSuccessDigest, which sorts by createdAt.
+          query: `query Deployments($serviceId: String!, $environmentId: String!) {
+            deployments(first: 10, input: { serviceId: $serviceId, environmentId: $environmentId }) {
+              edges { node { id status meta createdAt } }
+            }
+          }`,
+          variables: { serviceId, environmentId },
+        }),
+      });
+    } catch (e) {
+      if (
+        attempt < RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS &&
+        isRetryableTransportError(e, "fetch")
+      ) {
+        await railwayReadRetryDelay(attempt);
+        continue;
+      }
+      throw e;
+    }
+
+    if (!res.ok) {
+      const body = await readRailwayErrorBody(res);
+      const error = new Error(
+        `Railway deployments query HTTP ${res.status}: ${body}`,
+      );
+      if (
+        attempt < RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS &&
+        isRetryableRailwayReadStatus(res.status)
+      ) {
+        await railwayReadRetryDelay(attempt);
+        continue;
+      }
+      throw error;
+    }
+
+    let json: {
+      data?: DeploymentsResponse;
+      errors?: Array<{ message: string }>;
+    };
+    try {
+      json = (await res.json()) as {
+        data?: DeploymentsResponse;
+        errors?: Array<{ message: string }>;
+      };
+    } catch (e) {
+      if (
+        attempt < RAILWAY_DEPLOYMENTS_QUERY_ATTEMPTS &&
+        isRetryableTransportError(e, "body")
+      ) {
+        await railwayReadRetryDelay(attempt);
+        continue;
+      }
+      throw e;
+    }
+    if (json.errors?.length) {
+      throw new Error(
+        json.errors.map((e) => sanitizeErrorBody(e.message)).join("; "),
+      );
+    }
+    const edges = json.data?.deployments?.edges ?? [];
+    return pickNewestSuccessDigest(edges);
   }
-  const json = (await res.json()) as {
-    data?: DeploymentsResponse;
-    errors?: Array<{ message: string }>;
-  };
-  if (json.errors?.length) {
-    throw new Error(
-      json.errors.map((e) => sanitizeErrorBody(e.message)).join("; "),
-    );
-  }
-  const edges = json.data?.deployments?.edges ?? [];
-  return pickNewestSuccessDigest(edges);
+  throw new Error("Railway deployments query retry loop exhausted");
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

A single transient Railway deployment-read failure currently leaves a staging service unconfirmed and immediately alerts Slack. The recent [503 run](https://github.com/CopilotKit/CopilotKit/actions/runs/34247138533) confirmed 40 services, found no lagging services, and failed on one Railway read.

Retry transient Railway deployment reads up to three times, with 500 ms / 1,000 ms backoff and a fresh 30-second timeout per attempt. Retries cover HTTP 429/5xx, transport failures, and interrupted response-body reads. Authentication/client errors, malformed requests, JSON failures, and GraphQL errors still fail immediately. Exhausted reads still leave the service unconfirmed, post an alert, and fail the run.

This implements bounded retries within the same run, without cross-run debounce or cached monitor state. In-progress deployment handling remains separate from this read-failure fix.

## Validation

- 38 focused reconcile tests passed, including recovery, retry exhaustion, fresh timeout signals, and fail-fast request/auth/parse cases.
- Full scripts package: 78 test files and 2,554 tests passed.
- Nx formatter, lint, and explicit package typecheck passed.
- Regression tests failed against the original behavior before the fix; confirmation review found no remaining required fixes within this scope.

## Related PRs and Issues

- [#6613](https://github.com/CopilotKit/CopilotKit/pull/6613) — implements the bounded Railway-read retry portion of the requested narrowing.

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/CopilotKit/CopilotKit/blob/main/CONTRIBUTING.md).
- [x] Relevant implementation comments and regression tests are updated; this internal CI fix requires no product documentation change.
- [x] Maintainer edits: this branch is in the main repository, so standard repository permissions apply.
