### PR TITLE
docs(shell-docs): document useAgent thread scoping on the React Native reference

### DIFF
--- a/showcase/shell-docs/src/content/reference/react-native/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/hooks/useAgent.mdx
@@ -11,14 +11,25 @@ description: "React hook for accessing AG-UI agent instances in React Native"
   Re-exported from `@copilotkit/react-core/v2`. It is identical to the [React (V2) `useAgent`](/reference/v2/hooks/useAgent); only the import path differs.
 </Callout>
 
-**Throws error** if no agent is configured with the specified `agentId`.
+By default it binds to a shared agent from the CopilotKit registry. It can also register a private proxied agent for one thread, which is useful for custom thread switchers and multi-conversation UIs.
+
+**Throws an error** if no agent is configured with the specified `agentId`, or if only part of the thread-scoped option set is provided.
 
 ## Signature
 
 ```tsx
 import { useAgent } from "@copilotkit/react-native";
 
-function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
+function useAgent(options?: UseAgentProps): {
+  agent: AbstractAgent;
+  isReady: boolean;
+};
+```
+
+For fully headless UI that does not import the built-in chat rendering stack, import the hook from the headless entry:
+
+```tsx
+import { useAgent } from "@copilotkit/react-native/headless";
 ```
 
 ## Parameters
@@ -27,9 +38,19 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
   Configuration object for the hook.
 
 <PropertyReference name="agentId" type="string" default='"default"'>
-  ID of the agent to retrieve. Must match an agent configured in
-  `CopilotKitProvider`.
+  ID of the agent to retrieve. Resolution order is: explicit `agentId`, the
+  surrounding chat configuration's `agentId`, then `"default"`.
 </PropertyReference>
+
+  <PropertyReference name="threadId" type="string">
+    Thread ID for a private proxied agent. Must be passed together with
+    `agentId` and `runtimeAgentId`.
+  </PropertyReference>
+
+  <PropertyReference name="runtimeAgentId" type="string">
+    Runtime-side agent ID to route requests to when registering a private
+    proxied agent. Must be passed together with `agentId` and `threadId`.
+  </PropertyReference>
 
   <PropertyReference name="updates" type="UseAgentUpdate[]" default="[OnMessagesChanged, OnStateChanged, OnRunStatusChanged]">
     Controls which agent changes trigger component re-renders. Options:
@@ -40,12 +61,25 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
     Pass an empty array `[]` to prevent automatic re-renders.
 
   </PropertyReference>
+
+  <PropertyReference name="throttleMs" type="number">
+    Throttle interval, in milliseconds, for re-renders triggered by message and
+    state changes. Run lifecycle updates still fire immediately. If omitted,
+    the hook inherits the provider's `defaultThrottleMs`; if neither value is
+    set, updates are unthrottled. Pass `0` to disable provider throttling for
+    this hook.
+  </PropertyReference>
 </PropertyReference>
+
+There are two valid option shapes:
+
+- `useAgent()` or `useAgent({ agentId })`: bind to a shared agent. The thread comes from chat configuration or the agent itself.
+- `useAgent({ agentId, runtimeAgentId, threadId })`: register a private local agent under `agentId`, route it to the runtime agent named by `runtimeAgentId`, and pin it to `threadId`.
 
 ## Return Value
 
