### PR TITLE
fix(skills): correct react-core agent access against the shipped API

### DIFF
--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -171,16 +171,18 @@ class MyAgent extends AbstractAgent {
 ```
 
 Nothing validates the return value, so returning `this` fails silently rather
-than throwing. The suggestion engine clones the provider agent and then writes
-a suggestion thread id, seeded messages, and seeded state onto the copy — given
-`this`, it writes all three onto the live agent the user is talking to.
-Delegate cloning aliases the same way.
+than throwing. On the stateful suggestions path the engine clones the provider
+agent and then writes a suggestion thread id, seeded messages, and seeded state
+onto the copy — given `this`, it writes all three onto the live agent the user
+is talking to. (With `suggestions: true` on a multi-route runtime it builds a
+fresh `HttpAgent` instead and never clones, so the fault is configuration
+dependent.) Delegate cloning aliases the same way.
 
 `useAgent` itself does not clone. It either binds the shared registry instance
 or registers a private proxied agent; see the two shapes above.
 
-Source: `packages/core/src/core/suggestion-engine.ts:244-249` (clone, then
-seed onto the copy); `packages/core/src/agent.ts:448-472`
+Source: `packages/core/src/core/suggestion-engine.ts:218-249` (the branch, the
+clone, then the seeding); `packages/core/src/agent.ts:448-472`
 (`ProxiedCopilotRuntimeAgent.clone`, the reference implementation — it rebuilds
 field by field, then copies threadId, state, and messages)
 

--- a/packages/react-core/skills/react-core/references/agent-access.md
+++ b/packages/react-core/skills/react-core/references/agent-access.md
@@ -29,7 +29,6 @@ export function ChatDriver({
 }) {
   const { agent } = useAgent({
     agentId: "default",
-    threadId: "main",
     updates: [
       UseAgentUpdate.OnMessagesChanged,
       UseAgentUpdate.OnRunStatusChanged,
@@ -111,6 +110,35 @@ stand-in. It is a fully-constructed `AbstractAgent`, so every call on it
 is safe — but it is then **replaced**, and `agent` changes reference.
 Anything keyed to the old instance goes with it.
 
+### Scope a private agent to a thread
+
+`useAgent` admits exactly two shapes and nothing in between:
+
+- **Bind to an agent** — `useAgent()` or `useAgent({ agentId })`. The shared
+  instance from the registry; the thread comes from the chat configuration.
+- **Bind a private agent to a thread** —
+  `useAgent({ agentId, runtimeAgentId, threadId })`. All three are required.
+
+```tsx
+// A panel with a thread of its own, routed to the runtime's "default" agent.
+const { agent, isReady } = useAgent({
+  agentId: "extraction-panel", // local id this hook registers under
+  runtimeAgentId: "default", // the runtime agent to route to
+  threadId: extractionThreadId,
+});
+```
+
+The second shape registers a private `ProxiedCopilotRuntimeAgent` under the
+local `agentId` and unregisters it on unmount, so the thread is pinned to an
+instance nothing else shares. The registration is a single balanced effect, so
+it survives a StrictMode double-invoke: the cleanup unregisters before the
+remount re-registers.
+
+Pick a local `agentId` no real agent uses, and a different one per surface.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:126-137` (the two
+shapes), `:239-254` (register and unregister)
+
 ## Common Mistakes
 
 ### CRITICAL — Custom `AbstractAgent.clone()` that returns `this`
@@ -120,7 +148,7 @@ Wrong:
 ```tsx
 class MyAgent extends AbstractAgent {
   clone() {
-    return this; // wrong — same instance is reused across threads
+    return this; // aliases one instance everywhere a copy is expected
   }
 }
 ```
@@ -130,18 +158,31 @@ Correct:
 ```tsx
 class MyAgent extends AbstractAgent {
   clone() {
-    const next = new MyAgent(this.config);
-    next.state = { ...this.state };
+    // Pass the same constructor arguments this instance was built with.
+    // `AbstractAgent` takes `config` as a parameter and does not retain it, so
+    // keep whatever your subclass needs on a field of its own.
+    const next = new MyAgent(this.myConfig);
+    next.threadId = this.threadId;
+    next.setState(this.state);
+    next.setMessages(this.messages);
     return next;
   }
 }
 ```
 
-`useAgent` calls `source.clone()` to build a per-thread clone and throws
-`clone() must return a new, independent object` if the clone is the same
-instance. This guards per-thread isolation.
+Nothing validates the return value, so returning `this` fails silently rather
+than throwing. The suggestion engine clones the provider agent and then writes
+a suggestion thread id, seeded messages, and seeded state onto the copy — given
+`this`, it writes all three onto the live agent the user is talking to.
+Delegate cloning aliases the same way.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+`useAgent` itself does not clone. It either binds the shared registry instance
+or registers a private proxied agent; see the two shapes above.
+
+Source: `packages/core/src/core/suggestion-engine.ts:244-249` (clone, then
+seed onto the copy); `packages/core/src/agent.ts:448-472`
+(`ProxiedCopilotRuntimeAgent.clone`, the reference implementation — it rebuilds
+field by field, then copies threadId, state, and messages)
 
 ### HIGH — Deriving app state from `agent` without guarding on `isReady`
 
@@ -323,33 +364,33 @@ sees.
 
 Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx` (no `agentId` parameter); `packages/core/src/core/context-store.ts:26-31`
 
-### MEDIUM — Two components using the same `(agentId, threadId)` expecting isolation
+### MEDIUM — Scoping a thread with `agentId` and `threadId` alone
 
 Wrong:
 
 ```tsx
-function A() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
-}
-function B() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
-}
+// A compile error. Bypass the types and a runtime guard throws instead.
+useAgent({ agentId: "default", threadId: "t1" });
 ```
 
 Correct:
 
 ```tsx
