### PR TITLE
docs: house the last two runtime-skill hazard groups

### DIFF
--- a/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/copilot-runtime.mdx
@@ -92,6 +92,30 @@ The runtime supports multiple agent types. `BuiltInAgent` is the primary agent c
 - **Simple mode:** pass a model string and let CopilotKit handle the rest. Best for quick setup. See [Quickstart](/quickstart).
 - **Factory mode:** bring your own AI SDK, TanStack AI, or custom LLM backend. Best when you need full control. See [Factory Mode](/backend/custom-agent).
 
+<Callout type="warn" title="Wiring an external agent: what to pass, and which URL">
+Two mistakes account for most failures here.
+
+`agents` takes `AbstractAgent` instances. A framework's own SDK client is not one — pass the
+`@ag-ui/<framework>` wrapper for it, or a plain `HttpAgent`, rather than the client itself.
+
+And the URL an external agent takes is its **own** server or deployment, not
+`/api/copilotkit`. That path is the browser-to-runtime hop; this is the runtime-to-agent hop,
+and they are different addresses. Each integration guide names the exact URL its framework
+serves, including any required suffix.
+</Callout>
+
+<Callout type="warn" title="One agent instance runs one turn at a time">
+A `BuiltInAgent` refuses a second concurrent run on itself, with
+`Agent is already running. Call abortRun() first or create a new instance.` The instance in
+the examples here is created once at module scope, so on a server handling more than one
+person the second concurrent request is the one that fails.
+
+Per-thread state lives in the runner, not the agent, so the fix is to give each concurrent
+run its own agent instance — construct it inside the request rather than at module scope —
+or to serialise turns per user. A single shared instance is fine for local development and
+for a single-user surface.
+</Callout>
+
 ## The default agent
 
 If you register an agent under the name `"default"`, CopilotKit's prebuilt UI components will use it automatically without any additional configuration on the frontend. This is useful when you have one primary agent and don't want to specify an `agentId` everywhere.

--- a/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
+++ b/showcase/shell-docs/src/content/docs/backend/custom-agent.mdx
@@ -172,6 +172,14 @@ interface AgentFactoryContext {
 
 CopilotKit handles everything else: `RUN_STARTED` and `RUN_FINISHED` lifecycle events, stream-to-AG-UI conversion, error handling, and abort/cancellation. Your factory never needs to emit lifecycle events.
 
+<Callout type="warn" title="Don't call `.abort()` on the controller you were handed">
+`abortController` is passed in for backends like TanStack AI that require a full
+`AbortController` — hand it to them and let them own it. Aborting it yourself from inside the
+factory cancels the stream underneath CopilotKit rather than through it, so the run's own
+teardown does not happen. To cancel a run, call `abortRun()` on the agent. For anything that
+accepts a signal — the AI SDK, `fetch`, a custom backend — pass `abortSignal` instead.
+</Callout>
+
 The `runner: new InMemoryAgentRunner()` in the examples above is the persistence
 backend that stores threads in process memory. To understand the runner
 abstraction and how to swap in durable persistence, see


### PR DESCRIPTION
Completes the docs side of the runtime-skill consolidation. With #7005 and this, **every hazard the skill carries has a documented home**, so the deletion can proceed without losing anything.

Three callouts — because most of these 15 turned out to be documented already.

## Added

| Hazard | Home |
| --- | --- |
| A `BuiltInAgent` refuses a second concurrent run on itself | `backend/copilot-runtime.mdx` § Agents |
| Don't call `.abort()` on a factory's `abortController` | `backend/custom-agent.mdx` |
| What to pass when wiring an external agent, and which URL it takes | `backend/copilot-runtime.mdx` § Agents |

The concurrent-run one is the most valuable. `Agent is already running. Call abortRun() first or create a new instance.` — and every example constructs the instance at module scope, so on a server serving more than one person, the *second* concurrent request is the one that fails. Nothing in the docs said so.

## Already covered, so nothing written

`maxSteps` and the tool-call loop. The `"provider:model"` rule — `model-selection.mdx` states it *and* that `"provider/model"` also works, which matches `index.ts:178` normalising `/` to `:`. `forwardSystemMessages` defaulting to `false`. TanStack AI not surfacing reasoning events. State tools and `config.tools` being the factory's job, covered by both the Simple-versus-Factory table and the converter reference.

Four of the six wiring hazards **cite a docs page as their own source**, and each still holds: `getLocalAgents` returning a record is in the Mastra guide, and the `/run` and `/agui` suffixes are in the LlamaIndex and Agno guides.

## Not carried over

The skill flags defaulting to Simple Mode as a **HIGH** mistake and calls Factory Mode with TanStack AI "the preferred default". Source expresses no preference between the two — `isFactoryConfig` is a type guard and nothing more, and the word "prefer" does not appear. The skill's own evidence is an example file plus a maintainer conversation. The docs say to stick with simple mode until you need more, which nothing contradicts.

That is the **fourth** skill claim in this effort that source did not support, after the deprecated-handler pair, the edge-runtime adapters, and server-tool rendering. It was also the skill's headline recommendation for this entire surface.

Also skipped: a hazard about passing a URL to `A2AAgent`. The documented path is `A2AMiddlewareAgent`, so writing it would introduce an API the docs deliberately leave out.

## Method note

Two hazards looked uncovered to a keyword search and were not. `model-selection.mdx` states the model-string rule in quotes (`` `"provider:model"` ``), which my grep for `openai/` missed entirely; I only found it by reading the file. Every "covered" verdict above came from reading the page, and every "added" claim was verified against source — `index.ts:997` for the concurrent-run message, `:746-748` for the `abortController` JSDoc.

## Testing

Both changed files parse as MDX (`remark-parse` + `remark-mdx`):

```
OK   docs/backend/copilot-runtime.mdx
OK   docs/backend/custom-agent.mdx
```

## What this unblocks

The runtime skill's 27 files can now be deleted. Remaining prerequisites for that are no longer about content:

- `packages/runtime/package.json` `"files": ["dist", "skills"]` needs deciding
- Both copies must go together (`packages/runtime/skills/` and `skills/runtime/`), which `check:plugin-skills` enforces
- One hazard stays unresolved by design: whether a thrown error in a server tool kills the run. `/server-tools` says throw, the skill says it kills the run, and nothing in the repo pins it. Worth a live test before the deletion, so the answer isn't lost with the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for connecting external agents, including accepted agent types and endpoint configuration.
  - Documented concurrent-run limitations and recommended handling for per-request agents or serialized turns.
  - Clarified cancellation practices for custom agents to ensure proper teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->