### PR TITLE
fix(runtime): recover Intelligence runs after socket closes

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -142,3 +142,17 @@ Or use the `DO_NOT_TRACK` standard:
 ```bash
 export DO_NOT_TRACK=1
 ```
+
+## Intelligence runner reconnects
+
+`IntelligenceAgentRunner` retains unacknowledged events and retries them with the
+same IDs after reconnect. An unexpected normal WebSocket close (`1000`) also
+reconnects while the run remains active. Intentional cleanup does not reconnect.
+The runner advertises `runner_reconnect_v1` when it joins the
+gateway. Supporting gateways allow 60 seconds for a replacement connection
+before recording `RUNNER_CONNECTION_DROPPED`. Older gateways ignore the added
+capability and keep their existing disconnect behavior.
+
+This recovers a lost WebSocket while the agent runtime remains alive. It does
+not restart an agent after its runtime process exits. The existing 60-second
+event acknowledgment deadline still applies.

--- a/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
@@ -8,11 +8,13 @@ const chunks = Number(process.env.CPKI_KIND_EVENT_CHUNKS ?? "400");
 const resultPath = process.env.CPKI_KIND_RESULT_PATH;
 const closeMode = process.env.CPKI_KIND_CLOSE_MODE ?? "planned";
 const closeCodes: number[] = [];
+let interruptTransport: (() => void) | undefined;
 const NativeWebSocket = globalThis.WebSocket;
 
 class ObservedWebSocket extends NativeWebSocket {
   constructor(address: string | URL, protocols?: string | string[]) {
     super(address, protocols);
+    interruptTransport = () => this.close(1000, "test transport interruption");
     this.addEventListener("close", (event) => closeCodes.push(event.code));
   }
 }
