### PR TITLE
feat(web-inspector): point the feature buttons at the CLI intent routes

### DIFF
--- a/.github/workflows/test_integration-docs.yml
+++ b/.github/workflows/test_integration-docs.yml
@@ -16,6 +16,17 @@ on:
       - "showcase/shell-docs/src/lib/setup-concept.tsx"
       - "showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts"
       - "showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts"
+      # The docs feature prompts only name a CLI intent now, so the route owns
+      # the instructions. Nothing else in CI reads these files, and OSS-1150
+      # retired the prose that used to make a drift visible on the page.
+      - "showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts"
+      - "showcase/shell-docs/src/lib/learning-setup-prompt.ts"
+      - "showcase/shell-docs/src/lib/rich-threads-setup-prompt.ts"
+      - "showcase/shell-docs/src/lib/__tests__/learning-setup-docs.test.ts"
+      - "showcase/shell-docs/src/lib/__tests__/rich-threads-setup-docs.test.ts"
+      - "showcase/shell-docs/src/lib/__tests__/intelligence-quickstart-docs.test.ts"
+      - "showcase/shell-docs/src/components/__tests__/learning-setup-prompt.test.tsx"
+      - "showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx"
       - "showcase/scripts/bundle-setup-content.ts"
       - "showcase/shell-docs/package.json"
       - "showcase/shell-docs/package-lock.json"
@@ -39,6 +50,17 @@ on:
       - "showcase/shell-docs/src/lib/setup-concept.tsx"
       - "showcase/shell-docs/src/lib/__tests__/frontend-tools-setup-coverage.test.ts"
       - "showcase/shell-docs/src/lib/__tests__/setup-concept.test.ts"
+      # The docs feature prompts only name a CLI intent now, so the route owns
+      # the instructions. Nothing else in CI reads these files, and OSS-1150
+      # retired the prose that used to make a drift visible on the page.
+      - "showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts"
+      - "showcase/shell-docs/src/lib/learning-setup-prompt.ts"
+      - "showcase/shell-docs/src/lib/rich-threads-setup-prompt.ts"
+      - "showcase/shell-docs/src/lib/__tests__/learning-setup-docs.test.ts"
+      - "showcase/shell-docs/src/lib/__tests__/rich-threads-setup-docs.test.ts"
+      - "showcase/shell-docs/src/lib/__tests__/intelligence-quickstart-docs.test.ts"
+      - "showcase/shell-docs/src/components/__tests__/learning-setup-prompt.test.tsx"
+      - "showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx"
       - "showcase/scripts/bundle-setup-content.ts"
       - "showcase/shell-docs/package.json"
       - "showcase/shell-docs/package-lock.json"
@@ -134,6 +156,47 @@ jobs:
           npm exec -- vitest run \
             src/lib/__tests__/frontend-tools-setup-coverage.test.ts \
             src/lib/__tests__/setup-concept.test.ts
+
+  feature-prompt-intents:
+    name: Docs feature prompts name a CLI intent
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # zizmor: ignore[undocumented-permissions] Depot runner OIDC.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: showcase/shell-docs/package-lock.json
+      - name: Install dependencies
+        run: |
+          cd showcase/scripts && npm ci --ignore-scripts
+          cd ../shell-docs && npm ci --ignore-scripts
+      # Same two steps as setup-concept-coverage above, and for the same two
+      # reasons: the harness catalog resolves `js-yaml` by walking up from
+      # `showcase/harness/`, and `src/data/*.json` is gitignored.
+      - name: Link harness module scope
+        run: ln -s ../scripts/node_modules showcase/harness/node_modules
+      - name: Generate registry and bundled content
+        working-directory: showcase/shell-docs
+        run: npm run pretypecheck
+      # Scoped to these five files on purpose. The whole shell-docs suite is
+      # not green on main, so running it here would gate every prompt change on
+      # unrelated failures.
+      - name: Check the docs feature prompts reach a feature route
+        working-directory: showcase/shell-docs
+        run: |
+          npm exec -- vitest run \
+            src/lib/__tests__/learning-setup-docs.test.ts \
+            src/lib/__tests__/rich-threads-setup-docs.test.ts \
+            src/lib/__tests__/intelligence-quickstart-docs.test.ts \
+            src/components/__tests__/learning-setup-prompt.test.tsx \
+            src/components/__tests__/rich-threads-setup-prompt.test.tsx
 
   doc-tests:
     runs-on: depot-ubuntu-24.04-4

