### PR TITLE
fix(docs): load shared env files for nested Next.js runtimes

### DIFF
--- a/showcase/shell-docs/src/content/docs/intelligence/connect-your-runtime.mdx
+++ b/showcase/shell-docs/src/content/docs/intelligence/connect-your-runtime.mdx
@@ -36,6 +36,26 @@ CPK_INTELLIGENCE_API_KEY=cpk-...
   prefix — that ships it to the browser.
 </Callout>
 
+### Next.js apps in a subdirectory
+
+Next.js loads `.env*` files from the Next.js app directory. If your app is in
+`web/` and the CLI writes the key to a shared `.env` at the repository root,
+`process.env.CPK_INTELLIGENCE_API_KEY` will be unset unless the server process
+loads that file.
+
+For a shared root `.env`, start Next.js from `web/` with Node's explicit env-file
+option (Node.js 20.6 or later):
+
+```bash title="Terminal — from web/"
+node --env-file=../.env ./node_modules/next/dist/bin/next dev
+```
+
+Use the same prefix with `build` or `start` when those commands need the shared
+file. If the app owns its environment instead, put the key in `web/.env.local`.
+On a hosted deployment, set it in the server's environment settings. Load the
+key before constructing `CopilotKitIntelligence`; the `!` in the example below
+only affects TypeScript and does not load or validate an environment variable.
+
 ## Wire the runtime
 
 Construct the client once and pass it to `CopilotRuntime` as `intelligence`.


### PR DESCRIPTION
## Problem

A Next.js app in `web/` cannot read an Intelligence key stored in a shared repository-root `.env` without explicit environment loading. The runtime connection guide reads `process.env.CPK_INTELLIGENCE_API_KEY` without explaining this layout.

## Why

Next.js loads app-local env files. A sibling agent's root env-file configuration does not load that file for the Next.js process. TypeScript's non-null assertion does not supply the key.

## Fix

Document an explicit `node --env-file=../.env` Next.js startup command, the app-local alternative, and hosted server environment settings. One docs file; no runtime path guessing or secret handling change.

Validation with a synthetic key and Next.js's actual `@next/env` loader: loading the nested app directory leaves the root key undefined. Starting the same check with `node --env-file=../.env` exposes the key to that loader. MDX compilation and git whitespace checks pass. Full docs build and hosted Intelligence connection were not run; no real credentials were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring environment variables in Next.js applications located in subdirectories.
  * Documented how to explicitly load shared root `.env` files, including a Node.js 20.6+ command example.
  * Clarified app-local and hosted deployment environment configuration.
  * Explained that the environment key must be loaded before initializing the intelligence integration.
  * Noted that TypeScript’s non-null assertion does not load or validate environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->