### PR TITLE
fix(ci): pull ag-ui's LFS objects in the dojo e2e checkout

### DIFF
--- a/.github/workflows/test_e2e-dojo.yml
+++ b/.github/workflows/test_e2e-dojo.yml
@@ -186,6 +186,14 @@ jobs:
         if: steps.should-run.outputs.skip != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          # ag-ui stores its e2e image fixtures in Git LFS, and the dojo's
+          # suites assert the fixture is materialized rather than reading a
+          # pointer as if it were an image. Without this the pointer arrives
+          # verbatim and every langgraph suite fails on
+          # `apps/dojo/e2e/fixtures/test-image.png is a Git LFS pointer`.
+          # Upstream's own dojo-e2e workflow, which this one mirrors, sets it
+          # on both of its checkouts. The whole payload is two files, ~2.4 KB.
+          lfs: true
           repository: ag-ui-protocol/ag-ui
           path: ag-ui
           ref: main


### PR DESCRIPTION
## The failure

`test / e2e / dojo` has failed `langgraph-python`, `langgraph-typescript` and `langgraph-fastapi` on **every** run since 2026-09-10 — on `main` and on every open PR — with 27 occurrences of:

```
Event trace fixture /home/runner/work/CopilotKit/CopilotKit/ag-ui/apps/dojo/e2e/fixtures/test-image.png
is a Git LFS pointer, not the real file. Run git lfs pull before recording event traces.
```

It is not a flake. The failing job set is identical on every run with no rotation, which is the opposite of the known dojo `protoc` flake (there, the failing shard set rotates across identical runs).

## Cause

`test_e2e-dojo.yml` checks out **our** repository with `lfs: true` (line 180) but checks out **ag-ui** without it (lines 187-191). ag-ui LFS-tracks its e2e image fixtures, so the pointer file arrives verbatim.

Upstream's `assertFixtureMaterialized` then throws. That guard is doing its job — it landed in `24545e119` ("test(dojo): record real multimodal fixture traces"), and before it existed the suites read a 130-byte text file as though it were a PNG.

## Fix

`lfs: true` on the ag-ui checkout. This matches the CPK checkout directly above it, and matches [upstream's own `dojo-e2e.yml`](https://github.com/ag-ui-protocol/ag-ui/blob/main/.github/workflows/dojo-e2e.yml) — which this workflow's comments say it mirrors, and which sets `lfs: true` on both of its checkouts. Ours had drifted.

## Testing

Reproduced both states against a real clone of ag-ui, so the fix is verified at the mechanism rather than reasoned about.

**Before** — cloned with `GIT_LFS_SKIP_SMUDGE=1`, which is what the workflow does today:

```
$ file apps/dojo/e2e/fixtures/test-image.png
apps/dojo/e2e/fixtures/test-image.png: ASCII text
$ head -c 43 apps/dojo/e2e/fixtures/test-image.png
version https://git-lfs.github.com/spec/v1
```

**After** `git lfs pull`, which is what `lfs: true` does:

```
$ file apps/dojo/e2e/fixtures/test-image.png
apps/dojo/e2e/fixtures/test-image.png: PNG image data, 1 x 1, 8-bit/color RGBA, non-interlaced
$ ls -l apps/dojo/e2e/fixtures/test-image.png
70 bytes
```

**Cost** — negligible. ag-ui's entire LFS payload is two files totalling about 2.4 KB:

```
$ git lfs ls-files -s
94d24ce164 - apps/dojo/e2e/fixtures/test-image.png (70 B)
b4bdfc1896 - sdks/dotnet/tests/.../Samples/GettingStarted/ag-ui-logo.png (2.3 KB)
```

**Workflow validity** — parsed with `yaml.safe_load`; all three checkout steps resolve as expected:

```
job=detect-changes  name=None          lfs=None  repo=self
job=dojo            name=Checkout CPK  lfs=True  repo=self
job=dojo            name=Checkout AGUI lfs=True  repo=ag-ui-protocol/ag-ui
```

`oxfmt --check`: clean.

The real proof is this PR's own dojo run — it exercises the changed checkout directly, so the three jobs going green here is the test.

## One loose end

The cutover is 2026-09-10 08:21, but `24545e119` landed 2026-09-09 11:28 and our 21:26 run that same day genuinely executed all three langgraph jobs and passed (checked — they were not skipped). So a second factor is involved that I have not identified. It does not change the cause or the fix: the ag-ui checkout needs `lfs: true` either way, and upstream sets it.

Since the dojo workflow pulls ag-ui at floating `main`, this class of breakage can arrive from any upstream merge. Worth a separate conversation about pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed end-to-end test setup so required image fixtures are available correctly, preventing failures in LangGraph test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->