### PR TITLE
docs: align promoted API guidance

### DIFF
--- a/scripts/__tests__/public-skill-drift.test.ts
+++ b/scripts/__tests__/public-skill-drift.test.ts
@@ -196,8 +196,11 @@ describe("public skill drift", () => {
     );
   });
 
-  it("keeps debugging source inventory paths resolvable", () => {
-    const paths = read("skills/copilotkit-debug/sources.md")
+  it.each([
+    "skills/copilotkit-debug/sources.md",
+    "skills/copilotkit-setup/sources.md",
+  ])("keeps %s package inventory paths resolvable", (sourcesPath) => {
+    const paths = read(sourcesPath)
       .split("\n")
       .flatMap(
         (line) => line.match(/^- (packages\/\S+?)(?:\/)? \(/)?.[1] ?? [],

--- a/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
+++ b/showcase/shell-docs/src/content/reference/components/CopilotKit.mdx
@@ -124,9 +124,11 @@ CORS on your runtime endpoint:
 </CopilotKit>;
 
 // Backend (https://api.myapp.com)
-copilotRuntimeNextJSAppRouterEndpoint({
+import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
+
+const handler = createCopilotRuntimeHandler({
   runtime,
-  endpoint: "/copilotkit",
+  basePath: "/copilotkit",
   cors: {
     origin: "https://myapp.com",
     credentials: true,

--- a/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/docs-render.test.ts
@@ -393,6 +393,10 @@ describe("migration docs", () => {
     );
     expect(componentReference).toContain("`@copilotkit/react-core/v2`");
     expect(componentReference).not.toContain("not from the v2 subpackage");
+    expect(componentReference).toContain("createCopilotRuntimeHandler({");
+    expect(componentReference).not.toContain(
+      "copilotRuntimeNextJSAppRouterEndpoint",
+    );
   });
 
   it("does not recommend stale v2 package paths in authored docs", () => {

--- a/skills/copilotkit-setup/sources.md
+++ b/skills/copilotkit-setup/sources.md
@@ -1,47 +1,47 @@
 # Sources
 
 Files and directories read from CopilotKit/CopilotKit to generate this skill's references.
-Generated: 2026-03-28
+Generated: 2026-09-08
 
 ## framework-detection.md
 
 - examples/v2/ (Angular, React, Node, Node-Express, Next Pages Router directory structures)
 - examples/integrations/ (integration example directory structures for framework patterns)
-- packages/v2/runtime/src/ (endpoint factories: createCopilotEndpoint, createCopilotEndpointExpress, createCopilotEndpointSingleRoute)
-- packages/v2/react/src/ (`CopilotKit` provider props, stylesheet imports)
-- packages/v2/angular/src/ (Angular component package structure)
+- packages/runtime/src/v2/runtime/ (endpoint factories: createCopilotRuntimeHandler, createCopilotHonoHandler, createCopilotExpressHandler)
+- packages/react-core/src/v2/ (`CopilotKit` provider props, stylesheet imports)
+- packages/angular/src/ (Angular component package structure)
 
 ## runtime-architecture.md
 
-- packages/v2/runtime/src/ (CopilotRuntime, CopilotRuntimeOptions, AgentRunner, InMemoryAgentRunner, IntelligenceAgentRunner)
-- packages/v2/runtime/src/endpoints/ (createCopilotEndpoint, createCopilotEndpointExpress, createCopilotEndpointSingleRoute, createCopilotEndpointSingleRouteExpress, CORS config, route definitions)
-- packages/v2/runtime/src/intelligence-platform/ (CopilotKitIntelligence, CopilotSseRuntime, CopilotIntelligenceRuntime)
-- packages/v2/agent/src/ (BuiltInAgent, BasicAgent, defineTool, ToolDefinition, resolveModel, MCPClientConfig)
-- packages/v2/shared/src/ (TranscriptionService, BeforeRequestMiddleware, AfterRequestMiddleware)
+- packages/runtime/src/v2/runtime/ (CopilotRuntime, CopilotRuntimeOptions, AgentRunner, InMemoryAgentRunner, IntelligenceAgentRunner)
+- packages/runtime/src/v2/runtime/endpoints/ (createCopilotRuntimeHandler, createCopilotHonoHandler, createCopilotExpressHandler, CORS config, route definitions)
+- packages/runtime/src/v2/runtime/intelligence-platform/ (CopilotKitIntelligence, CopilotSseRuntime, CopilotIntelligenceRuntime)
+- packages/runtime/src/agent/ (BuiltInAgent, BasicAgent, defineTool, ToolDefinition, resolveModel, MCPClientConfig)
+- packages/shared/src/ (TranscriptionService, BeforeRequestMiddleware, AfterRequestMiddleware)
 
 ## assets/express-runtime.ts
 
-- packages/v2/runtime/src/ (CopilotRuntime constructor, createCopilotEndpointSingleRouteExpress)
-- packages/v2/agent/src/ (BuiltInAgent, defineTool, ToolDefinition)
+- packages/runtime/src/v2/runtime/ (CopilotRuntime constructor, createCopilotExpressHandler)
+- packages/runtime/src/agent/ (BuiltInAgent, defineTool, ToolDefinition)
 - examples/v2/node-express/ (Express server setup patterns)
 
 ## assets/nextjs-app-router-route.ts
 
-- packages/v2/runtime/src/ (CopilotRuntime, createCopilotEndpoint, InMemoryAgentRunner)
-- packages/v2/agent/src/ (BuiltInAgent)
+- packages/runtime/src/v2/runtime/ (CopilotRuntime, createCopilotHonoHandler, InMemoryAgentRunner)
+- packages/runtime/src/agent/ (BuiltInAgent)
 - examples/v2/react/ (Next.js App Router route handler patterns)
 
 ## assets/nextjs-app-router-page.tsx
 
-- packages/v2/react/src/ (`CopilotKit` provider, CopilotChat component exports)
+- packages/react-core/src/v2/ (`CopilotKit` provider, CopilotChat component exports)
 - examples/v2/react/ (Next.js App Router page component patterns)
 
 ## Step 2 Intelligence runtime and Step 6 (added 2026-08-01)
 
-- packages/runtime/dist/v2/runtime/core/runtime.d.mts (CopilotIntelligenceRuntimeOptions:
+- packages/runtime/src/v2/runtime/core/runtime.ts (CopilotIntelligenceRuntimeOptions:
   `intelligence`, required `identifyUser`, `channels`; CopilotSseRuntimeOptions has
   `channels?: undefined`)
-- packages/runtime/dist/v2/runtime/intelligence-platform/client.d.mts
+- packages/runtime/src/v2/runtime/intelligence-platform/client.ts
   (CopilotKitIntelligenceConfig: required `apiKey`, optional `apiUrl`/`wsUrl` defaulting to
   the managed platform, separate API and realtime hosts)
 - examples/slack/app/managed.ts (canonical managed wiring and env var names)


### PR DESCRIPTION
## Summary

- replace the legacy Next.js adapter example in the current CopilotKit v2 component reference with `createCopilotRuntimeHandler` from `@copilotkit/runtime/v2`
- align the public setup skill's source inventory with the repository's flat package layout and current runtime factories
- extend focused drift guards so the promoted reference example and setup source paths cannot silently regress

## Classification and scope

This PR fixes two stale forms in actively promoted, default-discovery surfaces:

- `showcase/shell-docs/src/content/reference/components/CopilotKit.mdx` was current v2 reference content but still taught `copilotRuntimeNextJSAppRouterEndpoint`
- `skills/copilotkit-setup/sources.md` was current public setup guidance but still pointed at retired `packages/v2/*` layouts and endpoint names

The docs landing implementation is deliberately unchanged. Its two remaining `copilotRuntimeNextJSAppRouterEndpoint` occurrences in `showcase/shell-docs/src/components/landing-sample-tabs.tsx` are deferred to [PDX-347](https://linear.app/copilotkit/issue/PDX-347/make-the-existing-docs-landing-page-the-authoritative-copilotkit), owned by Tyler Slaton.

## Validation

Passed:

- `pnpm exec oxfmt --check` on the changed files
- `pnpm exec oxlint` on the changed TypeScript test files
- `pnpm check:plugin-skills`
- focused public-skill drift tests: 8/8
- shell-docs typecheck
- `git diff --check origin/main...origin/codex/pdx-319-promoted-path-drift`
- source-inventory path existence check at the feature commit
- landing-page boundary check: no diff, exactly two deferred legacy-adapter occurrences

Also run:

- `nx run @copilotkit/showcase-scripts:verify-shell-docs:fast` — fails on broad pre-existing, untouched shell-docs debt (unknown snippet regions, dead links, and quality-gate gaps). This PR does not expand into that cleanup.

Linear: [PDX-319](https://linear.app/copilotkit/issue/PDX-319/remove-current-api-and-terminology-drift-from-docs-and-public-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the CopilotKit component reference with v1 compatibility details, provider behavior, agent naming options, and transport negotiation guidance.
  * Updated the backend example to use the current v2 runtime handler API.
  * Refreshed setup references with current source locations, handler names, TypeScript links, and generated date.

* **Tests**
  * Expanded source-inventory validation to cover debugging and setup references.
  * Added checks ensuring the CopilotKit documentation uses the current v2 runtime entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->