### PR TITLE
feat(web-inspector): add Learning setup escape actions

### DIFF
--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -3611,6 +3611,43 @@ describe("WebInspectorElement memories — view states", () => {
     expect(
       view?.shadowRoot?.querySelector(".step")?.classList.contains("complete"),
     ).toBe(true);
+
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    view?.shadowRoot?.querySelector<HTMLButtonElement>(".copy-again")?.click();
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => {
+      const updatedView =
+        el.shadowRoot?.querySelector<HTMLElement>("cpk-learning-view");
+      expect(
+        updatedView?.shadowRoot?.querySelector<HTMLButtonElement>(".copy-again")
+          ?.textContent,
+      ).toContain("Copied!");
+    });
+    const resetCallIndex = timeoutSpy.mock.calls.findIndex(
+      ([, delay]) => delay === 2_000,
+    );
+    const resetCall = timeoutSpy.mock.calls[resetCallIndex];
+    expect(resetCall).toBeDefined();
+    (resetCall?.[0] as () => void)();
+    clearTimeout(timeoutSpy.mock.results[resetCallIndex]?.value);
+    await vi.waitFor(() => {
+      const updatedView =
+        el.shadowRoot?.querySelector<HTMLElement>("cpk-learning-view");
+      expect(
+        updatedView?.shadowRoot?.querySelector<HTMLButtonElement>(".copy-again")
+          ?.textContent,
+      ).toContain("Copy prompt again");
+    });
+    timeoutSpy.mockRestore();
+
+    view?.shadowRoot
+      ?.querySelector<HTMLButtonElement>(".pane-actions button")
+      ?.click();
+    await el.updateComplete;
+    expect(internals.learningSetupMarker).toBeNull();
+    expect(learningPreview(el)?.textContent).toContain(
+      "Turn every interaction into reusable context.",
+    );
   });
 
   it("keeps all-agents Learning unscoped when several agents are present", () => {

--- a/packages/web-inspector/src/components/learning-view.spec.ts
+++ b/packages/web-inspector/src/components/learning-view.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { InspectorLearningSnapshotV1 } from "@copilotkit/shared";
 import type { CpkLearningView } from "./learning-view.js";
 import { deriveLearningViewState } from "./learning-view.js";
@@ -319,9 +319,46 @@ describe("Learning setup progress", () => {
     expect(promptStep.querySelector(".step-number")?.textContent).toBe("✓");
     expect(setupStep.classList.contains("current")).toBe(true);
     expect(
+      view.shadowRoot!.querySelector<HTMLButtonElement>(".copy-again")
+        ?.textContent,
+    ).toContain("Copy prompt again");
+    expect(
+      view.shadowRoot!.querySelector<HTMLButtonElement>(".pane-actions button")
+        ?.textContent,
+    ).toContain("Go back");
+    expect(
       view.shadowRoot!.querySelector<HTMLButtonElement>("button[disabled]")
         ?.textContent,
     ).toContain("Analyze Threads");
+    view.remove();
+  });
+
+  it("emits copy and back actions from setup progress", async () => {
+    const view = await renderProgress(snapshot(), true);
+    const copy = vi.fn();
+    const goBack = vi.fn();
+    view.addEventListener("learning-recopy-setup", copy);
+    view.addEventListener("learning-go-back", goBack);
+
+    view.shadowRoot!.querySelector<HTMLButtonElement>(".copy-again")?.click();
+    view
+      .shadowRoot!.querySelector<HTMLButtonElement>(".pane-actions button")
+      ?.click();
+
+    expect(copy).toHaveBeenCalledOnce();
+    expect(goBack).toHaveBeenCalledOnce();
+    view.remove();
+  });
+
+  it("confirms when the setup prompt is copied again", async () => {
+    const view = await renderProgress(snapshot(), true);
+    view.recopyState = "copied";
+    await view.updateComplete;
+
+    expect(
+      view.shadowRoot!.querySelector<HTMLButtonElement>(".copy-again")
+        ?.textContent,
+    ).toContain("Copied!");
     view.remove();
   });
 

--- a/packages/web-inspector/src/components/learning-view.ts
+++ b/packages/web-inspector/src/components/learning-view.ts
@@ -60,6 +60,7 @@ export class CpkLearningView extends LitElement {
     snapshot: { attribute: false },
     setupActive: { type: Boolean },
     copyState: { attribute: false },
+    recopyState: { attribute: false },
     setupPrompt: { attribute: false },
   };
 
@@ -70,6 +71,7 @@ export class CpkLearningView extends LitElement {
   snapshot: InspectorLearningSnapshotV1 | null = null;
   setupActive = false;
   copyState: "idle" | "copied" | "error" = "idle";
+  recopyState: "idle" | "copied" | "error" = "idle";
   setupPrompt = "";
   private promptOpen = false;
   private promptTrigger: HTMLElement | null = null;
@@ -213,6 +215,11 @@ export class CpkLearningView extends LitElement {
       font-size: 14px;
       line-height: 1.5;
     }
+    .pane-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
     .refreshing {
       color: var(--learning-muted-strong);
       font-size: 11px;
@@ -327,6 +334,17 @@ export class CpkLearningView extends LitElement {
       color: var(--learning-muted);
       font-size: 12px;
       line-height: 1.45;
+    }
+    .copy-again {
+      margin-top: 12px;
+      padding: 0;
+      color: var(--learning-secondary-ink);
+      background: none;
+      border: 0;
+      font-size: 11px;
+      font-weight: 750;
+      text-decoration: underline;
+      cursor: pointer;
     }
     .setup-support {
       margin-top: 14px;
@@ -1067,6 +1085,20 @@ export class CpkLearningView extends LitElement {
           <div class="step-header"><span class="step-number">✓</span></div>
           <h3>Copy the setup prompt</h3>
           <p>Nice work. You’ve completed the first step.</p>
+          <button
+            class="copy-again"
+            type="button"
+            aria-live="polite"
+            @click=${() => this.emit("learning-recopy-setup")}
+          >
+            ${
+              this.recopyState === "copied"
+                ? "✓ Copied!"
+                : this.recopyState === "error"
+                  ? "Try copying again"
+                  : "Copy prompt again"
+            }
+          </button>
         </li>
         <li
           class="step ${
@@ -1585,13 +1617,26 @@ export class CpkLearningView extends LitElement {
             <h1>Learning</h1>
             <p>Your Agent learns from conversations and improves over time.</p>
           </div>
-          ${
-            this.refreshing
-              ? html`
-                  <span class="refreshing" role="status">Refreshing</span>
-                `
-              : nothing
-          }
+          <div class="pane-actions">
+            ${
+              state === "setup" && this.setupActive
+                ? html`<button
+                    class="secondary"
+                    type="button"
+                    @click=${() => this.emit("learning-go-back")}
+                  >
+                    ← Go back
+                  </button>`
+                : nothing
+            }
+            ${
+              this.refreshing
+                ? html`
+                    <span class="refreshing" role="status">Refreshing</span>
+                  `
+                : nothing
+            }
+          </div>
         </header>
         ${retry}
         ${content}

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -206,6 +206,7 @@ export const THREAD_INSPECTOR_TAG = "cpk-thread-inspector" as const;
  * "memories" for persistence and telemetry stability.
  */
 const LEARNING_VIEW_LABEL = "Learning";
+const LEARNING_RECOPY_CONFIRMATION_MS = 2_000;
 
 /**
  * User-facing label for the What's new view. Its menu key stays `whats-new`
@@ -6481,8 +6482,12 @@ export class WebInspectorElement extends LitElement {
   private learningPollTimer: ReturnType<typeof setTimeout> | null = null;
   private learningPollFailureCount = 0;
   private learningSetupMarker: LearningSetupMarker | null = null;
+  private learningSetupCopyRequest = 0;
   private learningSetupUnsubscribe: (() => void) | null = null;
   private learningPromptCopyState: "idle" | "copied" | "error" = "idle";
+  private learningPromptRecopyState: "idle" | "copied" | "error" = "idle";
+  private learningPromptRecopyTimer: ReturnType<typeof setTimeout> | null =
+    null;
   private learningViewedState: LearningViewState | null = null;
   // ── Semantic recall (B3) ──────────────────────────────────────────────
   // `null` = no recall run yet (section hidden). `[]` = ran, no matches.
@@ -8149,25 +8154,45 @@ export class WebInspectorElement extends LitElement {
     }
   };
 
-  private handleLearningSetupCopy = async (event?: Event): Promise<void> => {
+  private handleLearningSetupCopy = async (
+    event?: Event,
+    recopy = false,
+  ): Promise<void> => {
     const service = this.getHomeFeaturePromptTarget("threads");
     if (!service || !this.core?.runtimeUrl) return;
+    const request = ++this.learningSetupCopyRequest;
     const copied = await this.copyFeaturePromptToClipboard(
       service,
       event,
       this.getOnboardingRunId(),
     );
+    if (request !== this.learningSetupCopyRequest) return;
     if (!this.core.telemetryDisabled) {
       trackLearningSetupPromptClicked({
         outcome: copied ? "success" : "failure",
       });
     }
     if (!copied) {
-      this.learningPromptCopyState = "error";
+      if (recopy) {
+        this.cancelLearningPromptRecopyReset();
+        this.learningPromptRecopyState = "error";
+      } else {
+        this.learningPromptCopyState = "error";
+      }
       this.requestUpdate();
       return;
     }
-    this.learningPromptCopyState = "copied";
+    if (recopy) {
+      this.cancelLearningPromptRecopyReset();
+      this.learningPromptRecopyState = "copied";
+      this.learningPromptRecopyTimer = setTimeout(() => {
+        this.learningPromptRecopyTimer = null;
+        this.learningPromptRecopyState = "idle";
+        this.requestUpdate();
+      }, LEARNING_RECOPY_CONFIRMATION_MS);
+    } else {
+      this.learningPromptCopyState = "copied";
+    }
     this.learningSetupMarker = writeLearningSetupMarker({
       runtimeUrl: this.core.runtimeUrl,
       agentId: this.getLearningAgentId(),
@@ -8176,6 +8201,25 @@ export class WebInspectorElement extends LitElement {
     this.persistState();
     this.requestUpdate();
     void this.refreshLearningSnapshot({ preserve: false });
+  };
+
+  private cancelLearningPromptRecopyReset(): void {
+    if (this.learningPromptRecopyTimer !== null) {
+      clearTimeout(this.learningPromptRecopyTimer);
+      this.learningPromptRecopyTimer = null;
+    }
+  }
+
+  private handleLearningGoBack = (): void => {
+    this.learningSetupCopyRequest += 1;
+    this.cancelLearningPromptRecopyReset();
+    clearLearningSetupMarker();
+    this.learningSetupMarker = null;
+    this.learningPromptCopyState = "idle";
+    this.learningPromptRecopyState = "idle";
+    this.cancelLearningPoll();
+    this.requestUpdate();
+    this.trackLearningViewState();
   };
 
   private handleLearningPage = (
@@ -8236,6 +8280,8 @@ export class WebInspectorElement extends LitElement {
     // activation re-subscribes (and re-evaluates SDK support) cleanly.
     this._memorySubscribed = false;
     this._memoryStoreUnsupported = false;
+    this.cancelLearningPromptRecopyReset();
+    this.learningPromptRecopyState = "idle";
     // Reset recall state and bump the sequence token so any in-flight recall
     // resolving after detach is ignored.
     this._recallSeq += 1;
@@ -18375,6 +18421,7 @@ export class WebInspectorElement extends LitElement {
         .snapshot=${this.learningSnapshot}
         .setupActive=${this.isLearningSetupActive()}
         .copyState=${this.learningPromptCopyState}
+        .recopyState=${this.learningPromptRecopyState}
         .setupPrompt=${
           this.getHomeFeaturePromptTarget("threads")
             ? homeFeatureImplementationPrompt(
@@ -18389,6 +18436,9 @@ export class WebInspectorElement extends LitElement {
           })}
         @learning-copy-setup=${(event: Event) =>
           this.handleLearningSetupCopy(event)}
+        @learning-recopy-setup=${(event: Event) =>
+          this.handleLearningSetupCopy(event, true)}
+        @learning-go-back=${this.handleLearningGoBack}
         @learning-page=${(event: CustomEvent) =>
           this.handleLearningPage(
             event as CustomEvent<{


### PR DESCRIPTION
## Summary

- Add a Go back action from Learning setup to the original Learning overview and video.
- Let users copy the setup prompt again without leaving the setup flow.
- Show a successful copy confirmation and reset the action after two seconds.

## Why

Copying the onboarding prompt moves users into setup, where they previously could not return to the overview or recover if the clipboard contents were replaced. This keeps the Learning onboarding flow reversible and makes repeated copying clear.

## How

- Clear the Learning setup marker when Go back is selected.
- Track initial-copy and re-copy feedback independently, including clipboard failure feedback.
- Cancel stale clipboard work and confirmation timers during navigation and teardown.
- Add component and Inspector integration coverage.
- Verify the behavior in the standalone Inspector workbench.
- Verify all 691 web-inspector tests and typechecks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy prompt again” action after setup, with “Copied!” confirmation and automatic reset.
  * Added a “Go back” action during setup to return to the landing preview.
  * Added feedback for copy failures.

* **Bug Fixes**
  * Improved handling of repeated copy actions and navigation during setup to prevent stale status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->