### PR TITLE
fix(docs): make ADK setup examples self-contained

### DIFF
--- a/showcase/integrations/google-adk/docs/setup/agent-setup.mdx
+++ b/showcase/integrations/google-adk/docs/setup/agent-setup.mdx
@@ -1,10 +1,18 @@
-First, pass `AGUIToolset()` in your `LlmAgent`'s `tools=` list and pair it
-with `stop_on_terminal_text` as the `after_model_callback`. The toolset is
-what makes every CopilotKit feature on the frontend — frontend tools, shared
-state, agent context, and generative UI components — visible to your ADK
-agent on every turn.
+Pass `AGUIToolset()` in your `LlmAgent`'s `tools=` list to expose
+CopilotKit's frontend tools and generative UI components to the agent.
+Use an ADK-supported model available to your project.
 
-<DemoCode file="src/agents/hitl_in_chat_agent.py" region="setup" />
+```python
+from ag_ui_adk import AGUIToolset
+from google.adk.agents import LlmAgent
+
+agent = LlmAgent(
+    name="assistant",
+    model="gemini-3.1-flash-lite",
+    instruction="Help the user and call the available frontend tools when appropriate.",
+    tools=[AGUIToolset()],
+)
+```
 
 <Accordions>
   <Accordion title="Install the SDK">

--- a/showcase/integrations/google-adk/docs/setup/agent-setup.mdx
+++ b/showcase/integrations/google-adk/docs/setup/agent-setup.mdx
@@ -2,15 +2,45 @@ Pass `AGUIToolset()` in your `LlmAgent`'s `tools=` list to expose
 CopilotKit's frontend tools and generative UI components to the agent.
 Use an ADK-supported model available to your project.
 
+The callback below preserves the Gemini termination safeguard: it stops on
+final text with a `STOP` finish reason, while leaving partial responses and
+pending tool calls alone. It is defined here in full, not imported from
+`ag-ui-adk` or a showcase-only module.
+
 ```python
 from ag_ui_adk import AGUIToolset
 from google.adk.agents import LlmAgent
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models.llm_response import LlmResponse
+
+
+def stop_on_terminal_text(
+    callback_context: CallbackContext, llm_response: LlmResponse
+) -> None:
+    content = llm_response.content
+    if llm_response.partial or not content or content.role != "model":
+        return
+    finish_reason = llm_response.finish_reason
+    if getattr(finish_reason, "name", finish_reason) != "STOP":
+        return
+    parts = content.parts or []
+    if not any(part.text for part in parts) or any(part.function_call for part in parts):
+        return
+    # ADK's invocation context is private; tolerate SDK changes.
+    invocation = getattr(callback_context, "_invocation_context", None)
+    if invocation is not None:
+        try:
+            invocation.end_invocation = True
+        except AttributeError:
+            pass
+
 
 agent = LlmAgent(
     name="assistant",
     model="gemini-3.1-flash-lite",
     instruction="Help the user and call the available frontend tools when appropriate.",
     tools=[AGUIToolset()],
+    after_model_callback=stop_on_terminal_text,
 )
 ```
 

--- a/showcase/integrations/google-adk/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/google-adk/docs/setup/frontend-tools-setup.mdx
@@ -10,13 +10,21 @@
   <Step>
     ### Add `AGUIToolset()` to your agent
 
-    `AGUIToolset()` is the tool that exposes CopilotKit's frontend-tool
-    channel to the model — drop it into your `LlmAgent`'s `tools=` list and
-    frontend tools become available on every turn. Pair it with
-    `stop_on_terminal_text` as the `after_model_callback` so CopilotKit's UI
-    knows when the agent has finished its turn.
+    `AGUIToolset()` exposes CopilotKit's frontend tools to the model.
+    Add it to your `LlmAgent`'s `tools=` list. Use an ADK-supported model
+    available to your project.
 
-    <DemoCode file="src/agents/hitl_in_chat_agent.py" region="setup" />
+    ```python
+    from ag_ui_adk import AGUIToolset
+    from google.adk.agents import LlmAgent
+
+    agent = LlmAgent(
+        name="assistant",
+        model="gemini-3.1-flash-lite",
+        instruction="Help the user and call the available frontend tools when appropriate.",
+        tools=[AGUIToolset()],
+    )
+    ```
 
   </Step>
 </Steps>

--- a/showcase/integrations/google-adk/docs/setup/frontend-tools-setup.mdx
+++ b/showcase/integrations/google-adk/docs/setup/frontend-tools-setup.mdx
@@ -14,15 +14,45 @@
     Add it to your `LlmAgent`'s `tools=` list. Use an ADK-supported model
     available to your project.
 
