### PR TITLE
fix(docs): check runtime readiness before opening the SPA

### DIFF
--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -153,31 +153,32 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
         npx tsx server.ts
         ```
 
-        Before opening the app, confirm the runtime is ready. In another
-        terminal, run:
-
-        ```bash
-        curl --fail --silent --show-error http://localhost:8200/api/copilotkit/info
-        ```
-
-        Wait until this succeeds and the JSON includes the `default` agent
-        registered above. Then start the React app:
+        Start the React app in another terminal:
 
         ```bash
         npm run dev
         ```
-
-        If a dev script starts both processes together, wait for that same
-        runtime readiness check before opening the browser. A listening Vite
-        server does not mean the separate runtime is ready. Opening the app
-        too early can leave its initial runtime connection in an error state;
-        reload after `/info` succeeds if that has already happened.
 
         Vite serves on `http://localhost:5173` and the runtime on `8200`, so the defaults don't collide. If you need to move the app, pass `--port` — **Vite ignores the `PORT` environment variable**, unlike Create React App:
 
         ```bash
         npm run dev -- --port 3000
         ```
+
+        Before opening the app, confirm the runtime is ready:
+
+        ```bash
+        curl --fail --silent --show-error http://localhost:8200/api/copilotkit/info
+        ```
+
+        Wait until this succeeds and the JSON includes the `default` agent
+        registered above.
+
+        If a dev script starts both processes together, wait for that same
+        runtime readiness check before opening the browser. A listening Vite
+        server does not mean the separate runtime is ready. Opening the app
+        too early can leave its initial runtime connection in an error state;
+        reload after `/info` succeeds if that has already happened.
 
         Open the dev server URL, send a message, and you'll see it stream back through Copilot Runtime.
 

--- a/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
+++ b/showcase/shell-docs/src/content/docs/frontends/react-spa.mdx
@@ -153,11 +153,25 @@ Exactly one instruction does not carry over: **where Copilot Runtime lives.** Th
         npx tsx server.ts
         ```
 
-        Start the React app in another terminal:
+        Before opening the app, confirm the runtime is ready. In another
+        terminal, run:
+
+        ```bash
+        curl --fail --silent --show-error http://localhost:8200/api/copilotkit/info
+        ```
+
+        Wait until this succeeds and the JSON includes the `default` agent
+        registered above. Then start the React app:
 
         ```bash
         npm run dev
         ```
+
+        If a dev script starts both processes together, wait for that same
+        runtime readiness check before opening the browser. A listening Vite
+        server does not mean the separate runtime is ready. Opening the app
+        too early can leave its initial runtime connection in an error state;
+        reload after `/info` succeeds if that has already happened.
 
         Vite serves on `http://localhost:5173` and the runtime on `8200`, so the defaults don't collide. If you need to move the app, pass `--port` — **Vite ignores the `PORT` environment variable**, unlike Create React App:
 


### PR DESCRIPTION
## Problem

The app can show a runtime error when the browser loads before `/api/copilotkit/info` is ready. Reloading after startup clears it.

## Why

A listening SPA server does not prove the separate runtime has registered its routes and agents. The SPA guide told readers to start both processes and open the browser without a readiness check.

## Fix

Check `/api/copilotkit/info` for a successful response containing the configured agent before opening the SPA. Explain how this also applies when a dev script launches both processes, and how to recover if the browser was already opened.

This is a surgical startup-guide fix. It does not add or change core reconnect behavior.

Reproduced against production `CopilotKitCore` with a real localhost HTTP server. The endpoint starts with 404, then returns valid runtime info:

```text
Failed to load runtime info (.../api/copilotkit/info): Runtime info request failed with status 404
BEFORE: /info is now HTTP 200, but the already-mounted client remains error.
AFTER: checking /info before mounting connects on the first load.
```

A temporary Nx test asserted the early client's error, successful HTTP readiness, continued error during the observed 300 ms interval, and a connected client when created after readiness: **1 test passed**. No fetch mocks, credentials, or model calls; this verifies the core connection sequence, not a full browser/Mastra onboarding run. The temporary harness is not shipped in this docs-only PR.

Validation: localhost reproduction passed, edited MDX parsed, and `git diff --check` passed. Full docs build not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the React SPA quickstart with a runtime readiness check before opening the app.
  - Added guidance to wait for the runtime’s `default` agent to appear in the response.
  - Clarified that a running Vite server does not guarantee runtime readiness.
  - Added recovery guidance to reload the app if its initial runtime connection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->