### PR TITLE
fix(runtime): keep streamed text at a partial <thinking> tag boundary

### DIFF
--- a/packages/runtime/src/v1-deprecated/service-adapters/anthropic/anthropic-adapter.test.ts
+++ b/packages/runtime/src/v1-deprecated/service-adapters/anthropic/anthropic-adapter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { FilterThinkingTextBuffer } from "./anthropic-adapter";
+
+/**
+ * Streams `chunks` through a fresh buffer the way the adapter does: only
+ * non-empty returns are emitted, and the block is flushed at the end.
+ */
+function stream(chunks: string[], { flush = true } = {}): string {
+  const buffer = new FilterThinkingTextBuffer();
+  const emitted: string[] = [];
+  for (const chunk of chunks) {
+    const text = buffer.onTextChunk(chunk);
+    if (text.length > 0) {
+      emitted.push(text);
+    }
+  }
+  if (flush) {
+    const rest = buffer.flush();
+    if (rest.length > 0) {
+      emitted.push(rest);
+    }
+  }
+  return emitted.join("");
+}
+
+describe("FilterThinkingTextBuffer", () => {
+  it("strips a thinking block that opens the content block", () => {
+    expect(stream(["<thinking>", "hidden", "</thinking>", "visible"])).toBe(
+      "visible",
+    );
+    expect(stream(["<thi", "nking>plan</thinking>answer"])).toBe("answer");
+    expect(stream(["<thinking>plan</thinking>", "answer"])).toBe("answer");
+  });
+
+  it("keeps everything held back when a chunk boundary falls inside a tag prefix", () => {
+    // Before the fix only the diverging chunk came out: the buffered prefix
+    // was dropped.
+    expect(stream(["<", "b>bold</b> text"])).toBe("<b>bold</b> text");
+    expect(stream(["<t", "able> rows"])).toBe("<table> rows");
+    expect(stream(["<", "d", "i", "v", ">"])).toBe("<div>");
+    expect(stream(["<", "5 is less than 10"])).toBe("<5 is less than 10");
+  });
+
+  it("only treats the start of the block as a tag", () => {
+    expect(
+      stream(["The tag is called ", "<thinking>", " and it hides text."]),
+    ).toBe("The tag is called <thinking> and it hides text.");
+    expect(stream(["if (a ", "< b) return;", "\n", "<"])).toBe(
+      "if (a < b) return;\n<",
+    );
+  });
+
+  it("releases a partial prefix when the block ends", () => {
+    expect(stream(["<"])).toBe("<");
+    expect(stream(["<thin"])).toBe("<thin");
+    // Without the flush the trailing text was lost for good.
+    expect(stream(["<"], { flush: false })).toBe("");
+  });
+
+  it("keeps an unterminated thinking block hidden", () => {
+    expect(stream(["<thinking>", "never closed"])).toBe("");
+  });
+
+  it("passes ordinary text through untouched", () => {
+    expect(stream(["Hello", " ", "world"])).toBe("Hello world");
+    expect(stream(["Hello <thinking> world"])).toBe("Hello <thinking> world");
+  });
+
+  it("starts over after reset", () => {
+    const buffer = new FilterThinkingTextBuffer();
+    expect(buffer.onTextChunk("plain")).toBe("plain");
+    buffer.reset();
+    expect(buffer.onTextChunk("<thinking>x</thinking>y")).toBe("y");
+    expect(buffer.flush()).toBe("");
+  });
+});

--- a/packages/runtime/src/v1-deprecated/service-adapters/anthropic/anthropic-adapter.ts
+++ b/packages/runtime/src/v1-deprecated/service-adapters/anthropic/anthropic-adapter.ts
@@ -424,6 +424,22 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
         let filterThinkingTextBuffer = new FilterThinkingTextBuffer();
         let hasReceivedContent = false;
 
