### PR TITLE
docs(react-core): document useAgent's thread-scoped shape

### DIFF
--- a/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgent.mdx
@@ -20,6 +20,41 @@ function useAgent(options?: UseAgentProps): {
 };
 ```
 
+## Two valid shapes
+
+The options object admits exactly two shapes, and the type rejects everything in between:
+
+```tsx
+// Bind to an agent — the shared instance from the registry. The thread comes
+// from the surrounding chat configuration.
+const { agent } = useAgent();
+const { agent } = useAgent({ agentId: "default" });
+
+// Bind a private agent to a thread — all three properties are required.
+const { agent } = useAgent({
+  agentId: "chat-1",          // local id to register the private agent under
+  runtimeAgentId: "default",  // the runtime agent it routes to
+  threadId: "thread-abc",     // the thread to pin it to
+});
+```
+
+<Callout type="warn">
+  Partial combinations do not compile. `useAgent({ agentId, threadId })`,
+  `useAgent({ agentId, runtimeAgentId })` and
+  `useAgent({ runtimeAgentId, threadId })` are all type errors.
+
+A runtime agent registered under a given id is a singleton. Writing a
+per-hook `threadId` straight onto it would let two `useAgent` calls that
+share an `agentId` clobber each other's thread, so scoping a thread requires
+a private agent to pin it to.
+
+</Callout>
+
+Use the second shape when several frontend agents — one per open thread, for
+instance — have to mount against a single runtime agent. `runtimeAgentId`
+registers a proxied agent through `CopilotKitCore.registerProxiedAgent`, so each
+hook gets its own instance instead of a shared one.
+
 ## Parameters
 
 <PropertyReference name="options" type="UseAgentProps">
@@ -28,7 +63,41 @@ function useAgent(options?: UseAgentProps): {
 <PropertyReference name="agentId" type="string" default='"default"'>
   ID of the agent to retrieve. Must match an agent configured in
   `CopilotKit`.
+
+  In the thread-scoped shape this is the **local** id to register the private
+  agent under, and it must not already be taken. The usual fallbacks — the chat
+  configuration's `agentId`, then the global default — name agents that already
+  exist, so pass an id of your own.
 </PropertyReference>
+
+  <PropertyReference name="runtimeAgentId" type="string">
+    The runtime agent to route outbound requests to, while the hook exposes a
+    distinct local `agentId`. Registers a proxied agent via
+    `CopilotKitCore.registerProxiedAgent`.
+
+    Requires `threadId`. Registering a private agent is only worth doing in
+    order to scope a thread to it.
+
+  </PropertyReference>
+
+  <PropertyReference name="threadId" type="string">
+    Thread to scope the agent's run to. It is written onto the underlying agent,
+    so `/agent/run`, `/agent/connect` and `/agent/stop` all address this thread.
+
+    Requires `runtimeAgentId`. Omit both to take the thread from the chat
+    configuration instead.
+
+  </PropertyReference>
+
+  <PropertyReference name="throttleMs" type="number">
+    How long to batch re-render notifications for. Run lifecycle callbacks
+    (`onRunInitialized`, `onRunFinalized`, `onRunFailed`, `onRunErrorEvent`)
+    always fire immediately regardless.
+
+    When unset it inherits the provider's `defaultThrottleMs`; if that is also
+    unset the effective value is `0`, meaning no throttle.
+
+  </PropertyReference>
 
   <PropertyReference name="updates" type="UseAgentUpdate[]" default="[OnMessagesChanged, OnStateChanged, OnRunStatusChanged]">
     Controls which agent changes trigger component re-renders. Options:

--- a/showcase/shell-docs/src/content/snippets/shared/threads/headless-threads.mdx
+++ b/showcase/shell-docs/src/content/snippets/shared/threads/headless-threads.mdx
@@ -216,9 +216,36 @@ before exposing thread lists or lifecycle actions.
       </Step>
 </Steps>
 
+## Driving one agent per thread
+
+`useThreads` lists and switches threads. To read or run an agent **scoped to a
+specific thread** — one open tab per thread, for instance — pass all three of
+`agentId`, `runtimeAgentId` and `threadId` to `useAgent`:
+
+```tsx
+const { agent } = useAgent({
+  agentId: `chat-${threadId}`, // local id, unique per mounted thread
+  runtimeAgentId: "default",   // the one runtime agent they all route to
+  threadId,                    // the thread this instance is pinned to
+});
+```
+
+This registers a private proxied agent per hook, so several threads can be
+mounted at once against a single runtime agent. `agent.runAgent()` then
+addresses that thread.
+
+<Callout type="warn">
+  The three properties are a matched set and partial combinations do not
+  compile. In particular `useAgent({ agentId, threadId })` is a type error: a
+  runtime agent is a singleton, so pinning a thread directly onto it would let
+  two hooks sharing an `agentId` overwrite each other's thread. See the
+  [`useAgent` reference](/reference/hooks/useAgent) for the full rules.
+</Callout>
+
 ## Next steps
 
 - **Prebuilt UI:** [Threads Drawer](/prebuilt-components/copilot-threads-drawer) — the drop-in thread switcher ([React reference](/reference/components/CopilotThreadsDrawer))
 - **Thread architecture:** [Threads & Persistence Architecture](/intelligence/threads-explained) — event replay model and WebSocket sync
 - **Production self-hosting:** [Self-host CopilotKit Intelligence](/intelligence/self-hosting) — run the Threads platform inside your infrastructure with CopilotKit Engineering
 - **API reference:** [useThreads](/reference/hooks/useThreads) — parameters, return values, types
+- **API reference:** [useAgent](/reference/hooks/useAgent) — including the thread-scoped shape above


### PR DESCRIPTION
## What

Documents `useAgent`'s thread-scoped shape, which has shipped since **v1.64.2** and has never appeared in the docs.

```tsx
useAgent({ agentId, runtimeAgentId, threadId })  // all three required
```

## Why

While closing out #7029 I checked whether the knowledge in the deleted `react-core` skill had actually reached the docs. This piece never had:

- `runtimeAgentId` appeared in **zero** docs files.
- I brace-matched every object-form `useAgent({...})` call site in `showcase/shell-docs/src/content` — **122 of them** — and not one passes a `threadId`.
- The API landed in `27827adee2` (2026-07-27) and was type-enforced by `acdd9a9ef5` two days later, released in v1.64.2.

So the shipped feature had no public documentation at all. Its only writeup was in `packages/react-core/skills/react-core/references/agent-access.md`, which #7029 deleted — and that writeup was **wrong**: it showed `useAgent({ agentId, threadId })`, which is a compile error, and credited per-thread isolation to `clone()` instead of `registerProxiedAgent`.

@deepshekhardas had already corrected exactly that in **#6636**, against the file #7029 removed. The prose here follows his correction; credit is his.

This also closes the discovery gap behind **#6125**, which asked for headless thread-switching parity with Vue's `cloneForThread`. The feature exists — it just could not be found.

## Changes

**`reference/hooks/useAgent`**

- New "Two valid shapes" section. The type admits exactly two: bind to a shared agent (`useAgent()` / `useAgent({ agentId })`), or bind a private agent to a thread (all three properties). It states why the partial combinations are rejected: a runtime agent registered under an id is a singleton, so a per-hook `threadId` written onto it would let two `useAgent` calls sharing an `agentId` overwrite each other's thread.
- `runtimeAgentId`, `threadId` and `throttleMs` property entries — all three were missing from the Parameters list.
- The `agentId` entry now notes that in the thread-scoped shape it is a *local* registry id that must not already be taken, since the usual fallbacks name agents that already exist.

**Headless Threads guide** — a "Driving one agent per thread" section showing `agentId: \`chat-${threadId}\`` against one shared `runtimeAgentId`. That guide is where someone building a multi-thread UI actually looks, and it previously never mentioned `useAgent`.

