### PR TITLE
feat(react-core): add useFrontendTools for variable-length tool lists

### DIFF
--- a/packages/react-core/src/v2/__tests__/headless-exports.test.ts
+++ b/packages/react-core/src/v2/__tests__/headless-exports.test.ts
@@ -15,6 +15,7 @@ describe("@copilotkit/react-core/v2/headless runtime exports", () => {
       "useCopilotKit",
       "useAgent",
       "useFrontendTool",
+      "useFrontendTools",
       "useComponent",
       "useHumanInTheLoop",
       "useInterrupt",

--- a/packages/react-core/src/v2/headless.ts
+++ b/packages/react-core/src/v2/headless.ts
@@ -41,6 +41,7 @@ export {
 // binding from this entry under isolatedModules, breaking consumers.
 export { useAgent, UseAgentUpdate } from "./hooks/use-agent";
 export { useFrontendTool } from "./hooks/use-frontend-tool";
+export { useFrontendTools } from "./hooks/use-frontend-tools";
 export { useComponent } from "./hooks/use-component";
 export { useHumanInTheLoop } from "./hooks/use-human-in-the-loop";
 export {

--- a/packages/react-core/src/v2/hooks/__tests__/use-frontend-tools.test.tsx
+++ b/packages/react-core/src/v2/hooks/__tests__/use-frontend-tools.test.tsx
@@ -1,0 +1,484 @@
+import React, { useState, useEffect } from "react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { z } from "zod";
+import { useFrontendTools } from "../use-frontend-tools";
+import { useCopilotKit } from "../../providers/CopilotKitProvider";
+import type { ReactFrontendTool } from "../../types";
+import { CopilotKitCoreReact } from "../../lib/react-core";
+import { renderWithCopilotKit } from "../../__tests__/utils/test-helpers";
+
+/**
+ * Component that captures the copilotkit core ref for test assertions.
+ */
+const CoreCapture: React.FC<{
+  onCore: (core: CopilotKitCoreReact) => void;
+}> = ({ onCore }) => {
+  const { copilotkit } = useCopilotKit();
+  useEffect(() => {
+    onCore(copilotkit);
+  }, [copilotkit, onCore]);
+  return null;
+};
+
+function makeTool(name: string): ReactFrontendTool<{ msg: string }> {
+  return {
+    name,
+    description: `Tool ${name}`,
+    parameters: z.object({ msg: z.string() }),
+    handler: async () => ({ result: name }),
+  };
+}
+
+/** Names registered on the core, restricted to the ones a test created. */
+function registeredNames(core: CopilotKitCoreReact, prefix: string): string[] {
+  return core.tools
+    .map((t) => t.name)
+    .filter((name) => name.startsWith(prefix))
+    .sort();
+}
+
+describe("useFrontendTools", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers every tool in the array on mount", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools([
+        makeTool("mount_a"),
+        makeTool("mount_b"),
+        makeTool("mount_c"),
+      ]);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(registeredNames(coreRef!, "mount_")).toEqual([
+        "mount_a",
+        "mount_b",
+        "mount_c",
+      ]);
+    });
+
+    ui.unmount();
+  });
+
+  it("registers nothing for an empty array", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools([]);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+    });
+    expect(registeredNames(coreRef!, "empty_")).toEqual([]);
+
+    ui.unmount();
+  });
+
+  it("treats undefined as an empty array", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools(undefined);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+    });
+
+    ui.unmount();
+  });
+
+  it("registers a tool added to the array and keeps the existing ones", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const GrowingTools: React.FC = () => {
+      const [count, setCount] = useState(2);
+      useFrontendTools(
+        Array.from({ length: count }, (_, i) => makeTool(`grow_${i}`)),
+      );
+      return (
+        <button data-testid="add" onClick={() => setCount((n) => n + 1)}>
+          add
+        </button>
+      );
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <GrowingTools />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(registeredNames(coreRef!, "grow_")).toEqual(["grow_0", "grow_1"]);
+    });
+
+    fireEvent.click(screen.getByTestId("add"));
+
+    await waitFor(() => {
+      expect(registeredNames(coreRef!, "grow_")).toEqual([
+        "grow_0",
+        "grow_1",
+        "grow_2",
+      ]);
+    });
+
+    ui.unmount();
+  });
+
+  it("unregisters exactly the tool dropped from the array", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ShrinkingTools: React.FC = () => {
+      const [names, setNames] = useState(["drop_a", "drop_b", "drop_c"]);
+      useFrontendTools(names.map(makeTool));
+      return (
+        <button
+          data-testid="drop-b"
+          onClick={() => setNames((prev) => prev.filter((n) => n !== "drop_b"))}
+        >
+          drop
+        </button>
+      );
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ShrinkingTools />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(registeredNames(coreRef!, "drop_")).toEqual([
+        "drop_a",
+        "drop_b",
+        "drop_c",
+      ]);
+    });
+
+    fireEvent.click(screen.getByTestId("drop-b"));
+
+    await waitFor(() => {
+      expect(registeredNames(coreRef!, "drop_")).toEqual(["drop_a", "drop_c"]);
+    });
+
+    ui.unmount();
+  });
+
+  it("unregisters every tool on unmount", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools([makeTool("unmount_a"), makeTool("unmount_b")]);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(registeredNames(coreRef!, "unmount_")).toEqual([
+        "unmount_a",
+        "unmount_b",
+      ]);
+    });
+
+    ui.unmount();
+
+    expect(registeredNames(coreRef!, "unmount_")).toEqual([]);
+  });
+
+  it("does not re-register when a re-render produces an equal array", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+    const addTool = vi.spyOn(CopilotKitCoreReact.prototype, "addTool");
+
+    const RerenderingTools: React.FC = () => {
+      const [, setTick] = useState(0);
+      // A fresh array literal on every render: identity always changes.
+      useFrontendTools([makeTool("stable_a"), makeTool("stable_b")]);
+      return (
+        <button data-testid="tick" onClick={() => setTick((n) => n + 1)}>
+          tick
+        </button>
+      );
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <RerenderingTools />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(registeredNames(coreRef!, "stable_")).toEqual([
+        "stable_a",
+        "stable_b",
+      ]);
+    });
+
+    const callsAfterMount = addTool.mock.calls.length;
+
+    fireEvent.click(screen.getByTestId("tick"));
+    fireEvent.click(screen.getByTestId("tick"));
+
+    await waitFor(() => {
+      expect(registeredNames(coreRef!, "stable_")).toEqual([
+        "stable_a",
+        "stable_b",
+      ]);
+    });
+    expect(addTool.mock.calls.length).toBe(callsAfterMount);
+
+    ui.unmount();
+  });
+
+  it("re-registers when a tool's available flag changes", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const TogglingTools: React.FC = () => {
+      const [enabled, setEnabled] = useState(true);
+      useFrontendTools([
+        { ...makeTool("avail_a"), available: enabled },
+        makeTool("avail_b"),
+      ]);
+      return (
+        <button data-testid="toggle" onClick={() => setEnabled((v) => !v)}>
+          toggle
+        </button>
+      );
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <TogglingTools />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(coreRef!.tools.find((t) => t.name === "avail_a")?.available).toBe(
+        true,
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("toggle"));
+
+    await waitFor(() => {
+      expect(coreRef!.tools.find((t) => t.name === "avail_a")?.available).toBe(
+        false,
+      );
+    });
+
+    ui.unmount();
+  });
+
+  it("registers a renderer only for tools that define render, and keeps it after unmount", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools([
+        { ...makeTool("render_with"), render: () => <div>rendered</div> },
+        makeTool("render_without"),
+      ]);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(
+        coreRef!.renderToolCalls.some((r) => r.name === "render_with"),
+      ).toBe(true);
+    });
+    expect(
+      coreRef!.renderToolCalls.some((r) => r.name === "render_without"),
+    ).toBe(false);
+
+    ui.unmount();
+
+    // Renderers survive unmount so past tool calls still render in history.
+    expect(coreRef!.renderToolCalls.some((r) => r.name === "render_with")).toBe(
+      true,
+    );
+  });
+
+  it("keeps the last entry and warns when a name is duplicated in one array", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools([
+        { ...makeTool("dup"), description: "first" },
+        { ...makeTool("dup"), description: "second" },
+      ]);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(registeredNames(coreRef!, "dup")).toEqual(["dup"]);
+    });
+
+    expect(coreRef!.tools.find((t) => t.name === "dup")?.description).toBe(
+      "second",
+    );
+    expect(
+      warn.mock.calls.some(
+        (call) =>
+          typeof call[0] === "string" &&
+          call[0].includes("listed more than once"),
+      ),
+    ).toBe(true);
+
+    ui.unmount();
+  });
+
+  it("scopes tools by agentId so the same name can serve two agents", async () => {
+    let coreRef: CopilotKitCoreReact | null = null;
+
+    const ToolsComponent: React.FC = () => {
+      useFrontendTools([
+        { ...makeTool("scoped"), agentId: "agent_one" },
+        { ...makeTool("scoped"), agentId: "agent_two" },
+      ]);
+      return null;
+    };
+
+    const ui = renderWithCopilotKit({
+      children: (
+        <>
+          <ToolsComponent />
+          <CoreCapture
+            onCore={(c) => {
+              coreRef = c;
+            }}
+          />
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(coreRef).not.toBeNull();
+      expect(coreRef!.tools.filter((t) => t.name === "scoped")).toHaveLength(2);
+    });
+
+    ui.unmount();
+
+    expect(coreRef!.tools.filter((t) => t.name === "scoped")).toHaveLength(0);
+  });
+});