-<PropertyReference name="object" type="{ agent: AbstractAgent }">
-  Object containing the agent instance.
+<PropertyReference name="object" type="{ agent: AbstractAgent; isReady: boolean }">
+  Object containing the agent instance and its readiness signal.
 
   <PropertyReference name="agent" type="AbstractAgent">
     The AG-UI agent instance. See [AbstractAgent documentation](https://docs.ag-ui.com/sdk/js/client/abstract-agent) for full interface details.
@@ -141,6 +175,19 @@ function useAgent(options?: UseAgentProps): { agent: AbstractAgent };
     </PropertyReference>
 
   </PropertyReference>
+
+  <PropertyReference name="isReady" type="boolean">
+    Whether `agent` is the real, runtime-synced agent rather than a provisional
+    stand-in returned while the runtime is still connecting.
+
+    `agent` is always a fully-constructed instance, so calling its methods is
+    always safe. While `isReady` is `false`, the instance is a placeholder that
+    is swapped for the real agent once the runtime finishes syncing. At that
+    point `agent` changes reference and dependent effects re-run. Guard on
+    `isReady` when you only want to act against the real agent, e.g. subscribing
+    to run-lifecycle events you don't want to miss during the provisional
+    window.
+  </PropertyReference>
 </PropertyReference>
 
 ## Usage
@@ -227,6 +274,28 @@ function MultiAgentView() {
 }
 ```
 
+### Thread-scoped Agent
+
+Use the thread-scoped form when one runtime agent needs multiple independent frontend instances, for example one per open conversation. The local `agentId` must be unique in the current provider.
+
+```tsx
+import { Text } from "react-native";
+import { useAgent } from "@copilotkit/react-native";
+
+function ThreadPreview({ threadId }: { threadId: string }) {
+  const { agent, isReady } = useAgent({
+    agentId: `preview-${threadId}`,
+    runtimeAgentId: "support",
+    threadId,
+    throttleMs: 100,
+  });
+
+  if (!isReady) return <Text>Loading...</Text>;
+
+  return <Text>{agent.messages.length} messages</Text>;
+}
+```
+
 ### Optimizing Re-renders
 
 ```tsx
@@ -246,7 +315,10 @@ function MessageCount() {
 ## Behavior
 
 - **Automatic Re-renders**: Component re-renders when agent state, messages, or execution status changes (configurable via `updates` parameter)
+- **Optional Throttling**: Message and state update re-renders can be throttled with `throttleMs` or the provider's `defaultThrottleMs`.
+- **Readiness**: While the runtime is connecting, `agent` is a fully-constructed provisional stand-in and `isReady` is `false`; once the runtime syncs, `agent` swaps to the real instance and `isReady` becomes `true`. Guard on `isReady` for work that must target the real agent (e.g. one-time subscriptions)
 - **Error Handling**: Throws error if no agent exists with specified `agentId`
+- **Thread Scoping**: `threadId` and `runtimeAgentId` must be passed together with an explicit local `agentId`; partial combinations throw at runtime and are rejected by the TypeScript type.
 - **State Synchronization**: State updates via `setState()` are immediately available to both app and agent
 - **Event Subscriptions**: Subscribe/unsubscribe pattern for lifecycle and custom events
 

--- a/showcase/shell-docs/src/content/reference/react-native/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/react-native/hooks/useAgent.mdx
@@ -39,7 +39,8 @@ import { useAgent } from "@copilotkit/react-native/headless";
 
 <PropertyReference name="agentId" type="string" default='"default"'>
   ID of the agent to retrieve. Resolution order is: explicit `agentId`, the
-  surrounding chat configuration's `agentId`, then `"default"`.
+  surrounding chat configuration's `agentId`, the provider-level `agentId`,
+  then `"default"`.
 </PropertyReference>
 
   <PropertyReference name="threadId" type="string">
@@ -178,7 +179,8 @@ There are two valid option shapes:
 
   <PropertyReference name="isReady" type="boolean">
     Whether `agent` is the real, runtime-synced agent rather than a provisional
-    stand-in returned while the runtime is still connecting.
+    stand-in returned while the runtime is still connecting, or after it has
+    failed to connect.
 
     `agent` is always a fully-constructed instance, so calling its methods is
     always safe. While `isReady` is `false`, the instance is a placeholder that


### PR DESCRIPTION
## Summary

The React Native `useAgent` reference page still documents the pre-`1.64.2` hook. Parameters list only `agentId` and `updates`, and the signature returns `{ agent: AbstractAgent }` with no `isReady`.

React Native re-exports react-core's `useAgent` verbatim (`packages/react-native/src/headless.ts:53`, re-exporting from `@copilotkit/react-core/v2/headless`), so it is the same hook with the same props. The page is simply stale.

This adds:

- `threadId`, `runtimeAgentId` and `throttleMs` parameters
- the `isReady` return value, and `isReady` in the signature
- the `@copilotkit/react-native/headless` import note
- the two valid option shapes, and a thread-scoped example
- `Optional Throttling`, `Readiness` and `Thread Scoping` behavior bullets

Content mirrors #6388, which makes the equivalent changes to the React page, so the two pages stay consistent. No overlap in files.

Docs only. No source or public API change.

## Context

Reported by a community user in #6125 for the React page: the thread-scoping API shipped in `v1.64.2` (#6141) and the Vue mirror in `v1.68.0` (#6234), but the docs site was never updated. #6388 covers the React page; this covers React Native.

## Testing

Verified against a live `next dev` render of shell-docs on `origin/main` (`35c1e801ae`), with the edited page in place.

**1. MDX compiles with the real compiler** (`@mdx-js/mdx` from `showcase/shell-docs/node_modules`, the untouched pages as controls):

```
OK    .../worktrees/docs-rn-useagent/.../react-native/hooks/useAgent.mdx   <- edited
OK    .../showcase/shell-docs/.../react-native/hooks/useAgent.mdx          <- control
OK    .../showcase/shell-docs/.../hooks/useAgent.mdx                       <- control
exit=0
```

**2. Component tags balance** (no unclosed `<PropertyReference>`, which renders as silently swallowed content):

```
open: 23 close: 23 self-closing: 0
BALANCED
fences: 20 (even=ok)
```

**3. Page serves 200 and renders the new content** (`next dev`, port 3003):

```
200  /reference/react-native/hooks/useAgent

threadId: 17      runtimeAgentId: 10     throttleMs: 5      isReady: 17
Thread-scoped Agent: 2                   Thread Scoping: 2
react-native/headless: 2                 preview-: 2

error markers: (none)
```

No `Unhandled Runtime Error`, `Build Error`, `Failed to compile`, or error overlay in the served HTML.

**4. Prop descriptions actually render**, checked against the untouched React page as a negative control. The new text is present on the edited page and correctly absent on the React page, which is what #6388 adds:

```
=== react-native (edited) ===
  ID of the agent to retrieve                   PRESENT
  Controls which agent changes trigger          PRESENT
  Thread ID for a private proxied agent         PRESENT
  Unique identifier for the agent instance      PRESENT
=== react (untouched control) ===
  Thread ID for a private proxied agent         absent
```

Not run: `showcase/shell-docs` `npm run dev` via its `predev` script fails in this environment on a pre-existing missing `js-yaml` in `showcase/harness`, unrelated to this change. I ran `next dev` directly instead, which is why the generators (registry, search index) did not run. Those generate demo and search content, not reference pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded `useAgent` reference documentation to cover shared and thread-scoped agent resolution.
  - Documented private proxied agents, headless imports, required option combinations, and runtime/type validation.
  - Added guidance for readiness states, provisional agents, connection failures, and thread-scoped usage.
  - Documented the `isReady` return value and `throttleMs` configuration for controlling update frequency.
  - Clarified agent ID resolution, including provider-level configuration and default fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->