### PR TITLE
fix(docs): pin compatible Zod for the LangGraph SDK

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/quickstart.mdx
@@ -21,6 +21,16 @@ Before you begin, you'll need the following:
 - Your favorite package manager
 - (Optional) A LangSmith API key - only required if using an existing LangGraph agent
 
+<Callout type="info" title="Zod version for TypeScript agents">
+When adding `@copilotkit/sdk-js` 1.71.0 to a TypeScript agent, install Zod 3 alongside it:
+
+```bash
+npm install @copilotkit/sdk-js@1.71.0 zod@3
+```
+
+An unversioned `zod` install selects Zod 4, which does not satisfy this SDK release's peer dependency. Use `zod@3` with pnpm or Yarn too. If your agent already requires Zod 4, check SDK compatibility before changing its dependencies; do not bypass the conflict with `--force` or `--legacy-peer-deps`.
+</Callout>
+
 ## Getting started
 
 <Steps>


### PR DESCRIPTION
## Problem

An onboarding run using CLI 4.9.1 installed unversioned Zod alongside `@copilotkit/sdk-js` 1.71.0 and hit npm `ERESOLVE`.

## Why

The SDK's declared Zod peer range accepts only v3. Unversioned installs select v4. The LangGraph quickstart, also served at `/langgraph-typescript/quickstart.md`, does not explain this constraint.

## Fix

Add a version-scoped installation note with `npm install @copilotkit/sdk-js@1.71.0 zod@3`, equivalent package-manager guidance, and a note for existing Zod 4 applications. This avoids expanding SDK compatibility in a documentation fix.

Reproduction in a clean temporary directory using published packages:

```text
npm install --package-lock-only --ignore-scripts --no-audit --no-fund @copilotkit/sdk-js@1.71.0 zod@4
ERESOLVE: Found zod@4.6.1; SDK requires ^3.23.3 || ^3.24.0 || ^3.25.0

npm install --package-lock-only --ignore-scripts --no-audit --no-fund @copilotkit/sdk-js@1.71.0 zod@3
up to date in 2s (exit 0)
```

LangGraph quickstart MDX compilation and `git diff --check` pass. Full docs build not run. No SDK runtime behavior changes or claims of Zod 4 support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prerequisite note for TypeScript users integrating LangGraph agents.
  * Clarified the required Zod version when installing the CopilotKit SDK.
  * Added guidance to avoid bypassing dependency conflicts with force-install options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->