### PR TITLE
Stop the Slack Channel skill from vouching for a broken SDK pair

### DIFF
--- a/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/channels-docs.test.ts
@@ -214,8 +214,15 @@ describe("Channels documentation journey", () => {
         source,
         `${slug} retains the broken Channels 0.6.0 release`,
       ).not.toContain("@copilotkit/channels@0.6.0");
+      expect(
+        source,
+        `${slug} retains Channels 0.6.1, which cannot render components`,
+      ).not.toContain("@copilotkit/channels@0.6.1");
       expect(source, `${slug} retains Runtime 1.64.2`).not.toContain(
         "@copilotkit/runtime@1.64.2",
+      );
+      expect(source, `${slug} retains Runtime 1.65.0`).not.toContain(
+        "@copilotkit/runtime@1.65.0",
       );
     }
   });

--- a/skills/setup-slack-channel/SKILL.md
+++ b/skills/setup-slack-channel/SKILL.md
@@ -77,15 +77,11 @@ its listening line, returns HTTP 200 on `/api/copilotkit/info`, and answers
 nothing. `/api/copilotkit/info` reports license and runtime info, **not** channel
 state, so a 200 there is not evidence of anything Slack-related.
 
-The SDK behaviors asserted here were verified against
-`@copilotkit/channels@0.6.0` and `@copilotkit/runtime@1.65.0`, the pair
-published when this skill was written. They have **not** been re-verified
-against the current pair, `@copilotkit/channels@0.9.2` and
-`@copilotkit/runtime@1.70.3` (as of 2026-09-09). Do not install 0.6.0 on the
-strength of this note — it records where these claims came from, not a version
-to pin. A starter may pin something older or newer, and this API is moving fast.
-If a claim here contradicts what you observe, **trust the installed package**
-and re-read it — do not argue with the runtime.
+This skill targets `@copilotkit/channels@0.9.2` and `@copilotkit/runtime@1.70.3`,
+which ship as a tested pair and must be bumped together. The API is moving fast
+and a starter may pin something else. If a claim here contradicts what you
+observe, **trust the installed package** and re-read it — do not argue with the
+runtime.
 
 ## Scope — read before planning
 

--- a/skills/setup-slack-channel/SKILL.md
+++ b/skills/setup-slack-channel/SKILL.md
@@ -77,11 +77,15 @@ its listening line, returns HTTP 200 on `/api/copilotkit/info`, and answers
 nothing. `/api/copilotkit/info` reports license and runtime info, **not** channel
 state, so a 200 there is not evidence of anything Slack-related.
 
-The SDK behaviors asserted here were verified against the currently published
-`@copilotkit/channels@0.6.0` and `@copilotkit/runtime@1.65.0`. A starter may pin
-something older or newer, and this API is moving fast. If a claim here
-contradicts what you observe, **trust the installed package** and re-read it —
-do not argue with the runtime.
+The SDK behaviors asserted here were verified against
+`@copilotkit/channels@0.6.0` and `@copilotkit/runtime@1.65.0`, the pair
+published when this skill was written. They have **not** been re-verified
+against the current pair, `@copilotkit/channels@0.9.2` and
+`@copilotkit/runtime@1.70.3` (as of 2026-09-09). Do not install 0.6.0 on the
+strength of this note — it records where these claims came from, not a version
+to pin. A starter may pin something older or newer, and this API is moving fast.
+If a claim here contradicts what you observe, **trust the installed package**
+and re-read it — do not argue with the runtime.
 
 ## Scope — read before planning
 

--- a/skills/setup-slack-channel/references/troubleshooting.md
+++ b/skills/setup-slack-channel/references/troubleshooting.md
@@ -4,10 +4,14 @@ Diagnose by layer, in this order: **runtime → Intelligence → Slack → agent
 Runtime comes first because one command there names the failure, which saves you
 from guessing at the other three.
 
-Everything below was verified against the currently published
-`@copilotkit/channels@0.6.0` and `@copilotkit/runtime@1.65.0`. Never quote line
-numbers at the developer, and re-read the installed package if a claim looks
-wrong — the API is moving, and a starter may pin something older or newer.
+Everything below was verified against `@copilotkit/channels@0.6.0` and
+`@copilotkit/runtime@1.65.0`, the pair published when this page was written. It
+has **not** been re-verified against the current pair,
+`@copilotkit/channels@0.9.2` and `@copilotkit/runtime@1.70.3` (as of
+2026-09-09). That older pair records where these claims came from; it is not a
+version to pin. Never quote line numbers at the developer, and re-read the
+installed package if a claim looks wrong — the API is moving, and a starter may
+pin something older or newer.
 
 ## First move: make the runtime tell the truth
 

