### PR TITLE
fix(skills): stop the runtime skill condemning the supported handlers

### DIFF
--- a/packages/runtime/skills/runtime/SKILL.md
+++ b/packages/runtime/skills/runtime/SKILL.md
@@ -7,8 +7,8 @@ description: >
   LangGraph, CrewAI Crews/Flows, PydanticAI, ADK, LlamaIndex, Agno, AWS Strands, MS Agent
   Framework, AG2, A2A), enable Intelligence mode for durable threads + websocket,
   register server-side tools via defineTool, and wire voice transcription. Uses the
-  fetch-based createCopilotRuntimeHandler primitive — the Express/Hono adapters are
-  discouraged. Load the reference under references/ that matches your task.
+  fetch-based createCopilotRuntimeHandler primitive, or the supported Express/Hono
+  adapters. Load the reference under references/ that matches your task.
 type: core
 library: copilotkit
 library_version: "1.71.0"
@@ -82,7 +82,7 @@ export default { fetch: handler };
 
 ## Invariants and gotchas (load-once, before any reference)
 
-- `createCopilotRuntimeHandler` is the canonical primitive. `createCopilotExpressHandler` / `createCopilotHonoHandler` exist but are **avoid at all costs** — delegate from Express/Hono routes to the fetch primitive instead.
+- `createCopilotRuntimeHandler` is the fetch-native primitive, and the right choice on Workers, Bun, Deno and any other fetch runtime. `createCopilotExpressHandler` / `createCopilotHonoHandler` are the **current, supported** adapters for those two frameworks — the deprecated names are `createCopilotEndpoint`, `createCopilotEndpointExpress` and their single-route variants, each of which now points at one of the two handlers.
 - Intelligence credentials are server-side. The CLI writes `CPK_INTELLIGENCE_API_KEY` into the runtime's environment; no client-side key is involved.
 - Intelligence mode auto-wires `IntelligenceAgentRunner`. Passing both `runner` and `intelligence` to `CopilotRuntime` is rejected at construction.
 - Intelligence mode targets the managed CopilotKit Intelligence service (`api.cloud.copilotkit.ai`) and is **not self-hostable**.

--- a/packages/runtime/skills/runtime/references/server-side-tools.md
+++ b/packages/runtime/skills/runtime/references/server-side-tools.md
@@ -214,8 +214,11 @@ useFrontendTool({
 });
 ```
 
-Server tools execute on the server and stream only results back. The browser never sees a
-`TOOL_CALL_START` for a server tool, so there is nothing to mount a renderer against.
+`execute` runs on the server, so it cannot touch the DOM or component state — put the
+action in `useFrontendTool` when the action itself belongs in the browser. Rendering is a
+separate matter: a server tool's call does stream to the browser, so a render-only
+`useRenderTool` registration under the same name can give it UI while `execute` stays on
+the server.
 
 Source: `dev-docs/architecture/plugin-points.md:36-77`;
 `docs/content/docs/integrations/built-in-agent/server-tools.mdx:9-14`.

--- a/packages/runtime/skills/runtime/references/setup-endpoint.md
+++ b/packages/runtime/skills/runtime/references/setup-endpoint.md
@@ -193,9 +193,12 @@ export default {
 };
 ```
 
-### Delegate from Express / Hono to the fetch primitive
+### Delegate from Express / Hono to the fetch primitive by hand
 
