### PR TITLE
fix(core): keep the runtimeUrl trailing slash for single-route requests

### DIFF
--- a/packages/core/src/__tests__/agent-registry-runtime-url-trailing-slash.test.ts
+++ b/packages/core/src/__tests__/agent-registry-runtime-url-trailing-slash.test.ts
@@ -54,6 +54,30 @@ describe("runtimeUrl with a trailing slash", () => {
     expect((agent as ProxiedCopilotRuntimeAgent).url).toBe(runtimeUrl);
   });
 
+  it("rebuilds the proxy when only the trailing slash changes", async () => {
+    const { core, fetchMock } = setupCore(runtimeUrl, "single");
+    await vi.waitFor(() => {
+      expect(core.getAgent("default")).toBeDefined();
+    });
+    const before = core.getAgent("default") as ProxiedCopilotRuntimeAgent;
+
+    fetchMock.mockResolvedValueOnce(runtimeInfoResponse());
+    core.setRuntimeUrl("https://runtime.example/service/copilotkit");
+    await vi.waitFor(() => {
+      const agent = core.getAgent("default") as
+        | ProxiedCopilotRuntimeAgent
+        | undefined;
+      expect(agent).toBeDefined();
+      expect(agent).not.toBe(before);
+    });
+
+    const after = core.getAgent("default") as ProxiedCopilotRuntimeAgent;
+    expect(after.url).toBe("https://runtime.example/service/copilotkit");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://runtime.example/service/copilotkit",
+    );
+  });
+
   it("joins REST paths without a double slash", async () => {
     const { core, fetchMock } = setupCore(runtimeUrl, "rest");
 

--- a/packages/core/src/__tests__/agent-registry-runtime-url-trailing-slash.test.ts
+++ b/packages/core/src/__tests__/agent-registry-runtime-url-trailing-slash.test.ts
@@ -1,0 +1,72 @@
+import type { RuntimeInfo } from "@copilotkit/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProxiedCopilotRuntimeAgent } from "../agent";
+import { CopilotKitCore } from "../core";
+
+/** A Runtime `/info` answer advertising one agent. */
+function runtimeInfoResponse(): Response {
+  const info: RuntimeInfo = {
+    version: "1.0.0",
+    agents: {
+      default: {
+        name: "default",
+        className: "HttpAgent",
+        description: "assistant",
+      },
+    },
+    audioFileTranscriptionEnabled: false,
+    mode: "sse",
+  };
+  return new Response(JSON.stringify(info), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function setupCore(runtimeUrl: string, runtimeTransport: "rest" | "single") {
+  const fetchMock = vi.fn<typeof globalThis.fetch>();
+  fetchMock.mockResolvedValueOnce(runtimeInfoResponse());
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("fetch", fetchMock);
+  const core = new CopilotKitCore({ runtimeUrl, runtimeTransport });
+  return { core, fetchMock };
+}
+
+describe("runtimeUrl with a trailing slash", () => {
+  const runtimeUrl = "https://runtime.example/service/copilotkit/";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the caller's URL verbatim as the single-route endpoint", async () => {
+    const { core, fetchMock } = setupCore(runtimeUrl, "single");
+
+    await vi.waitFor(() => {
+      expect(core.getAgent("default")).toBeDefined();
+    });
+
+    // The single-route identification request targets that same endpoint.
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(runtimeUrl);
+    const agent = core.getAgent("default");
+    expect(agent).toBeInstanceOf(ProxiedCopilotRuntimeAgent);
+    expect((agent as ProxiedCopilotRuntimeAgent).url).toBe(runtimeUrl);
+  });
+
+  it("joins REST paths without a double slash", async () => {
+    const { core, fetchMock } = setupCore(runtimeUrl, "rest");
+
+    await vi.waitFor(() => {
+      expect(core.getAgent("default")).toBeDefined();
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://runtime.example/service/copilotkit/info",
+    );
+    const agent = core.getAgent("default") as ProxiedCopilotRuntimeAgent;
+    expect(agent.url).toBe(
+      "https://runtime.example/service/copilotkit/agent/default/run",
+    );
+  });
+});

--- a/packages/core/src/__tests__/agent-registry-runtime-url-trailing-slash.test.ts
+++ b/packages/core/src/__tests__/agent-registry-runtime-url-trailing-slash.test.ts
@@ -4,7 +4,9 @@ import { ProxiedCopilotRuntimeAgent } from "../agent";
 import { CopilotKitCore } from "../core";
 
 /** A Runtime `/info` answer advertising one agent. */
-function runtimeInfoResponse(): Response {
+function runtimeInfoResponse(
+  singleRoute?: RuntimeInfo["singleRoute"],
+): Response {
   const info: RuntimeInfo = {
     version: "1.0.0",
     agents: {
@@ -16,6 +18,7 @@ function runtimeInfoResponse(): Response {
     },
     audioFileTranscriptionEnabled: false,
     mode: "sse",
+    ...(singleRoute ? { singleRoute } : {}),
   };
   return new Response(JSON.stringify(info), {
     status: 200,
@@ -23,9 +26,24 @@ function runtimeInfoResponse(): Response {
   });
 }
 
-function setupCore(runtimeUrl: string, runtimeTransport: "rest" | "single") {
+/** A runtime that accepts Intelligence resource calls through the one route. */
+const RESOURCE_SINGLE_ROUTE: RuntimeInfo["singleRoute"] = {
+  resourceOperations: true,
+  threadEndpoints: {
+    list: true,
+    inspect: true,
+    mutations: true,
+    realtimeMetadata: false,
+  },
+};
+
+function setupCore(
+  runtimeUrl: string,
+  runtimeTransport: "rest" | "single",
+  singleRoute?: RuntimeInfo["singleRoute"],
+) {
   const fetchMock = vi.fn<typeof globalThis.fetch>();
-  fetchMock.mockResolvedValueOnce(runtimeInfoResponse());
+  fetchMock.mockResolvedValueOnce(runtimeInfoResponse(singleRoute));
   vi.stubGlobal("window", {});
   vi.stubGlobal("fetch", fetchMock);
   const core = new CopilotKitCore({ runtimeUrl, runtimeTransport });
@@ -76,6 +94,35 @@ describe("runtimeUrl with a trailing slash", () => {
     expect(fetchMock.mock.calls[1]?.[0]).toBe(
       "https://runtime.example/service/copilotkit",
     );
+  });
+
+  // The resource envelope POSTs to the endpoint itself, so it is the second
+  // request family that must not lose the slash - `createSingleRouteResourceRequest`
+  // uses its `runtimeUrl` argument verbatim as the target.
+  it("keeps the slash for Intelligence resource requests", async () => {
+    const { core, fetchMock } = setupCore(
+      runtimeUrl,
+      "single",
+      RESOURCE_SINGLE_ROUTE,
+    );
+
+    await vi.waitFor(() => {
+      expect(core.getAgent("default")).toBeDefined();
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ threads: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    await core.ɵruntimeFetch(`${runtimeUrl}threads`, { method: "GET" });
+
+    const [target, init] = fetchMock.mock.calls[1] ?? [];
+    // Asserted first: without it the case still passes when the envelope path
+    // was never taken and the GET went out untouched.
+    expect(init?.method).toBe("POST");
+    expect(target).toBe(runtimeUrl);
   });
 
   it("joins REST paths without a double slash", async () => {

--- a/packages/core/src/__tests__/proxied-runtime-transport.test.ts
+++ b/packages/core/src/__tests__/proxied-runtime-transport.test.ts
@@ -1124,4 +1124,38 @@ describe("ProxiedCopilotRuntimeAgent runtimeUrl with a trailing slash", () => {
       "https://runtime.example/service/copilotkit/agent/agent/run",
     );
   });
+
+  it("keeps the verbatim endpoint when auto detection falls back to single-route", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "agent",
+      transport: "auto",
+    });
+    // REST /info is not there; the single-route info envelope answers.
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 404 }));
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ version: "1.0.0", agents: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    fetchMock.mockResolvedValueOnce(createSseResponse());
+
+    await agent.runAgent({});
+
+    const urls = fetchMock.mock.calls.map(([url]) => url);
+    expect(urls[0]).toBe("https://runtime.example/service/copilotkit/info");
+    expect(urls[1]).toBe(runtimeUrl);
+    expect(urls[2]).toBe(runtimeUrl);
+  });
+
+  it("clones with the verbatim endpoint", () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "agent",
+      transport: "single",
+    });
+
+    expect(agent.clone().url).toBe(runtimeUrl);
+  });
 });

