### PR TITLE
fix(shell-docs): render the CTACards a page actually authors

### DIFF
--- a/showcase/shell-docs/src/components/docs-page-view.tsx
+++ b/showcase/shell-docs/src/components/docs-page-view.tsx
@@ -43,7 +43,7 @@ import { SignupLink } from "@/components/react/signup-link";
 import type { SignupLinkProps } from "@/components/react/signup-link";
 import { FrameworkSetup } from "@/lib/setup-concept";
 import { docsComponents } from "@/lib/mdx-registry";
-import { resolveDocsHref } from "@/lib/docs-link-rewrite";
+import { resolveCtaCardHrefs, resolveDocsHref } from "@/lib/docs-link-rewrite";
 import { transformerMeta } from "@/lib/rehype-code-meta";
 import { getIntegration, getTabDefault } from "@/lib/registry";
 import type { NavNode } from "@/lib/docs-render";
@@ -319,6 +319,31 @@ export async function DocsPageView({
                               : props.href;
                           return <CardComp {...props} href={href} />;
                         },
+                        // `<CTACards>` renders its cards through the
+                        // `Card` imported by the registry, so they never
+                        // reach the href-resolving `Card` override
+                        // above. Resolve each card href here instead.
+                        // Without this, a card on
+                        // `/ms-agent-python/human-in-the-loop` links to
+                        // the authored `/human-in-the-loop/...` path,
+                        // which leaves the active framework.
+                        CTACards: (
+                          props: React.ComponentProps<
+                            typeof docsComponents.CTACards
+                          >,
+                        ) => {
+                          const CTACardsComp = docsComponents.CTACards;
+                          return (
+                            <CTACardsComp
+                              {...props}
+                              cards={resolveCtaCardHrefs(props.cards, {
+                                slugHrefPrefix,
+                                frameworkOverride,
+                                frontendOverride,
+                              })}
+                            />
+                          );
+                        },
                         ChannelsStartPrompt: (
                           props: ChannelsStartPromptProps,
                         ) => (
@@ -565,6 +590,26 @@ export async function DocsPageView({
                         ),
                       }}
                       options={{
+                        // next-mdx-remote 6 defaults `blockJS` to true,
+                        // which runs a remark plugin that DELETES every
+                        // JSX attribute whose value is an expression
+                        // (`cards={[...]}`, `icon={<Sparkles />}`) and
+                        // every `{expression}` node. The default
+                        // sandboxes untrusted remote MDX; every source
+                        // here is first-party content from
+                        // `src/content`, so the sandbox only silently
+                        // dropped authored props — a `<CTACards
+                        // cards={[...]} />` reached the component with
+                        // no props at all and rendered an empty grid.
+                        // `blockDangerousJS` keeps its default.
+                        //
+                        // Scoped to this route on purpose. The other
+                        // MDXRemote call sites keep the default; the
+                        // ag-ui tree in particular relies on the
+                        // stripping, because `ag-ui/introduction.mdx`
+                        // authors inline `onMouseEnter={...}` handlers
+                        // that would otherwise reach a server component.
+                        blockJS: false,
                         mdxOptions: {
                           remarkPlugins: [remarkGfm],
                           // Use Fumadocs's Shiki-based `rehypeCode` for

--- a/showcase/shell-docs/src/content/docs/integrations/crewai-flows/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/crewai-flows/human-in-the-loop/index.mdx
@@ -61,7 +61,7 @@ Read more about the approach to HITL in CrewAI Flows.
       title: "Flow-based",
       description:
         "Utilize CrewAI Flows to create Human-in-the-Loop workflows.",
-      href: "/crewai-flows/human-in-the-loop/flow",
+      href: "/human-in-the-loop/flow",
     },
   ]}
 />

--- a/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/mastra/human-in-the-loop/index.mdx
@@ -39,14 +39,14 @@ Mastra supports HITL through frontend tools that render UI and collect user inpu
       title: "Tool-based (Supported)",
       description:
         "Register frontend tools with useHumanInTheLoop that render UI and wait for user responses. This is the working approach for Mastra.",
-      href: "/mastra/human-in-the-loop/tool-based",
+      href: "/human-in-the-loop/tool-based",
     },
     {
       iconKey: "circlePause",
       title: "Interrupt-based (Not Supported)",
       description:
         "Mastra does not support native interrupt flow. See this page to understand why and learn about the tool-based alternative.",
-      href: "/mastra/human-in-the-loop/interrupt-flow",
+      href: "/human-in-the-loop/interrupt-flow",
     },
   ]}
 />