-function A() {
-  useAgent({ agentId: "default", threadId: "a" });
-}
-function B() {
-  useAgent({ agentId: "default", threadId: "b" });
-}
+useAgent({
+  agentId: "panel-1", // a local id of this hook's own
+  runtimeAgentId: "default", // the runtime agent to route to
+  threadId: "t1",
+});
 ```
 
-Per-thread clones are cached in a module-level WeakMap keyed by
-`(registryAgent, threadId)`. Two consumers of the same `(agentId,
-threadId)` observe the same state. Give each surface a distinct `threadId`
-when isolation is intentional.
+`threadId` is written onto a single agent instance, and an agent resolved by
+`agentId` alone is a shared singleton, so pinning a thread to it would clobber
+every other `useAgent` caller. The three keys are therefore a matched set: the
+type rejects every partial combination, and three runtime guards throw for
+callers who bypass the types, each naming the correct call.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+Give each surface its own local `agentId`. Two mounted hooks registering the
+same one throw `already registered` rather than quietly sharing state.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:160-198` (the guards);
+`packages/core/src/core/agent-registry.ts:486-491` (the duplicate-id throw)

--- a/packages/react-core/skills/react-core/references/chat-components.md
+++ b/packages/react-core/skills/react-core/references/chat-components.md
@@ -201,11 +201,15 @@ Correct:
 // ...or mount only one <CopilotChat> instance per agent/thread.
 ```
 
-Both components resolve to the same per-thread clone (cached in a
-module-level WeakMap) and submit duplicate messages. See `agent-access` for
-the clone semantics.
+Both components resolve the same shared agent. `CopilotChat` binds with
+`useAgent({ agentId })` — the shared-instance shape — and then writes
+`agent.threadId` onto it, so two instances naming one `(agentId, threadId)`
+pair drive a single agent on a single thread and both submit. There is no
+per-thread clone. See `agent-access` for the two shapes `useAgent` admits and
+which one owns a private instance.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+Source: `packages/react-core/src/v2/components/chat/CopilotChat.tsx:138-141`
+(the shared bind); `:395` (the threadId write)
 
 ### MEDIUM — Missing the v2 CSS import
 

--- a/packages/react-core/skills/react-core/references/chat-components.md
+++ b/packages/react-core/skills/react-core/references/chat-components.md
@@ -203,13 +203,26 @@ Correct:
 
 Both components resolve the same shared agent. `CopilotChat` binds with
 `useAgent({ agentId })` — the shared-instance shape — and then writes
-`agent.threadId` onto it, so two instances naming one `(agentId, threadId)`
-pair drive a single agent on a single thread and both submit. There is no
-per-thread clone. See `agent-access` for the two shapes `useAgent` admits and
-which one owns a private instance.
+`agent.threadId` onto it. There is no per-thread clone, so two instances
+naming one `(agentId, threadId)` pair drive a single instance:
+
+- Each runs its own connect effect against that instance, so the same thread is
+  connected twice.
+- Each assigns `agent.abortController`, so the later mount replaces the
+  earlier one and unmounting either can abort the other's in-flight request.
+- Each calls `setMessages` on it, so whichever connect resolves last wins.
+
+The bookkeeping that would prevent this (`lastConnectedThreadId`,
+`activeConnectCountRef`) is per component, so it does not coordinate across
+two instances.
+
+See `agent-access` for the two shapes `useAgent` admits and which one owns a
+private instance.
 
 Source: `packages/react-core/src/v2/components/chat/CopilotChat.tsx:138-141`
-(the shared bind); `:395` (the threadId write)
+(the shared bind), `:395` (the threadId write), `:421-423` (the shared
+abortController), `:429` (the connect call), `:261-266` (the per-instance
+bookkeeping)
 
 ### MEDIUM — Missing the v2 CSS import
 

--- a/skills/react-core/references/agent-access.md
+++ b/skills/react-core/references/agent-access.md
@@ -171,16 +171,18 @@ class MyAgent extends AbstractAgent {
 ```
 
 Nothing validates the return value, so returning `this` fails silently rather
