### PR TITLE
fix(web-inspector): point the Learning pane's setup button at Learning

### DIFF
--- a/packages/web-inspector/dev/learning-setup-persistence.browser.ts
+++ b/packages/web-inspector/dev/learning-setup-persistence.browser.ts
@@ -17,7 +17,7 @@ for (const transport of ["rest", "single"] as const) {
     });
 
     await page
-      .getByRole("button", { name: "Copy setup prompt for Threads" })
+      .getByRole("button", { name: "Copy setup prompt for Learning" })
       .click();
 
     const setup = page.getByRole("region", { name: "Set up Learning" });

--- a/packages/web-inspector/dev/learning-workbench.browser.ts
+++ b/packages/web-inspector/dev/learning-workbench.browser.ts
@@ -62,7 +62,7 @@ test("enumerates and navigates the complete Automatic Learning matrix at the roo
     }),
   ).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Copy setup prompt for Threads" }),
+    page.getByRole("button", { name: "Copy setup prompt for Learning" }),
   ).toBeVisible();
   await expect(
     page.locator('[data-inspector-locked-feature-talk="memory"]'),
@@ -161,7 +161,7 @@ test("provides a dedicated post-copy Learning setup state", async ({
     setup.getByRole("heading", { name: "Waiting for Learning setup" }),
   ).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Copy setup prompt for Threads" }),
+    page.getByRole("button", { name: "Copy setup prompt for Learning" }),
   ).toHaveCount(0);
 });
 
@@ -191,7 +191,7 @@ test("keeps the copied Learning setup state after a root workbench reload", asyn
   });
   await openWorkbenchState(page, "landing");
   await page
-    .getByRole("button", { name: "Copy setup prompt for Threads" })
+    .getByRole("button", { name: "Copy setup prompt for Learning" })
     .click();
 
   const setup = page.getByRole("region", { name: "Set up Learning" });
@@ -223,7 +223,7 @@ test("keeps the copied Learning setup state after a root workbench reload", asyn
       .first(),
   ).toHaveClass(/complete/);
   await expect(
-    page.getByRole("button", { name: "Copy setup prompt for Threads" }),
+    page.getByRole("button", { name: "Copy setup prompt for Learning" }),
   ).toHaveCount(0);
 });
 

--- a/packages/web-inspector/src/__tests__/web-inspector.spec.ts
+++ b/packages/web-inspector/src/__tests__/web-inspector.spec.ts
@@ -3582,8 +3582,12 @@ describe("WebInspectorElement memories — view states", () => {
     expect(landing?.textContent).toContain(
       "Turn every interaction into reusable context.",
     );
+    // The Learning pane asks for Learning. It used to borrow the Threads
+    // target, so this button copied a Threads prompt and announced itself as
+    // one, on a page headed "Turn every interaction into reusable context"
+    // (OSS-1151).
     const copy = landing?.querySelector<HTMLButtonElement>(
-      '[data-inspector-feature-setup-prompt="threads"]',
+      '[data-inspector-feature-setup-prompt="memory"]',
     );
     expect(copy).not.toBeNull();
     copy?.click();
@@ -3595,6 +3599,13 @@ describe("WebInspectorElement memories — view states", () => {
         agentId: null,
       });
     });
+    // What the developer actually pastes. `add-learning` refuses cleanly
+    // through `feature/stop` when a prerequisite is missing, which is why the
+    // route beats this pane guessing at one.
+    expect(String(writeText.mock.calls[0]?.[0])).toContain(
+      "--intent add-learning",
+    );
+    expect(copy?.getAttribute("aria-label")).toContain("Learning");
     expect(internals.selectedMenu).toBe("memories");
     await el.updateComplete;
     const view = el.shadowRoot?.querySelector<HTMLElement>("cpk-learning-view");
@@ -3895,7 +3906,7 @@ describe("WebInspectorElement memories — view states", () => {
     const preview = learningPreview(el);
 
     expect(
-      preview.querySelector('[data-inspector-feature-setup-prompt="threads"]'),
+      preview.querySelector('[data-inspector-feature-setup-prompt="memory"]'),
     ).not.toBeNull();
     expect(preview.textContent).toContain("Copy setup prompt");
   });

