### PR TITLE
fix(docs): explain named agent selection for React SPAs

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -139,6 +139,19 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
           Every framework quickstart uses a relative `runtimeUrl="/api/copilotkit"`. That works **only** because Next.js serves the app and the runtime from the same origin. In a single-page app the runtime is a separate process on a separate port, so the URL has to name it in full — host and port included. Read it from an env var (`import.meta.env.VITE_COPILOT_RUNTIME_URL` in Vite) so you can point it at your deployed runtime in production.
         </Callout>
 
+        To use a named agent from an integration quickstart, set `agentId` to the key registered in the runtime's `agents` map:
+
+        ```tsx
+        <CopilotKitProvider
+          runtimeUrl="http://localhost:8200/api/copilotkit"
+          agentId="sample_agent"
+        >
+          <CopilotChat />
+        </CopilotKitProvider>
+        ```
+
+        `CopilotKitProvider` uses `agentId`; the `agent` prop shown in legacy `<CopilotKit>` examples is not a provider prop. Omit `agentId` when using the `default` agent above.
+
         <Callout type="info" title="Pick your chat layout">
           `CopilotChat` is a full-height chat. Swap it for `CopilotSidebar` (a collapsible side panel) or `CopilotPopup` (a floating widget) for a different layout. They take the same props.
         </Callout>


### PR DESCRIPTION
## Problem

An onboarding run reported a type error from passing `agent` to the v2 `CopilotKitProvider` when connecting a React SPA to LangGraph.

## Why

The integration quickstart shows the legacy `CopilotKit agent="sample_agent"` API, while the SPA guide introduces `CopilotKitProvider`. The SPA guide only demonstrates the default agent and sends readers back to integration guides for external agents, leaving this mapping unstated.

The report's precise claim that the SPA page itself passes `agent` could not be reproduced: both its current source and live Markdown omit that prop. The type error itself is reproducible against published 1.71.0 declarations.

## Fix

Add one named-agent example with `agentId="sample_agent"`, matching the runtime registration, and explain when to omit it. No provider behavior changes.

Validation using published `@copilotkit/react-core@1.71.0` declarations:

```text
const props: CopilotKitProviderProps = { children: null, runtimeUrl: 'http://localhost:8200/api/copilotkit', agent: 'sample_agent' };
TS2561: 'agent' does not exist in type 'CopilotKitProviderProps'. Did you mean 'agentId'?
```

Changing only `agent` to `agentId` passes `tsc --noEmit --skipLibCheck --module esnext --moduleResolution bundler`. The React SPA MDX compiles and `git diff --check` passes. Full docs build not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring `CopilotKitProvider` with a named `agentId`.
  - Included a `sample_agent` configuration example.
  - Clarified that `agentId` is the supported provider property.
  - Documented that the legacy `agent` property is invalid.
  - Explained that `agentId` should be omitted when using the `default` agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->