### PR TITLE
Point the Channels docs at an SDK pair that can render components

### DIFF
--- a/showcase/shell-docs/src/content/docs/channels/deploy-and-operate.mdx
+++ b/showcase/shell-docs/src/content/docs/channels/deploy-and-operate.mdx
@@ -12,7 +12,7 @@ consumer or WebSocket worker.
 ## Use the tested runtime pair
 
 ```bash title="Terminal"
-npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0
+npm install --save-exact @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2
 ```
 
 Run Node.js 22 or later. The managed launcher relies on the global `WebSocket`

--- a/showcase/shell-docs/src/content/docs/frontends/slack.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/slack.mdx
@@ -37,7 +37,7 @@ You should have `CHANNEL_CODE` and `CPK_INTELLIGENCE_API_KEY`.
     cd my-slack-channel
     npm init -y
     npm pkg set type=module
-    npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0
+    npm install --save-exact @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2
     npm install -D tsx typescript @types/node
     ```
 

--- a/showcase/shell-docs/src/content/docs/frontends/teams.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/teams.mdx
@@ -65,7 +65,7 @@ re-installing.
     cd my-teams-channel
     npm init -y
     npm pkg set type=module
-    npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0
+    npm install --save-exact @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2
     npm install -D tsx typescript @types/node
     ```
 

--- a/showcase/shell-docs/src/content/reference/channels/index.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/index.mdx
@@ -10,8 +10,11 @@ the agent, tools, approvals, state, and deployment. The package also exports
 developer-operated direct adapters for Slack, Teams, Discord, Telegram, and
 WhatsApp.
 
+`@copilotkit/channels` and `@copilotkit/runtime` ship as an exact, tested
+pair. Install them with `--save-exact` and upgrade them together.
+
 ```sh
-npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0
+npm install --save-exact @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2
 ```
 
 ## API reference

--- a/showcase/shell-docs/src/content/reference/channels/sdk/direct-adapters.mdx
+++ b/showcase/shell-docs/src/content/reference/channels/sdk/direct-adapters.mdx
@@ -11,7 +11,7 @@ description: Public Slack, Teams, Discord, Telegram, and WhatsApp adapter entry 
 | Direct adapter       | `createChannel({ name, adapters, identifyUser, agent })` | Your Channels process stores provider credentials and owns the provider socket or webhook | Slack, Microsoft Teams, Discord, Telegram, and WhatsApp |
 
 Managed Intelligence support for Discord and WhatsApp is coming soon. Their
-direct adapters already ship in `@copilotkit/channels@0.6.1`.
+direct adapters already ship in `@copilotkit/channels@0.9.2`.
 
 <Callout type="info" title="Direct does not mean standalone">
   A direct adapter moves the provider connection into your process. The
@@ -27,7 +27,7 @@ direct adapters already ship in `@copilotkit/channels@0.6.1`.
 Install the umbrella package and its tested runtime version:
 
 ```sh
-npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0
+npm install --save-exact @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2
 ```
 
 The package and all provider subpaths are ESM-only public exports. Use