@@ -45,6 +47,10 @@ class SlowLifecycleAgent extends AbstractAgent {
     } as BaseEvent);
 
     for (let index = 0; index < chunks; index += 1) {
+      if (closeMode === "transport" && index === 20) {
+        // Close only the transport. The gateway and agent remain alive.
+        interruptTransport?.();
+      }
       emit({
         type: EventType.TEXT_MESSAGE_CONTENT,
         messageId: "message-kind-handoff",
@@ -130,6 +136,11 @@ async function main(): Promise<void> {
   if (closeMode === "abrupt" && !closeCodes.includes(1006)) {
     throw new Error(
       `expected abnormal close 1006, observed ${closeCodes.join(",")}`,
+    );
+  }
+  if (closeMode === "transport" && !closeCodes.includes(1000)) {
+    throw new Error(
+      `expected transport close 1000, observed ${closeCodes.join(",")}`,
     );
   }
   if (agent.runCount !== 1) {

--- a/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/integration/kind-gateway-drain-runner.ts
@@ -15,6 +15,12 @@ class ObservedWebSocket extends NativeWebSocket {
   constructor(address: string | URL, protocols?: string | string[]) {
     super(address, protocols);
     interruptTransport = () => this.close(1000, "test transport interruption");
+    this.addEventListener("open", () =>
+      process.stdout.write("CPKI_KIND_SOCKET open\n"),
+    );
+    this.addEventListener("error", () =>
+      process.stderr.write("CPKI_KIND_SOCKET error\n"),
+    );
     this.addEventListener("close", (event) => closeCodes.push(event.code));
   }
 }
@@ -87,8 +93,31 @@ class SlowLifecycleAgent extends AbstractAgent {
 
 async function main(): Promise<void> {
   const { IntelligenceAgentRunner } = await import("../../intelligence");
+  const gatewayUrl =
+    process.env.CPKI_KIND_GATEWAY_URL ?? "ws://127.0.0.1:4401/runner";
+  const healthUrl = new URL("/health/ready", gatewayUrl.replace(/^ws/, "http"));
+  // Pod readiness can precede service routing in a fresh Kind cluster. Keep
+  // setup separate from the runner interruption under test.
+  let reachable = false;
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    try {
+      const health = await fetch(healthUrl, {
+        signal: AbortSignal.timeout(3_000),
+      });
+      await health.arrayBuffer();
+      if (health.ok) {
+        reachable = true;
+        break;
+      }
+    } catch {
+      process.stdout.write(`CPKI_KIND_WAIT_GATEWAY ${attempt + 1}\n`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  if (!reachable)
+    throw new Error("gateway was not reachable before the runner test");
   const runner = new IntelligenceAgentRunner({
-    url: process.env.CPKI_KIND_GATEWAY_URL ?? "ws://127.0.0.1:4401/runner",
+    url: gatewayUrl,
     authToken: "ck_test_longsecret",
     maxReconnectMs: 500,
     maxRejoinMs: 500,

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-reconnect.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-reconnect.test.ts
@@ -1,0 +1,103 @@
+import { AbstractAgent } from "@ag-ui/client";
+import { Socket } from "phoenix";
+import { EMPTY } from "rxjs";
+import { expect, test, vi } from "vitest";
+import { IntelligenceAgentRunner } from "../intelligence";
+
+class IdleAgent extends AbstractAgent {
+  run(): ReturnType<AbstractAgent["run"]> {
+    return EMPTY;
+  }
+}
+
+/** Capture the real Phoenix join payload without opening a network connection. */
+function setup() {
+  const connect = vi
+    .spyOn(Socket.prototype, "connect")
+    .mockImplementation(() => {});
+  const channel = vi.spyOn(Socket.prototype, "channel");
+  const onClose = vi.spyOn(Socket.prototype, "onClose");
+  const runner = new IntelligenceAgentRunner({
+    url: "ws://localhost:4000/runner",
+  });
+  const subscription = runner
+    .run({
+      threadId: "thread-reconnect",
+      agent: new IdleAgent(),
+      input: {
+        threadId: "thread-reconnect",
+        runId: "run-reconnect",
+        messages: [],
+        tools: [],
+        context: [],
+        state: {},
+        forwardedProps: {},
+      },
+    })
+    .subscribe();
+  return {
+    channel,
+    connect,
+    subscription,
+    close: onClose.mock.calls[0][0],
+    teardown() {
+      subscription.unsubscribe();
+      onClose.mockRestore();
+      channel.mockRestore();
+      connect.mockRestore();
+    },
+  };
+}
+
+test("runner advertises reconnect support so a transport close does not terminalize the run", () => {
+  const { channel, teardown } = setup();
+  try {
+    expect(channel).toHaveBeenCalledWith("ingestion:run-reconnect", {
+      thread_id: "thread-reconnect",
+      run_id: "run-reconnect",
+      capabilities: ["runner_reconnect_v1"],
+    });
+  } finally {
+    teardown();
+  }
+});
+
+/** Build the browser close event shape without requiring a browser global. */
+function normalClose(): CloseEvent {
+  return Object.assign(new Event("close"), {
+    code: 1000,
+    reason: "",
+    wasClean: true,
+  });
+}
+
+test("an unexpected normal close reconnects an active runner", async () => {
+  vi.useFakeTimers();
+  const { connect, close, teardown } = setup();
+  try {
+    await close(normalClose());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(connect).toHaveBeenCalledTimes(2);
+  } finally {
+    teardown();
+    vi.useRealTimers();
+  }
+});
+
+test("intentional runner teardown cancels a pending normal-close reconnect", async () => {
+  vi.useFakeTimers();
+  const { connect, close, subscription, teardown } = setup();
+  try {
+    await close(normalClose());
+    subscription.unsubscribe();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await close(normalClose());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(connect).toHaveBeenCalledTimes(1);
+  } finally {
+    teardown();
+    vi.useRealTimers();
+  }
+});

--- a/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
+++ b/packages/runtime/src/v2/runtime/runner/__tests__/intelligence-runner.test.ts
@@ -1881,7 +1881,11 @@ describe("IntelligenceAgentRunner", () => {
       );
       const ch = mockChannels[0];
       expect(ch.topic).toBe("ingestion:r-jc");
-      expect(ch.params).toEqual({ thread_id: threadId, run_id: "r-jc" });
+      expect(ch.params).toEqual({
+        thread_id: threadId,
+        run_id: "r-jc",
+        capabilities: ["runner_reconnect_v1"],
+      });
       ch.triggerJoin("ok");
       await eventsPromise;
     });

--- a/packages/runtime/src/v2/runtime/runner/intelligence.ts
+++ b/packages/runtime/src/v2/runtime/runner/intelligence.ts
@@ -224,6 +224,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
       const channel = socket.channel(`ingestion:${input.runId}`, {
         thread_id: threadId,
         run_id: input.runId,
+        // New gateways defer disconnect errors while this runner rejoins and
+        // replays its pending events. Older gateways ignore the capability.
+        capabilities: ["runner_reconnect_v1"],
       });
 
       const state: ThreadState = {
@@ -261,7 +264,9 @@ export class IntelligenceAgentRunner extends AgentRunner {
           return;
         }
         plannedRestart = plannedRestart || event?.code === 1012;
-        if (event?.code !== 1000 && state.socketReconnectWatchdog === null) {
+        // Phoenix does not retry a normal (1000) close. A live run still
+        // needs its transport; removeThread marks intentional cleanup inactive.
+        if (state.socketReconnectWatchdog === null) {
           state.socketReconnectWatchdog = setTimeout(() => {
             state.socketReconnectWatchdog = null;
             if (!state.isRunning || socket.isConnected()) {


### PR DESCRIPTION
An active Intelligence run can stall after a normal WebSocket close (`1000`): Phoenix does not reconnect it, and the runner watchdog skipped that code. The runner now reconnects while its run remains active. Intentional cleanup still cancels recovery.

The ingestion join also advertises `runner_reconnect_v1`. The paired [Intelligence gateway change](https://github.com/CopilotKit/Intelligence/pull/1179) gives these runners a bounded reconnect window instead of immediately recording `RUNNER_CONNECTION_DROPPED`. Older gateways ignore the additive field. This does not resume execution after the agent runtime process exits or change the event acknowledgment deadline.

Validation:
- Regression tests failed before each fix: missing join capability and no reconnect after `1000`. Both pass, including intentional-teardown coverage.
- `pnpm nx test @copilotkit/runtime`: 2,294 tests passed.
- `pnpm nx run @copilotkit/runtime:check-types` and `pnpm nx build @copilotkit/runtime`: passed.
- Commit-hook tests, publint, and attw passed for the runtime and affected dependent packages. Focused oxlint has zero errors and three existing warnings.
- `COPILOTKIT_REPO=/path/to/this/worktree pnpm nx run realtime-gateway:test-kind-drain` from the paired Intelligence worktree passed. Transport close (`1000`), planned rollout (`1012`), and abrupt gateway loss (`1006`) each preserved 404 ordered events with one agent execution, no runner errors, and no aborts. The test also verified PostgreSQL projection, an empty outbox, readiness drain, and stale provider recovery. The harness waits for service reachability before starting the run.

The existing runner test file retains its structure; only its exact join-payload expectation changes. New regression tests are flat and self-contained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Active agent runs now automatically reconnect after unexpected WebSocket interruptions, including normal connection closures.
  * Unacknowledged events are retained and retried with their original IDs after reconnection.
  * Intentional shutdowns do not trigger reconnection attempts.
  * Recovery is available while the agent runtime remains active; the existing 60-second event acknowledgment deadline still applies.

* **Documentation**
  * Added guidance describing reconnect behavior, gateway compatibility, recovery limits, and connection-drop timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->