-Do not use `createCopilotExpressHandler` / `createCopilotHonoHandler`.
+`createCopilotExpressHandler` and `createCopilotHonoHandler` are the normal way to mount on
+those two frameworks — reach for them first. Delegate by hand only when you need the raw
+fetch handler inside an existing app, for instance to control middleware ordering around it
+yourself.
 
 ```typescript
 // Express — requires Node 18.17+ for Readable.fromWeb + fetch body: req
@@ -282,54 +285,6 @@ Single-route mode exposes a single `POST basePath` that accepts
 
 ## Common Mistakes
 
-### CRITICAL Using createCopilotExpressHandler / createCopilotHonoHandler in new code
-
-Wrong:
-
-```typescript
-import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
-app.use(
-  "/api/copilotkit",
-  createCopilotExpressHandler({ runtime, basePath: "/api/copilotkit" }),
-);
-```
-
-Correct:
-
-```typescript
-import { Readable } from "node:stream";
-import type { ReadableStream as WebReadableStream } from "node:stream/web";
-import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
-const handler = createCopilotRuntimeHandler({
-  runtime,
-  basePath: "/api/copilotkit",
-});
-app.all("/api/copilotkit/*", async (req, res) => {
-  // Requires Node 18.17+ (Readable.fromWeb + duplex: "half")
-  const webReq = new Request(new URL(req.url, `http://${req.headers.host}`), {
-    method: req.method,
-    headers: req.headers as any,
-    body: ["GET", "HEAD"].includes(req.method!) ? undefined : req,
-    duplex: "half",
-  } as any);
-  const webRes = await handler(webReq);
-  res.status(webRes.status);
-  webRes.headers.forEach((v, k) => res.setHeader(k, v));
-  // Stream, don't buffer — /agent/*/run is SSE.
-  if (webRes.body) {
-    Readable.fromWeb(webRes.body as unknown as WebReadableStream).pipe(res);
-  } else {
-    res.end();
-  }
-});
-```
-
-The Express and Hono adapters are a discouraged surface — the maintainer flags them as
-"avoid at all costs." They pull in heavier dependencies, add framework binding, and make
-it harder to port. The fetch handler works from any Express/Hono route.
-
-Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:1-27`; maintainer Phase 4d.
-
 ### CRITICAL Instantiating Express handler without basePath
 
 Wrong:
@@ -354,31 +309,6 @@ app.all("/api/copilotkit/*", (req, res) => {
 and crashes the server.
 
 Source: `packages/runtime/src/v2/runtime/endpoints/express.ts:161`.
-
-### HIGH Using framework adapter on Workers / Bun / Deno
-
-Wrong:
-
-```typescript
-// Cloudflare Worker
-import { createCopilotHonoHandler } from "@copilotkit/runtime/v2/hono";
-export default app;
-```
-
-Correct:
-
-```typescript
-import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
-const handler = createCopilotRuntimeHandler({
-  runtime,
-  basePath: "/api/copilotkit",
-});
-export default { fetch: (req: Request) => handler(req) };
-```
-
-Adapters bundle Node polyfills unnecessarily in fetch-native runtimes.
-
-Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:1-27`.
 
 ### HIGH Returning a Response from beforeRequestMiddleware
 

--- a/skills/runtime/SKILL.md
+++ b/skills/runtime/SKILL.md
@@ -7,8 +7,8 @@ description: >
   LangGraph, CrewAI Crews/Flows, PydanticAI, ADK, LlamaIndex, Agno, AWS Strands, MS Agent
   Framework, AG2, A2A), enable Intelligence mode for durable threads + websocket,
   register server-side tools via defineTool, and wire voice transcription. Uses the
-  fetch-based createCopilotRuntimeHandler primitive — the Express/Hono adapters are
-  discouraged. Load the reference under references/ that matches your task.
+  fetch-based createCopilotRuntimeHandler primitive, or the supported Express/Hono
+  adapters. Load the reference under references/ that matches your task.
 type: core
 library: copilotkit
 library_version: "1.71.0"
@@ -82,7 +82,7 @@ export default { fetch: handler };
 
 ## Invariants and gotchas (load-once, before any reference)
 
-- `createCopilotRuntimeHandler` is the canonical primitive. `createCopilotExpressHandler` / `createCopilotHonoHandler` exist but are **avoid at all costs** — delegate from Express/Hono routes to the fetch primitive instead.
+- `createCopilotRuntimeHandler` is the fetch-native primitive, and the right choice on Workers, Bun, Deno and any other fetch runtime. `createCopilotExpressHandler` / `createCopilotHonoHandler` are the **current, supported** adapters for those two frameworks — the deprecated names are `createCopilotEndpoint`, `createCopilotEndpointExpress` and their single-route variants, each of which now points at one of the two handlers.
 - Intelligence credentials are server-side. The CLI writes `CPK_INTELLIGENCE_API_KEY` into the runtime's environment; no client-side key is involved.
 - Intelligence mode auto-wires `IntelligenceAgentRunner`. Passing both `runner` and `intelligence` to `CopilotRuntime` is rejected at construction.
 - Intelligence mode targets the managed CopilotKit Intelligence service (`api.cloud.copilotkit.ai`) and is **not self-hostable**.

--- a/skills/runtime/references/server-side-tools.md
+++ b/skills/runtime/references/server-side-tools.md
@@ -214,8 +214,11 @@ useFrontendTool({
 });
 ```
 
-Server tools execute on the server and stream only results back. The browser never sees a
-`TOOL_CALL_START` for a server tool, so there is nothing to mount a renderer against.
+`execute` runs on the server, so it cannot touch the DOM or component state — put the
+action in `useFrontendTool` when the action itself belongs in the browser. Rendering is a
+separate matter: a server tool's call does stream to the browser, so a render-only
+`useRenderTool` registration under the same name can give it UI while `execute` stays on
+the server.
 
 Source: `dev-docs/architecture/plugin-points.md:36-77`;
 `docs/content/docs/integrations/built-in-agent/server-tools.mdx:9-14`.

--- a/skills/runtime/references/setup-endpoint.md
+++ b/skills/runtime/references/setup-endpoint.md
@@ -193,9 +193,12 @@ export default {
 };
 ```
 
-### Delegate from Express / Hono to the fetch primitive
+### Delegate from Express / Hono to the fetch primitive by hand
 
-Do not use `createCopilotExpressHandler` / `createCopilotHonoHandler`.
+`createCopilotExpressHandler` and `createCopilotHonoHandler` are the normal way to mount on
+those two frameworks — reach for them first. Delegate by hand only when you need the raw
+fetch handler inside an existing app, for instance to control middleware ordering around it
+yourself.
 
 ```typescript
 // Express — requires Node 18.17+ for Readable.fromWeb + fetch body: req
@@ -282,54 +285,6 @@ Single-route mode exposes a single `POST basePath` that accepts
 
 ## Common Mistakes
 
-### CRITICAL Using createCopilotExpressHandler / createCopilotHonoHandler in new code
-
-Wrong:
-
-```typescript
-import { createCopilotExpressHandler } from "@copilotkit/runtime/v2/express";
-app.use(
-  "/api/copilotkit",
-  createCopilotExpressHandler({ runtime, basePath: "/api/copilotkit" }),
-);
-```
-
-Correct:
-
-```typescript
-import { Readable } from "node:stream";
-import type { ReadableStream as WebReadableStream } from "node:stream/web";
-import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
-const handler = createCopilotRuntimeHandler({
-  runtime,
-  basePath: "/api/copilotkit",
-});
-app.all("/api/copilotkit/*", async (req, res) => {
-  // Requires Node 18.17+ (Readable.fromWeb + duplex: "half")
-  const webReq = new Request(new URL(req.url, `http://${req.headers.host}`), {
-    method: req.method,
-    headers: req.headers as any,
-    body: ["GET", "HEAD"].includes(req.method!) ? undefined : req,
-    duplex: "half",
-  } as any);
-  const webRes = await handler(webReq);
-  res.status(webRes.status);
-  webRes.headers.forEach((v, k) => res.setHeader(k, v));
-  // Stream, don't buffer — /agent/*/run is SSE.
-  if (webRes.body) {
-    Readable.fromWeb(webRes.body as unknown as WebReadableStream).pipe(res);
-  } else {
-    res.end();
-  }
-});
-```
-
-The Express and Hono adapters are a discouraged surface — the maintainer flags them as
-"avoid at all costs." They pull in heavier dependencies, add framework binding, and make
-it harder to port. The fetch handler works from any Express/Hono route.
-
-Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:1-27`; maintainer Phase 4d.
-
 ### CRITICAL Instantiating Express handler without basePath
 
 Wrong:
@@ -354,31 +309,6 @@ app.all("/api/copilotkit/*", (req, res) => {
 and crashes the server.
 
 Source: `packages/runtime/src/v2/runtime/endpoints/express.ts:161`.
-
-### HIGH Using framework adapter on Workers / Bun / Deno
-
-Wrong:
-
-```typescript
-// Cloudflare Worker
-import { createCopilotHonoHandler } from "@copilotkit/runtime/v2/hono";
-export default app;
-```
-
-Correct:
-
-```typescript
-import { createCopilotRuntimeHandler } from "@copilotkit/runtime/v2";
-const handler = createCopilotRuntimeHandler({
-  runtime,
-  basePath: "/api/copilotkit",
-});
-export default { fetch: (req: Request) => handler(req) };
-```
-
-Adapters bundle Node polyfills unnecessarily in fetch-native runtimes.
-
-Source: `packages/runtime/src/v2/runtime/core/fetch-handler.ts:1-27`.
 
 ### HIGH Returning a Response from beforeRequestMiddleware
 


### PR DESCRIPTION
The packaged `runtime` skill tells agents, in **five places**, not to use `createCopilotExpressHandler` or `createCopilotHonoHandler`. The source says the opposite:

```ts
/** @deprecated Use `createCopilotExpressHandler` instead. */
export { createCopilotExpressHandler as createCopilotEndpointExpress };

/** @deprecated Use `createCopilotHonoHandler` instead. */
export const createCopilotEndpoint = createCopilotHonoHandler;
```

Those two handlers are **current and supported**. The deprecated names are `createCopilotEndpoint*`, which now alias them. The docs use the handlers as the primary path (12 occurrences) and are correct.

The consequence is not cosmetic: the skill steers agents off the supported API and, in its delegate-by-hand section, onto ~30 lines of manual `Readable.fromWeb` stream plumbing presented as the required alternative.

## The five sites

| Site | Was | Now |
| --- | --- | --- |
| `SKILL.md` frontmatter description | "the Express/Hono adapters are discouraged" | names them as supported |
| `SKILL.md` invariants | "**avoid at all costs**" | states which names are actually deprecated |
| `setup-endpoint.md` | `### CRITICAL Using createCopilotExpressHandler / createCopilotHonoHandler in new code` | removed |
| `setup-endpoint.md` | "Do not use `createCopilotExpressHandler` / `createCopilotHonoHandler`." | reframed — hand-delegating is a real technique, just not the default |
| `setup-endpoint.md` | `### HIGH Using framework adapter on Workers / Bun / Deno` | removed |

The frontmatter description matters most: it is what an agent reads to decide whether to load the skill at all.

The Workers/Bun/Deno gotcha went because the adapters are not the problem there — `runtime-server-adapter.mdx` carries dedicated sections for Bun, Deno, Cloudflare Workers **and** Elysia. The skill's claim conflates "Express needs Node" with "adapters don't work on edge runtimes".

## A second false claim, same skill

`server-side-tools.md` said a server tool's call never reaches the browser, so nothing can render it. Both `TOOL_CALL_START` emissions in `packages/runtime/src/agent/index.ts` are driven by the model's stream parts — `tool-input-start` and `tool-call` — with **no filtering** on whether the tool has a server-side `execute`. So the call does stream, and a render-only `useRenderTool` registration can give it UI while `execute` stays on the server.

Rewritten around the distinction that holds: `execute` runs on the server and cannot touch the DOM or component state.

## Why patch a skill that is slated for deletion

The removal is blocked on two hazard groups still needing documented homes, plus an information-architecture decision about `built-in-agent.mdx`. That is not days. Leaving three verified-false claims live through the migration was the worse option — every agent that loads this skill today is told to avoid the current API.

This changes no plan. The skill still goes once its hazards have homes.

## Testing

```
$ tsx scripts/sync-plugin-skills.ts --check
plugin skill mirror in sync

$ vitest run scripts/__tests__/public-skill-drift.test.ts scripts/__tests__/sync-plugin-skills.test.ts
 Test Files  2 passed (2)
      Tests  20 passed (20)

$ tsx scripts/validate-intelligence-env-names.ts
Intelligence env var names and hosts are canonical.

$ oxfmt --check packages/runtime/skills/runtime/**/*.md
All matched files use the correct format. (28 files)
```

Both copies updated through the sync script — `packages/runtime/skills/` is the source, `skills/` the mirror. A final sweep for the condemning language across the whole skill comes back empty, and the five surviving gotchas in `setup-endpoint.md` are intact and correctly ordered after the two removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated runtime guidance to recognize Express and Hono adapters as supported mounting options.
  - Clarified when to use framework adapters versus the fetch-native handler.
  - Documented deprecated endpoint names and their supported replacements.
  - Clarified that server-side tools can provide browser-rendered UI through render-only tool registrations.
  - Removed outdated guidance discouraging framework adapters and incorrectly limiting server-tool rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->