--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -1340,11 +1340,11 @@ test("Home feature actions copy correlated onboarding prompts", async () => {
       expect(prompt).toContain(
         "never reveal credentials or send optional diagnostic feedback reports",
       );
-      expect(prompt).toContain(
-        "local validation proves A2UI works—not merely that the code compiles",
-      );
-      expect(prompt).toContain("A2UI guide");
-      expect(prompt).not.toContain("--intent");
+      // The A2UI route owns the guide link, the plan and the proof step. The
+      // button's whole job is to name the outcome.
+      expect(prompt).toContain("--intent add-a2ui");
+      expect(prompt).not.toContain("A2UI guide");
+      expect(prompt).not.toContain("not merely that the code compiles");
       const match = prompt.match(
         /--run ([A-Za-z0-9_-]{12}) --coding-agent <coding-agent-slug>/,
       );

--- a/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
+++ b/packages/web-inspector/src/__tests__/launcher-hud.spec.ts
@@ -466,11 +466,13 @@ test("disabled feature rows open their landing pages, where setup prompts can be
 
     expect(writeText).toHaveBeenCalledTimes(1);
     const threadsPrompt = String(writeText.mock.calls[0]?.[0]);
-    expect(threadsPrompt).toContain(
+    // The Threads button names the outcome and lets the route carry the rest;
+    // the guide link it used to paste belongs to feature/rich-threads.
+    expect(threadsPrompt).toContain("--intent add-rich-threads");
+    expect(threadsPrompt).not.toContain(
       "This task is specifically to enable Threads",
     );
-    expect(threadsPrompt).toContain("https://docs.copilotkit.ai/threads");
-    expect(threadsPrompt).not.toContain("--intent");
+    expect(threadsPrompt).not.toContain("https://docs.copilotkit.ai/threads");
     expect(copyThreads.dataset.copyState).toBe("copied");
     expect(copyThreads.getAttribute("aria-label")).toBe(
       "Threads setup prompt copied",

--- a/packages/web-inspector/src/__tests__/threads-states.spec.ts
+++ b/packages/web-inspector/src/__tests__/threads-states.spec.ts
@@ -1241,9 +1241,10 @@ test("locked Threads copy the feature setup prompt", async () => {
 
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const prompt = writeText.mock.calls[0]?.[0] ?? "";
-    expect(prompt).toContain("This task is specifically to enable Threads");
-    expect(prompt).toContain("https://docs.copilotkit.ai/threads");
-    expect(prompt).toContain("Preserve the project's framework");
+    expect(prompt).toContain("--intent add-rich-threads");
+    expect(prompt).not.toContain("This task is specifically to enable Threads");
+    expect(prompt).not.toContain("https://docs.copilotkit.ai/threads");
+    expect(prompt).not.toContain("Preserve the project's framework");
 
     await harness.flush();
     expect(

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -98,7 +98,6 @@ import type {
 } from "./lib/inspector-metadata.js";
 import {
   buildHomeModel,
-  homeFeatureImplementationPrompt,
   runtimeConnectionNeedsAttention,
 } from "./lib/home-briefing.js";
 import type {
@@ -161,6 +160,7 @@ import {
   trackWhatsNewViewed,
 } from "./lib/telemetry.js";
 import {
+  createFeatureOnboardingPrompt,
   createOnboardingPrompt,
   createOnboardingRunId,
 } from "./lib/onboarding-prompt.js";
@@ -412,7 +412,6 @@ type HomeFeaturePromptId = HomeServiceId;
 type HomeFeaturePromptTarget = Readonly<{
   id: HomeFeaturePromptId;
   label: string;
-  docsUrl: string;
 }>;
 
 const LAUNCHER_SIGNALS: Readonly<
@@ -8144,9 +8143,7 @@ export class WebInspectorElement extends LitElement {
     if (!clipboard?.writeText) return false;
     try {
       await clipboard.writeText(
-        homeFeatureImplementationPrompt(service, {
-          onboardingRunId,
-        }),
+        createFeatureOnboardingPrompt(service.id, onboardingRunId),
       );
       return true;
     } catch {
@@ -18422,14 +18419,10 @@ export class WebInspectorElement extends LitElement {
         .setupActive=${this.isLearningSetupActive()}
         .copyState=${this.learningPromptCopyState}
         .recopyState=${this.learningPromptRecopyState}
-        .setupPrompt=${
-          this.getHomeFeaturePromptTarget("threads")
-            ? homeFeatureImplementationPrompt(
-                this.getHomeFeaturePromptTarget("threads")!,
-                { onboardingRunId: this.getOnboardingRunId() },
-              )
-            : ""
-        }
+        .setupPrompt=${createFeatureOnboardingPrompt(
+          "threads",
+          this.getOnboardingRunId(),
+        )}
         @learning-retry=${() =>
           this.refreshLearningSnapshot({
             preserve: this.learningSnapshot !== null,

--- a/packages/web-inspector/src/lib/__tests__/home-briefing.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/home-briefing.test.ts
@@ -4,7 +4,6 @@ import { projectInspectorMetadata } from "../inspector-metadata.js";
 import {
   announcementPreview,
   buildHomeModel,
-  homeFeatureImplementationPrompt,
   homeHeroActionFromMetadata,
   runtimeConnectionNeedsAttention,
 } from "../home-briefing.js";
@@ -76,16 +75,6 @@ describe("home-briefing", () => {
       docsUrl:
         "https://docs.copilotkit.ai/reference/hooks/useConfigureSuggestions",
     });
-    expect(
-      homeFeatureImplementationPrompt(learning!, {
-        onboardingRunId: "21bcf98aa5fd",
-      }),
-    )
-      .toBe(`Identify your coding-agent slug (for example, \`codex\` or \`claude-code\`). From the target project root, run \`npx copilotkit@latest onboard start --run 21bcf98aa5fd --coding-agent <coding-agent-slug>\` and use its output as onboarding context. If it requires a CopilotKit CLI session check, you have permission to run it; never reveal credentials or send optional diagnostic feedback reports.
-
-This task is specifically to enable Learning, not to re-onboard the application. First inspect the existing CopilotKit runtime, provider, agent, and UI wiring, and confirm that Learning is not already enabled. Then read the Learning guide (https://docs.copilotkit.ai/intelligence/intelligence-platform) and make a short plan before editing. Preserve the project's framework, package manager, installed CopilotKit version, existing agent IDs, routes, provider layout, and working behavior. Do not create, select, or alter a CopilotKit Intelligence project—or add Intelligence configuration—unless this feature's official guide explicitly requires it or the user asks.
-
-Implement the smallest complete integration: wire every feature-required client and runtime configuration into the chat-to-agent path people already use, reuse local patterns, and do not invent environment values or hardcode secrets. Add or update focused tests and run the relevant project checks. Finish only after local validation proves Learning works—not merely that the code compiles. Use a feature-specific runtime or Inspector capability check and, when the feature supports one, a representative UI interaction that proves the user-facing result. If the project overrides default rendering (for example, with a wildcard tool renderer), make that override compatible with this feature; a capability flag alone is not success. Summarize the changed files, validation, and any manual setup still required.`);
   });
 
   it("marks a linked project as connected and keeps Threads usage on the project card", () => {

--- a/packages/web-inspector/src/lib/__tests__/onboarding-prompt.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/onboarding-prompt.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  FEATURE_ONBOARDING_INTENT,
+  FEATURE_ONBOARDING_PROMPT_TEMPLATE,
+  ONBOARDING_INTENTS,
   ONBOARDING_PROMPT_TEMPLATE,
+  createFeatureOnboardingPrompt,
   createOnboardingPrompt,
   createOnboardingRunId,
 } from "../onboarding-prompt.js";
+import { buildHomeModel } from "../home-briefing.js";
+import { projectInspectorMetadata } from "../inspector-metadata.js";
 
 describe("onboarding-prompt", () => {
   afterEach(() => {
@@ -56,5 +62,90 @@ describe("onboarding-prompt", () => {
 
     expect(id).toHaveLength(12);
     expect(id).toMatch(/^[0-9a-f]{12}$/);
+  });
+});
+
+describe("feature onboarding intents", () => {
+  it("names one intent for every Home feature tile, and every intent once", () => {
+    // The two sets are held equal in both directions on purpose. A new tile
+    // with no intent leaves a button that cannot reach the graph; an intent
+    // no tile names is a route with no caller, which is the whole of
+    // OSS-1150.
+    const tiles = buildHomeModel({
+      intelligenceConnected: false,
+      threadsAvailable: false,
+      metadata: projectInspectorMetadata(undefined, undefined),
+      runtimeConnectionState: "unavailable",
+      learningOn: false,
+      a2uiOn: false,
+      openGenUiOn: false,
+      suggestionsOn: false,
+      audioOn: false,
+    }).services.map((service) => service.id);
+
+    expect(Object.keys(FEATURE_ONBOARDING_INTENT).sort()).toEqual(
+      [...tiles].sort(),
+    );
+    expect(Object.values(FEATURE_ONBOARDING_INTENT).sort()).toEqual(
+      [...ONBOARDING_INTENTS].sort(),
+    );
+  });
+
+  it("keeps the slugs the CLI graph exposes", () => {
+    // Byte-equal to ONBOARDING_INTENT_ROOTS in Intelligence's
+    // apps/cli/onboarding-intents.cjs. The repositories cannot import each
+    // other, so this list is the agreement.
+    expect([...ONBOARDING_INTENTS]).toEqual([
+      "add-a2ui",
+      "add-chat-suggestions",
+      "add-learning",
+      "add-open-generative-ui",
+      "add-realtime-sync",
+      "add-rich-threads",
+      "add-voice",
+    ]);
+  });
+
+  it("maps the Learning tile to the Learning route, not to Threads", () => {
+    // The tile id and the `memories` menu key are older names for the pane
+    // that `learningOn` gates on a configured Learning container, which is
+    // what feature/learning sets up.
+    expect(FEATURE_ONBOARDING_INTENT.memory).toBe("add-learning");
+    expect(FEATURE_ONBOARDING_INTENT.threads).toBe("add-rich-threads");
+  });
+
+  it("sends the coding agent to one feature route and nothing else", () => {
+    const prompt = createFeatureOnboardingPrompt("a2ui", "abc123def456");
+
+    expect(prompt).toContain(
+      "npx --yes copilotkit@latest onboard start --run abc123def456 --coding-agent <coding-agent-slug> --intent add-a2ui",
+    );
+    expect(prompt).not.toContain("<run-id>");
+    expect(prompt).not.toContain("<intent>");
+    // The agent-slug placeholder is the coding agent's to fill, so it stays.
+    expect(prompt).toContain("<coding-agent-slug>");
+  });
+
+  it("carries no feature-specific instruction of its own", () => {
+    // Everything below belonged to the prose this prompt replaced. The route
+    // owns it now, and a copied paragraph would drift from it.
+    for (const serviceId of Object.keys(
+      FEATURE_ONBOARDING_INTENT,
+    ) as (keyof typeof FEATURE_ONBOARDING_INTENT)[]) {
+      const prompt = createFeatureOnboardingPrompt(serviceId, "abc123def456");
+
+      expect(prompt).not.toContain("This task is specifically to enable");
+      expect(prompt).not.toContain("docs.copilotkit.ai");
+      expect(prompt).not.toContain(" guide");
+      expect(prompt).not.toContain(" plan");
+      expect(prompt).not.toContain("focused tests");
+      expect(prompt).not.toContain("smallest complete integration");
+      expect(prompt).not.toContain("not merely that the code compiles");
+    }
+  });
+
+  it("keeps the placeholders the template promises", () => {
+    expect(FEATURE_ONBOARDING_PROMPT_TEMPLATE).toContain("<run-id>");
+    expect(FEATURE_ONBOARDING_PROMPT_TEMPLATE).toContain("<intent>");
   });
 });

--- a/packages/web-inspector/src/lib/home-briefing.ts
+++ b/packages/web-inspector/src/lib/home-briefing.ts
@@ -39,27 +39,6 @@ export type HomeServiceTile = {
   docsUrl: string;
 };
 
-export type HomeFeatureImplementationPromptContext = {
-  onboardingRunId: string;
-};
-
-/**
- * A self-contained handoff for a coding agent. It answers the onboarding
- * workflow's session and feedback consent gates up front, while keeping the
- * feature guide—not a generic product-onboarding branch—in control of the
- * implementation plan.
- */
-export function homeFeatureImplementationPrompt(
-  service: Pick<HomeServiceTile, "label" | "docsUrl">,
-  context: HomeFeatureImplementationPromptContext,
-): string {
-  return `Identify your coding-agent slug (for example, \`codex\` or \`claude-code\`). From the target project root, run \`npx copilotkit@latest onboard start --run ${context.onboardingRunId} --coding-agent <coding-agent-slug>\` and use its output as onboarding context. If it requires a CopilotKit CLI session check, you have permission to run it; never reveal credentials or send optional diagnostic feedback reports.
-
-This task is specifically to enable ${service.label}, not to re-onboard the application. First inspect the existing CopilotKit runtime, provider, agent, and UI wiring, and confirm that ${service.label} is not already enabled. Then read the ${service.label} guide (${service.docsUrl}) and make a short plan before editing. Preserve the project's framework, package manager, installed CopilotKit version, existing agent IDs, routes, provider layout, and working behavior. Do not create, select, or alter a CopilotKit Intelligence project—or add Intelligence configuration—unless this feature's official guide explicitly requires it or the user asks.
-
-Implement the smallest complete integration: wire every feature-required client and runtime configuration into the chat-to-agent path people already use, reuse local patterns, and do not invent environment values or hardcode secrets. Add or update focused tests and run the relevant project checks. Finish only after local validation proves ${service.label} works—not merely that the code compiles. Use a feature-specific runtime or Inspector capability check and, when the feature supports one, a representative UI interaction that proves the user-facing result. If the project overrides default rendering (for example, with a wildcard tool renderer), make that override compatible with this feature; a capability flag alone is not success. Summarize the changed files, validation, and any manual setup still required.`;
-}
-
 export type HomeModel = {
   hero: {
     connection: HomeConnection;

--- a/packages/web-inspector/src/lib/onboarding-prompt.ts
+++ b/packages/web-inspector/src/lib/onboarding-prompt.ts
@@ -1,3 +1,5 @@
+import type { HomeServiceId } from "./home-briefing.js";
+
 /**
  * The Intelligence install prompt the Inspector hands to a coding agent.
  *
@@ -10,6 +12,14 @@
  * Intelligence app (`apps/app-frontend/react-shell/src/home/intelligence-home.tsx`).
  * The CLI resolves `onboard start` against a prompt graph, so the two surfaces
  * must not drift — if the CLI's entry point changes, both change together.
+ *
+ * This one stays generic, and so do the docs and Intelligence web-app copies
+ * of it (OSS-1150). Those three are entry points for a developer with no
+ * CopilotKit app yet, and every `--intent` route requires an existing app: it
+ * inspects for one first and reads `feature/stop` when it is missing. The
+ * feature buttons on Home are the surface that knows which feature the
+ * developer is looking at, so they are the surface that names an intent — see
+ * `FEATURE_ONBOARDING_PROMPT_TEMPLATE` below.
  */
 const RUN_ID_PLACEHOLDER = "<run-id>";
 
@@ -57,4 +67,91 @@ export function createOnboardingRunId(): string {
 /** Bind one run id into the prompt text that gets copied. */
 export function createOnboardingPrompt(runId: string): string {
   return ONBOARDING_PROMPT_TEMPLATE.replace(RUN_ID_PLACEHOLDER, runId);
+}
+
+/**
+ * The closed set of feature outcomes the CLI prompt graph can start at.
+ *
+ * Kept equal to `ONBOARDING_INTENT_ROOTS` in Intelligence's
+ * `apps/cli/onboarding-intents.cjs`, which is the build-time source of truth.
+ * The two repositories cannot import each other, so the agreement is held by
+ * this list plus the CLI's own `onboarding-intents.spec.ts`. Drift is loud
+ * rather than silent: `onboard start` refuses an unknown `--intent` before it
+ * persists a run, so a stale slug fails on the first command instead of
+ * quietly onboarding the wrong feature.
+ */
+export const ONBOARDING_INTENTS = [
+  "add-a2ui",
+  "add-chat-suggestions",
+  "add-learning",
+  "add-open-generative-ui",
+  "add-realtime-sync",
+  "add-rich-threads",
+  "add-voice",
+] as const;
+
+export type OnboardingIntent = (typeof ONBOARDING_INTENTS)[number];
+
+/**
+ * Which feature outcome each Home tile asks the CLI for.
+ *
+ * The two vocabularies stay separate on purpose. A `HomeServiceId` names a
+ * tile and the pane behind it, so `websocket` and `audio` are the right words
+ * for it; an intent names the work to be done, so `add-realtime-sync` and
+ * `add-voice` are the right words for that. One table maps between them, and
+ * `Record<HomeServiceId, OnboardingIntent>` makes a new tile or a renamed
+ * slug a type error rather than a missing button.
+ *
+ * `memory` maps to `add-learning` because the tile is the Learning tile: it is
+ * enabled by a *configured Learning container* (see `learningOn` in
+ * `index.ts`), which is exactly what `feature/learning` sets up. The tile id
+ * and the `memories` menu key are older names for that same pane.
+ */
+export const FEATURE_ONBOARDING_INTENT: Record<
+  HomeServiceId,
+  OnboardingIntent
+> = {
+  threads: "add-rich-threads",
+  memory: "add-learning",
+  a2ui: "add-a2ui",
+  "open-gen-ui": "add-open-generative-ui",
+  suggestions: "add-chat-suggestions",
+  audio: "add-voice",
+  websocket: "add-realtime-sync",
+};
+
+const INTENT_PLACEHOLDER = "<intent>";
+
+/**
+ * The prompt a Home feature button copies.
+ *
+ * It carries no feature-specific instruction, and it must not gain any. The
+ * `--intent` route owns the plan, the guide links, the per-phase check-ins,
+ * the refusal when a prerequisite is missing, and the proof step; prose copied
+ * here would duplicate all of that and then drift from it the next time the
+ * underlying API changes.
+ *
+ * What is left is the caller's own business: identify yourself, run this
+ * command, and the standing permission for the session check that the
+ * developer granted by copying the prompt.
+ */
+export const FEATURE_ONBOARDING_PROMPT_TEMPLATE =
+  "Identify your coding-agent slug (for example, `codex` or `claude-code`). " +
+  "From the target project root, run `npx --yes copilotkit@latest onboard " +
+  `start --run ${RUN_ID_PLACEHOLDER} --coding-agent <coding-agent-slug> ` +
+  `--intent ${INTENT_PLACEHOLDER}` +
+  "`. Follow the Markdown instructions it prints until onboarding is " +
+  "complete. If it requires a CopilotKit CLI session check, you have " +
+  "permission to run it; never reveal credentials or send optional " +
+  "diagnostic feedback reports.";
+
+/** Bind one run id and one tile's feature outcome into the copied prompt. */
+export function createFeatureOnboardingPrompt(
+  serviceId: HomeServiceId,
+  runId: string,
+): string {
+  return FEATURE_ONBOARDING_PROMPT_TEMPLATE.replace(
+    RUN_ID_PLACEHOLDER,
+    runId,
+  ).replace(INTENT_PLACEHOLDER, FEATURE_ONBOARDING_INTENT[serviceId]);
 }

--- a/showcase/shell-docs/src/components/__tests__/learning-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/learning-setup-prompt.test.tsx
@@ -59,3 +59,18 @@ test("configures the shared coding-agent prompt card for Automatic Learning", as
     }
   }
 });
+
+test("sends the coding agent to the Learning route and carries nothing else", () => {
+  // The route owns the guide link, the container-selection rules and the
+  // `getLearningContainerId` wiring this prompt used to repeat. That copy had
+  // already drifted from the shipped API once; OSS-1150 retired it.
+  expect(LEARNING_SETUP_PROMPT).toContain(
+    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-learning",
+  );
+  expect(LEARNING_SETUP_PROMPT).not.toContain("docs.copilotkit.ai");
+  expect(LEARNING_SETUP_PROMPT).not.toContain("getLearningContainerId");
+  expect(LEARNING_SETUP_PROMPT).not.toContain("container");
+  // No run id: this string is static and llm-text inlines it into cached raw
+  // Markdown, so one minted here would be shared by every reader.
+  expect(LEARNING_SETUP_PROMPT).not.toContain("--run");
+});

--- a/showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx
@@ -105,26 +105,22 @@ test("copies the canonical Rich Threads repair prompt and announces success", as
   }
 });
 
-test("keeps the Rich Threads repair prompt anchored and safe for autonomous edits", () => {
+test("sends the coding agent to the Rich Threads route and carries nothing else", () => {
+  // The route owns the guide links, the identity rules, the ownership checks
+  // and the Inspector proof this prompt used to repeat. A copy of them here
+  // drifts the next time the Runtime API changes, which is what OSS-1150
+  // retired.
   expect(RICH_THREADS_SETUP_PROMPT).toContain(
-    "https://docs.copilotkit.ai/backend/runtime-endpoints#enable-rich-threads-routes",
+    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-rich-threads",
   );
-  expect(RICH_THREADS_SETUP_PROMPT).toContain(
-    "existing server-verified signed-in application user",
-  );
-  expect(RICH_THREADS_SETUP_PROMPT).toContain(
-    "Preserve existing authentication middleware and access checks",
-  );
-  expect(RICH_THREADS_SETUP_PROMPT).toContain(
+  expect(RICH_THREADS_SETUP_PROMPT).not.toContain("docs.copilotkit.ai");
+  expect(RICH_THREADS_SETUP_PROMPT).not.toContain("identifyUser");
+  expect(RICH_THREADS_SETUP_PROMPT).not.toContain(
     "Never use a fixed demo identity in production",
   );
-  expect(RICH_THREADS_SETUP_PROMPT).toContain(
-    "Home shows Intelligence connected",
-  );
-  expect(RICH_THREADS_SETUP_PROMPT).toContain("open Threads in Inspector");
-  expect(RICH_THREADS_SETUP_PROMPT).toContain(
-    "React Native does not include Inspector",
-  );
+  // No run id: this string is static and llm-text inlines it into cached raw
+  // Markdown, so one minted here would be shared by every reader.
+  expect(RICH_THREADS_SETUP_PROMPT).not.toContain("--run");
 });
 
 test("reports a blocked Rich Threads prompt copy without claiming success", async () => {

--- a/showcase/shell-docs/src/lib/__tests__/intelligence-quickstart-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/intelligence-quickstart-docs.test.ts
@@ -59,7 +59,7 @@ test("expands the setup prompt for coding agents", () => {
   const output = renderDoc("intelligence/quickstart");
 
   expect(output).toContain("Copy this prompt into your coding agent");
-  expect(output).toContain("finish setting up Rich Threads in this repository");
+  expect(output).toContain("--intent add-rich-threads");
   expect(output).not.toContain("<RichThreadsSetupPrompt />");
 });
 

--- a/showcase/shell-docs/src/lib/__tests__/learning-setup-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/learning-setup-docs.test.ts
@@ -23,12 +23,10 @@ test("expands the Automatic Learning prompt for Markdown and LLM readers", () =>
     loadSlug: "learning",
   });
 
+  // The route owns the instructions; the raw-Markdown route only has to
+  // carry the command that reaches it. See `createFeatureSetupPrompt`.
   expect(output).toContain(
-    "Read https://docs.copilotkit.ai/learning and set up Automatic Learning",
+    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-learning",
   );
-  expect(output).toContain(
-    "do not add the deprecated `\u0275learning` Runtime option",
-  );
-  expect(output).toContain("keep each Thread's assignment stable");
   expect(output).not.toContain("<LearningSetupPrompt />");
 });

--- a/showcase/shell-docs/src/lib/__tests__/rich-threads-setup-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/rich-threads-setup-docs.test.ts
@@ -23,11 +23,10 @@ test("expands the Rich Threads agent prompt for Markdown and LLM readers", () =>
     loadSlug: "backend/runtime-endpoints",
   });
 
+  // The route owns the instructions; the raw-Markdown route only has to
+  // carry the command that reaches it. See `createFeatureSetupPrompt`.
   expect(output).toContain(
-    "Read https://docs.copilotkit.ai/backend/runtime-endpoints#enable-rich-threads-routes",
-  );
-  expect(output).toContain(
-    "Preserve existing authentication middleware and access checks",
+    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-rich-threads",
   );
   expect(output).not.toContain("<RichThreadsSetupPrompt />");
 });

--- a/showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts
+++ b/showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts
@@ -48,3 +48,42 @@ export function createOnboardingRunId(): string {
 export function createIntelligenceOnboardingPrompt(runId: string): string {
   return INTELLIGENCE_ONBOARDING_PROMPT.replace(RUN_ID_PLACEHOLDER, runId);
 }
+
+/**
+ * The feature outcomes a docs guide asks the CLI prompt graph for.
+ *
+ * A subset of `ONBOARDING_INTENT_ROOTS` in Intelligence's
+ * `apps/cli/onboarding-intents.cjs`, which is the source of truth for the
+ * full set of seven. Only the guides that ship a prompt card appear here; the
+ * rest of the docs keep the generic prompt above, because a reader who has no
+ * CopilotKit app yet cannot be served by a route that requires one.
+ */
+export type FeatureOnboardingIntent = "add-learning" | "add-rich-threads";
+
+/**
+ * The prompt a feature guide's card copies.
+ *
+ * It carries no setup instruction of its own, and it must not gain any. The
+ * `--intent` route owns the guide links, the plan, the per-phase check-ins,
+ * the refusal when a prerequisite is missing, and the proof step. Prose
+ * repeated here would drift from the route the next time the underlying API
+ * changes, which is what happened to the hand-written Learning prompt this
+ * function replaced.
+ *
+ * No `--run` id: these strings are static, and `llm-text` inlines them into
+ * cached raw Markdown, so one id minted here would be shared by every reader.
+ * The CLI mints its own when the flag is absent.
+ */
+export function createFeatureSetupPrompt(
+  intent: FeatureOnboardingIntent,
+): string {
+  return (
+    "Identify your coding-agent slug (for example, `codex` or " +
+    "`claude-code`). From the root of this repository, run `npx --yes " +
+    `copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent ${intent}` +
+    "`. Follow the Markdown instructions it prints until setup is complete. " +
+    "If it requires a CopilotKit CLI session check, you have permission to " +
+    "run it; never reveal credentials or send optional diagnostic feedback " +
+    "reports."
+  );
+}

--- a/showcase/shell-docs/src/lib/learning-setup-prompt.ts
+++ b/showcase/shell-docs/src/lib/learning-setup-prompt.ts
@@ -1,10 +1,9 @@
-/** Canonical coding-agent prompt for configuring Automatic Learning. */
-export const LEARNING_SETUP_PROMPT = `Read https://docs.copilotkit.ai/learning and set up Automatic Learning in this repository.
+import { createFeatureSetupPrompt } from "./intelligence-onboarding-prompt";
 
-First inspect the repository's agent instructions, installed CopilotKit versions, Runtime adapter, existing CopilotKit Intelligence client, authentication, and tests. Preserve the current frontend, agent framework, deployment model, authentication, and unrelated behavior. Use the current CopilotKit v2 APIs; do not add the deprecated \`\u0275learning\` Runtime option.
-
-If CopilotKit Intelligence is not connected yet, follow https://docs.copilotkit.ai/intelligence/quickstart without inventing an API key, project, user identity, or access policy. Ask me which existing Intelligence project or trusted identity source to use if the repository does not make that clear.
-
-Choose one focused workflow that would benefit from repeated examples. Reuse an existing Learning container and stable ID when the repository already names one. Otherwise, propose a descriptive lowercase, hyphenated container ID and ask me to create or confirm that container in CopilotKit Intelligence. Configure \`getLearningContainerId\` on the existing \`CopilotKitIntelligence\` client so only the intended new Threads are assigned. Return \`undefined\` for unrelated runs, keep each Thread's assignment stable, and do not imply that existing Threads will be backfilled.
-
-Run focused tests, lint, and typecheck. If the app and required credentials are available, start it, complete one representative workflow, and confirm that the Thread reaches the selected Learning container. Then give me the exact remaining steps to run Learning, review the evidence-backed Insights, approve a proposed Skill, and download the published Skill with the CopilotKit CLI. Report the files changed, commands run, verification result, and any dashboard action I still need to take. If blocked, explain the missing input instead of inventing setup.`;
+/**
+ * Canonical coding-agent prompt for configuring Automatic Learning.
+ *
+ * The `add-learning` route owns every instruction; see
+ * `createFeatureSetupPrompt` for why none of them are repeated here.
+ */
+export const LEARNING_SETUP_PROMPT = createFeatureSetupPrompt("add-learning");

--- a/showcase/shell-docs/src/lib/rich-threads-setup-prompt.ts
+++ b/showcase/shell-docs/src/lib/rich-threads-setup-prompt.ts
@@ -1,8 +1,10 @@
-/** Canonical coding-agent prompt for completing Rich Threads Runtime setup. */
-export const RICH_THREADS_SETUP_PROMPT = `Read https://docs.copilotkit.ai/backend/runtime-endpoints#enable-rich-threads-routes and finish setting up Rich Threads in this repository.
+import { createFeatureSetupPrompt } from "./intelligence-onboarding-prompt";
 
-First inspect the repository's agent instructions, installed CopilotKit versions, Runtime adapter, frontend provider, route or proxy setup, and existing authentication. Preserve the current framework and deployment model. Preserve existing authentication middleware and access checks on every Runtime route.
-
-Follow the guide to enable the multi-route Runtime, align the frontend transport, and expose the full Runtime subtree for GET, POST, PATCH, and DELETE. Authenticate every Runtime route with onRequest. Set identifyUser from the existing server-verified signed-in application user. Enforce thread ownership for threads/events, threads/state, and agent/stop as described in https://docs.copilotkit.ai/auth#thread-authorization. Never use a fixed demo identity in production. If no trusted user identity or ownership source exists, stop and ask me which source to use.
-
-Start the app. For a browser frontend, open Inspector and verify that Home shows Intelligence connected. Send one message, open Threads in Inspector, and confirm that the new thread contains the message. React Native does not include Inspector, so verify its new thread in the selected hosted Intelligence project instead. Run focused tests, lint, and typecheck. Report the files changed, commands run, and verification result. If blocked, explain the missing input; do not invent setup.`;
+/**
+ * Canonical coding-agent prompt for completing Rich Threads Runtime setup.
+ *
+ * The `add-rich-threads` route owns every instruction; see
+ * `createFeatureSetupPrompt` for why none of them are repeated here.
+ */
+export const RICH_THREADS_SETUP_PROMPT =
+  createFeatureSetupPrompt("add-rich-threads");


### PR DESCRIPTION
## What does this PR do?

Points the Inspector's seven per-feature "Copy setup prompt" buttons at the CLI's seven `--intent` feature routes, and retires the prose that duplicated them.

Intelligence#994 shipped `onboard start --intent <slug>` and seven feature routes. Nothing emitted the flag, so the only way to reach a route was to type it by hand — and the Inspector had already solved the same problem its own way, with a per-feature template of its own. Two implementations of feature onboarding for the same seven outcomes, and the routes had no caller at all.

**What changed**

* Home's feature buttons emit `onboard start --run <id> --coding-agent <slug> --intent <slug>`.
* `homeFeatureImplementationPrompt` is gone. Its body — inspect first, read the guide, make a plan, implement the smallest change, prove it works — is what the route already carries, with per-phase check-ins, a `feature/stop` route for a missing prerequisite, prompts pinned to a CLI version through `onboarding-graph.lock.json`, and intent-tagged telemetry on every step. A copied paragraph carries none of that and drifts the moment the API moves, which had already happened once to Learning.
* One table, `FEATURE_ONBOARDING_INTENT`, maps each tile to one intent. `Record<HomeServiceId, OnboardingIntent>` makes a new tile without an intent a type error, and a test holds the two sets equal in both directions.
* The two docs feature prompts follow: the Learning and Rich Threads guides name an intent instead of repeating setup prose. They pass no `--run` id, because these strings are static and `llm-text` inlines them into cached raw Markdown, where one minted id would be shared by every reader. The CLI mints its own when the flag is absent.

**Two naming decisions, both recorded in code**

The two id sets stay separate. A `HomeServiceId` names a tile and the pane behind it, so `websocket` and `audio` are right for it; an intent names work to be done, so `add-realtime-sync` and `add-voice` are right for that. One table maps between them rather than forcing one string to be both.

`memory` maps to `add-learning`, and that is now a fact rather than a guess. `learningOn` is `learningSnapshot?.configuration.state === "configured"` — a configured Learning *container*, which is exactly what `feature/learning/start.md` sets up through `getLearningContainerId`. The tile id `memory` and the `memories` menu key are older names for that same pane.

**The generic prompts stay generic**

The Inspector's install prompt, the docs CTA, and the Intelligence web app keep pointing at the generic route. All three are entry points for a developer with no CopilotKit app yet, and every feature route requires one: it inspects for an app first and reads `feature/stop` when it is missing. The reasoning is written into `onboarding-prompt.ts` so the next person does not have to rederive it.

## The release blocker is cleared

`copilotkit@4.9.50` published on 2026-09-10 and is now `latest`. Its tarball carries all seven `intentRoots` and all seven `prompts/feature/` directories, built from Intelligence `1e703c3c`.

The exact string this PR's buttons copy was run against the real package:

```
$ npx --yes copilotkit@latest onboard start --run abc123def456 \
    --coding-agent claude-code --intent add-a2ui
onboarding_run_id: abc123def456
onboarding_graph_tree: 249d0337...
# Add A2UI to the existing CopilotKit app
```

All seven intents exit 0 against the published package. An unknown intent is refused with `ONBOARDING_INTENT_NOT_FOUND` and a list of the seven valid slugs, so a future drift between the table in this PR and the CLI's map fails on the first command rather than onboarding the wrong feature.

The release pinned the same CopilotKit template commit as 4.9.47 (`380ad122`), so the only delta between the two CLI versions is Intelligence-side.

## The shell-docs half was ungated, so this adds a job

No CI job ran the `showcase/shell-docs` vitest suite, and none of the prompt files were in `test_integration-docs.yml`'s paths filter. The assertions in that half were verified on a developer's machine and nowhere else, which is the same gap the retired prose had. `feature-prompt-intents` now runs the five prompt test files on any change to them, scoped to those files because the whole suite is not green on main. Verified by running the job's exact command locally: 5 files, 17 tests, all passing.

## Related PRs and Issues

- Closes OSS-1150
- Follow-up: OSS-1151
- Callers for CopilotKit/Intelligence#994

## Validation

Run in a worktree off `origin/main`, with pre-existing failures confirmed by running the same specs against unmodified `origin/main` in the same worktree.

* `web-inspector` — `tsc --noEmit` clean; `tsdown` build clean; `vitest run` 662 passed, 35 failed. All 35 are `threads-states.spec.ts` dying in `setupSettledState` on `Cannot assign to read only property 'mock'`, which reproduces identically on `origin/main` (35 failed | 1 passed of 36, before and after). The one assertion this PR changes in that file is therefore not exercised locally; the same button is covered by `launcher-hud.spec.ts`, which passes.
* `web-inspector` — `tsc --project dev/tsconfig.json` reports 2 errors in `dev/*-state-lab-server.ts`, both `Uint8Array` vs `BodyInit`; same 2 on `origin/main`.
* `shell-docs` — `tsc --noEmit` clean; `vitest run` 875 passed, 6 failed in `brand-nav`, `angular-docs-content`, `llm-text` (mastra) and `ms-agent-python-stable-api`; the same 6 fail on `origin/main`.
* `oxfmt --check` and `oxlint` clean on every file in the diff. The three files oxfmt still flags are two generated JSON bundles and `page-tree-bridge.ts`, none of them touched here.

## Checklist

- [x] I have read the Contribution Guide
- [x] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
