### PR TITLE
fix(react-core): make document attachments downloadable

### DIFF
--- a/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
@@ -106,16 +106,29 @@ const VideoAttachment = memo(function VideoAttachment({
 });
 
 const DocumentAttachment = memo(function DocumentAttachment({
+  src,
   source,
   filename,
   className,
 }: {
+  src: string;
   source: InputContentSource;
   filename?: string;
   className?: string;
 }) {
+  const label = filename || source.mimeType || "Document attachment";
+
+  // `download` is honoured for same-origin, data: and blob: URLs. Browsers
+  // ignore it for cross-origin URLs unless the server sends
+  // `Content-Disposition: attachment`; `target="_blank"` keeps those from
+  // navigating the chat away and lets the file open in a new tab instead.
   return (
-    <div
+    <a
+      href={src}
+      download={filename ?? ""}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={label}
       className={cn(
         "cpk:inline-flex cpk:max-w-full cpk:items-center cpk:gap-2 cpk:px-3 cpk:py-2 cpk:border cpk:border-border cpk:rounded-lg cpk:bg-muted",
         className,
@@ -127,7 +140,7 @@ const DocumentAttachment = memo(function DocumentAttachment({
       <span className="cpk:text-sm cpk:text-muted-foreground cpk:truncate">
         {filename || source.mimeType || "Unknown type"}
       </span>
-    </div>
+    </a>
   );
 });
 
@@ -148,6 +161,7 @@ export const CopilotChatAttachmentRenderer: React.FC<
     case "document":
       return (
         <DocumentAttachment
+          src={src}
           source={source}
           filename={filename}
           className={className}

--- a/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatAttachmentRenderer.tsx
@@ -117,7 +117,7 @@ const DocumentAttachment = memo(function DocumentAttachment({
   return (
     <div
       className={cn(
-        "cpk:inline-flex cpk:items-center cpk:gap-2 cpk:px-3 cpk:py-2 cpk:border cpk:border-border cpk:rounded-lg cpk:bg-muted",
+        "cpk:inline-flex cpk:max-w-full cpk:items-center cpk:gap-2 cpk:px-3 cpk:py-2 cpk:border cpk:border-border cpk:rounded-lg cpk:bg-muted",
         className,
       )}
     >

--- a/packages/react-core/src/v2/components/chat/CopilotChatUserMessage.tsx
+++ b/packages/react-core/src/v2/components/chat/CopilotChatUserMessage.tsx
@@ -219,7 +219,7 @@ export function CopilotChatUserMessage({
       {...props}
     >
       {mediaParts.length > 0 && (
-        <div className="cpk:flex cpk:flex-row cpk:flex-wrap cpk:justify-end cpk:gap-2 cpk:mb-2">
+        <div className="cpk:flex cpk:flex-row cpk:flex-wrap cpk:max-w-full cpk:justify-end cpk:gap-2 cpk:mb-2">
           {mediaParts.map((part, index) => (
             <CopilotChatAttachmentRenderer
               key={index}

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatAttachmentRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatAttachmentRenderer.test.tsx
@@ -36,7 +36,11 @@ describe("CopilotChatAttachmentRenderer", () => {
     render(
       <CopilotChatAttachmentRenderer
         type="document"
-        source={{ type: "base64", value: "JVBERi0=", mimeType: "application/pdf" }}
+        source={{
+          type: "data",
+          value: "JVBERi0=",
+          mimeType: "application/pdf",
+        }}
       />,
     );
 

--- a/packages/react-core/src/v2/components/chat/__tests__/CopilotChatAttachmentRenderer.test.tsx
+++ b/packages/react-core/src/v2/components/chat/__tests__/CopilotChatAttachmentRenderer.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+import { CopilotChatAttachmentRenderer } from "../CopilotChatAttachmentRenderer";
+
+describe("CopilotChatAttachmentRenderer", () => {
+  it("links a document attachment to its resolved source URL", () => {
+    const href =
+      "https://files.example.test/download/document.pdf?signature=preserved";
+
+    render(
+      <CopilotChatAttachmentRenderer
+        type="document"
+        source={{
+          type: "url",
+          value: href,
+          mimeType: "application/pdf",
+        }}
+        filename="document.pdf"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "document.pdf" });
+
+    expect(link).toHaveAttribute("href", href);
+    expect(link).toHaveAttribute("download", "document.pdf");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveTextContent("document.pdf");
+  });
+
+  it("keeps a data URL downloadable when no filename is known", () => {
+    const href = "data:application/pdf;base64,JVBERi0=";
+
+    render(
+      <CopilotChatAttachmentRenderer
+        type="document"
+        source={{ type: "base64", value: "JVBERi0=", mimeType: "application/pdf" }}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "application/pdf" });
+
+    expect(link).toHaveAttribute("href", href);
+    expect(link).toHaveAttribute("download", "");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Two small fixes for attachments in the v2 chat:

- **Document attachments were not downloadable.** `DocumentAttachment` rendered a plain block, so a user could see the file name but had no way to open or save the file. It is now an anchor with `href={src}` and `download={filename ?? ""}`, with an `aria-label` naming the file, and keeps the same visual style. `download` is honoured for same-origin, data: and blob: URLs; browsers ignore it for cross-origin URLs unless the server sends `Content-Disposition: attachment`, so the link also opens in a new tab with `rel="noopener noreferrer"` and never navigates the chat away. Tests cover both a URL and a data source.
- **Attachments could overflow the message width.** The attachment renderer and the user message container lacked `max-w-full`, so a wide image or a long file name pushed the bubble outside the chat column. Both get `cpk:max-w-full`.

## Related PRs and Issues

- None

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


## Current validation

Rebased onto current main (`cf191b55`). Node 22.23.1, pnpm 10.33.4. Build, full react-core tests, type checking, publint and package type resolution checks passed. Build/codegen ran before the final type check because generated GraphQL source files are required.

```text
pnpm exec nx run-many -t build,test,check-types,publint,attw --projects=@copilotkit/react-core --skipNxCache
pnpm exec nx run-many -t check-types --projects=@copilotkit/runtime-client-gql,@copilotkit/react-core --excludeTaskDependencies --skipNxCache
```

The data-source fixture now uses the official `type: "data"` union member. All 1,686 react-core tests and the subsequent package checks passed. Downstream dev and production browser tests now pass against the published package: clicking a same-origin attachment downloads the expected filename and original bytes, both live and after a cold backend restart. The separate data/blob/cross-origin manual matrix remains incomplete because the native browser connection failed. The component unit tests cover the link attributes; they do not establish cross-origin download enforcement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document attachments in chat can now be downloaded by selecting their filename.
  * Downloads open securely in a new browser tab and include accessible labeling.

* **Style**
  * Attachment containers now fit within the available message width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