--- a/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/microsoft-agent-framework/human-in-the-loop/index.mdx
@@ -24,14 +24,14 @@ Use **tool-based** HITL when the frontend owns the work. You define a tool that 
       title: "Interrupt-based",
       description:
         "Mark a backend tool as approval-gated. The agent pauses, useInterrupt renders your approval UI, and your answer resumes the run.",
-      href: "/microsoft-agent-framework/human-in-the-loop/interrupt-flow",
+      href: "/human-in-the-loop/interrupt-flow",
     },
     {
       iconKey: "share2",
       title: "Tool-based",
       description:
         "Register a frontend tool with useHumanInTheLoop that renders UI and waits for the user's response before returning a result.",
-      href: "/microsoft-agent-framework/human-in-the-loop/tool-based",
+      href: "/human-in-the-loop/tool-based",
     },
   ]}
 />

--- a/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop/index.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/pydantic-ai/human-in-the-loop/index.mdx
@@ -54,7 +54,7 @@ Read more about the approach to HITL in Pydantic AI Agents.
       title: "Flow-based",
       description:
         "Utilize Pydantic AI Agents to create Human-in-the-Loop workflows.",
-href: "/pydantic-ai/human-in-the-loop/agent",
+href: "/human-in-the-loop/agent",
     },
   ]}
 /> 

--- a/showcase/shell-docs/src/lib/__tests__/cta-cards.test.tsx
+++ b/showcase/shell-docs/src/lib/__tests__/cta-cards.test.tsx
@@ -1,9 +1,12 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { compileMDX } from "next-mdx-remote/rsc";
 import { renderToStaticMarkup } from "react-dom/server";
+import remarkGfm from "remark-gfm";
 import { describe, expect, it } from "vitest";
 
+import { resolveCtaCardHrefs } from "../docs-link-rewrite";
 import { ctaIcons, docsComponents } from "../mdx-registry";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -28,13 +31,13 @@ const cards: CTACard[] = [
     iconKey: "circlePause",
     title: "Interrupt-based",
     description: "The agent pauses and your approval UI resumes the run.",
-    href: "/microsoft-agent-framework/human-in-the-loop/interrupt-flow",
+    href: "/human-in-the-loop/interrupt-flow",
   },
   {
     iconKey: "share2",
     title: "Tool-based",
     description: "A frontend tool renders UI and waits for the user.",
-    href: "/microsoft-agent-framework/human-in-the-loop/tool-based",
+    href: "/human-in-the-loop/tool-based",
   },
 ];
 
@@ -57,13 +60,30 @@ describe("CTACards", () => {
     }
   });
 
