### PR TITLE
fix(react-core): stop useInterrupt re-renders on agent updates

### DIFF
--- a/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-interrupt.test.tsx
@@ -209,6 +209,17 @@ describe("useInterrupt", () => {
     expect(unsubscribeMock).toHaveBeenCalledTimes(1);
   });
 
+  it("opts out of agent re-render updates", () => {
+    render(<Harness renderInChat={false} />);
+
+    // Interrupt events arrive via a direct agent.subscribe() in the hook,
+    // so the useAgent() handle must not force re-renders on every
+    // message/state/run-status change (see #6934).
+    expect(mockUseAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: [] }),
+    );
+  });
+
   it("ignores non-interrupt custom events", () => {
     render(<Harness renderInChat={false} />);
 

--- a/packages/react-core/src/v2/hooks/use-interrupt.tsx
+++ b/packages/react-core/src/v2/hooks/use-interrupt.tsx
@@ -172,7 +172,7 @@ export function useInterrupt<
 ): UseInterruptReturn<TRenderInChat> {
   /* eslint-enable @typescript-eslint/no-explicit-any */
   const { copilotkit } = useCopilotKit();
-  const { agent } = useAgent({ agentId: config.agentId });
+  const { agent } = useAgent({ agentId: config.agentId, updates: [] });
   const [pending, setPending] = useState<PendingInterrupt | null>(null);
   const pendingRef = useRef(pending);
   pendingRef.current = pending;


### PR DESCRIPTION
fix #6934

useInterrupt only needs the agent handle - interrupt events arrive via its own direct agent.subscribe(). But useAgent() with no update filter force-updates the consumer on every message/state/run-status change. Passing updates: [] skips the re-render subscription entirely (use-agent early-returns on an empty list) while the agent handle still resolves.

Includes a regression test asserting the hook opts out of agent updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interrupt handling by preventing unnecessary re-renders when unrelated agent updates occur.
  - Interrupt-related behavior now remains stable when chat rendering is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->