### PR TITLE
fix(docs): load env files for the standalone SPA runtime

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -15,7 +15,7 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
 
 - An OpenAI API key (or another model provider supported by [Model Selection](/model-selection))
 - React 18+
-- Node.js 20+
+- Node.js 20.6+ (for `--env-file`)
 
 ## Getting started
 
@@ -146,12 +146,19 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
     <Step>
         ### Run the runtime and app
 
-        You are running two dev servers, so they need two different ports. Start Copilot Runtime in one terminal:
+        You are running two dev servers, so they need two different ports. Create `.env` beside `server.ts` and keep it out of version control:
+
+        ```dotenv title=".env"
+        OPENAI_API_KEY=sk-...
+        ```
+
+        Start Copilot Runtime from that directory in one terminal:
 
         ```bash
-        export OPENAI_API_KEY=sk-...
-        npx tsx server.ts
+        npx tsx --env-file=.env server.ts
         ```
+
+        A standalone Node process does not load `.env` automatically. The flag loads it before runtime imports run, including `CPK_INTELLIGENCE_API_KEY` when you connect [Intelligence](/intelligence/connect-your-runtime). If the CLI wrote `.env` in a parent directory, point `--env-file` at that file instead. Keep server credentials out of `VITE_*` variables, which are exposed to the browser.
 
         Start the React app in another terminal:
 
@@ -173,7 +180,7 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
                 - **404s on `/api/copilotkit`**: Your `runtimeUrl` is relative. A SPA needs the absolute `http://localhost:8200/api/copilotkit`.
                 - **No response from the agent**: Confirm the runtime server is running and `http://localhost:8200/api/copilotkit/info` returns agent information.
                 - **Chat renders unstyled**: Make sure you imported `@copilotkit/react-core/v2/styles.css` in your app entry.
-                - **Model auth errors**: Confirm `OPENAI_API_KEY` is set in the terminal running `npx tsx server.ts`.
+                - **Model auth errors or Intelligence remains unconfigured**: Confirm the runtime starts with `npx tsx --env-file=.env server.ts` and the selected env file contains the required server credentials. Vite loading its own env file does not configure the runtime process.
             </Accordion>
         </Accordions>
     </Step>

--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -146,7 +146,13 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
     <Step>
         ### Run the runtime and app
 
-        You are running two dev servers, so they need two different ports. Create `.env` beside `server.ts` and keep it out of version control:
+        You are running two dev servers, so they need two different ports. Before creating the server credential file, add this entry to your project's `.gitignore`:
+
+        ```gitignore title=".gitignore"
+        .env
+        ```
+
+        Create `.env` beside `server.ts`:
 
         ```dotenv title=".env"
         OPENAI_API_KEY=sk-...


### PR DESCRIPTION
## Problem

An onboarding run using CLI 4.9.1 reported that the standalone React SPA runtime never reads the `.env` written during onboarding.

## Why

`tsx server.ts` does not load `.env`. Vite loading the file in a separate process does not configure the runtime.

## Fix

Start with `tsx --env-file=.env server.ts`, require Node 20.6+, and explain env-file location and server-only credentials. Changes are confined to the React SPA guide.

Validation: ran the same TypeScript probe beside a `.env` with dummy model and Intelligence credentials. Before: `{"intelligenceConfigured":false,"modelConfigured":false}`. After adding the documented flag: `{"intelligenceConfigured":true,"modelConfigured":true}`. React SPA MDX compilation and `git diff --check` pass. No live credentials or model requests used. Full docs build not run; this checkout has no shell-docs Nx target.

A broader earlier proposal (#6831) was closed without merging; this PR addresses only this run's standalone runtime env-loading issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated React SPA prerequisites to require Node.js 20.6 or later.
  - Added instructions for starting the application with runtime environment variables from a `.env` file.
  - Documented how to configure runtime and Intelligence credentials.
  - Added guidance for keeping sensitive credentials out of browser-exposed variables.
  - Added troubleshooting information for missing runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Review follow-up: the guide now adds `.env` to `.gitignore` before creating credentials. Verified against the official Vite template: `git check-ignore .env` fails before the added rule and succeeds afterward. MDX compilation and whitespace checks pass.