## Testing

Docs-only; no runtime code changed.

Every claim is taken from the source's own JSDoc rather than paraphrased — `packages/react-core/src/v2/hooks/use-agent.tsx:52-138` states "There are exactly two valid shapes, and the type admits nothing in between" and enumerates the three rejected combinations. The `registerProxiedAgent` mechanism is verified at `use-agent.tsx:244`, and `clone()` appears nowhere in that file, which is what made the old skill's claim wrong.

Verified:

- The three links introduced (`/reference/hooks/useAgent`, `/reference/hooks/useThreads`, `/prebuilt-components/copilot-threads-drawer`) each return **200** live.
- JSX tag inventory diffed against `origin/main`: the reference page gains exactly 1 `Callout` and 3 `PropertyReference` pairs (both open and close), the guide exactly 1 `Callout` pair — nothing unbalanced.
- `PropertyReference` nesting re-read after the edit: the `options` wrapper opens once and closes once, with all five child properties inside it.
- `oxfmt` does not process `.mdx`, so there is no formatting gate to satisfy here; the shell-docs build check in CI is the real one.

## Not in scope

`cloneForThread` — the Vue API #6125 cites for parity — is also undocumented. Same class of gap, different surface, so it is not folded in here.

Refs #6125, #6636

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded `useAgent` guidance to document shared registry-bound agents and thread-scoped private agents.
  * Clarified required parameter combinations, thread scoping, runtime agent behavior, and invalid partial configurations.
  * Documented render-throttling behavior and `defaultThrottleMs` inheritance.
  * Added a headless threads example showing how to drive one agent per thread.
  * Added a link to the `useAgent` reference in the headless threads next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->