### PR TITLE
docs: show the component tool imports for the built-in agent

### DIFF
--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-based.mdx
@@ -37,6 +37,14 @@ around a real backend tool, see [Tool rendering](/generative-ui/tool-rendering).
 
 <FrameworkSetup concept="frontend-tools-setup" />
 
+Import the React hook and Zod in the component that registers the tool. This also
+applies to the built-in agent, which needs no backend tool-registration step.
+
+```tsx
+import { useComponent } from "@copilotkit/react-core/v2";
+import { z } from "zod";
+```
+
 `useComponent` takes a name, a Zod schema for its props, and the component
 to render. The runtime registers it as a frontend tool so the agent can
 discover it, and Zod validates the LLM's arguments before they reach your


### PR DESCRIPTION
The Components as Tools page shows a `useComponent` call without its import. An onboarding run using the built-in agent had to inspect installed type declarations to find it (friction report R16).

Show the `@copilotkit/react-core/v2` hook import and Zod import directly on the shared page, including the built-in agent route.

Validation:
- `npm run typecheck` and `npm run build` passed in `showcase/shell-docs`.
- `npm run test -- src/lib/__tests__/docs-render.test.ts src/lib/__tests__/setup-concept.test.ts --maxWorkers=1` — 39 tests passed.
- Browser smoke against the production build verified the visible imports at `/built-in-agent/generative-ui/tool-based` and the same import in its `.md` response.
- `pnpm exec oxlint showcase/shell-docs` — zero errors, existing warnings remain; commit hooks and `git diff --check` passed.
- The broad docs test suite hit unrelated navigation/search UI failures and excessive worker memory use; it was stopped. No application behavior changed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for importing `useComponent` and Zod when registering tools for tool-based Generative UI.
  * Clarified that the same approach applies to the built-in agent, which does not require backend tool registration.
  * Included a TypeScript example showing the required imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->