--- a/packages/core/src/__tests__/proxied-runtime-transport.test.ts
+++ b/packages/core/src/__tests__/proxied-runtime-transport.test.ts
@@ -1079,3 +1079,49 @@ describe("AgentRegistry runtime info requests", () => {
     });
   });
 });
+
+describe("ProxiedCopilotRuntimeAgent runtimeUrl with a trailing slash", () => {
+  const originalFetch = global.fetch;
+  const runtimeUrl = "https://runtime.example/service/copilotkit/";
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it("keeps the caller's URL verbatim as the single-route endpoint", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "agent",
+      transport: "single",
+    });
+    fetchMock.mockResolvedValueOnce(createSseResponse());
+
+    await agent.runAgent({});
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(runtimeUrl);
+  });
+
+  it("joins REST paths without a double slash", async () => {
+    const agent = new ProxiedCopilotRuntimeAgent({
+      runtimeUrl,
+      agentId: "agent",
+      transport: "rest",
+    });
+    fetchMock.mockResolvedValueOnce(createSseResponse());
+
+    await agent.runAgent({});
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://runtime.example/service/copilotkit/agent/agent/run",
+    );
+  });
+});

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -121,9 +121,12 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       : undefined;
     const transport = config.transport ?? "auto";
     const routedId = config.runtimeAgentId ?? config.agentId ?? "";