--- a/skills/setup-slack-channel/references/troubleshooting.md
+++ b/skills/setup-slack-channel/references/troubleshooting.md
@@ -4,14 +4,10 @@ Diagnose by layer, in this order: **runtime → Intelligence → Slack → agent
 Runtime comes first because one command there names the failure, which saves you
 from guessing at the other three.
 
-Everything below was verified against `@copilotkit/channels@0.6.0` and
-`@copilotkit/runtime@1.65.0`, the pair published when this page was written. It
-has **not** been re-verified against the current pair,
-`@copilotkit/channels@0.9.2` and `@copilotkit/runtime@1.70.3` (as of
-2026-09-09). That older pair records where these claims came from; it is not a
-version to pin. Never quote line numbers at the developer, and re-read the
-installed package if a claim looks wrong — the API is moving, and a starter may
-pin something older or newer.
+This page targets `@copilotkit/channels@0.9.2` and `@copilotkit/runtime@1.70.3`.
+Never quote line numbers at the developer, and re-read the installed package if
+a claim looks wrong — the API is moving, and a starter may pin something older
+or newer.
 
 ## First move: make the runtime tell the truth
 


### PR DESCRIPTION
## The problem

#6952 moved every install line in the Channels docs onto a pair that can actually render
components, and deliberately left two files behind: `skills/setup-slack-channel/SKILL.md:81` and
`skills/setup-slack-channel/references/troubleshooting.md:8`. It called them "same class of bug,
outside docs content, left for a separate decision."

Both named `@copilotkit/channels@0.6.0` and `@copilotkit/runtime@1.65.0` as **"the currently
published"** pair. That has not been true for four minors — the registry says `0.9.2` and `1.70.3`
— and 0.6.0 is the release this repository's own guard test calls "the broken Channels 0.6.0
release" and ratchets against. So a skill whose job is to stop a coding agent guessing told that
agent its baseline was both current and a release we elsewhere call broken.

The shape of the sentence is what made this awkward to fix. Neither line was an install pin —
`skills/setup-slack-channel/` has no install command anywhere — so the number was not instructing
anyone to install 0.6.0. Each was a *verification* claim: "verified against X." A verification
claim cannot be updated by editing the version, because nobody re-verified anything. The first
attempt on this branch kept the claim and hedged it, which left four version references and two
qualifications in a paragraph a model has to parse. The "Agents, Everywhere" hackathon runs
Saturday 12 September across 51 cities and this skill is how an agent gets a Slack Channel working,
so the paragraph a model reads first should be the short one.

## The approach

**Stop asserting a verification.** Both paragraphs now say what the skill *targets* rather than
what it was checked against. There is then nothing false to assert, no unperformed verification
implied, and no reason for `0.6.0` or `1.65.0` to appear in the text at all — so they do not. No
date stamp either, so nothing in the paragraph goes stale on its own. Both paragraphs end up
shorter than they are on main.

`SKILL.md` keeps the tested-pair framing, since that is the part a reading agent needs to act on:
the two packages ship together and must be bumped together. Both paragraphs keep their original
closing guidance — trust the installed package, do not argue with the runtime — which was already
right and is what makes a stated target safe rather than brittle.

**No `version:` bump.** Repo precedent is that `fix(skills):` commits correcting stale claims leave
the frontmatter `version` alone (77e5415c45, bc5f807351); only `feat(skills):` bumps it
(ae0dbc2fd7).

**The guard test gains the two ratchet entries #6952 flagged.** `0.6.1` and `1.65.0` now sit
alongside the existing `0.5.0`, `0.6.0` and `1.64.2` entries, in the same shape. Nothing is
restructured, and no existing assertion is loosened or removed.

**That ratchet buys less than it looks, and the gap is worth naming.** It runs only over
`providerQuickstartSlugs` — the Slack and Teams quickstarts. It does not cover `skills/`; nothing
reads that tree. So it prevents recurrence in the docs #6952 already fixed, not in the files this
PR fixes. And no CI job runs `channels-docs.test.ts` at all: `test_integration-docs.yml` invokes
only `ms-agent-dotnet-provider`, `frontend-tools-setup-coverage` and `setup-concept`, and both jobs
in `test_unit-showcase.yml` are scoped to `showcase/harness` and `showcase/shell-dashboard`. It is
a local-only guard — a plausible answer to how the docs drifted four minors unnoticed.

## What is not covered

