### PR TITLE
fix(docs): distinguish tool inputs from completed results

### DIFF
--- a/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
+++ b/showcase/shell-docs/src/content/docs/generative-ui/tool-rendering.mdx
@@ -81,6 +81,22 @@ The most expressive path is one renderer per tool name. The primary
 receives the tool's parsed arguments, a live `status`, and (once the agent
 returns) the `result`:
 
+### Tool inputs and results are separate
+
+In `useRenderTool`, `parameters` contains the **inputs** the agent sent to the
+tool. It does not change into the tool's return value when `status` becomes
+`"complete"`. The completed output arrives separately as `result`, a string.
+For a tool that returns JSON, parse that string before reading its fields.
+
+For example, `get_weather` might receive `{ "location": "Paris" }` and return
+`{ "temperature": 22 }`. Read `parameters.location` for the requested city and
+the parsed `result.temperature` for the temperature. Adding `temperature` to
+the renderer's `parameters` schema does not copy it from the result.
+
+If a card says **complete** but still shows placeholder details, check whether
+those details come from `parameters` instead of the parsed `result`. Completion
+reports that the tool returned; it does not fill the card's props for you.
+
 The frontend pattern is the same for every backend. This shared, docs-only
 example includes every component, type, and helper that its renderers use:
 


### PR DESCRIPTION
## Problem

A completed tool card can still show placeholder details when its renderer reads output fields from the tool inputs.

## Why

`useRenderTool` keeps `parameters` (inputs) separate from `result` (the completed output string). Completion does not replace inputs with output, and declaring a field in the parameters schema does not populate it from the result. The guide showed a working example but did not explain this distinction.

## Fix

Add one explanation beside the existing per-tool example, including the exact completed-placeholder symptom and how to read JSON output. No API or runtime changes.

Reproduction against the real `useRenderTool` registration and `useRenderToolCall` resolver (only surrounding context mocked), using identical input and result messages:

```html
<article>
  <p data-testid="before">complete: Placeholder detail</p>
  <p data-testid="after">complete: Sunny, 22 C</p>
</article>
```

The first card reads an absent input field; the second parses `result`. A temporary Nx reproduction target ran the existing resolver tests plus this case: **9 tests passed**. The temporary harness is not shipped in this docs-only PR. MDX parsing and `git diff --check` passed. Full docs build not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how tool inputs and completed outputs are represented when using tool rendering.
  - Added guidance for parsing JSON results and distinguishing input parameters from output data.
  - Documented how to diagnose placeholder data that appears after tool execution completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->