### PR TITLE
fix(docs): use title case for Copy Prompt

### DIFF
--- a/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/docs-page-tools.test.tsx
@@ -80,7 +80,7 @@ it("renders the onboarding button when a framework is passed", () => {
   renderRow({ slug: "mastra", name: "Mastra" });
 
   const button = screen.getByRole("button", { name: /copy prompt/i });
-  expect(button.textContent).toContain("COPY PROMPT");
+  expect(button.textContent).toContain("Copy Prompt");
   expect(
     screen.getByRole("button", { name: "Open in Claude Code" }),
   ).toBeTruthy();

--- a/showcase/shell-docs/src/components/__tests__/prompt-pill.test.tsx
+++ b/showcase/shell-docs/src/components/__tests__/prompt-pill.test.tsx
@@ -66,7 +66,7 @@ it("views and copies the same prompt without launching an app", async () => {
   await waitFor(() => expect(writeText).toHaveBeenCalledWith("Run 1"));
   expect(launch).not.toHaveBeenCalled();
   expect(screen.getByRole("button", { name: "Copy prompt" }).textContent).toBe(
-    "COPY PROMPT",
+    "Copy Prompt",
   );
 });
 

--- a/showcase/shell-docs/src/components/content/landing-pages/__tests__/framework-overview.test.tsx
+++ b/showcase/shell-docs/src/components/content/landing-pages/__tests__/framework-overview.test.tsx
@@ -40,7 +40,7 @@ describe("FrameworkOverview", () => {
     );
 
     // The prompt button carries the accent treatment...
-    expect(markup).toContain("COPY PROMPT");
+    expect(markup).toContain("Copy Prompt");
     expect(markup).toContain('data-surface="docs_framework_hero"');
     expect(markup).toContain("prompt-pill-dock");
     expect(markup).toContain("Open in Claude Code");
@@ -71,12 +71,12 @@ describe("FrameworkOverview", () => {
       />,
     );
 
-    expect(markup).toContain("COPY PROMPT");
+    expect(markup).toContain("Copy Prompt");
     expect(markup).toContain('data-surface="docs_framework_hero"');
     expect(markup).toContain(initCommand);
 
     // Prompt first, then Quickstart in the bordered treatment, then the chip.
-    expect(markup.indexOf("COPY PROMPT")).toBeLessThan(
+    expect(markup.indexOf("Copy Prompt")).toBeLessThan(
       markup.indexOf("Quickstart"),
     );
     expect(markup.indexOf("Quickstart")).toBeLessThan(

--- a/showcase/shell-docs/src/components/prompt-pill.tsx
+++ b/showcase/shell-docs/src/components/prompt-pill.tsx
@@ -169,7 +169,7 @@ export function PromptPill({
           ) : (
             <Copy aria-hidden="true" />
           )}
-          <span>COPY PROMPT</span>
+          <span>Copy Prompt</span>
         </button>
         <span className="prompt-pill-divider" aria-hidden="true" />
         <button


### PR DESCRIPTION
The shared docs button now reads “Copy Prompt” instead of “COPY PROMPT”, matching the requested Title Case treatment. This follows the merged prompt-button PR #7038 and updates the existing label assertions.

Validation from `showcase/shell-docs`:

```sh
npm exec -- vitest run src/components/__tests__/prompt-pill.test.tsx src/components/__tests__/docs-page-tools.test.tsx src/components/content/landing-pages/__tests__/framework-overview.test.tsx
npm run typecheck
npm run lint
npm run build
```

23 focused tests passed. Browser checks cover the docs home and Quickstart page at 1440px and 320px, asserting the exact label and computed `text-transform: none`. No screenshots are committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the copy prompt button label from “COPY PROMPT” to “Copy Prompt” for consistent title-case presentation.

- **Tests**
  - Updated related interface checks to reflect the revised button label across prompt and framework overview experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->