+    // The single endpoint is the caller's URL exactly as given: a trailing
+    // slash can select a different proxy location, so it must survive. Only
+    // the path joins (`/agent/…`, `/info`) use the slash-stripped form.
     const runUrl =
       transport === "single"
-        ? (normalizedRuntimeUrl ?? config.runtimeUrl ?? "")
+        ? (config.runtimeUrl ?? "")
         : `${normalizedRuntimeUrl ?? config.runtimeUrl}/agent/${encodeURIComponent(routedId)}/run`;
 
     if (!runUrl) {
@@ -147,7 +150,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       this.debug = config.debug;
     }
     if (this.transport === "single") {
-      this.singleEndpointUrl = this.runtimeUrl;
+      this.singleEndpointUrl = config.runtimeUrl;
     }
   }
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -108,6 +108,13 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
   // stop/connect/single-route paths).
   readonly runtimeAgentId?: string;
   private transport: CopilotRuntimeTransport;
+  /**
+   * The runtime URL exactly as the caller supplied it. `runtimeUrl` is the
+   * slash-stripped form used for path joins; the single-route endpoint (run,
+   * connect, stop, info envelopes) is this verbatim value, because a trailing
+   * slash can select a different proxy location.
+   */
+  private readonly runtimeEndpointUrl?: string;
   private singleEndpointUrl?: string;
   private runtimeMode: ResolvedRuntimeMode;
   private intelligence?: IntelligenceRuntimeInfo;
@@ -140,6 +147,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       url: runUrl,
     });
     this.runtimeUrl = normalizedRuntimeUrl ?? config.runtimeUrl;
+    this.runtimeEndpointUrl = config.runtimeUrl;
     this.credentials = config.credentials;
     this.runtimeAgentId = config.runtimeAgentId;
     this.transport = transport;
@@ -150,7 +158,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       this.debug = config.debug;
     }
     if (this.transport === "single") {
-      this.singleEndpointUrl = config.runtimeUrl;
+      this.singleEndpointUrl = this.runtimeEndpointUrl;
     }
   }
 