+        const emitText = (text: string) => {
+          if (text.length === 0) {
+            return;
+          }
+          if (!didOutputText) {
+            eventStream$.sendTextMessageStart({
+              messageId: currentMessageId,
+            });
+            didOutputText = true;
+          }
+          eventStream$.sendTextMessageContent({
+            messageId: currentMessageId,
+            content: text,
+          });
+        };
+
         try {
           for await (const chunk of stream as AsyncIterable<any>) {
             if (chunk.type === "message_start") {
@@ -455,21 +471,9 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
                 continue;
               }
               if (chunk.delta.type === "text_delta") {
-                const text = filterThinkingTextBuffer.onTextChunk(
-                  chunk.delta.text,
+                emitText(
+                  filterThinkingTextBuffer.onTextChunk(chunk.delta.text),
                 );
-                if (text.length > 0) {
-                  if (!didOutputText) {
-                    eventStream$.sendTextMessageStart({
-                      messageId: currentMessageId,
-                    });
-                    didOutputText = true;
-                  }
-                  eventStream$.sendTextMessageContent({
-                    messageId: currentMessageId,
-                    content: text,
-                  });
-                }
               } else if (chunk.delta.type === "input_json_delta") {
                 eventStream$.sendActionExecutionArgs({
                   actionExecutionId: currentToolCallId,
@@ -478,6 +482,9 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
               }
             } else if (chunk.type === "content_block_stop") {
               if (mode === "message") {
+                // Text held back as a possible `<thinking>` prefix is real
+                // output once the block ends without resolving it.
+                emitText(filterThinkingTextBuffer.flush());
                 if (didOutputText) {
                   eventStream$.sendTextMessageEnd({
                     messageId: currentMessageId,
@@ -541,36 +548,85 @@ export class AnthropicAdapter implements CopilotServiceAdapter {
 const THINKING_TAG = "<thinking>";
 const THINKING_TAG_END = "</thinking>";
 
-class FilterThinkingTextBuffer {
-  private buffer: string;
-  private didFilterThinkingTag: boolean = false;
-
-  constructor() {
-    this.buffer = "";
-  }
+/**
+ * Strips a `<thinking>…</thinking>` block that opens a streamed text content
+ * block, passing everything else through unchanged.
+ *
+ * Only the START of a content block can be a thinking tag. Text is held back
+ * while the block's opening characters could still turn into `<thinking>`;
+ * the moment they diverge, everything held back is emitted in one piece and
+ * the detector disarms for the rest of the block, so a literal `<thinking>`
+ * mentioned later in the answer is never treated as a tag. `flush()` releases
+ * whatever is still held back when the content block ends (a block that is
+ * just `<`, for example).
+ */
+export class FilterThinkingTextBuffer {
+  private buffer: string = "";
+  /**
+   * True once the block's start is known to be, or not to be, a thinking tag;
+   * from then on chunks pass straight through.
+   */
+  private resolved: boolean = false;
 
   onTextChunk(text: string): string {
-    this.buffer += text;
-    if (this.didFilterThinkingTag) {
+    if (this.resolved) {
       return text;
     }
-    const potentialTag = this.buffer.slice(0, THINKING_TAG.length);
-    if (THINKING_TAG.startsWith(potentialTag)) {
-      if (this.buffer.includes(THINKING_TAG_END)) {
-        const end = this.buffer.indexOf(THINKING_TAG_END);
-        const filteredText = this.buffer.slice(end + THINKING_TAG_END.length);
-        this.buffer = filteredText;
-        this.didFilterThinkingTag = true;
-        return filteredText;
-      } else {
+    this.buffer += text;
+
+    if (this.buffer.length < THINKING_TAG.length) {
+      if (THINKING_TAG.startsWith(this.buffer)) {
+        // Still a possible tag prefix — keep holding it back.
         return "";
       }
+      return this.release();
     }
-    return text;
+
+    if (!this.buffer.startsWith(THINKING_TAG)) {
+      // Diverged from `<thinking>`: emit the whole held-back text, not just
+      // this chunk, and stop looking.
+      return this.release();
+    }
+
+    const end = this.buffer.indexOf(THINKING_TAG_END);
+    if (end === -1) {
+      // Inside the thinking block — swallow until it closes.
+      return "";
+    }
+    const rest = this.buffer.slice(end + THINKING_TAG_END.length);
+    this.buffer = "";
+    this.resolved = true;
+    return rest;
+  }
+
+  /**
+   * Text still held back when the content block ends. A partial tag prefix
+   * (`<`, `<thin`) is real output and comes back; an unterminated thinking
+   * block stays hidden.
+   */
+  flush(): string {
+    if (this.resolved) {
+      return "";
+    }
+    const pending =
+      this.buffer.length < THINKING_TAG.length &&
+      THINKING_TAG.startsWith(this.buffer)
+        ? this.buffer
+        : "";
+    this.buffer = "";
+    this.resolved = true;
+    return pending;
   }
 
   reset() {
     this.buffer = "";
-    this.didFilterThinkingTag = false;
+    this.resolved = false;
+  }
+
+  private release(): string {
+    const pending = this.buffer;
+    this.buffer = "";
+    this.resolved = true;
+    return pending;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #7008.

`FilterThinkingTextBuffer` in the v1 Anthropic adapter (`packages/runtime/src/v1-deprecated/service-adapters/anthropic/anthropic-adapter.ts`) silently dropped streamed text when a chunk boundary fell inside a prefix of `<thinking>`: on divergence it returned only the current chunk, so a reply whose first delta was a bare `<` lost that character (`["<", "b>bold</b> text"]` → `b>bold</b> text`). It also re-armed on every chunk, so a literal `<thinking>` later in an answer hid the rest of the message (the trap PR #6026 fell into), and nothing released a still-buffered prefix when the content block ended.

## Change

All four points from the issue:

1. **Divergence emits the whole buffer.** Once the block's opening characters can no longer become `<thinking>`, everything held back is emitted in one piece.
2. **Anchored to the start of the block.** The detector resolves once (tag or not) and then passes chunks straight through, so a literal `<thinking>` mid-answer is never treated as a tag.
3. **Flush at `content_block_stop`.** New `flush()` returns a still-pending partial prefix (`<`, `<thin`); the adapter emits it before `sendTextMessageEnd`. An unterminated thinking block stays hidden.
4. **Tests** (`anthropic-adapter.test.ts`, the class is now exported): the chunk sequences from the issue, the two regression cases (`"The tag is called ", "<thinking>", " and it hides text."` and `"if (a ", "< b) return;", "\n", "<"`), thinking-block stripping across chunk boundaries, flush at block end, unterminated block, plain text, and `reset()`.

The text-emission logic in the stream loop (`sendTextMessageStart` on first output, then `sendTextMessageContent`) is factored into a local `emitText` helper shared by the delta and stop paths. v1 only; nothing else uses this class.

## Verification

`cd packages/runtime && npx vitest run …/anthropic-adapter.test.ts` → 7 passed; with the original class the "chunk boundary inside a tag prefix" and "partial prefix at block end" cases fail (2 failed / 5 passed). The lefthook pre-commit run (lint, intelligence env names, `nx test/publint/attw` across the packages) passed. Prettier clean. No changeset added, per the repo's changeset check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic streaming to hide complete `<thinking>` sections from displayed text.
  * Preserved regular text and correctly handled tags split across streamed chunks.
  * Ensured buffered content is flushed appropriately when text blocks end.
* **Tests**
  * Added coverage for thinking-tag filtering, partial chunks, flushing, ordinary text, and buffer resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->