--- a/packages/react-core/src/v2/hooks/index.ts
+++ b/packages/react-core/src/v2/hooks/index.ts
@@ -3,6 +3,7 @@ export { useRenderToolCall } from "./use-render-tool-call";
 export { useRenderCustomMessages } from "./use-render-custom-messages";
 export { useRenderActivityMessage } from "./use-render-activity-message";
 export { useFrontendTool } from "./use-frontend-tool";
+export { useFrontendTools } from "./use-frontend-tools";
 export { useComponent } from "./use-component";
 export { useRenderTool } from "./use-render-tool";
 export { useDefaultRenderTool } from "./use-default-render-tool";

--- a/packages/react-core/src/v2/hooks/use-frontend-tools.tsx
+++ b/packages/react-core/src/v2/hooks/use-frontend-tools.tsx
@@ -1,0 +1,130 @@
+import { useLayoutEffect } from "react";
+import { useCopilotKit } from "../context";
+import type { ReactFrontendTool } from "../types/frontend-tool";
+
+const EMPTY_DEPS: ReadonlyArray<unknown> = [];
+const EMPTY_TOOLS: ReadonlyArray<ReactFrontendTool<any>> = [];
+
+/**
+ * Register a list of frontend tools whose length can change between renders.
+ *
+ * `useFrontendTool` registers exactly one tool per call, so it cannot be called
+ * in a loop over a runtime-length list without breaking the rules of hooks.
+ * This hook runs a single effect over the whole array instead, which makes it
+ * safe to build the list from state, props, or a server response.
+ *
+ * Tools are keyed by `name` plus `agentId`, the same as `useFrontendTool`. A
+ * tool that disappears from the array is unregistered on the next render, and
+ * every tool is unregistered on unmount. Renderers stay registered after
+ * unmount so past tool calls still render in the chat history.
+ *
+ * @param tools - The tools to register. May be empty and may change length.
+ * @param deps - Extra dependencies that force re-registration. Use this when a
+ * handler closes over a value that is not part of the tool definition.
+ *
+ * @example
+ * Register one tool per item in application state:
+ * ```tsx
+ * const [reports, setReports] = useState<Report[]>([]);
+ *
+ * useFrontendTools(
+ *   reports.map((report) => ({
+ *     name: `open_${report.id}`,
+ *     description: `Open the ${report.title} report`,
+ *     handler: async () => navigate(`/reports/${report.id}`),
+ *   })),
+ *   [navigate],
+ * );
+ * ```
+ *
+ * @example
+ * Register tools described by the backend:
+ * ```tsx
+ * const { data } = useQuery(fetchToolDescriptors);
+ *
+ * useFrontendTools(
+ *   (data ?? []).map((descriptor) => ({
+ *     name: descriptor.name,
+ *     description: descriptor.description,
+ *     parameters: z.object({ query: z.string() }),
+ *     handler: async ({ query }) => runDescriptor(descriptor.id, query),
+ *   })),
+ * );
+ * ```
+ */
+export function useFrontendTools(
+  tools: ReadonlyArray<ReactFrontendTool<any>> | undefined,
+  deps?: ReadonlyArray<unknown>,
+) {
+  const { copilotkit } = useCopilotKit();
+  const toolList = tools ?? EMPTY_TOOLS;
+  const extraDeps = deps ?? EMPTY_DEPS;
+
+  // The array is usually built inline, so its identity changes on every render
+  // and cannot be a dependency. Derive a value signature from the same fields
+  // useFrontendTool keys on, so the effect re-runs when the set of tools
+  // actually changes and not merely when the caller re-renders.
+  const signature = JSON.stringify(
+    toolList.map((tool) => [
+      tool.name,
+      tool.agentId ?? null,
+      tool.available ?? null,
+      tool.webmcp ?? null,
+    ]),
+  );
+
+  useLayoutEffect(() => {
+    // Collapse duplicate names so the last entry wins, which matches the
+    // override behavior of useFrontendTool, and so the cleanup below removes
+    // each (name, agentId) pair exactly once.
+    const deduped = new Map<string, ReactFrontendTool<any>>();
+    for (const tool of toolList) {
+      const key = `${tool.agentId ?? ""}:${tool.name}`;
+      if (deduped.has(key)) {
+        console.warn(
+          `Tool '${tool.name}' is listed more than once for agent '${tool.agentId || "global"}' in the same useFrontendTools call. Using the last entry.`,
+        );
+      }
+      deduped.set(key, tool);
+    }
+
+    const registered = [...deduped.values()];
+
+    for (const tool of registered) {
+      // Always register/override the tool for this name on mount
+      if (copilotkit.getTool({ toolName: tool.name, agentId: tool.agentId })) {
+        console.warn(
+          `Tool '${tool.name}' already exists for agent '${tool.agentId || "global"}'. Overriding with latest registration.`,
+        );
+        copilotkit.removeTool(tool.name, tool.agentId);
+      }
+      copilotkit.addTool(tool);
+
+      // Register/override renderer by name and agentId through core.
+      // The render function is registered even when tool.parameters is
+      // undefined — tools like HITL confirm dialogs have no parameters
+      // but still need their UI rendered in the chat.
+      if (tool.render) {
+        copilotkit.addHookRenderToolCall({
+          name: tool.name,
+          args: tool.parameters,
+          agentId: tool.agentId,
+          render: tool.render,
+        });
+      }
+    }
+
+    return () => {
+      // Remove exactly what this run registered. Reading the current array here
+      // would miss a tool that was dropped from it before the effect re-ran.
+      for (const tool of registered) {
+        copilotkit.removeTool(tool.name, tool.agentId);
+      }
+      // we are intentionally not removing the render here so that the tools can still render in the chat history
+    };
+    // `signature` is the value-based key for `toolList`, so the array itself is
+    // deliberately not a dependency. `available` and `webmcp` are folded into
+    // the signature for the same reasons they are dependencies of
+    // useFrontendTool: toggling either must re-register the tool.
+  }, [signature, copilotkit, JSON.stringify(extraDeps)]);
+}

