### PR TITLE
fix(docs): explain SPA runtime project env precedence

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -153,6 +153,31 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
         npx tsx server.ts
         ```
 
+        If the key lives in the project's `.env`, the separate runtime must load
+        that file itself; Vite's environment loading does not reach this process.
+        For local development, install `dotenv` and add this before constructing
+        the agent in `server.ts`:
+
+        ```bash
+        npm install dotenv
+        ```
+
+        ```ts title="server.ts — load the project environment"
+        import { config } from "dotenv";
+
+        config({
+          path: new URL("./.env", import.meta.url),
+          override: true,
+        });
+        ```
+
+        This path selects the `.env` beside `server.ts`. Use `override: true`
+        only when that file should take precedence over the inherited shell
+        environment. Without it, an exported `OPENAI_API_KEY` wins even when
+        `.env` contains a different key, which can send calls to the wrong
+        project or cause model authentication errors. Keep the key server-side;
+        do not prefix it with `VITE_` or include it in frontend code.
+
         Start the React app in another terminal:
 
         ```bash

--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -158,9 +158,23 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
         For local development, install `dotenv` and add this before constructing
         the agent in `server.ts`:
 
-        ```bash
-        npm install dotenv
-        ```
+        <Tabs groupId="package-manager" items={['npm', 'pnpm', 'yarn']}>
+            <Tab value="npm">
+                ```bash
+                npm install dotenv
+                ```
+            </Tab>
+            <Tab value="pnpm">
+                ```bash
+                pnpm add dotenv
+                ```
+            </Tab>
+            <Tab value="yarn">
+                ```bash
+                yarn add dotenv
+                ```
+            </Tab>
+        </Tabs>
 
         ```ts title="server.ts — load the project environment"
         import { config } from "dotenv";


### PR DESCRIPTION
## Problem

An inherited `OPENAI_API_KEY` can take precedence over the project's `.env`, causing `invalid_organization` errors in the standalone SPA runtime.

## Why

Vite does not load environment files for the separate Node runtime. Default dotenv loading also preserves inherited variables, so adding a project key does not necessarily select it.

## Fix

Document explicit, file-relative project `.env` loading before agent construction and opt-in `override: true` for local development. Explain when to use this precedence and keep the key out of Vite's client bundle. Existing shell-based setup stays supported; no global credential precedence changes.

Reproduced using installed dotenv 16.6.1 and synthetic keys only:

```text
BEFORE: default dotenv loading selects inherited shell key over project .env
AFTER: explicit override selects project .env key
```

Both selections were asserted against distinct synthetic shell/project values. No real keys or OpenAI requests were used, so the provider's `invalid_organization` response was not independently reproduced. The reproduced cause is environment precedence.

Validation: executed the dotenv reproduction, parsed the edited MDX, and ran `git diff --check`. Full docs build not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the React SPA quickstart with instructions for loading environment variables in the Copilot Runtime process.
  * Added guidance for making local `.env` values override existing shell variables and avoiding configuration issues caused by conflicting API keys.
  * Reiterated that API keys should remain server-side and should not use a `VITE_` prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->