### PR TITLE
docs: carry the runtime skill's hazards into the docs

### DIFF
--- a/showcase/shell-docs/src/content/docs/backend/agent-runner.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/agent-runner.mdx
@@ -71,6 +71,12 @@ agent it serves. The same runner handles `run`, `connect`, and `stop` for all
 registered agents.
 </Callout>
 
+<Callout type="warn" title="Don't pass a `runner` on an Intelligence runtime">
+An Intelligence runtime wires `IntelligenceAgentRunner` itself, so it accepts no `runner` of
+your own — passing one is a type error, and if you force it past the types the Intelligence
+runner is used anyway. Choosing a runner is a decision for a self-hosted runtime only.
+</Callout>
+
 ## Bounding in-memory history
 
 `InMemoryAgentRunner` holds every thread's run history in a process-global

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -431,9 +431,10 @@ app.use(
 ```
 
 <Callout type="warn" title="`basePath` is required, in both modes">
-The Express and single-route handlers throw at mount time when `basePath` is missing —
-`basePath must be provided for Express endpoint` — so the server fails to start rather than
-serving on the wrong paths. Give it the same path the route is mounted at.
+The Express and single-route handlers each throw at mount time when `basePath` is missing —
+`basePath must be provided for Express endpoint` and `... for single-route endpoint`
+respectively — so the server fails to start rather than serving on the wrong paths. Give it
+the same path the route is mounted at.
 </Callout>
 
 <Callout type="warn" title="Keep every runtime import on `/v2`">

--- a/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/runtime-endpoints.mdx
@@ -430,6 +430,19 @@ app.use(
 );
 ```
 
+<Callout type="warn" title="`basePath` is required, in both modes">
+The Express and single-route handlers throw at mount time when `basePath` is missing —
+`basePath must be provided for Express endpoint` — so the server fails to start rather than
+serving on the wrong paths. Give it the same path the route is mounted at.
+</Callout>
+
+<Callout type="warn" title="Keep every runtime import on `/v2`">
+Import the runtime from `@copilotkit/runtime/v2` (and the Express adapter from
+`@copilotkit/runtime/v2/express`). Reaching into the package root, `@copilotkit/runtime`,
+gets you the v1 surface: a `CopilotRuntime` built there does not serve these routes, and the
+mismatch shows up as routes that 404 rather than as an import error.
+</Callout>
+
 The optional Inspector metadata operation uses the same endpoint with this
 envelope:
 

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/server-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/server-tools.mdx
@@ -14,11 +14,14 @@ Server tools are functions that run on your backend that the Built-in Agent can 
 - You want type-safe tool parameters with validation
 - The tool logic requires server-side secrets or resources
 
-<Callout type="warn" title="Server tools cannot render UI">
-A server tool runs on the server and streams only its result back. The browser never sees a
-tool-call start event for it, so there is nothing for a renderer to attach to. For a tool that
-draws something — a modal, a form, a confirmation — use
-[`useFrontendTool`](/frontend-tools) and keep the tool on the client.
+<Callout type="warn" title="The tool runs on the server; the UI still runs in the browser">
+`execute` runs on your server, so it can reach secrets, a database, or an internal service —
+and it cannot touch the DOM, component state, or anything else in the page. When the *action*
+itself belongs in the browser, use [`useFrontendTool`](/frontend-tools) instead.
+
+Rendering is separate from executing. A server tool's call still streams to the browser, so
+you can give it UI with a render-only `useRenderTool` registration under the same tool name
+while `execute` keeps running on the server.
 </Callout>
 
 ## Defining a tool
@@ -62,9 +65,9 @@ Tools can return any JSON-serializable value. The agent uses the response to con
 Pass an array of tools — the agent chooses which to call based on the user's request:
 
 <Callout type="warn" title="Two names to avoid">
-`AGUISendStateSnapshot` and `AGUISendStateDelta` are injected for you when the Built-in Agent
-runs with a `tools` array. Defining your own tool under either name replaces the built-in one
-and breaks shared state.
+`AGUISendStateSnapshot` and `AGUISendStateDelta` are injected for you whenever the Built-in
+Agent makes the model call itself. Defining your own tool under either name replaces the
+built-in one and breaks shared state.
 
 A server tool also wins any name collision with a frontend tool: define `getWeather` on both
 sides and the model only ever sees the server one, so the frontend handler never fires. Give
@@ -157,9 +160,8 @@ const getUser = defineTool({
 
 <Callout type="warn" title="Return plain data">
 Whatever a tool returns is serialized before the model sees it. A class instance, a circular
-reference, or anything else `JSON.stringify` refuses becomes the literal string
-`[Unserializable tool result from <toolName>]`, and the model reasons over that instead of
-your data. Return plain objects, arrays and primitives — including for error shapes.
+reference, or anything else `JSON.stringify` refuses is replaced by a placeholder string
+naming the tool, and the model reasons over that instead of your data. Return plain objects, arrays and primitives — including for error shapes.
 </Callout>
 
 ## Multi-step tool calling

--- a/showcase/shell-docs/src/content/docs/integrations/built-in-agent/server-tools.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/built-in-agent/server-tools.mdx
@@ -14,6 +14,13 @@ Server tools are functions that run on your backend that the Built-in Agent can 
 - You want type-safe tool parameters with validation
 - The tool logic requires server-side secrets or resources
 
+<Callout type="warn" title="Server tools cannot render UI">
+A server tool runs on the server and streams only its result back. The browser never sees a
+tool-call start event for it, so there is nothing for a renderer to attach to. For a tool that
+draws something — a modal, a form, a confirmation — use
+[`useFrontendTool`](/frontend-tools) and keep the tool on the client.
+</Callout>
+
 ## Defining a tool
 
 ```typescript title="src/copilotkit.ts"
@@ -39,6 +46,13 @@ const builtInAgent = new BuiltInAgent({
 });
 ```
 
+<Callout type="warn" title="`parameters` takes a schema validator, not JSON Schema">
+`parameters` must be a Standard Schema v1 validator — Zod, Valibot, ArkType and others
+qualify. Handing it a plain JSON Schema object throws while the tool's schema is being
+converted. The validator is also what gives `execute` its inferred argument type, so a
+hand-written JSON Schema loses that too.
+</Callout>
+
 ## Tool response
 
 Tools can return any JSON-serializable value. The agent uses the response to continue the conversation.
@@ -46,6 +60,16 @@ Tools can return any JSON-serializable value. The agent uses the response to con
 ## Multiple tools
 
 Pass an array of tools — the agent chooses which to call based on the user's request:
+
+<Callout type="warn" title="Two names to avoid">
+`AGUISendStateSnapshot` and `AGUISendStateDelta` are injected for you when the Built-in Agent
+runs with a `tools` array. Defining your own tool under either name replaces the built-in one
+and breaks shared state.
+
+A server tool also wins any name collision with a frontend tool: define `getWeather` on both
+sides and the model only ever sees the server one, so the frontend handler never fires. Give
+each side a distinct name when both need their own.
+</Callout>
 
 ```typescript title="src/copilotkit.ts"
 const searchDocs = defineTool({
@@ -131,6 +155,13 @@ const getUser = defineTool({
 });
 ```
 
+<Callout type="warn" title="Return plain data">
+Whatever a tool returns is serialized before the model sees it. A class instance, a circular
+reference, or anything else `JSON.stringify` refuses becomes the literal string
+`[Unserializable tool result from <toolName>]`, and the model reasons over that instead of
+your data. Return plain objects, arrays and primitives — including for error shapes.
+</Callout>
+
 ## Multi-step tool calling
 
 By default, the agent performs a single step. If your agent needs to chain tool calls (e.g., search first, then create a ticket), set `maxSteps`:
@@ -151,6 +182,14 @@ With `maxSteps: 5`, the agent can:
 
 <Callout type="info">
 See [Advanced Configuration](/advanced-configuration) for more options like `toolChoice`, `temperature`, and `providerOptions`.
+</Callout>
+
+<Callout type="warn" title="A factory ignores the `tools` array">
+Everything on this page describes a Built-in Agent constructed with `model` and `tools`. If
+you build one from a `factory` instead, the `tools` array is not read — the factory owns the
+model call, so it has to pass the tools itself. Convert them with
+`convertToolDefinitionsToVercelAITools` for an AI SDK factory, or the equivalent converter for
+your runner, and pass the result into the call the factory makes.
 </Callout>
 
 <Callout type="info" title="Using a custom backend?">

--- a/showcase/shell-docs/src/content/docs/intelligence/connect-your-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/connect-your-runtime.mdx
@@ -65,8 +65,14 @@ const runtime = new CopilotRuntime({
 export const { GET, POST } = createCopilotRuntimeHandler({ runtime });
 ```
 
-`apiKey` is the only required field. The key scopes the project, so there is no
-separate organization or project id to pass.
+`apiKey` is the only required field on the Intelligence client. The key scopes the project,
+so there is no separate organization or project id to pass.
+
+<Callout type="warn" title="`identifyUser` is required, not advisory">
+On the runtime itself, `identifyUser` is required whenever the runtime serves a web surface —
+the options type will not accept its absence. The one exception is a Channels-only runtime,
+which serves no web surface and passes a non-empty `channels` array instead.
+</Callout>
 
 ## Confirm the credential is actually used
 

--- a/showcase/shell-docs/src/content/docs/voice.mdx
+++ b/showcase/shell-docs/src/content/docs/voice.mdx
@@ -45,6 +45,20 @@ Wire up the V2 runtime with a `TranscriptionService`. The V1 wrapper drops the `
 
 The `basePath: "/api/copilotkit-voice"` in `createCopilotRuntimeHandler` must match the API route's directory path. With `transcriptionService` set, the runtime advertises `audioFileTranscriptionEnabled: true` on `/info` (which is what tells the chat to render the mic button) and routes `POST /transcribe` to the service.
 
+<Callout type="warn" title="Without a service, `/transcribe` answers 503">
+A runtime with no `transcriptionService` still serves the route, and answers every request
+`503` with `{ "error": "service_not_configured" }`. The mic button never appears, so the
+symptom is a chat with no voice input rather than a visible server error — check `/info` for
+`audioFileTranscriptionEnabled` when voice silently doesn't show up.
+</Callout>
+
+<Callout type="warn" title="Calling `/transcribe` yourself">
+The chat handles this for you; these are the rules if you post to the route directly. As
+multipart, the audio field must be named `audio` — any other name reads as absent and the
+route answers `invalid_request`. As JSON, `mimeType` is required alongside the base64
+`audio`, and a payload without it is rejected the same way.
+</Callout>
+
 <WhenFrameworkHas flag="voice_backend_pattern" equals="adk-fastapi-agent-path">
 For the Google ADK showcase, agent runs take one more hop: this Next.js route registers the `voice-demo` agent with an `HttpAgent` pointed at `${AGENT_URL}/voice`. The Python `agent_server.py` mounts registered ADK agents with `add_adk_fastapi_endpoint(app, ..., path=f"/{agent_name}")`, so the browser talks to `/api/copilotkit-voice` while the Next.js runtime forwards voice-demo agent runs to the backend `/voice` endpoint.
 </WhenFrameworkHas>
@@ -52,6 +66,16 @@ For the Google ADK showcase, agent runs take one more hop: this Next.js route re
 ### Custom transcription backends
 
 `TranscriptionService` from `@copilotkit/runtime/v2` is an abstract class. Subclass it to plug in any transcription provider — Whisper, AssemblyAI, Deepgram, your own model. The library ships `TranscriptionServiceOpenAI` as the canonical reference implementation.
+
+<Callout type="warn" title="Return a string, and let provider errors through">
+`transcribe` returns the transcript as a string — the handler wraps it into
+`{ transcription }` itself, so returning a richer object is a type error.
+
+Let the provider's own errors propagate unchanged. The runtime classifies failures by reading
+the error text for markers like `rate`, `429`, `auth` and `too long`, so a provider message
+such as `OpenAI returned 429 rate limited` maps to the right error code on its own. Replacing
+it with your own wording bypasses that and everything lands as a generic provider error.
+</Callout>
 
 A useful pattern is wrapping your service in a guard that returns a clean 4xx when credentials aren't configured, instead of an opaque 5xx from the underlying SDK:
 


### PR DESCRIPTION
First half of consolidating the packaged `runtime` skill onto the docs. Cleanup of the skill itself follows in a second PR, once every hazard has a documented home.

## Why

The skill is 4,509 lines: **61% cached API surface** the docs already supply, and **38% Common Mistakes** they do not. Caching the first half is why the skill rots — its predecessors prescribed two dead hostnames up to v1.62.2. This moves the second half in, as inline `<Callout type="warn">`, which the docs already use 70-plus times.

## What landed

Twelve callouts across five pages, covering **17 of the skill's 51 hazards**.

| Page | Added |
| --- | --- |
| `/server-tools` | 5 callouts — it had **no warnings at all** |
| `backend/runtime-endpoints` | `basePath` throws at mount; keep runtime imports on `/v2` |
| `voice` | `/transcribe` 503 with no service; the wire contract for direct calls; return-a-string and let-provider-errors-through |
| `backend/agent-runner` | Don't pass a `runner` on an Intelligence runtime |
| `intelligence/connect-your-runtime` | `identifyUser` is required by the options type |

The `identifyUser` one corrects a misleading comment. The page said omitting it means "every visitor shares one history", implying it is optional with a downside. The options type is a discriminated union: it is required whenever the runtime serves a web surface, and the only exception is a Channels-only runtime passing a non-empty `channels` array.

## What needed nothing

**Sixteen hazards were already covered — several better than the skill.** `backend/agent-runner` documents eviction semantics, `onConcurrentRun`, and the process-global limits clobber, none of which the skill mentions. The lifecycle-hooks table already states "Throw `Response` to short-circuit". `connect-your-runtime` maps wsUrl symptoms to causes in a table.

The whole `middleware` group came out moot: the docs teach `hooks` and never teach `beforeRequestMiddleware`, so hazards about the legacy API have nothing to attach to.

## Two skill claims I did not carry over, because they are wrong

- The skill flags `createCopilotExpressHandler` / `createCopilotHonoHandler` as **CRITICAL to avoid in new code**. The source says the opposite:

  ```
  /** @deprecated Use `createCopilotExpressHandler` instead. */
  export { createCopilotExpressHandler as createCopilotEndpointExpress };
  ```

  It is `createCopilotEndpoint*` that is deprecated, in favour of exactly the two handlers the skill condemns. The docs use them 12 times as the primary path and are correct. Following the skill here would have degraded working documentation.

- The skill warns against framework adapters on Workers / Bun / Deno. `runtime-server-adapter.mdx` carries dedicated sections for all three, plus Elysia. The skill's claim conflates "Express needs Node" with "adapters don't work on edge runtimes".

An `A2AAgent`/`A2AClient` hazard was also skipped: the docs teach `A2AMiddlewareAgent`, and writing the hazard would introduce an API the docs deliberately don't document.

## Deliberately unresolved

The skill says a thrown error inside a server tool's `execute` kills the run. `/server-tools` tells readers to throw, and the model will see the error. `execute` is handed to the underlying SDK rather than called by CopilotKit, no test in the repo pins the behaviour, and I could not settle it statically — so **neither claim was written**. The serialization half, which I did verify, is in the callout; the throw half is untouched.

## Still outstanding

Two hazard groups: `wiring-external-agents` (6) and `built-in-agent` (9). Both want their own pass rather than a rushed one. Two things found while scoping them:

- `built-in-agent.mdx` at the docs root is a **12-line placeholder** with a `TODO` comment, while 1,450 lines of real content sit under `integrations/built-in-agent/`. Its nine hazards have no root page to land on.
- "Simple Mode" / "Factory Mode" appears in only **2 files**, and most of those nine hazards are about that distinction.

The runtime-skill deletion should not start until these two groups land, so the cleanup PR can cite where every hazard went.

## Testing

Every changed file parses as MDX (`remark-parse` + `remark-mdx`):

```
OK   docs/backend/agent-runner.mdx
OK   docs/backend/runtime-endpoints.mdx
OK   docs/integrations/built-in-agent/server-tools.mdx
OK   docs/intelligence/connect-your-runtime.mdx
OK   docs/voice.mdx
```

Every claim written was verified against the tree at this commit — `express.ts:205` for the `basePath` throw, `agent/index.ts:1699-1703` for the serialization fallback, `runtime.ts:253-266` for the `identifyUser` union, `handle-transcribe.ts` for the 503 and the field-name and `mimeType` rules. Placement was chosen after reading each page in full; an earlier pass of this work misjudged coverage twice by reading headings instead of prose, and once by reading a stale checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified runner selection rules for Intelligence and self-hosted runtimes.
  - Documented required `basePath` configuration and endpoint-specific errors.
  - Added guidance on server-tool limitations, validation, naming conflicts, serialization, and factory-created agents.
  - Clarified Intelligence client requirements, including API key and runtime user identification.
  - Documented voice transcription setup, request formats, configuration errors, and custom backend requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->