-than throwing. The suggestion engine clones the provider agent and then writes
-a suggestion thread id, seeded messages, and seeded state onto the copy — given
-`this`, it writes all three onto the live agent the user is talking to.
-Delegate cloning aliases the same way.
+than throwing. On the stateful suggestions path the engine clones the provider
+agent and then writes a suggestion thread id, seeded messages, and seeded state
+onto the copy — given `this`, it writes all three onto the live agent the user
+is talking to. (With `suggestions: true` on a multi-route runtime it builds a
+fresh `HttpAgent` instead and never clones, so the fault is configuration
+dependent.) Delegate cloning aliases the same way.
 
 `useAgent` itself does not clone. It either binds the shared registry instance
 or registers a private proxied agent; see the two shapes above.
 
-Source: `packages/core/src/core/suggestion-engine.ts:244-249` (clone, then
-seed onto the copy); `packages/core/src/agent.ts:448-472`
+Source: `packages/core/src/core/suggestion-engine.ts:218-249` (the branch, the
+clone, then the seeding); `packages/core/src/agent.ts:448-472`
 (`ProxiedCopilotRuntimeAgent.clone`, the reference implementation — it rebuilds
 field by field, then copies threadId, state, and messages)
 

--- a/skills/react-core/references/agent-access.md
+++ b/skills/react-core/references/agent-access.md
@@ -29,7 +29,6 @@ export function ChatDriver({
 }) {
   const { agent } = useAgent({
     agentId: "default",
-    threadId: "main",
     updates: [
       UseAgentUpdate.OnMessagesChanged,
       UseAgentUpdate.OnRunStatusChanged,
@@ -111,6 +110,35 @@ stand-in. It is a fully-constructed `AbstractAgent`, so every call on it
 is safe — but it is then **replaced**, and `agent` changes reference.
 Anything keyed to the old instance goes with it.
 
+### Scope a private agent to a thread
+
+`useAgent` admits exactly two shapes and nothing in between:
+
+- **Bind to an agent** — `useAgent()` or `useAgent({ agentId })`. The shared
+  instance from the registry; the thread comes from the chat configuration.
+- **Bind a private agent to a thread** —
+  `useAgent({ agentId, runtimeAgentId, threadId })`. All three are required.
+
+```tsx
+// A panel with a thread of its own, routed to the runtime's "default" agent.
+const { agent, isReady } = useAgent({
+  agentId: "extraction-panel", // local id this hook registers under
+  runtimeAgentId: "default", // the runtime agent to route to
+  threadId: extractionThreadId,
+});
+```
+
+The second shape registers a private `ProxiedCopilotRuntimeAgent` under the
+local `agentId` and unregisters it on unmount, so the thread is pinned to an
+instance nothing else shares. The registration is a single balanced effect, so
+it survives a StrictMode double-invoke: the cleanup unregisters before the
+remount re-registers.
+
+Pick a local `agentId` no real agent uses, and a different one per surface.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:126-137` (the two
+shapes), `:239-254` (register and unregister)
+
 ## Common Mistakes
 
 ### CRITICAL — Custom `AbstractAgent.clone()` that returns `this`
@@ -120,7 +148,7 @@ Wrong:
 ```tsx
 class MyAgent extends AbstractAgent {
   clone() {
-    return this; // wrong — same instance is reused across threads
+    return this; // aliases one instance everywhere a copy is expected
   }
 }
 ```
@@ -130,18 +158,31 @@ Correct:
 ```tsx
 class MyAgent extends AbstractAgent {
   clone() {
-    const next = new MyAgent(this.config);
-    next.state = { ...this.state };
+    // Pass the same constructor arguments this instance was built with.
+    // `AbstractAgent` takes `config` as a parameter and does not retain it, so
+    // keep whatever your subclass needs on a field of its own.
+    const next = new MyAgent(this.myConfig);
+    next.threadId = this.threadId;
+    next.setState(this.state);
+    next.setMessages(this.messages);
     return next;
   }
 }
 ```
 
-`useAgent` calls `source.clone()` to build a per-thread clone and throws
-`clone() must return a new, independent object` if the clone is the same
-instance. This guards per-thread isolation.
+Nothing validates the return value, so returning `this` fails silently rather
+than throwing. The suggestion engine clones the provider agent and then writes
+a suggestion thread id, seeded messages, and seeded state onto the copy — given
+`this`, it writes all three onto the live agent the user is talking to.
+Delegate cloning aliases the same way.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:58-69`
+`useAgent` itself does not clone. It either binds the shared registry instance
+or registers a private proxied agent; see the two shapes above.
+
+Source: `packages/core/src/core/suggestion-engine.ts:244-249` (clone, then
+seed onto the copy); `packages/core/src/agent.ts:448-472`
+(`ProxiedCopilotRuntimeAgent.clone`, the reference implementation — it rebuilds
+field by field, then copies threadId, state, and messages)
 
 ### HIGH — Deriving app state from `agent` without guarding on `isReady`
 
@@ -323,33 +364,33 @@ sees.
 
 Source: `packages/react-core/src/v2/hooks/use-agent-context.tsx` (no `agentId` parameter); `packages/core/src/core/context-store.ts:26-31`
 
-### MEDIUM — Two components using the same `(agentId, threadId)` expecting isolation
+### MEDIUM — Scoping a thread with `agentId` and `threadId` alone
 
 Wrong:
 
 ```tsx
-function A() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
-}
-function B() {
-  const { agent } = useAgent({ agentId: "default", threadId: "t1" });
-}
+// A compile error. Bypass the types and a runtime guard throws instead.
+useAgent({ agentId: "default", threadId: "t1" });
 ```
 
 Correct:
 
 ```tsx
-function A() {
-  useAgent({ agentId: "default", threadId: "a" });
-}
-function B() {
-  useAgent({ agentId: "default", threadId: "b" });
-}
+useAgent({
+  agentId: "panel-1", // a local id of this hook's own
+  runtimeAgentId: "default", // the runtime agent to route to
+  threadId: "t1",
+});
 ```
 
-Per-thread clones are cached in a module-level WeakMap keyed by
-`(registryAgent, threadId)`. Two consumers of the same `(agentId,
-threadId)` observe the same state. Give each surface a distinct `threadId`
-when isolation is intentional.
+`threadId` is written onto a single agent instance, and an agent resolved by
+`agentId` alone is a shared singleton, so pinning a thread to it would clobber
+every other `useAgent` caller. The three keys are therefore a matched set: the
+type rejects every partial combination, and three runtime guards throw for
+callers who bypass the types, each naming the correct call.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+Give each surface its own local `agentId`. Two mounted hooks registering the
+same one throw `already registered` rather than quietly sharing state.
+
+Source: `packages/react-core/src/v2/hooks/use-agent.tsx:160-198` (the guards);
+`packages/core/src/core/agent-registry.ts:486-491` (the duplicate-id throw)

--- a/skills/react-core/references/chat-components.md
+++ b/skills/react-core/references/chat-components.md
@@ -201,11 +201,15 @@ Correct:
 // ...or mount only one <CopilotChat> instance per agent/thread.
 ```
 
-Both components resolve to the same per-thread clone (cached in a
-module-level WeakMap) and submit duplicate messages. See `agent-access` for
-the clone semantics.
+Both components resolve the same shared agent. `CopilotChat` binds with
+`useAgent({ agentId })` — the shared-instance shape — and then writes
+`agent.threadId` onto it, so two instances naming one `(agentId, threadId)`
+pair drive a single agent on a single thread and both submit. There is no
+per-thread clone. See `agent-access` for the two shapes `useAgent` admits and
+which one owns a private instance.
 
-Source: `packages/react-core/src/v2/hooks/use-agent.tsx:78-119`
+Source: `packages/react-core/src/v2/components/chat/CopilotChat.tsx:138-141`
+(the shared bind); `:395` (the threadId write)
 
 ### MEDIUM — Missing the v2 CSS import
 

--- a/skills/react-core/references/chat-components.md
+++ b/skills/react-core/references/chat-components.md
@@ -203,13 +203,26 @@ Correct:
 
 Both components resolve the same shared agent. `CopilotChat` binds with
 `useAgent({ agentId })` — the shared-instance shape — and then writes
-`agent.threadId` onto it, so two instances naming one `(agentId, threadId)`
-pair drive a single agent on a single thread and both submit. There is no
-per-thread clone. See `agent-access` for the two shapes `useAgent` admits and
-which one owns a private instance.
+`agent.threadId` onto it. There is no per-thread clone, so two instances
+naming one `(agentId, threadId)` pair drive a single instance:
+
+- Each runs its own connect effect against that instance, so the same thread is
+  connected twice.
+- Each assigns `agent.abortController`, so the later mount replaces the
+  earlier one and unmounting either can abort the other's in-flight request.
+- Each calls `setMessages` on it, so whichever connect resolves last wins.
+
+The bookkeeping that would prevent this (`lastConnectedThreadId`,
+`activeConnectCountRef`) is per component, so it does not coordinate across
+two instances.
+
+See `agent-access` for the two shapes `useAgent` admits and which one owns a
+private instance.
 
 Source: `packages/react-core/src/v2/components/chat/CopilotChat.tsx:138-141`
-(the shared bind); `:395` (the threadId write)
+(the shared bind), `:395` (the threadId write), `:421-423` (the shared
+abortController), `:429` (the connect call), `:261-266` (the per-instance
+bookkeeping)
 
 ### MEDIUM — Missing the v2 CSS import
 


### PR DESCRIPTION
Refs #6125.

## Summary

The bundled `react-core` skill documented a pre-`registerProxiedAgent` architecture. It ships inside the `@copilotkit/react-core` tarball via `"files": ["dist", "skills"]`, so it reaches every consumer with no install step and no telemetry.

Three classes of defect, all in the same root cause.

### 1. A compile error, five times over

`useAgent({ agentId, threadId })` appeared five times in `agent-access.md`, including as the **first example in the file**. `use-agent.tsx:126-137` states there are exactly two valid shapes and that this is not one of them; three runtime guards at `:160-198` reject it for callers who bypass the types.

`runtimeAgentId` — the key that makes thread scoping work — did not appear once in the file.

Now documented as the two shapes the hook admits, plus the rule that each surface needs its own local `agentId` because a duplicate throws `already registered` (`agent-registry.ts:486-491`).

### 2. A caching mechanism that does not exist

Two files claimed per-thread clones are cached "in a module-level WeakMap keyed by `(registryAgent, threadId)`". There is no such WeakMap. What actually happens:

- `useAgent` either binds the shared registry instance, or registers a private `ProxiedCopilotRuntimeAgent` under the local `agentId` and unregisters it on unmount (`use-agent.tsx:239-254`).
- `CopilotChat` binds the **shared** agent with `useAgent({ agentId, throttleMs })` (`CopilotChat.tsx:138-141`) and then writes `agent.threadId = resolvedThreadId` (`:395`). That is why two chats naming one `(agentId, threadId)` both submit — one instance, one thread, no clone.

### 3. A CRITICAL gotcha describing a guard that was removed

`agent-access.md` claimed `useAgent` calls `source.clone()` and throws `clone() must return a new, independent object`. `useAgent` never clones, and that message exists nowhere in the repo — I searched `packages/**` source for it.

Returning `this` is still wrong, and worse than the doc said: nothing validates the result, so it fails silently. `suggestion-engine.ts:244-249` clones the provider agent and then writes a suggestion thread id, seeded messages, and seeded state onto the copy — given `this`, it writes all three onto the live agent the user is talking to.

Its "Correct" example also constructed from `this.config`. `AbstractAgent` takes `config` as a constructor parameter and does not retain it (`agent.ts:136` spreads it), so that property does not exist. The example now says to keep what the subclass needs on a field of its own, and points at `ProxiedCopilotRuntimeAgent.clone` (`agent.ts:448-472`) as the reference implementation.

## On the issue

#6125 asked for two things. The second, "fix `agent-access.md` to match the shipped API", is this PR.

The first was a public headless thread-switching API, because the reporter was relying on an unblessed `agent.threadId = crypto.randomUUID()` mutation. That now exists in supported form as `useAgent({ agentId, runtimeAgentId, threadId })`, which is what the corrected doc describes. I have used `Refs` rather than `Closes` so a maintainer can confirm that satisfies them before closing.

## Testing

Docs-only, so the evidence is the gates plus the verification method.

Gates:

```
$ tsx scripts/sync-plugin-skills.ts
synced 3 package skill(s)

$ tsx scripts/sync-plugin-skills.ts --check
plugin skill mirror in sync

$ oxfmt --check skills/react-core/references/*.md
All matched files use the correct format.
```

Edits were made in `packages/react-core/skills/` (the source of truth) and mirrored to `skills/` by the sync script, not hand-edited in both.

Verification: every claim and every `Source:` citation in both touched files was checked against the tree at this commit.

| Citation | Verdict |
| --- | --- |
| `use-agent.tsx:78-119` (WeakMap, ×2 files) | stale — now prop docs. Replaced. |
| `use-agent.tsx:58-69` (clone guard) | stale — now `UseAgentThreadScopedProps.agentId`. Replaced. |
| `use-agent.tsx:36-48` (throttling) | correct, unchanged |
| `use-agent.tsx:226-290,465-481` (provisional agent, `isReady`) | correct, unchanged |

I also swept the whole skill set for the same defect elsewhere: `useAgent({ ... threadId ... })` without `runtimeAgentId` appears in no other reference, and the WeakMap claim had exactly the one other home, in `chat-components.md`, fixed here.

Not done: I did not re-audit citations in the other 13 `react-core` references. Given four of six were stale in these two files, that sweep is probably worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified supported `useAgent` configurations for shared agents and private agents scoped to specific threads.
  - Updated cloning guidance, including field-by-field construction and validation behavior.
  - Documented compile-time and runtime safeguards for invalid agent/thread combinations.
  - Explained how multiple chat components sharing an agent and thread can interfere through duplicate connections, shared abort handling, and competing message updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->