--- a/showcase/shell-docs/src/content/docs/frontend-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/frontend-tools.mdx
@@ -43,4 +43,27 @@ what happened.
 
 <Snippet region="frontend-tool-handler" title="frontend/src/app/page.tsx — handler body" />
 
+## Registering a list of tools
+
+`useFrontendTool` registers one tool per call, so it cannot be called in a loop
+over a list whose length changes between renders. When the set of tools comes
+from state, from props, or from a backend response, use
+[`useFrontendTools`](/reference/hooks/useFrontendTools) instead. It takes an
+array and runs a single effect over it, so the array can be empty on one render
+and hold twenty entries on the next.
+
+```tsx
+useFrontendTools(
+  reports.map((report) => ({
+    name: `open_${report.id}`,
+    description: `Open the ${report.title} report`,
+    handler: async () => navigate(`/reports/${report.id}`),
+  })),
+  [navigate],
+);
+```
+
+Tools that leave the array are unregistered, tools that join it are registered,
+and a re-render that produces an equal list does not re-register anything.
+
 <IntegrationGrid path="frontend-tools" />

--- a/showcase/shell-docs/src/content/reference/hooks/useFrontendTools.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useFrontendTools.mdx
@@ -1,0 +1,166 @@
+---
+title: "useFrontendTools"
+description: "React hook for registering a list of client-side tools whose length can change between renders"
+---
+
+## Overview
+
+`useFrontendTools` registers many client-side tools in one call. Use it when the set of tools is not known when you write the component: tools built from state, from props, or from a list the backend returned.
+
+[`useFrontendTool`](/reference/hooks/useFrontendTool) registers exactly one tool per call, so it cannot be called in a loop over a list whose length changes. That breaks the rules of hooks. `useFrontendTools` runs a single effect over the whole array instead, so the array may be empty on one render and hold twenty entries on the next.
+
+Each entry is the same `ReactFrontendTool` object that `useFrontendTool` takes. See that page for the full tool shape, including `parameters`, `handler`, `render`, and `webmcp`.
+
+## Signature
+
+```tsx
+import { useFrontendTools } from "@copilotkit/react-core/v2";
+
+function useFrontendTools(
+  tools: ReadonlyArray<ReactFrontendTool<any>> | undefined,
+  deps?: ReadonlyArray<unknown>,
+): void;
+```
+
+## Parameters
+
+<PropertyReference name="tools" type="ReadonlyArray<ReactFrontendTool<any>> | undefined" required>
+  The tools to register. The array may be empty, may change length between
+  renders, and may be `undefined` while data is still loading. Each entry takes
+  the same fields as the `tool` argument of
+  [`useFrontendTool`](/reference/hooks/useFrontendTool).
+
+  Tools are identified by `name` plus `agentId`, so the same `name` can serve
+  two different agents. If one array lists the same `name` and `agentId` twice,
+  the last entry wins and a warning is logged.
+</PropertyReference>
+
+<PropertyReference name="deps" type="ReadonlyArray<unknown>">
+  An optional dependency array, similar to `useEffect`. Registration is
+  refreshed whenever any value in the array changes. Use this when a handler
+  captures external state that is not part of the tool definition, such as a
+  router or a mutation function.
+</PropertyReference>
+
+## Usage
+
+### Tools built from application state
+
+```tsx
+function ReportTools({ reports }: { reports: Report[] }) {
+  const navigate = useNavigate();
+
+  useFrontendTools(
+    reports.map((report) => ({
+      name: `open_${report.id}`,
+      description: `Open the ${report.title} report`,
+      handler: async () => {
+        navigate(`/reports/${report.id}`);
+        return `Opened ${report.title}`;
+      },
+    })),
+    [navigate],
+  );
+
+  return null;
+}
+```
+
+When `reports` grows, the new tools are registered. When a report disappears from the list, its tool is unregistered and the rest stay registered.
+
+### Tools described by the backend
+
+```tsx
+function BackendTools() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["tool-descriptors"],
+    queryFn: fetchToolDescriptors,
+  });
+
+  useFrontendTools(
+    data?.map((descriptor) => ({
+      name: descriptor.name,
+      description: descriptor.description,
+      parameters: z.object({
+        query: z.string().describe("What to look up"),
+      }),
+      handler: async ({ query }) => {
+        const result = await runDescriptor(descriptor.id, query);
+        return JSON.stringify(result);
+      },
+    })),
+    [],
+  );
+
+  return isLoading ? <Spinner /> : null;
+}
+```
+
+Passing `undefined` while the query is in flight registers nothing. The tools appear once the data arrives, without a second code path for the loading state.
+
+### Turning a subset of tools off
+
+```tsx
+function PermissionedTools({ isAdmin }: { isAdmin: boolean }) {
+  useFrontendTools([
+    {
+      name: "searchOrders",
+      description: "Search orders by status",
+      parameters: z.object({ status: z.string() }),
+      handler: async ({ status }) => JSON.stringify(await search(status)),
+    },
+    {
+      name: "refundOrder",
+      description: "Refund an order by ID (admin only)",
+      parameters: z.object({ orderId: z.string() }),
+      handler: async ({ orderId }) => refund(orderId),
+      available: isAdmin,
+    },
+  ]);
+
+  return null;
+}
+```
+
+`available: false` keeps the tool registered but hides it from the agent. Toggling it re-registers that tool, the same as with `useFrontendTool`.
+
+### Tools with render components
+
+```tsx
+function ChartTools({ metrics }: { metrics: Metric[] }) {
+  useFrontendTools(
+    metrics.map((metric) => ({
+      name: `chart_${metric.key}`,
+      description: `Chart the ${metric.label} metric`,
+      parameters: z.object({ days: z.number() }),
+      handler: async ({ days }) => JSON.stringify(await load(metric, days)),
+      render: ({ status, result }) => {
+        if (status !== ToolCallStatus.Complete || !result) {
+          return <div className="animate-pulse">Loading {metric.label}…</div>;
+        }
+        return <Chart data={JSON.parse(result)} />;
+      },
+    })),
+    [],
+  );
+
+  return null;
+}
+```
+
+## Behavior
+
+- **Value-based re-registration**: The array is normally built inline, so its identity changes on every render. The hook keys on the `name`, `agentId`, `available`, and `webmcp` of every entry instead. A re-render that produces an equal list does not re-register anything.
+- **Adding and removing**: When the list changes, tools that are new get registered and tools that left get unregistered. Tools present in both the old and new list are re-registered with their latest definition.
+- **Unmount**: Every tool the hook registered is unregistered on unmount.
+- **Duplicate names**: A `name` and `agentId` pair listed twice in one array is a mistake in the calling code. The last entry wins and the hook logs a warning naming the tool.
+- **Overriding another registration**: If a tool with the same `name` and `agentId` was already registered elsewhere, the hook overrides it and logs a warning, matching `useFrontendTool`.
+- **Render component lifecycle**: Entries with a `render` function register a renderer. Renderers are deliberately left in place after unmount so that past tool calls still render in the chat history.
+- **Handlers are not part of the key**: Changing only a `handler` does not re-register on its own. Pass `deps` when a handler closes over a value that must stay current.
+- **No return value**: The hook returns `void`.
+
+## Related
+
+- [`useFrontendTool`](/reference/hooks/useFrontendTool) -- register a single tool; the reference for the tool shape
+- [`useHumanInTheLoop`](/reference/hooks/useHumanInTheLoop) -- for tools that pause execution and wait for user input
+- [`useRenderTool`](/reference/hooks/useRenderTool) -- register renderer-only tool call UI (named or wildcard)


