### PR TITLE
feat(web-inspector,shell-docs): shrink the copied onboarding prompt to one command

### DIFF
--- a/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
+++ b/packages/web-inspector/src/__tests__/inspector-navigation.spec.ts
@@ -1334,20 +1334,21 @@ test("Home feature actions copy correlated onboarding prompts", async () => {
       String(prompt),
     );
     const onboardingRunIds = copiedPrompts.map((prompt) => {
+      // Identification left the copied text for the graph, which asks for the
+      // slug with `onboard identify` (Intelligence OSS-1157). The standing
+      // permission stays: a human grants it by copying this, and the graph
+      // cannot grant it to itself.
+      expect(prompt).toContain("Help me set this up in my CopilotKit app.");
+      expect(prompt).not.toContain("Identify your coding-agent slug");
       expect(prompt).toContain(
-        "Identify your coding-agent slug (for example, `codex` or `claude-code`)",
-      );
-      expect(prompt).toContain(
-        "never reveal credentials or send optional diagnostic feedback reports",
+        "Never reveal credentials or send optional diagnostic feedback reports",
       );
       // The A2UI route owns the guide link, the plan and the proof step. The
       // button's whole job is to name the outcome.
       expect(prompt).toContain("--intent add-a2ui");
       expect(prompt).not.toContain("A2UI guide");
       expect(prompt).not.toContain("not merely that the code compiles");
-      const match = prompt.match(
-        /--run ([A-Za-z0-9_-]{12}) --coding-agent <coding-agent-slug>/,
-      );
+      const match = prompt.match(/--run ([A-Za-z0-9_-]{12})/);
       expect(match?.[1]).toBeDefined();
       return match![1]!;
     });

--- a/packages/web-inspector/src/lib/__tests__/onboarding-prompt.test.ts
+++ b/packages/web-inspector/src/lib/__tests__/onboarding-prompt.test.ts
@@ -20,7 +20,7 @@ describe("onboarding-prompt", () => {
     // If this string drifts, the copied prompt sends the coding agent to a
     // command the CLI does not expose and onboarding dead-ends silently.
     expect(ONBOARDING_PROMPT_TEMPLATE).toContain(
-      "npx --yes copilotkit@latest onboard start --run <run-id> --coding-agent <coding-agent-slug>",
+      "npx --yes copilotkit@latest onboard start --run <run-id>",
     );
   });
 
@@ -30,7 +30,7 @@ describe("onboarding-prompt", () => {
     expect(prompt).toContain("--run abc123def456");
     expect(prompt).not.toContain("<run-id>");
     // The agent-slug placeholder is the coding agent's to fill, so it stays.
-    expect(prompt).toContain("<coding-agent-slug>");
+    expect(prompt).not.toContain("<coding-agent-slug>");
   });
 
   it("mints a 12-character id from randomUUID", () => {
@@ -118,12 +118,12 @@ describe("feature onboarding intents", () => {
     const prompt = createFeatureOnboardingPrompt("a2ui", "abc123def456");
 
     expect(prompt).toContain(
-      "npx --yes copilotkit@latest onboard start --run abc123def456 --coding-agent <coding-agent-slug> --intent add-a2ui",
+      "npx --yes copilotkit@latest onboard start --run abc123def456 --intent add-a2ui",
     );
     expect(prompt).not.toContain("<run-id>");
     expect(prompt).not.toContain("<intent>");
     // The agent-slug placeholder is the coding agent's to fill, so it stays.
-    expect(prompt).toContain("<coding-agent-slug>");
+    expect(prompt).not.toContain("<coding-agent-slug>");
   });
 
   it("carries no feature-specific instruction of its own", () => {

--- a/packages/web-inspector/src/lib/onboarding-prompt.ts
+++ b/packages/web-inspector/src/lib/onboarding-prompt.ts
@@ -13,6 +13,13 @@ import type { HomeServiceId } from "./home-briefing.js";
  * The CLI resolves `onboard start` against a prompt graph, so the two surfaces
  * must not drift — if the CLI's entry point changes, both change together.
  *
+ * Two lines, and deliberately nothing else. It used to open by telling the
+ * agent to identify itself and pass the slug as a flag -- two sentences of
+ * instruction to a machine, in the one piece of text a human reads, decides on
+ * and pastes. The graph asks for the slug itself now, with `onboard identify`,
+ * which is the surface that talks to the agent for the rest of the run
+ * (Intelligence OSS-1157).
+ *
  * This one stays generic, and so do the docs and Intelligence web-app copies
  * of it (OSS-1150). Those three are entry points for a developer with no
  * CopilotKit app yet, and every `--intent` route requires an existing app: it
@@ -24,12 +31,9 @@ import type { HomeServiceId } from "./home-briefing.js";
 const RUN_ID_PLACEHOLDER = "<run-id>";
 
 export const ONBOARDING_PROMPT_TEMPLATE =
-  "Identify which coding-agent product you are, using a short slug such as " +
-  "`codex` or `claude-code`. From the root of the project where you want " +
-  "CopilotKit, run `npx --yes copilotkit@latest onboard start --run " +
-  `${RUN_ID_PLACEHOLDER}` +
-  " --coding-agent <coding-agent-slug>`. Follow the Markdown instructions it " +
-  "prints until onboarding is complete.";
+  "Help me get started with CopilotKit. Run this command and follow the " +
+  "instructions:\n\nnpx --yes copilotkit@latest onboard start --run " +
+  `${RUN_ID_PLACEHOLDER}`;
 
 /** Length and alphabet are the CLI's, so a run id copied here resolves there. */
 const RUN_ID_LENGTH = 12;
@@ -136,14 +140,12 @@ const INTENT_PLACEHOLDER = "<intent>";
  * developer granted by copying the prompt.
  */
 export const FEATURE_ONBOARDING_PROMPT_TEMPLATE =
-  "Identify your coding-agent slug (for example, `codex` or `claude-code`). " +
-  "From the target project root, run `npx --yes copilotkit@latest onboard " +
-  `start --run ${RUN_ID_PLACEHOLDER} --coding-agent <coding-agent-slug> ` +
-  `--intent ${INTENT_PLACEHOLDER}` +
-  "`. Follow the Markdown instructions it prints until onboarding is " +
-  "complete. If it requires a CopilotKit CLI session check, you have " +
-  "permission to run it; never reveal credentials or send optional " +
-  "diagnostic feedback reports.";
+  "Help me set this up in my CopilotKit app. Run this command and follow the " +
+  "instructions:\n\nnpx --yes copilotkit@latest onboard start --run " +
+  `${RUN_ID_PLACEHOLDER} --intent ${INTENT_PLACEHOLDER}` +
+  "\n\nIf it requires a CopilotKit CLI session check, you have permission to " +
+  "run it. Never reveal credentials or send optional diagnostic feedback " +
+  "reports.";
 
 /** Bind one run id and one tile's feature outcome into the copied prompt. */
 export function createFeatureOnboardingPrompt(

--- a/showcase/shell-docs/src/components/__tests__/hero-onboarding-prompt-button.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/hero-onboarding-prompt-button.test.tsx
@@ -84,7 +84,7 @@ it("embeds a run id the CLI accepts", async () => {
   await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 
   const copied = writeText.mock.calls[0][0] as string;
-  const runId = copied.match(/onboard start --run (\S+) --coding-agent/)?.[1];
+  const runId = copied.match(/onboard start --run (\S+)/)?.[1];
   expect(runId).toMatch(/^[A-Za-z0-9_-]{12}$/);
 });
 
@@ -111,9 +111,7 @@ it("copies the canonical prompt unchanged when no framework is given", async () 
   await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 
   const copied = writeText.mock.calls[0][0] as string;
-  const runId = copied.match(
-    /onboard start --run (\S+) --coding-agent/,
-  )?.[1] as string;
+  const runId = copied.match(/onboard start --run (\S+)/)?.[1] as string;
   expect(copied).toBe(createIntelligenceOnboardingPrompt(runId));
   expect(copied.endsWith("until onboarding is complete.")).toBe(true);
 });
@@ -155,7 +153,7 @@ it("keeps the run id intact when the framework sentence is appended", async () =
   await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 
   const copied = writeText.mock.calls[0][0] as string;
-  const runId = copied.match(/onboard start --run (\S+) --coding-agent/)?.[1];
+  const runId = copied.match(/onboard start --run (\S+)/)?.[1];
   expect(runId).toMatch(/^[A-Za-z0-9_-]{12}$/);
 });
 
@@ -213,9 +211,7 @@ it("stays canonical for a framework the onboarding graph does not cover", async 
   await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
 
   const copied = writeText.mock.calls[0][0] as string;
-  const runId = copied.match(
-    /onboard start --run (\S+) --coding-agent/,
-  )?.[1] as string;
+  const runId = copied.match(/onboard start --run (\S+)/)?.[1] as string;
   expect(copied).toBe(createIntelligenceOnboardingPrompt(runId));
 
   await waitFor(() => expect(analytics.capture).toHaveBeenCalledTimes(1));

--- a/showcase/shell-docs/src/components/__tests__/learning-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/learning-setup-prompt.test.tsx
@@ -65,7 +65,7 @@ test("sends the coding agent to the Learning route and carries nothing else", ()
   // `getLearningContainerId` wiring this prompt used to repeat. That copy had
   // already drifted from the shipped API once; OSS-1150 retired it.
   expect(LEARNING_SETUP_PROMPT).toContain(
-    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-learning",
+    "npx --yes copilotkit@latest onboard start --intent add-learning",
   );
   expect(LEARNING_SETUP_PROMPT).not.toContain("docs.copilotkit.ai");
   expect(LEARNING_SETUP_PROMPT).not.toContain("getLearningContainerId");

--- a/showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/rich-threads-setup-prompt.test.tsx
@@ -111,7 +111,7 @@ test("sends the coding agent to the Rich Threads route and carries nothing else"
   // drifts the next time the Runtime API changes, which is what OSS-1150
   // retired.
   expect(RICH_THREADS_SETUP_PROMPT).toContain(
-    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-rich-threads",
+    "npx --yes copilotkit@latest onboard start --intent add-rich-threads",
   );
   expect(RICH_THREADS_SETUP_PROMPT).not.toContain("docs.copilotkit.ai");
   expect(RICH_THREADS_SETUP_PROMPT).not.toContain("identifyUser");

--- a/showcase/shell-docs/src/lib/__tests__/learning-setup-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/learning-setup-docs.test.ts
@@ -26,7 +26,7 @@ test("expands the Automatic Learning prompt for Markdown and LLM readers", () =>
   // The route owns the instructions; the raw-Markdown route only has to
   // carry the command that reaches it. See `createFeatureSetupPrompt`.
   expect(output).toContain(
-    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-learning",
+    "npx --yes copilotkit@latest onboard start --intent add-learning",
   );
   expect(output).not.toContain("<LearningSetupPrompt />");
 });

--- a/showcase/shell-docs/src/lib/__tests__/rich-threads-setup-docs.test.ts
+++ b/showcase/shell-docs/src/lib/__tests__/rich-threads-setup-docs.test.ts
@@ -26,7 +26,7 @@ test("expands the Rich Threads agent prompt for Markdown and LLM readers", () =>
   // The route owns the instructions; the raw-Markdown route only has to
   // carry the command that reaches it. See `createFeatureSetupPrompt`.
   expect(output).toContain(
-    "npx --yes copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent add-rich-threads",
+    "npx --yes copilotkit@latest onboard start --intent add-rich-threads",
   );
   expect(output).not.toContain("<RichThreadsSetupPrompt />");
 });

--- a/showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts
+++ b/showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts
@@ -13,12 +13,9 @@ export const INTELLIGENCE_ONBOARDING_EVENTS = {
  * inspects the repository; the docs CTA only changes the feature promise.
  */
 export const INTELLIGENCE_ONBOARDING_PROMPT =
-  "Identify which coding-agent product you are, using a short slug such as " +
-  "`codex` or `claude-code`. From the root of the project where you want " +
-  "CopilotKit, run `npx --yes copilotkit@latest onboard start --run " +
-  `${RUN_ID_PLACEHOLDER}` +
-  " --coding-agent <coding-agent-slug>`. Follow the Markdown instructions it " +
-  "prints until onboarding is complete.";
+  "Help me get started with CopilotKit. Run this command and follow the " +
+  "instructions:\n\nnpx --yes copilotkit@latest onboard start --run " +
+  `${RUN_ID_PLACEHOLDER}`;
 
 const RUN_ID_LENGTH = 12;
 
@@ -78,12 +75,11 @@ export function createFeatureSetupPrompt(
   intent: FeatureOnboardingIntent,
 ): string {
   return (
-    "Identify your coding-agent slug (for example, `codex` or " +
-    "`claude-code`). From the root of this repository, run `npx --yes " +
-    `copilotkit@latest onboard start --coding-agent <coding-agent-slug> --intent ${intent}` +
-    "`. Follow the Markdown instructions it prints until setup is complete. " +
-    "If it requires a CopilotKit CLI session check, you have permission to " +
-    "run it; never reveal credentials or send optional diagnostic feedback " +
-    "reports."
+    "Help me set this up in my CopilotKit app. Run this command and follow " +
+    "the instructions:\n\nnpx --yes copilotkit@latest onboard start " +
+    `--intent ${intent}` +
+    "\n\nIf it requires a CopilotKit CLI session check, you have permission " +
+    "to run it. Never reveal credentials or send optional diagnostic " +
+    "feedback reports."
   );
 }


### PR DESCRIPTION
**Draft.** Pairs with Intelligence [#1196](https://github.com/CopilotKit/Intelligence/pull/1196) (OSS-1157), which is also open. Neither has to land first — see *Ordering*.

## What changes

The prompt a developer copies — from the Inspector, the docs hero, the feature cards — opened with two sentences of instruction to the coding agent.

**Before**

> Identify which coding-agent product you are, using a short slug such as `codex` or `claude-code`. From the root of the project where you want CopilotKit, run `npx --yes copilotkit@latest onboard start --run <run-id> --coding-agent <coding-agent-slug>`. Follow the Markdown instructions it prints until onboarding is complete.

**After**

> Help me get started with CopilotKit. Run this command and follow the instructions:
>
> `npx --yes copilotkit@latest onboard start --run <run-id>`

Identification moves into the prompt graph, which is the surface that talks to the agent for the rest of the run: `onboard identify --coding-agent <slug>`, run by `authenticate/start`.

Sites updated, kept byte-identical with Intelligence's own `createCodingAgentOnboardingPrompt`:

- `packages/web-inspector/src/lib/onboarding-prompt.ts` — `ONBOARDING_PROMPT_TEMPLATE` and `FEATURE_ONBOARDING_PROMPT_TEMPLATE`
- `showcase/shell-docs/src/lib/intelligence-onboarding-prompt.ts` — `INTELLIGENCE_ONBOARDING_PROMPT` and `createFeatureSetupPrompt`

## What the feature prompts keep

Their standing permission for the CLI session check stays: *"If it requires a CopilotKit CLI session check, you have permission to run it. Never reveal credentials or send optional diagnostic feedback reports."* That sentence is the developer granting something by copying the text, and the graph cannot grant it to itself. Only the identification half is cut.

## Ordering

No lockstep. The CLI still accepts `--coding-agent` on `start`, so the old wording keeps working, and the new wording works against the published CLI today because `--run` alone was always valid. Either repository can merge first.

## Verification

| Suite | Result |
|---|---|
| `packages/web-inspector` — `onboarding-prompt.test.ts` | 11 passed |
| `packages/web-inspector` — `inspector-navigation.spec.ts` | 22 passed |
| `oxlint` + `oxfmt --check` on the changed files | clean |
| pre-commit hook (`lint-fix`, env-name check, `test,publint,attw` over 5 affected packages) | ran on commit |

**Not run locally:** the `showcase/shell-docs` suites. That package installs with npm separately from the pnpm workspace, so its `react` does not resolve in a fresh worktree. Its assertions are updated in this diff (`hero-onboarding-prompt-button`, `learning-setup-prompt`, `rich-threads-setup-prompt`, `learning-setup-docs`, `rich-threads-setup-docs`) and CI covers them — that is the main thing to watch before this leaves draft.

## Still to do before undraft

- Confirm shell-docs CI is green.
- The marketing site has a fifth copy of this prompt, inline in `src/components/home/copy-onboarding-prompt-button.tsx`. Separate draft PR on `CopilotKit/website`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified onboarding prompts by removing the requirement to identify or provide a coding-agent slug.
  - Onboarding commands now start directly with the setup run or selected feature intent.
  - Updated prompts to provide clearer setup instructions and more concise session-check guidance.
  - Refined credential-safety messaging to clearly warn users never to reveal credentials or send optional diagnostic reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->