+    The callback below preserves the Gemini termination safeguard: it stops on
+    final text with a `STOP` finish reason, while leaving partial responses and
+    pending tool calls alone. It is defined here in full, not imported from
+    `ag-ui-adk` or a showcase-only module.
+
     ```python
     from ag_ui_adk import AGUIToolset
     from google.adk.agents import LlmAgent
+    from google.adk.agents.callback_context import CallbackContext
+    from google.adk.models.llm_response import LlmResponse
+
+
+    def stop_on_terminal_text(
+        callback_context: CallbackContext, llm_response: LlmResponse
+    ) -> None:
+        content = llm_response.content
+        if llm_response.partial or not content or content.role != "model":
+            return
+        finish_reason = llm_response.finish_reason
+        if getattr(finish_reason, "name", finish_reason) != "STOP":
+            return
+        parts = content.parts or []
+        if not any(part.text for part in parts) or any(part.function_call for part in parts):
+            return
+        # ADK's invocation context is private; tolerate SDK changes.
+        invocation = getattr(callback_context, "_invocation_context", None)
+        if invocation is not None:
+            try:
+                invocation.end_invocation = True
+            except AttributeError:
+                pass
+
 
     agent = LlmAgent(
         name="assistant",
         model="gemini-3.1-flash-lite",
         instruction="Help the user and call the available frontend tools when appropriate.",
         tools=[AGUIToolset()],
+        after_model_callback=stop_on_terminal_text,
     )
     ```
 

--- a/showcase/integrations/google-adk/tests/python/test_setup_doc_examples.py
+++ b/showcase/integrations/google-adk/tests/python/test_setup_doc_examples.py
@@ -1,0 +1,67 @@
+"""Keep copied ADK setup examples executable and safe during streaming."""
+
+from pathlib import Path
+import re
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+from google.adk.models.llm_response import LlmResponse
+from google.genai import types
+
+SETUP_DIR = Path(__file__).resolve().parents[2] / "docs" / "setup"
+
+
+@pytest.fixture(params=["agent-setup.mdx", "frontend-tools-setup.mdx"])
+def example(request):
+    source = (SETUP_DIR / request.param).read_text()
+    code = re.search(r"```python\n(.*?)```", source, re.DOTALL).group(1)
+    namespace = {}
+    exec(textwrap.dedent(code), namespace)
+    return namespace
+
+
+def test_setup_defines_and_registers_termination_callback(example):
+    callback = example["stop_on_terminal_text"]
+    assert example["agent"].after_model_callback is callback
+
+
+@pytest.mark.parametrize(
+    "partial,finish_reason,role,text,tool_call,should_stop",
+    [
+        (False, "STOP", "model", "Done", False, True),
+        (True, "STOP", "model", "Partial", False, False),
+        (False, None, "model", "Thinking", False, False),
+        (False, "STOP", "model", "Calling", True, False),
+        (False, "STOP", "model", None, True, False),
+        (False, "STOP", "user", "Done", False, False),
+        (False, "STOP", "model", None, False, False),
+    ],
+)
+def test_setup_callback_preserves_pending_model_output(
+    example, partial, finish_reason, role, text, tool_call, should_stop
+):
+    parts = [types.Part(text=text)] if text else []
+    if tool_call:
+        parts.append(
+            types.Part(function_call=types.FunctionCall(name="get_records", args={}))
+        )
+    response = LlmResponse(
+        content=types.Content(role=role, parts=parts),
+        partial=partial,
+        finish_reason=finish_reason,
+    )
+    invocation = SimpleNamespace(end_invocation=False)
+    context = SimpleNamespace(_invocation_context=invocation)
+    assert example["stop_on_terminal_text"](context, response) is None
+    assert invocation.end_invocation is should_stop
+
+
+def test_setup_callback_tolerates_missing_private_adk_context(example):
+    response = LlmResponse(
+        content=types.Content(role="model", parts=[types.Part(text="Done")]),
+        finish_reason="STOP",
+    )
+    callback = example["stop_on_terminal_text"]
+    assert callback(SimpleNamespace(), response) is None
+    assert callback(SimpleNamespace(_invocation_context=object()), response) is None


### PR DESCRIPTION
## Problem

The Google ADK frontend-tool setup, embedded in `/google-adk/generative-ui/tool-based`, imports `get_model` and `stop_on_terminal_text` from an undefined `agents.shared_chat` module. This prevents copying the example into a new project.

## Why

The setup snippet was extracted from a showcase agent and carried its repository-local helper dependency. Installing `ag-ui-adk` does not provide that module or export `stop_on_terminal_text`.

Reproduction: executing the extracted setup with installed ADK dependencies in an empty project raises `ModuleNotFoundError: No module named 'agents'`; `hasattr(ag_ui_adk, 'stop_on_terminal_text')` is false.

## Fix

Make the two shared setup snippets standalone: use public `LlmAgent` and `AGUIToolset` imports and an explicit model name. Define and register the termination callback inline, preserving its final-text, streaming, pending-tool, and private-context guards without undefined helper imports. Showcase runtime agents are unchanged.

Validation: regenerated the production setup-content bundle through Nx, then extracted and executed both bundled Python examples in an isolated Python environment. Both construct an agent with `AGUIToolset` successfully. `git diff --check` passes. The two authored setup inputs and a Python regression test change; generated data is not committed. The copied examples and canonical callback pass 26 Python checks, covering callback registration, final text, partial/thinking output, pending tool calls, and missing private ADK context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Rewrote Google ADK integration setup instructions with clearer examples for enabling CopilotKit frontend tools and generative UI components.
  - Updated agent configuration guidance to use `AGUIToolset()` in the agent’s tools list.
  - Replaced referenced demo components with inline Python examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->