### PR DESCRIPTION
Closes #2435.

## Problem

`useFrontendTool` registers exactly one tool per call, so it cannot be called in a loop over a list whose length changes between renders. That leaves no supported way to register a tool set built from state, from props, or from a backend response. The reporter's workaround was to call the hook a fixed 100 times and no-op the unused slots:

> Since the amount and order of hooks should remain the same, the best thing I can do is to call useCopilotAction exactly 100 times in a loop [...] Ofc that's assuming that I can make sure that the list of actions does not exceed 100.

No plural registration API existed on any binding — `grep` for `useFrontendTools`, `useCopilotActions`, and `addTools` across `packages/` returned nothing. `CopilotKitCore.setTools` accepts an array but **replaces the entire tool set**, so it is unusable from a hook: it would erase tools registered by other components.

## What changed

`useFrontendTools(tools, deps?)` in `@copilotkit/react-core/v2`, exported from both the main v2 entry and `/v2/headless`.

```tsx
useFrontendTools(
  reports.map((report) => ({
    name: `open_${report.id}`,
    description: `Open the ${report.title} report`,
    handler: async () => navigate(`/reports/${report.id}`),
  })),
  [navigate],
);
```

Three details worth reviewer attention:

- **The dependency key is a value signature, not the array.** The array is normally built inline, so its identity changes on every render. The effect keys on a signature over each entry's `name`, `agentId`, `available`, and `webmcp` — the same fields `useFrontendTool` already depends on.
- **Cleanup removes precisely what that run registered**, captured in a local array rather than read from current props. That is what makes a tool dropped from the array get unregistered while its siblings stay put.
- **It uses `useLayoutEffect`, matching `useFrontendTool`.** Register and teardown for one registry key must share an effect phase, or a keyed remount inverts their order.