- **No recording.** Text in three files, no runtime surface to demonstrate. The durable evidence is
  the registry state and the test output below.
- **`@copilotkit/runtime@1.70.3` vs the docs' `1.70.2`.** npm published 1.70.3 on 2026-09-08, about
  three hours after 1.70.2 and roughly an hour before #6952 merged, so the docs' install pin is now
  one patch behind. The skills name 1.70.3 because that is what is currently published. The docs
  pin is a tested-pair claim and I have not touched it — whether the tested pair should follow to
  1.70.3 is a maintainer call, and if it does, these two files should move with it.
- **`reference/channels/functions/createChannel.mdx:114`** still reads "Channels 0.6.1 warns when
  enumerable fields are dropped." Deliberately untouched, as in #6952: it is a claim about when
  behaviour changed, not a pin. Does it mean "as of 0.6.1" or "in 0.6.1"? If the former, the number
  wants updating; if the latter, it is correct as written.
- **Three `doctest.json` files pin `@copilotkit/runtime@1.68.3`** —
  `src/content/doctest.json`, `docs/integrations/langgraph/doctest.json`,
  `docs/integrations/mastra/doctest.json`. Stale, different purpose, untouched.
- **`CopilotKit/channels-sdk` is worse than this repo and is not fixed here.**
  `.agents/skills/build-channels-agent/SKILL.md:70` carries a real install pin —
  `npm install --save-exact @copilotkit/channels@0.6.1 @copilotkit/runtime@1.65.0` — the exact line
  #6952 removed from our docs. It is not a one-line fix: lines 39-40 say the samples were
  typechecked against `0.7.1` + `1.66.1` and "the `0.6.1` + `1.65.0` pair that the
  [Slack guide](https://docs.copilotkit.ai/slack) pins", and that guide now pins 0.9.2 + 1.70.2, so
  that sentence is stale too. The same page states `defineChannelComponent` is "**0.7+ only**"
  fifteen lines above an install block pinning 0.6.1. Bumping the install alone would leave the page
  contradicting itself in two places, so it needs its own PR and a decision about what the samples
  are claimed to compile against.
- **No other stale `@copilotkit` pin exists in `skills/`.** The only other matches are
  `@copilotkit/react-textarea@1.x` (a major line, not a pin), `@latest` in the v1-to-v2 upgrade
  guide (intentional), unpinned `npm install` lines in `copilotkit-setup`, and a `0.5.0`/`0.6.0`
  range on an unrelated Python `llama-index-llms-openai` dependency.
- **The skill's behavioural claims are still unverified against 0.9.2.** Saying the skill targets a
  pair is not the same as having replayed it against that pair, and this PR does not close that.
  What it removes is the false assertion that the claims were checked against something else.

## Verification

Registry state re-checked immediately before the final commit: `npm view @copilotkit/channels
version` → `0.9.2`; `npm view @copilotkit/runtime version` → `1.70.3`. `dist-tags.latest` confirms
both.

`channels-docs.test.ts`, per the CI recipe in `test_integration-docs.yml` (`npm ci --ignore-scripts`
in `showcase/scripts` and `showcase/shell-docs`, harness symlink, `npm run pretypecheck`):

```
npm exec -- vitest run src/lib/__tests__/channels-docs.test.ts
Test Files  1 passed (1)
     Tests  30 passed (30)      # 28 before, +2 from the new ratchet entries
```

Both new assertions were negative-controlled rather than assumed. Injecting a stray
`@copilotkit/channels@0.6.1` into `frontends/slack.mdx` while leaving the correct pin in place
fails exactly one test with the intended message — `frontends/slack retains Channels 0.6.1, which
cannot render components` — and the file was restored afterwards.

Whole-suite delta, to show nothing else moved: `npm exec -- vitest run` gives
`6 failed | 868 passed (874)`. The same failures occur on an unmodified tree (`brand-nav`,
`angular-docs-content` x3, `llm-text`, `ms-agent-python-stable-api`), confirmed by stashing the
change and re-running those files: `6 failed | 100 passed (106)`. Zero new failures. The only test
that reads `skills/` at all is `inspector-docs.test.ts`, and it reads
`skills/inspector-docs/references/pane-map.md` — not this skill, and nothing version-pinned.

`npx tsc --noEmit` in `showcase/shell-docs` exits 0. `oxlint` reports nothing on the test file, and
`oxfmt --check` (0.36.0, matching the root pin) reports all three files correctly formatted.
`grep` for `0.6.0`, `0.6.1` and `1.65.0` across `skills/` now returns only an unrelated Python
dependency range.

No source, config, or lockfile changes. No new test files.