@@ -450,7 +458,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
 
   public override clone(): ProxiedCopilotRuntimeAgent {
     const cloned = new ProxiedCopilotRuntimeAgent({
-      runtimeUrl: this.runtimeUrl,
+      runtimeUrl: this.runtimeEndpointUrl ?? this.runtimeUrl,
       agentId: this.agentId,
       runtimeAgentId: this.runtimeAgentId,
       description: this.description,
@@ -562,7 +570,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       if (!headers["Content-Type"]) {
         headers["Content-Type"] = "application/json";
       }
-      url = this.runtimeUrl!;
+      url = this.singleEndpointUrl;
       init = { method: "POST", body: JSON.stringify({ method: "info" }) };
     } else {
       url = `${this.runtimeUrl}/info`;
@@ -605,7 +613,8 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
     if (!singleHeaders["Content-Type"]) {
       singleHeaders["Content-Type"] = "application/json";
     }
-    const response = await this.fetch(this.runtimeUrl!, {
+    const endpointUrl = this.runtimeEndpointUrl ?? this.runtimeUrl!;
+    const response = await this.fetch(endpointUrl, {
       method: "POST",
       headers: singleHeaders,
       body: JSON.stringify({ method: "info" }),
@@ -615,7 +624,7 @@ export class ProxiedCopilotRuntimeAgent extends HttpAgent {
       throw await runtimeInfoError(response);
     }
     this.transport = "single";
-    this.singleEndpointUrl = this.runtimeUrl;
+    this.singleEndpointUrl = endpointUrl;
     return (await response.json()) as RuntimeInfo;
   }
 

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -631,7 +631,11 @@ export class AgentRegistry {
               ? await createSingleRouteResourceRequest(
                   input,
                   init,
-                  this._runtimeUrl,
+                  // The endpoint itself is the POST target here, so it has to be
+                  // the caller's URL verbatim - a trailing slash can select a
+                  // different proxy location. `_runtimeUrl` is the slash-stripped
+                  // form kept for path joins (issue #7028).
+                  this._runtimeEndpointUrl ?? this._runtimeUrl,
                 )
               : null;
           const response = singleRouteRequest

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -84,6 +84,8 @@ interface RuntimeConnectionAttempt {
 
 interface RuntimeAgentConnection {
   runtimeUrl: string;
+  /** The caller-supplied URL the proxy was built with (trailing slash intact). */
+  endpointUrl?: string;
   transport: CopilotRuntimeTransport;
 }
 
@@ -759,7 +761,7 @@ export class AgentRegistry {
         const response =
           resolvedTransport === "single"
             ? await this.fetchInspectorMetadataSingle({
-                runtimeUrl,
+                runtimeUrl: this.singleEndpointUrlFor(runtimeUrl),
                 headers,
                 credentials,
                 signal: abortController.signal,
@@ -1125,7 +1127,9 @@ export class AgentRegistry {
 
   /** Return the stable key that scopes connection and entitlement retries. */
   private runtimeConnectionKey(): string {
-    return `${this._runtimeUrl ?? ""}::${this._requestedTransport}`;
+    // The endpoint URL is part of the identity: a change that only adds or
+    // drops the trailing slash targets a different single-route endpoint.
+    return `${this._runtimeEndpointUrl ?? this._runtimeUrl ?? ""}::${this._requestedTransport}`;
   }
 
   /** Return whether a proxy still targets this Runtime connection. */
@@ -1140,6 +1144,7 @@ export class AgentRegistry {
     const connection = this.remoteAgentConnections.get(agent);
     return (
       connection?.runtimeUrl === runtimeUrl.replace(/\/$/, "") &&
+      connection.endpointUrl === this._runtimeEndpointUrl &&
       connection.transport === transport
     );
   }
@@ -1352,6 +1357,7 @@ export class AgentRegistry {
             }
             this.remoteAgentConnections.set(agent, {
               runtimeUrl,
+              endpointUrl: this._runtimeEndpointUrl,
               transport: this._runtimeTransport,
             });
             return [id, agent];

--- a/packages/core/src/core/agent-registry.ts
+++ b/packages/core/src/core/agent-registry.ts
@@ -127,6 +127,8 @@ export class AgentRegistry {
   private readonly mintedThreadIds = new WeakMap<AbstractAgent, string>();
 
   private _runtimeUrl?: string;
+  /** The runtime URL as the caller supplied it; the single-route endpoint uses it verbatim. */
+  private _runtimeEndpointUrl?: string;
   // Tracks an in-flight `/info` connection so concurrent calls targeting the
   // same runtime (url + requested transport) collapse to a single request
   // instead of each firing their own. See #5801.
@@ -305,8 +307,12 @@ export class AgentRegistry {
     const normalizedRuntimeUrl = runtimeUrl
       ? runtimeUrl.replace(/\/$/, "")
       : undefined;
+    const runtimeEndpointUrl = runtimeUrl || undefined;
 
-    if (this._runtimeUrl === normalizedRuntimeUrl) {
+    if (
+      this._runtimeUrl === normalizedRuntimeUrl &&
+      this._runtimeEndpointUrl === runtimeEndpointUrl
+    ) {
       return;
     }
 
@@ -319,6 +325,7 @@ export class AgentRegistry {
     this._runtimeEntitlements = undefined;
     this._singleRouteResourceOperations = false;
     this._runtimeUrl = normalizedRuntimeUrl;
+    this._runtimeEndpointUrl = runtimeEndpointUrl;
 
     // Deferred construction (see CopilotKitCore.connect / #5801): record the URL
     // so getters/hooks see it synchronously, but do NOT start the `/info` fetch
@@ -493,7 +500,7 @@ export class AgentRegistry {
     const friends = this.core as unknown as CopilotKitCoreFriendsAccess;
     const debug = friends.debug;
     const agent = new ProxiedCopilotRuntimeAgent({
-      runtimeUrl: this._runtimeUrl,
+      runtimeUrl: this._runtimeEndpointUrl ?? this._runtimeUrl,
       agentId,
       runtimeAgentId,
       transport: this._runtimeTransport,
@@ -1325,7 +1332,7 @@ export class AgentRegistry {
               return [id, existing];
             }
             const agent = new ProxiedCopilotRuntimeAgent({
-              runtimeUrl,
+              runtimeUrl: this._runtimeEndpointUrl ?? runtimeUrl,
               agentId: id, // Runtime agents always have their ID set correctly
               description: description,
               transport: this._runtimeTransport,
@@ -1505,7 +1512,7 @@ export class AgentRegistry {
     if (runtimeTransport === "single") {
       return {
         runtimeInfo: await this.fetchRuntimeInfoSingle(
-          runtimeUrl,
+          this.singleEndpointUrlFor(runtimeUrl),
           headers,
           credentials,
           signal,
@@ -1536,6 +1543,19 @@ export class AgentRegistry {
       runtimeInfo: (await response.json()) as RuntimeInfo,
       resolvedTransport: "rest",
     };
+  }
+
+  /**
+   * The URL a single-route request targets: the runtime URL as the caller
+   * supplied it. `runtimeUrl` is the slash-stripped form used for path joins;
+   * a trailing slash can select a different proxy location, so the endpoint
+   * itself keeps it.
+   */
+  private singleEndpointUrlFor(runtimeUrl: string): string {
+    return this._runtimeEndpointUrl !== undefined &&
+      this._runtimeUrl === runtimeUrl
+      ? this._runtimeEndpointUrl
+      : runtimeUrl;
   }
 
   private async fetchRuntimeInfoSingle(
@@ -1590,7 +1610,7 @@ export class AgentRegistry {
     }
 
     const runtimeInfo = await this.fetchRuntimeInfoSingle(
-      runtimeUrl,
+      this.singleEndpointUrlFor(runtimeUrl),
       { ...headers },
       credentials,
       signal,


### PR DESCRIPTION
## What does this PR do?

`runtimeUrl` was slash-stripped as soon as it was received, both in `AgentRegistry.setRuntimeUrl` and in the `ProxiedCopilotRuntimeAgent` constructor. That is right for path joins, but the single-route transport uses the runtime URL *itself* as the request target, so a provider configured with `https://host/service/copilotkit/` sent its requests to `https://host/service/copilotkit`. A trailing slash can select a different proxy or gateway location, so the endpoint has to be used exactly as given (#7028).

Changes in `packages/core`:

- `agent.ts`: the single-route `runUrl` and `singleEndpointUrl` use `config.runtimeUrl` verbatim; the slash-stripped form is still what `/agent/<id>/run`, `/info`, `/stop` and `/connect` are joined onto, so REST URLs never get a double slash.
- `core/agent-registry.ts`: the registry keeps the caller's URL alongside the normalized one (`_runtimeEndpointUrl`), hands it to the proxied agents it creates, and uses it for the single-route identification request (`fetchRuntimeInfoSingle`), including the REST-to-single fallback of the `auto` transport. Change detection in `setRuntimeUrl` now also notices a slash-only change. The public `runtimeUrl` getter and the connection key are unchanged.

No behaviour change for a `runtimeUrl` without a trailing slash.

## Related PRs and Issues

- Fixes #7028

## Tests

- `proxied-runtime-transport.test.ts`: with `https://runtime.example/service/copilotkit/`, a single-route run posts to exactly that URL, and a REST run goes to `…/copilotkit/agent/agent/run`.
- `agent-registry-runtime-url-trailing-slash.test.ts`: a `CopilotKitCore` with that URL sends its single-route identification request to the verbatim URL and creates the runtime agent with it; with the REST transport the identification request is `…/copilotkit/info` and the agent's run URL has no double slash.

The single-route cases fail on `main`. `vitest run` in `packages/core`: 843 passed; `tsc --noEmit` clean. No changeset added (the repo no longer uses them).

## Checklist

- [x] I have read the [Contribution Guide](https://github.com/copilotkit/copilotkit/blob/master/CONTRIBUTING.md)
- [ ] If the PR changes or adds functionality, I have updated the relevant documentation
- [x] "Allow edits by maintainers" is checked (lets us help iterate on your PR directly — faster turnaround for everyone)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed runtime URL handling when configured URLs include trailing slashes.
  - Single-route connections now preserve the provided endpoint URL exactly.
  - REST connections build runtime and agent paths without duplicate slashes.
  - Improved runtime discovery, endpoint updates, cloning, and agent connections across supported transport modes.

- **Tests**
  - Added coverage for trailing-slash URLs, runtime information requests, agent routing, endpoint changes, cloning, and automatic transport handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->