### PR TITLE
fix(docs): correct LangGraph TypeScript context state key

### DIFF
--- a/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
+++ b/showcase/shell-docs/src/content/docs/integrations/langgraph/agent-app-context.mdx
@@ -103,6 +103,10 @@ This context can then be shared with your LangGraph agent.
                 The state of a LangGraph agent is the "hub" for applicative information used by the agent.
                 Naturally, the context from CopilotKit will be injected there.
 
+                In both Python and TypeScript, the CopilotKit state key is lowercase
+                `copilotkit`. Read `state.copilotkit.context` in TypeScript; the
+                SDK's state schema does not define a `copilotKit` field.
+
                 <Tabs groupId="language_langgraph_agent" items={['Python', 'TypeScript']} default="Python" persist>
                     <Tab value="Python">
                         ```python title="agent.py"
@@ -164,7 +168,7 @@ This context can then be shared with your LangGraph agent.
 
                         async function chat_node(state: AgentState, config: RunnableConfig) {
                           // Extract the colleagues from CopilotKit context
-                          const copilotKitContext = state.copilotKit.context
+                          const copilotKitContext = state.copilotkit.context
                           const colleaguesContextItem = copilotKitContext.find(contextItem => contextItem.description === "The current user's colleagues")
 
                           // [!code highlight:5]


### PR DESCRIPTION
## Problem

The LangGraph TypeScript app-context example reads `state.copilotKit.context`, but the SDK schema and CopilotKit runtime adapter supply lowercase `copilotkit`.

## Why

The TypeScript spelling differs from the actual state field. Following the example throws before it can consume frontend context.

## Fix

Correct the expression and explain the lowercase state key. One docs file; no runtime behavior change.

Validation: sent a synthetic colleague through the real CopilotKit LangGraph adapter's state merge and a compiled LangGraph node using the expression extracted from this page. Before: `TypeError: Cannot read properties of undefined (reading 'context')`. After: the node reads colleague `Ada`. MDX syntax compilation passes after stripping snippet imports, as the docs loader does. Git whitespace and commit hooks pass. No hosted browser/model call was needed for this deterministic reproduction; full docs build was not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the CopilotKit state key is lowercase `copilotkit` in Python and TypeScript integrations.
  - Updated the TypeScript example to access context using the correct lowercase state key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->