A duplicated `name`/`agentId` pair inside one array is a caller bug: the last entry wins and the hook warns, matching the singular hook's existing override behavior.

`useFrontendTool` is deliberately **not** refactored to delegate to the new hook. It is on the hot path for every existing app and the v1 shims ride it; sharing one implementation is worth doing as a follow-up gated on its own test suite, not inside this PR.

## Testing

All commands run in a worktree at `origin/main` (851081e093).

**1. New unit tests — 11 pass**

```
$ npx vitest run src/v2/hooks/__tests__/use-frontend-tools.test.tsx
 ✓ src/v2/hooks/__tests__/use-frontend-tools.test.tsx (11 tests) 55ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Covering: mount registers all; empty array; `undefined`; growing the array; dropping one tool; unmount; no re-registration on an equal array; `available` toggle; renderers registered only for entries with `render` and kept after unmount; duplicate-name last-wins; `agentId` scoping.

**2. Mutation checks — every test earns its keep**

Each mutation was applied to the hook, the suite re-run, and the file restored. No mutation passed silently.

| Mutation | Tests killed |
|---|---|
| `signature` replaced with a constant | 3 — grow, drop, `available` toggle |
| cleanup does not remove tools | 3 — drop, unmount, `agentId` scoping |
| depend on array identity instead of `signature` | 1 — equal-array re-render |
| first entry wins instead of last | 1 — duplicate name |
| register `render` unconditionally | 1 — renderer selection |
| dropped from the `/v2/headless` entry | 1 — `headless-exports` guard |

**3. Full `@copilotkit/react-core` suite — green**

```
$ npx tsc --noEmit
TSC OK
$ npx vitest run
 Test Files  147 passed | 1 skipped (148)
      Tests  1693 passed | 2 skipped (1695)
