### PR TITLE
fix(docs): document the ADK agent context state key

### DIFF
--- a/showcase/integrations/google-adk/docs/setup/agent-context-setup.mdx
+++ b/showcase/integrations/google-adk/docs/setup/agent-context-setup.mdx
@@ -10,12 +10,43 @@
   <Step>
     ### Read CopilotKit context before each model call
 
-    `useAgentContext` entries arrive in ADK session state under
-    `state["copilotkit"]["context"]`. Add `AGUIToolset()` to the agent and
-    use a `before_model_callback` to inject those read-only values into the
-    system instruction.
+    The adapter copies the AG-UI request's `context` list into ADK session
+    state at `CONTEXT_STATE_KEY` (the public constant for `"_ag_ui_context"`).
+    Read it from an instruction provider's `ctx.state`, a callback's
+    `callback_context.state`, or a tool's `tool_context.state`.
 
-    <DemoCode file="src/agents/readonly_state_agent_context_agent.py" region="agent-context-setup" />
+    Each entry is a dictionary with `description` and `value` strings.
+    Object and array values registered with `useAgentContext` arrive as JSON
+    strings; use `json.loads(entry["value"])` when you need structured data.
+
+    An instruction provider can include the context in the model's prompt:
+
+    ```python
+    from ag_ui_adk import AGUIToolset, CONTEXT_STATE_KEY
+    from google.adk.agents import LlmAgent
+    from google.adk.agents.readonly_context import ReadonlyContext
+
+    def instructions(ctx: ReadonlyContext) -> str:
+        entries = ctx.state.get(CONTEXT_STATE_KEY, [])
+        context = "\n".join(
+            f"{entry['description']}: {entry['value']}" for entry in entries
+        )
+        return (
+            "Help the user using the following read-only application context.\n"
+            + context
+        )
+
+    agent = LlmAgent(
+        name="assistant",
+        model="gemini-3.1-flash-lite",
+        instruction=instructions,
+        tools=[AGUIToolset()],
+    )
+    ```
+
+    `AGUIToolset()` exposes frontend tools; it does not automatically add
+    context to the model's instructions. The instruction provider above
+    performs that step. Expose this agent through your `ADKAgent` endpoint.
 
   </Step>
 </Steps>

--- a/showcase/integrations/google-adk/docs/setup/agent-context-setup.mdx
+++ b/showcase/integrations/google-adk/docs/setup/agent-context-setup.mdx
@@ -19,12 +19,36 @@
     Object and array values registered with `useAgentContext` arrive as JSON
     strings; use `json.loads(entry["value"])` when you need structured data.
 
-    An instruction provider can include the context in the model's prompt:
+    An instruction provider can include the context in the model's prompt.
+    The fully defined callback preserves the Gemini termination safeguard
+    without stopping partial responses or pending tool calls:
 
     ```python
     from ag_ui_adk import AGUIToolset, CONTEXT_STATE_KEY
     from google.adk.agents import LlmAgent
     from google.adk.agents.readonly_context import ReadonlyContext
+    from google.adk.agents.callback_context import CallbackContext
+    from google.adk.models.llm_response import LlmResponse
+
+    def stop_on_terminal_text(
+        callback_context: CallbackContext, llm_response: LlmResponse
+    ) -> None:
+        content = llm_response.content
+        if llm_response.partial or not content or content.role != "model":
+            return
+        finish_reason = llm_response.finish_reason
+        if getattr(finish_reason, "name", finish_reason) != "STOP":
+            return
+        parts = content.parts or []
+        if not any(part.text for part in parts) or any(part.function_call for part in parts):
+            return
+        # ADK's invocation context is private; tolerate SDK changes.
+        invocation = getattr(callback_context, "_invocation_context", None)
+        if invocation is not None:
+            try:
+                invocation.end_invocation = True
+            except AttributeError:
+                pass
 
     def instructions(ctx: ReadonlyContext) -> str:
         entries = ctx.state.get(CONTEXT_STATE_KEY, [])
@@ -41,6 +65,7 @@
         model="gemini-3.1-flash-lite",
         instruction=instructions,
         tools=[AGUIToolset()],
+        after_model_callback=stop_on_terminal_text,
     )
     ```
 

--- a/showcase/shell-docs/src/content/reference/hooks/useAgentContext.mdx
+++ b/showcase/shell-docs/src/content/reference/hooks/useAgentContext.mdx
@@ -157,7 +157,27 @@ const entry = context.find(
 const records = entry ? JSON.parse(entry.value) : undefined;
 ```
 
-Where that context list surfaces in your agent depends on your framework's AG-UI adapter -- see your integration's guide for the field it populates.
+Where that context list surfaces in your agent depends on your framework's AG-UI adapter.
+
+### Google ADK
+
+`ag-ui-adk` stores the request's context list in ADK session state under
+`CONTEXT_STATE_KEY`, a public export whose value is `"_ag_ui_context"`:
+
+```python
+from ag_ui_adk import CONTEXT_STATE_KEY
+
+def dashboard_records_for_adk(ctx):
+    return dashboard_records(ctx.state.get(CONTEXT_STATE_KEY, []))
+```
+
+Use the `ctx` passed to an ADK instruction provider, `callback_context` in a
+callback, or `tool_context` in a tool. The entries are dictionaries with string
+`description` and `value` fields. To make these values visible to the model,
+include them in an instruction provider or a before-model callback;
+`AGUIToolset()` alone does not inject them into the prompt. See the
+[Google ADK read-only context setup](/google-adk/shared-state/agent-readonly)
+for a complete agent example.
 
 <Callout type="warn">
   Do not type-check `value` against the shape you registered.


### PR DESCRIPTION
## Problem

The documentation does not clearly establish the Google ADK agent-side path for `useAgentContext`. The hook reference points generically to integration guides, while the existing ADK setup uses `state["copilotkit"]["context"]`, which is not where the adapter stores the AG-UI request context.

## Why

Reproduced using the actual adapter and ADK Runner with an instruction provider and a deterministic local model. Given `RunAgentInput.context=[{description: "Incident records", value: "[{\"id\":\"INC-1041\"}]"}]` and empty request state:

```text
state["copilotkit"]["context"]: []
state[CONTEXT_STATE_KEY] (_ag_ui_context):
  [{"description": "Incident records", "value": "[{\"id\":\"INC-1041\"}]"}]
```

## Fix

Document the public `CONTEXT_STATE_KEY` export in the hook reference and link directly to the ADK context guide. Replace that guide's setup with a standalone instruction-provider example using the correct state key. Preserve the Gemini final-text termination safeguard with a fully defined callback in the same example. Explain the string values, parsing structured values, callback/tool access, and the distinction between exposing frontend tools and including context in model instructions.

Validation: regenerated the setup-content bundle through Nx, extracted and executed its Python example, and drove the documented instruction provider through the real adapter/Runner. It delivered `INC-1041` into the model request's system instruction and completed with text events and `RUN_FINISHED`. This is a deterministic integration reproduction, not a live Gemini/browser test. `git diff --check` passes.

Targeted shell-docs checks: **26 passed across 3 files** (`setup-content`, `setup-concept`, and `frontend-tools-setup-coverage`), run through Nx after generating the normal docs prerequisites.

The context example also passes nine copied-code callback checks (registration, final text, partial/thinking output, tool calls, and private-context compatibility). The bundled context-to-model execution check and 26 targeted docs tests pass after this correction.