--- a/packages/web-inspector/src/index.ts
+++ b/packages/web-inspector/src/index.ts
@@ -8155,7 +8155,18 @@ export class WebInspectorElement extends LitElement {
     event?: Event,
     recopy = false,
   ): Promise<void> => {
-    const service = this.getHomeFeaturePromptTarget("threads");
+    // The Learning tile, not the Threads one. This pane borrowed the Threads
+    // target, so its button copied a Threads prompt and announced itself as
+    // "Threads setup prompt copied" under a Learning heading (OSS-1151).
+    //
+    // Learning does not need the Threads feature first. A runtime mounted
+    // `mode: "single-route"` serves no thread route at all and still binds
+    // Containers, because the binding happens server-side while a run starts;
+    // and `learningOn` reads the `memory` tile independently of `threadsOn`.
+    // `add-learning` inspects its own prerequisites and refuses through
+    // `feature/stop` when one is missing, which is why the route decides that
+    // rather than this pane.
+    const service = this.getHomeFeaturePromptTarget("memory");
     if (!service || !this.core?.runtimeUrl) return;
     const request = ++this.learningSetupCopyRequest;
     const copied = await this.copyFeaturePromptToClipboard(
@@ -18402,7 +18413,7 @@ export class WebInspectorElement extends LitElement {
         videoTitle: "CopilotKit Learning overview",
         outlineItems: LEARNING_LOCKED_FEATURE_OUTLINE,
         setupPrompt: {
-          serviceId: "threads",
+          serviceId: "memory",
           copyState: this.learningPromptCopyState,
           onClick: (event) => void this.handleLearningSetupCopy(event),
         },
@@ -18420,7 +18431,7 @@ export class WebInspectorElement extends LitElement {
         .copyState=${this.learningPromptCopyState}
         .recopyState=${this.learningPromptRecopyState}
         .setupPrompt=${createFeatureOnboardingPrompt(
-          "threads",
+          "memory",
           this.getOnboardingRunId(),
         )}
         @learning-retry=${() =>


### PR DESCRIPTION
## Problem

A developer on the Learning pane clicks **Copy setup prompt** and gets a prompt for **Threads**.

Three sites hard-coded the Threads tile as the feature target on a pane whose own `serviceId` is `memory`:

- `handleLearningSetupCopy` called `getHomeFeaturePromptTarget("threads")`.
- the locked Learning overview passed `setupPrompt: { serviceId: "threads" }`.
- `cpk-learning-view`'s `.setupPrompt` was built from `"threads"`.

The mislabelling reached the reader, not just the internals: the button's `aria-label` and its live-region announcement both read "Threads setup prompt copied" under the heading "Turn every interaction into reusable context." After #7004 moved these buttons onto the CLI intent routes, the copied text read `--intent add-rich-threads` — equally wrong, on the same three lines.

#7004 left them alone on purpose, because the target looked like a product decision rather than a naming slip.

## Why it is a bug and not a flow

Threads-first was the defensible reading: Learning needs threads, so send the developer to set up Threads first. Three checks say that premise is false.

1. **Learning works with no thread routes at all.** A runtime mounted `mode: "single-route"` serves no `threads/*` route, and Learning still binds Containers — the binding happens server-side while a run starts, in the Intelligence run handler, independent of the mount. Intelligence PR #1198 proves a full round trip and Container assignment on exactly that shape.
2. **The Inspector does not gate it.** `learningOn` reads the `memory` tile and `threadsOn` reads `threads`, independently. Nothing conditions one on the other.
3. **The route does not require them.** `feature/learning/start.md` lists existing thread routes among the things it *inspects*; its only hard stop is a project with no CopilotKit app.

So the target was the bug. The intent table in `onboarding-prompt.ts` already maps `memory` to `add-learning`, and its comment already says why — the tile is the Learning tile, enabled by a configured Learning Container, "which is exactly what `feature/learning` sets up". These three call sites were the leftover.

Pointing at `add-learning` is also the more robust answer: that route inspects its own prerequisites and refuses cleanly through `feature/stop` when one is missing, instead of this pane hard-coding a guess at which prerequisite matters.

## Evidence

RED first. Two existing tests pinned the wrong behavior by asserting the Learning preview's button is the `"threads"` one; inverted to `"memory"`, they failed with `expected null not to be null` — the Learning button did not exist. They now also assert what actually reaches the clipboard (`--intent add-learning`) and that the accessible label says Learning rather than Threads.

```
@copilotkit/web-inspector test         697 passed (38 files)
@copilotkit/web-inspector check-types  clean
oxfmt --check on both changed files    clean
```

## What is deliberately unchanged

- `renderThreadsView` keeps its own `serviceId: "threads"`. It is the Threads pane.
- The Home Threads tile keeps its target, and its test still reaches it through `clickHud("threads")`.
- `inspector-metadata.spec.ts`'s Threads-tab assertion is untouched for the same reason.

Only the Learning pane borrowed the Threads target, and only that borrowing is removed.

Closes OSS-1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Learning setup prompt to target the correct Learning feature.
  * Copied setup instructions now provide Learning-specific configuration.
  * Updated the setup prompt button’s accessibility label to identify Learning correctly.
  * Learning onboarding no longer requires the Threads feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->