### PR TITLE
fix(runtime): accept nullable frontend tool schemas

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -86,13 +86,6 @@ Deploy the Intelligence producer before releasing a runtime that advertises the
 capability. New runtimes treat a `404` from an older Intelligence App API as
 compatible absence and return `204` to the client.
 
-## Nullable frontend tool parameters
-
-The built-in agent accepts nullable frontend tool fields in JSON Schema, including
-`anyOf`, `oneOf`, and type arrays such as `["string", "null"]`. A required nullable
-field accepts `null` but still requires the field to be present. Optional fields
-can be omitted. The runtime preserves this distinction when it builds model tools.
-
 ## Documentation
 
 To get started with CopilotKit, please check out the [documentation](https://docs.copilotkit.ai).

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -86,6 +86,13 @@ Deploy the Intelligence producer before releasing a runtime that advertises the
 capability. New runtimes treat a `404` from an older Intelligence App API as
 compatible absence and return `204` to the client.
 
+## Nullable frontend tool parameters
+
+The built-in agent accepts nullable frontend tool fields in JSON Schema, including
+`anyOf`, `oneOf`, and type arrays such as `["string", "null"]`. A required nullable
+field accepts `null` but still requires the field to be present. Optional fields
+can be omitted. The runtime preserves this distinction when it builds model tools.
+
 ## Documentation
 
 To get started with CopilotKit, please check out the [documentation](https://docs.copilotkit.ai).

--- a/packages/runtime/src/agent/__tests__/nullable-tools.test.ts
+++ b/packages/runtime/src/agent/__tests__/nullable-tools.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "vitest";
+import { z } from "zod";
+import { z as z4 } from "zod/v4";
+import { convertToolsToVercelAITools } from "../index";
+
+/** Builds the same tool boundary a frontend nullable field reaches. */
+function toolSchema(parameters: Record<string, unknown>) {
+  const tools = convertToolsToVercelAITools([
+    { name: "show_card", description: "Show a card", parameters },
+  ]);
+  const schema: unknown = tools.show_card.inputSchema;
+  if (!(schema instanceof z.ZodType))
+    throw new Error("Expected a Zod tool schema");
+  return schema;
+}
+
+test("frontend nullable anyOf fields accept null without admitting other types", () => {
+  const schema = toolSchema({
+    type: "object",
+    properties: {
+      subtitle: { anyOf: [{ type: "string" }, { type: "null" }] },
+    },
+    required: ["subtitle"],
+  });
+
+  expect(schema.parse({ subtitle: null })).toEqual({ subtitle: null });
+  expect(schema.parse({ subtitle: "Details" })).toEqual({
+    subtitle: "Details",
+  });
+  expect(schema.safeParse({ subtitle: 42 }).success).toBe(false);
+  expect(schema.safeParse({}).success).toBe(false);
+});
+
+test("Zod v4 nullable tool fields survive their emitted JSON Schema", () => {
+  const frontend = z4.object({ subtitle: z4.string().nullable() });
+
+  const schema = toolSchema(z4.toJSONSchema(frontend));
+
+  expect(schema.parse({ subtitle: null })).toEqual({ subtitle: null });
+  expect(schema.parse({ subtitle: "Details" })).toEqual({
+    subtitle: "Details",
+  });
+  expect(schema.safeParse({ subtitle: false }).success).toBe(false);
+  expect(schema.safeParse({}).success).toBe(false);
+});
+
+test("optional nullable array items preserve null and reject invalid values", () => {
+  const schema = toolSchema({
+    type: "object",
+    properties: {
+      values: {
+        type: "array",
+        items: { oneOf: [{ type: "number" }, { type: "null" }] },
+      },
+    },
+  });
+
+  expect(schema.parse({})).toEqual({});
+  expect(schema.parse({ values: [1, null] })).toEqual({ values: [1, null] });
+  expect(schema.safeParse({ values: ["invalid"] }).success).toBe(false);
+});

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -571,17 +571,15 @@ export function convertMessagesToVercelAISDKMessages(
 /**
  * JSON Schema type definition
  */
-type JsonSchemaType =
-  | "object"
-  | "string"
-  | "number"
-  | "integer"
-  | "boolean"
-  | "array"
-  | "null";
-
 interface JsonSchema {
-  type?: JsonSchemaType | JsonSchemaType[];
+  type?:
+    | "object"
+    | "string"
+    | "number"
+    | "integer"
+    | "boolean"
+    | "array"
+    | "null";
   description?: string;
   properties?: Record<string, JsonSchema>;
   required?: string[];
@@ -601,17 +599,6 @@ export function convertJsonSchemaToZodSchema(
   jsonSchema: JsonSchema,
   required: boolean,
 ): z.ZodSchema {
-  // Zod can emit nullable values as a type array instead of anyOf.
-  if (Array.isArray(jsonSchema.type)) {
-    return convertJsonSchemaToZodSchema(
-      {
-        ...jsonSchema,
-        type: undefined,
-        anyOf: jsonSchema.type.map((type) => ({ ...jsonSchema, type })),
-      },
-      required,
-    );
-  }
   if (jsonSchema.type === "null") {
     const schema = z.null().describe(jsonSchema.description ?? "");
     return required ? schema : schema.optional();

--- a/packages/runtime/src/agent/index.ts
+++ b/packages/runtime/src/agent/index.ts
@@ -571,8 +571,17 @@ export function convertMessagesToVercelAISDKMessages(
 /**
  * JSON Schema type definition
  */
+type JsonSchemaType =
+  | "object"
+  | "string"
+  | "number"
+  | "integer"
+  | "boolean"
+  | "array"
+  | "null";
+
 interface JsonSchema {
-  type?: "object" | "string" | "number" | "integer" | "boolean" | "array";
+  type?: JsonSchemaType | JsonSchemaType[];
   description?: string;
   properties?: Record<string, JsonSchema>;
   required?: string[];
@@ -592,6 +601,22 @@ export function convertJsonSchemaToZodSchema(
   jsonSchema: JsonSchema,
   required: boolean,
 ): z.ZodSchema {
+  // Zod can emit nullable values as a type array instead of anyOf.
+  if (Array.isArray(jsonSchema.type)) {
+    return convertJsonSchemaToZodSchema(
+      {
+        ...jsonSchema,
+        type: undefined,
+        anyOf: jsonSchema.type.map((type) => ({ ...jsonSchema, type })),
+      },
+      required,
+    );
+  }
+  if (jsonSchema.type === "null") {
+    const schema = z.null().describe(jsonSchema.description ?? "");
+    return required ? schema : schema.optional();
+  }
+
   // Handle `anyOf` / `oneOf` unions (e.g. `z.discriminatedUnion` or `z.union`
   // on a frontend tool) as `z.union`. These nodes usually carry no top-level
   // `type`, so they MUST be handled before the empty-schema guard below —


### PR DESCRIPTION
A nullable frontend tool field can reach the built-in agent as `anyOf: [{type: "string"}, {type: "null"}]`. The converter handles the union but throws `Invalid JSON schema` for its null branch before the model is called. This matches R14 in the September 3–8 onboarding friction audit.

Accept explicit null branches when converting frontend tools. Required nullable fields still require a value; optional fields can be omitted. Invalid non-null values still fail validation.

Validation:
- RED: both the explicit anyOf input and a real Zod v4 nullable schema failed with `Invalid JSON schema` before the fix.
- `pnpm nx test @copilotkit/runtime` — 2,293 tests passed, including HTTP runtime integration tests.
- `pnpm nx test @copilotkit/runtime -- src/agent/__tests__/nullable-tools.test.ts` — 3 focused tests passed after the final test typing change.
- `pnpm nx run-many -t test,check-types,build -p @copilotkit/runtime` passed on the revised head (2,293 tests).
- `pnpm exec oxlint packages/runtime/src/agent/index.ts packages/runtime/src/agent/__tests__/nullable-tools.test.ts` — no errors; three existing shadowing warnings.
- `pnpm exec oxfmt --check packages/runtime/src/agent/index.ts packages/runtime/src/agent/__tests__/nullable-tools.test.ts` and `git diff --check` passed.

No live model request was needed: the regression exercises the actual AG-UI-to-model-tool conversion and validates accepted and rejected arguments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of nullable tool fields, including nullable unions, arrays, and fields generated by Zod.
  - Invalid values and missing required fields continue to be rejected during tool schema validation.
- **Compatibility**
  - JSON Schema type declarations now use a single type value; arrays of schema types are no longer converted automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->