$ npm run test:scripts
# tests 47
# pass 47
# fail 0
```

`test:scripts` covers the headless-purity and bundle-size guards. No public-API surface test broke.

**4. Build and dist**

```
$ nx run @copilotkit/react-core:build
Successfully ran target build for project @copilotkit/react-core and 17 tasks it depends on
context-singleton-preflight: OK
$ grep -o "useFrontendTools" dist/v2/headless.mjs
useFrontendTools
```

**5. Formatting and lint**

`oxfmt --check` clean on all five source files. `oxlint` reports 3 warnings, 0 errors — the same `exhaustive-deps` and `consistent-type-imports` shapes the existing `use-frontend-tool.tsx` and its test already produce (4 warnings there). `oxlint .` runs without `--deny-warnings`.

**6. Docs**

Both MDX files parse through the repo's own `remark-parse` + `remark-mdx` pipeline. `shell-docs` is not a pnpm workspace member, so its vitest suite was not run; the v2 reference nav is generated by walking the `reference/` tree and reading frontmatter, and no test asserts an exact hook list.

## Not in scope

Two adjacent issues I found and deliberately left alone:

- `showcase/shell-docs/src/content/reference/hooks/useFrontendTool.mdx` documents `available` as `"enabled" | "disabled" | "remote"`. The actual type is `available?: boolean` (`packages/core/src/types.ts:89`); no `"remote"` string exists anywhere in core or v2 types. The existing page is wrong. My page documents `boolean`.
- The Hook Explorer table in `docs/troubleshooting/hook-explorer.mdx` lists the hooks the VS Code extension recognizes. Adding `useFrontendTools` there would claim extension support I have not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `useFrontendTools` for registering and managing dynamic lists of frontend tools.
  * Supports tool availability changes, agent-specific tools, duplicate-name handling, and custom renderers.
  * Exported the hook through the headless React Core v2 API.

* **Documentation**
  * Added usage guidance, examples, and reference documentation for `useFrontendTools`.

* **Tests**
  * Added coverage for registration, updates, cleanup, duplicate tools, agent scoping, and renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->