--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -186,9 +186,9 @@ describe("Channels documentation journey", () => {
 
   it("installs the exact stable Channels SDK pair in both provider quickstarts", () => {
     const testedInstall =
-      "npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0";
+      "npm install --save-exact @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2";
     const nonExactInstall =
-      "npm install @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0";
+      "npm install @copilotkit/channels@0.9.2 @copilotkit/runtime@1.70.2";
 
     for (const slug of providerQuickstartSlugs) {
       const source = bodyFor(slug);


### PR DESCRIPTION
## The problem

Every Channels page that tells a reader what to install named a pair that is four minors stale:

```sh
npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0
```

That pin is not merely old, it is load-bearing in the wrong direction. `@copilotkit/channels@0.6.1`
does not export `defineChannelComponent`. Compiling an agent-rendered component against the version
our own quickstart installs fails outright:

```
error TS2724: '"@copilotkit/channels"' has no exported member named
'defineChannelComponent'. Did you mean 'ChannelComponent'?
```

The export listing confirms where the boundary sits. `@copilotkit/channels-core@0.6.1` ships
`defineChannelCommand` and `defineChannelTool` and nothing else in that family; `defineChannelComponent`
first appears in the 0.6.2 canary line and first ships stable in 0.7.0.

So the two halves of our own documentation disagree. The Channels setup guide gates success on "at
least one `defineChannelComponent` must render," while the reference page and both provider
quickstarts hand the reader a version in which that success criterion cannot be satisfied. A builder
following the docs faithfully reaches a compile error, and the error blames their code rather than
our pin. The bad trade they make next is guessing — dropping `--save-exact`, reaching for `@latest`,
or abandoning agent-rendered components entirely, each of which discards the tested-pair guarantee
the pin existed to provide.

The timing is what makes this worth a same-day fix rather than a queued one. The "Agents, Everywhere"
global hackathon runs Saturday 12 September 2026 across 51 cities with CopilotKit as a global
sponsor, and these are precisely the pages participants will open first.

## The approach

Every pinned pair in the Channels docs moves to `@copilotkit/channels@0.9.2` +
`@copilotkit/runtime@1.70.2`, the current published pair as of 2026-09-08. Five install lines across
the reference index, the direct-adapters reference, the deploy-and-operate how-to, and the Slack and
Teams quickstarts.

**The pin is what changes, not the prose.** Where a page's guidance implies agent-rendered components
are available, that guidance was already correct — it was the version underneath it that was wrong.
Nothing about the described behaviour is edited.

**The direct-adapters availability note moves too.** It read "their direct adapters already ship in
`@copilotkit/channels@0.6.1`," an availability claim rather than a first-shipped-in claim, sitting
directly above an install block that now names 0.9.2. Leaving it would make the page contradict
itself within fifteen lines.

**The SDK reference index gains the tested-pair framing it was missing.** The quickstarts and the
deploy-and-operate page already explain that the two packages ship as a tested pair and must be
upgraded together; the reference index pinned exact versions while explaining nothing, which is how a
pin decays into a number nobody knows they may not touch.

**One file outside the docs content changes, and the cost is worth naming.**
`src/lib/__tests__/channels-docs.test.ts` asserts the quickstarts contain the exact tested install
string, so it hard-codes the pair. Updating the docs without it produces a red PR. Only the two
version constants move; no assertion is added, removed, or loosened.

## What is not covered

- **No recording.** The change is text in six files with no runtime surface to demonstrate. The
  durable evidence is the export listing above, which is reproducible from the registry rather than
  from this branch.
- `showcase/shell-docs/src/content/reference/channels/functions/createChannel.mdx:114` still reads
  "Channels 0.6.1 warns when enumerable fields are dropped." This is a behaviour-provenance note, not
  an install pin, and rewriting the number would change a factual claim about when the behaviour
  changed. It needs a maintainer to say whether it means "as of 0.6.1" or "in 0.6.1."
- `skills/setup-slack-channel/SKILL.md:81` and `skills/setup-slack-channel/references/troubleshooting.md:8`
  reference `@copilotkit/channels@0.6.0` and `@copilotkit/runtime@1.65.0` — an even older pin, and one
  the guard test explicitly calls "the broken Channels 0.6.0 release." Same class of bug, outside docs
  content, left for a separate decision.
- The three `doctest.json` files pin `@copilotkit/runtime@1.68.3`, also stale, also a different
  purpose.
- `CopilotKit/channels-sdk` carries the same stale install line in
  `.agents/skills/build-channels-agent/SKILL.md`. Different repository.
- The docs do not document `defineChannelComponent` anywhere, despite the setup guide gating success
  on it. That gap is not addressed here.
- The guard test could ratchet against 0.6.1 and 1.65.0 the way it already ratchets against 0.5.0,
  0.6.0, and 1.64.2, which would stop this recurring. Deliberately not added, to keep the diff to the
  bug.

## Verification

Registry state re-checked at edit time: `npm view @copilotkit/channels version` → `0.9.2`,
`npm view @copilotkit/runtime version` → `1.70.2`.

Export boundary confirmed by unpacking the published tarballs: `channels-core@0.6.1` has no
`defineChannelComponent`; `0.6.2-canary.1785779327`, `0.7.0`, `0.7.1`, and `0.9.2` all have it.

All 10 assertions in the `channels-docs` guard test's install and Node-version blocks were replayed
against the edited files for both provider quickstart slugs — 20 checks, all passing. The `--save-exact`
negative lookaheads still hold: the docs contain no unpinned `@copilotkit/channels` or
`@copilotkit/runtime` install, no `@latest` or `@next` tag, and none of the previously blocked 0.5.0,
0.6.0, or 1.64.2 versions.

`grep` across `showcase/shell-docs/src` returns no remaining `channels@0.6.1` or `runtime@1.65.0`.

No new test files. No source, config, or lockfile changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated channel, Slack, Teams, and direct adapter setup guides with the latest pinned SDK versions.
  * Updated the channel reference documentation to reflect the current package versions.

* **Tests**
  * Updated documentation checks to validate the newer SDK versions in provider quickstarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->