-  it("honors the columns prop in the grid template", () => {
-    expect(
-      renderToStaticMarkup(<CTACards columns={1} cards={cards} />),
-    ).toContain("repeat(1, 1fr)");
-    expect(
-      renderToStaticMarkup(<CTACards columns={2} cards={cards} />),
-    ).toContain("repeat(2, 1fr)");
+  it("renders each description through the Card description prop", () => {
+    // Children land in Card's generic trailing <div>; the `description`
+    // prop lands in the <p> the rest of the docs card grids style.
+    const markup = renderToStaticMarkup(<CTACards cards={cards} />);
+
+    expect(markup).toMatch(
+      /<p[^>]*>The agent pauses and your approval UI resumes the run\.<\/p>/,
+    );
+  });
+
+  it("stacks to one column below the sm breakpoint", () => {
+    // An inline `grid-template-columns` cannot be overridden by a class,
+    // so a fixed inline template would keep two columns on a phone.
+    const twoUp = renderToStaticMarkup(<CTACards columns={2} cards={cards} />);
+
+    expect(twoUp).toContain("grid-cols-1 sm:grid-cols-2");
+    expect(twoUp).not.toContain("grid-template-columns");
+  });
+
+  it("honors the columns prop", () => {
+    const oneUp = renderToStaticMarkup(<CTACards columns={1} cards={cards} />);
+
+    expect(oneUp).toContain("grid-cols-1");
+    expect(oneUp).not.toContain("sm:grid-cols-2");
   });
 
   it("still wraps children when no cards prop is supplied", () => {
@@ -86,6 +106,17 @@ describe("CTACards", () => {
     expect(markup).toContain("Still here");
     expect(markup).toContain("/x");
   });
+
+  it("ignores an iconKey that only matches an inherited property", () => {
+    const markup = renderToStaticMarkup(
+      <CTACards
+        cards={[{ iconKey: "toString", title: "Inherited", href: "/y" }]}
+      />,
+    );
+
+    expect(markup).toContain("Inherited");
+    expect(markup).not.toContain("[object");
+  });
 });
 
 describe("CTACards iconKey coverage", () => {
@@ -104,6 +135,85 @@ describe("CTACards iconKey coverage", () => {
     }
 
     expect(used.size).toBeGreaterThan(0);
-    expect([...used].filter((key) => !(key in ctaIcons)).sort()).toEqual([]);
+    expect(
+      [...used].filter((key) => !Object.hasOwn(ctaIcons, key)).sort(),
+    ).toEqual([]);
+  });
+});
+
+describe("CTACards card hrefs", () => {
+  it("resolves an authored href into the framework being read", () => {
+    // The same option shape `docs-page-view.tsx` passes for
+    // `/ms-agent-python/human-in-the-loop`.
+    expect(
+      resolveCtaCardHrefs(cards, {
+        slugHrefPrefix: "/ms-agent-python",
+        frameworkOverride: "ms-agent-python",
+      }),
+    ).toEqual([
+      {
+        ...cards[0],
+        href: "/ms-agent-python/human-in-the-loop/interrupt-flow",
+      },
+      { ...cards[1], href: "/ms-agent-python/human-in-the-loop/tool-based" },
+    ]);
+  });
+
+  it("keeps root-surface hrefs unprefixed", () => {
+    expect(resolveCtaCardHrefs(cards, { slugHrefPrefix: "" })).toEqual(cards);
+  });
+});
+
+// The unit tests above call the component directly, which is exactly the
+// blind spot that let the original stub ship: on the real page the MDX
+// runs through next-mdx-remote, whose `blockJS` default DELETES every
+// JSX attribute whose value is an expression. `cards={[...]}` never
+// reached the component. Compile the authored source the way
+// `docs-page-view.tsx` does and assert the cards survive the pipeline.
+describe("CTACards through the MDX pipeline", () => {
+  const HITL_PAGES = [
+    "docs/integrations/crewai-flows/human-in-the-loop/index.mdx",
+    "docs/integrations/mastra/human-in-the-loop/index.mdx",
+    "docs/integrations/microsoft-agent-framework/human-in-the-loop/index.mdx",
+    "docs/integrations/pydantic-ai/human-in-the-loop/index.mdx",
+  ];
+
+  async function renderMdx(source: string): Promise<string> {
+    const { content } = await compileMDX({
+      source,
+      components: { ...docsComponents },
+      options: {
+        blockJS: false,
+        mdxOptions: { remarkPlugins: [remarkGfm] },
+      },
+    });
+    return renderToStaticMarkup(content);
+  }
+
+  it("passes cards and columns through a compile", async () => {
+    const markup = await renderMdx(
+      '<CTACards columns={1} cards={[{ iconKey: "share2", title: "Flow-based", href: "/human-in-the-loop/flow" }]} />',
+    );
+
+    expect(markup).toContain("Flow-based");
+    expect(markup).toContain("/human-in-the-loop/flow");
+    expect(markup).toContain("grid-cols-1");
+  });
+
+  it.each(HITL_PAGES)("renders every card authored by %s", async (page) => {
+    const source = readFileSync(resolve(CONTENT_DIR, page), "utf8").replace(
+      /^---[\s\S]*?---\n?/,
+      "",
+    );
+    const block = source.match(/<CTACards[\s\S]*?\/>/)?.[0];
+    expect(block).toBeDefined();
+
+    const hrefs = [...block!.matchAll(/href:\s*"([^"]+)"/g)].map((m) => m[1]);
+    const titles = [...block!.matchAll(/title:\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(hrefs.length).toBeGreaterThan(0);
+
+    const markup = await renderMdx(block!);
+    for (const href of hrefs) expect(markup).toContain(`href="${href}"`);
+    for (const title of titles) expect(markup).toContain(title);
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/cta-cards.test.tsx
+++ b/showcase/shell-docs/src/lib/__tests__/cta-cards.test.tsx
@@ -1,10 +1,14 @@
+import React from "react";
+import type { ReactElement, ReactNode } from "react";
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { compileMDX } from "next-mdx-remote/rsc";
+import { MDXRemote, compileMDX } from "next-mdx-remote/rsc";
 import { renderToStaticMarkup } from "react-dom/server";
 import remarkGfm from "remark-gfm";
 import { describe, expect, it } from "vitest";
+
+import { DocsPageView } from "@/components/docs-page-view";
 
 import { resolveCtaCardHrefs } from "../docs-link-rewrite";
 import { ctaIcons, docsComponents } from "../mdx-registry";
@@ -197,7 +201,9 @@ describe("CTACards through the MDX pipeline", () => {
 
     expect(markup).toContain("Flow-based");
     expect(markup).toContain("/human-in-the-loop/flow");
-    expect(markup).toContain("grid-cols-1");
+    // `grid-cols-1` alone would also match the two-column class, so the
+    // absence of the `sm:` variant is what proves `columns` arrived.
+    expect(markup).not.toContain("sm:grid-cols-2");
   });
 
   it.each(HITL_PAGES)("renders every card authored by %s", async (page) => {
@@ -211,9 +217,65 @@ describe("CTACards through the MDX pipeline", () => {
     const hrefs = [...block!.matchAll(/href:\s*"([^"]+)"/g)].map((m) => m[1]);
     const titles = [...block!.matchAll(/title:\s*"([^"]+)"/g)].map((m) => m[1]);
     expect(hrefs.length).toBeGreaterThan(0);
+    expect(titles.length).toBe(hrefs.length);
 
     const markup = await renderMdx(block!);
     for (const href of hrefs) expect(markup).toContain(`href="${href}"`);
     for (const title of titles) expect(markup).toContain(title);
+  });
+});
+
+// The two fixes above only reach a reader if the page wires them up:
+// `blockJS` has to be off in the page's own MDXRemote options, and the
+// page has to register the href-resolving `CTACards` override. Walk the
+// rendered tree the way `docs-page-view-angular-backend.test.tsx` does
+// and check both on the real page.
+describe("DocsPageView CTACards wiring", () => {
+  type MdxProps = {
+    children?: ReactNode;
+    components?: Record<string, React.ComponentType<Record<string, unknown>>>;
+    options?: { blockJS?: boolean };
+  };
+
+  function findMdxRemote(node: ReactNode): ReactElement<MdxProps> | undefined {
+    if (!React.isValidElement(node)) return undefined;
+
+    const element = node as ReactElement<MdxProps>;
+    if (element.type === MDXRemote) return element;
+
+    for (const child of React.Children.toArray(element.props.children)) {
+      const found = findMdxRemote(child);
+      if (found) return found;
+    }
+
+    return undefined;
+  }
+
+  it("keeps expression props and prefixes card hrefs with the framework", async () => {
+    const page = await DocsPageView({
+      slugPath: "human-in-the-loop",
+      contentSlugPath:
+        "integrations/microsoft-agent-framework/human-in-the-loop",
+      slugHrefPrefix: "/ms-agent-python",
+      frameworkOverride: "ms-agent-python",
+      navTree: [],
+    });
+
+    const mdx = findMdxRemote(page);
+    expect(mdx).toBeDefined();
+    expect(mdx!.props.options?.blockJS).toBe(false);
+
+    const Override = mdx!.props.components?.CTACards;
+    expect(Override).toBeDefined();
+
+    const markup = renderToStaticMarkup(
+      React.createElement(Override!, { cards, columns: 2 }),
+    );
+    expect(markup).toContain(
+      'href="/ms-agent-python/human-in-the-loop/interrupt-flow"',
+    );
+    expect(markup).toContain(
+      'href="/ms-agent-python/human-in-the-loop/tool-based"',
+    );
   });
 });

--- a/showcase/shell-docs/src/lib/__tests__/cta-cards.test.tsx
+++ b/showcase/shell-docs/src/lib/__tests__/cta-cards.test.tsx
@@ -1,0 +1,109 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ctaIcons, docsComponents } from "../mdx-registry";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CONTENT_DIR = resolve(here, "../../content");
+
+type CTACard = {
+  iconKey?: string;
+  title: string;
+  description?: string;
+  href: string;
+};
+
+const CTACards = docsComponents.CTACards as React.ComponentType<{
+  cards?: CTACard[];
+  columns?: number;
+  children?: React.ReactNode;
+}>;
+
+// The prop shape every human-in-the-loop landing page authors.
+const cards: CTACard[] = [
+  {
+    iconKey: "circlePause",
+    title: "Interrupt-based",
+    description: "The agent pauses and your approval UI resumes the run.",
+    href: "/microsoft-agent-framework/human-in-the-loop/interrupt-flow",
+  },
+  {
+    iconKey: "share2",
+    title: "Tool-based",
+    description: "A frontend tool renders UI and waits for the user.",
+    href: "/microsoft-agent-framework/human-in-the-loop/tool-based",
+  },
+];
+
+function listMdx(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return listMdx(path);
+    return entry.name.endsWith(".mdx") ? [path] : [];
+  });
+}
+
+describe("CTACards", () => {
+  it("renders a link for every card in the cards prop", () => {
+    const markup = renderToStaticMarkup(<CTACards columns={2} cards={cards} />);
+
+    for (const card of cards) {
+      expect(markup).toContain(card.href);
+      expect(markup).toContain(card.title);
+      expect(markup).toContain(card.description);
+    }
+  });
+
+  it("honors the columns prop in the grid template", () => {
+    expect(
+      renderToStaticMarkup(<CTACards columns={1} cards={cards} />),
+    ).toContain("repeat(1, 1fr)");
+    expect(
+      renderToStaticMarkup(<CTACards columns={2} cards={cards} />),
+    ).toContain("repeat(2, 1fr)");
+  });
+
+  it("still wraps children when no cards prop is supplied", () => {
+    const markup = renderToStaticMarkup(
+      <CTACards>
+        <span>legacy child</span>
+      </CTACards>,
+    );
+
+    expect(markup).toContain("legacy child");
+  });
+
+  it("renders a card whose iconKey is unknown instead of throwing", () => {
+    const markup = renderToStaticMarkup(
+      <CTACards
+        cards={[{ iconKey: "nope", title: "Still here", href: "/x" }]}
+      />,
+    );
+
+    expect(markup).toContain("Still here");
+    expect(markup).toContain("/x");
+  });
+});
+
+describe("CTACards iconKey coverage", () => {
+  it("has an icon registered for every iconKey used in content", () => {
+    const used = new Set<string>();
+
+    for (const file of listMdx(CONTENT_DIR)) {
+      const text = readFileSync(file, "utf8");
+      // Only iconKeys inside a <CTACards ...> block; other components
+      // resolve iconKey against `customIcons` instead.
+      for (const block of text.match(/<CTACards[\s\S]*?\/>/g) ?? []) {
+        for (const match of block.matchAll(/iconKey:\s*"([^"]+)"/g)) {
+          used.add(match[1]);
+        }
+      }
+    }
+
+    expect(used.size).toBeGreaterThan(0);
+    expect([...used].filter((key) => !(key in ctaIcons)).sort()).toEqual([]);
+  });
+});

--- a/showcase/shell-docs/src/lib/docs-link-rewrite.ts
+++ b/showcase/shell-docs/src/lib/docs-link-rewrite.ts
@@ -243,3 +243,23 @@ export function resolveDocsHref(
 
   return href;
 }
+
+/**
+ * Resolve the `href` of every `<CTACards>` card against the active docs
+ * surface.
+ *
+ * The cards render through the `Card` imported by `mdx-registry.tsx`, so
+ * they never pass through the href-resolving `Card` override in the
+ * page's MDX component map. Content authors these hrefs root-relative
+ * (`/human-in-the-loop/tool-based`), and each one must pick up the
+ * framework prefix of the page being read.
+ */
+export function resolveCtaCardHrefs<Card extends { href: string }>(
+  cards: Card[] | undefined,
+  options: ResolveDocsHrefOptions,
+): Card[] | undefined {
+  return cards?.map((card) => ({
+    ...card,
+    href: resolveDocsHref(card.href, options) ?? card.href,
+  }));
+}

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -274,6 +274,27 @@ export const ctaIcons: Record<string, React.ComponentType> = {
   share2: Share2,
 };
 
+// Own keys only. A plain `iconKey in ctaIcons` also matches inherited
+// names (`toString`, `constructor`), which resolve to a non-component
+// and break the no-icon fallback above.
+export function ctaIconFor(
+  iconKey: string | undefined,
+): React.ComponentType | undefined {
+  if (!iconKey || !Object.hasOwn(ctaIcons, iconKey)) return undefined;
+  return ctaIcons[iconKey];
+}
+
+// Grid classes per authored `columns` value. Tailwind only emits classes
+// it can find as literal text, so each variant is spelled out instead of
+// interpolated from `columns`. `@container` matches the shared `<Cards>`
+// wrapper so the cards' own container queries resolve the same way.
+const CTA_GRID_COLUMNS: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+  4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+};
+
 export const docsComponents = {
   Callout,
   Cards,
@@ -685,6 +706,12 @@ export const docsComponents = {
   // `EcosystemTable` below: render from the prop when it is supplied,
   // otherwise wrap children so any legacy `<CTACards>...</CTACards>`
   // authoring keeps working.
+  //
+  // Authored `href`s are root-relative docs paths. They only pick up the
+  // active framework prefix when the page-level `CTACards` override in
+  // `docs-page-view.tsx` resolves them, because the cards render through
+  // the `Card` imported here rather than the href-resolving `Card` in
+  // that page's component map.
   CTACards: ({
     cards,
     columns = 2,
@@ -700,25 +727,21 @@ export const docsComponents = {
     children?: React.ReactNode;
   }) => (
     <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: `repeat(${columns}, 1fr)`,
-        gap: "0.75rem",
-        marginBottom: "1rem",
-      }}
+      className={`not-prose @container my-6 grid gap-4 ${
+        CTA_GRID_COLUMNS[columns] ?? CTA_GRID_COLUMNS[2]
+      }`}
     >
       {cards && cards.length > 0
         ? cards.map((card) => {
-            const Icon = card.iconKey ? ctaIcons[card.iconKey] : undefined;
+            const Icon = ctaIconFor(card.iconKey);
             return (
               <Card
                 key={card.href}
                 href={card.href}
                 title={card.title}
+                description={card.description}
                 icon={Icon ? <Icon /> : undefined}
-              >
-                {card.description}
-              </Card>
+              />
             );
           })
         : children}
@@ -769,11 +792,12 @@ export const docsComponents = {
       {children}
     </div>
   ),
-  // `<EcosystemTable data={[...]} />` is used by
-  // `concepts/generative-ui-overview.mdx` to render a 4-column matrix
-  // of generative-UI approaches. There is no partial for this — the
-  // data is supplied inline by the page — so the stub returns a real
-  // table rendered from `props.data` instead of a `<div>`.
+  // `<EcosystemTable data={[...]} />` renders a 4-column matrix of
+  // generative-UI approaches from data the page supplies inline, so the
+  // stub returns a real table rendered from `props.data` instead of a
+  // `<div>`. No content file calls it today: it used to back
+  // `concepts/generative-ui-overview.mdx`, which no longer references
+  // it. Kept as the prop-or-children precedent `CTACards` follows.
   EcosystemTable: ({
     data,
     children,

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -5,6 +5,7 @@
 
 import React from "react";
 import Link from "next/link";
+import { CirclePause, Share2 } from "lucide-react";
 import {
   Cards,
   Card,
@@ -263,6 +264,15 @@ function warnSilentNull(component: string, reason: string): void {
   // eslint-disable-next-line no-console
   console.warn(`[mdx-registry] <${component}> rendered nothing — ${reason}`);
 }
+
+// `iconKey` values used by `<CTACards>` in content. These are lucide
+// names, not the framework keys in `customIcons`, so they need their own
+// lookup. An unlisted key renders the card with no icon rather than
+// throwing, which keeps a typo from blanking the page.
+export const ctaIcons: Record<string, React.ComponentType> = {
+  circlePause: CirclePause,
+  share2: Share2,
+};
 
 export const docsComponents = {
   Callout,
@@ -668,16 +678,50 @@ export const docsComponents = {
         />
       </div>
     ) : null,
-  CTACards: ({ children }: { children?: React.ReactNode }) => (
+  // `<CTACards columns={2} cards={[...]} />` is the shape every
+  // human-in-the-loop landing page authors. The previous stub accepted
+  // only `children`, so all four call sites rendered an empty grid and
+  // silently dropped their links. Same fallback contract as
+  // `EcosystemTable` below: render from the prop when it is supplied,
+  // otherwise wrap children so any legacy `<CTACards>...</CTACards>`
+  // authoring keeps working.
+  CTACards: ({
+    cards,
+    columns = 2,
+    children,
+  }: {
+    cards?: Array<{
+      iconKey?: string;
+      title: string;
+      description?: string;
+      href: string;
+    }>;
+    columns?: number;
+    children?: React.ReactNode;
+  }) => (
     <div
       style={{
         display: "grid",
-        gridTemplateColumns: "repeat(2, 1fr)",
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
         gap: "0.75rem",
         marginBottom: "1rem",
       }}
     >
-      {children}
+      {cards && cards.length > 0
+        ? cards.map((card) => {
+            const Icon = card.iconKey ? ctaIcons[card.iconKey] : undefined;
+            return (
+              <Card
+                key={card.href}
+                href={card.href}
+                title={card.title}
+                icon={Icon ? <Icon /> : undefined}
+              >
+                {card.description}
+              </Card>
+            );
+          })
+        : children}
     </div>
   ),
   AttributeCards: ({ children }: { children?: React.ReactNode }) => (

--- a/showcase/shell-docs/src/lib/mdx-registry.tsx
+++ b/showcase/shell-docs/src/lib/mdx-registry.tsx
@@ -701,8 +701,11 @@ export const docsComponents = {
     ) : null,
   // `<CTACards columns={2} cards={[...]} />` is the shape every
   // human-in-the-loop landing page authors. The previous stub accepted
-  // only `children`, so all four call sites rendered an empty grid and
-  // silently dropped their links. Same fallback contract as
+  // only `children`, so every call site rendered an empty grid and
+  // silently dropped its links. Four content files author the block and
+  // three of them are live pages: the pydantic-ai one is shadowed by the
+  // sibling `integrations/pydantic-ai/human-in-the-loop.mdx` leaf and
+  // renders nowhere. Same fallback contract as
   // `EcosystemTable` below: render from the prop when it is supplied,
   // otherwise wrap children so any legacy `<CTACards>...</CTACards>`
   // authoring keeps working.


### PR DESCRIPTION
## Problem

`CTACards` in `mdx-registry.tsx` accepted only `children`:

```tsx
CTACards: ({ children }: { children?: React.ReactNode }) => (
  <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", ... }}>
    {children}
  </div>
),
```

Every call site in content authors it self-closing with props instead:

```mdx
<CTACards
  columns={2}
  cards={[
    { iconKey: "circlePause", title: "Interrupt-based", description: "...", href: "..." },
    { iconKey: "share2", title: "Tool-based", description: "...", href: "..." },
  ]}
/>
```

The grid rendered empty and the pages lost their links. Nothing errored.

Four files author a `<CTACards>` block. Three of them are live pages:

- `docs/integrations/crewai-flows/human-in-the-loop/index.mdx` → `/crewai-crews/human-in-the-loop`
- `docs/integrations/mastra/human-in-the-loop/index.mdx` → `/mastra/human-in-the-loop`
- `docs/integrations/microsoft-agent-framework/human-in-the-loop/index.mdx` → `/ms-agent-python/human-in-the-loop` and `/ms-agent-dotnet/human-in-the-loop`

The fourth, `docs/integrations/pydantic-ai/human-in-the-loop/index.mdx`, renders nowhere: the sibling leaf file `integrations/pydantic-ai/human-in-the-loop.mdx` shadows the directory index, and the leaf is what `/pydantic-ai/human-in-the-loop` serves. It is edited here for consistency, but which of the two bodies should win is a separate content decision. pydantic-ai is the only one of the four with that duplicate.

This was pre-existing on the first three. It surfaced while reviewing #6922, which added the fourth.

## The part the first pass missed

Rendering from `cards` is necessary but not sufficient. Measured on the docs dev server, the component received **zero props** on the real page:

```
SENTINEL-KEYS[]TYPES[]                      # <CTACards columns={2} cards={[...]} />
SENTINEL-KEYS[foo]TYPES[foo:string]         # <CTACards foo="bar" num={7} />
```

String attributes survive. Expression attributes do not. `next-mdx-remote@6.0.0` defaults `blockJS` to `true`, which adds `removeJavaScriptExpressions` (`dist/serialize.js:19`) — a remark plugin that deletes every JSX attribute whose value is an expression and every `{expression}` node. `shell-docs` never set `blockJS`.

The original unit tests passed because they call the component directly and skip the MDX pipeline entirely.

## Fix

**Render from `cards`.** Through the shared `Card`, with `description` passed as the `description` prop so it lands in the styled `<p>` that every other docs card grid uses. `iconKey` resolves against a `ctaIcons` lookup of lucide names, matched on own properties only, and an unregistered key renders the card without an icon. When `cards` is absent, fall back to wrapping `children`, the same prop-or-children contract `EcosystemTable` uses.

**Turn `blockJS` off for the docs route.** Every MDX source there is first-party content from `src/content`, so the sandbox only dropped authored props. `blockDangerousJS` keeps its default. Scoped to this one call site on purpose: the other five keep the default, and `ag-ui/introduction.mdx` in particular depends on the stripping, because it authors 26 inline `onMouseEnter`/`onMouseLeave` handlers that would otherwise reach a server component. The remaining call sites are worth a follow-up, not a drive-by flip.

**Resolve each card href against the framework being read.** The cards render through the `Card` imported by the registry, so they never reached the href-resolving `Card` override in the page's component map. On `/ms-agent-python/human-in-the-loop` the authored `/microsoft-agent-framework/...` href 301-redirected to `/ms-agent-dotnet/...`, moving a Python reader to the .NET page. Content now authors these hrefs root-relative, and a new `resolveCtaCardHrefs` helper prefixes them per page.

**Stack to one column below `sm`.** An inline `grid-template-columns` cannot be overridden by a class, so once the cards actually rendered, two of them stayed 157px wide side by side on a 390px viewport. The wrapper now uses the same grid classes and `@container` as the shared `<Cards>`.

## Testing

### Unit

`vitest run src/lib/__tests__/cta-cards.test.tsx`

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

**Mutation-checked.** Each mutation was applied alone and reverted:

| Mutation | Result |
| --- | --- |
| Component back to the `({ children })` stub | 11 failed, 4 passed |
| `blockJS: false` removed from the pipeline test | 5 failed, 10 passed |
| `blockJS: false` removed from the page | 1 failed, 15 passed |
| `CTACards` override removed from the page | 1 failed, 15 passed |
| `columns` ignored by the grid | 2 failed, 14 passed |
| `description` passed as children again | 1 failed, 14 passed |
| Inline `gridTemplateColumns` restored | 3 failed, 12 passed |
| `resolveCtaCardHrefs` made a no-op | 1 failed, 14 passed |
| `Object.hasOwn` back to `in` | 1 failed, 14 passed |

Two kinds of test carry the weight the first pass was missing. The pipeline tests compile the four authored `<CTACards>` blocks through `compileMDX` with the page's options, and fail the moment `blockJS` returns to its default. The wiring test walks the rendered `DocsPageView` tree, checks `blockJS` in the page's own MDXRemote options, and renders the registered `CTACards` override to confirm it prefixes hrefs; removing either the option or the override fails it.

### Live

Docs dev server on the branch head. Card destinations and grid classes read out of the served HTML:

```
/ms-agent-python/human-in-the-loop   200  grid-cols-1 sm:grid-cols-2
   /ms-agent-python/human-in-the-loop/interrupt-flow  /ms-agent-python/human-in-the-loop/tool-based
/ms-agent-dotnet/human-in-the-loop   200  grid-cols-1 sm:grid-cols-2
   /ms-agent-dotnet/human-in-the-loop/interrupt-flow  /ms-agent-dotnet/human-in-the-loop/tool-based
/mastra/human-in-the-loop            200  grid-cols-1 sm:grid-cols-2
   /mastra/human-in-the-loop/tool-based  /mastra/human-in-the-loop/interrupt-flow
/crewai-crews/human-in-the-loop      200  grid-cols-1
   /crewai-crews/human-in-the-loop/flow
```

All seven card destinations return 200 directly, with no redirect hop.

Layout, measured in the browser:

```
1440px viewport:  gridTemplateColumns "360px 360px", cards at x=360 and x=736   (identical to a stock <Cards> grid on /mastra/quickstart)
 390px viewport:  gridTemplateColumns "326px", cards stacked at y=1167 and y=1374
 columns={1}:     gridTemplateColumns "736px", one full-width card
```

Before this change, the same 390px measurement was two 157px cards side by side.

### Regression sweep for `blockJS: false`

Every docs route, one per content file under `src/content/docs`, crawled against the running dev server following redirects:

```
675 routes: 673 x 200, 2 x 404
```

The two 404s are `/frontends/react-spa` and `/frontends/docs-status`. Both are 404 with this change and 404 without it.

The full crawl replaced a narrower first pass over the 424 routes whose own file carries an expression. That sample missed pages that inline a snippet through `inlineSnippets`, where the snippet body carries the expression and the page does not. Those pages are covered here.

### Full suite

`vitest run`, same worktree, with and without this diff:

```
before:  Test Files  16 failed | 92 passed (108)    Tests  53 failed | 795 passed (848)
after:   Test Files  16 failed | 92 passed (108)    Tests  53 failed | 805 passed (858)
```

The failing set is byte-identical between the two runs (50 named failures, `diff` clean). Those failures come from stale generated bundles in `src/data` in this sandbox, not from the diff. The delta is the tests added here.

### Typecheck, format, lint

`tsc --noEmit`: **0 errors**.

This corrects the earlier revision of this description, which reported a 21-error baseline. Those 21 were missing-dependency noise from a stale local install (17 x `Cannot find module '@testing-library/react'`, 2 x `@clerk/nextjs`, 2 unrelated implicit-any). With dependencies installed the tree is clean before and after.

`oxfmt --check`: all four touched files correctly formatted.
`oxlint`: 2 warnings in `mdx-registry.tsx`, both on pre-existing `iframe sandbox` attributes at lines 427 and 696. The same two appear on the file at `HEAD` in the same run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable call-to-action card grids to documentation pages.
  * Cards support titles, descriptions, links, icons, and adjustable column layouts.
  * Existing child-based card content remains supported when no card data is provided.
  * Unrecognized or invalid icon names are handled safely without disrupting page rendering.

* **Bug Fixes**
  * Fixed CTA card links so they resolve correctly on framework-specific documentation pages.
  * Fixed card data and layout settings not rendering in certain authored documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
